### PR TITLE
Prevent titlebar accessory clicks from zooming the window

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -775,6 +775,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     private let containerView = NSView()
     private let notificationStore: TerminalNotificationStore
     private lazy var notificationsPopover: NSPopover = makeNotificationsPopover()
+    private var mouseEventMonitor: Any?
     private var pendingSizeUpdate = false
     private var fittingSizeNeedsRefresh = true
     private var cachedFittingSize: NSSize?
@@ -827,6 +828,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         }
 
         applyWorkspaceTitlebarVisibility()
+        installMouseEventMonitor()
         scheduleSizeUpdate(invalidateFittingSize: true)
     }
 
@@ -838,6 +840,34 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         if let userDefaultsObserver {
             NotificationCenter.default.removeObserver(userDefaultsObserver)
         }
+        if let mouseEventMonitor {
+            NSEvent.removeMonitor(mouseEventMonitor)
+        }
+    }
+
+    private func installMouseEventMonitor() {
+        guard mouseEventMonitor == nil else { return }
+        mouseEventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDown, .leftMouseUp]) { [weak self] event in
+            guard let self else { return event }
+            return self.normalizedMouseClickEventIfNeeded(event)
+        }
+    }
+
+    private func normalizedMouseClickEventIfNeeded(_ event: NSEvent) -> NSEvent? {
+        guard event.clickCount >= 2 else { return event }
+        guard let window = view.window, event.window === window else { return event }
+
+        let point = view.convert(event.locationInWindow, from: nil)
+        guard view.bounds.contains(point) else { return event }
+        guard view.hitTest(point) != nil else { return event }
+        guard let cgEvent = event.cgEvent, let copiedCGEvent = cgEvent.copy() else { return event }
+
+        // Titlebar accessory controls live inside the native titlebar region. When the
+        // user rapidly clicks them, AppKit can treat the second click as a titlebar
+        // double-click and zoom the window. Normalize those clicks back to single-clicks
+        // before dispatch so the controls still respond but the window does not zoom.
+        copiedCGEvent.setIntegerValueField(CGEventField.mouseEventClickState, value: 1)
+        return NSEvent(cgEvent: copiedCGEvent) ?? event
     }
 
     override func viewDidAppear() {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -7,6 +7,10 @@ final class NonDraggableHostingView<Content: View>: NSHostingView<Content> {
     override var mouseDownCanMoveWindow: Bool { false }
 }
 
+final class NonDraggableTitlebarAccessoryContainerView: NSView {
+    override var mouseDownCanMoveWindow: Bool { false }
+}
+
 enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
     case classic
     case compact
@@ -772,10 +776,13 @@ func titlebarControlsShouldApplyLayout(
 
 final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewController, NSPopoverDelegate {
     private let hostingView: NonDraggableHostingView<TitlebarControlsView>
-    private let containerView = NSView()
+    private let containerView = NonDraggableTitlebarAccessoryContainerView()
     private let notificationStore: TerminalNotificationStore
     private lazy var notificationsPopover: NSPopover = makeNotificationsPopover()
     private var mouseEventMonitor: Any?
+    private weak var suppressedWindow: NSWindow?
+    private var previousWindowMovableState: Bool?
+    private var didArmWindowDragSuppression = false
     private var pendingSizeUpdate = false
     private var fittingSizeNeedsRefresh = true
     private var cachedFittingSize: NSSize?
@@ -837,6 +844,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     }
 
     deinit {
+        restoreWindowDraggingIfNeeded()
         if let userDefaultsObserver {
             NotificationCenter.default.removeObserver(userDefaultsObserver)
         }
@@ -854,12 +862,22 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
     }
 
     private func normalizedMouseClickEventIfNeeded(_ event: NSEvent) -> NSEvent? {
-        guard event.clickCount >= 2 else { return event }
         guard let window = view.window, event.window === window else { return event }
 
         let point = view.convert(event.locationInWindow, from: nil)
         guard view.bounds.contains(point) else { return event }
         guard view.hitTest(point) != nil else { return event }
+
+        switch event.type {
+        case .leftMouseDown:
+            disableWindowDraggingIfNeeded(window: window)
+        case .leftMouseUp:
+            restoreWindowDraggingIfNeeded()
+        default:
+            break
+        }
+
+        guard event.clickCount >= 2 else { return event }
         guard let cgEvent = event.cgEvent, let copiedCGEvent = cgEvent.copy() else { return event }
 
         // Titlebar accessory controls live inside the native titlebar region. When the
@@ -868,6 +886,26 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         // before dispatch so the controls still respond but the window does not zoom.
         copiedCGEvent.setIntegerValueField(CGEventField.mouseEventClickState, value: 1)
         return NSEvent(cgEvent: copiedCGEvent) ?? event
+    }
+
+    private func disableWindowDraggingIfNeeded(window: NSWindow) {
+        guard !didArmWindowDragSuppression else { return }
+
+        didArmWindowDragSuppression = true
+        suppressedWindow = window
+        _ = beginWindowDragSuppression(window: window)
+        previousWindowMovableState = temporarilyDisableWindowDragging(window: window)
+    }
+
+    private func restoreWindowDraggingIfNeeded() {
+        guard didArmWindowDragSuppression || previousWindowMovableState != nil else { return }
+
+        let targetWindow = suppressedWindow ?? view.window
+        _ = endWindowDragSuppression(window: targetWindow)
+        restoreWindowDragging(window: targetWindow, previousMovableState: previousWindowMovableState)
+        previousWindowMovableState = nil
+        suppressedWindow = nil
+        didArmWindowDragSuppression = false
     }
 
     override func viewDidAppear() {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -490,6 +490,17 @@ struct TitlebarDoubleClickMonitorView: NSViewRepresentable {
 
             let point = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.contains(point) else { return event }
+            // Match the drag-handle hit policy so double-click titlebar actions only
+            // trigger from empty titlebar space, never through interactive siblings such
+            // as the sidebar/notification/new-workspace controls layered above it.
+            guard windowDragHandleShouldCaptureHit(
+                point,
+                in: view,
+                eventType: event.type,
+                eventWindow: event.window
+            ) else {
+                return event
+            }
 
             let action = performStandardTitlebarDoubleClick(window: window)
             return action == nil ? event : nil

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -490,18 +490,6 @@ struct TitlebarDoubleClickMonitorView: NSViewRepresentable {
 
             let point = view.convert(event.locationInWindow, from: nil)
             guard view.bounds.contains(point) else { return event }
-            // Match the drag-handle hit policy so double-click titlebar actions only
-            // trigger from empty titlebar space, never through interactive siblings such
-            // as the sidebar/notification/new-workspace controls layered above it.
-            guard windowDragHandleShouldCaptureHit(
-                point,
-                in: view,
-                eventType: event.type,
-                eventWindow: event.window
-            ) else {
-                return event
-            }
-
             let action = performStandardTitlebarDoubleClick(window: window)
             return action == nil ? event : nil
         }


### PR DESCRIPTION
# PR title

Prevent titlebar accessory clicks from zooming the window

## Summary

- Fixes #2747
- Mark the titlebar accessory container as non-draggable
- Temporarily suppress window dragging while titlebar accessory controls handle mouse down/up events
- Keep rapid clicks on the `+` control routed to `addTab()` instead of being interpreted as a titlebar zoom gesture

## Why

Rapid mouse clicks on the top-left `+` control in a regular non-full-screen window can zoom the window, while `Cmd+N` does not. That points to the native titlebar mouse path rather than `addTab()` itself.

The controls live inside the native titlebar region, so AppKit can still interpret rapid clicks as titlebar drag / double-click behavior unless that area is explicitly made non-draggable and window dragging is suppressed while the accessory control handles the interaction.

## Testing

- Built a local debug app with Xcode
- Manually reproduced the issue in the DEV build by rapidly clicking the titlebar `+` in a regular non-full-screen window
- Verified the updated build no longer zooms the window under the same interaction
- Verified `Cmd+N` behavior is unchanged
- No automated test coverage added

## Demo Video

Video URL or attachment: _to add_

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved