### PR TITLE
Open .md files in MarkdownPanel on CMD+click

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -708,10 +708,11 @@ private func cmuxResolveVisibleLinePath(
 enum TerminalOpenURLTarget: Equatable {
     case embeddedBrowser(URL)
     case external(URL)
+    case markdownViewer(URL)
 
     var url: URL {
         switch self {
-        case let .embeddedBrowser(url), let .external(url):
+        case let .embeddedBrowser(url), let .external(url), let .markdownViewer(url):
             return url
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3091,6 +3091,34 @@ class GhosttyApp {
                 #endif
                 return false
             }
+            if case let .markdownViewer(url) = target {
+                let filePath = url.path
+                #if DEBUG
+                dlog("link.openURL target=markdownViewer, opening markdown panel filePath=\(filePath)")
+                #endif
+                let sourceWorkspaceId = callbackTabId ?? surfaceView.tabId
+                let sourcePanelId = callbackSurfaceId ?? surfaceView.terminalSurface?.id
+                return performOnMain {
+                    guard let sourceWorkspaceId,
+                          let sourcePanelId,
+                          let app = AppDelegate.shared,
+                          let resolved = app.workspaceContainingPanel(
+                              panelId: sourcePanelId,
+                              preferredWorkspaceId: sourceWorkspaceId
+                          ) else {
+                        #if DEBUG
+                        dlog("link.openURL markdownViewer but workspace lookup failed")
+                        #endif
+                        return false
+                    }
+                    let workspace = resolved.workspace
+                    return workspace.newMarkdownSplit(
+                        from: sourcePanelId,
+                        orientation: .horizontal,
+                        filePath: filePath
+                    ) != nil
+                }
+            }
             if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
                 #if DEBUG
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
@@ -3184,6 +3212,9 @@ class GhosttyApp {
                         return workspace.newBrowserSplit(from: sourcePanelId, orientation: .horizontal, url: url) != nil
                     }
                 }
+            case .markdownViewer:
+                // Handled above before the browser settings guard.
+                return false
             }
         default:
             return false

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -791,6 +791,11 @@ final class GhosttyDefaultBackgroundNotificationDispatcher {
     }
 }
 
+private func isMarkdownExtension(_ path: String) -> Bool {
+    let ext = (path as NSString).pathExtension.lowercased()
+    return ext == "md" || ext == "markdown"
+}
+
 func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? {
     let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
     #if DEBUG
@@ -804,6 +809,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
     }
 
     if NSString(string: trimmed).isAbsolutePath {
+        if isMarkdownExtension(trimmed) {
+            #if DEBUG
+            dlog("link.resolve result=markdownViewer(absolutePath) url=\(trimmed)")
+            #endif
+            return .markdownViewer(URL(fileURLWithPath: trimmed))
+        }
         #if DEBUG
         dlog("link.resolve result=external(absolutePath) url=\(trimmed)")
         #endif
@@ -823,6 +834,12 @@ func resolveTerminalOpenURLTarget(_ rawValue: String) -> TerminalOpenURLTarget? 
             dlog("link.resolve result=embeddedBrowser url=\(parsed)")
             #endif
             return .embeddedBrowser(parsed)
+        }
+        if scheme == "file" && isMarkdownExtension(parsed.path) {
+            #if DEBUG
+            dlog("link.resolve result=markdownViewer(fileScheme) url=\(parsed)")
+            #endif
+            return .markdownViewer(parsed)
         }
         #if DEBUG
         dlog("link.resolve result=external(scheme=\(scheme)) url=\(parsed)")

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3712,6 +3712,71 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
             XCTFail("Expected hostless HTTPS URL to open externally")
         }
     }
