### PR TITLE
Add named workspace groups to sidebar

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2029,6 +2029,127 @@ struct CMUXCLI {
                 }
             }
 
+        case "list-workspace-groups":
+            var params: [String: Any] = [:]
+            if let windowId {
+                params["window_id"] = windowId
+            }
+            let payload = try client.sendV2(method: "workspace_group.list", params: params)
+            if jsonOutput {
+                print(jsonString(formatIDs(payload, mode: idFormat)))
+            } else {
+                let groups = payload["groups"] as? [[String: Any]] ?? []
+                if groups.isEmpty {
+                    print("No workspace groups")
+                } else {
+                    for group in groups {
+                        let handle = textHandle(group, idFormat: idFormat)
+                        let name = (group["path"] as? String) ?? ((group["name"] as? String) ?? "")
+                        let collapsed = (group["collapsed"] as? Bool) == true ? "  [collapsed]" : ""
+                        print("  \(handle)  \(name)\(collapsed)")
+                    }
+                }
+            }
+
+        case "create-workspace-group":
+            guard let name = optionValue(commandArgs, name: "--name") else {
+                throw CLIError(message: "create-workspace-group requires --name")
+            }
+            let parentRaw = optionValue(commandArgs, name: "--parent")
+            var params: [String: Any] = ["name": name]
+            if let windowId {
+                params["window_id"] = windowId
+            }
+            if let parentHandle = try normalizeWorkspaceGroupHandle(parentRaw, client: client, windowHandle: windowId) {
+                params["parent_group_id"] = parentHandle
+            }
+            let payload = try client.sendV2(method: "workspace_group.create", params: params)
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["group"])
+            )
+
+        case "rename-workspace-group":
+            guard let groupRaw = optionValue(commandArgs, name: "--group") else {
+                throw CLIError(message: "rename-workspace-group requires --group")
+            }
+            guard let name = optionValue(commandArgs, name: "--name") else {
+                throw CLIError(message: "rename-workspace-group requires --name")
+            }
+            guard let groupHandle = try normalizeWorkspaceGroupHandle(groupRaw, client: client, windowHandle: windowId) else {
+                throw CLIError(message: "Invalid workspace group handle")
+            }
+            let payload = try client.sendV2(method: "workspace_group.rename", params: [
+                "group_id": groupHandle,
+                "name": name
+            ])
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["group"])
+            )
+
+        case "delete-workspace-group":
+            guard let groupRaw = optionValue(commandArgs, name: "--group") else {
+                throw CLIError(message: "delete-workspace-group requires --group")
+            }
+            guard let groupHandle = try normalizeWorkspaceGroupHandle(groupRaw, client: client, windowHandle: windowId) else {
+                throw CLIError(message: "Invalid workspace group handle")
+            }
+            let payload = try client.sendV2(method: "workspace_group.delete", params: [
+                "group_id": groupHandle
+            ])
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["group"])
+            )
+
+        case "move-workspace-to-group":
+            guard let workspaceRaw = optionValue(commandArgs, name: "--workspace") else {
+                throw CLIError(message: "move-workspace-to-group requires --workspace")
+            }
+            guard let workspaceHandle = try normalizeWorkspaceHandle(workspaceRaw, client: client, windowHandle: windowId) else {
+                throw CLIError(message: "Invalid workspace handle")
+            }
+            let groupRaw = optionValue(commandArgs, name: "--group")
+            let groupHandle = try normalizeWorkspaceGroupHandle(groupRaw, client: client, windowHandle: windowId)
+            var params: [String: Any] = ["workspace_id": workspaceHandle]
+            if let groupHandle {
+                params["group_id"] = groupHandle
+            } else {
+                params["group_id"] = NSNull()
+            }
+            let payload = try client.sendV2(method: "workspace_group.move_workspace", params: params)
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace", "group"])
+            )
+
+        case "collapse-workspace-group", "expand-workspace-group":
+            guard let groupRaw = optionValue(commandArgs, name: "--group") else {
+                throw CLIError(message: "\(command) requires --group")
+            }
+            guard let groupHandle = try normalizeWorkspaceGroupHandle(groupRaw, client: client, windowHandle: windowId) else {
+                throw CLIError(message: "Invalid workspace group handle")
+            }
+            let payload = try client.sendV2(method: "workspace_group.set_collapsed", params: [
+                "group_id": groupHandle,
+                "collapsed": command == "collapse-workspace-group"
+            ])
+            printV2Payload(
+                payload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["group"])
+            )
+
         case "ssh":
             try runSSH(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
         case "ssh-session-end":
@@ -3210,7 +3331,7 @@ struct CMUXCLI {
         let pieces = value.split(separator: ":", omittingEmptySubsequences: false)
         guard pieces.count == 2 else { return false }
         let kind = String(pieces[0]).lowercased()
-        guard ["window", "workspace", "pane", "surface"].contains(kind) else { return false }
+        guard ["window", "workspace", "group", "pane", "surface"].contains(kind) else { return false }
         return Int(String(pieces[1])) != nil
     }
 
@@ -3269,6 +3390,50 @@ struct CMUXCLI {
             return (item["ref"] as? String) ?? (item["id"] as? String)
         }
         throw CLIError(message: "Workspace index not found")
+    }
+
+    private func normalizeWorkspaceGroupHandle(
+        _ raw: String?,
+        client: SocketClient,
+        windowHandle: String? = nil
+    ) throws -> String? {
+        guard let raw else { return nil }
+
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return nil }
+        if isUUID(trimmed) || isHandleRef(trimmed) {
+            return trimmed
+        }
+
+        var params: [String: Any] = [:]
+        if let windowHandle {
+            params["window_id"] = windowHandle
+        }
+        let listed = try client.sendV2(method: "workspace_group.list", params: params)
+        let items = listed["groups"] as? [[String: Any]] ?? []
+
+        if let wantedIndex = Int(trimmed) {
+            for item in items where intFromAny(item["index"]) == wantedIndex {
+                return (item["ref"] as? String) ?? (item["id"] as? String)
+            }
+            throw CLIError(message: "Workspace group index not found")
+        }
+
+        let exactMatches = items.filter { item in
+            let name = ((item["name"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            let path = ((item["path"] as? String) ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            return name.caseInsensitiveCompare(trimmed) == .orderedSame
+                || path.caseInsensitiveCompare(trimmed) == .orderedSame
+        }
+
+        if exactMatches.count == 1 {
+            return (exactMatches[0]["ref"] as? String) ?? (exactMatches[0]["id"] as? String)
+        }
+        if exactMatches.count > 1 {
+            throw CLIError(message: "Workspace group name is ambiguous; use a UUID, ref, or full path")
+        }
+
+        throw CLIError(message: "Workspace group not found")
     }
 
     private func normalizePaneHandle(
@@ -6941,6 +7106,55 @@ struct CMUXCLI {
 
             Example:
               cmux move-workspace-to-window --workspace workspace:2 --window window:1
+            """
+        case "list-workspace-groups":
+            return """
+            Usage: cmux list-workspace-groups
+
+            List workspace groups in the current window.
+            """
+        case "create-workspace-group":
+            return """
+            Usage: cmux create-workspace-group --name <name> [--parent <id|ref|index|name>]
+
+            Create an empty workspace group.
+
+            Flags:
+              --name <name>                      Group name (required)
+              --parent <id|ref|index|name>      Optional parent group
+
+            Example:
+              cmux create-workspace-group --name frontend
+            """
+        case "rename-workspace-group":
+            return """
+            Usage: cmux rename-workspace-group --group <id|ref|index|name> --name <name>
+
+            Rename a workspace group.
+            """
+        case "delete-workspace-group":
+            return """
+            Usage: cmux delete-workspace-group --group <id|ref|index|name>
+
+            Delete a workspace group and move its contents to the parent level.
+            """
+        case "move-workspace-to-group":
+            return """
+            Usage: cmux move-workspace-to-group --workspace <id|ref|index> [--group <id|ref|index|name>]
+
+            Move a workspace into a group. Omit --group to move it back to the sidebar root.
+            """
+        case "collapse-workspace-group":
+            return """
+            Usage: cmux collapse-workspace-group --group <id|ref|index|name>
+
+            Collapse a workspace group in the sidebar.
+            """
+        case "expand-workspace-group":
+            return """
+            Usage: cmux expand-workspace-group --group <id|ref|index|name>
+
+            Expand a workspace group in the sidebar.
             """
         case "move-surface":
             return """
@@ -14339,6 +14553,13 @@ struct CMUXCLI {
           focus-window --window <id>
           close-window --window <id>
           move-workspace-to-window --workspace <id|ref> --window <id|ref>
+          list-workspace-groups
+          create-workspace-group --name <name> [--parent <id|ref|index|name>]
+          rename-workspace-group --group <id|ref|index|name> --name <name>
+          delete-workspace-group --group <id|ref|index|name>
+          move-workspace-to-group --workspace <id|ref|index> [--group <id|ref|index|name>]
+          collapse-workspace-group --group <id|ref|index|name>
+          expand-workspace-group --group <id|ref|index|name>
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>]
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>]
           list-workspaces

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87391,6 +87391,329 @@
           }
         }
       }
+    },
+    "alert.deleteWorkspaceGroup.delete": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "削除"
+          }
+        }
+      }
+    },
+    "alert.deleteWorkspaceGroup.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete \"%@\"? Its contents will move to the parent level."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」を削除しますか？ 内容は親の階層に移動します。"
+          }
+        }
+      }
+    },
+    "alert.deleteWorkspaceGroup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループを削除"
+          }
+        }
+      }
+    },
+    "alert.newWorkspaceGroup.create": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Create"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作成"
+          }
+        }
+      }
+    },
+    "alert.newWorkspaceGroup.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a name for the new workspace group."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいワークスペースグループの名前を入力してください。"
+          }
+        }
+      }
+    },
+    "alert.newWorkspaceGroup.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループ名"
+          }
+        }
+      }
+    },
+    "alert.newWorkspaceGroup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいワークスペースグループ"
+          }
+        }
+      }
+    },
+    "alert.renameWorkspaceGroup.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter a new name for this workspace group."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このワークスペースグループの新しい名前を入力してください。"
+          }
+        }
+      }
+    },
+    "alert.renameWorkspaceGroup.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Group name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "グループ名"
+          }
+        }
+      }
+    },
+    "alert.renameWorkspaceGroup.rename": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名称変更"
+          }
+        }
+      }
+    },
+    "alert.renameWorkspaceGroup.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループの名称変更"
+          }
+        }
+      }
+    },
+    "contextMenu.collapseWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Collapse Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループを折りたたむ"
+          }
+        }
+      }
+    },
+    "contextMenu.deleteWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループを削除"
+          }
+        }
+      }
+    },
+    "contextMenu.expandWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Expand Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループを展開"
+          }
+        }
+      }
+    },
+    "contextMenu.moveToWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Move to Workspace Group"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループに移動"
+          }
+        }
+      }
+    },
+    "contextMenu.moveToWorkspaceGroup.root": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sidebar Root"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サイドバーのルート"
+          }
+        }
+      }
+    },
+    "contextMenu.newChildWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Child Workspace Group…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "子ワークスペースグループを作成…"
+          }
+        }
+      }
+    },
+    "contextMenu.newWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Workspace Group…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループを作成…"
+          }
+        }
+      }
+    },
+    "contextMenu.renameWorkspaceGroup": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rename Workspace Group…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースグループの名称変更…"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2938,7 +2938,7 @@ struct ContentView: View {
             }
             if selectedTabIds.isEmpty, let selectedId = tabManager.selectedTabId {
                 selectedTabIds = [selectedId]
-                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
             }
             syncSidebarSelectedWorkspaceIds()
             applyUITestSidebarSelectionIfNeeded(tabs: tabManager.tabs)
@@ -2973,7 +2973,7 @@ struct ContentView: View {
                 // Ensure sidebar selection is valid.
                 if selectedTabIds.isEmpty, let selectedId = tabManager.selectedTabId {
                     selectedTabIds = [selectedId]
-                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                    lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
                     didRecover = true
                 }
 
@@ -3010,7 +3010,7 @@ struct ContentView: View {
             guard let newValue else { return }
             if selectedTabIds.count <= 1 {
                 selectedTabIds = [newValue]
-                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == newValue }
+                lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == newValue }
             }
             updateTitlebarText()
         })
@@ -9937,6 +9937,12 @@ struct VerticalTabsSidebar: View {
         let canCloseWorkspace = workspaceCount > 1
         let workspaceNumberShortcut = self.workspaceNumberShortcut
         let tabItemSettings = tabItemSettingsStore.snapshot
+        let displayEntries = tabManager.sidebarDisplayEntries()
+        let visibleWorkspaceIds = displayEntries.compactMap { entry -> UUID? in
+            guard case .workspace(let workspaceId) = entry.kind else { return nil }
+            return workspaceId
+        }
+        let workspaceGroupSummaries = tabManager.sidebarWorkspaceGroupsInDisplayOrder()
         let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
             ($0.element.id, $0.offset)
         })
@@ -9960,73 +9966,110 @@ struct VerticalTabsSidebar: View {
                         // Workspaces are bounded, so prefer a non-lazy stack here.
                         // LazyVStack + drag-state invalidations can recurse through layout.
                         VStack(spacing: tabRowSpacing) {
-                            ForEach(tabs, id: \.id) { tab in
-                                let index = tabIndexById[tab.id] ?? 0
-                                let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
-                                let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
-                                    ? selectedContextTargetIds
-                                    : [tab.id]
-                                let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
-                                    ? selectedRemoteContextMenuWorkspaceIds
-                                    : (tab.isRemoteWorkspace ? [tab.id] : [])
-                                let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
-                                    ? allSelectedRemoteContextMenuTargetsConnecting
-                                    : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
-                                let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
-                                    ? allSelectedRemoteContextMenuTargetsDisconnected
-                                    : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
-                                let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
-                                let liveLatestNotificationText: String? = {
-                                    guard showsSidebarNotificationMessage,
-                                          let notification = notificationStore.latestNotification(forTabId: tab.id) else {
-                                        return nil
+                            ForEach(displayEntries) { entry in
+                                switch entry.kind {
+                                case .group(let groupId):
+                                    if let group = tabManager.sidebarGroup(for: groupId) {
+                                        SidebarWorkspaceGroupRow(
+                                            group: group,
+                                            level: entry.level,
+                                            workspaceCount: entry.descendantWorkspaceIds.count,
+                                            unreadCount: entry.descendantWorkspaceIds.reduce(into: 0) { partial, workspaceId in
+                                                partial += notificationStore.unreadCount(forTabId: workspaceId)
+                                            },
+                                            isDropTargeted: false,
+                                            onToggleCollapsed: {
+                                                _ = tabManager.setWorkspaceGroupCollapsed(
+                                                    groupId: group.id,
+                                                    collapsed: !group.isCollapsed
+                                                )
+                                            },
+                                            onCreateChildGroup: {
+                                                promptCreateWorkspaceGroup(parentGroupId: group.id)
+                                            },
+                                            onRenameGroup: {
+                                                promptRenameWorkspaceGroup(groupId: group.id, currentName: group.name)
+                                            },
+                                            onDeleteGroup: {
+                                                confirmDeleteWorkspaceGroup(groupId: group.id, groupName: group.name)
+                                            }
+                                        )
                                     }
-                                    let text = notification.body.isEmpty ? notification.title : notification.body
-                                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                    return trimmed.isEmpty ? nil : trimmed
-                                }()
-                                let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
-                                let livePresentation = SidebarTabItemPresentationSnapshot(
-                                    tabId: tab.id,
-                                    unreadCount: liveUnreadCount,
-                                    latestNotificationText: liveLatestNotificationText,
-                                    showsModifierShortcutHints: liveShowsModifierShortcutHints
-                                )
-                                let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
-                                    ? frozenTabItemPresentation
-                                    : nil
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
-                                    index: index,
-                                    isActive: tabManager.selectedTabId == tab.id,
-                                    workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                                        at: index,
-                                        workspaceCount: workspaceCount
-                                    ),
-                                    workspaceShortcutModifierSymbol: workspaceNumberShortcut.numberedDigitHintPrefix,
-                                    canCloseWorkspace: canCloseWorkspace,
-                                    accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: frozenPresentation?.unreadCount ?? liveUnreadCount,
-                                    latestNotificationText: frozenPresentation?.latestNotificationText ?? liveLatestNotificationText,
-                                    rowSpacing: tabRowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                                    showsModifierShortcutHints: frozenPresentation?.showsModifierShortcutHints ?? liveShowsModifierShortcutHints,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
-                                    contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-                                    remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
-                                    allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
-                                    allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
-                                    settings: tabItemSettings,
-                                    livePresentation: livePresentation,
-                                    frozenPresentation: $frozenTabItemPresentation
-                                )
-                                .equatable()
+                                case .workspace(let workspaceId):
+                                    if let tab = tabs.first(where: { $0.id == workspaceId }) {
+                                        let index = tabIndexById[tab.id] ?? 0
+                                        let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
+                                        let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
+                                            ? selectedContextTargetIds
+                                            : [tab.id]
+                                        let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
+                                            ? selectedRemoteContextMenuWorkspaceIds
+                                            : (tab.isRemoteWorkspace ? [tab.id] : [])
+                                        let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
+                                            ? allSelectedRemoteContextMenuTargetsConnecting
+                                            : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
+                                        let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
+                                            ? allSelectedRemoteContextMenuTargetsDisconnected
+                                            : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
+                                        let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
+                                        let liveLatestNotificationText: String? = {
+                                            guard showsSidebarNotificationMessage,
+                                                  let notification = notificationStore.latestNotification(forTabId: tab.id) else {
+                                                return nil
+                                            }
+                                            let text = notification.body.isEmpty ? notification.title : notification.body
+                                            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                            return trimmed.isEmpty ? nil : trimmed
+                                        }()
+                                        let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
+                                        let livePresentation = SidebarTabItemPresentationSnapshot(
+                                            tabId: tab.id,
+                                            unreadCount: liveUnreadCount,
+                                            latestNotificationText: liveLatestNotificationText,
+                                            showsModifierShortcutHints: liveShowsModifierShortcutHints
+                                        )
+                                        let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
+                                            ? frozenTabItemPresentation
+                                            : nil
+                                        let visibleIndex = visibleWorkspaceIds.firstIndex(of: tab.id) ?? index
+                                        TabItemView(
+                                            tabManager: tabManager,
+                                            notificationStore: notificationStore,
+                                            tab: tab,
+                                            index: index,
+                                            visibleIndex: visibleIndex,
+                                            indentLevel: entry.level,
+                                            visibleWorkspaceIds: visibleWorkspaceIds,
+                                            availableWorkspaceGroups: workspaceGroupSummaries,
+                                            isActive: tabManager.selectedTabId == tab.id,
+                                            workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                                                at: index,
+                                                workspaceCount: workspaceCount
+                                            ),
+                                            workspaceShortcutModifierSymbol: workspaceNumberShortcut.numberedDigitHintPrefix,
+                                            canCloseWorkspace: canCloseWorkspace,
+                                            accessibilityWorkspaceCount: workspaceCount,
+                                            unreadCount: frozenPresentation?.unreadCount ?? liveUnreadCount,
+                                            latestNotificationText: frozenPresentation?.latestNotificationText ?? liveLatestNotificationText,
+                                            rowSpacing: tabRowSpacing,
+                                            setSelectionToTabs: { selection = .tabs },
+                                            selectedTabIds: $selectedTabIds,
+                                            lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                            showsModifierShortcutHints: frozenPresentation?.showsModifierShortcutHints ?? liveShowsModifierShortcutHints,
+                                            dragAutoScrollController: dragAutoScrollController,
+                                            draggedTabId: $draggedTabId,
+                                            dropIndicator: $dropIndicator,
+                                            contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                                            remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                                            allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
+                                            allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                                            settings: tabItemSettings,
+                                            livePresentation: livePresentation,
+                                            frozenPresentation: $frozenTabItemPresentation
+                                        )
+                                        .equatable()
+                                    }
+                                }
                             }
                         }
                         .padding(.vertical, 8)
@@ -10034,12 +10077,16 @@ struct VerticalTabsSidebar: View {
 
                         SidebarEmptyArea(
                             rowSpacing: tabRowSpacing,
+                            visibleWorkspaceIds: visibleWorkspaceIds,
                             selection: $selection,
                             selectedTabIds: $selectedTabIds,
                             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
                             dragAutoScrollController: dragAutoScrollController,
                             draggedTabId: $draggedTabId,
-                            dropIndicator: $dropIndicator
+                            dropIndicator: $dropIndicator,
+                            onCreateWorkspaceGroup: {
+                                promptCreateWorkspaceGroup()
+                            }
                         )
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                     }
@@ -10144,6 +10191,203 @@ struct VerticalTabsSidebar: View {
     private func debugShortSidebarTabId(_ id: UUID?) -> String {
         guard let id else { return "nil" }
         return String(id.uuidString.prefix(5))
+    }
+
+    private func promptCreateWorkspaceGroup(
+        parentGroupId: UUID? = nil,
+        workspaceIds: [UUID] = []
+    ) {
+        guard let name = promptSidebarTextField(
+            title: String(localized: "alert.newWorkspaceGroup.title", defaultValue: "New Workspace Group"),
+            message: String(localized: "alert.newWorkspaceGroup.message", defaultValue: "Enter a name for the new workspace group."),
+            placeholder: String(localized: "alert.newWorkspaceGroup.placeholder", defaultValue: "Group name"),
+            actionTitle: String(localized: "alert.newWorkspaceGroup.create", defaultValue: "Create")
+        ) else {
+            return
+        }
+        _ = tabManager.createWorkspaceGroup(
+            name: name,
+            parentGroupId: parentGroupId,
+            workspaceIds: workspaceIds
+        )
+    }
+
+    private func promptRenameWorkspaceGroup(groupId: UUID, currentName: String) {
+        guard let name = promptSidebarTextField(
+            title: String(localized: "alert.renameWorkspaceGroup.title", defaultValue: "Rename Workspace Group"),
+            message: String(localized: "alert.renameWorkspaceGroup.message", defaultValue: "Enter a new name for this workspace group."),
+            placeholder: String(localized: "alert.renameWorkspaceGroup.placeholder", defaultValue: "Group name"),
+            actionTitle: String(localized: "alert.renameWorkspaceGroup.rename", defaultValue: "Rename"),
+            initialValue: currentName
+        ) else {
+            return
+        }
+        _ = tabManager.renameWorkspaceGroup(groupId: groupId, name: name)
+    }
+
+    private func confirmDeleteWorkspaceGroup(groupId: UUID, groupName: String) {
+        let messageFormat = String(
+            localized: "alert.deleteWorkspaceGroup.message",
+            defaultValue: "Delete \"%@\"? Its contents will move to the parent level."
+        )
+        let didConfirm = confirmSidebarDestructiveAction(
+            title: String(localized: "alert.deleteWorkspaceGroup.title", defaultValue: "Delete Workspace Group"),
+            message: String(
+                format: messageFormat,
+                locale: .current,
+                groupName
+            ),
+            actionTitle: String(localized: "alert.deleteWorkspaceGroup.delete", defaultValue: "Delete")
+        )
+        guard didConfirm else { return }
+        _ = tabManager.deleteWorkspaceGroup(groupId: groupId)
+    }
+}
+
+@MainActor
+private func promptSidebarTextField(
+    title: String,
+    message: String,
+    placeholder: String,
+    actionTitle: String,
+    initialValue: String = ""
+) -> String? {
+    let alert = NSAlert()
+    alert.messageText = title
+    alert.informativeText = message
+    let input = NSTextField(string: initialValue)
+    input.placeholderString = placeholder
+    alert.accessoryView = input
+    alert.addButton(withTitle: actionTitle)
+    alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+    let alertWindow = alert.window
+    alertWindow.initialFirstResponder = input
+    DispatchQueue.main.async {
+        alertWindow.makeFirstResponder(input)
+    }
+
+    let response = alert.runModal()
+    guard response == .alertFirstButtonReturn else { return nil }
+
+    let trimmed = input.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    return trimmed.isEmpty ? nil : trimmed
+}
+
+@MainActor
+private func confirmSidebarDestructiveAction(
+    title: String,
+    message: String,
+    actionTitle: String
+) -> Bool {
+    let alert = NSAlert()
+    alert.alertStyle = .warning
+    alert.messageText = title
+    alert.informativeText = message
+    alert.addButton(withTitle: actionTitle)
+    alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+    return alert.runModal() == .alertFirstButtonReturn
+}
+
+private struct SidebarWorkspaceGroupRow: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    let group: SidebarWorkspaceGroupModel
+    let level: Int
+    let workspaceCount: Int
+    let unreadCount: Int
+    let isDropTargeted: Bool
+    let onToggleCollapsed: () -> Void
+    let onCreateChildGroup: () -> Void
+    let onRenameGroup: () -> Void
+    let onDeleteGroup: () -> Void
+
+    @State private var isHovering = false
+
+    private var backgroundColor: Color {
+        if isDropTargeted {
+            return cmuxAccentColor().opacity(colorScheme == .dark ? 0.18 : 0.12)
+        }
+        if isHovering {
+            return Color.primary.opacity(colorScheme == .dark ? 0.10 : 0.06)
+        }
+        return Color.primary.opacity(colorScheme == .dark ? 0.06 : 0.035)
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "chevron.right")
+                .font(.system(size: 9, weight: .semibold))
+                .foregroundColor(.secondary)
+                .rotationEffect(.degrees(group.isCollapsed ? 0 : 90))
+                .animation(.easeInOut(duration: 0.14), value: group.isCollapsed)
+
+            Image(systemName: "folder.fill")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(cmuxAccentColor())
+
+            Text(group.name)
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+
+            Spacer(minLength: 0)
+
+            Text("\(workspaceCount)")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(.secondary)
+
+            if unreadCount > 0 {
+                ZStack {
+                    Capsule(style: .continuous)
+                        .fill(cmuxAccentColor())
+                    Text("\(unreadCount)")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                }
+                .fixedSize()
+            }
+        }
+        .padding(.leading, 6 + CGFloat(level) * 18)
+        .padding(.trailing, 6)
+        .padding(.vertical, 5)
+        .background(
+            RoundedRectangle(cornerRadius: 6)
+                .fill(backgroundColor)
+        )
+        .padding(.horizontal, 6)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onToggleCollapsed()
+        }
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .contextMenu {
+            Button(
+                group.isCollapsed
+                    ? String(localized: "contextMenu.expandWorkspaceGroup", defaultValue: "Expand Workspace Group")
+                    : String(localized: "contextMenu.collapseWorkspaceGroup", defaultValue: "Collapse Workspace Group")
+            ) {
+                onToggleCollapsed()
+            }
+
+            Button(String(localized: "contextMenu.newChildWorkspaceGroup", defaultValue: "New Child Workspace Group…")) {
+                onCreateChildGroup()
+            }
+
+            Button(String(localized: "contextMenu.renameWorkspaceGroup", defaultValue: "Rename Workspace Group…")) {
+                onRenameGroup()
+            }
+
+            Divider()
+
+            Button(String(localized: "contextMenu.deleteWorkspaceGroup", defaultValue: "Delete Workspace Group")) {
+                onDeleteGroup()
+            }
+        }
     }
 }
 
@@ -12252,12 +12496,14 @@ private final class SidebarScrollViewResolverView: NSView {
 private struct SidebarEmptyArea: View {
     @EnvironmentObject var tabManager: TabManager
     let rowSpacing: CGFloat
+    let visibleWorkspaceIds: [UUID]
     @Binding var selection: SidebarSelection
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
     let dragAutoScrollController: SidebarDragAutoScrollController
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
+    let onCreateWorkspaceGroup: () -> Void
 
     var body: some View {
         Color.clear
@@ -12267,7 +12513,7 @@ private struct SidebarEmptyArea: View {
                 tabManager.addWorkspace(placementOverride: .end)
                 if let selectedId = tabManager.selectedTabId {
                     selectedTabIds = [selectedId]
-                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                    lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
                 }
                 selection = .tabs
             }
@@ -12290,6 +12536,11 @@ private struct SidebarEmptyArea: View {
                         .offset(y: -(rowSpacing / 2))
                 }
             }
+            .contextMenu {
+                Button(String(localized: "contextMenu.newWorkspaceGroup", defaultValue: "New Workspace Group…")) {
+                    onCreateWorkspaceGroup()
+                }
+            }
     }
 
     private var shouldShowTopDropIndicator: Bool {
@@ -12297,7 +12548,7 @@ private struct SidebarEmptyArea: View {
         if indicator.tabId == nil {
             return true
         }
-        guard indicator.edge == .bottom, let lastTabId = tabManager.tabs.last?.id else { return false }
+        guard indicator.edge == .bottom, let lastTabId = visibleWorkspaceIds.last else { return false }
         return indicator.tabId == lastTabId
     }
 }
@@ -12417,6 +12668,10 @@ private struct TabItemView: View, Equatable {
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
+        lhs.visibleIndex == rhs.visibleIndex &&
+        lhs.indentLevel == rhs.indentLevel &&
+        lhs.visibleWorkspaceIds == rhs.visibleWorkspaceIds &&
+        lhs.availableWorkspaceGroups == rhs.availableWorkspaceGroups &&
         lhs.isActive == rhs.isActive &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.workspaceShortcutModifierSymbol == rhs.workspaceShortcutModifierSymbol &&
@@ -12441,6 +12696,10 @@ private struct TabItemView: View, Equatable {
     @Environment(\.colorScheme) private var colorScheme
     let tab: Tab
     let index: Int
+    let visibleIndex: Int
+    let indentLevel: Int
+    let visibleWorkspaceIds: [UUID]
+    let availableWorkspaceGroups: [SidebarWorkspaceGroupSummary]
     let isActive: Bool
     let workspaceShortcutDigit: Int?
     let workspaceShortcutModifierSymbol: String
@@ -13018,7 +13277,8 @@ private struct TabItemView: View, Equatable {
                     }
                 }
         )
-        .padding(.horizontal, 6)
+        .padding(.leading, 6 + CGFloat(indentLevel) * 18)
+        .padding(.trailing, 6)
         .background {
             GeometryReader { proxy in
                 Color.clear
@@ -13307,7 +13567,38 @@ private struct TabItemView: View, Equatable {
             }
         }
 
+        Divider()
+
+        Button(String(localized: "contextMenu.newWorkspaceGroup", defaultValue: "New Workspace Group…")) {
+            promptCreateWorkspaceGroup(workspaceIds: targetIds)
+        }
+
+        if !availableWorkspaceGroups.isEmpty || contextMenuWorkspaceIds.contains(where: { tabManager.isWorkspaceGrouped($0) }) {
+            Menu(String(localized: "contextMenu.moveToWorkspaceGroup", defaultValue: "Move to Workspace Group")) {
+                Button(
+                    String(
+                        localized: "contextMenu.moveToWorkspaceGroup.root",
+                        defaultValue: "Sidebar Root"
+                    )
+                ) {
+                    moveTargetWorkspaces(toGroupId: nil)
+                }
+
+                if !availableWorkspaceGroups.isEmpty {
+                    Divider()
+                }
+
+                ForEach(availableWorkspaceGroups) { groupSummary in
+                    Button(groupSummary.displayName) {
+                        moveTargetWorkspaces(toGroupId: groupSummary.id)
+                    }
+                }
+            }
+        }
+
         if let copyableSidebarSSHError {
+            Divider()
+
             Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
                 copyTextToPasteboard(copyableSidebarSSHError)
             }
@@ -13318,18 +13609,18 @@ private struct TabItemView: View, Equatable {
         Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
             moveBy(-1)
         }
-        .disabled(index == 0)
+        .disabled(!tabManager.canMoveWorkspace(tab.id, by: -1))
 
         Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
             moveBy(1)
         }
-        .disabled(index >= tabManager.tabs.count - 1)
+        .disabled(!tabManager.canMoveWorkspace(tab.id, by: 1))
 
         Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
             tabManager.moveTabsToTop(Set(targetIds))
             syncSelectionAfterMutation()
         }
-        .disabled(targetIds.isEmpty)
+        .disabled(targetIds.isEmpty || (targetIds.count == 1 && !tabManager.canMoveWorkspaceToTop(tab.id)))
 
         let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
         let windowMoveTargets = AppDelegate.shared?.windowMoveTargets(referenceWindowId: referenceWindowId) ?? []
@@ -13463,12 +13754,12 @@ private struct TabItemView: View, Equatable {
         }
 
         guard indicator.edge == .bottom,
-              let currentIndex = tabManager.tabs.firstIndex(where: { $0.id == tab.id }),
+              let currentIndex = visibleWorkspaceIds.firstIndex(of: tab.id),
               currentIndex > 0
         else {
             return false
         }
-        return tabManager.tabs[currentIndex - 1].id == indicator.tabId
+        return visibleWorkspaceIds[currentIndex - 1] == indicator.tabId
     }
 
     private var accessibilityTitle: String {
@@ -13476,11 +13767,9 @@ private struct TabItemView: View, Equatable {
     }
 
     private func moveBy(_ delta: Int) {
-        let targetIndex = index + delta
-        guard targetIndex >= 0, targetIndex < tabManager.tabs.count else { return }
-        guard tabManager.reorderWorkspace(tabId: tab.id, toIndex: targetIndex) else { return }
+        guard tabManager.moveWorkspace(tab.id, by: delta) else { return }
         selectedTabIds = [tab.id]
-        lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == tab.id }
+        lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == tab.id }
         tabManager.selectTab(tab)
         setSelectionToTabs()
     }
