### PR TITLE
fix: explicitly look up MDM client identity for TLS auth challenges

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5993,16 +5993,27 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        // WKWebView rejects all authentication challenges by default when this
-        // delegate method is not implemented (.rejectProtectionSpace). This
-        // breaks TLS client-certificate flows such as Microsoft Entra ID
-        // Conditional Access, which verifies device compliance via a client
-        // certificate stored in the system keychain by MDM enrollment.
+        // WKWebView's .performDefaultHandling does NOT search the system keychain
+        // for client identities the way Safari does — Safari's web content process
+        // has special entitlements that third-party apps lack. On MDM-enrolled Macs,
+        // Microsoft Entra ID (Conditional Access) issues a TLS client-certificate
+        // challenge to verify device compliance. Without an explicit keychain lookup,
+        // no certificate is sent and the user sees "this device needs to be under
+        // policy."
         //
-        // By returning .performDefaultHandling the system's standard URL-loading
-        // behaviour takes over: the keychain is searched for matching client
-        // identities, MDM-installed root CAs are trusted, and any configured SSO
-        // extensions (e.g. Microsoft Enterprise SSO) can intercept the challenge.
+        // SecIdentityCopyPreferred runs in the app process (which has keychain
+        // access) and returns the preferred client identity matching the server's
+        // host and acceptable CA distinguished names — the same lookup Safari
+        // performs internally.
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+            let host = challenge.protectionSpace.host
+            let issuers = challenge.protectionSpace.distinguishedNames as CFArray?
+            if let identity = SecIdentityCopyPreferred(host as CFString, nil, issuers) {
+                let credential = URLCredential(identity: identity, certificates: nil, persistence: .forSession)
+                completionHandler(.useCredential, credential)
+                return
+            }
+        }
         completionHandler(.performDefaultHandling, nil)
     }
 

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Bonsplit
 import ObjectiveC
+import Security
 import WebKit
 
 func browserPopupContentRect(
@@ -617,8 +618,18 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
         didReceive challenge: URLAuthenticationChallenge,
         completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
     ) {
-        // Parity with main browser: performDefaultHandling enables system keychain
-        // lookups, MDM client certs, and SSO extensions (e.g. Microsoft Entra ID).
+        // Parity with main browser: explicitly look up MDM client identity from
+        // the system keychain since WKWebView's .performDefaultHandling does not
+        // search the keychain the way Safari does.
+        if challenge.protectionSpace.authenticationMethod == NSURLAuthenticationMethodClientCertificate {
+            let host = challenge.protectionSpace.host
+            let issuers = challenge.protectionSpace.distinguishedNames as CFArray?
+            if let identity = SecIdentityCopyPreferred(host as CFString, nil, issuers) {
+                let credential = URLCredential(identity: identity, certificates: nil, persistence: .forSession)
+                completionHandler(.useCredential, credential)
+                return
+            }
+        }
         completionHandler(.performDefaultHandling, nil)
     }
 


### PR DESCRIPTION
## Summary

- Replaces blanket `.performDefaultHandling` with explicit `SecIdentityCopyPreferred` keychain lookup for `NSURLAuthenticationMethodClientCertificate` challenges
- Fixes Microsoft Entra ID "this device needs to be under policy" error in browser pane on MDM-enrolled Macs
- Applied to both `BrowserNavigationDelegate` and `PopupNavigationDelegate` for parity

## Problem

PR #806 added `webView(_:didReceive:completionHandler:)` returning `.performDefaultHandling` to fix Microsoft managed device authentication. While this works for server trust evaluation (validating MDM-installed root CAs), it does **not** trigger the system keychain lookup needed for **client certificate** challenges in WKWebView.

Safari's web content process has special entitlements that allow `.performDefaultHandling` to automatically search the keychain for matching client identities. Third-party apps' WKWebViews lack these entitlements, so `.performDefaultHandling` for `NSURLAuthenticationMethodClientCertificate` effectively sends no certificate — making it functionally identical to the pre-#806 behavior for this specific challenge type.

## Fix

When a `NSURLAuthenticationMethodClientCertificate` challenge arrives, explicitly call `SecIdentityCopyPreferred(_:_:_:)` with the server's host and acceptable CA distinguished names. This runs in the app process (which has keychain access) and returns the MDM device identity certificate. The credential is then provided to WebKit via `.useCredential`.

- Non-MDM machines are unaffected — `SecIdentityCopyPreferred` returns nil when no matching identity exists, and the fallback to `.performDefaultHandling` preserves all other authentication flows (server trust, NTLM, Kerberos, SSO extensions, etc.)

## Test plan

- [ ] On an MDM-enrolled Mac, open cmux browser and navigate to `github.com` (or any Microsoft Entra ID-protected SSO)
- [ ] Sign in with corporate credentials — should no longer show "this device needs to be under policy"
- [ ] Verify regular HTTPS sites still load normally
- [ ] Verify non-MDM Macs are unaffected (graceful nil fallback)
- [ ] Verify popup windows (OAuth flows) also handle client cert challenges

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Explicitly resolve the MDM client certificate from the system keychain for TLS client‑cert challenges in `WKWebView`, fixing Microsoft Entra ID “this device needs to be under policy” errors. Applied to both the main browser and popup windows; other auth flows remain unchanged.

- **Bug Fixes**
  - For `NSURLAuthenticationMethodClientCertificate`, use `SecIdentityCopyPreferred` with the host and acceptable CA DNs, then pass the identity via `.useCredential`.
  - Fall back to `.performDefaultHandling` when no identity is found, preserving server trust, NTLM/Kerberos, and SSO behavior across `BrowserNavigationDelegate` and `PopupNavigationDelegate`.

<sup>Written for commit 9c35c8db9b3abf9381b3e577a4fdd3c542854cb0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced client certificate authentication handling in browser panels and popup windows.
  * Implemented intelligent certificate selection based on host and issuer requirements when accessing sites that require client certificates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->