### PR TITLE
Fix copy-on-select: override to clipboard and fix ghostty UAF

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1798,6 +1798,12 @@ class GhosttyApp {
                 prefix: "cmux-shell-integration-override",
                 logLabel: "shell integration override (fallback)"
             )
+            loadInlineGhosttyConfig(
+                "copy-on-select = clipboard",
+                into: fallbackConfig,
+                prefix: "cmux-copy-on-select",
+                logLabel: "copy-on-select override (fallback)"
+            )
             usesHostLayerBackground = true
             ghostty_config_finalize(fallbackConfig)
             updateDefaultBackground(from: fallbackConfig, source: "initialize.fallbackConfig")
@@ -1887,6 +1893,17 @@ class GhosttyApp {
         ghostty_config_load_recursive_files(config)
         loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         loadCJKFontFallbackIfNeeded(config)
+        // Ghostty's default copy-on-select = true writes to a private
+        // named pasteboard (com.mitchellh.ghostty.selection) that is not
+        // the system clipboard. Override to "clipboard" so that selecting
+        // text copies to NSPasteboard.general and Cmd+V works as macOS
+        // users expect.
+        loadInlineGhosttyConfig(
+            "copy-on-select = clipboard",
+            into: config,
+            prefix: "cmux-copy-on-select",
+            logLabel: "copy-on-select override"
+        )
         let useHostLayerBackground = !hasConfiguredBackgroundImage(config)
         usesHostLayerBackground = useHostLayerBackground
         if !useHostLayerBackground {

--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -15,6 +15,7 @@ When we change the fork, update this document and the parent submodule SHA.
 Fork main has advanced beyond the March 30, 2026 rebase onto upstream `main`
 at `3509ccf78` (`v1.3.1-457-g3509ccf78`).
 Current cmux pinned fork head: `3b684a085` (`tip-1717-g3b684a085`).
+Branch `fix-copy-on-select-uaf` (`8eaee4d95`) carries the section 9 fix below (manaflow-ai/ghostty#36).
 
 ### 1) macOS display link restart on display changes
 
@@ -122,6 +123,17 @@ tend to conflict together during rebases.
 
 Fork main now carries the section 8 APC handling fix plus later upstream merges;
 the current cmux pin is the head listed above.
+
+### 9) Fix use-after-free in copy-on-select
+
+- Commit: `8eaee4d95` (Fix use-after-free in copy-on-select)
+- Branch: `fix-copy-on-select-uaf` (manaflow-ai/ghostty#36, pending merge)
+- Files:
+  - `src/Surface.zig`
+- Summary:
+  - Fixes a use-after-free in `setSelection()`. The old code called `Screen.select()` which freed tracked pins via `old.deinit()`, then compared the new selection against the freed `prev` pointer via `eql()`. Since freed memory usually retains old values, `eql()` returned true and `copySelectionToClipboards` was silently skipped — producing the one-character-paste symptom (cmux #2664).
+  - The fix evaluates `eql()` BEFORE `Screen.select()` frees the old pins.
+  - Additionally, copies the final selection to the clipboard directly on mouse-up (left-button release) to guarantee the clipboard is always up-to-date at the end of a drag selection.
 
 ## Upstreamed fork changes
 


### PR DESCRIPTION
## Summary

- Override `copy-on-select = clipboard` so selecting text copies to the system clipboard (Cmd+V works)
- Update ghostty submodule to include fix for use-after-free that silently skipped clipboard writes
- Update `docs/ghostty-fork.md` with section 8 documenting the ghostty fork change

## Problem

Two issues combined to break copy-on-select after PR #2420:

1. **PR #2420 removed the `copy-on-select = false` override**, activating Ghostty's default of `.true`. This exposed a latent use-after-free bug in Ghostty's `setSelection()` where `Screen.select()` frees old tracked pins, then `eql()` dereferences the freed pointer. Since freed memory usually retains old values, `eql()` returns `true` and `copySelectionToClipboards` is silently skipped.

2. **Even when copy-on-select fires**, `.true` writes to a private named pasteboard (`com.mitchellh.ghostty.selection`), not `NSPasteboard.general`. Cmd+V doesn't paste the selection.

## Fix

- **Ghostty fork** (manaflow-ai/ghostty#36): Bypass `setSelection()` in the mouse release handler and call `copySelectionToClipboards` directly, fixing the use-after-free.
- **cmux** (this PR): Override `copy-on-select = clipboard` so selections write to the system clipboard.

## Dependencies

This PR includes the ghostty submodule SHA update pointing to the fix commit. The ghostty fork PR (manaflow-ai/ghostty#36) should be merged first.

Fixes #2664

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force copy-on-select to use the macOS system clipboard in both primary and fallback init paths, and update the `ghostty` fork with a use-after-free fix so selections always copy. Cmd+V now reliably pastes selected text.

- **Bug Fixes**
  - Apply `copy-on-select = clipboard` in both config init paths so selections write to `NSPasteboard.general` instead of `com.mitchellh.ghostty.selection`.

- **Dependencies**
  - Update `ghostty` submodule to include the copy-on-select UAF fix and a final copy on mouse-up, preventing silent clipboard skips.

<sup>Written for commit ca436bed61f029dd651be162335e3782c22cd005. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copy-on-select now reliably writes to the macOS system clipboard during startup and fallback paths.
  * Resolved a selection stability issue and a use-after-free that could prevent or corrupt clipboard copy at end of drag selections; selection is now copied correctly on mouse-up.

* **Documentation**
  * Updated fork docs to describe the copy-on-select fix and the selection stability improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->