### PR TITLE
Fix terminal selection autoscroll past viewport edge

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7188,11 +7188,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let surface = surface else { return }
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
-        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         // Only update mouse position on the first click to prevent unwanted cursor
         // movement during double-click selection (issue #1698)
         if event.clickCount == 1 {
-            ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+            ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
         }
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
     }
@@ -7939,18 +7938,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
-        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         ghostty_surface_mouse_pos(
             surface,
-            point.x,
-            bounds.height - point.y,
+            eventPoint.x,
+            bounds.height - eventPoint.y,
             hoverModsFromFlags(
                 event.modifierFlags,
                 suppressCommandPathHover: suppressCommandPathHover
             )
         )
         updateWordPathHover(
-            at: point,
+            at: eventPoint,
             cmdHeld: event.modifierFlags.contains(.command),
             suppressPathHover: suppressCommandPathHover
         )
@@ -7963,18 +7961,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
-        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
         ghostty_surface_mouse_pos(
             surface,
-            point.x,
-            bounds.height - point.y,
+            eventPoint.x,
+            bounds.height - eventPoint.y,
             hoverModsFromFlags(
                 event.modifierFlags,
                 suppressCommandPathHover: suppressCommandPathHover
             )
         )
         updateWordPathHover(
-            at: point,
+            at: eventPoint,
             cmdHeld: event.modifierFlags.contains(.command),
             suppressPathHover: suppressCommandPathHover
         )
@@ -8013,8 +8010,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let surface = surface else { return }
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
-        let point = preferredPointerPoint(from: eventPoint) ?? eventPoint
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, modsFromEvent(event))
+        // Forward the raw drag coordinates, including out-of-bounds positions.
+        // Selection auto-scroll depends on libghostty observing the pointer leave
+        // the viewport rather than a cached in-bounds hover point.
+        ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
     }
 
     override func scrollWheel(with event: NSEvent) {


### PR DESCRIPTION
Fixes #2705

Investigation started from the reported #2379 / Ghostty 1.3.0 focus-transfer suspicion, but the regression turned out to be in cmux's later cmd-hover work from #2579. That change introduced `preferredPointerPoint(...)` and reused its cached in-bounds fallback in the real mouse input path.

When a selection drag crossed the top or bottom edge of the terminal pane, `mouseDragged` stopped forwarding the raw out-of-bounds coordinates to libghostty and instead kept reusing the last in-bounds hover point. That prevented libghostty from ever observing the pointer leave the viewport, so selection autoscroll never started.

This change narrows the fallback behavior back to hover/path-resolution use only and restores raw event coordinates for actual mouse input forwarding (`mouseDown`, `mouseMoved`, `mouseEntered`, `mouseDragged`). That preserves the cmd-hover/path-resolution behavior from #2579 while allowing legitimate selection drags to extend through scrollback again.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches mouse event forwarding in `GhosttyTerminalView`, so regressions could affect selection, hover, or pointer interactions. Scope is small and primarily swaps coordinate source back to raw event points to fix edge/out-of-bounds behavior.
> 
> **Overview**
> Fixes selection autoscroll when dragging beyond the terminal viewport by **stopping use of `preferredPointerPoint(...)`’s in-bounds fallback** for real mouse input forwarding.
> 
> `mouseDown`, `mouseMoved`, `mouseEntered`, and `mouseDragged` now send raw `eventPoint` coordinates to `ghostty_surface_mouse_pos` (and hover updates), allowing libghostty to observe out-of-bounds drags and trigger auto-scroll while keeping the cached point logic for command-hover/path resolution only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d576d913e179bd3613ddf5cd6c143a89a241f84a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores selection autoscroll when dragging beyond the terminal viewport. Fixes #2705 by forwarding raw mouse coordinates to libghostty instead of a cached in-bounds hover point.

- **Bug Fixes**
  - Send unmodified coordinates for `mouseDown`, `mouseMoved`, `mouseEntered`, `mouseDragged` (including out-of-bounds).
  - Limit `preferredPointerPoint(...)` fallback to hover/path-resolution only, preserving cmd-hover behavior from #2579.

<sup>Written for commit d576d913e179bd3613ddf5cd6c143a89a241f84a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mouse coordinate accuracy in the terminal view by refining how pointer positions are calculated and forwarded during mouse interactions (clicks, drags, and movement).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->