+
+    func testResolvesAbsoluteMarkdownPathAsMarkdownViewer() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("/tmp/readme.md"))
+        switch target {
+        case let .markdownViewer(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.path, "/tmp/readme.md")
+        default:
+            XCTFail("Expected .md absolute path to route to markdown viewer, got \(target)")
+        }
+    }
+
+    func testResolvesAbsoluteMarkdownExtensionPathAsMarkdownViewer() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("/tmp/notes.markdown"))
+        switch target {
+        case let .markdownViewer(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.path, "/tmp/notes.markdown")
+        default:
+            XCTFail("Expected .markdown absolute path to route to markdown viewer, got \(target)")
+        }
+    }
+
+    func testResolvesUppercaseMDExtensionAsMarkdownViewer() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("/tmp/README.MD"))
+        switch target {
+        case let .markdownViewer(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.path, "/tmp/README.MD")
+        default:
+            XCTFail("Expected .MD absolute path to route to markdown viewer, got \(target)")
+        }
+    }
+
+    func testResolvesFileSchemeMarkdownAsMarkdownViewer() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("file:///tmp/design.md"))
+        switch target {
+        case let .markdownViewer(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.path, "/tmp/design.md")
+        default:
+            XCTFail("Expected file:// .md URL to route to markdown viewer, got \(target)")
+        }
+    }
+
+    func testResolvesAbsoluteTextPathAsExternal() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("/tmp/notes.txt"))
+        switch target {
+        case let .external(url):
+            XCTAssertTrue(url.isFileURL)
+            XCTAssertEqual(url.path, "/tmp/notes.txt")
+        default:
+            XCTFail("Expected .txt path to remain external, got \(target)")
+        }
+    }
+
+    func testResolvesHTTPMarkdownURLAsEmbeddedBrowser() throws {
+        let target = try XCTUnwrap(resolveTerminalOpenURLTarget("https://example.com/README.md"))
+        switch target {
+        case .embeddedBrowser:
+            break
+        default:
+            XCTFail("Expected HTTPS .md URL to route to embedded browser, got \(target)")
+        }
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- CMD+clicking a `.md` or `.markdown` file path in the terminal now opens it in the built-in MarkdownPanel viewer instead of failing in the embedded browser or opening an external app
- Adds `markdownViewer(URL)` case to `TerminalOpenURLTarget` enum
- Handles both absolute paths (`/path/to/file.md`) and `file://` scheme URLs
- Case-insensitive extension matching (`.md`, `.MD`, `.markdown`)
- Markdown viewer opens independently of the `browserOpenTerminalLinksInCmuxBrowser` setting, since it's a native cmux panel, not the browser

## Changes

- **`Sources/GhosttyTerminalView.swift`** — New enum case, `isMarkdownExtension()` helper, modified `resolveTerminalOpenURLTarget()` for markdown detection, and `.markdownViewer` handler in `GHOSTTY_ACTION_OPEN_URL` that calls `workspace.newMarkdownSplit()`
- **`cmuxTests/TerminalAndGhosttyTests.swift`** — 6 new tests in `TerminalOpenURLTargetResolutionTests`: `.md`, `.markdown`, `.MD` (case insensitive), `file://` scheme, plus regression tests for `.txt` (stays external) and HTTPS `.md` URLs (stays in browser)

## Test plan

- [x] Unit tests for `resolveTerminalOpenURLTarget` with `.md`, `.markdown`, `.MD` extensions
- [x] Regression tests: `.txt` still external, HTTPS `.md` URLs still in browser
- [ ] Manual: CMD+click a `.md` path → MarkdownPanel opens as horizontal split
- [ ] Manual: CMD+click a `.txt` path → external app opens (unchanged)
- [ ] Manual: CMD+click an HTTPS URL → embedded browser opens (unchanged)
- [ ] Manual: With "open links in cmux browser" disabled, CMD+click `.md` → still opens MarkdownPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
CMD+clicking `.md` or `.markdown` file paths now opens them in the native MarkdownPanel split. Absolute paths and `file://` URLs route to the viewer; HTTPS `.md` still opens in the embedded browser.

- **New Features**
  - Added `.markdownViewer(URL)` to `TerminalOpenURLTarget`.
  - Case-insensitive extension detection for `.md` and `.markdown`.
  - Viewer routing for absolute paths and `file://` URLs.
  - MarkdownPanel opens regardless of `browserOpenTerminalLinksInCmuxBrowser`.

<sup>Written for commit 9885974cae3f64b064a731966eebed8a2f99265c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Markdown files (`.md`, `.markdown`) opened from the terminal now display in a built-in markdown viewer instead of external applications
  * Support for case-insensitive file extension recognition and `file://` scheme URLs

* **Tests**
  * Added verification tests for markdown file resolution and URL handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->