### PR TITLE
Fix minimal-mode traffic-light inset for new workspaces

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1903,6 +1903,20 @@ class TabManager: ObservableObject {
         )
     }
 
+    private func applyCreationChromeInheritance(
+        to newWorkspace: Workspace,
+        from sourceWorkspace: Workspace?
+    ) {
+        guard let sourceWorkspace else { return }
+        // Sidebar-toggle relayout updates the live Bonsplit leading inset so minimal-mode
+        // workspaces reserve traffic-light space. New workspaces need that same inset
+        // copied immediately because creation itself does not trigger the resync path.
+        let inheritedLeadingInset = sourceWorkspace.bonsplitController.configuration.appearance.tabBarLeadingInset
+        if newWorkspace.bonsplitController.configuration.appearance.tabBarLeadingInset != inheritedLeadingInset {
+            newWorkspace.bonsplitController.configuration.appearance.tabBarLeadingInset = inheritedLeadingInset
+        }
+    }
+
     /// Test seam for mutating live workspace state after the creation snapshot is captured.
     func didCaptureWorkspaceCreationSnapshot() {}
 
@@ -1984,6 +1998,10 @@ class TabManager: ObservableObject {
                 configTemplate: inheritedConfig,
                 initialTerminalCommand: initialTerminalCommand,
                 initialTerminalEnvironment: initialTerminalEnvironment
+            )
+            applyCreationChromeInheritance(
+                to: newWorkspace,
+                from: sourceWorkspace ?? capturedTabs.first
             )
             newWorkspace.owningTabManager = self
             if title != nil {


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/2737

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change that only propagates an existing `tabBarLeadingInset` value into newly created workspaces; potential impact is limited to tab bar spacing/appearance.
> 
> **Overview**
> Fixes new workspace creation to immediately inherit the current chrome/layout state by copying `bonsplitController.configuration.appearance.tabBarLeadingInset` from the source (selected/first) workspace.
> 
> This prevents newly created tabs in minimal mode from briefly using the default leading inset (and overlapping the macOS traffic-light area) until a later relayout/resync occurs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8510503d641e15dabab0e18ecae856cb1fe10890. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minimal-mode workspaces not reserving the macOS traffic-light inset on creation by inheriting the tab bar leading inset from the source workspace (or first captured tab). Prevents overlap/flicker until any later relayout.

- **Bug Fixes**
  - Added applyCreationChromeInheritance in TabManager to copy `appearance.tabBarLeadingInset` to the new workspace on creation, using the source workspace or `capturedTabs.first` as fallback.

<sup>Written for commit 8510503d641e15dabab0e18ecae856cb1fe10890. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace creation to preserve tab bar layout settings from source workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->