### PR TITLE
エージェント階層サイドバー + 色連携 + 独立タブ昇格

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1728,6 +1728,7 @@ struct CMUXCLI {
         // so help text is available even when cmux is not running.
         if command != "__tmux-compat",
            command != "claude-teams",
+           command != "claude-teams-debug",
            command != "codex",
            (commandArgs.contains("--help") || commandArgs.contains("-h")) {
             if dispatchSubcommandHelp(command: command, commandArgs: commandArgs) {
@@ -1770,7 +1771,7 @@ struct CMUXCLI {
             return
         }
 
-        if command == "claude-teams" {
+        if command == "claude-teams" || command == "claude-teams-debug" {
             try runClaudeTeams(
                 commandArgs: commandArgs,
                 socketPath: resolvedSocketPath,
@@ -6885,9 +6886,10 @@ struct CMUXCLI {
               cmux themes set --light "Catppuccin Latte" --dark "Catppuccin Mocha"
               cmux themes clear
             """
-        case "claude-teams":
+        case "claude-teams", "claude-teams-debug":
             return String(localized: "cli.claude-teams.usage", defaultValue: """
             Usage: cmux claude-teams [claude-args...]
+                   cmux claude-teams-debug [claude-args...]
 
             Launch Claude Code with agent teams enabled.
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10146,6 +10146,81 @@ struct CMUXCLI {
         "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
+    /// Parse a tmux pane style string (e.g. "bg=colour160,fg=white" or "bg=#C0392B")
+    /// and extract the background color as a normalized #RRGGBB hex string.
+    private func parseTmuxStyleBackgroundHex(_ style: String) -> String? {
+        // Split style into key=value pairs: "bg=colour160,fg=white" → ["bg=colour160", "fg=white"]
+        let pairs = style.split(separator: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+        guard let bgPair = pairs.first(where: { $0.lowercased().hasPrefix("bg=") }) else {
+            return nil
+        }
+        let bgValue = String(bgPair.dropFirst(3)).trimmingCharacters(in: .whitespaces)
+        guard !bgValue.isEmpty, bgValue.lowercased() != "default" else { return nil }
+
+        // Case 1: Already a hex color (#RRGGBB or RRGGBB)
+        let stripped = bgValue.hasPrefix("#") ? String(bgValue.dropFirst()) : bgValue
+        if stripped.count == 6, UInt64(stripped, radix: 16) != nil {
+            return "#" + stripped.uppercased()
+        }
+
+        // Case 2: tmux colour0..colour255 (xterm-256color palette)
+        let lowered = bgValue.lowercased()
+        if lowered.hasPrefix("colour"), let n = Int(lowered.dropFirst("colour".count)), n >= 0, n < 256 {
+            return Self.xterm256ColorHex(n)
+        }
+        if lowered.hasPrefix("color"), let n = Int(lowered.dropFirst("color".count)), n >= 0, n < 256 {
+            return Self.xterm256ColorHex(n)
+        }
+
+        // Case 3: Named tmux colors
+        return Self.tmuxNamedColorHex(lowered)
+    }
+
+    private static func tmuxNamedColorHex(_ name: String) -> String? {
+        switch name {
+        case "black": return "#000000"
+        case "red": return "#CD0000"
+        case "green": return "#00CD00"
+        case "yellow": return "#CDCD00"
+        case "blue": return "#0000EE"
+        case "magenta": return "#CD00CD"
+        case "cyan": return "#00CDCD"
+        case "white": return "#E5E5E5"
+        case "brightblack": return "#7F7F7F"
+        case "brightred": return "#FF0000"
+        case "brightgreen": return "#00FF00"
+        case "brightyellow": return "#FFFF00"
+        case "brightblue": return "#5C5CFF"
+        case "brightmagenta": return "#FF00FF"
+        case "brightcyan": return "#00FFFF"
+        case "brightwhite": return "#FFFFFF"
+        default: return nil
+        }
+    }
+
+    /// Convert xterm-256 color index to #RRGGBB hex.
+    private static func xterm256ColorHex(_ n: Int) -> String? {
+        guard n >= 0, n < 256 else { return nil }
+        // Standard 16 colors (0-15)
+        let standard16: [String] = [
+            "#000000", "#CD0000", "#00CD00", "#CDCD00", "#0000EE", "#CD00CD", "#00CDCD", "#E5E5E5",
+            "#7F7F7F", "#FF0000", "#00FF00", "#FFFF00", "#5C5CFF", "#FF00FF", "#00FFFF", "#FFFFFF"
+        ]
+        if n < 16 { return standard16[n] }
+        // 216-color cube (16-231)
+        if n < 232 {
+            let idx = n - 16
+            let r = idx / 36
+            let g = (idx % 36) / 6
+            let b = idx % 6
+            let vals = [0, 95, 135, 175, 215, 255]
+            return String(format: "#%02X%02X%02X", vals[r], vals[g], vals[b])
+        }
+        // Grayscale ramp (232-255)
+        let gray = 8 + (n - 232) * 10
+        return String(format: "#%02X%02X%02X", gray, gray, gray)
+    }
+
     private func tmuxShellCommandText(commandTokens: [String], cwd: String?) -> String? {
         let trimmedCwd = cwd?.trimmingCharacters(in: .whitespacesAndNewlines)
         let commandText = commandTokens.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines)
@@ -11500,9 +11575,18 @@ struct CMUXCLI {
 
         case "select-pane", "selectp":
             let parsed = try parseTmuxArguments(rawArgs, valueFlags: ["-P", "-T", "-t"], boolFlags: [])
-            if parsed.value("-P") != nil || parsed.value("-T") != nil {
-                return
+            if let style = parsed.value("-P") {
+                if let hex = parseTmuxStyleBackgroundHex(style) {
+                    if let target = try? tmuxResolveSurfaceTarget(parsed.value("-t"), client: client) {
+                        _ = try? client.sendV2(method: "surface.set_color", params: [
+                            "workspace_id": target.workspaceId,
+                            "surface_id": target.surfaceId,
+                            "color": hex
+                        ])
+                    }
+                }
             }
+            guard parsed.value("-P") == nil, parsed.value("-T") == nil else { return }
             let target = try tmuxResolvePaneTarget(parsed.value("-t"), client: client)
             _ = try client.sendV2(method: "pane.focus", params: [
                 "workspace_id": target.workspaceId,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12994,6 +12994,37 @@ private struct TabItemView: View, Equatable {
                 .foregroundColor(activeSecondaryColor(0.75))
                 .lineLimit(1)
             }
+
+            // Surface child rows for multi-surface workspaces (agent teams)
+            if tab.panels.count > 1 {
+                let orderedIds = tab.sidebarOrderedPanelIds()
+                let currentFocusedPanelId = tab.focusedPanelId
+                VStack(spacing: 2) {
+                    ForEach(orderedIds, id: \.self) { panelId in
+                        SurfaceChildRow(
+                            title: tab.panelTitles[panelId] ?? String(localized: "sidebar.surfaceChild.defaultTitle", defaultValue: "Terminal"),
+                            colorHex: tab.panelColors[panelId],
+                            isFocused: panelId == currentFocusedPanelId,
+                            isWorkspaceActive: isActive,
+                            colorScheme: colorScheme
+                        )
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            updateSelection()
+                            tab.focusPanel(panelId)
+                        }
+                        .contextMenu {
+                            Button(String(localized: "sidebar.surfaceChild.openInNewWorkspace", defaultValue: "Open in New Workspace")) {
+                                tabManager.promoteSurfaceToNewWorkspace(
+                                    sourceWorkspace: tab,
+                                    panelId: panelId
+                                )
+                            }
+                        }
+                    }
+                }
+                .padding(.top, 4)
+            }
         }
         .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
         .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
@@ -13440,12 +13471,21 @@ private struct TabItemView: View, Equatable {
     }
 
     private var resolvedCustomTabColor: Color? {
-        guard let hex = tab.customColor else { return nil }
+        let hex = tab.customColor ?? representativePanelColorHex
+        guard let hex else { return nil }
         return WorkspaceTabColorSettings.displayColor(
             hex: hex,
             colorScheme: colorScheme,
             forceBright: activeTabIndicatorStyle == .leftRail
         )
+    }
+
+    /// When a workspace has no customColor but has panel colors (e.g. from agent teams),
+    /// use the first panel's color as the representative color for the workspace rail.
+    private var representativePanelColorHex: String? {
+        guard tab.customColor == nil, !tab.panelColors.isEmpty else { return nil }
+        let orderedIds = tab.sidebarOrderedPanelIds()
+        return orderedIds.lazy.compactMap { tab.panelColors[$0] }.first
     }
 
     private func tabColorSwatchColor(for hex: String) -> NSColor {
@@ -14169,6 +14209,58 @@ private struct SidebarMetadataRows: View {
 
     private var shouldShowToggle: Bool {
         entries.count > collapsedEntryLimit
+    }
+}
+
+private struct SurfaceChildRow: View {
+    let title: String
+    let colorHex: String?
+    let isFocused: Bool
+    let isWorkspaceActive: Bool
+    let colorScheme: ColorScheme
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: 6, height: 6)
+            Text(title)
+                .font(.system(size: 10))
+                .foregroundColor(textColor)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 0)
+        }
+        .padding(.vertical, 2)
+        .padding(.horizontal, 4)
+        .background(
+            RoundedRectangle(cornerRadius: 4)
+                .fill(isFocused ? focusedBackgroundColor : Color.clear)
+        )
+    }
+
+    private var dotColor: Color {
+        if let hex = colorHex,
+           let color = WorkspaceTabColorSettings.displayColor(hex: hex, colorScheme: colorScheme) {
+            return color
+        }
+        return Color.secondary.opacity(0.5)
+    }
+
+    private var textColor: Color {
+        if isWorkspaceActive {
+            return isFocused
+                ? Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 0.95))
+                : Color(nsColor: sidebarSelectedWorkspaceForegroundNSColor(opacity: 0.7))
+        }
+        return isFocused ? .primary : .secondary
+    }
+
+    private var focusedBackgroundColor: Color {
+        if isWorkspaceActive {
+            return Color.white.opacity(0.1)
+        }
+        return Color.primary.opacity(0.05)
     }
 }
 

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -332,6 +332,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customTitle: String?
     var customDescription: String?
     var customColor: String?
+    var panelColors: [String: String]?  // panelId.uuidString -> hex
     var isPinned: Bool
     var currentDirectory: String
     var focusedPanelId: UUID?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3561,6 +3561,53 @@ class TabManager: ObservableObject {
         tab.setCustomColor(color)
     }
 
+    /// Detach a surface from its current workspace and open it in a new workspace as an independent tab.
+    func promoteSurfaceToNewWorkspace(sourceWorkspace: Workspace, panelId: UUID) {
+        guard sourceWorkspace.panels[panelId] != nil else { return }
+        guard sourceWorkspace.panels.count > 1 else { return }
+
+        // Transfer panel color before detach (detach removes it from the source)
+        let panelColor = sourceWorkspace.panelColors[panelId]
+        let panelTitle = sourceWorkspace.panelTitles[panelId]
+
+        guard let transfer = sourceWorkspace.detachSurface(panelId: panelId) else { return }
+
+        let newWorkspace = addWorkspace(
+            title: panelTitle ?? transfer.title,
+            select: true,
+            eagerLoadTerminal: false
+        )
+
+        guard let targetPane = newWorkspace.bonsplitController.allPaneIds.first else {
+            // Rollback: reattach to source
+            if let rollbackPane = sourceWorkspace.bonsplitController.allPaneIds.first {
+                sourceWorkspace.attachDetachedSurface(transfer, inPane: rollbackPane, focus: true)
+            }
+            return
+        }
+
+        // Identify the dummy terminal that addWorkspace auto-created
+        let dummyPanelIds = Set(newWorkspace.panels.keys)
+
+        guard newWorkspace.attachDetachedSurface(transfer, inPane: targetPane, focus: true) != nil else {
+            // Rollback: reattach to source
+            if let rollbackPane = sourceWorkspace.bonsplitController.allPaneIds.first {
+                sourceWorkspace.attachDetachedSurface(transfer, inPane: rollbackPane, focus: true)
+            }
+            return
+        }
+
+        // Close the dummy terminal surface that was auto-created with the new workspace
+        for dummyId in dummyPanelIds {
+            _ = newWorkspace.closePanel(dummyId, force: true)
+        }
+
+        // Apply the panel color as the new workspace's custom color
+        if let panelColor {
+            newWorkspace.setCustomColor(panelColor)
+        }
+    }
+
     func togglePin(tabId: UUID) {
         guard let index = tabs.firstIndex(where: { $0.id == tabId }) else { return }
         let tab = tabs[index]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2136,6 +2136,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceClose(params: params))
         case "surface.move":
             return v2Result(id: id, self.v2SurfaceMove(params: params))
+        case "surface.set_color":
+            return v2Result(id: id, self.v2SurfaceSetColor(params: params))
         case "surface.reorder":
             return v2Result(id: id, self.v2SurfaceReorder(params: params))
         case "surface.action":
@@ -4910,6 +4912,38 @@ class TerminalController {
 
             ws.focusPanel(surfaceId)
             result = .ok(["workspace_id": ws.id.uuidString, "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id), "surface_id": surfaceId.uuidString, "surface_ref": v2Ref(kind: .surface, uuid: surfaceId), "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString), "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager))])
+        }
+        return result
+    }
+
+    private func v2SurfaceSetColor(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to set surface color", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+            guard let surfaceId = v2UUID(params, "surface_id"), ws.panels[surfaceId] != nil else {
+                result = .err(code: "not_found", message: "Surface not found", data: nil)
+                return
+            }
+
+            let colorRaw = v2String(params, "color")?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let colorRaw, !colorRaw.isEmpty {
+                if let normalized = WorkspaceTabColorSettings.normalizedHex(colorRaw) {
+                    ws.setPanelColor(surfaceId, hex: normalized)
+                    result = .ok(["surface_id": surfaceId.uuidString, "color": normalized])
+                } else {
+                    result = .err(code: "invalid_params", message: "Invalid color hex", data: nil)
+                }
+            } else {
+                ws.setPanelColor(surfaceId, hex: nil)
+                result = .ok(["surface_id": surfaceId.uuidString, "color": NSNull()])
+            }
         }
         return result
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -297,6 +297,7 @@ extension Workspace {
             customTitle: customTitle,
             customDescription: customDescription,
             customColor: customColor,
+            panelColors: panelColors.isEmpty ? nil : Dictionary(uniqueKeysWithValues: panelColors.map { ($0.key.uuidString, $0.value) }),
             isPinned: isPinned,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -337,6 +338,13 @@ extension Workspace {
         setCustomTitle(snapshot.customTitle)
         setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
+        if let savedPanelColors = snapshot.panelColors {
+            for (key, hex) in savedPanelColors {
+                if let uuid = UUID(uuidString: key) {
+                    setPanelColor(uuid, hex: hex)
+                }
+            }
+        }
         isPinned = snapshot.isPinned
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
@@ -6486,6 +6494,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
+    @Published var panelColors: [UUID: String] = [:]  // panelId -> hex string
     @Published var currentDirectory: String
     private(set) var preferredBrowserProfileID: UUID?
 
@@ -6658,6 +6667,8 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($remoteConnectionDetail),
             sidebarObservationSignal($activeRemoteTerminalSessionCount),
             sidebarObservationSignal($listeningPorts),
+            sidebarObservationSignal($panelColors),
+            sidebarObservationSignal($panelTitles),
         ]
 
         return Publishers.MergeMany(publishers).eraseToAnyPublisher()
@@ -7519,6 +7530,14 @@ final class Workspace: Identifiable, ObservableObject {
             customColor = WorkspaceTabColorSettings.normalizedHex(hex)
         } else {
             customColor = nil
+        }
+    }
+
+    func setPanelColor(_ panelId: UUID, hex: String?) {
+        if let hex, let normalized = WorkspaceTabColorSettings.normalizedHex(hex) {
+            panelColors[panelId] = normalized
+        } else {
+            panelColors.removeValue(forKey: panelId)
         }
     }
 


### PR DESCRIPTION
## 概要
Claude Code の agent teams で 1 ワークスペース内に複数エージェントが生成される際、左サイドバーに各 surface を子行として階層表示し、色やフォーカスジャンプ、独立タブ昇格を可能にする。

## 変更点
- サイドバーに surface 子行を表示 (panels > 1 のとき自動展開)
- Claude Code teams の `select-pane -P` から色を取り込み (`surface.set_color` socket コマンド)
- tmux colour0-255 / named color / hex → #RRGGBB 変換ヘルパ
- 親行の左レールに代表 panel 色を伝播
- 子行右クリック → "Open in New Workspace" で独立タブ昇格
- `panelColors` の SessionPersistence 永続化
- `cmux claude-teams-debug` コマンドエイリアス追加

## テスト
- `cmux claude-teams-debug` で 3 体エージェント起動 → サイドバーに子行表示確認
- 子行クリックで surface フォーカス確認
- 子行右クリック → "Open in New Workspace" で独立タブ化確認
- アプリ再起動後に色が復元されることを確認

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an agent surface hierarchy in the sidebar with per-surface colors and lets you promote a surface to its own workspace tab. Improves focus navigation and keeps colors in sync with `tmux`.

- New Features
  - Sidebar shows child rows for each surface when a workspace has multiple panels. Click to focus. Colored dot reflects surface color. The first panel color is used on the workspace rail when no custom color is set.
  - Color sync from `tmux` via `select-pane -P bg=…`. Supports `colour0-255`, named colors, and hex, normalized to `#RRGGBB`. New socket command `surface.set_color`. Colors persist via `panelColors` in session snapshots.
  - Right-click a surface row → “Open in New Workspace” to detach it into a new tab. Carries over its title and color, closes the dummy terminal, and safely rolls back on failure.
  - CLI: add `cmux claude-teams-debug` as an alias for `cmux claude-teams` with updated help text.

<sup>Written for commit 09eb1e76d182b80818ec18da06e24cce3553e79f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Promote individual surfaces to independent workspaces via context menu
  * Customize and persist per-panel colors across sessions
  * Enhanced sidebar with improved panel organization and visual indicators
  * Workspace colors now automatically reflect representative panel colors when no custom color is set
  * Extended command support for surface color management in terminal automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->