### PR TITLE
feat: restore Claude Code sessions across app restarts

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -169,6 +169,19 @@ _cmux_install_claude_wrapper() {
     eval 'claude() { "$_CMUX_CLAUDE_WRAPPER" "$@"; }'
 }
 _cmux_install_claude_wrapper
+
+# Resume a Claude Code session saved before app restart. The env var is set by
+# the session restore path in SessionPersistence / Workspace.swift.
+_cmux_restore_claude_session_once() {
+    local session_id="${CMUX_RESTORE_CLAUDE_SESSION:-}"
+    [[ -n "$session_id" ]] || return 0
+    unset CMUX_RESTORE_CLAUDE_SESSION
+
+    printf '\033[2m%s\033[0m\n' "Resuming Claude Code session…"
+    claude --resume "$session_id"
+}
+_cmux_restore_claude_session_once
+
 _cmux_now() {
     printf '%s\n' "${EPOCHSECONDS:-$SECONDS}"
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -174,6 +174,18 @@ _cmux_install_claude_wrapper() {
 }
 _cmux_install_claude_wrapper
 
+# Resume a Claude Code session saved before app restart. The env var is set by
+# the session restore path in SessionPersistence / Workspace.swift.
+_cmux_restore_claude_session_once() {
+    local session_id="${CMUX_RESTORE_CLAUDE_SESSION:-}"
+    [[ -n "$session_id" ]] || return 0
+    unset CMUX_RESTORE_CLAUDE_SESSION
+
+    printf '\033[2m%s\033[0m\n' "Resuming Claude Code session…"
+    claude --resume "$session_id"
+}
+_cmux_restore_claude_session_once
+
 # Throttle heavy work to avoid prompt latency.
 typeset -g _CMUX_PWD_LAST_PWD=""
 typeset -g _CMUX_GIT_LAST_PWD=""

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -514,7 +514,12 @@ enum SessionClaudeSessionStore {
 
     /// Find the most recently updated Claude Code session ID for a workspace.
     static func sessionId(forWorkspaceId workspaceId: String) -> String? {
-        guard let data = try? Data(contentsOf: URL(fileURLWithPath: storePath)) else { return nil }
+        sessionId(forWorkspaceId: workspaceId, storeURL: URL(fileURLWithPath: storePath))
+    }
+
+    /// Testable overload that reads from an arbitrary store URL.
+    static func sessionId(forWorkspaceId workspaceId: String, storeURL: URL) -> String? {
+        guard let data = try? Data(contentsOf: storeURL) else { return nil }
         guard let store = try? JSONDecoder().decode(StoreFile.self, from: data) else { return nil }
 
         return store.sessions.values

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -341,6 +341,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var logEntries: [SessionLogEntrySnapshot]
     var progress: SessionProgressSnapshot?
     var gitBranch: SessionGitBranchSnapshot?
+    var claudeSessionId: String?
 }
 
 struct SessionTabManagerSnapshot: Codable, Sendable {
@@ -484,5 +485,41 @@ enum SessionScrollbackReplayStore {
         } catch {
             return nil
         }
+    }
+}
+
+/// Reads the Claude hook session store to find active Claude Code session IDs
+/// for a given workspace. The store is maintained by the CLI at
+/// `~/.cmuxterm/claude-hook-sessions.json`.
+enum SessionClaudeSessionStore {
+    private struct StoreFile: Codable {
+        var version: Int
+        var sessions: [String: SessionRecord]
+    }
+
+    private struct SessionRecord: Codable {
+        var sessionId: String
+        var workspaceId: String
+        var surfaceId: String
+        var cwd: String?
+        var pid: Int?
+        var startedAt: TimeInterval
+        var updatedAt: TimeInterval
+    }
+
+    private static let storePath: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/.cmuxterm/claude-hook-sessions.json"
+    }()
+
+    /// Find the most recently updated Claude Code session ID for a workspace.
+    static func sessionId(forWorkspaceId workspaceId: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: storePath)) else { return nil }
+        guard let store = try? JSONDecoder().decode(StoreFile.self, from: data) else { return nil }
+
+        return store.sessions.values
+            .filter { $0.workspaceId == workspaceId }
+            .max(by: { $0.updatedAt < $1.updatedAt })?
+            .sessionId
     }
 }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -492,6 +492,8 @@ enum SessionScrollbackReplayStore {
 /// for a given workspace. The store is maintained by the CLI at
 /// `~/.cmuxterm/claude-hook-sessions.json`.
 enum SessionClaudeSessionStore {
+    private static let supportedStoreVersion = 1
+
     private struct StoreFile: Codable {
         var version: Int
         var sessions: [String: SessionRecord]
@@ -521,6 +523,7 @@ enum SessionClaudeSessionStore {
     static func sessionId(forWorkspaceId workspaceId: String, storeURL: URL) -> String? {
         guard let data = try? Data(contentsOf: storeURL) else { return nil }
         guard let store = try? JSONDecoder().decode(StoreFile.self, from: data) else { return nil }
+        guard store.version == supportedStoreVersion else { return nil }
 
         return store.sessions.values
             .filter { $0.workspaceId == workspaceId }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -324,7 +324,10 @@ extension Workspace {
         // terminal panel — focusedPanelId may point at a browser or markdown
         // panel, in which case we fall back to the first terminal panel (nil
         // target means "first terminal created").
-        if let claudeSessionId = snapshot.claudeSessionId {
+        pendingClaudeSessionRestore = nil
+        if let claudeSessionId = snapshot.claudeSessionId?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !claudeSessionId.isEmpty {
             let targetTerminalId: UUID? = {
                 if let focusedId = snapshot.focusedPanelId,
                    snapshot.panels.first(where: { $0.id == focusedId })?.type == .terminal {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -292,6 +292,13 @@ extension Workspace {
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
 
+        // Capture the active Claude Code session ID so it can be resumed on
+        // restore. The hook session store maps session IDs to workspace IDs.
+        let claudeSessionId: String? = {
+            guard agentPIDs["claude_code"] != nil else { return nil }
+            return SessionClaudeSessionStore.sessionId(forWorkspaceId: id.uuidString)
+        }()
+
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
             customTitle: customTitle,
@@ -305,12 +312,20 @@ extension Workspace {
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
             progress: progressSnapshot,
-            gitBranch: gitBranchSnapshot
+            gitBranch: gitBranchSnapshot,
+            claudeSessionId: claudeSessionId
         )
     }
 
     func restoreSessionSnapshot(_ snapshot: SessionWorkspaceSnapshot) {
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
+
+        // Queue Claude Code session for resume. The focused terminal panel (or
+        // the first terminal if no focus info) will receive a
+        // CMUX_RESTORE_CLAUDE_SESSION env var that shell integration picks up.
+        if let claudeSessionId = snapshot.claudeSessionId {
+            pendingClaudeSessionRestore = (sessionId: claudeSessionId, targetPanelId: snapshot.focusedPanelId)
+        }
 
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedCurrentDirectory.isEmpty {
@@ -640,9 +655,18 @@ extension Workspace {
         switch snapshot.type {
         case .terminal:
             let workingDirectory = snapshot.terminal?.workingDirectory ?? snapshot.directory ?? currentDirectory
-            let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
+            var replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: snapshot.terminal?.scrollback
             )
+
+            // Inject Claude Code session resume for the targeted panel. Falls
+            // back to the first terminal panel when no specific target is set.
+            if let pending = pendingClaudeSessionRestore,
+               pending.targetPanelId == nil || pending.targetPanelId == snapshot.id {
+                replayEnvironment["CMUX_RESTORE_CLAUDE_SESSION"] = pending.sessionId
+                pendingClaudeSessionRestore = nil
+            }
+
             guard let terminalPanel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
@@ -6613,6 +6637,10 @@ final class Workspace: Identifiable, ObservableObject {
     /// Used for stale-session detection: if the PID is dead, the status entry is cleared.
     var agentPIDs: [String: pid_t] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
+
+    /// Holds the Claude Code session ID to resume during session restore.
+    /// Cleared after it's consumed by the first matching terminal panel.
+    private var pendingClaudeSessionRestore: (sessionId: String, targetPanelId: UUID?)?
 
     private func sidebarObservationSignal<Value: Equatable>(
         _ publisher: Published<Value>.Publisher

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -320,11 +320,19 @@ extension Workspace {
     func restoreSessionSnapshot(_ snapshot: SessionWorkspaceSnapshot) {
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
 
-        // Queue Claude Code session for resume. The focused terminal panel (or
-        // the first terminal if no focus info) will receive a
-        // CMUX_RESTORE_CLAUDE_SESSION env var that shell integration picks up.
+        // Queue Claude Code session for resume. Resolve the target to a
+        // terminal panel — focusedPanelId may point at a browser or markdown
+        // panel, in which case we fall back to the first terminal panel (nil
+        // target means "first terminal created").
         if let claudeSessionId = snapshot.claudeSessionId {
-            pendingClaudeSessionRestore = (sessionId: claudeSessionId, targetPanelId: snapshot.focusedPanelId)
+            let targetTerminalId: UUID? = {
+                if let focusedId = snapshot.focusedPanelId,
+                   snapshot.panels.first(where: { $0.id == focusedId })?.type == .terminal {
+                    return focusedId
+                }
+                return nil
+            }()
+            pendingClaudeSessionRestore = (sessionId: claudeSessionId, targetPanelId: targetTerminalId)
         }
 
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -669,10 +669,13 @@ extension Workspace {
 
             // Inject Claude Code session resume for the targeted panel. Falls
             // back to the first terminal panel when no specific target is set.
-            if let pending = pendingClaudeSessionRestore,
-               pending.targetPanelId == nil || pending.targetPanelId == snapshot.id {
-                replayEnvironment["CMUX_RESTORE_CLAUDE_SESSION"] = pending.sessionId
-                pendingClaudeSessionRestore = nil
+            // Clear the pending token only after the terminal is created
+            // successfully so a failed surface doesn't swallow the restore.
+            let matchedClaudeRestore = pendingClaudeSessionRestore.flatMap { pending in
+                (pending.targetPanelId == nil || pending.targetPanelId == snapshot.id) ? pending : nil
+            }
+            if let matchedClaudeRestore {
+                replayEnvironment["CMUX_RESTORE_CLAUDE_SESSION"] = matchedClaudeRestore.sessionId
             }
 
             guard let terminalPanel = newTerminalSurface(
@@ -682,6 +685,9 @@ extension Workspace {
                 startupEnvironment: replayEnvironment
             ) else {
                 return nil
+            }
+            if matchedClaudeRestore != nil {
+                pendingClaudeSessionRestore = nil
             }
             let fallbackScrollback = SessionPersistencePolicy.truncatedScrollback(snapshot.terminal?.scrollback)
             if let fallbackScrollback {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -117,6 +117,40 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testSaveAndLoadRoundTripPreservesClaudeSessionId() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        var snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+        snapshot.windows[0].tabManager.workspaces[0].claudeSessionId = "01JQVX8K3M5N7P2R4T6W9Y0ZAB"
+
+        XCTAssertTrue(SessionPersistenceStore.save(snapshot, fileURL: snapshotURL))
+
+        let loaded = SessionPersistenceStore.load(fileURL: snapshotURL)
+        XCTAssertEqual(
+            loaded?.windows.first?.tabManager.workspaces.first?.claudeSessionId,
+            "01JQVX8K3M5N7P2R4T6W9Y0ZAB"
+        )
+    }
+
+    func testSaveAndLoadRoundTripOmitsNilClaudeSessionId() {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let snapshotURL = tempDir.appendingPathComponent("session.json", isDirectory: false)
+        let snapshot = makeSnapshot(version: SessionSnapshotSchema.currentVersion)
+
+        XCTAssertTrue(SessionPersistenceStore.save(snapshot, fileURL: snapshotURL))
+
+        let loaded = SessionPersistenceStore.load(fileURL: snapshotURL)
+        XCTAssertNil(loaded?.windows.first?.tabManager.workspaces.first?.claudeSessionId)
+    }
+
     func testSaveSkipsRewritingIdenticalSnapshotData() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
@@ -914,6 +948,68 @@ final class SessionPersistenceTests: XCTestCase {
     private func fileNumber(for fileURL: URL) throws -> Int {
         let attributes = try FileManager.default.attributesOfItem(atPath: fileURL.path)
         return try XCTUnwrap(attributes[.systemFileNumber] as? Int)
+    }
+}
+
+final class SessionClaudeSessionStoreTests: XCTestCase {
+    func testSessionIdLookupFindsMatchingWorkspace() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-claude-store-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let storeURL = tempDir.appendingPathComponent("claude-hook-sessions.json")
+        let json = """
+        {
+          "version": 1,
+          "sessions": {
+            "abc123": {
+              "sessionId": "abc123",
+              "workspaceId": "WS-1",
+              "surfaceId": "SF-1",
+              "cwd": "/tmp",
+              "pid": 9999,
+              "startedAt": 1000,
+              "updatedAt": 2000
+            },
+            "def456": {
+              "sessionId": "def456",
+              "workspaceId": "WS-2",
+              "surfaceId": "SF-2",
+              "cwd": "/home",
+              "pid": 8888,
+              "startedAt": 1000,
+              "updatedAt": 3000
+            }
+          }
+        }
+        """
+        try json.write(to: storeURL, atomically: true, encoding: .utf8)
+
+        // SessionClaudeSessionStore reads from a hardcoded path, so we test
+        // the decoding logic indirectly via the round-trip snapshot test above.
+        // This test validates that the JSON structure matches expectations.
+        let data = try Data(contentsOf: storeURL)
+        let decoded = try JSONDecoder().decode(ClaudeHookStoreTestFile.self, from: data)
+        XCTAssertEqual(decoded.sessions.count, 2)
+        XCTAssertEqual(decoded.sessions["abc123"]?.workspaceId, "WS-1")
+        XCTAssertEqual(decoded.sessions["def456"]?.sessionId, "def456")
+    }
+
+    /// Mirror of the private struct in SessionClaudeSessionStore for test decoding.
+    private struct ClaudeHookStoreTestFile: Codable {
+        var version: Int
+        var sessions: [String: ClaudeHookStoreTestRecord]
+    }
+
+    private struct ClaudeHookStoreTestRecord: Codable {
+        var sessionId: String
+        var workspaceId: String
+        var surfaceId: String
+        var cwd: String?
+        var pid: Int?
+        var startedAt: TimeInterval
+        var updatedAt: TimeInterval
     }
 }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -952,14 +952,17 @@ final class SessionPersistenceTests: XCTestCase {
 }
 
 final class SessionClaudeSessionStoreTests: XCTestCase {
-    func testSessionIdLookupFindsMatchingWorkspace() throws {
+    private func writeStore(_ json: String) throws -> URL {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-claude-store-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
-        defer { try? FileManager.default.removeItem(at: tempDir) }
-
         let storeURL = tempDir.appendingPathComponent("claude-hook-sessions.json")
-        let json = """
+        try json.write(to: storeURL, atomically: true, encoding: .utf8)
+        return storeURL
+    }
+
+    func testSessionIdLookupFindsMatchingWorkspace() throws {
+        let storeURL = try writeStore("""
         {
           "version": 1,
           "sessions": {
@@ -983,33 +986,76 @@ final class SessionClaudeSessionStoreTests: XCTestCase {
             }
           }
         }
-        """
-        try json.write(to: storeURL, atomically: true, encoding: .utf8)
+        """)
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
 
-        // SessionClaudeSessionStore reads from a hardcoded path, so we test
-        // the decoding logic indirectly via the round-trip snapshot test above.
-        // This test validates that the JSON structure matches expectations.
-        let data = try Data(contentsOf: storeURL)
-        let decoded = try JSONDecoder().decode(ClaudeHookStoreTestFile.self, from: data)
-        XCTAssertEqual(decoded.sessions.count, 2)
-        XCTAssertEqual(decoded.sessions["abc123"]?.workspaceId, "WS-1")
-        XCTAssertEqual(decoded.sessions["def456"]?.sessionId, "def456")
+        XCTAssertEqual(
+            SessionClaudeSessionStore.sessionId(forWorkspaceId: "WS-1", storeURL: storeURL),
+            "abc123"
+        )
+        XCTAssertEqual(
+            SessionClaudeSessionStore.sessionId(forWorkspaceId: "WS-2", storeURL: storeURL),
+            "def456"
+        )
     }
 
-    /// Mirror of the private struct in SessionClaudeSessionStore for test decoding.
-    private struct ClaudeHookStoreTestFile: Codable {
-        var version: Int
-        var sessions: [String: ClaudeHookStoreTestRecord]
+    func testSessionIdLookupReturnsNilForUnknownWorkspace() throws {
+        let storeURL = try writeStore("""
+        {
+          "version": 1,
+          "sessions": {
+            "abc123": {
+              "sessionId": "abc123",
+              "workspaceId": "WS-1",
+              "surfaceId": "SF-1",
+              "startedAt": 1000,
+              "updatedAt": 2000
+            }
+          }
+        }
+        """)
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        XCTAssertNil(
+            SessionClaudeSessionStore.sessionId(forWorkspaceId: "WS-UNKNOWN", storeURL: storeURL)
+        )
     }
 
-    private struct ClaudeHookStoreTestRecord: Codable {
-        var sessionId: String
-        var workspaceId: String
-        var surfaceId: String
-        var cwd: String?
-        var pid: Int?
-        var startedAt: TimeInterval
-        var updatedAt: TimeInterval
+    func testSessionIdLookupReturnsMostRecentlyUpdated() throws {
+        let storeURL = try writeStore("""
+        {
+          "version": 1,
+          "sessions": {
+            "old-session": {
+              "sessionId": "old-session",
+              "workspaceId": "WS-1",
+              "surfaceId": "SF-1",
+              "startedAt": 1000,
+              "updatedAt": 1000
+            },
+            "new-session": {
+              "sessionId": "new-session",
+              "workspaceId": "WS-1",
+              "surfaceId": "SF-2",
+              "startedAt": 2000,
+              "updatedAt": 5000
+            }
+          }
+        }
+        """)
+        defer { try? FileManager.default.removeItem(at: storeURL.deletingLastPathComponent()) }
+
+        XCTAssertEqual(
+            SessionClaudeSessionStore.sessionId(forWorkspaceId: "WS-1", storeURL: storeURL),
+            "new-session"
+        )
+    }
+
+    func testSessionIdLookupReturnsNilForMissingFile() {
+        let bogusURL = URL(fileURLWithPath: "/tmp/cmux-nonexistent-\(UUID().uuidString).json")
+        XCTAssertNil(
+            SessionClaudeSessionStore.sessionId(forWorkspaceId: "WS-1", storeURL: bogusURL)
+        )
     }
 }
 


### PR DESCRIPTION
## Summary

When cmux restarts (update, quit/relaunch), all active Claude Code sessions are lost. This PR adds automatic session resume by:

- **Saving** the active Claude Code session ID in the workspace snapshot (read from `~/.cmuxterm/claude-hook-sessions.json` at snapshot time)
- **Restoring** via a `CMUX_RESTORE_CLAUDE_SESSION` env var passed to the shell on restore
- **Shell integration** (bash + zsh) picks up the env var and runs `claude --resume <session-id>` automatically

### How it works

1. During `sessionSnapshot()`, if a workspace has an active Claude agent (`agentPIDs["claude_code"]`), the session ID is looked up from the hook session store
2. The session ID is saved as `claudeSessionId` on `SessionWorkspaceSnapshot` (optional field, backward-compatible — no schema version bump needed)
3. On restore, the focused terminal panel receives `CMUX_RESTORE_CLAUDE_SESSION=<id>` in its startup environment
4. Shell integration consumes the env var once and runs `claude --resume <id>`, printing a dim "Resuming Claude Code session…" message

### Design decisions

- **Auto-resume, no prompt** — matches cmux's existing restore philosophy (scrollback, URLs, directories all restore silently)
- **Per-workspace, applied to focused panel** — avoids multiple terminals in the same workspace all trying to resume
- **Reads existing hook store** — no new IPC commands or socket protocol changes needed
- **Backward-compatible snapshot** — `claudeSessionId` is an optional field; old snapshots decode fine without it

### Files changed

| File | Change |
|------|--------|
| `Sources/SessionPersistence.swift` | Add `claudeSessionId` to workspace snapshot + `SessionClaudeSessionStore` reader |
| `Sources/Workspace.swift` | Capture session ID on save, inject env var on restore |
| `Resources/shell-integration/cmux-{bash,zsh}-integration.{bash,zsh}` | `_cmux_restore_claude_session_once()` |
| `cmuxTests/SessionPersistenceTests.swift` | Round-trip tests for the new field |

Related: #1984 (partial — addresses Claude Code session continuity without the full `cmuxd` daemon approach)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically restores active Claude Code sessions after cmux restarts. Saves the session ID in workspace snapshots and resumes it via shell integration, targeting the correct terminal.

- **New Features**
  - Save active Claude session ID to `SessionWorkspaceSnapshot` via `SessionClaudeSessionStore` (reads `~/.cmuxterm/claude-hook-sessions.json`).
  - On restore, inject `CMUX_RESTORE_CLAUDE_SESSION` into the targeted terminal; bash/zsh run `claude --resume <id>` once.
  - Per‑workspace, single‑panel resume; snapshot is backward‑compatible; added round‑trip and store‑lookup tests.

- **Bug Fixes**
  - Handle `focusedPanelId` pointing to a non‑terminal by falling back to the first terminal.
  - Defer clearing the restore token until the terminal is created to avoid losing the resume on failure.
  - Validate hook store version; trim and ignore empty session IDs; reset pending restore state at restore start.

<sup>Written for commit 1b1d4e9585b2064aad75a4d52322683edc34478c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Claude Code sessions automatically resume when a workspace is restored after an app restart, targeting the appropriate terminal (or the first terminal created).
  * A one-time resume attempt displays a dim "Resuming Claude Code session…" status and is triggered during shell integration initialization.
* **Tests**
  * Added tests verifying session ID persistence and correct session lookup/selection during restore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->