### PR TITLE
Suppress right-edge scroll bar on TUI alt-screen and add disable setting (fixes 2728)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87391,6 +87391,108 @@
           }
         }
       }
+    },
+    "contextMenu.workspaceSettings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース設定"
+          }
+        }
+      }
+    },
+    "contextMenu.workspaceSettings.hideTerminalScrollBar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Terminal Scroll Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのスクロールバーを隠す"
+          }
+        }
+      }
+    },
+    "settings.section.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Terminal Scroll Bar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルのスクロールバーを表示"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右端のターミナルスクロールバーを全体で非表示にします。変更はすぐに反映され、再起動後も保持されます。"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルのスクロールバックでは右端のターミナルスクロールバーを表示します。cmux は代替画面系の TUI では自動的に隠し、ワークスペースごとにも無効化できます。"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5810,7 +5810,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         var refreshedCount = 0
         forEachTerminalPanel { terminalPanel in
             terminalPanel.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
-            terminalPanel.hostedView.reconcileGeometryNow()
             terminalPanel.surface.forceRefresh(reason: "appDelegate.refreshAfterGhosttyConfigReload")
             refreshedCount += 1
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9940,6 +9940,7 @@ struct VerticalTabsSidebar: View {
         let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
             ($0.element.id, $0.offset)
         })
+        let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
         let orderedSelectedTabs = tabs.filter { selectedTabIds.contains($0.id) }
         let selectedContextTargetIds = orderedSelectedTabs.map(\.id)
         let selectedRemoteContextMenuTargets = orderedSelectedTabs.filter { $0.isRemoteWorkspace }
@@ -9969,6 +9970,10 @@ struct VerticalTabsSidebar: View {
                                 let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedRemoteContextMenuWorkspaceIds
                                     : (tab.isRemoteWorkspace ? [tab.id] : [])
+                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
+                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
+                                        tabsById[workspaceId]?.terminalScrollBarHidden == true
+                                    }
                                 let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
                                     ? allSelectedRemoteContextMenuTargetsConnecting
                                     : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
