### PR TITLE
Add chromeless mode for browser surfaces

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2151,11 +2151,13 @@ struct CMUXCLI {
             let type = optionValue(commandArgs, name: "--type")
             let direction = optionValue(commandArgs, name: "--direction") ?? "right"
             let url = optionValue(commandArgs, name: "--url")
+            let chromeless = hasFlag(commandArgs, name: "--chromeless") || hasFlag(commandArgs, name: "--no-nav")
             var params: [String: Any] = ["direction": direction]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
+            if chromeless { params["chromeless"] = true }
             let payload = try client.sendV2(method: "pane.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
@@ -2164,6 +2166,7 @@ struct CMUXCLI {
             let type = optionValue(commandArgs, name: "--type")
             let paneRaw = optionValue(commandArgs, name: "--pane")
             let url = optionValue(commandArgs, name: "--url")
+            let chromeless = hasFlag(commandArgs, name: "--chromeless") || hasFlag(commandArgs, name: "--no-nav")
             var params: [String: Any] = [:]
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client)
             if let wsId { params["workspace_id"] = wsId }
@@ -2171,6 +2174,7 @@ struct CMUXCLI {
             if let paneId { params["pane_id"] = paneId }
             if let type { params["type"] = type }
             if let url { params["url"] = url }
+            if chromeless { params["chromeless"] = true }
             let payload = try client.sendV2(method: "surface.create", params: params)
             printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["surface", "pane", "workspace"]))
 
@@ -5439,7 +5443,9 @@ struct CMUXCLI {
 
         if subcommand == "open" || subcommand == "open-split" || subcommand == "new" {
             // Parse routing flags before URL assembly so they never leak into the URL string.
-            let (workspaceOpt, argsAfterWorkspace) = parseOption(subArgs, name: "--workspace")
+            let chromeless = hasFlag(subArgs, name: "--chromeless") || hasFlag(subArgs, name: "--no-nav")
+            let openArgs = subArgs.filter { $0 != "--chromeless" && $0 != "--no-nav" }
+            let (workspaceOpt, argsAfterWorkspace) = parseOption(openArgs, name: "--workspace")
             let (windowOpt, urlArgs) = parseOption(argsAfterWorkspace, name: "--window")
             let url = urlArgs.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
             let respectExternalOpenRules: Bool = {
@@ -5480,6 +5486,9 @@ struct CMUXCLI {
             }
             if respectExternalOpenRules {
                 params["respect_external_open_rules"] = true
+            }
+            if chromeless {
+                params["chromeless"] = true
             }
             if let windowRaw = windowOpt {
                 if let window = try normalizeWindowHandle(windowRaw, client: client) {
@@ -7247,10 +7256,12 @@ struct CMUXCLI {
               --direction <left|right|up|down>    Split direction (default: right)
               --workspace <id|ref>                Target workspace (default: $CMUX_WORKSPACE_ID)
               --url <url>                         URL for browser panes
+              --chromeless, --no-nav             Hide browser chrome for browser panes
 
             Example:
               cmux new-pane
               cmux new-pane --type browser --direction down --url https://example.com
+              cmux new-pane --type browser --chromeless --url https://example.com
             """
         case "new-surface":
             return """
@@ -7263,10 +7274,12 @@ struct CMUXCLI {
               --pane <id|ref>             Target pane
               --workspace <id|ref>        Target workspace (default: $CMUX_WORKSPACE_ID)
               --url <url>                 URL for browser surfaces
+              --chromeless, --no-nav      Hide browser chrome for browser surfaces
 
             Example:
               cmux new-surface
               cmux new-surface --type browser --pane pane:1 --url https://example.com
+              cmux new-surface --type browser --pane pane:1 --chromeless --url https://example.com
             """
         case "close-surface":
             return """
@@ -7956,6 +7969,7 @@ struct CMUXCLI {
 
             Example:
               cmux browser open https://example.com
+              cmux browser open --chromeless https://example.com
               cmux browser surface:1 navigate https://google.com
               cmux browser --surface surface:1 snapshot --interactive
             """
@@ -14350,8 +14364,8 @@ struct CMUXCLI {
           list-pane-surfaces [--workspace <id|ref>] [--pane <id|ref>]
           tree [--all] [--workspace <id|ref|index>]
           focus-pane --pane <id|ref> [--workspace <id|ref>]
-          new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>]
-          new-surface [--type <terminal|browser>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>]
+          new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>] [--chromeless|--no-nav]
+          new-surface [--type <terminal|browser>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>] [--chromeless|--no-nav]
           close-surface [--surface <id|ref>] [--workspace <id|ref>]
           move-surface --surface <id|ref|index> [--pane <id|ref|index>] [--workspace <id|ref|index>] [--window <id|ref|index>] [--before <id|ref|index>] [--after <id|ref|index>] [--index <n>] [--focus <true|false>]
           reorder-surface --surface <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>)
@@ -14405,8 +14419,9 @@ struct CMUXCLI {
           markdown [open] <path>             (open markdown file in formatted viewer panel with live reload)
 
           browser [--surface <id|ref|index> | <surface>] <subcommand> ...
-          browser open [url]                   (create browser split in caller's workspace; if surface supplied, behaves like navigate)
-          browser open-split [url]
+          browser open [url] [--chromeless|--no-nav]
+                                             (create browser split in caller's workspace; if surface supplied, behaves like navigate)
+          browser open-split [url] [--chromeless|--no-nav]
           browser goto|navigate <url> [--snapshot-after]
           browser back|forward|reload [--snapshot-after]
           browser url|get-url

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -7644,6 +7644,23 @@
         }
       }
     },
+    "browser.contextMenu.hideChrome": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Browser Chrome"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザのUIを隠す"
+          }
+        }
+      }
+    },
     "browser.contextMenu.openLinkInNewTab": {
       "extractionState": "manual",
       "localizations": {
@@ -7759,6 +7776,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Відкрити посилання в новій вкладці"
+          }
+        }
+      }
+    },
+    "browser.contextMenu.showChrome": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Browser Chrome"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザのUIを表示"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11635,6 +11635,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func focusBrowserAddressBar(in panel: BrowserPanel) {
+        guard panel.showsBrowserChrome else {
+            browserAddressBarFocusedPanelId = nil
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: panel.id)
+            return
+        }
 #if DEBUG
         let requestId = panel.requestAddressBarFocus()
         dlog(

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -248,6 +248,7 @@ struct CmuxSurfaceDefinition: Codable, Sendable {
     var cwd: String?
     var env: [String: String]?
     var url: String?
+    var chromeless: Bool?
     var focus: Bool?
 }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2134,6 +2134,9 @@ final class BrowserPanel: Panel, ObservableObject {
     /// New browser tabs stay in an empty "new tab" state until first navigation.
     @Published private(set) var shouldRenderWebView: Bool = false
 
+    /// When true, hide the browser address bar and navigation controls.
+    @Published private(set) var chromeless: Bool = false
+
     /// True when the browser is showing the internal empty new-tab page (no WKWebView attached yet).
     var isShowingNewTabPage: Bool {
         !shouldRenderWebView
@@ -2313,6 +2316,35 @@ final class BrowserPanel: Panel, ObservableObject {
 
     var currentBrowserThemeMode: BrowserThemeMode {
         browserThemeMode
+    }
+
+    var showsBrowserChrome: Bool {
+        !chromeless
+    }
+
+    func setChromeless(_ chromeless: Bool) {
+        guard self.chromeless != chromeless else { return }
+        self.chromeless = chromeless
+
+        if chromeless {
+            pendingAddressBarFocusRequestId = nil
+            if preferredFocusIntent == .addressBar {
+                preferredFocusIntent = .webView
+            }
+            endSuppressWebViewFocusForAddressBar()
+            clearWebViewFocusSuppression()
+            invalidateAddressBarPageFocusRestoreAttempts()
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)
+            return
+        }
+
+        if searchState == nil && !shouldRenderWebView {
+            preferredFocusIntent = .addressBar
+        }
+    }
+
+    func toggleChromeless() {
+        setChromeless(!chromeless)
     }
 
     private static let portalHostAreaThreshold: CGFloat = 4
@@ -2561,6 +2593,22 @@ final class BrowserPanel: Panel, ObservableObject {
         webView.onContextMenuOpenLinkInNewTab = { [weak self] url in
             self?.openLinkInNewTab(url: url)
         }
+        webView.onContextMenuToggleBrowserChrome = { [weak self] in
+            self?.toggleChromeless()
+        }
+        webView.contextMenuBrowserChromeToggleTitleProvider = { [weak self] in
+            guard let self else { return "" }
+            if self.chromeless {
+                return String(
+                    localized: "browser.contextMenu.showChrome",
+                    defaultValue: "Show Browser Chrome"
+                )
+            }
+            return String(
+                localized: "browser.contextMenu.hideChrome",
+                defaultValue: "Hide Browser Chrome"
+            )
+        }
         configureNavigationDelegateCallbacks()
         webView.navigationDelegate = navigationDelegate
         webView.uiDelegate = uiDelegate
@@ -2607,6 +2655,7 @@ final class BrowserPanel: Panel, ObservableObject {
         workspaceId: UUID,
         profileID: UUID? = nil,
         initialURL: URL? = nil,
+        chromeless: Bool = false,
         bypassInsecureHTTPHostOnce: String? = nil,
         proxyEndpoint: BrowserProxyEndpoint? = nil,
         isRemoteWorkspace: Bool = false,
@@ -2620,6 +2669,7 @@ final class BrowserPanel: Panel, ObservableObject {
             : BrowserProfileStore.shared.builtInDefaultProfileID
         self.profileID = resolvedProfileID
         self.historyStore = BrowserProfileStore.shared.historyStore(for: resolvedProfileID)
+        self.chromeless = chromeless
         self.insecureHTTPBypassHostOnce = BrowserInsecureHTTPSettings.normalizeHost(bypassInsecureHTTPHostOnce ?? "")
         self.remoteProxyEndpoint = proxyEndpoint
         self.usesRemoteWorkspaceProxy = isRemoteWorkspace
@@ -3045,6 +3095,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     func restoreSessionSnapshot(_ snapshot: SessionBrowserPanelSnapshot) {
         let restoredURL = Self.sanitizedSessionHistoryURL(snapshot.urlString)
+        setChromeless(snapshot.chromeless)
 
         restoreSessionNavigationHistory(
             backHistoryURLStrings: snapshot.backHistoryURLStrings ?? [],
@@ -4043,7 +4094,7 @@ extension BrowserPanel {
         abandonRestoredSessionHistoryIfNeeded()
 
         pendingAddressBarFocusRequestId = nil
-        preferredFocusIntent = .addressBar
+        preferredFocusIntent = chromeless ? .webView : .addressBar
         suppressOmnibarAutofocusUntil = nil
         suppressWebViewFocusUntil = nil
         endSuppressWebViewFocusForAddressBar()
@@ -4224,7 +4275,8 @@ extension BrowserPanel {
             url: url,
             focus: true,
             preferredProfileID: profileID,
-            bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce
+            bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce,
+            chromeless: chromeless
         )
 #if DEBUG
         dlog(
@@ -5080,6 +5132,14 @@ extension BrowserPanel {
 
     @discardableResult
     func requestAddressBarFocus() -> UUID {
+        guard !chromeless else {
+            clearWebViewFocusSuppression()
+            endSuppressWebViewFocusForAddressBar()
+            pendingAddressBarFocusRequestId = nil
+            preferredFocusIntent = .webView
+            NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)
+            return UUID()
+        }
         preferredFocusIntent = .addressBar
         invalidateSearchFocusRequests(reason: "requestAddressBarFocus")
         beginSuppressWebViewFocusForAddressBar()
@@ -5129,6 +5189,13 @@ extension BrowserPanel {
     }
 
     func captureFocusIntent(in window: NSWindow?) -> PanelFocusIntent {
+        if chromeless {
+            if searchState != nil && preferredFocusIntent == .findField {
+                return .browser(.findField)
+            }
+            return .browser(.webView)
+        }
+
         if pendingAddressBarFocusRequestId != nil || AppDelegate.shared?.focusedBrowserAddressBarPanelId() == id {
             return .browser(.addressBar)
         }
@@ -5146,6 +5213,13 @@ extension BrowserPanel {
     }
 
     func preferredFocusIntentForActivation() -> PanelFocusIntent {
+        if chromeless {
+            if searchState != nil && preferredFocusIntent == .findField {
+                return .browser(.findField)
+            }
+            return .browser(.webView)
+        }
+
         if pendingAddressBarFocusRequestId != nil {
             return .browser(.addressBar)
         }
@@ -5164,6 +5238,12 @@ extension BrowserPanel {
             invalidateSearchFocusRequests(reason: "prepareWebView")
             endSuppressWebViewFocusForAddressBar()
         case .addressBar:
+            guard !chromeless else {
+                preferredFocusIntent = .webView
+                invalidateSearchFocusRequests(reason: "prepareAddressBar.chromeless")
+                endSuppressWebViewFocusForAddressBar()
+                break
+            }
             preferredFocusIntent = .addressBar
             invalidateSearchFocusRequests(reason: "prepareAddressBar")
             beginSuppressWebViewFocusForAddressBar()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -552,8 +552,10 @@ struct BrowserPanelView: View {
         // Layering contract: browser Cmd+F UI is mounted in the portal-hosted AppKit
         // container. Rendering it here can hide it behind the portal-hosted WKWebView.
         VStack(spacing: 0) {
-            addressBar
-                .fixedSize(horizontal: false, vertical: true)
+            if panel.showsBrowserChrome {
+                addressBar
+                    .fixedSize(horizontal: false, vertical: true)
+            }
             webView
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -584,7 +586,10 @@ struct BrowserPanelView: View {
                 .allowsHitTesting(false)
         }
         .overlay(alignment: .topLeading) {
-            if addressBarFocused, !omnibarState.suggestions.isEmpty, omnibarPillFrame.width > 0 {
+            if panel.showsBrowserChrome,
+               addressBarFocused,
+               !omnibarState.suggestions.isEmpty,
+               omnibarPillFrame.width > 0 {
                 OmnibarSuggestionsView(
                     engineName: searchEngine.displayName,
                     items: omnibarState.suggestions,
@@ -718,6 +723,17 @@ struct BrowserPanelView: View {
             if addressBarFocused {
                 refreshSuggestions()
             }
+        }
+        .onChange(of: panel.chromeless) { chromeless in
+            if chromeless {
+                addressBarHeight = 0
+                if addressBarFocused {
+                    setAddressBarFocused(false, reason: "chromeless.enabled")
+                }
+            } else {
+                autoFocusOmnibarIfBlank()
+            }
+            syncWebViewResponderPolicyWithViewState(reason: "chromelessChanged")
         }
         .onChange(of: isVisibleInUI) { visibleInUI in
             if visibleInUI {
@@ -1274,7 +1290,7 @@ struct BrowserPanelView: View {
                             onFieldDidFocus: { panel.noteFindFieldFocused() }
                         )
                     },
-                    paneTopChromeHeight: addressBarHeight
+                    paneTopChromeHeight: panel.showsBrowserChrome ? addressBarHeight : 0
                 )
                 .accessibilityIdentifier("BrowserWebViewSurface")
                 // Keep the host stable for normal pane churn, but force a remount when
@@ -1297,6 +1313,11 @@ struct BrowserPanelView: View {
                 Color(nsColor: browserChromeBackgroundColor)
                     .contentShape(Rectangle())
                     .accessibilityIdentifier(browserContentAccessibilityIdentifier)
+                    .contextMenu {
+                        Button(browserChromeContextMenuTitle) {
+                            panel.toggleChromeless()
+                        }
+                    }
                     .onTapGesture {
                         onRequestPanelFocus()
                         if addressBarFocused {
@@ -1320,6 +1341,19 @@ struct BrowserPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .layoutPriority(1)
         .zIndex(0)
+    }
+
+    private var browserChromeContextMenuTitle: String {
+        if panel.chromeless {
+            return String(
+                localized: "browser.contextMenu.showChrome",
+                defaultValue: "Show Browser Chrome"
+            )
+        }
+        return String(
+            localized: "browser.contextMenu.hideChrome",
+            defaultValue: "Hide Browser Chrome"
+        )
     }
 
     private func triggerFocusFlashAnimation() {
@@ -1511,6 +1545,11 @@ struct BrowserPanelView: View {
     private func applyPendingAddressBarFocusRequestIfNeeded() {
         guard let requestId = panel.pendingAddressBarFocusRequestId else {
             clearPendingAddressBarFocusRetry()
+            return
+        }
+        guard panel.showsBrowserChrome else {
+            clearPendingAddressBarFocusRetry()
+            panel.acknowledgeAddressBarFocusRequest(requestId)
             return
         }
         guard !isCommandPaletteVisibleForPanelWindow() else {
@@ -1730,6 +1769,12 @@ struct BrowserPanelView: View {
     }
 
     private func autoFocusOmnibarIfBlank() {
+        guard panel.showsBrowserChrome else {
+#if DEBUG
+            logBrowserFocusState(event: "addressBarFocus.autoFocus.skip", detail: "reason=chromeless")
+#endif
+            return
+        }
         guard isFocused else {
 #if DEBUG
             logBrowserFocusState(event: "addressBarFocus.autoFocus.skip", detail: "reason=panel_not_focused")

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -149,13 +149,17 @@ final class CmuxWebView: WKWebView {
     }
 
     private static var contextMenuFallbackKey: UInt8 = 0
+    private static let browserChromeToggleMenuItemIdentifier =
+        NSUserInterfaceItemIdentifier("cmux.browser.toggleChrome")
 
     var onContextMenuDownloadStateChanged: ((Bool) -> Void)?
     /// Called when "Open Link in New Tab" context menu is selected.
     /// Bypasses createWebViewWith so the link opens as a tab, not a popup.
     var onContextMenuOpenLinkInNewTab: ((URL) -> Void)?
+    var onContextMenuToggleBrowserChrome: (() -> Void)?
     var contextMenuLinkURLProvider: ((CmuxWebView, NSPoint, @escaping (URL?) -> Void) -> Void)?
     var contextMenuDefaultBrowserOpener: ((URL) -> Bool)?
+    var contextMenuBrowserChromeToggleTitleProvider: (() -> String)?
     /// Guard against background panes stealing first responder (e.g. page autofocus).
     /// BrowserPanelView updates this as pane focus state changes.
     var allowsFirstResponderAcquisition: Bool = true
@@ -1634,6 +1638,8 @@ final class CmuxWebView: WKWebView {
             item.target = self
             menu.insertItem(item, at: min(openLinkInsertionIndex, menu.items.count))
         }
+
+        appendBrowserChromeToggleMenuItem(to: menu)
     }
 
     @objc private func contextMenuOpenLinkInDefaultBrowser(_ sender: Any?) {
@@ -1651,6 +1657,11 @@ final class CmuxWebView: WKWebView {
             guard let self, let url else { return }
             self.onContextMenuOpenLinkInNewTab?(url)
         }
+    }
+
+    @objc private func contextMenuToggleBrowserChrome(_ sender: Any?) {
+        _ = sender
+        onContextMenuToggleBrowserChrome?()
     }
 
     @objc private func contextMenuCopyImage(_ sender: Any?) {
@@ -1864,6 +1875,29 @@ final class CmuxWebView: WKWebView {
                 )
             }
         }
+    }
+
+    private func appendBrowserChromeToggleMenuItem(to menu: NSMenu) {
+        guard menu.items.contains(where: { $0.identifier == Self.browserChromeToggleMenuItemIdentifier }) == false,
+              let rawTitle = contextMenuBrowserChromeToggleTitleProvider?() else {
+            return
+        }
+
+        let title = rawTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+
+        if let last = menu.items.last, !last.isSeparatorItem {
+            menu.addItem(NSMenuItem.separator())
+        }
+
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(contextMenuToggleBrowserChrome(_:)),
+            keyEquivalent: ""
+        )
+        item.identifier = Self.browserChromeToggleMenuItemIdentifier
+        item.target = self
+        menu.addItem(item)
     }
 
     @objc private func contextMenuDownloadLinkedFile(_ sender: Any?) {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -230,10 +230,54 @@ struct SessionBrowserPanelSnapshot: Codable, Sendable {
     var urlString: String?
     var profileID: UUID?
     var shouldRenderWebView: Bool
+    var chromeless: Bool
     var pageZoom: Double
     var developerToolsVisible: Bool
     var backHistoryURLStrings: [String]?
     var forwardHistoryURLStrings: [String]?
+
+    enum CodingKeys: String, CodingKey {
+        case urlString
+        case profileID
+        case shouldRenderWebView
+        case chromeless
+        case pageZoom
+        case developerToolsVisible
+        case backHistoryURLStrings
+        case forwardHistoryURLStrings
+    }
+
+    init(
+        urlString: String?,
+        profileID: UUID?,
+        shouldRenderWebView: Bool,
+        chromeless: Bool,
+        pageZoom: Double,
+        developerToolsVisible: Bool,
+        backHistoryURLStrings: [String]?,
+        forwardHistoryURLStrings: [String]?
+    ) {
+        self.urlString = urlString
+        self.profileID = profileID
+        self.shouldRenderWebView = shouldRenderWebView
+        self.chromeless = chromeless
+        self.pageZoom = pageZoom
+        self.developerToolsVisible = developerToolsVisible
+        self.backHistoryURLStrings = backHistoryURLStrings
+        self.forwardHistoryURLStrings = forwardHistoryURLStrings
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        urlString = try container.decodeIfPresent(String.self, forKey: .urlString)
+        profileID = try container.decodeIfPresent(UUID.self, forKey: .profileID)
+        shouldRenderWebView = try container.decode(Bool.self, forKey: .shouldRenderWebView)
+        chromeless = try container.decodeIfPresent(Bool.self, forKey: .chromeless) ?? false
+        pageZoom = try container.decode(Double.self, forKey: .pageZoom)
+        developerToolsVisible = try container.decode(Bool.self, forKey: .developerToolsVisible)
+        backHistoryURLStrings = try container.decodeIfPresent([String].self, forKey: .backHistoryURLStrings)
+        forwardHistoryURLStrings = try container.decodeIfPresent([String].self, forKey: .forwardHistoryURLStrings)
+    }
 }
 
 struct SessionMarkdownPanelSnapshot: Codable, Sendable {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5438,7 +5438,8 @@ class TabManager: ObservableObject {
                inPane: originalPane,
                url: snapshot.url,
                focus: true,
-               preferredProfileID: snapshot.profileID
+               preferredProfileID: snapshot.profileID,
+               chromeless: snapshot.chromeless
            ) {
             let tabCount = workspace.bonsplitController.tabs(inPane: originalPane).count
             let maxIndex = max(0, tabCount - 1)
@@ -5457,7 +5458,8 @@ class TabManager: ObservableObject {
                orientation: orientation,
                insertFirst: snapshot.fallbackSplitInsertFirst,
                url: snapshot.url,
-               preferredProfileID: snapshot.profileID
+               preferredProfileID: snapshot.profileID,
+               chromeless: snapshot.chromeless
            )?.id {
             return browserPanelId
         }
@@ -5469,7 +5471,8 @@ class TabManager: ObservableObject {
             inPane: focusedPane,
             url: snapshot.url,
             focus: true,
-            preferredProfileID: snapshot.profileID
+            preferredProfileID: snapshot.profileID,
+            chromeless: snapshot.chromeless
         )?.id
     }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -4655,7 +4655,8 @@ class TerminalController {
                 guard let newPanel = workspace.newBrowserSurface(
                     inPane: paneId,
                     url: browserPanel.currentURL,
-                    focus: true
+                    focus: true,
+                    chromeless: browserPanel.chromeless
                 ) else {
                     result = .err(code: "internal_error", message: "Failed to duplicate tab", data: nil)
                     return
@@ -4969,6 +4970,7 @@ class TerminalController {
         let panelType = v2PanelType(params, "type") ?? .terminal
         let urlStr = v2String(params, "url")
         let url = urlStr.flatMap { URL(string: $0) }
+        let chromeless = (v2Bool(params, "chromeless") ?? v2Bool(params, "no_nav")) ?? false
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create surface", data: nil)
         v2MainSync {
@@ -4994,7 +4996,12 @@ class TerminalController {
 
             let newPanelId: UUID?
             if panelType == .browser {
-                newPanelId = ws.newBrowserSurface(inPane: paneId, url: url, focus: v2FocusAllowed())?.id
+                newPanelId = ws.newBrowserSurface(
+                    inPane: paneId,
+                    url: url,
+                    focus: v2FocusAllowed(),
+                    chromeless: chromeless
+                )?.id
             } else {
                 newPanelId = ws.newTerminalSurface(inPane: paneId, focus: v2FocusAllowed())?.id
             }
@@ -5014,7 +5021,8 @@ class TerminalController {
                 "pane_ref": v2Ref(kind: .pane, uuid: paneId.id),
                 "surface_id": newPanelId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: newPanelId),
-                "type": panelType.rawValue
+                "type": panelType.rawValue,
+                "chromeless": panelType == .browser ? chromeless : false
             ])
         }
         return result
@@ -6293,6 +6301,7 @@ class TerminalController {
         let panelType = v2PanelType(params, "type") ?? .terminal
         let urlStr = v2String(params, "url")
         let url = urlStr.flatMap { URL(string: $0) }
+        let chromeless = (v2Bool(params, "chromeless") ?? v2Bool(params, "no_nav")) ?? false
 
         let orientation = direction.orientation
         let insertFirst = direction.insertFirst
@@ -6317,6 +6326,7 @@ class TerminalController {
                     orientation: orientation,
                     insertFirst: insertFirst,
                     url: url,
+                    chromeless: chromeless,
                     focus: v2FocusAllowed()
                 )?.id
             } else {
@@ -6343,7 +6353,8 @@ class TerminalController {
                 "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
                 "surface_id": newPanelId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: newPanelId),
-                "type": panelType.rawValue
+                "type": panelType.rawValue,
+                "chromeless": panelType == .browser ? chromeless : false
             ])
         }
         return result
@@ -7679,6 +7690,7 @@ class TerminalController {
         }
         let urlStr = v2String(params, "url")
         let url = urlStr.flatMap { URL(string: $0) }
+        let chromeless = (v2Bool(params, "chromeless") ?? v2Bool(params, "no_nav")) ?? false
         let respectExternalOpenRules = v2Bool(params, "respect_external_open_rules") ?? false
 
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create browser", data: nil)
@@ -7734,11 +7746,21 @@ class TerminalController {
             var placementStrategy = "split_right"
             let createdPanel: BrowserPanel?
             if let targetPane = ws.preferredBrowserTargetPane(fromPanelId: sourceSurfaceId) {
-                createdPanel = ws.newBrowserSurface(inPane: targetPane, url: url, focus: true)
+                createdPanel = ws.newBrowserSurface(
+                    inPane: targetPane,
+                    url: url,
+                    focus: true,
+                    chromeless: chromeless
+                )
                 createdSplit = false
                 placementStrategy = "reuse_right_sibling"
             } else {
-                createdPanel = ws.newBrowserSplit(from: sourceSurfaceId, orientation: .horizontal, url: url)
+                createdPanel = ws.newBrowserSplit(
+                    from: sourceSurfaceId,
+                    orientation: .horizontal,
+                    url: url,
+                    chromeless: chromeless
+                )
             }
 
             guard let browserPanelId = createdPanel?.id else {
@@ -7764,7 +7786,8 @@ class TerminalController {
                 "target_pane_id": v2OrNull(targetPaneUUID?.uuidString),
                 "target_pane_ref": v2Ref(kind: .pane, uuid: targetPaneUUID),
                 "created_split": createdSplit,
-                "placement_strategy": placementStrategy
+                "placement_strategy": placementStrategy,
+                "chromeless": createdPanel?.chromeless ?? chromeless
             ])
         }
         return result
@@ -10233,6 +10256,7 @@ class TerminalController {
         }
 
         let url = v2String(params, "url").flatMap(URL.init(string:))
+        let chromeless = (v2Bool(params, "chromeless") ?? v2Bool(params, "no_nav")) ?? false
         var result: V2CallResult = .err(code: "internal_error", message: "Failed to create browser tab", data: nil)
         v2MainSync {
             guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
@@ -10250,7 +10274,12 @@ class TerminalController {
                 return
             }
 
-            guard let panel = ws.newBrowserSurface(inPane: pane, url: url, focus: true) else {
+            guard let panel = ws.newBrowserSurface(
+                inPane: pane,
+                url: url,
+                focus: true,
+                chromeless: chromeless
+            ) else {
                 result = .err(code: "internal_error", message: "Failed to create browser tab", data: nil)
                 return
             }
@@ -10261,7 +10290,8 @@ class TerminalController {
                 "pane_ref": v2Ref(kind: .pane, uuid: pane.id),
                 "surface_id": panel.id.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: panel.id),
-                "url": panel.currentURL?.absoluteString ?? ""
+                "url": panel.currentURL?.absoluteString ?? "",
+                "chromeless": panel.chromeless
             ])
         }
         return result
@@ -11375,8 +11405,8 @@ class TerminalController {
         Split & surface commands:
           new_split <direction> [panel]   - Split panel (left/right/up/down)
           drag_surface_to_split <id|idx> <direction> - Move surface into a new split (drag-to-edge)
-          new_pane [--type=terminal|browser] [--direction=left|right|up|down] [--url=...]
-          new_surface [--type=terminal|browser] [--pane=<pane-id|index>] [--url=...]
+          new_pane [--type=terminal|browser] [--direction=left|right|up|down] [--url=...] [--chromeless|--no-nav]
+          new_surface [--type=terminal|browser] [--pane=<pane-id|index>] [--url=...] [--chromeless|--no-nav]
           list_surfaces [workspace]       - List surfaces for workspace (current if omitted)
           list_panes                      - List all panes with IDs
           list_pane_surfaces [--pane=<pane-id|index>] - List surfaces in pane
@@ -11433,7 +11463,7 @@ class TerminalController {
           reset_sidebar [--tab=X] - Clear sidebar metadata
 
         Browser commands:
-          open_browser [url]              - Create browser panel with optional URL
+          open_browser [url] [--chromeless|--no-nav] - Create browser panel with optional URL
           navigate <panel_id> <url>       - Navigate browser to URL
           browser_back <panel_id>         - Go back in browser history
           browser_forward <panel_id>      - Go forward in browser history
@@ -13851,8 +13881,19 @@ class TerminalController {
     private func openBrowser(_ args: String) -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
-        let trimmed = args.trimmingCharacters(in: .whitespacesAndNewlines)
-        let url: URL? = trimmed.isEmpty ? nil : URL(string: trimmed)
+        let parts = args.split(separator: " ").map(String.init)
+        var urlString: String?
+        var chromeless = false
+        for part in parts {
+            if part == "--chromeless" || part == "--no-nav" {
+                chromeless = true
+            } else if part.hasPrefix("--url=") {
+                urlString = String(part.dropFirst(6))
+            } else if !part.hasPrefix("--"), urlString == nil {
+                urlString = part
+            }
+        }
+        let url = urlString.flatMap(URL.init(string:))
 
         var result = "ERROR: Failed to create browser panel"
         let focus = socketCommandAllowsInAppFocusMutations()
@@ -13867,6 +13908,7 @@ class TerminalController {
                 from: focusedPanelId,
                 orientation: .horizontal,
                 url: url,
+                chromeless: chromeless,
                 focus: focus
             )?.id {
                 result = "OK \(browserPanelId.uuidString)"
@@ -14239,10 +14281,11 @@ class TerminalController {
     private func newPane(_ args: String) -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
-        // Parse arguments: --type=terminal|browser --direction=left|right|up|down --url=...
+        // Parse arguments: --type=terminal|browser --direction=left|right|up|down --url=... [--chromeless|--no-nav]
         var panelType: PanelType = .terminal
         var direction: SplitDirection = .right
         var url: URL? = nil
+        var chromeless = false
         var invalidDirection = false
 
         let parts = args.split(separator: " ")
@@ -14261,6 +14304,8 @@ class TerminalController {
             } else if partStr.hasPrefix("--url=") {
                 let urlStr = String(partStr.dropFirst(6))
                 url = URL(string: urlStr)
+            } else if partStr == "--chromeless" || partStr == "--no-nav" {
+                chromeless = true
             }
         }
 
@@ -14287,6 +14332,7 @@ class TerminalController {
                     orientation: orientation,
                     insertFirst: insertFirst,
                     url: url,
+                    chromeless: chromeless,
                     focus: focus
                 )?.id
             } else {
@@ -15771,10 +15817,11 @@ class TerminalController {
     private func newSurface(_ args: String) -> String {
         guard let tabManager = tabManager else { return "ERROR: TabManager not available" }
 
-        // Parse arguments: --type=terminal|browser --pane=<pane_id> --url=...
+        // Parse arguments: --type=terminal|browser --pane=<pane_id> --url=... [--chromeless|--no-nav]
         var panelType: PanelType = .terminal
         var paneArg: String? = nil
         var url: URL? = nil
+        var chromeless = false
 
         let parts = args.split(separator: " ")
         for part in parts {
@@ -15787,6 +15834,8 @@ class TerminalController {
             } else if partStr.hasPrefix("--url=") {
                 let urlStr = String(partStr.dropFirst(6))
                 url = URL(string: urlStr)
+            } else if partStr == "--chromeless" || partStr == "--no-nav" {
+                chromeless = true
             }
         }
 
@@ -15820,7 +15869,12 @@ class TerminalController {
 
             let newPanelId: UUID?
             if panelType == .browser {
-                newPanelId = tab.newBrowserSurface(inPane: targetPaneId, url: url, focus: focus)?.id
+                newPanelId = tab.newBrowserSurface(
+                    inPane: targetPaneId,
+                    url: url,
+                    focus: focus,
+                    chromeless: chromeless
+                )?.id
             } else {
                 newPanelId = tab.newTerminalSurface(inPane: targetPaneId, focus: focus)?.id
             }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -480,6 +480,7 @@ extension Workspace {
                 urlString: browserPanel.preferredURLStringForOmnibar(),
                 profileID: browserPanel.profileID,
                 shouldRenderWebView: browserPanel.shouldRenderWebView,
+                chromeless: browserPanel.chromeless,
                 pageZoom: Double(browserPanel.currentPageZoomFactor()),
                 developerToolsVisible: browserPanel.isDeveloperToolsVisible(),
                 backHistoryURLStrings: historySnapshot.backHistoryURLStrings,
@@ -664,7 +665,8 @@ extension Workspace {
                 inPane: paneId,
                 url: nil,
                 focus: false,
-                preferredProfileID: snapshot.browser?.profileID
+                preferredProfileID: snapshot.browser?.profileID,
+                chromeless: snapshot.browser?.chromeless ?? false
             ) else {
                 return nil
             }
@@ -889,7 +891,12 @@ extension Workspace {
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
-            if let panel = newBrowserSurface(inPane: paneId, url: url, focus: false) {
+            if let panel = newBrowserSurface(
+                inPane: paneId,
+                url: url,
+                focus: false,
+                chromeless: surface.chromeless == true
+            ) {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
@@ -919,7 +926,12 @@ extension Workspace {
 
         case .browser:
             let url = surface.url.flatMap { URL(string: $0) }
-            if let panel = newBrowserSurface(inPane: paneId, url: url, focus: false) {
+            if let panel = newBrowserSurface(
+                inPane: paneId,
+                url: url,
+                focus: false,
+                chromeless: surface.chromeless == true
+            ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
             }
@@ -6469,6 +6481,7 @@ struct ClosedBrowserPanelRestoreSnapshot {
     let workspaceId: UUID
     let url: URL?
     let profileID: UUID?
+    let chromeless: Bool
     let originalPaneId: UUID
     let originalTabIndex: Int
     let fallbackSplitOrientation: SplitOrientation?
@@ -9009,6 +9022,7 @@ final class Workspace: Identifiable, ObservableObject {
         insertFirst: Bool = false,
         url: URL? = nil,
         preferredProfileID: UUID? = nil,
+        chromeless: Bool = false,
         focus: Bool = true
     ) -> BrowserPanel? {
         // Find the pane containing the source panel
@@ -9032,6 +9046,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: panelId
             ),
             initialURL: url,
+            chromeless: chromeless,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
             remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil
@@ -9096,7 +9111,8 @@ final class Workspace: Identifiable, ObservableObject {
         focus: Bool? = nil,
         insertAtEnd: Bool = false,
         preferredProfileID: UUID? = nil,
-        bypassInsecureHTTPHostOnce: String? = nil
+        bypassInsecureHTTPHostOnce: String? = nil,
+        chromeless: Bool = false
     ) -> BrowserPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
         let sourcePanelId = effectiveSelectedPanelId(inPane: paneId)
@@ -9110,6 +9126,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: sourcePanelId
             ),
             initialURL: url,
+            chromeless: chromeless,
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce,
             proxyEndpoint: remoteProxyEndpoint,
             isRemoteWorkspace: isRemoteWorkspace,
@@ -9555,6 +9572,7 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             url: resolvedURL,
             profileID: browserPanel.profileID,
+            chromeless: browserPanel.chromeless,
             originalPaneId: pane.id,
             originalTabIndex: tabIndex,
             fallbackSplitOrientation: fallbackPlan?.orientation,
@@ -10969,7 +10987,8 @@ final class Workspace: Identifiable, ObservableObject {
             inPane: paneId,
             url: browser.currentURL,
             focus: true,
-            preferredProfileID: browser.profileID
+            preferredProfileID: browser.profileID,
+            chromeless: browser.chromeless
         ) else { return }
         _ = reorderSurface(panelId: newPanel.id, toIndex: targetIndex)
     }

--- a/web/app/[locale]/docs/browser-automation/page.tsx
+++ b/web/app/[locale]/docs/browser-automation/page.tsx
@@ -95,6 +95,9 @@ export default function BrowserAutomationPage() {
       <CodeBlock lang="bash">{`# Open a new browser split
 cmux browser open https://example.com
 
+# Open a chromeless browser pane for dashboards or embedded UI
+cmux new-pane --type browser --chromeless --url https://example.com
+
 # Discover focused IDs and browser metadata
 cmux browser identify
 cmux browser identify --surface surface:2


### PR DESCRIPTION
## Summary
- add a chromeless browser-surface mode that hides the omnibar and nav controls while preserving focus behavior
- plumb chromeless through CLI, socket/v2 creation APIs, config/session persistence, duplication, reopen, and docs
- add a runtime show/hide chrome toggle via the browser surface context menu without depending on bonsplit submodule changes

## Testing
- not run locally (per repo policy)

Closes https://github.com/manaflow-ai/cmux/issues/2693

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: threads a new `chromeless` flag through CLI/V2/socket APIs, workspace/tab creation paths, and session persistence, which could regress browser focus behavior or restoration of tabs/splits.
> 
> **Overview**
> Adds a *chromeless* mode for browser panes/surfaces that hides the omnibar/navigation chrome while keeping focus handling sane.
> 
> Plumbs a `chromeless`/`--no-nav` flag through `cmux` CLI commands (`new-pane`, `new-surface`, `browser open/open-split`) and server-side V2/socket handlers so new browser surfaces/splits can be created chromeless and return that state in responses.
> 
> Persists/restores the setting via config (`CmuxSurfaceDefinition.chromeless`) and session snapshots, propagates it through duplicate/reopen flows, and adds a runtime context-menu toggle (“Show/Hide Browser Chrome”) with new localized strings plus view/focus guards when chrome is hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e033a548a6af373cddf353b6c6686e95881a400. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a chromeless mode for browser surfaces to hide the omnibar and nav controls while keeping focus behavior predictable. Usable from the CLI and context menu, and persisted across sessions and restores.

- **New Features**
  - New chromeless browser mode that hides the address bar and nav buttons; focus defaults to the web view when enabled.
  - Runtime toggle in the browser surface context menu (“Show/Hide Browser Chrome”), with new localized strings.
  - CLI: `--chromeless`/`--no-nav` for `cmux new-pane`, `cmux new-surface`, `cmux browser open`, and `cmux browser open-split`.
  - v2/socket commands accept and return `chromeless` (also supported as `no_nav`) for surface/pane creation and browser open operations.
  - Config/session: `chromeless` added to `CmuxSurfaceDefinition` and session snapshots; duplication, reopen, and restore preserve the setting.
  - Docs: added a quick example for opening a chromeless browser pane.

<sup>Written for commit 5e033a548a6af373cddf353b6c6686e95881a400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added chromeless browser mode to hide the address bar and UI elements via `--chromeless` CLI flag or right-click context menu in browser panes
  * Chromeless preference is automatically saved and restored across workspace sessions

* **Documentation**
  * Updated browser automation documentation with chromeless mode examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->