@@ -13501,9 +13790,9 @@ private struct TabItemView: View, Equatable {
         let wasSelected = tabManager.selectedTabId == tab.id
 
         if isShift, let lastIndex = lastSidebarSelectionIndex {
-            let lower = min(lastIndex, index)
-            let upper = max(lastIndex, index)
-            let rangeIds = tabManager.tabs[lower...upper].map { $0.id }
+            let lower = min(lastIndex, visibleIndex)
+            let upper = max(lastIndex, visibleIndex)
+            let rangeIds = Array(visibleWorkspaceIds[lower...upper])
             if isCommand {
                 selectedTabIds.formUnion(rangeIds)
             } else {
@@ -13519,7 +13808,7 @@ private struct TabItemView: View, Equatable {
             selectedTabIds = [tab.id]
         }
 
-        lastSidebarSelectionIndex = index
+        lastSidebarSelectionIndex = visibleIndex
         tabManager.selectTab(tab)
         if wasSelected, !isCommand, !isShift {
             tabManager.dismissNotificationOnDirectInteraction(
@@ -13592,8 +13881,33 @@ private struct TabItemView: View, Equatable {
             selectedTabIds = [selectedId]
         }
         if let selectedId = tabManager.selectedTabId {
-            lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+            lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
         }
+    }
+
+    private func promptCreateWorkspaceGroup(workspaceIds: [UUID]) {
+        guard let name = promptSidebarTextField(
+            title: String(localized: "alert.newWorkspaceGroup.title", defaultValue: "New Workspace Group"),
+            message: String(localized: "alert.newWorkspaceGroup.message", defaultValue: "Enter a name for the new workspace group."),
+            placeholder: String(localized: "alert.newWorkspaceGroup.placeholder", defaultValue: "Group name"),
+            actionTitle: String(localized: "alert.newWorkspaceGroup.create", defaultValue: "Create")
+        ) else {
+            return
+        }
+        _ = tabManager.createWorkspaceGroup(name: name, workspaceIds: workspaceIds)
+        syncSelectionAfterMutation()
+    }
+
+    private func moveTargetWorkspaces(toGroupId groupId: UUID?) {
+        let orderedWorkspaceIds = tabManager.tabs.compactMap { workspace in
+            contextMenuWorkspaceIds.contains(workspace.id) ? workspace.id : nil
+        }
+        guard !orderedWorkspaceIds.isEmpty else { return }
+
+        for workspaceId in orderedWorkspaceIds {
+            _ = tabManager.moveWorkspaceToGroup(workspaceId: workspaceId, groupId: groupId)
+        }
+        syncSelectionAfterMutation()
     }
 
     private var remoteStateHelpText: String {
@@ -14778,7 +15092,7 @@ private struct SidebarBonsplitTabDropDelegate: DropDelegate {
 
     private func syncSidebarSelection() {
         if let selectedId = tabManager.selectedTabId {
-            lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+            lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
         } else {
             lastSidebarSelectionIndex = nil
         }
@@ -14798,10 +15112,14 @@ private struct SidebarTabDropDelegate: DropDelegate {
     func validateDrop(info: DropInfo) -> Bool {
         let hasType = info.hasItemsConforming(to: [SidebarTabDragPayload.typeIdentifier])
         let hasDrag = draggedTabId != nil
+        let canDrop = draggedTabId.map { tabManager.canReorderWorkspaceDrop(draggedWorkspaceId: $0, targetWorkspaceId: targetTabId) } ?? false
         #if DEBUG
-        dlog("sidebar.validateDrop target=\(targetTabId?.uuidString.prefix(5) ?? "end") hasType=\(hasType) hasDrag=\(hasDrag)")
+        dlog(
+            "sidebar.validateDrop target=\(targetTabId?.uuidString.prefix(5) ?? "end") " +
+            "hasType=\(hasType) hasDrag=\(hasDrag) canDrop=\(canDrop)"
+        )
         #endif
-        return hasType && hasDrag
+        return hasType && hasDrag && canDrop
     }
 
     func dropEntered(info: DropInfo) {
@@ -14848,41 +15166,41 @@ private struct SidebarTabDropDelegate: DropDelegate {
 #endif
             return false
         }
-        guard let fromIndex = tabManager.tabs.firstIndex(where: { $0.id == draggedTabId }) else {
+        guard tabManager.tabs.contains(where: { $0.id == draggedTabId }) else {
 #if DEBUG
             dlog("sidebar.drop.abort reason=draggedTabMissing tab=\(draggedTabId.uuidString.prefix(5))")
 #endif
             return false
         }
-        let tabIds = tabManager.tabs.map(\.id)
-        guard let targetIndex = SidebarDropPlanner.targetIndex(
-            draggedTabId: draggedTabId,
-            targetTabId: targetTabId,
-            indicator: dropIndicator,
-            tabIds: tabIds,
-            pinnedTabIds: Set(tabManager.tabs.filter(\.isPinned).map(\.id))
-        ) else {
+
+        let didMove: Bool
+        if let targetTabId, let indicator = dropIndicator {
+            switch indicator.edge {
+            case .top:
+                didMove = tabManager.reorderWorkspace(tabId: draggedTabId, before: targetTabId)
+            case .bottom:
+                didMove = tabManager.reorderWorkspace(tabId: draggedTabId, after: targetTabId)
+            }
+        } else {
+            didMove = tabManager.moveWorkspaceToGroup(workspaceId: draggedTabId, groupId: nil)
+        }
+
+        guard didMove else {
 #if DEBUG
             dlog(
-                "sidebar.drop.abort reason=noTargetIndex tab=\(draggedTabId.uuidString.prefix(5)) " +
+                "sidebar.drop.abort reason=moveFailed tab=\(draggedTabId.uuidString.prefix(5)) " +
                 "target=\(targetTabId?.uuidString.prefix(5) ?? "end") indicator=\(debugIndicator(dropIndicator))"
             )
 #endif
             return false
         }
 
-        guard fromIndex != targetIndex else {
 #if DEBUG
-            dlog("sidebar.drop.noop from=\(fromIndex) to=\(targetIndex)")
+        dlog(
+            "sidebar.drop.commit tab=\(draggedTabId.uuidString.prefix(5)) " +
+            "target=\(targetTabId?.uuidString.prefix(5) ?? "end") indicator=\(debugIndicator(dropIndicator))"
+        )
 #endif
-            syncSidebarSelection()
-            return true
-        }
-
-#if DEBUG
-        dlog("sidebar.drop.commit tab=\(draggedTabId.uuidString.prefix(5)) from=\(fromIndex) to=\(targetIndex)")
-#endif
-        _ = tabManager.reorderWorkspace(tabId: draggedTabId, toIndex: targetIndex)
         if let selectedId = tabManager.selectedTabId {
             selectedTabIds = [selectedId]
             syncSidebarSelection(preferredSelectedTabId: selectedId)
@@ -14894,16 +15212,15 @@ private struct SidebarTabDropDelegate: DropDelegate {
     }
 
     private func updateDropIndicator(for info: DropInfo) {
-        let tabIds = tabManager.tabs.map(\.id)
-        let pinnedTabIds = Set(tabManager.tabs.filter(\.isPinned).map(\.id))
-        let nextIndicator = SidebarDropPlanner.indicator(
-            draggedTabId: draggedTabId,
-            targetTabId: targetTabId,
-            tabIds: tabIds,
-            pinnedTabIds: pinnedTabIds,
-            pointerY: targetTabId == nil ? nil : info.location.y,
-            targetHeight: targetRowHeight
-        )
+        let nextIndicator: SidebarDropIndicator?
+        if let targetTabId,
+           draggedTabId != nil,
+           let targetRowHeight {
+            let edge: SidebarDropEdge = info.location.y < (targetRowHeight / 2) ? .top : .bottom
+            nextIndicator = SidebarDropIndicator(tabId: targetTabId, edge: edge)
+        } else {
+            nextIndicator = nil
+        }
         guard dropIndicator != nextIndicator else { return }
         dropIndicator = nextIndicator
     }
@@ -14911,7 +15228,7 @@ private struct SidebarTabDropDelegate: DropDelegate {
     private func syncSidebarSelection(preferredSelectedTabId: UUID? = nil) {
         let selectedId = preferredSelectedTabId ?? tabManager.selectedTabId
         if let selectedId {
-            lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+            lastSidebarSelectionIndex = tabManager.sidebarVisibleWorkspaceIds().firstIndex { $0 == selectedId }
         } else {
             lastSidebarSelectionIndex = nil
         }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -284,6 +284,23 @@ struct SessionPaneLayoutSnapshot: Codable, Sendable {
     var selectedPanelId: UUID?
 }
 
+struct SessionSidebarWorkspaceItemSnapshot: Codable, Sendable, Hashable {
+    enum Kind: String, Codable, Sendable {
+        case workspace
+        case group
+    }
+
+    var kind: Kind
+    var id: UUID
+}
+
+struct SessionSidebarWorkspaceGroupSnapshot: Codable, Sendable {
+    var id: UUID
+    var name: String
+    var isCollapsed: Bool
+    var childItems: [SessionSidebarWorkspaceItemSnapshot]
+}
+
 struct SessionSplitLayoutSnapshot: Codable, Sendable {
     var orientation: SessionSplitOrientation
     var dividerPosition: Double
@@ -328,6 +345,7 @@ indirect enum SessionWorkspaceLayoutSnapshot: Codable, Sendable {
 }
 
 struct SessionWorkspaceSnapshot: Codable, Sendable {
+    var id: UUID?
     var processTitle: String
     var customTitle: String?
     var customDescription: String?
@@ -346,6 +364,8 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
 struct SessionTabManagerSnapshot: Codable, Sendable {
     var selectedWorkspaceIndex: Int?
     var workspaces: [SessionWorkspaceSnapshot]
+    var sidebarRootItems: [SessionSidebarWorkspaceItemSnapshot]?
+    var sidebarGroups: [SessionSidebarWorkspaceGroupSnapshot]?
 }
 
 struct SessionWindowSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -235,6 +235,103 @@ enum WorkspacePlacementSettings {
     }
 }
 
+enum SidebarWorkspaceItemReference: Hashable, Sendable {
+    case workspace(UUID)
+    case group(UUID)
+
+    var id: UUID {
+        switch self {
+        case .workspace(let id), .group(let id):
+            return id
+        }
+    }
+
+    var sessionSnapshot: SessionSidebarWorkspaceItemSnapshot {
+        switch self {
+        case .workspace(let id):
+            return SessionSidebarWorkspaceItemSnapshot(kind: .workspace, id: id)
+        case .group(let id):
+            return SessionSidebarWorkspaceItemSnapshot(kind: .group, id: id)
+        }
+    }
+
+    init(snapshot: SessionSidebarWorkspaceItemSnapshot) {
+        switch snapshot.kind {
+        case .workspace:
+            self = .workspace(snapshot.id)
+        case .group:
+            self = .group(snapshot.id)
+        }
+    }
+}
+
+struct SidebarWorkspaceGroupModel: Identifiable, Equatable, Sendable {
+    var id: UUID
+    var name: String
+    var isCollapsed: Bool
+    var childItems: [SidebarWorkspaceItemReference]
+
+    var sessionSnapshot: SessionSidebarWorkspaceGroupSnapshot {
+        SessionSidebarWorkspaceGroupSnapshot(
+            id: id,
+            name: name,
+            isCollapsed: isCollapsed,
+            childItems: childItems.map(\.sessionSnapshot)
+        )
+    }
+
+    init(
+        id: UUID = UUID(),
+        name: String,
+        isCollapsed: Bool = false,
+        childItems: [SidebarWorkspaceItemReference] = []
+    ) {
+        self.id = id
+        self.name = name
+        self.isCollapsed = isCollapsed
+        self.childItems = childItems
+    }
+
+    init(snapshot: SessionSidebarWorkspaceGroupSnapshot) {
+        self.id = snapshot.id
+        self.name = snapshot.name
+        self.isCollapsed = snapshot.isCollapsed
+        self.childItems = snapshot.childItems.map(SidebarWorkspaceItemReference.init(snapshot:))
+    }
+}
+
+struct SidebarWorkspaceDisplayEntry: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case workspace(UUID)
+        case group(UUID)
+    }
+
+    let kind: Kind
+    let level: Int
+    let descendantWorkspaceIds: [UUID]
+
+    var id: String {
+        switch kind {
+        case .workspace(let id):
+            return "workspace:\(id.uuidString)"
+        case .group(let id):
+            return "group:\(id.uuidString)"
+        }
+    }
+}
+
+struct SidebarWorkspaceGroupSummary: Identifiable, Equatable, Sendable {
+    let id: UUID
+    let name: String
+    let path: String
+    let parentGroupId: UUID?
+    let isCollapsed: Bool
+
+    var displayName: String {
+        path.isEmpty ? name : path
+    }
+}
+
 struct WorkspaceTabColorEntry: Equatable, Identifiable {
     let name: String
     let hex: String
@@ -868,6 +965,7 @@ class TabManager: ObservableObject {
     @Published private(set) var isWorkspaceCycleHot: Bool = false
     @Published private(set) var pendingBackgroundWorkspaceLoadIds: Set<UUID> = []
     @Published private(set) var debugPinnedWorkspaceLoadIds: Set<UUID> = []
+    @Published private(set) var sidebarStructureRevision: UInt64 = 0
 
     /// Global monotonically increasing counter for CMUX_PORT ordinal assignment.
     /// Static so port ranges don't overlap across multiple windows (each window has its own TabManager).
@@ -991,6 +1089,8 @@ class TabManager: ObservableObject {
     private var workspaceCycleCooldownTask: Task<Void, Never>?
     private var pendingWorkspaceUnfocusTarget: (tabId: UUID, panelId: UUID)?
     private var sidebarSelectedWorkspaceIds: Set<UUID> = []
+    private var sidebarRootItems: [SidebarWorkspaceItemReference] = []
+    private var sidebarGroupsById: [UUID: SidebarWorkspaceGroupModel] = [:]
     var confirmCloseHandler: ((String, String, Bool) -> Bool)?
     private struct WorkspaceCreationTabSnapshot {
         let id: UUID
@@ -1077,6 +1177,544 @@ class TabManager: ObservableObject {
         selectedWorkspaceGitMetadataPollTimer?.cancel()
         workspacePullRequestPollTimer?.cancel()
         workspacePullRequestRefreshTask?.cancel()
+    }
+
+    private func bumpSidebarStructureRevision() {
+        sidebarStructureRevision &+= 1
+    }
+
+    func sidebarGroup(for groupId: UUID) -> SidebarWorkspaceGroupModel? {
+        sidebarGroupsById[groupId]
+    }
+
+    func sidebarGroupId(forWorkspace workspaceId: UUID) -> UUID? {
+        parentGroupId(containing: .workspace(workspaceId))
+    }
+
+    func isWorkspaceGrouped(_ workspaceId: UUID) -> Bool {
+        sidebarGroupId(forWorkspace: workspaceId) != nil
+    }
+
+    func sidebarHasGroups() -> Bool {
+        !sidebarGroupsById.isEmpty
+    }
+
+    func sidebarDisplayEntries() -> [SidebarWorkspaceDisplayEntry] {
+        var entries: [SidebarWorkspaceDisplayEntry] = []
+
+        func walk(items: [SidebarWorkspaceItemReference], level: Int) {
+            for item in items {
+                switch item {
+                case .workspace(let workspaceId):
+                    entries.append(
+                        SidebarWorkspaceDisplayEntry(
+                            kind: .workspace(workspaceId),
+                            level: level,
+                            descendantWorkspaceIds: [workspaceId]
+                        )
+                    )
+                case .group(let groupId):
+                    guard let group = sidebarGroupsById[groupId] else { continue }
+                    let descendants = descendantWorkspaceIds(in: group.childItems)
+                    entries.append(
+                        SidebarWorkspaceDisplayEntry(
+                            kind: .group(groupId),
+                            level: level,
+                            descendantWorkspaceIds: descendants
+                        )
+                    )
+                    if !group.isCollapsed {
+                        walk(items: group.childItems, level: level + 1)
+                    }
+                }
+            }
+        }
+
+        walk(items: sidebarRootItems, level: 0)
+        return entries
+    }
+
+    func sidebarVisibleWorkspaceIds() -> [UUID] {
+        sidebarDisplayEntries().compactMap { entry in
+            guard case .workspace(let workspaceId) = entry.kind else { return nil }
+            return workspaceId
+        }
+    }
+
+    func sidebarWorkspaceGroupsInDisplayOrder() -> [SidebarWorkspaceGroupSummary] {
+        var summaries: [SidebarWorkspaceGroupSummary] = []
+
+        func walk(
+            items: [SidebarWorkspaceItemReference],
+            ancestorNames: [String],
+            parentGroupId: UUID?
+        ) {
+            for item in items {
+                guard case .group(let groupId) = item,
+                      let group = sidebarGroupsById[groupId] else {
+                    continue
+                }
+                let names = ancestorNames + [group.name]
+                summaries.append(
+                    SidebarWorkspaceGroupSummary(
+                        id: group.id,
+                        name: group.name,
+                        path: names.joined(separator: " / "),
+                        parentGroupId: parentGroupId,
+                        isCollapsed: group.isCollapsed
+                    )
+                )
+                walk(items: group.childItems, ancestorNames: names, parentGroupId: group.id)
+            }
+        }
+
+        walk(items: sidebarRootItems, ancestorNames: [], parentGroupId: nil)
+        return summaries
+    }
+
+    func workspaceGroupSummary(forWorkspace workspaceId: UUID) -> SidebarWorkspaceGroupSummary? {
+        guard let groupId = sidebarGroupId(forWorkspace: workspaceId),
+              let group = sidebarGroupsById[groupId] else {
+            return nil
+        }
+
+        let pathNames = sidebarGroupPath(groupId: groupId).map(\.name)
+        return SidebarWorkspaceGroupSummary(
+            id: group.id,
+            name: group.name,
+            path: pathNames.joined(separator: " / "),
+            parentGroupId: parentGroupId(containing: .group(groupId)),
+            isCollapsed: group.isCollapsed
+        )
+    }
+
+    @discardableResult
+    func createWorkspaceGroup(
+        name: String,
+        parentGroupId explicitParentGroupId: UUID? = nil,
+        workspaceIds: [UUID] = []
+    ) -> SidebarWorkspaceGroupModel? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let explicitParentGroupId, sidebarGroupsById[explicitParentGroupId] == nil {
+            return nil
+        }
+
+        let orderedWorkspaceIds = tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
+        let groupedParentIds = orderedWorkspaceIds.map { sidebarGroupId(forWorkspace: $0) }
+        let sharedParentGroupId: UUID? = {
+            guard explicitParentGroupId == nil,
+                  let firstParent = groupedParentIds.first,
+                  groupedParentIds.allSatisfy({ $0 == firstParent }) else {
+                return explicitParentGroupId
+            }
+            return firstParent
+        }()
+
+        let insertionParentGroupId = explicitParentGroupId ?? sharedParentGroupId
+        let insertionIndex: Int? = {
+            guard let firstWorkspaceId = orderedWorkspaceIds.first else { return nil }
+            return itemIndex(
+                .workspace(firstWorkspaceId),
+                inGroup: insertionParentGroupId
+            )
+        }()
+
+        let group = SidebarWorkspaceGroupModel(name: trimmed)
+        sidebarGroupsById[group.id] = group
+        insertSidebarItem(.group(group.id), intoGroup: insertionParentGroupId, at: insertionIndex)
+        if let insertionParentGroupId {
+            expandAncestorGroups(forGroup: insertionParentGroupId)
+        }
+
+        if !orderedWorkspaceIds.isEmpty {
+            var updated = sidebarGroupsById[group.id] ?? group
+            for workspaceId in orderedWorkspaceIds {
+                removeSidebarItemFromContainers(.workspace(workspaceId))
+                updated.childItems.append(.workspace(workspaceId))
+            }
+            sidebarGroupsById[group.id] = updated
+        }
+
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+        return sidebarGroupsById[group.id]
+    }
+
+    @discardableResult
+    func renameWorkspaceGroup(groupId: UUID, name: String) -> Bool {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              var group = sidebarGroupsById[groupId],
+              group.name != trimmed else {
+            return false
+        }
+        group.name = trimmed
+        sidebarGroupsById[groupId] = group
+        bumpSidebarStructureRevision()
+        return true
+    }
+
+    @discardableResult
+    func deleteWorkspaceGroup(groupId: UUID) -> Bool {
+        guard let group = sidebarGroupsById[groupId] else { return false }
+        let parentGroupId = parentGroupId(containing: .group(groupId))
+        guard var containerItems = sidebarItems(inGroup: parentGroupId),
+              let groupIndex = containerItems.firstIndex(of: .group(groupId)) else {
+            return false
+        }
+
+        containerItems.remove(at: groupIndex)
+        containerItems.insert(contentsOf: group.childItems, at: groupIndex)
+        setSidebarItems(containerItems, inGroup: parentGroupId)
+        sidebarGroupsById.removeValue(forKey: groupId)
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+        return true
+    }
+
+    @discardableResult
+    func setWorkspaceGroupCollapsed(groupId: UUID, collapsed: Bool) -> Bool {
+        guard var group = sidebarGroupsById[groupId],
+              group.isCollapsed != collapsed else {
+            return false
+        }
+        group.isCollapsed = collapsed
+        sidebarGroupsById[groupId] = group
+        bumpSidebarStructureRevision()
+        return true
+    }
+
+    @discardableResult
+    func moveWorkspaceToGroup(workspaceId: UUID, groupId: UUID?) -> Bool {
+        guard tabs.contains(where: { $0.id == workspaceId }) else { return false }
+        if let groupId, sidebarGroupsById[groupId] == nil {
+            return false
+        }
+
+        removeSidebarItemFromContainers(.workspace(workspaceId))
+        insertSidebarItem(.workspace(workspaceId), intoGroup: groupId, at: nil)
+        if let groupId {
+            expandAncestorGroups(forGroup: groupId)
+        }
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+        return true
+    }
+
+    func expandAncestorGroups(containing workspaceId: UUID) {
+        var currentGroupId = sidebarGroupId(forWorkspace: workspaceId)
+        var didChange = false
+
+        while let groupId = currentGroupId {
+            guard var group = sidebarGroupsById[groupId] else { break }
+            if group.isCollapsed {
+                group.isCollapsed = false
+                sidebarGroupsById[groupId] = group
+                didChange = true
+            }
+            currentGroupId = parentGroupId(containing: .group(groupId))
+        }
+
+        if didChange {
+            bumpSidebarStructureRevision()
+        }
+    }
+
+    private func expandAncestorGroups(forGroup groupId: UUID) {
+        var currentGroupId: UUID? = groupId
+        var didChange = false
+
+        while let current = currentGroupId {
+            guard var group = sidebarGroupsById[current] else { break }
+            if group.isCollapsed {
+                group.isCollapsed = false
+                sidebarGroupsById[current] = group
+                didChange = true
+            }
+            currentGroupId = parentGroupId(containing: .group(current))
+        }
+
+        if didChange {
+            bumpSidebarStructureRevision()
+        }
+    }
+
+    private func sidebarGroupPath(groupId: UUID) -> [SidebarWorkspaceGroupModel] {
+        var path: [SidebarWorkspaceGroupModel] = []
+        var currentGroupId: UUID? = groupId
+
+        while let groupId = currentGroupId,
+              let group = sidebarGroupsById[groupId] {
+            path.append(group)
+            currentGroupId = parentGroupId(containing: .group(groupId))
+        }
+
+        return path.reversed()
+    }
+
+    private func descendantWorkspaceIds(in items: [SidebarWorkspaceItemReference]) -> [UUID] {
+        var ids: [UUID] = []
+
+        for item in items {
+            switch item {
+            case .workspace(let workspaceId):
+                ids.append(workspaceId)
+            case .group(let groupId):
+                guard let group = sidebarGroupsById[groupId] else { continue }
+                ids.append(contentsOf: descendantWorkspaceIds(in: group.childItems))
+            }
+        }
+
+        return ids
+    }
+
+    private func flattenedWorkspaceIds(
+        in items: [SidebarWorkspaceItemReference]
+    ) -> [UUID] {
+        descendantWorkspaceIds(in: items)
+    }
+
+    private func parentGroupId(containing item: SidebarWorkspaceItemReference) -> UUID? {
+        for (groupId, group) in sidebarGroupsById where group.childItems.contains(item) {
+            return groupId
+        }
+        return nil
+    }
+
+    private func itemIndex(
+        _ item: SidebarWorkspaceItemReference,
+        inGroup groupId: UUID?
+    ) -> Int? {
+        guard let items = sidebarItems(inGroup: groupId) else { return nil }
+        return items.firstIndex(of: item)
+    }
+
+    private func sidebarItems(inGroup groupId: UUID?) -> [SidebarWorkspaceItemReference]? {
+        if let groupId {
+            return sidebarGroupsById[groupId]?.childItems
+        }
+        return sidebarRootItems
+    }
+
+    private func setSidebarItems(
+        _ items: [SidebarWorkspaceItemReference],
+        inGroup groupId: UUID?
+    ) {
+        if let groupId {
+            guard var group = sidebarGroupsById[groupId] else { return }
+            group.childItems = items
+            sidebarGroupsById[groupId] = group
+        } else {
+            sidebarRootItems = items
+        }
+    }
+
+    private func insertSidebarItem(
+        _ item: SidebarWorkspaceItemReference,
+        intoGroup groupId: UUID?,
+        at index: Int?
+    ) {
+        var items = sidebarItems(inGroup: groupId) ?? []
+        let insertionIndex = min(max(index ?? items.count, 0), items.count)
+        items.insert(item, at: insertionIndex)
+        setSidebarItems(items, inGroup: groupId)
+    }
+
+    private func removeSidebarItemFromContainers(_ item: SidebarWorkspaceItemReference) {
+        sidebarRootItems.removeAll { $0 == item }
+        for groupId in Array(sidebarGroupsById.keys) {
+            guard var group = sidebarGroupsById[groupId] else { continue }
+            group.childItems.removeAll { $0 == item }
+            sidebarGroupsById[groupId] = group
+        }
+    }
+
+    private func sidebarContainerInfo(
+        forWorkspace workspaceId: UUID
+    ) -> (parentGroupId: UUID?, items: [SidebarWorkspaceItemReference], index: Int)? {
+        let parentGroupId = sidebarGroupId(forWorkspace: workspaceId)
+        guard let items = sidebarItems(inGroup: parentGroupId),
+              let index = items.firstIndex(of: .workspace(workspaceId)) else {
+            return nil
+        }
+        return (parentGroupId, items, index)
+    }
+
+    private func rootPinnedWorkspaceItemCount(
+        in items: [SidebarWorkspaceItemReference]
+    ) -> Int {
+        items.reduce(into: 0) { partial, item in
+            guard case .workspace(let workspaceId) = item,
+                  let workspace = tabs.first(where: { $0.id == workspaceId }),
+                  workspace.isPinned else {
+                return
+            }
+            partial += 1
+        }
+    }
+
+    private func clampedSidebarInsertionIndex(
+        for item: SidebarWorkspaceItemReference,
+        desiredIndex: Int,
+        itemsAfterRemoval: [SidebarWorkspaceItemReference],
+        parentGroupId: UUID?
+    ) -> Int {
+        let clamped = max(0, min(desiredIndex, itemsAfterRemoval.count))
+        guard parentGroupId == nil,
+              case .workspace(let workspaceId) = item,
+              let workspace = tabs.first(where: { $0.id == workspaceId }) else {
+            return clamped
+        }
+
+        let pinnedCount = rootPinnedWorkspaceItemCount(in: itemsAfterRemoval)
+        if workspace.isPinned {
+            return min(clamped, pinnedCount)
+        }
+        return max(clamped, pinnedCount)
+    }
+
+    @discardableResult
+    private func reorderSidebarItem(
+        _ item: SidebarWorkspaceItemReference,
+        withinGroup parentGroupId: UUID?,
+        toIndex targetIndex: Int
+    ) -> Bool {
+        guard var items = sidebarItems(inGroup: parentGroupId),
+              let currentIndex = items.firstIndex(of: item) else {
+            return false
+        }
+
+        let movingItem = items.remove(at: currentIndex)
+        let adjustedTargetIndex = targetIndex > currentIndex ? targetIndex - 1 : targetIndex
+        let insertionIndex = clampedSidebarInsertionIndex(
+            for: movingItem,
+            desiredIndex: adjustedTargetIndex,
+            itemsAfterRemoval: items,
+            parentGroupId: parentGroupId
+        )
+        items.insert(movingItem, at: insertionIndex)
+        setSidebarItems(items, inGroup: parentGroupId)
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+        return true
+    }
+
+    func canMoveWorkspace(_ workspaceId: UUID, by delta: Int) -> Bool {
+        guard let container = sidebarContainerInfo(forWorkspace: workspaceId) else { return false }
+        let targetIndex = container.index + delta
+        return targetIndex >= 0 && targetIndex < container.items.count
+    }
+
+    func canMoveWorkspaceToTop(_ workspaceId: UUID) -> Bool {
+        guard let container = sidebarContainerInfo(forWorkspace: workspaceId) else { return false }
+        let insertionIndex = clampedSidebarInsertionIndex(
+            for: .workspace(workspaceId),
+            desiredIndex: 0,
+            itemsAfterRemoval: Array(container.items.enumerated())
+                .compactMap { $0.offset == container.index ? nil : $0.element },
+            parentGroupId: container.parentGroupId
+        )
+        return container.index != insertionIndex
+    }
+
+    @discardableResult
+    func moveWorkspace(_ workspaceId: UUID, by delta: Int) -> Bool {
+        guard let container = sidebarContainerInfo(forWorkspace: workspaceId) else { return false }
+        let targetIndex = container.index + delta
+        guard targetIndex >= 0 && targetIndex < container.items.count else { return false }
+        return reorderSidebarItem(.workspace(workspaceId), withinGroup: container.parentGroupId, toIndex: targetIndex)
+    }
+
+    @discardableResult
+    func moveWorkspaceToTop(_ workspaceId: UUID) -> Bool {
+        guard let container = sidebarContainerInfo(forWorkspace: workspaceId) else { return false }
+        return reorderSidebarItem(.workspace(workspaceId), withinGroup: container.parentGroupId, toIndex: 0)
+    }
+
+    func canReorderWorkspaceDrop(
+        draggedWorkspaceId: UUID,
+        targetWorkspaceId: UUID?
+    ) -> Bool {
+        guard tabs.contains(where: { $0.id == draggedWorkspaceId }) else { return false }
+        guard let targetWorkspaceId else { return true }
+        return tabs.contains(where: { $0.id == targetWorkspaceId })
+    }
+
+    private func normalizeSidebarStructure(preferredWorkspaceOrder: [UUID]? = nil) {
+        let workspaceOrder = preferredWorkspaceOrder ?? tabs.map(\.id)
+        let validWorkspaceIds = Set(workspaceOrder)
+        let existingGroups = sidebarGroupsById
+
+        var sanitizedGroups: [UUID: SidebarWorkspaceGroupModel] = [:]
+        var seenWorkspaceIds: Set<UUID> = []
+        var seenGroupIds: Set<UUID> = []
+
+        func sanitizeGroupReference(
+            _ groupId: UUID,
+            ancestors: Set<UUID>
+        ) -> SidebarWorkspaceItemReference? {
+            guard !ancestors.contains(groupId),
+                  !seenGroupIds.contains(groupId),
+                  var group = existingGroups[groupId] else {
+                return nil
+            }
+
+            seenGroupIds.insert(groupId)
+            group.childItems = sanitizeItems(group.childItems, ancestors: ancestors.union([groupId]))
+            sanitizedGroups[groupId] = group
+            return .group(groupId)
+        }
+
+        func sanitizeItems(
+            _ items: [SidebarWorkspaceItemReference],
+            ancestors: Set<UUID>
+        ) -> [SidebarWorkspaceItemReference] {
+            var sanitized: [SidebarWorkspaceItemReference] = []
+
+            for item in items {
+                switch item {
+                case .workspace(let workspaceId):
+                    guard validWorkspaceIds.contains(workspaceId),
+                          seenWorkspaceIds.insert(workspaceId).inserted else {
+                        continue
+                    }
+                    sanitized.append(.workspace(workspaceId))
+                case .group(let groupId):
+                    guard let sanitizedGroupReference = sanitizeGroupReference(groupId, ancestors: ancestors) else {
+                        continue
+                    }
+                    sanitized.append(sanitizedGroupReference)
+                }
+            }
+
+            return sanitized
+        }
+
+        var sanitizedRootItems = sanitizeItems(sidebarRootItems, ancestors: [])
+
+        let orphanGroupIds = existingGroups.keys
+            .sorted(by: { $0.uuidString < $1.uuidString })
+            .filter { !seenGroupIds.contains($0) }
+        for groupId in orphanGroupIds {
+            guard let sanitizedGroupReference = sanitizeGroupReference(groupId, ancestors: []) else {
+                continue
+            }
+            sanitizedRootItems.append(sanitizedGroupReference)
+        }
+
+        for workspaceId in workspaceOrder where validWorkspaceIds.contains(workspaceId) {
+            guard seenWorkspaceIds.insert(workspaceId).inserted else { continue }
+            sanitizedRootItems.append(.workspace(workspaceId))
+        }
+
+        sidebarGroupsById = sanitizedGroups
+        sidebarRootItems = sanitizedRootItems
+
+        let orderedWorkspaceIds = flattenedWorkspaceIds(in: sanitizedRootItems)
+        let workspacesById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
+        let orderedTabs = orderedWorkspaceIds.compactMap { workspacesById[$0] }
+        if orderedTabs.map(\.id) != tabs.map(\.id) {
+            tabs = orderedTabs
+        }
+
+        bumpSidebarStructureRevision()
     }
 
     // MARK: - Agent PID Sweep
@@ -2002,6 +2640,11 @@ class TabManager: ObservableObject {
                 updatedTabs.append(newWorkspace)
             }
             tabs = updatedTabs
+            let rootInsertIndex = sidebarGroupsById.isEmpty
+                ? min(max(insertIndex, 0), sidebarRootItems.count)
+                : nil
+            insertSidebarItem(.workspace(newWorkspace.id), intoGroup: nil, at: rootInsertIndex)
+            normalizeSidebarStructure(preferredWorkspaceOrder: updatedTabs.map(\.id))
             if let terminalPanel = newWorkspace.focusedTerminalPanel {
                 scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
                     workspaceId: newWorkspace.id,
@@ -3477,60 +4120,129 @@ class TabManager: ObservableObject {
     }
 
     func moveTabToTop(_ tabId: UUID) {
-        guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
-        guard index != 0 else { return }
-        let tab = tabs.remove(at: index)
-        let pinnedCount = tabs.filter { $0.isPinned }.count
-        let insertIndex = tab.isPinned ? 0 : pinnedCount
-        tabs.insert(tab, at: insertIndex)
+        _ = moveWorkspaceToTop(tabId)
     }
 
     func moveTabsToTop(_ tabIds: Set<UUID>) {
         guard !tabIds.isEmpty else { return }
-        let selectedTabs = tabs.filter { tabIds.contains($0.id) }
-        guard !selectedTabs.isEmpty else { return }
-        let remainingTabs = tabs.filter { !tabIds.contains($0.id) }
-        let selectedPinned = selectedTabs.filter { $0.isPinned }
-        let selectedUnpinned = selectedTabs.filter { !$0.isPinned }
-        let remainingPinned = remainingTabs.filter { $0.isPinned }
-        let remainingUnpinned = remainingTabs.filter { !$0.isPinned }
-        tabs = selectedPinned + remainingPinned + selectedUnpinned + remainingUnpinned
+
+        let selectedWorkspaceIds = tabs.compactMap { tabIds.contains($0.id) ? $0.id : nil }
+        guard !selectedWorkspaceIds.isEmpty else { return }
+
+        let groupedByContainer = Dictionary(grouping: selectedWorkspaceIds) {
+            sidebarGroupId(forWorkspace: $0)
+        }
+        var didChange = false
+
+        for (parentGroupId, workspaceIds) in groupedByContainer {
+            guard var items = sidebarItems(inGroup: parentGroupId) else { continue }
+            let selectedItems = items.filter { item in
+                guard case .workspace(let workspaceId) = item else { return false }
+                return workspaceIds.contains(workspaceId)
+            }
+            guard !selectedItems.isEmpty else { continue }
+
+            items.removeAll { item in
+                guard case .workspace(let workspaceId) = item else { return false }
+                return workspaceIds.contains(workspaceId)
+            }
+
+            let selectedPinnedItems = selectedItems.filter { item in
+                guard case .workspace(let workspaceId) = item,
+                      let workspace = tabs.first(where: { $0.id == workspaceId }) else {
+                    return false
+                }
+                return workspace.isPinned
+            }
+            let selectedUnpinnedItems = selectedItems.filter { item in
+                guard case .workspace(let workspaceId) = item,
+                      let workspace = tabs.first(where: { $0.id == workspaceId }) else {
+                    return false
+                }
+                return !workspace.isPinned
+            }
+
+            let insertionIndex = parentGroupId == nil ? rootPinnedWorkspaceItemCount(in: items) : 0
+            items.insert(contentsOf: selectedPinnedItems, at: 0)
+            items.insert(contentsOf: selectedUnpinnedItems, at: min(insertionIndex + selectedPinnedItems.count, items.count))
+            setSidebarItems(items, inGroup: parentGroupId)
+            didChange = true
+        }
+
+        if didChange {
+            normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+        }
     }
 
     func moveTabToTopForNotification(_ tabId: UUID) {
-        guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
-        let pinnedCount = tabs.filter { $0.isPinned }.count
-        guard index != pinnedCount else { return }
-        let tab = tabs[index]
-        guard !tab.isPinned else { return }
-        tabs.remove(at: index)
-        tabs.insert(tab, at: pinnedCount)
+        guard !isWorkspaceGrouped(tabId),
+              let workspace = tabs.first(where: { $0.id == tabId }),
+              !workspace.isPinned else {
+            return
+        }
+        _ = moveWorkspaceToTop(tabId)
     }
 
     @discardableResult
     func reorderWorkspace(tabId: UUID, toIndex targetIndex: Int) -> Bool {
-        guard let currentIndex = tabs.firstIndex(where: { $0.id == tabId }) else { return false }
-        if tabs.count <= 1 { return true }
+        guard let currentIndex = tabs.firstIndex(where: { $0.id == tabId }),
+              tabs.count > 1 else {
+            return false
+        }
 
-        let workspace = tabs[currentIndex]
-        let clamped = clampedReorderIndex(for: workspace, targetIndex: targetIndex)
-        if currentIndex == clamped { return true }
+        let clamped = max(0, min(targetIndex, tabs.count - 1))
+        if currentIndex == clamped {
+            return true
+        }
 
-        tabs.remove(at: currentIndex)
-        tabs.insert(workspace, at: clamped)
-        return true
+        let visibleWorkspaceIds = tabs.map(\.id)
+        let targetWorkspaceId = visibleWorkspaceIds[clamped]
+        if clamped < currentIndex {
+            return reorderWorkspace(tabId: tabId, before: targetWorkspaceId)
+        }
+        return reorderWorkspace(tabId: tabId, after: targetWorkspaceId)
     }
 
     @discardableResult
     func reorderWorkspace(tabId: UUID, before beforeId: UUID? = nil, after afterId: UUID? = nil) -> Bool {
         guard tabs.contains(where: { $0.id == tabId }) else { return false }
         if let beforeId {
-            guard let idx = tabs.firstIndex(where: { $0.id == beforeId }) else { return false }
-            return reorderWorkspace(tabId: tabId, toIndex: idx)
+            guard beforeId != tabId else { return true }
+            guard tabs.contains(where: { $0.id == beforeId }) else { return false }
+            let targetParentGroupId = sidebarGroupId(forWorkspace: beforeId)
+            guard let targetItems = sidebarItems(inGroup: targetParentGroupId),
+                  let targetIndex = targetItems.firstIndex(of: .workspace(beforeId)) else {
+                return false
+            }
+
+            let currentParentGroupId = sidebarGroupId(forWorkspace: tabId)
+            if currentParentGroupId == targetParentGroupId {
+                return reorderSidebarItem(.workspace(tabId), withinGroup: currentParentGroupId, toIndex: targetIndex)
+            }
+
+            removeSidebarItemFromContainers(.workspace(tabId))
+            insertSidebarItem(.workspace(tabId), intoGroup: targetParentGroupId, at: targetIndex)
+            normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+            return true
         }
         if let afterId {
-            guard let idx = tabs.firstIndex(where: { $0.id == afterId }) else { return false }
-            return reorderWorkspace(tabId: tabId, toIndex: idx + 1)
+            guard afterId != tabId else { return true }
+            guard tabs.contains(where: { $0.id == afterId }) else { return false }
+            let targetParentGroupId = sidebarGroupId(forWorkspace: afterId)
+            guard let targetItems = sidebarItems(inGroup: targetParentGroupId),
+                  let targetIndex = targetItems.firstIndex(of: .workspace(afterId)) else {
+                return false
+            }
+
+            let currentParentGroupId = sidebarGroupId(forWorkspace: tabId)
+            if currentParentGroupId == targetParentGroupId {
+                return reorderSidebarItem(.workspace(tabId), withinGroup: currentParentGroupId, toIndex: targetIndex + 1)
+            }
+
+            removeSidebarItemFromContainers(.workspace(tabId))
+            insertSidebarItem(.workspace(tabId), intoGroup: targetParentGroupId, at: targetIndex + 1)
+            normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+            return true
         }
         return false
     }
@@ -3574,20 +4286,11 @@ class TabManager: ObservableObject {
     }
 
     private func reorderTabForPinnedState(_ tab: Workspace) {
-        guard let index = tabs.firstIndex(where: { $0.id == tab.id }) else { return }
-        tabs.remove(at: index)
-        let pinnedCount = tabs.filter { $0.isPinned }.count
-        let insertIndex = min(pinnedCount, tabs.count)
-        tabs.insert(tab, at: insertIndex)
-    }
-
-    private func clampedReorderIndex(for workspace: Workspace, targetIndex: Int) -> Int {
-        let clamped = max(0, min(targetIndex, tabs.count - 1))
-        let pinnedCount = tabs.filter { $0.isPinned }.count
-        if workspace.isPinned {
-            return min(clamped, max(0, pinnedCount - 1))
+        guard !isWorkspaceGrouped(tab.id) else {
+            normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
+            return
         }
-        return max(clamped, pinnedCount)
+        _ = moveWorkspaceToTop(tab.id)
     }
 
     // MARK: - Surface Directory Updates (Backwards Compatibility)
@@ -3797,6 +4500,8 @@ class TabManager: ObservableObject {
                 selectedTabId = tabs[newIndex].id
             }
         }
+        removeSidebarItemFromContainers(.workspace(workspace.id))
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
     }
 
     /// Detach a workspace from this window without closing its panels.
@@ -3811,6 +4516,7 @@ class TabManager: ObservableObject {
         unwireClosedBrowserTracking(for: removed)
         removed.owningTabManager = nil
         lastFocusedPanelByTab.removeValue(forKey: removed.id)
+        removeSidebarItemFromContainers(.workspace(removed.id))
 
         if tabs.isEmpty {
             // The UI assumes each window always has at least one workspace.
@@ -3823,6 +4529,7 @@ class TabManager: ObservableObject {
             selectedTabId = tabs[nextIndex].id
         }
 
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
         return removed
     }
 
@@ -3835,6 +4542,11 @@ class TabManager: ObservableObject {
             return max(0, min(index, tabs.count))
         }()
         tabs.insert(workspace, at: insertIndex)
+        let rootInsertIndex = sidebarGroupsById.isEmpty
+            ? min(max(insertIndex, 0), sidebarRootItems.count)
+            : nil
+        insertSidebarItem(.workspace(workspace.id), intoGroup: nil, at: rootInsertIndex)
+        normalizeSidebarStructure(preferredWorkspaceOrder: tabs.map(\.id))
         if select {
             selectedTabId = workspace.id
         }
@@ -3953,6 +4665,7 @@ class TabManager: ObservableObject {
     }
 
     func selectWorkspace(_ workspace: Workspace) {
+        expandAncestorGroups(containing: workspace.id)
 #if DEBUG
         debugPrimeWorkspaceSwitchTrigger("select", to: workspace.id)
 #endif
@@ -6721,6 +7434,7 @@ extension TabManager {
         var hasher = Hasher()
         hasher.combine(selectedTabId)
         hasher.combine(tabs.count)
+        hasher.combine(sidebarStructureRevision)
 
         for workspace in tabs.prefix(SessionPersistencePolicy.maxWorkspacesPerWindow) {
             hasher.combine(workspace.id)
@@ -6756,6 +7470,36 @@ extension TabManager {
             }
         }
 
+        for item in sidebarRootItems {
+            switch item {
+            case .workspace(let workspaceId):
+                hasher.combine("root.workspace")
+                hasher.combine(workspaceId)
+            case .group(let groupId):
+                hasher.combine("root.group")
+                hasher.combine(groupId)
+            }
+        }
+
+        for summary in sidebarWorkspaceGroupsInDisplayOrder() {
+            hasher.combine(summary.id)
+            hasher.combine(summary.name)
+            hasher.combine(summary.parentGroupId)
+            hasher.combine(summary.isCollapsed)
+            if let group = sidebarGroupsById[summary.id] {
+                for item in group.childItems {
+                    switch item {
+                    case .workspace(let workspaceId):
+                        hasher.combine("child.workspace")
+                        hasher.combine(workspaceId)
+                    case .group(let groupId):
+                        hasher.combine("child.group")
+                        hasher.combine(groupId)
+                    }
+                }
+            }
+        }
+
         return hasher.finalize()
     }
 
@@ -6770,7 +7514,11 @@ extension TabManager {
         }
         return SessionTabManagerSnapshot(
             selectedWorkspaceIndex: selectedWorkspaceIndex,
-            workspaces: workspaceSnapshots
+            workspaces: workspaceSnapshots,
+            sidebarRootItems: sidebarRootItems.map(\.sessionSnapshot),
+            sidebarGroups: sidebarWorkspaceGroupsInDisplayOrder().compactMap { summary in
+                sidebarGroupsById[summary.id]?.sessionSnapshot
+            }
         )
     }
 
@@ -6794,6 +7542,8 @@ extension TabManager {
         for key in existingProbeKeys {
             clearWorkspaceGitProbe(key)
         }
+        sidebarRootItems.removeAll()
+        sidebarGroupsById.removeAll()
         workspaceGitTrackedDirectoryByKey.removeAll()
         resetWorkspacePullRequestRefreshState()
 
@@ -6820,6 +7570,7 @@ extension TabManager {
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
             let workspace = Workspace(
+                restoredId: workspaceSnapshot.id,
                 title: workspaceSnapshot.processTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,
                 portOrdinal: ordinal
@@ -6851,6 +7602,14 @@ extension TabManager {
         // Single atomic assignment of @Published properties so SwiftUI observers
         // never see an intermediate state with empty tabs or nil selection.
         tabs = newTabs
+        sidebarRootItems = snapshot.sidebarRootItems?.map(SidebarWorkspaceItemReference.init(snapshot:)) ?? []
+        sidebarGroupsById = Dictionary(
+            uniqueKeysWithValues: (snapshot.sidebarGroups ?? []).map {
+                let model = SidebarWorkspaceGroupModel(snapshot: $0)
+                return (model.id, model)
+            }
+        )
+        normalizeSidebarStructure(preferredWorkspaceOrder: newTabs.map(\.id))
         selectedTabId = newSelectedId
         let existingIds = Set(newTabs.map(\.id))
         pruneBackgroundWorkspaceLoads(existingIds: existingIds)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -147,6 +147,7 @@ class TerminalController {
     private enum V2HandleKind: String, CaseIterable {
         case window
         case workspace
+        case group
         case pane
         case surface
     }
@@ -154,18 +155,21 @@ class TerminalController {
     private var v2NextHandleOrdinal: [V2HandleKind: Int] = [
         .window: 1,
         .workspace: 1,
+        .group: 1,
         .pane: 1,
         .surface: 1,
     ]
     private var v2RefByUUID: [V2HandleKind: [UUID: String]] = [
         .window: [:],
         .workspace: [:],
+        .group: [:],
         .pane: [:],
         .surface: [:],
     ]
     private var v2UUIDByRef: [V2HandleKind: [String: UUID]] = [
         .window: [:],
         .workspace: [:],
+        .group: [:],
         .pane: [:],
         .surface: [:],
     ]
@@ -2073,6 +2077,18 @@ class TerminalController {
         // Workspaces
         case "workspace.list":
             return v2Result(id: id, self.v2WorkspaceList(params: params))
+        case "workspace_group.list":
+            return v2Result(id: id, self.v2WorkspaceGroupList(params: params))
+        case "workspace_group.create":
+            return v2Result(id: id, self.v2WorkspaceGroupCreate(params: params))
+        case "workspace_group.rename":
+            return v2Result(id: id, self.v2WorkspaceGroupRename(params: params))
+        case "workspace_group.delete":
+            return v2Result(id: id, self.v2WorkspaceGroupDelete(params: params))
+        case "workspace_group.set_collapsed":
+            return v2Result(id: id, self.v2WorkspaceGroupSetCollapsed(params: params))
+        case "workspace_group.move_workspace":
+            return v2Result(id: id, self.v2WorkspaceGroupMoveWorkspace(params: params))
         case "workspace.create":
             return v2Result(id: id, self.v2WorkspaceCreate(params: params))
         case "workspace.select":
@@ -2464,6 +2480,12 @@ class TerminalController {
             "window.create",
             "window.close",
             "workspace.list",
+            "workspace_group.list",
+            "workspace_group.create",
+            "workspace_group.rename",
+            "workspace_group.delete",
+            "workspace_group.set_collapsed",
+            "workspace_group.move_workspace",
             "workspace.create",
             "workspace.select",
             "workspace.current",
@@ -3059,6 +3081,9 @@ class TerminalController {
                         _ = v2EnsureHandleRef(kind: .surface, uuid: panelId)
                     }
                 }
+                for group in tm.sidebarWorkspaceGroupsInDisplayOrder() {
+                    _ = v2EnsureHandleRef(kind: .group, uuid: group.id)
+                }
             }
         }
     }
@@ -3133,6 +3158,17 @@ class TerminalController {
         }
         return v2ResolveHandleRef(trimmed)
     }
+
+    private func v2UUIDArray(_ params: [String: Any], _ key: String) -> [UUID]? {
+        if let raw = params[key] as? [Any] {
+            return raw.compactMap(v2UUIDAny(_:))
+        }
+        if let single = v2UUID(params, key) {
+            return [single]
+        }
+        return nil
+    }
+
     private func v2Bool(_ params: [String: Any], _ key: String) -> Bool? {
         if let b = params[key] as? Bool { return b }
         if let n = params[key] as? NSNumber { return n.boolValue }
@@ -3162,6 +3198,22 @@ class TerminalController {
         }
         return nil
     }
+
+    private func v2LocateWorkspaceGroup(
+        _ groupId: UUID
+    ) -> (windowId: UUID, tabManager: TabManager, summary: SidebarWorkspaceGroupSummary)? {
+        guard let app = AppDelegate.shared else { return nil }
+        let windows = app.listMainWindowSummaries()
+        for item in windows {
+            guard let tm = app.tabManagerFor(windowId: item.windowId),
+                  let summary = tm.sidebarWorkspaceGroupsInDisplayOrder().first(where: { $0.id == groupId }) else {
+                continue
+            }
+            return (item.windowId, tm, summary)
+        }
+        return nil
+    }
+
     private func v2Int(_ params: [String: Any], _ key: String) -> Int? {
         if let i = params[key] as? Int { return i }
         if let n = params[key] as? NSNumber { return n.intValue }
@@ -3317,8 +3369,10 @@ class TerminalController {
     private func v2WorkspaceSummaryPayload(
         workspace: Workspace,
         index: Int?,
-        selected: Bool
+        selected: Bool,
+        tabManager: TabManager
     ) -> [String: Any] {
+        let groupSummary = tabManager.workspaceGroupSummary(forWorkspace: workspace.id)
         var payload: [String: Any] = [
             "id": workspace.id.uuidString,
             "ref": v2Ref(kind: .workspace, uuid: workspace.id),
@@ -3330,6 +3384,29 @@ class TerminalController {
             "remote": workspace.remoteStatusPayload(),
             "current_directory": v2OrNull(workspace.currentDirectory),
             "custom_color": v2OrNull(workspace.customColor)
+        ]
+        payload["group_id"] = v2OrNull(groupSummary?.id.uuidString)
+        payload["group_ref"] = v2Ref(kind: .group, uuid: groupSummary?.id)
+        payload["group_name"] = v2OrNull(groupSummary?.name)
+        payload["group_path"] = v2OrNull(groupSummary?.path)
+        if let index {
+            payload["index"] = index
+        }
+        return payload
+    }
+
+    private func v2WorkspaceGroupPayload(
+        summary: SidebarWorkspaceGroupSummary,
+        index: Int?
+    ) -> [String: Any] {
+        var payload: [String: Any] = [
+            "id": summary.id.uuidString,
+            "ref": v2Ref(kind: .group, uuid: summary.id),
+            "name": summary.name,
+            "path": summary.path,
+            "collapsed": summary.isCollapsed,
+            "parent_group_id": v2OrNull(summary.parentGroupId?.uuidString),
+            "parent_group_ref": v2Ref(kind: .group, uuid: summary.parentGroupId)
         ]
         if let index {
             payload["index"] = index
@@ -3348,7 +3425,8 @@ class TerminalController {
                 v2WorkspaceSummaryPayload(
                     workspace: ws,
                     index: index,
-                    selected: ws.id == tabManager.selectedTabId
+                    selected: ws.id == tabManager.selectedTabId,
+                    tabManager: tabManager
                 )
             }
         }
@@ -3360,6 +3438,216 @@ class TerminalController {
             "workspaces": workspaces
         ])
     }
+
+    private func v2WorkspaceGroupList(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var groups: [[String: Any]] = []
+        v2MainSync {
+            groups = tabManager.sidebarWorkspaceGroupsInDisplayOrder().enumerated().map { index, summary in
+                v2WorkspaceGroupPayload(summary: summary, index: index)
+            }
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "groups": groups
+        ])
+    }
+
+    private func v2WorkspaceGroupCreate(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let name = v2String(params, "name") else {
+            return .err(code: "invalid_params", message: "Missing or invalid name", data: nil)
+        }
+        let parentGroupId = v2UUID(params, "parent_group_id")
+        let workspaceIds = v2UUIDArray(params, "workspace_ids") ?? []
+
+        var summary: SidebarWorkspaceGroupSummary?
+        v2MainSync {
+            guard let group = tabManager.createWorkspaceGroup(
+                name: name,
+                parentGroupId: parentGroupId,
+                workspaceIds: workspaceIds
+            ) else {
+                return
+            }
+            summary = tabManager.sidebarWorkspaceGroupsInDisplayOrder().first(where: { $0.id == group.id })
+        }
+
+        guard let summary else {
+            return .err(code: "invalid_params", message: "Failed to create workspace group", data: nil)
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "group": v2WorkspaceGroupPayload(summary: summary, index: nil),
+            "group_id": summary.id.uuidString,
+            "group_ref": v2Ref(kind: .group, uuid: summary.id)
+        ])
+    }
+
+    private func v2WorkspaceGroupRename(params: [String: Any]) -> V2CallResult {
+        guard let groupId = v2UUID(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        guard let name = v2String(params, "name") else {
+            return .err(code: "invalid_params", message: "Missing or invalid name", data: nil)
+        }
+
+        guard let located = v2MainSync({ self.v2LocateWorkspaceGroup(groupId) }) else {
+            return .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        var summary: SidebarWorkspaceGroupSummary?
+        v2MainSync {
+            _ = located.tabManager.renameWorkspaceGroup(groupId: groupId, name: name)
+            summary = located.tabManager.sidebarWorkspaceGroupsInDisplayOrder().first(where: { $0.id == groupId })
+        }
+
+        guard let summary else {
+            return .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        return .ok([
+            "window_id": located.windowId.uuidString,
+            "window_ref": v2Ref(kind: .window, uuid: located.windowId),
+            "group": v2WorkspaceGroupPayload(summary: summary, index: nil),
+            "group_id": summary.id.uuidString,
+            "group_ref": v2Ref(kind: .group, uuid: summary.id)
+        ])
+    }
+
+    private func v2WorkspaceGroupDelete(params: [String: Any]) -> V2CallResult {
+        guard let groupId = v2UUID(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+
+        guard let located = v2MainSync({ self.v2LocateWorkspaceGroup(groupId) }) else {
+            return .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        var deleted = false
+        v2MainSync {
+            deleted = located.tabManager.deleteWorkspaceGroup(groupId: groupId)
+        }
+
+        return deleted
+            ? .ok([
+                "window_id": located.windowId.uuidString,
+                "window_ref": v2Ref(kind: .window, uuid: located.windowId),
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+            : .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+    }
+
+    private func v2WorkspaceGroupSetCollapsed(params: [String: Any]) -> V2CallResult {
+        guard let groupId = v2UUID(params, "group_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid group_id", data: nil)
+        }
+        guard let collapsed = v2Bool(params, "collapsed") else {
+            return .err(code: "invalid_params", message: "Missing or invalid collapsed flag", data: nil)
+        }
+
+        guard let located = v2MainSync({ self.v2LocateWorkspaceGroup(groupId) }) else {
+            return .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        var summary: SidebarWorkspaceGroupSummary?
+        v2MainSync {
+            _ = located.tabManager.setWorkspaceGroupCollapsed(groupId: groupId, collapsed: collapsed)
+            summary = located.tabManager.sidebarWorkspaceGroupsInDisplayOrder().first(where: { $0.id == groupId })
+        }
+
+        guard let summary else {
+            return .err(code: "not_found", message: "Workspace group not found", data: [
+                "group_id": groupId.uuidString,
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        return .ok([
+            "window_id": located.windowId.uuidString,
+            "window_ref": v2Ref(kind: .window, uuid: located.windowId),
+            "group": v2WorkspaceGroupPayload(summary: summary, index: nil),
+            "group_id": summary.id.uuidString,
+            "group_ref": v2Ref(kind: .group, uuid: summary.id),
+            "collapsed": summary.isCollapsed
+        ])
+    }
+
+    private func v2WorkspaceGroupMoveWorkspace(params: [String: Any]) -> V2CallResult {
+        guard let workspaceId = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+
+        let groupId = v2HasNonNullParam(params, "group_id") ? v2UUID(params, "group_id") : nil
+        if v2HasNonNullParam(params, "group_id"), params["group_id"] != nil, groupId == nil {
+            return .err(code: "invalid_params", message: "Invalid group_id", data: nil)
+        }
+
+        guard let tabManager = v2MainSync({ AppDelegate.shared?.tabManagerFor(tabId: workspaceId) }) else {
+            return .err(code: "not_found", message: "Workspace or group not found", data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                "group_id": v2OrNull(groupId?.uuidString),
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        var moved = false
+        var groupSummary: SidebarWorkspaceGroupSummary?
+        v2MainSync {
+            moved = tabManager.moveWorkspaceToGroup(workspaceId: workspaceId, groupId: groupId)
+            groupSummary = tabManager.workspaceGroupSummary(forWorkspace: workspaceId)
+        }
+
+        guard moved else {
+            return .err(code: "not_found", message: "Workspace or group not found", data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                "group_id": v2OrNull(groupId?.uuidString),
+                "group_ref": v2Ref(kind: .group, uuid: groupId)
+            ])
+        }
+
+        let windowId = v2ResolveWindowId(tabManager: tabManager)
+        return .ok([
+            "window_id": v2OrNull(windowId?.uuidString),
+            "window_ref": v2Ref(kind: .window, uuid: windowId),
+            "workspace_id": workspaceId.uuidString,
+            "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+            "group_id": v2OrNull(groupSummary?.id.uuidString),
+            "group_ref": v2Ref(kind: .group, uuid: groupSummary?.id),
+            "group_name": v2OrNull(groupSummary?.name),
+            "group_path": v2OrNull(groupSummary?.path)
+        ])
+    }
+
     private func v2WorkspaceCreate(params: [String: Any]) -> V2CallResult {
         guard let tabManager = v2ResolveTabManager(params: params) else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -3466,7 +3754,8 @@ class TerminalController {
                 wsPayload = v2WorkspaceSummaryPayload(
                     workspace: workspace,
                     index: index,
-                    selected: true
+                    selected: true,
+                    tabManager: tabManager
                 )
             }
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -293,6 +293,7 @@ extension Workspace {
         }
 
         return SessionWorkspaceSnapshot(
+            id: id,
             processTitle: processTitle,
             customTitle: customTitle,
             customDescription: customDescription,
@@ -6849,6 +6850,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     init(
+        restoredId: UUID? = nil,
         title: String = "Terminal",
         workingDirectory: String? = nil,
         portOrdinal: Int = 0,
@@ -6856,7 +6858,7 @@ final class Workspace: Identifiable, ObservableObject {
         initialTerminalCommand: String? = nil,
         initialTerminalEnvironment: [String: String] = [:]
     ) {
-        self.id = UUID()
+        self.id = restoredId ?? UUID()
         self.portOrdinal = portOrdinal
         self.processTitle = title
         self.title = title

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -921,11 +921,8 @@ struct cmuxApp: App {
     }
 
     private func moveSelectedWorkspace(in manager: TabManager, by delta: Int) {
-        guard let workspace = manager.selectedWorkspace,
-              let currentIndex = selectedWorkspaceIndex(in: manager, workspaceId: workspace.id) else { return }
-        let targetIndex = currentIndex + delta
-        guard targetIndex >= 0, targetIndex < manager.tabs.count else { return }
-        _ = manager.reorderWorkspace(tabId: workspace.id, toIndex: targetIndex)
+        guard let workspace = manager.selectedWorkspace else { return }
+        _ = manager.moveWorkspace(workspace.id, by: delta)
         manager.selectWorkspace(workspace)
     }
 
@@ -1029,17 +1026,17 @@ struct cmuxApp: App {
         Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
             moveSelectedWorkspace(in: manager, by: -1)
         }
-        .disabled(workspaceIndex == nil || workspaceIndex == 0)
+        .disabled(workspace == nil || !(workspace.map { manager.canMoveWorkspace($0.id, by: -1) } ?? false))
 
         Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
             moveSelectedWorkspace(in: manager, by: 1)
         }
-        .disabled(workspaceIndex == nil || workspaceIndex == manager.tabs.count - 1)
+        .disabled(workspace == nil || !(workspace.map { manager.canMoveWorkspace($0.id, by: 1) } ?? false))
 
         Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
             moveSelectedWorkspaceToTop(in: manager)
         }
-        .disabled(workspace == nil || workspaceIndex == 0)
+        .disabled(workspace == nil || !(workspace.map { manager.canMoveWorkspaceToTop($0.id) } ?? false))
 
         Menu(String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {


### PR DESCRIPTION
## Summary
- add a persisted manual workspace-group tree for the sidebar, including nested child groups, collapse state, and in-group ordering
- render collapsible group headers in the SwiftUI sidebar and keep grouped workspaces exempt from notification-driven reorder-to-top behavior
- add CLI and socket commands to list, create, rename, delete, collapse, expand, and move workspaces between groups

Closes https://github.com/manaflow-ai/cmux/issues/2701

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new persisted sidebar tree model and rewires workspace ordering/drag-drop around it, which could affect session restore and workspace reordering behavior. Also expands the RPC/CLI surface area for group management, requiring careful validation of ID/handle resolution and window scoping.
> 
> **Overview**
> Adds **named, nested workspace groups** to the sidebar with per-group collapse state, indentation, unread-count rollups, and context-menu actions to create/rename/delete groups and move workspaces into/out of them.
> 
> Introduces a **persisted sidebar tree structure** (root items + group definitions) stored in session snapshots, restores stable workspace IDs across restarts, and updates autosave fingerprinting to include sidebar structure changes.
> 
> Extends the V2 socket API and `cmux` CLI with `workspace_group.*` methods/commands (list/create/rename/delete/collapse/expand/move workspace), updates handle parsing to include `group` refs, and adjusts reordering logic so moves/drag-drop operate within the sidebar structure (including preventing notification-driven reorder-to-top for grouped workspaces).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71b94dd52390640e0e0355f1b4615de9571d3eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add named workspace groups to the sidebar with nested, collapsible groups and persistent ordering. Adds CLI and socket API to manage groups and moves, and updates the UI to render group headers while keeping grouped workspaces from auto-bubbling.

- **New Features**
  - Sidebar: create named groups, nest groups, collapse/expand, and reorder groups/items; grouped workspaces no longer jump to top on activity.
  - Persistence: saves group tree and collapse state; preserves workspace UUIDs across sessions for stable references.
  - CLI and V2 socket: add commands/methods to list/create/rename/delete/collapse/expand groups and move workspaces between groups; introduce group handles.

<sup>Written for commit 71b94dd52390640e0e0355f1b4615de9571d3eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace groups for organizing workspaces in the sidebar
  * Create, rename, delete, collapse, and expand groups via UI and CLI
  * Move workspaces between groups through context menus and CLI commands
  * Hierarchical workspace display with nested group support

* **Improvements**
  * Workspace reordering now respects group organization
  * Sidebar state and grouping structure persist across sessions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->