### PR TITLE
Add command-palette toggle for external link/open routing

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -17173,13 +17173,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Open Terminal Links and open Command URLs in cmux Browser"
+            "value": "Browser Mode: cmux (Terminal URLs)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルリンクとopenコマンドURLをcmuxブラウザで開く"
+            "value": "ブラウザモード: cmux (ターミナルURL)"
           }
         }
       }
@@ -17190,13 +17190,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Open Terminal Links and open Command URLs in External Browser"
+            "value": "Browser Mode: External (Terminal URLs)"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルリンクとopenコマンドURLを外部ブラウザで開く"
+            "value": "ブラウザモード: 外部 (ターミナルURL)"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -17167,6 +17167,40 @@
         }
       }
     },
+    "command.disableExternalBrowserForTerminalLinksAndOpenCommand.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Terminal Links and open Command URLs in cmux Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルリンクとopenコマンドURLをcmuxブラウザで開く"
+          }
+        }
+      }
+    },
+    "command.enableExternalBrowserForTerminalLinksAndOpenCommand.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Terminal Links and open Command URLs in External Browser"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルリンクとopenコマンドURLを外部ブラウザで開く"
+          }
+        }
+      }
+    },
     "command.installCLI.subtitle": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2192,6 +2192,7 @@ struct ContentView: View {
         static let panelShouldPin = "panel.shouldPin"
         static let panelHasUnread = "panel.hasUnread"
 
+        static let terminalLinksAndOpenCommandOpenExternallyOnly = "browser.terminalLinksAndOpenCommandOpenExternallyOnly"
         static let updateHasAvailable = "update.hasAvailable"
         static let cliInstalledInPATH = "cli.installedInPATH"
 
@@ -6242,6 +6243,10 @@ struct ContentView: View {
     ) -> CommandPaletteContextSnapshot {
         var snapshot = CommandPaletteContextSnapshot()
         snapshot.setBool(CommandPaletteContextKeys.workspaceMinimalModeEnabled, isMinimalMode)
+        snapshot.setBool(
+            CommandPaletteContextKeys.terminalLinksAndOpenCommandOpenExternallyOnly,
+            BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly()
+        )
 
         if let workspace = tabManager.selectedWorkspace {
             snapshot.setBool(CommandPaletteContextKeys.hasWorkspace, true)
@@ -6548,6 +6553,34 @@ struct ContentView: View {
                 title: constant(String(localized: "command.restartSocketListener.title", defaultValue: "Restart CLI Listener")),
                 subtitle: constant(String(localized: "command.restartSocketListener.subtitle", defaultValue: "Global")),
                 keywords: ["restart", "socket", "listener", "cli", "cmux", "control"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.enableExternalBrowserForTerminalLinksAndOpenCommand",
+                title: constant(
+                    String(
+                        localized: "command.enableExternalBrowserForTerminalLinksAndOpenCommand.title",
+                        defaultValue: "Open Terminal Links and open Command URLs in External Browser"
+                    )
+                ),
+                subtitle: constant(String(localized: "command.browserClearHistory.subtitle", defaultValue: "Browser")),
+                keywords: ["terminal", "links", "external", "browser", "cmd", "click", "open", "command", "url"],
+                when: { !$0.bool(CommandPaletteContextKeys.terminalLinksAndOpenCommandOpenExternallyOnly) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.disableExternalBrowserForTerminalLinksAndOpenCommand",
+                title: constant(
+                    String(
+                        localized: "command.disableExternalBrowserForTerminalLinksAndOpenCommand.title",
+                        defaultValue: "Open Terminal Links and open Command URLs in cmux Browser"
+                    )
+                ),
+                subtitle: constant(String(localized: "command.browserClearHistory.subtitle", defaultValue: "Browser")),
+                keywords: ["terminal", "links", "cmux", "browser", "embedded", "cmd", "click", "open", "command", "url"],
+                when: { $0.bool(CommandPaletteContextKeys.terminalLinksAndOpenCommandOpenExternallyOnly) }
             )
         )
 
@@ -7206,6 +7239,12 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.restartSocketListener") {
             AppDelegate.shared?.restartSocketListener(nil)
+        }
+        registry.register(commandId: "palette.enableExternalBrowserForTerminalLinksAndOpenCommand") {
+            BrowserLinkOpenSettings.setTerminalLinksAndOpenCommandOpenExternallyOnly(true)
+        }
+        registry.register(commandId: "palette.disableExternalBrowserForTerminalLinksAndOpenCommand") {
+            BrowserLinkOpenSettings.setTerminalLinksAndOpenCommandOpenExternallyOnly(false)
         }
 
         registry.register(commandId: "palette.renameWorkspace") {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6561,11 +6561,11 @@ struct ContentView: View {
                 title: constant(
                     String(
                         localized: "command.enableExternalBrowserForTerminalLinksAndOpenCommand.title",
-                        defaultValue: "Open Terminal Links and open Command URLs in External Browser"
+                        defaultValue: "Browser Mode: External (Terminal URLs)"
                     )
                 ),
                 subtitle: constant(String(localized: "command.browserClearHistory.subtitle", defaultValue: "Browser")),
-                keywords: ["terminal", "links", "external", "browser", "cmd", "click", "open", "command", "url"],
+                keywords: ["browser", "mode", "terminal", "links", "external", "cmd", "click", "open", "command", "url"],
                 when: { !$0.bool(CommandPaletteContextKeys.terminalLinksAndOpenCommandOpenExternallyOnly) }
             )
         )
@@ -6575,11 +6575,11 @@ struct ContentView: View {
                 title: constant(
                     String(
                         localized: "command.disableExternalBrowserForTerminalLinksAndOpenCommand.title",
-                        defaultValue: "Open Terminal Links and open Command URLs in cmux Browser"
+                        defaultValue: "Browser Mode: cmux (Terminal URLs)"
                     )
                 ),
                 subtitle: constant(String(localized: "command.browserClearHistory.subtitle", defaultValue: "Browser")),
-                keywords: ["terminal", "links", "cmux", "browser", "embedded", "cmd", "click", "open", "command", "url"],
+                keywords: ["browser", "mode", "terminal", "links", "cmux", "embedded", "cmd", "click", "open", "command", "url"],
                 when: { $0.bool(CommandPaletteContextKeys.terminalLinksAndOpenCommandOpenExternallyOnly) }
             )
         )

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -587,6 +587,17 @@ enum BrowserLinkOpenSettings {
         interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
     }
 
+    static func terminalLinksAndOpenCommandOpenExternallyOnly(defaults: UserDefaults = .standard) -> Bool {
+        !openTerminalLinksInCmuxBrowser(defaults: defaults)
+            && !interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+    }
+
+    static func setTerminalLinksAndOpenCommandOpenExternallyOnly(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        let useCmuxBrowser = !enabled
+        defaults.set(useCmuxBrowser, forKey: openTerminalLinksInCmuxBrowserKey)
+        defaults.set(useCmuxBrowser, forKey: interceptTerminalOpenCommandInCmuxBrowserKey)
+    }
+
     static func hostWhitelist(defaults: UserDefaults = .standard) -> [String] {
         let raw = defaults.string(forKey: browserHostWhitelistKey) ?? defaultBrowserHostWhitelist
         return raw

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3172,6 +3172,36 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         XCTAssertTrue(BrowserLinkOpenSettings.initialInterceptTerminalOpenCommandInCmuxBrowserValue(defaults: defaults))
     }
 
+    func testTerminalLinksAndOpenCommandOpenExternallyOnlyDefaultsToDisabled() {
+        XCTAssertFalse(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+    }
+
+    func testTerminalLinksAndOpenCommandOpenExternallyOnlyRequiresBothTerminalLinkPathsDisabled() {
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        defaults.set(true, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+        XCTAssertFalse(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+
+        defaults.set(true, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        defaults.set(false, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+        XCTAssertFalse(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+
+        defaults.set(false, forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+        defaults.set(false, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+        XCTAssertTrue(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+    }
+
+    func testSetTerminalLinksAndOpenCommandOpenExternallyOnlyUpdatesBothTerminalLinkSettings() {
+        BrowserLinkOpenSettings.setTerminalLinksAndOpenCommandOpenExternallyOnly(true, defaults: defaults)
+        XCTAssertFalse(BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser(defaults: defaults))
+        XCTAssertFalse(BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults))
+        XCTAssertTrue(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+
+        BrowserLinkOpenSettings.setTerminalLinksAndOpenCommandOpenExternallyOnly(false, defaults: defaults)
+        XCTAssertTrue(BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser(defaults: defaults))
+        XCTAssertTrue(BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults))
+        XCTAssertFalse(BrowserLinkOpenSettings.terminalLinksAndOpenCommandOpenExternallyOnly(defaults: defaults))
+    }
+
     func testExternalOpenPatternsDefaultToEmpty() {
         XCTAssertTrue(BrowserLinkOpenSettings.externalOpenPatterns(defaults: defaults).isEmpty)
     }


### PR DESCRIPTION
## Summary
- add Cmd+Shift+P command-palette actions to toggle routing of terminal link opens and terminal `open` command URLs between cmux browser and external browser
- persist the toggle by updating both existing browser settings keys so Settings reflects the current state immediately
- add unit coverage for the new combined toggle helper in `BrowserLinkOpenSettings`

## Testing
- `./scripts/reload.sh --tag task-toggle-external-browser-links` (build succeeds)

## Issues
- Related: User task request in chat: "make cmd shift p action for enabling/disabling (toggling) opening links in external browser (aka temporarily stop using cmux browser to open links entirely, for both open and cmd click)."

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a command-palette toggle to route Terminal links and `open` command URLs to the cmux Browser or your external browser. Commands now use single-string labels (“Browser Mode: External (Terminal URLs)” / “Browser Mode: cmux (Terminal URLs)”), and the choice persists so Settings reflects it immediately.

- **New Features**
  - Added `Cmd+Shift+P` commands to enable or disable external routing for Terminal links and `open` URLs.
  - Commands show/hide based on a combined setting in `BrowserLinkOpenSettings`.
  - Persists by updating both underlying settings to keep behavior consistent across link types.
  - Added localized titles (EN/JA) and unit tests for the new helper.

<sup>Written for commit ce9aa80b9e59d1d902a7f8f0a55ceccac58a3b15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Two new command-palette commands let users toggle whether terminal links and the open command use the internal or external browser; visibility is context-aware.
  * Added English and Japanese localized titles for these commands.

* **Tests**
  * Added unit tests verifying the combined toggle behavior and persistence of the related settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->