@@ -10019,6 +10024,7 @@ struct VerticalTabsSidebar: View {
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
@@ -12427,6 +12433,7 @@ private struct TabItemView: View, Equatable {
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
+        lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
@@ -12457,6 +12464,7 @@ private struct TabItemView: View, Equatable {
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
     let contextMenuWorkspaceIds: [UUID]
+    let allContextMenuWorkspacesHideTerminalScrollBar: Bool
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
@@ -13277,12 +13285,15 @@ private struct TabItemView: View, Equatable {
 
         Menu(String(localized: "contextMenu.workspaceSettings", defaultValue: "Workspace Settings")) {
             Button {
-                toggleWorkspaceTerminalScrollBarHidden(targetIds: targetIds)
+                toggleWorkspaceTerminalScrollBarHidden(
+                    targetIds: targetIds,
+                    currentlyHidden: allContextMenuWorkspacesHideTerminalScrollBar
+                )
             } label: {
                 Label {
                     Text(String(localized: "contextMenu.workspaceSettings.hideTerminalScrollBar", defaultValue: "Hide Terminal Scroll Bar"))
                 } icon: {
-                    if allTargetWorkspacesHideTerminalScrollBar(in: targetIds) {
+                    if allContextMenuWorkspacesHideTerminalScrollBar {
                         Image(systemName: "checkmark")
                     }
                 }
@@ -13992,16 +14003,8 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private func allTargetWorkspacesHideTerminalScrollBar(in targetIds: [UUID]) -> Bool {
-        let workspaces = targetIds.compactMap { targetId in
-            tabManager.tabs.first(where: { $0.id == targetId })
-        }
-        guard !workspaces.isEmpty else { return false }
-        return workspaces.allSatisfy { $0.terminalScrollBarHidden }
-    }
-
-    private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
-        let hideScrollBar = !allTargetWorkspacesHideTerminalScrollBar(in: targetIds)
+    private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID], currentlyHidden: Bool) {
+        let hideScrollBar = !currentlyHidden
         for targetId in targetIds {
             tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13275,6 +13275,20 @@ private struct TabItemView: View, Equatable {
             .disabled(allRemoteContextMenuTargetsDisconnected)
         }
 
+        Menu(String(localized: "contextMenu.workspaceSettings", defaultValue: "Workspace Settings")) {
+            Button {
+                toggleWorkspaceTerminalScrollBarHidden(targetIds: targetIds)
+            } label: {
+                Label {
+                    Text(String(localized: "contextMenu.workspaceSettings.hideTerminalScrollBar", defaultValue: "Hide Terminal Scroll Bar"))
+                } icon: {
+                    if allTargetWorkspacesHideTerminalScrollBar(in: targetIds) {
+                        Image(systemName: "checkmark")
+                    }
+                }
+            }
+        }
+
         Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
             if tab.customColor != nil {
                 Button {
@@ -13975,6 +13989,21 @@ private struct TabItemView: View, Equatable {
     private func applyTabColor(_ hex: String?, targetIds: [UUID]) {
         for targetId in targetIds {
             tabManager.setTabColor(tabId: targetId, color: hex)
+        }
+    }
+
+    private func allTargetWorkspacesHideTerminalScrollBar(in targetIds: [UUID]) -> Bool {
+        let workspaces = targetIds.compactMap { targetId in
+            tabManager.tabs.first(where: { $0.id == targetId })
+        }
+        guard !workspaces.isEmpty else { return false }
+        return workspaces.allSatisfy { $0.terminalScrollBarHidden }
+    }
+
+    private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
+        let hideScrollBar = !allTargetWorkspacesHideTerminalScrollBar(in: targetIds)
+        for targetId in targetIds {
+            tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9937,7 +9937,6 @@ struct VerticalTabsSidebar: View {
         let canCloseWorkspace = workspaceCount > 1
         let workspaceNumberShortcut = self.workspaceNumberShortcut
         let tabItemSettings = tabItemSettingsStore.snapshot
-        let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
         let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
             ($0.element.id, $0.offset)
         })
@@ -9967,10 +9966,6 @@ struct VerticalTabsSidebar: View {
                                 let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedContextTargetIds
                                     : [tab.id]
-                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
-                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
-                                        tabsById[workspaceId]?.terminalScrollBarHidden == true
-                                    }
                                 let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedRemoteContextMenuWorkspaceIds
                                     : (tab.isRemoteWorkspace ? [tab.id] : [])
@@ -10024,7 +10019,6 @@ struct VerticalTabsSidebar: View {
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
@@ -12433,7 +12427,6 @@ private struct TabItemView: View, Equatable {
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
-        lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
@@ -12464,7 +12457,6 @@ private struct TabItemView: View, Equatable {
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
     let contextMenuWorkspaceIds: [UUID]
-    let allContextMenuWorkspacesHideTerminalScrollBar: Bool
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
@@ -12697,6 +12689,10 @@ private struct TabItemView: View, Equatable {
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {
         settings.visibleAuxiliaryDetails
+    }
+
+    private var allContextMenuWorkspacesHideTerminalScrollBar: Bool {
+        allWorkspacesHideTerminalScrollBar(targetIds: contextMenuWorkspaceIds)
     }
 
     var body: some View {
@@ -13175,6 +13171,14 @@ private struct TabItemView: View, Equatable {
         guard !remoteContextMenuWorkspaceIds.isEmpty else { return [] }
         return remoteContextMenuWorkspaceIds.compactMap { workspaceId in
             tabManager.tabs.first(where: { $0.id == workspaceId })
+        }
+    }
+
+    private func allWorkspacesHideTerminalScrollBar(targetIds: [UUID]) -> Bool {
+        guard !targetIds.isEmpty else { return false }
+        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
+        return targetIds.allSatisfy { targetId in
+            workspacesById[targetId]?.terminalScrollBarHidden == true
         }
     }
 
@@ -14001,10 +14005,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
-        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
-        let currentlyHidden = !targetIds.isEmpty && targetIds.allSatisfy { targetId in
-            workspacesById[targetId]?.terminalScrollBarHidden == true
-        }
+        let currentlyHidden = allWorkspacesHideTerminalScrollBar(targetIds: targetIds)
         let hideScrollBar = !currentlyHidden
         for targetId in targetIds {
             tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9966,6 +9966,10 @@ struct VerticalTabsSidebar: View {
                                 let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedContextTargetIds
                                     : [tab.id]
+                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
+                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
+                                        tabsById[workspaceId]?.terminalScrollBarHidden == true
+                                    }
                                 let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedRemoteContextMenuWorkspaceIds
                                     : (tab.isRemoteWorkspace ? [tab.id] : [])
@@ -10019,6 +10023,7 @@ struct VerticalTabsSidebar: View {
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
@@ -12427,6 +12432,7 @@ private struct TabItemView: View, Equatable {
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
+        lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
@@ -12457,6 +12463,7 @@ private struct TabItemView: View, Equatable {
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
     let contextMenuWorkspaceIds: [UUID]
+    let allContextMenuWorkspacesHideTerminalScrollBar: Bool
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
@@ -13170,19 +13177,11 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private func allTargetWorkspacesHideTerminalScrollBar(_ targetIds: [UUID]) -> Bool {
-        guard !targetIds.isEmpty else { return false }
-        return targetIds.allSatisfy { targetId in
-            tabManager.tabs.first(where: { $0.id == targetId })?.terminalScrollBarHidden == true
-        }
-    }
-
     @ViewBuilder
     private var workspaceContextMenu: some View {
         let targetIds = contextMenuWorkspaceIds
         let isMulti = targetIds.count > 1
         let tabColorPalette = WorkspaceTabColorSettings.palette()
-        let hidesTerminalScrollBarForAllTargets = allTargetWorkspacesHideTerminalScrollBar(targetIds)
         let shouldPin = !tab.isPinned
         let reconnectLabel = contextMenuLabel(
             multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
@@ -13290,7 +13289,7 @@ private struct TabItemView: View, Equatable {
                 Label {
                     Text(String(localized: "contextMenu.workspaceSettings.hideTerminalScrollBar", defaultValue: "Hide Terminal Scroll Bar"))
                 } icon: {
-                    if hidesTerminalScrollBarForAllTargets {
+                    if allContextMenuWorkspacesHideTerminalScrollBar {
                         Image(systemName: "checkmark")
                     }
                 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9940,7 +9940,6 @@ struct VerticalTabsSidebar: View {
         let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
             ($0.element.id, $0.offset)
         })
-        let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
         let orderedSelectedTabs = tabs.filter { selectedTabIds.contains($0.id) }
         let selectedContextTargetIds = orderedSelectedTabs.map(\.id)
         let selectedRemoteContextMenuTargets = orderedSelectedTabs.filter { $0.isRemoteWorkspace }
@@ -9970,10 +9969,6 @@ struct VerticalTabsSidebar: View {
                                 let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
                                     ? selectedRemoteContextMenuWorkspaceIds
                                     : (tab.isRemoteWorkspace ? [tab.id] : [])
-                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
-                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
-                                        tabsById[workspaceId]?.terminalScrollBarHidden == true
-                                    }
                                 let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
                                     ? allSelectedRemoteContextMenuTargetsConnecting
                                     : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
@@ -10024,7 +10019,6 @@ struct VerticalTabsSidebar: View {
                                     draggedTabId: $draggedTabId,
                                     dropIndicator: $dropIndicator,
                                     contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
@@ -12433,7 +12427,6 @@ private struct TabItemView: View, Equatable {
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
-        lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
@@ -12464,7 +12457,6 @@ private struct TabItemView: View, Equatable {
     @Binding var draggedTabId: UUID?
     @Binding var dropIndicator: SidebarDropIndicator?
     let contextMenuWorkspaceIds: [UUID]
-    let allContextMenuWorkspacesHideTerminalScrollBar: Bool
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
@@ -13178,11 +13170,19 @@ private struct TabItemView: View, Equatable {
         }
     }
 
+    private func allTargetWorkspacesHideTerminalScrollBar(_ targetIds: [UUID]) -> Bool {
+        guard !targetIds.isEmpty else { return false }
+        return targetIds.allSatisfy { targetId in
+            tabManager.tabs.first(where: { $0.id == targetId })?.terminalScrollBarHidden == true
+        }
+    }
+
     @ViewBuilder
     private var workspaceContextMenu: some View {
         let targetIds = contextMenuWorkspaceIds
         let isMulti = targetIds.count > 1
         let tabColorPalette = WorkspaceTabColorSettings.palette()
+        let hidesTerminalScrollBarForAllTargets = allTargetWorkspacesHideTerminalScrollBar(targetIds)
         let shouldPin = !tab.isPinned
         let reconnectLabel = contextMenuLabel(
             multi: String(localized: "contextMenu.reconnectWorkspaces", defaultValue: "Reconnect Workspaces"),
@@ -13290,7 +13290,7 @@ private struct TabItemView: View, Equatable {
                 Label {
                     Text(String(localized: "contextMenu.workspaceSettings.hideTerminalScrollBar", defaultValue: "Hide Terminal Scroll Bar"))
                 } icon: {
-                    if allContextMenuWorkspacesHideTerminalScrollBar {
+                    if hidesTerminalScrollBarForAllTargets {
                         Image(systemName: "checkmark")
                     }
                 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13285,10 +13285,7 @@ private struct TabItemView: View, Equatable {
 
         Menu(String(localized: "contextMenu.workspaceSettings", defaultValue: "Workspace Settings")) {
             Button {
-                toggleWorkspaceTerminalScrollBarHidden(
-                    targetIds: targetIds,
-                    currentlyHidden: allContextMenuWorkspacesHideTerminalScrollBar
-                )
+                toggleWorkspaceTerminalScrollBarHidden(targetIds: targetIds)
             } label: {
                 Label {
                     Text(String(localized: "contextMenu.workspaceSettings.hideTerminalScrollBar", defaultValue: "Hide Terminal Scroll Bar"))
@@ -14003,7 +14000,11 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID], currentlyHidden: Bool) {
+    private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
+        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
+        let currentlyHidden = !targetIds.isEmpty && targetIds.allSatisfy { targetId in
+            workspacesById[targetId]?.terminalScrollBarHidden == true
+        }
         let hideScrollBar = !currentlyHidden
         for targetId in targetIds {
             tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9910,6 +9910,7 @@ struct VerticalTabsSidebar: View {
     @State private var draggedTabId: UUID?
     @State private var dropIndicator: SidebarDropIndicator?
     @State private var frozenTabItemPresentation: SidebarTabItemPresentationSnapshot?
+    @State private var terminalScrollBarVisibilityGeneration: UInt64 = 0
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
 
@@ -9932,6 +9933,7 @@ struct VerticalTabsSidebar: View {
     }
 
     var body: some View {
+        let _ = terminalScrollBarVisibilityGeneration
         let tabs = tabManager.tabs
         let workspaceCount = tabs.count
         let canCloseWorkspace = workspaceCount > 1
@@ -10145,6 +10147,19 @@ struct VerticalTabsSidebar: View {
             dlog("sidebar.dragClear tab=\(debugShortSidebarTabId(draggedTabId)) reason=\(reason)")
 #endif
             draggedTabId = nil
+        }
+        .onReceive(
+            NotificationCenter.default.publisher(for: Workspace.terminalScrollBarHiddenDidChangeNotification)
+                .receive(on: RunLoop.main)
+        ) { notification in
+            guard let workspace = notification.object as? Workspace,
+                  tabManager.tabs.contains(where: { $0 === workspace }) else {
+                return
+            }
+
+            // Workspace scrollbar visibility changes do not publish on TabManager.tabs,
+            // so bump a local generation to refresh the precomputed context-menu state.
+            terminalScrollBarVisibilityGeneration &+= 1
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9937,6 +9937,7 @@ struct VerticalTabsSidebar: View {
         let canCloseWorkspace = workspaceCount > 1
         let workspaceNumberShortcut = self.workspaceNumberShortcut
         let tabItemSettings = tabItemSettingsStore.snapshot
+        let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
         let tabIndexById = Dictionary(uniqueKeysWithValues: tabs.enumerated().map {
             ($0.element.id, $0.offset)
         })

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9944,6 +9944,9 @@ struct VerticalTabsSidebar: View {
         let selectedContextTargetIds = orderedSelectedTabs.map(\.id)
         let selectedRemoteContextMenuTargets = orderedSelectedTabs.filter { $0.isRemoteWorkspace }
         let selectedRemoteContextMenuWorkspaceIds = selectedRemoteContextMenuTargets.map(\.id)
+        let workspaceTerminalScrollBarHiddenById = Dictionary(
+            uniqueKeysWithValues: tabs.map { ($0.id, $0.terminalScrollBarHidden) }
+        )
         let allSelectedRemoteContextMenuTargetsConnecting = !selectedRemoteContextMenuTargets.isEmpty &&
             selectedRemoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .connecting }
         let allSelectedRemoteContextMenuTargetsDisconnected = !selectedRemoteContextMenuTargets.isEmpty &&
@@ -9975,6 +9978,10 @@ struct VerticalTabsSidebar: View {
                                 let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
                                     ? allSelectedRemoteContextMenuTargetsDisconnected
                                     : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
+                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
+                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
+                                        workspaceTerminalScrollBarHiddenById[workspaceId] == true
+                                    }
                                 let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
                                 let liveLatestNotificationText: String? = {
                                     guard showsSidebarNotificationMessage,
@@ -10022,6 +10029,7 @@ struct VerticalTabsSidebar: View {
                                     remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
                                     allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
                                     allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
                                     settings: tabItemSettings,
                                     livePresentation: livePresentation,
                                     frozenPresentation: $frozenTabItemPresentation
@@ -12430,6 +12438,7 @@ private struct TabItemView: View, Equatable {
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
         lhs.allRemoteContextMenuTargetsDisconnected == rhs.allRemoteContextMenuTargetsDisconnected &&
+        lhs.allContextMenuWorkspacesHideTerminalScrollBar == rhs.allContextMenuWorkspacesHideTerminalScrollBar &&
         lhs.settings == rhs.settings
     }
 
@@ -12460,6 +12469,7 @@ private struct TabItemView: View, Equatable {
     let remoteContextMenuWorkspaceIds: [UUID]
     let allRemoteContextMenuTargetsConnecting: Bool
     let allRemoteContextMenuTargetsDisconnected: Bool
+    let allContextMenuWorkspacesHideTerminalScrollBar: Bool
     let settings: SidebarTabItemSettingsSnapshot
     let livePresentation: SidebarTabItemPresentationSnapshot
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
@@ -12689,10 +12699,6 @@ private struct TabItemView: View, Equatable {
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {
         settings.visibleAuxiliaryDetails
-    }
-
-    private var allContextMenuWorkspacesHideTerminalScrollBar: Bool {
-        allWorkspacesHideTerminalScrollBar(targetIds: contextMenuWorkspaceIds)
     }
 
     var body: some View {
@@ -13171,14 +13177,6 @@ private struct TabItemView: View, Equatable {
         guard !remoteContextMenuWorkspaceIds.isEmpty else { return [] }
         return remoteContextMenuWorkspaceIds.compactMap { workspaceId in
             tabManager.tabs.first(where: { $0.id == workspaceId })
-        }
-    }
-
-    private func allWorkspacesHideTerminalScrollBar(targetIds: [UUID]) -> Bool {
-        guard !targetIds.isEmpty else { return false }
-        let workspacesById = Dictionary(uniqueKeysWithValues: tabManager.tabs.map { ($0.id, $0) })
-        return targetIds.allSatisfy { targetId in
-            workspacesById[targetId]?.terminalScrollBarHidden == true
         }
     }
 
@@ -14005,7 +14003,9 @@ private struct TabItemView: View, Equatable {
     }
 
     private func toggleWorkspaceTerminalScrollBarHidden(targetIds: [UUID]) {
-        let currentlyHidden = allWorkspacesHideTerminalScrollBar(targetIds: targetIds)
+        let currentlyHidden = !targetIds.isEmpty && targetIds.allSatisfy { targetId in
+            tabManager.tabs.first(where: { $0.id == targetId })?.terminalScrollBarHidden == true
+        }
         let hideScrollBar = !currentlyHidden
         for targetId in targetIds {
             tabManager.setWorkspaceTerminalScrollBarHidden(tabId: targetId, hidden: hideScrollBar)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8544,6 +8544,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var activeImageTransferOperation: TerminalImageTransferOperation?
     private var activeImageTransferCancelHandler: (() -> Void)?
     private var lastSearchOverlayStateID: ObjectIdentifier?
+    private weak var cachedOwningWorkspace: Workspace?
     private var searchOverlayMutationGeneration: UInt64 = 0
     private var observers: [NSObjectProtocol] = []
     private var windowObservers: [NSObjectProtocol] = []
@@ -9062,6 +9063,14 @@ final class GhosttySurfaceScrollView: NSView {
             self?.handlePreferredScrollerStyleChange()
         })
 
+        observers.append(NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleTerminalScrollBarPreferenceChange()
+        })
+
     }
 
     required init?(coder: NSCoder) {
@@ -9161,10 +9170,14 @@ final class GhosttySurfaceScrollView: NSView {
         CATransaction.setDisableActions(true)
         defer { CATransaction.commit() }
 
+        let didScrollbarAppearanceChange = synchronizeScrollbarAppearance()
         let previousSurfaceSize = surfaceView.frame.size
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         _ = setFrameIfNeeded(scrollView, to: bounds)
-        let targetSize = scrollView.bounds.size
+        let targetSize = CGSize(
+            width: max(0, scrollView.bounds.width - terminalScrollBarReservedWidth()),
+            height: scrollView.bounds.height
+        )
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
@@ -9202,6 +9215,9 @@ final class GhosttySurfaceScrollView: NSView {
         }
         // NSScrollView can defer clip-view/content-size updates until its own layout pass,
         // which makes interactive width changes arrive a queue turn late on Sequoia.
+        if didScrollbarAppearanceChange {
+            scrollView.tile()
+        }
         scrollView.layoutSubtreeIfNeeded()
         updateNotificationRingPath()
         updateFlashPath(style: lastFlashStyle)
@@ -11130,10 +11146,7 @@ final class GhosttySurfaceScrollView: NSView {
     /// regions such as scrollbar space) when telling libghostty the terminal size.
     @discardableResult
     private func synchronizeCoreSurface() -> Bool {
-        // Reserving extra overlay-scroller gutter here causes AppKit and libghostty to fight
-        // over terminal columns during split churn. The width can flap by one scrollbar gutter,
-        // which redraws the shell prompt multiple times on Cmd+D. Favor stable columns.
-        let width = max(0, scrollView.contentSize.width)
+        let width = max(0, surfaceView.frame.width)
         let height = surfaceView.frame.height
         guard width > 0, height > 0 else { return false }
         return surfaceView.pushTargetSurfaceSize(CGSize(width: width, height: height))
@@ -11265,23 +11278,36 @@ final class GhosttySurfaceScrollView: NSView {
         guard let scrollbar = notification.userInfo?[GhosttyNotificationKey.scrollbar] as? GhosttyScrollbar else {
             return
         }
+        let wasVisible = shouldShowTerminalScrollBar()
         if pendingExplicitWheelScroll {
             userScrolledAwayFromBottom = scrollbar.offset + scrollbar.len < scrollbar.total
             allowExplicitScrollbarSync = true
             pendingExplicitWheelScroll = false
         }
         surfaceView.scrollbar = scrollbar
+        let isVisible = shouldShowTerminalScrollBar()
+        if wasVisible != isVisible {
+            _ = synchronizeGeometryAndContent()
+            return
+        }
         synchronizeScrollView()
     }
 
-    private func synchronizeScrollbarAppearance() {
-        scrollView.hasVerticalScroller = GhosttyApp.shared.scrollbarVisibility() != .never
+    @discardableResult
+    private func synchronizeScrollbarAppearance() -> Bool {
+        let shouldShowScrollBar = shouldShowTerminalScrollBar()
+        let didChange =
+            scrollView.hasVerticalScroller != shouldShowScrollBar ||
+            scrollView.autohidesScrollers != false ||
+            scrollView.scrollerStyle != .overlay
+        scrollView.hasVerticalScroller = shouldShowScrollBar
         // Mirror upstream Ghostty: keep overlay scrollers even when the
         // system preference is legacy so terminal content never sits beneath a
         // permanently reserved scrollbar gutter.
         scrollView.autohidesScrollers = false
         scrollView.scrollerStyle = .overlay
         updateTrackingAreas()
+        return didChange
     }
 
     private func handlePreferredScrollerStyleChange() {
@@ -11292,13 +11318,18 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
-        synchronizeScrollbarAppearance()
+        _ = synchronizeGeometryAndContent()
+    }
 
-        // Retile just the scroll view so contentSize reflects the current
-        // scrollbar mode without perturbing viewport origin or hosted view
-        // geometry; the broader reconcile path caused visible content glitches.
-        scrollView.tile()
-        _ = synchronizeCoreSurface()
+    private func handleTerminalScrollBarPreferenceChange() {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.handleTerminalScrollBarPreferenceChange()
+            }
+            return
+        }
+
+        _ = synchronizeGeometryAndContent()
     }
 
     private func documentHeight() -> CGFloat {
@@ -11310,6 +11341,42 @@ final class GhosttySurfaceScrollView: NSView {
             return documentGridHeight + padding
         }
         return contentHeight
+    }
+
+    private func owningWorkspace() -> Workspace? {
+        let workspaceId = surfaceView.terminalSurface?.tabId
+        if let cachedOwningWorkspace,
+           cachedOwningWorkspace.id == workspaceId {
+            return cachedOwningWorkspace
+        }
+        let workspace = surfaceView.terminalSurface?.owningWorkspace()
+        cachedOwningWorkspace = workspace
+        return workspace
+    }
+
+    private func terminalScrollBarAllowedBySettings() -> Bool {
+        guard GhosttyApp.shared.scrollbarVisibility() != .never else { return false }
+        guard TerminalScrollBarSettings.isVisible() else { return false }
+        guard owningWorkspace()?.terminalScrollBarHidden != true else { return false }
+        return true
+    }
+
+    private func surfaceHasScrollback() -> Bool {
+        guard let scrollbar = surfaceView.scrollbar else { return false }
+        // Embedded Ghostty exposes alternate-screen TUIs to the wrapper as a
+        // viewport with no additional scrollback (`total <= len`). Treat that
+        // as the signal to suppress the overlay scrollbar so full-screen apps
+        // like nvim/htop do not pin it on top of the rightmost cell column.
+        return scrollbar.total > scrollbar.len
+    }
+
+    private func shouldShowTerminalScrollBar() -> Bool {
+        terminalScrollBarAllowedBySettings() && surfaceHasScrollback()
+    }
+
+    private func terminalScrollBarReservedWidth() -> CGFloat {
+        guard shouldShowTerminalScrollBar() else { return 0 }
+        return ceil(NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay))
     }
 }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9064,7 +9064,7 @@ final class GhosttySurfaceScrollView: NSView {
         })
 
         observers.append(NotificationCenter.default.addObserver(
-            forName: UserDefaults.didChangeNotification,
+            forName: TerminalScrollBarSettings.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
@@ -11278,14 +11278,14 @@ final class GhosttySurfaceScrollView: NSView {
         guard let scrollbar = notification.userInfo?[GhosttyNotificationKey.scrollbar] as? GhosttyScrollbar else {
             return
         }
-        let wasVisible = shouldShowTerminalScrollBar()
+        let wasVisible = scrollView.hasVerticalScroller
         if pendingExplicitWheelScroll {
             userScrolledAwayFromBottom = scrollbar.offset + scrollbar.len < scrollbar.total
             allowExplicitScrollbarSync = true
             pendingExplicitWheelScroll = false
         }
         surfaceView.scrollbar = scrollbar
-        let isVisible = shouldShowTerminalScrollBar()
+        let isVisible = terminalScrollBarAllowedBySettings() && scrollbar.total > scrollbar.len
         if wasVisible != isVisible {
             _ = synchronizeGeometryAndContent()
             return
@@ -11318,7 +11318,12 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
-        _ = synchronizeGeometryAndContent()
+        synchronizeScrollbarAppearance()
+
+        // Retile just the scroll view so contentSize reflects the current
+        // scroller preference without perturbing hosted terminal geometry.
+        scrollView.tile()
+        _ = synchronizeCoreSurface()
     }
 
     private func handleTerminalScrollBarPreferenceChange() {
@@ -11375,7 +11380,9 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func terminalScrollBarReservedWidth() -> CGFloat {
-        guard shouldShowTerminalScrollBar() else { return 0 }
+        // Keep the PTY width stable while scrollback appears/disappears so
+        // entering alternate-screen TUIs does not reflow the surface.
+        guard terminalScrollBarAllowedBySettings() else { return 0 }
         return ceil(NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay))
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9179,10 +9179,7 @@ final class GhosttySurfaceScrollView: NSView {
         let previousSurfaceSize = surfaceView.frame.size
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         _ = setFrameIfNeeded(scrollView, to: bounds)
-        let targetSize = CGSize(
-            width: max(0, scrollView.bounds.width - terminalScrollBarReservedWidth()),
-            height: scrollView.bounds.height
-        )
+        let targetSize = scrollView.bounds.size
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
@@ -9403,8 +9400,9 @@ final class GhosttySurfaceScrollView: NSView {
         let workspace = terminalSurface.owningWorkspace()
         cachedOwningWorkspace = workspace
         updateWorkspaceTerminalScrollBarObserver(workspace)
-        // Preserve the bootstrap 800x600 surface until the host has real bounds.
-        guard bounds.width > 0, bounds.height > 0 else { return }
+        // Preserve the bootstrap 800x600 surface until portal reattach churn
+        // has produced a real host size instead of a transient 1x1 placeholder.
+        guard bounds.width > 1, bounds.height > 1 else { return }
         _ = synchronizeGeometryAndContent()
     }
 
@@ -11417,12 +11415,6 @@ final class GhosttySurfaceScrollView: NSView {
         terminalScrollBarAllowedBySettings() && surfaceHasScrollback()
     }
 
-    private func terminalScrollBarReservedWidth() -> CGFloat {
-        // Keep the PTY width stable while scrollback appears/disappears so
-        // entering alternate-screen TUIs does not reflow the surface.
-        guard terminalScrollBarAllowedBySettings() else { return 0 }
-        return ceil(NSScroller.scrollerWidth(for: .regular, scrollerStyle: .overlay))
-    }
 }
 
 // MARK: - NSTextInputClient

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9403,6 +9403,7 @@ final class GhosttySurfaceScrollView: NSView {
         let workspace = terminalSurface.owningWorkspace()
         cachedOwningWorkspace = workspace
         updateWorkspaceTerminalScrollBarObserver(workspace)
+        _ = synchronizeGeometryAndContent()
     }
 
     func setFocusHandler(_ handler: (() -> Void)?) {
@@ -9841,7 +9842,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func refreshHostBackgroundAfterGhosttyConfigReload() {
-        synchronizeScrollbarAppearance()
+        _ = synchronizeGeometryAndContent()
         surfaceView.applySurfaceBackground()
         surfaceView.applyWindowBackgroundIfActive()
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11349,7 +11349,9 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func updateWorkspaceTerminalScrollBarObserver(_ workspace: Workspace?) {
-        guard observedWorkspaceTerminalScrollBar !== workspace || workspaceTerminalScrollBarObserver == nil else {
+        if let observedWorkspaceTerminalScrollBar,
+           observedWorkspaceTerminalScrollBar === workspace,
+           workspaceTerminalScrollBarObserver != nil {
             return
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9403,6 +9403,8 @@ final class GhosttySurfaceScrollView: NSView {
         let workspace = terminalSurface.owningWorkspace()
         cachedOwningWorkspace = workspace
         updateWorkspaceTerminalScrollBarObserver(workspace)
+        // Preserve the bootstrap 800x600 surface until the host has real bounds.
+        guard bounds.width > 0, bounds.height > 0 else { return }
         _ = synchronizeGeometryAndContent()
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11402,8 +11402,8 @@ final class GhosttySurfaceScrollView: NSView {
         return true
     }
 
-    private func surfaceHasScrollback() -> Bool {
-        guard let scrollbar = surfaceView.scrollbar else { return false }
+    private func surfaceHasScrollback() -> Bool? {
+        guard let scrollbar = surfaceView.scrollbar else { return nil }
         // Embedded Ghostty exposes alternate-screen TUIs to the wrapper as a
         // viewport with no additional scrollback (`total <= len`). Treat that
         // as the signal to suppress the overlay scrollbar so full-screen apps
@@ -11412,7 +11412,14 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private func shouldShowTerminalScrollBar() -> Bool {
-        terminalScrollBarAllowedBySettings() && surfaceHasScrollback()
+        guard terminalScrollBarAllowedBySettings() else { return false }
+        guard let hasScrollback = surfaceHasScrollback() else {
+            // Ghostty reports scrollback asynchronously. Until the first packet
+            // arrives, keep the scroller visible so restored/reattached
+            // surfaces with existing scrollback do not appear broken.
+            return true
+        }
+        return hasScrollback
     }
 
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11294,7 +11294,7 @@ final class GhosttySurfaceScrollView: NSView {
             pendingExplicitWheelScroll = false
         }
         surfaceView.scrollbar = scrollbar
-        let isVisible = terminalScrollBarAllowedBySettings() && scrollbar.total > scrollbar.len
+        let isVisible = shouldShowTerminalScrollBar()
         if wasVisible != isVisible {
             _ = synchronizeGeometryAndContent()
             return

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8545,8 +8545,10 @@ final class GhosttySurfaceScrollView: NSView {
     private var activeImageTransferCancelHandler: (() -> Void)?
     private var lastSearchOverlayStateID: ObjectIdentifier?
     private weak var cachedOwningWorkspace: Workspace?
+    private weak var observedWorkspaceTerminalScrollBar: Workspace?
     private var searchOverlayMutationGeneration: UInt64 = 0
     private var observers: [NSObjectProtocol] = []
+    private var workspaceTerminalScrollBarObserver: NSObjectProtocol?
     private var windowObservers: [NSObjectProtocol] = []
     private var scrollbarTrackingArea: NSTrackingArea?
     private var isLiveScrolling = false
@@ -9086,6 +9088,9 @@ final class GhosttySurfaceScrollView: NSView {
         )
 #endif
         observers.forEach { NotificationCenter.default.removeObserver($0) }
+        if let workspaceTerminalScrollBarObserver {
+            NotificationCenter.default.removeObserver(workspaceTerminalScrollBarObserver)
+        }
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         deferredSearchOverlayMutationWorkItem?.cancel()
         imageTransferIndicatorShowWorkItem?.cancel()
@@ -9395,6 +9400,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     func attachSurface(_ terminalSurface: TerminalSurface) {
         surfaceView.attachSurface(terminalSurface)
+        let workspace = terminalSurface.owningWorkspace()
+        cachedOwningWorkspace = workspace
+        updateWorkspaceTerminalScrollBarObserver(workspace)
     }
 
     func setFocusHandler(_ handler: (() -> Void)?) {
@@ -11337,6 +11345,29 @@ final class GhosttySurfaceScrollView: NSView {
         _ = synchronizeGeometryAndContent()
     }
 
+    private func updateWorkspaceTerminalScrollBarObserver(_ workspace: Workspace?) {
+        guard observedWorkspaceTerminalScrollBar !== workspace || workspaceTerminalScrollBarObserver == nil else {
+            return
+        }
+
+        if let workspaceTerminalScrollBarObserver {
+            NotificationCenter.default.removeObserver(workspaceTerminalScrollBarObserver)
+            self.workspaceTerminalScrollBarObserver = nil
+        }
+
+        observedWorkspaceTerminalScrollBar = workspace
+
+        guard let workspace else { return }
+
+        workspaceTerminalScrollBarObserver = NotificationCenter.default.addObserver(
+            forName: Workspace.terminalScrollBarHiddenDidChangeNotification,
+            object: workspace,
+            queue: .main
+        ) { [weak self] _ in
+            self?.handleTerminalScrollBarPreferenceChange()
+        }
+    }
+
     private func documentHeight() -> CGFloat {
         let contentHeight = scrollView.contentSize.height
         let cellHeight = surfaceView.cellSize.height
@@ -11352,10 +11383,12 @@ final class GhosttySurfaceScrollView: NSView {
         let workspaceId = surfaceView.terminalSurface?.tabId
         if let cachedOwningWorkspace,
            cachedOwningWorkspace.id == workspaceId {
+            updateWorkspaceTerminalScrollBarObserver(cachedOwningWorkspace)
             return cachedOwningWorkspace
         }
         let workspace = surfaceView.terminalSurface?.owningWorkspace()
         cachedOwningWorkspace = workspace
+        updateWorkspaceTerminalScrollBarObserver(workspace)
         return workspace
     }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1117,26 +1117,31 @@ final class CmuxSettingsFileStore {
             return
         }
 
+        var didMutateStoredValue = false
         switch value {
         case .bool(let next):
             let current = defaults.object(forKey: defaultsKey) as? Bool
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
         case .int(let next):
             let current = defaults.object(forKey: defaultsKey) as? Int
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
         case .double(let next):
             let current = defaults.object(forKey: defaultsKey) as? Double
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
         case .string(let next):
             let current = defaults.string(forKey: defaultsKey)
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
         case .nullableString(let next):
             let current = defaults.string(forKey: defaultsKey)
@@ -1146,17 +1151,24 @@ final class CmuxSettingsFileStore {
                 } else {
                     defaults.removeObject(forKey: defaultsKey)
                 }
+                didMutateStoredValue = true
             }
         case .stringArray(let next):
             let current = defaults.array(forKey: defaultsKey) as? [String]
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
         case .stringDictionary(let next):
             let current = defaults.dictionary(forKey: defaultsKey) as? [String: String]
             if current != next {
                 defaults.set(next, forKey: defaultsKey)
+                didMutateStoredValue = true
             }
+        }
+
+        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey, didMutateStoredValue {
+            TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
         }
 
         switch defaultsKey {
@@ -1199,6 +1211,10 @@ final class CmuxSettingsFileStore {
             defaults.set(value, forKey: defaultsKey)
         case .stringDictionary(let value):
             defaults.set(value, forKey: defaultsKey)
+        }
+
+        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey {
+            TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
         }
 
         switch defaultsKey {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -38,6 +38,7 @@ final class CmuxSettingsFileStore {
         "app.warnBeforeQuit",
         "app.renameSelectsExistingName",
         "app.commandPaletteSearchesAllSurfaces",
+        "terminal.showScrollBar",
         "notifications.dockBadge",
         "notifications.showInMenuBar",
         "notifications.unreadPaneRing",
@@ -348,6 +349,9 @@ final class CmuxSettingsFileStore {
         if let appSection = root["app"] as? [String: Any] {
             parseAppSection(appSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
+        if let terminalSection = root["terminal"] as? [String: Any] {
+            parseTerminalSection(terminalSection, sourcePath: sourcePath, snapshot: &snapshot)
+        }
         if let notificationsSection = root["notifications"] as? [String: Any] {
             parseNotificationsSection(notificationsSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
@@ -471,6 +475,18 @@ final class CmuxSettingsFileStore {
         }
         if let raw = jsonString(section["command"]) {
             snapshot.managedUserDefaults[NotificationSoundSettings.customCommandKey] = .string(raw)
+        }
+    }
+
+    private func parseTerminalSection(
+        _ section: [String: Any],
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        if let value = jsonBool(section["showScrollBar"]) {
+            snapshot.managedUserDefaults[TerminalScrollBarSettings.showScrollBarKey] = .bool(value)
+        } else if section.keys.contains("showScrollBar") {
+            logInvalid("terminal.showScrollBar", sourcePath: sourcePath)
         }
     }
 
@@ -1322,6 +1338,11 @@ final class CmuxSettingsFileStore {
                     "warnBeforeQuit": QuitWarningSettings.defaultWarnBeforeQuit,
                     "renameSelectsExistingName": CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus,
                     "commandPaletteSearchesAllSurfaces": CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces,
+                ],
+            ],
+            [
+                "terminal": [
+                    "showScrollBar": TerminalScrollBarSettings.defaultShowScrollBar,
                 ],
             ],
             [

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -333,6 +333,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customDescription: String?
     var customColor: String?
     var isPinned: Bool
+    var terminalScrollBarHidden: Bool?
     var currentDirectory: String
     var focusedPanelId: UUID?
     var layout: SessionWorkspaceLayoutSnapshot

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3561,6 +3561,11 @@ class TabManager: ObservableObject {
         tab.setCustomColor(color)
     }
 
+    func setWorkspaceTerminalScrollBarHidden(tabId: UUID, hidden: Bool) {
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        tab.setTerminalScrollBarHidden(hidden)
+    }
+
     func togglePin(tabId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let tab = tabs[index]
@@ -6730,6 +6735,7 @@ extension TabManager {
             hasher.combine(workspace.customDescription ?? "")
             hasher.combine(workspace.customColor ?? "")
             hasher.combine(workspace.isPinned)
+            hasher.combine(workspace.terminalScrollBarHidden)
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)
             hasher.combine(workspace.metadataBlocks.count)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6488,7 +6488,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
-    @Published var terminalScrollBarHidden: Bool = false
+    @Published private(set) var terminalScrollBarHidden: Bool = false
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -6633,7 +6633,6 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
-            sidebarObservationSignal($terminalScrollBarHidden),
         ]
 
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -298,6 +298,7 @@ extension Workspace {
             customDescription: customDescription,
             customColor: customColor,
             isPinned: isPinned,
+            terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
             layout: layout,
@@ -338,6 +339,7 @@ extension Workspace {
         setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
+        setTerminalScrollBarHidden(snapshot.terminalScrollBarHidden ?? false)
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -6486,6 +6488,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    @Published var terminalScrollBarHidden: Bool = false
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -6630,6 +6633,7 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
+            sidebarObservationSignal($terminalScrollBarHidden),
         ]
 
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()
@@ -7520,6 +7524,12 @@ final class Workspace: Identifiable, ObservableObject {
         } else {
             customColor = nil
         }
+    }
+
+    func setTerminalScrollBarHidden(_ hidden: Bool) {
+        guard terminalScrollBarHidden != hidden else { return }
+        terminalScrollBarHidden = hidden
+        scheduleTerminalGeometryReconcile()
     }
 
     private static func normalizedCustomDescription(_ description: String?) -> String? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7537,7 +7537,6 @@ final class Workspace: Identifiable, ObservableObject {
             name: Self.terminalScrollBarHiddenDidChangeNotification,
             object: self
         )
-        scheduleTerminalGeometryReconcile()
     }
 
     private static func normalizedCustomDescription(_ description: String?) -> String? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6637,6 +6637,7 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
+            sidebarObservationSignal($terminalScrollBarHidden),
         ]
 
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6482,6 +6482,10 @@ struct ClosedBrowserPanelRestoreSnapshot {
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 @MainActor
 final class Workspace: Identifiable, ObservableObject {
+    static let terminalScrollBarHiddenDidChangeNotification = Notification.Name(
+        "cmux.workspaceTerminalScrollBarHiddenDidChange"
+    )
+
     let id: UUID
     @Published var title: String
     @Published var customTitle: String?
@@ -7528,6 +7532,10 @@ final class Workspace: Identifiable, ObservableObject {
     func setTerminalScrollBarHidden(_ hidden: Bool) {
         guard terminalScrollBarHidden != hidden else { return }
         terminalScrollBarHidden = hidden
+        NotificationCenter.default.post(
+            name: Self.terminalScrollBarHiddenDidChangeNotification,
+            object: self
+        )
         scheduleTerminalGeometryReconcile()
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -96,6 +96,18 @@ enum PaneFirstClickFocusSettings {
     }
 }
 
+enum TerminalScrollBarSettings {
+    static let showScrollBarKey = "terminal.showScrollBar"
+    static let defaultShowScrollBar = true
+
+    static func isVisible(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: showScrollBarKey) == nil {
+            return defaultShowScrollBar
+        }
+        return defaults.bool(forKey: showScrollBarKey)
+    }
+}
+
 enum UITestLaunchManifest {
     static let argumentName = "-cmuxUITestLaunchManifest"
 
@@ -4102,6 +4114,8 @@ struct SettingsView: View {
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(PaneFirstClickFocusSettings.enabledKey)
     private var paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+    @AppStorage(TerminalScrollBarSettings.showScrollBarKey)
+    private var showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
@@ -5156,6 +5170,25 @@ struct SettingsView: View {
                         .disabled(sidebarHideAllDetails)
                     }
 
+                    SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))
+                    SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("terminal.showScrollBar"),
+                            String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"),
+                            subtitle: showTerminalScrollBar
+                                ? String(localized: "settings.terminal.scrollBar.subtitleOn", defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace.")
+                                : String(localized: "settings.terminal.scrollBar.subtitleOff", defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches.")
+                        ) {
+                            Toggle("", isOn: $showTerminalScrollBar)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsTerminalScrollBarToggle")
+                                .accessibilityLabel(
+                                    String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar")
+                                )
+                        }
+                    }
+
                     SettingsSectionHeader(title: String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors"))
                     SettingsCard {
                         SettingsPickerRow(
@@ -6148,6 +6181,7 @@ struct SettingsView: View {
         defaults.removeObject(forKey: WorkspaceButtonFadeSettings.legacyPaneTabBarControlsVisibilityModeKey)
         closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
         paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+        showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
         sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -99,12 +99,17 @@ enum PaneFirstClickFocusSettings {
 enum TerminalScrollBarSettings {
     static let showScrollBarKey = "terminal.showScrollBar"
     static let defaultShowScrollBar = true
+    static let didChangeNotification = Notification.Name("cmux.terminalScrollBarSettingsDidChange")
 
     static func isVisible(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: showScrollBarKey) == nil {
             return defaultShowScrollBar
         }
         return defaults.bool(forKey: showScrollBarKey)
+    }
+
+    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
     }
 }
 
@@ -4228,6 +4233,17 @@ struct SettingsView: View {
         )
     }
 
+    private var showTerminalScrollBarBinding: Binding<Bool> {
+        Binding(
+            get: { showTerminalScrollBar },
+            set: { newValue in
+                guard showTerminalScrollBar != newValue else { return }
+                showTerminalScrollBar = newValue
+                TerminalScrollBarSettings.notifyDidChange()
+            }
+        )
+    }
+
     private var selectedSidebarActiveTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
         SidebarActiveTabIndicatorSettings.resolvedStyle(rawValue: sidebarActiveTabIndicatorStyle)
     }
@@ -5179,7 +5195,7 @@ struct SettingsView: View {
                                 ? String(localized: "settings.terminal.scrollBar.subtitleOn", defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace.")
                                 : String(localized: "settings.terminal.scrollBar.subtitleOff", defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches.")
                         ) {
-                            Toggle("", isOn: $showTerminalScrollBar)
+                            Toggle("", isOn: showTerminalScrollBarBinding)
                                 .labelsHidden()
                                 .controlSize(.small)
                                 .accessibilityIdentifier("SettingsTerminalScrollBarToggle")

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6197,7 +6197,11 @@ struct SettingsView: View {
         defaults.removeObject(forKey: WorkspaceButtonFadeSettings.legacyPaneTabBarControlsVisibilityModeKey)
         closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
         paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+        let previousShowTerminalScrollBar = showTerminalScrollBar
         showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
+        if previousShowTerminalScrollBar != showTerminalScrollBar {
+            TerminalScrollBarSettings.notifyDidChange()
+        }
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
         sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2825,8 +2825,10 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
             fi
 
             cmux_test_ready() {
+              [[ -e "$CMUX_TEST_READY" ]] && return 0
               print -r -- "PRE=$CMUX_STARTUP_THEME_TERM|$CMUX_STARTUP_THEME_BRANCH|$TERM|${CMUX_ZSH_RESTORE_TERM-unset}" > "$CMUX_TEST_OUTPUT"
               : > "$CMUX_TEST_READY"
+              precmd_functions=(${precmd_functions:#cmux_test_ready})
             }
             precmd_functions+=(cmux_test_ready)
             """

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -35,6 +35,7 @@ const schemaSourceUrl =
   "https://github.com/manaflow-ai/cmux/blob/main/web/data/cmux-settings.schema.json";
 const sectionOrder = [
   "app",
+  "terminal",
   "notifications",
   "sidebar",
   "workspaceColors",
@@ -52,6 +53,10 @@ const settingsFileExample = `{
   // "app": {
   //   "appearance": "dark",
   //   "newWorkspacePlacement": "afterCurrent"
+  // },
+
+  // "terminal": {
+  //   "showScrollBar": false
   // },
 
   // "browser": {
@@ -286,8 +291,8 @@ working-directory = ~/code`}</CodeBlock>
       <h2>Schema reference</h2>
       <p>
         This reference covers every supported key in <code>settings.json</code>. The embedded
-        browser, sidebar, notifications, automation, and cmux-owned keyboard shortcuts all live
-        here.
+        browser, terminal, sidebar, notifications, automation, and cmux-owned keyboard shortcuts
+        all live here.
       </p>
 
       <h3>Metadata</h3>

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -95,6 +95,19 @@
         }
       }
     },
+    "terminal": {
+      "title": "terminal",
+      "description": "Terminal presentation settings from Settings > Terminal.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "showScrollBar": {
+          "type": "boolean",
+          "default": true,
+          "description": "Show the right-edge terminal scroll bar when scrollback is available. cmux automatically suppresses it for alternate-screen style TUI surfaces."
+        }
+      }
+    },
     "notifications": {
       "title": "notifications",
       "description": "Notification behavior from Settings > Notifications.",


### PR DESCRIPTION
Fixes #2728

## Root cause
- #2678 switched the terminal scroll bar to auto-hide, but cmux still renders the overlay on top of the terminal viewport.
- Full-screen TUI apps such as `nvim`, `htop`, `less`, `tmux`, `lazygit`, and `k9s` repaint continuously, so AppKit keeps the overlay scroller effectively visible.
- Because the overlay sits inside the terminal surface bounds, it covers the rightmost cell column and can obscure editor sign columns and in-app scroll indicators.

## What changed
- cmux now suppresses the right-edge terminal scroll bar for alternate-screen-style TUI surfaces by using Ghostty's per-surface scrollbar telemetry. In the embedded surface path, those full-screen TUI states surface as a viewport with no extra scrollback (`total <= len`), so the wrapper treats that as the alt-screen/no-scrollback signal and hides the bar for that surface.
- Added a global Settings > Terminal toggle, `Show Terminal Scroll Bar`, which defaults to on.
- Added a per-workspace override in the workspace context menu under `Workspace Settings > Hide Terminal Scroll Bar`.
- Persisted the per-workspace override in the existing workspace session snapshot/store so it survives restart/restore.
- Reserved a right gutter whenever terminal scrollbar support is enabled by shrinking the Ghostty surface width before pushing geometry back into libghostty. That keeps the scrollbar out of the rightmost terminal cell column and keeps the PTY width stable instead of adding/removing a column when switching between shell scrollback and alt-screen TUIs.
- Added `settings.json` support and docs/schema for `terminal.showScrollBar`.

## Behavior note
- In `nvim` and other alt-screen TUIs, the scrollbar itself is hidden.
- The default behavior still keeps a reserved right gutter so the terminal grid does not reflow when scrollback appears or disappears.
- If you want full-bleed TUI content with no reserved gutter, turn off the terminal scrollbar globally in `Settings > Terminal > Show Terminal Scroll Bar` or per workspace via `Workspace Settings > Hide Terminal Scroll Bar`.

## Why the auto-hide from #2678 was not enough
- Auto-hide only changes when the overlay fades; it does not change where cmux paints the scrollbar.
- For repaint-heavy TUIs, the overlay rarely gets a chance to disappear, so the visual overlap remains even though static shell content looks fine.
- This PR fixes the overlap in two ways: hide the bar for alt-screen/no-scrollback TUI surfaces, and reserve width outside the terminal grid when scrollbar support is enabled.

## How to use the new setting
- Global: open `Settings > Terminal` and toggle `Show Terminal Scroll Bar`.
- Per workspace: right-click a workspace in the sidebar, then use `Workspace Settings > Hide Terminal Scroll Bar`.
- File-managed config: set `terminal.showScrollBar` in `~/.config/cmux/settings.json`.

## Manual test checklist
- [ ] Open `nvim` and confirm the rightmost cell column is unobstructed.
- [ ] Open `htop` and confirm the rightmost cell column is unobstructed.
- [ ] Open a long-scrolling shell session and confirm the terminal scroll bar still appears.
- [ ] Toggle `Show Terminal Scroll Bar` in Settings and confirm the bar and reserved gutter disappear immediately.
- [ ] Restart cmux and confirm the chosen setting persists.

## Validation
- Built with `./scripts/reload.sh --tag nvim-scrollbar-overlap`.
- Per repo policy, local tests were not run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal scroll bar visibility and sizing logic, plus adds new persisted settings and workspace state; risk is mainly UI/layout regressions and session restore compatibility issues.
> 
> **Overview**
> Updates the embedded Ghostty terminal to **only show the right-edge scroll bar when scrollback is available**, suppressing it automatically for alternate-screen/TUI states (based on Ghostty scrollbar telemetry) and retiling/layouting when visibility changes.
> 
> Adds a **global** `Settings > Terminal > Show Terminal Scroll Bar` toggle (backed by new `TerminalScrollBarSettings`, `terminal.showScrollBar` file-managed setting, schema/docs updates, and localized strings) and a **per-workspace** context-menu override (`Workspace Settings > Hide Terminal Scroll Bar`) that is persisted in session snapshots and applied on restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1b45d57503cdf2b6ffc3e20fc9943b0b586aa5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->