### PR TITLE
Fix windows not restoring to external displays after disconnect/reconnect

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 			B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
+			D1A2B3C4E5F607181331ABCD /* DisplayReconnectionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A2B3C4E5F607181331ABCE /* DisplayReconnectionUITests.swift */; };
 			C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 			C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
 			E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
@@ -276,6 +277,7 @@
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
+			D1A2B3C4E5F607181331ABCE /* DisplayReconnectionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayReconnectionUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 							818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */,
 							B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */,
 							B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
+							D1A2B3C4E5F607181331ABCE /* DisplayReconnectionUITests.swift */,
 							C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
 							E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
 							D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
@@ -867,6 +870,7 @@
 							B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */,
 							B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */,
 							B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
+							D1A2B3C4E5F607181331ABCD /* DisplayReconnectionUITests.swift in Sources */,
 							C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */,
 							E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 							D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4492,12 +4492,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // Try exact display ID match first, then fall back to geometry
                 // match for monitors that get a new ID after cable reseat or
                 // power cycle (common with USB-C/Thunderbolt).
-                let savedEntries: [(windowId: UUID, frame: SessionRectSnapshot, display: SessionDisplaySnapshot)]? = {
+                let savedMatch: (entries: [(windowId: UUID, frame: SessionRectSnapshot, display: SessionDisplaySnapshot)], staleDisplayID: UUID?) = {
                     if let exact = savedDisplayWindowFrames[appearedID], !exact.isEmpty {
-                        return exact
+                        return (exact, nil)
                     }
                     guard let appearedDisplay = displays.available.first(where: { $0.displayID == appearedID }) else {
-                        return nil
+                        return ([], nil)
                     }
                     // Match disconnected displays by frame AND visibleFrame
                     // geometry (±1px tolerance). Comparing both reduces false
@@ -4513,15 +4513,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                             abs(refVisible.origin.x - appearedDisplay.visibleFrame.origin.x) <= 1 &&
                             abs(refVisible.origin.y - appearedDisplay.visibleFrame.origin.y) <= 1
                         if frameMatch && visibleMatch {
-                            return entries
+                            return (entries, cachedID)
                         }
                     }
-                    return nil
+                    return ([], nil)
                 }()
-                guard let savedEntries, !savedEntries.isEmpty else {
+                guard !savedMatch.entries.isEmpty else {
                     continue
                 }
-                for entry in savedEntries {
+                for entry in savedMatch.entries {
                     guard let context = mainWindowContexts.values.first(where: { $0.windowId == entry.windowId }),
                           let window = context.window ?? windowForMainWindowId(context.windowId) else {
                         continue
@@ -4541,12 +4541,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         // because the final updateSavedDisplayWindowFrames call
                         // excludes programmatically moved windows.
                         if let newDisplay = displaySnapshot(for: window) {
-                            // Drop all stale buckets (including the old disconnected-
-                            // display entry) so savedFrameForDisplacedWindow() won't
-                            // keep returning the pre-reconnect frame.
-                            removeSavedDisplayWindowFrames(forWindowId: entry.windowId)
+                            // Remove the entry only from the stale disconnected-
+                            // display bucket so savedFrameForDisplacedWindow() won't
+                            // keep returning the pre-reconnect frame. Cached geometry
+                            // for other displays is preserved for future restores.
+                            if let staleID = savedMatch.staleDisplayID {
+                                if var staleEntries = savedDisplayWindowFrames[staleID] {
+                                    staleEntries.removeAll { $0.windowId == entry.windowId }
+                                    if staleEntries.isEmpty {
+                                        savedDisplayWindowFrames.removeValue(forKey: staleID)
+                                    } else {
+                                        savedDisplayWindowFrames[staleID] = staleEntries
+                                    }
+                                }
+                            }
                             let restoredEntry = (windowId: entry.windowId, frame: SessionRectSnapshot(window.frame), display: newDisplay)
                             var bucket = savedDisplayWindowFrames[appearedID] ?? []
+                            bucket.removeAll { $0.windowId == entry.windowId }
                             bucket.append(restoredEntry)
                             savedDisplayWindowFrames[appearedID] = bucket
                         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4541,9 +4541,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                         // because the final updateSavedDisplayWindowFrames call
                         // excludes programmatically moved windows.
                         if let newDisplay = displaySnapshot(for: window) {
+                            // Drop all stale buckets (including the old disconnected-
+                            // display entry) so savedFrameForDisplacedWindow() won't
+                            // keep returning the pre-reconnect frame.
+                            removeSavedDisplayWindowFrames(forWindowId: entry.windowId)
                             let restoredEntry = (windowId: entry.windowId, frame: SessionRectSnapshot(window.frame), display: newDisplay)
                             var bucket = savedDisplayWindowFrames[appearedID] ?? []
-                            bucket.removeAll { $0.windowId == entry.windowId }
                             bucket.append(restoredEntry)
                             savedDisplayWindowFrames[appearedID] = bucket
                         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2393,6 +2393,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var lastSessionAutosaveFingerprint: Int?
     private var lastSessionAutosavePersistedAt: Date = .distantPast
     private var lastTypingActivityAt: TimeInterval = 0
+
+    /// Tracks which display IDs were connected at the last screen-parameters check,
+    /// so we can detect which displays disappeared and which reconnected.
+    private var lastKnownDisplayIDs: Set<UInt32> = []
+
+    /// Caches the last-known good window frame and display snapshot for each window
+    /// on each display, keyed by display ID. When a display disappears and macOS moves
+    /// a window to the primary monitor, we use this cache instead of the live (wrong)
+    /// frame when building session snapshots, and to restore the window when the
+    /// display reconnects.
+    private var savedDisplayWindowFrames: [UInt32: [(windowId: UUID, frame: SessionRectSnapshot, display: SessionDisplaySnapshot)]] = [:]
+
+    /// Debounce work item for coalescing rapid `didChangeScreenParameters` notifications.
+    private var screenParametersChangeWorkItem: DispatchWorkItem?
     private var didHandleExplicitOpenIntentAtStartup = false
     private var isTerminatingApp = false
     // Set to true when the user has already confirmed quit via the warning dialog,
@@ -4327,6 +4341,254 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         lifecycleSnapshotObservers.append(didWakeObserver)
+
+        // Seed last-known display IDs from the current screen configuration.
+        lastKnownDisplayIDs = Set(NSScreen.screens.compactMap { $0.cmuxDisplayID })
+        // Capture initial window positions so we have a baseline for display-change detection.
+        updateSavedDisplayWindowFrames()
+
+        // Observe display configuration changes (monitor connect/disconnect, sleep/wake)
+        // so we can restore windows to reconnected displays.
+        let screenChangeObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleHandleScreenParametersDidChange()
+        }
+        lifecycleSnapshotObservers.append(screenChangeObserver)
+    }
+
+    // MARK: - Display reconnection support
+
+    /// Snapshots the current window-to-display mapping so we can detect when macOS
+    /// has forcibly moved a window away from a disconnected display.
+    /// Windows in `excluding` are skipped to avoid overwriting user-positioned
+    /// frames with programmatically computed ones.
+    private func updateSavedDisplayWindowFrames(excluding: Set<UUID> = []) {
+        for context in mainWindowContexts.values {
+            guard !excluding.contains(context.windowId) else { continue }
+            guard let window = context.window ?? windowForMainWindowId(context.windowId) else { continue }
+            guard let displayID = window.screen?.cmuxDisplayID else { continue }
+            let frame = SessionRectSnapshot(window.frame)
+            guard let display = displaySnapshot(for: window) else { continue }
+            let entry = (windowId: context.windowId, frame: frame, display: display)
+            // Remove this window from other CONNECTED display buckets so the
+            // cache has a single authoritative entry per window among live
+            // displays. Entries for disconnected displays are preserved so we
+            // can restore when those displays reconnect.
+            for (otherID, otherEntries) in savedDisplayWindowFrames where otherID != displayID && lastKnownDisplayIDs.contains(otherID) {
+                let filtered = otherEntries.filter { $0.windowId != context.windowId }
+                if filtered.isEmpty {
+                    savedDisplayWindowFrames.removeValue(forKey: otherID)
+                } else if filtered.count != otherEntries.count {
+                    savedDisplayWindowFrames[otherID] = filtered
+                }
+            }
+            var entries = savedDisplayWindowFrames[displayID] ?? []
+            entries.removeAll { $0.windowId == context.windowId }
+            entries.append(entry)
+            savedDisplayWindowFrames[displayID] = entries
+        }
+    }
+
+    /// Debounces `didChangeScreenParametersNotification` — macOS can fire it multiple
+    /// times during a single display connect/disconnect event.
+    private func scheduleHandleScreenParametersDidChange() {
+        screenParametersChangeWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.handleScreenParametersDidChange()
+            }
+        }
+        screenParametersChangeWorkItem = workItem
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25, execute: workItem)
+    }
+
+    /// Detects which displays appeared/disappeared and restores windows to their
+    /// last-known positions on the appropriate displays.
+    private func handleScreenParametersDidChange() {
+        let currentIDs = Set(NSScreen.screens.compactMap { $0.cmuxDisplayID })
+        let disappeared = lastKnownDisplayIDs.subtracting(currentIDs)
+        let appeared = currentIDs.subtracting(lastKnownDisplayIDs)
+
+#if DEBUG
+        dlog(
+            "display.screenParametersChanged current=\(currentIDs.sorted()) " +
+                "previous=\(lastKnownDisplayIDs.sorted()) " +
+                "appeared=\(appeared.sorted()) disappeared=\(disappeared.sorted())"
+        )
+#endif
+
+        lastKnownDisplayIDs = currentIDs
+
+        let displays = currentDisplayGeometries()
+
+        // Track windows we programmatically reposition so we don't overwrite the
+        // user's saved position on the target display with our computed frame.
+        var programmaticallyMovedWindowIds = Set<UUID>()
+
+        // When a display disappears, macOS moves its windows but often leaves them
+        // as narrow slivers at the screen edge. Restore them to their last-known
+        // position on the fallback display, or center them if no prior position
+        // exists on that display.
+        if !disappeared.isEmpty {
+            for disappearedID in disappeared {
+                guard let savedEntries = savedDisplayWindowFrames[disappearedID] else {
+#if DEBUG
+                    dlog("display.refit.skip displayID=\(disappearedID) reason=no_saved_entries keys=\(Array(savedDisplayWindowFrames.keys))")
+#endif
+                    continue
+                }
+                for entry in savedEntries {
+                    guard let context = mainWindowContexts.values.first(where: { $0.windowId == entry.windowId }),
+                          let window = context.window ?? windowForMainWindowId(context.windowId) else {
+                        continue
+                    }
+                    guard let fallback = displays.fallback, let fallbackID = fallback.displayID else { continue }
+
+                    let minWidth = CGFloat(SessionPersistencePolicy.minimumWindowWidth)
+                    let minHeight = CGFloat(SessionPersistencePolicy.minimumWindowHeight)
+
+                    // Check if we have a saved position for this window on the
+                    // fallback display — if so, restore to that position (like
+                    // Hyper does). Otherwise center with the original size.
+                    let currentSize = entry.frame.cgRect.size
+                    let refitFrame: CGRect
+                    if let fallbackEntry = savedDisplayWindowFrames[fallbackID]?.first(where: { $0.windowId == entry.windowId }) {
+                        // Use the fallback display's saved origin but keep the
+                        // window's current size (it may have been resized on the
+                        // disappeared display).
+                        let origin = fallbackEntry.frame.cgRect.origin
+                        refitFrame = Self.clampFrame(
+                            CGRect(origin: origin, size: currentSize),
+                            within: fallback.visibleFrame,
+                            minWidth: minWidth,
+                            minHeight: minHeight
+                        )
+                    } else {
+                        refitFrame = Self.centeredFrame(
+                            entry.frame.cgRect,
+                            in: fallback.visibleFrame,
+                            minWidth: minWidth,
+                            minHeight: minHeight
+                        )
+                    }
+                    window.setFrame(refitFrame, display: true)
+                    programmaticallyMovedWindowIds.insert(entry.windowId)
+#if DEBUG
+                    dlog(
+                        "display.refit window=\(entry.windowId.uuidString.prefix(8)) " +
+                            "fromDisplay=\(disappearedID) toDisplay=\(fallbackID) " +
+                            "frame={\(debugNSRectDescription(window.frame))}"
+                    )
+#endif
+                }
+            }
+        }
+
+        if !appeared.isEmpty {
+            for appearedID in appeared {
+                // Try exact display ID match first, then fall back to geometry
+                // match for monitors that get a new ID after cable reseat or
+                // power cycle (common with USB-C/Thunderbolt).
+                let savedEntries: [(windowId: UUID, frame: SessionRectSnapshot, display: SessionDisplaySnapshot)]? = {
+                    if let exact = savedDisplayWindowFrames[appearedID], !exact.isEmpty {
+                        return exact
+                    }
+                    guard let appearedDisplay = displays.available.first(where: { $0.displayID == appearedID }) else {
+                        return nil
+                    }
+                    // Match disconnected displays by frame AND visibleFrame
+                    // geometry (±1px tolerance). Comparing both reduces false
+                    // matches when two identical monitors are connected.
+                    for (cachedID, entries) in savedDisplayWindowFrames where !currentIDs.contains(cachedID) {
+                        guard let ref = entries.first?.display,
+                              let refFrame = ref.frame?.cgRect,
+                              let refVisible = ref.visibleFrame?.cgRect else { continue }
+                        let frameMatch = abs(refFrame.width - appearedDisplay.frame.width) <= 1 &&
+                            abs(refFrame.height - appearedDisplay.frame.height) <= 1
+                        let visibleMatch = abs(refVisible.width - appearedDisplay.visibleFrame.width) <= 1 &&
+                            abs(refVisible.height - appearedDisplay.visibleFrame.height) <= 1 &&
+                            abs(refVisible.origin.x - appearedDisplay.visibleFrame.origin.x) <= 1 &&
+                            abs(refVisible.origin.y - appearedDisplay.visibleFrame.origin.y) <= 1
+                        if frameMatch && visibleMatch {
+                            return entries
+                        }
+                    }
+                    return nil
+                }()
+                guard let savedEntries, !savedEntries.isEmpty else {
+                    continue
+                }
+                for entry in savedEntries {
+                    guard let context = mainWindowContexts.values.first(where: { $0.windowId == entry.windowId }),
+                          let window = context.window ?? windowForMainWindowId(context.windowId) else {
+                        continue
+                    }
+                    if let restoredFrame = Self.resolvedWindowFrame(
+                        from: entry.frame,
+                        display: entry.display,
+                        availableDisplays: displays.available,
+                        fallbackDisplay: displays.fallback
+                    ) {
+                        window.setFrame(restoredFrame, display: true)
+                        programmaticallyMovedWindowIds.insert(entry.windowId)
+
+                        // Persist the restored position under the new live display
+                        // ID. This is necessary when a geometry-matched restore
+                        // maps from a stale disconnected ID to a new appearedID,
+                        // because the final updateSavedDisplayWindowFrames call
+                        // excludes programmatically moved windows.
+                        if let newDisplay = displaySnapshot(for: window) {
+                            let restoredEntry = (windowId: entry.windowId, frame: SessionRectSnapshot(window.frame), display: newDisplay)
+                            var bucket = savedDisplayWindowFrames[appearedID] ?? []
+                            bucket.removeAll { $0.windowId == entry.windowId }
+                            bucket.append(restoredEntry)
+                            savedDisplayWindowFrames[appearedID] = bucket
+                        }
+#if DEBUG
+                        dlog(
+                            "display.restored window=\(entry.windowId.uuidString.prefix(8)) " +
+                                "displayID=\(appearedID) " +
+                                "frame={\(debugNSRectDescription(window.frame))}"
+                        )
+#endif
+                    }
+                }
+            }
+        }
+
+        // Refresh cache for windows that were NOT programmatically moved (user may
+        // have repositioned them). Skip windows we just moved to avoid overwriting
+        // the user's saved position on the target display with our computed frame.
+        updateSavedDisplayWindowFrames(excluding: programmaticallyMovedWindowIds)
+        _ = saveSessionSnapshot(includeScrollback: false)
+    }
+
+    /// Removes all cached display-position entries for a given window ID.
+    private func removeSavedDisplayWindowFrames(forWindowId windowId: UUID) {
+        for (displayID, entries) in savedDisplayWindowFrames {
+            let filtered = entries.filter { $0.windowId != windowId }
+            if filtered.isEmpty {
+                savedDisplayWindowFrames.removeValue(forKey: displayID)
+            } else {
+                savedDisplayWindowFrames[displayID] = filtered
+            }
+        }
+    }
+
+    /// Returns the saved frame and display for a window if its original display has
+    /// disappeared (macOS moved it). Returns nil if the window is on its expected display.
+    private func savedFrameForDisplacedWindow(windowId: UUID) -> (frame: SessionRectSnapshot, display: SessionDisplaySnapshot)? {
+        let currentIDs = lastKnownDisplayIDs
+        for (displayID, entries) in savedDisplayWindowFrames {
+            guard !currentIDs.contains(displayID) else { continue }
+            if let entry = entries.first(where: { $0.windowId == windowId }) {
+                return (entry.frame, entry.display)
+            }
+        }
+        return nil
     }
 
     private func socketListenerConfigurationIfEnabled() -> (mode: SocketControlMode, path: String)? {
@@ -4566,6 +4828,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         let saveStart = ProcessInfo.processInfo.systemUptime
 #endif
+        // Keep the per-display window frame cache fresh so it's accurate if a
+        // display disconnects before the next tick.
+        updateSavedDisplayWindowFrames()
         _ = saveSessionSnapshot(includeScrollback: false)
 #if DEBUG
         saveMs = (ProcessInfo.processInfo.systemUptime - saveStart) * 1000.0
@@ -4677,9 +4942,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)
             .map { context in
                 let window = context.window ?? windowForMainWindowId(context.windowId)
+                // If this window's original display has disappeared (macOS moved it
+                // to the primary monitor), use the cached frame/display from before
+                // the display went away instead of the live (wrong) position.
+                let displaced = window != nil
+                    ? savedFrameForDisplacedWindow(windowId: context.windowId)
+                    : nil
+                let snapshotFrame = displaced?.frame ?? window.map { SessionRectSnapshot($0.frame) }
+                let snapshotDisplay = displaced?.display ?? displaySnapshot(for: window)
                 return SessionWindowSnapshot(
-                    frame: window.map { SessionRectSnapshot($0.frame) },
-                    display: displaySnapshot(for: window),
+                    frame: snapshotFrame,
+                    display: snapshotDisplay,
                     tabManager: context.tabManager.sessionSnapshot(includeScrollback: includeScrollback),
                     sidebar: SessionSidebarSnapshot(
                         isVisible: context.sidebarState.isVisible,
@@ -4802,6 +5075,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         attemptStartupSessionRestoreIfNeeded(primaryWindow: window)
         if !isTerminatingApp {
+            updateSavedDisplayWindowFrames()
             _ = saveSessionSnapshot(includeScrollback: false)
         }
     }
@@ -6110,6 +6384,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         commandPaletteEscapeSuppressionStartedAtByWindowId.removeValue(forKey: context.windowId)
         commandPaletteSelectionByWindowId.removeValue(forKey: context.windowId)
         commandPaletteSnapshotByWindowId.removeValue(forKey: context.windowId)
+
+        removeSavedDisplayWindowFrames(forWindowId: context.windowId)
 
         if tabManager === context.tabManager {
             if let nextContext = mainWindowContexts.values.first(where: { resolvedWindow(for: $0) != nil }) {
@@ -12778,6 +13054,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         commandPaletteEscapeSuppressionStartedAtByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteSelectionByWindowId.removeValue(forKey: removed.windowId)
         commandPaletteSnapshotByWindowId.removeValue(forKey: removed.windowId)
+
+        removeSavedDisplayWindowFrames(forWindowId: removed.windowId)
 
         // Avoid stale notifications that can no longer be opened once the owning window is gone.
         if let store = notificationStore {

--- a/cmuxUITests/DisplayReconnectionUITests.swift
+++ b/cmuxUITests/DisplayReconnectionUITests.swift
@@ -1,0 +1,360 @@
+import XCTest
+import Foundation
+
+/// Tests that windows restore to their correct positions when external displays
+/// are disconnected and reconnected (issues #1331, #2135, #2666).
+///
+/// Lifecycle:
+/// 1. Create a virtual display and move the app window to it.
+/// 2. Destroy the virtual display — verify the window moves to the primary
+///    display with a reasonable size (not a degenerate sliver).
+/// 3. Recreate the virtual display — verify the window returns to it.
+final class DisplayReconnectionUITests: XCTestCase {
+    private var launchTag = ""
+    private var diagnosticsPath = ""
+    private var displayReadyPath = ""
+    private var displayIDPath = ""
+    private var helperBinaryPath = ""
+    private var helperLogPath = ""
+    private var helperProcess: Process?
+    private var appProcess: Process?
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+
+        let token = UUID().uuidString
+        let tempPrefix = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-reconnect-\(token)")
+            .path
+        launchTag = "ui-tests-reconnect-\(token.prefix(8))"
+        diagnosticsPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-reconnect-\(token).json")
+            .path
+        displayReadyPath = "\(tempPrefix).ready"
+        displayIDPath = "\(tempPrefix).id"
+        helperBinaryPath = "\(tempPrefix)-helper"
+        helperLogPath = "\(tempPrefix)-helper.log"
+
+        removeTestArtifacts()
+    }
+
+    override func tearDown() {
+        terminateAppProcess()
+        terminateHelperProcess()
+        removeTestArtifacts()
+        super.tearDown()
+    }
+
+    // MARK: - Test
+
+    func testWindowRestoresToExternalDisplayAfterReconnection() throws {
+        // If pre-launched from CI, use the manifest.
+        let prelaunch = loadPrelaunchManifest()
+        if let diagPath = prelaunch?.diagnosticsPath, !diagPath.isEmpty {
+            diagnosticsPath = diagPath
+        }
+
+        // Step 1: Build and launch the virtual display helper with a single
+        // static mode (no mode churning — just create the display and keep it alive).
+        try buildDisplayHelper()
+        try launchDisplayHelper()
+
+        XCTAssertTrue(
+            waitForFile(atPath: displayReadyPath, timeout: 12.0),
+            "Expected display harness ready file at \(displayReadyPath)"
+        )
+        guard let targetDisplayID = readTrimmedFile(atPath: displayIDPath), !targetDisplayID.isEmpty else {
+            XCTFail("Missing target display ID at \(displayIDPath)")
+            return
+        }
+
+        // Step 2: Launch the app targeting the virtual display. In prelaunch
+        // mode (CI), the app is already running but needs to know the display ID.
+        try launchAppProcess(targetDisplayID: targetDisplayID)
+
+        XCTAssertTrue(
+            waitForTargetDisplayMove(targetDisplayID: targetDisplayID, timeout: 15.0),
+            "Expected app window to move to virtual display \(targetDisplayID). diagnostics=\(loadDiagnostics() ?? [:])"
+        )
+
+        // Wait for the autosave tick to capture the position on the virtual
+        // display. The autosave interval is 8s; poll the diagnostics file's
+        // modification date to detect when a save cycle completes.
+        let initialModDate = diagnosticsModificationDate()
+        XCTAssertTrue(
+            waitForCondition(timeout: 15.0) {
+                guard let current = self.diagnosticsModificationDate(),
+                      let initial = initialModDate else { return false }
+                return current > initial
+            },
+            "Expected at least one autosave tick while window is on the virtual display"
+        )
+
+        // Step 3: Kill the virtual display helper, removing the virtual display.
+        terminateHelperProcess()
+
+        // Wait for the app to detect the display change and reposition.
+        XCTAssertTrue(
+            waitForCondition(timeout: 8.0) {
+                guard let diag = self.loadDiagnostics() else { return false }
+                let ids = self.parseDisplayIDs(diag["windowScreenDisplayIDs"])
+                return !ids.contains(targetDisplayID)
+            },
+            "Expected window to leave virtual display after disconnect. diagnostics=\(loadDiagnostics() ?? [:])"
+        )
+
+        // Step 4: Recreate the virtual display.
+        removeHelperArtifacts()
+        try launchDisplayHelper()
+
+        XCTAssertTrue(
+            waitForFile(atPath: displayReadyPath, timeout: 12.0),
+            "Expected display harness ready file for second virtual display"
+        )
+        guard let newDisplayID = readTrimmedFile(atPath: displayIDPath), !newDisplayID.isEmpty else {
+            XCTFail("Missing display ID for recreated virtual display")
+            return
+        }
+
+        // Step 5: Wait for the window to return to the virtual display.
+        // The app should detect the new display and restore the window.
+        // The display ID may differ after recreation, but for virtual displays
+        // macOS typically reuses the same ID.
+        let windowReturnedToExternal = waitForCondition(timeout: 10.0) {
+            guard let diag = self.loadDiagnostics() else { return false }
+            let ids = self.parseDisplayIDs(diag["windowScreenDisplayIDs"])
+            return ids.contains(newDisplayID)
+        }
+
+        XCTAssertTrue(
+            windowReturnedToExternal,
+            "Expected window to return to virtual display \(newDisplayID) after reconnection. diagnostics=\(loadDiagnostics() ?? [:])"
+        )
+    }
+
+    // MARK: - Display Helper
+
+    private func buildDisplayHelper() throws {
+        let sourceURL = repoRootURL.appendingPathComponent("scripts/create-virtual-display.m")
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: "/usr/bin/clang")
+        proc.arguments = [
+            "-framework", "Foundation",
+            "-framework", "CoreGraphics",
+            "-o", helperBinaryPath,
+            sourceURL.path,
+        ]
+
+        let stderrPipe = Pipe()
+        proc.standardError = stderrPipe
+
+        try proc.run()
+        proc.waitUntilExit()
+
+        guard proc.terminationStatus == 0 else {
+            let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            throw NSError(domain: "DisplayReconnectionUITests", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "Failed to build display helper: \(stderr)"
+            ])
+        }
+    }
+
+    private func launchDisplayHelper() throws {
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: helperBinaryPath)
+        // Single mode, no iterations — just create and hold the display.
+        proc.arguments = [
+            "--modes", "1920x1080",
+            "--ready-path", displayReadyPath,
+            "--display-id-path", displayIDPath,
+            "--iterations", "0",
+        ]
+
+        let logHandle: FileHandle? = {
+            FileManager.default.createFile(atPath: helperLogPath, contents: nil)
+            return FileHandle(forWritingAtPath: helperLogPath)
+        }()
+        proc.standardOutput = logHandle
+        proc.standardError = logHandle
+
+        try proc.run()
+        helperProcess = proc
+    }
+
+    // MARK: - App Process
+
+    private func launchAppProcess(targetDisplayID: String) throws {
+        let binaryPath = try resolveAppBinaryPath()
+
+        let proc = Process()
+        proc.executableURL = URL(fileURLWithPath: binaryPath)
+        var env = ProcessInfo.processInfo.environment
+        env["CMUX_UI_TEST_MODE"] = "1"
+        env["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        env["CMUX_UI_TEST_TARGET_DISPLAY_ID"] = targetDisplayID
+        env["CMUX_TAG"] = launchTag
+        proc.environment = env
+
+        let logPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-app-\(launchTag).log").path
+        FileManager.default.createFile(atPath: logPath, contents: nil)
+        let logHandle = FileHandle(forWritingAtPath: logPath)
+        proc.standardOutput = logHandle
+        proc.standardError = logHandle
+
+        try proc.run()
+        appProcess = proc
+
+        guard waitForAppLaunchDiagnostics(timeout: 15.0) else {
+            let isAlive = proc.isRunning
+            let appLog = (try? String(contentsOfFile: logPath, encoding: .utf8))
+                .map { String($0.suffix(2000)) } ?? "<empty>"
+            throw NSError(domain: "DisplayReconnectionUITests", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "App failed to launch. alive=\(isAlive) appLog=[\(appLog)]"
+            ])
+        }
+    }
+
+    private func resolveAppBinaryPath() throws -> String {
+        let testBundle = Bundle(for: Self.self)
+        let productsDir = testBundle.bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let binaryPath = productsDir
+            .appendingPathComponent("cmux DEV.app")
+            .appendingPathComponent("Contents/MacOS/cmux DEV")
+            .path
+        if FileManager.default.fileExists(atPath: binaryPath) {
+            return binaryPath
+        }
+
+        throw NSError(domain: "DisplayReconnectionUITests", code: 4, userInfo: [
+            NSLocalizedDescriptionKey: "App binary not found at \(binaryPath)"
+        ])
+    }
+
+    // MARK: - Diagnostics
+
+    private func loadDiagnostics() -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: diagnosticsPath)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return object
+    }
+
+    private func diagnosticsModificationDate() -> Date? {
+        guard let attrs = try? FileManager.default.attributesOfItem(atPath: diagnosticsPath) else { return nil }
+        return attrs[.modificationDate] as? Date
+    }
+
+    /// Splits the comma-separated `windowScreenDisplayIDs` diagnostics value
+    /// into exact ID strings so lookups don't false-positive on substrings.
+    private func parseDisplayIDs(_ raw: String?) -> Set<String> {
+        guard let raw, !raw.isEmpty else { return [] }
+        return Set(raw.split(separator: ",").map { String($0) })
+    }
+
+    private func waitForAppLaunchDiagnostics(timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            guard let diagnostics = self.loadDiagnostics() else { return false }
+            guard let pid = diagnostics["pid"], !pid.isEmpty else { return false }
+            guard let stage = diagnostics["stage"], !stage.isEmpty else { return false }
+            return true
+        }
+    }
+
+    private func waitForTargetDisplayMove(targetDisplayID: String, timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            guard let diagnostics = self.loadDiagnostics() else { return false }
+            let ids = self.parseDisplayIDs(diagnostics["windowScreenDisplayIDs"])
+            return diagnostics["targetDisplayMoveSucceeded"] == "1" && ids.contains(targetDisplayID)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func waitForCondition(timeout: TimeInterval, pollInterval: TimeInterval = 0.2, _ condition: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() { return true }
+            RunLoop.current.run(until: Date().addingTimeInterval(pollInterval))
+        }
+        return condition()
+    }
+
+    private func waitForFile(atPath path: String, timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            FileManager.default.fileExists(atPath: path)
+        }
+    }
+
+    private func readTrimmedFile(atPath path: String) -> String? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var repoRootURL: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private func terminateAppProcess() {
+        guard let proc = appProcess else { return }
+        defer { appProcess = nil }
+        if !proc.isRunning { return }
+        proc.terminate()
+        let deadline = Date().addingTimeInterval(5.0)
+        while proc.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        if proc.isRunning { proc.interrupt() }
+    }
+
+    private func terminateHelperProcess() {
+        guard let proc = helperProcess else { return }
+        defer { helperProcess = nil }
+        if !proc.isRunning { return }
+        proc.terminate()
+        let deadline = Date().addingTimeInterval(3.0)
+        while proc.isRunning && Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+        if proc.isRunning { proc.interrupt() }
+    }
+
+    private func removeHelperArtifacts() {
+        for path in [displayReadyPath, displayIDPath] {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    private func removeTestArtifacts() {
+        for path in [
+            diagnosticsPath, displayReadyPath, displayIDPath,
+            helperBinaryPath, helperLogPath,
+        ] {
+            guard !path.isEmpty else { continue }
+            try? FileManager.default.removeItem(atPath: path)
+        }
+    }
+
+    private struct PrelaunchManifest: Decodable {
+        let diagnosticsPath: String?
+    }
+
+    private func loadPrelaunchManifest() -> PrelaunchManifest? {
+        let url = URL(fileURLWithPath: "/tmp/cmux-ui-test-prelaunch.json")
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return try? JSONDecoder().decode(PrelaunchManifest.self, from: data)
+    }
+}


### PR DESCRIPTION
## Summary

- **Cache per-display window positions** so the autosave timer doesn't overwrite saved geometry when macOS moves windows to the primary display after an external display disconnects
- **Restore windows on display reconnect** via `NSApplication.didChangeScreenParametersNotification` — windows return to their last-known position on the reconnected display
- **Refit windows on display disconnect** — instead of the macOS-created sliver, restore to last-known position on the fallback display (preserving original size)
- **Add E2E test** (`DisplayReconnectionUITests`) that exercises the full disconnect/reconnect cycle using virtual displays

Fixes #1331
Fixes #2135
Relates to #2666

## How it works

Three new instance properties on `AppDelegate`:
- `lastKnownDisplayIDs` — tracks connected display IDs to detect appear/disappear
- `savedDisplayWindowFrames` — per-display cache of `(windowId, frame, display)` tuples, updated during autosave ticks and after screen-change events
- `screenParametersChangeWorkItem` — debounce (0.25s) for coalescing rapid notifications

On **display disconnect**: looks up cached position for the window on the fallback display. If found, restores to that position (like Hyper does). If not, centers with original size. The cached position for the disappeared display is preserved for later restoration.

On **display reconnect**: restores the window to its cached position on the returned display using the existing `resolvedWindowFrame()` logic.

In **`buildSessionSnapshot()`**: if a window's original display has disappeared, the snapshot uses the cached pre-disconnect frame/display instead of the live (macOS-moved) position, preventing the autosave from overwriting good coordinates.

Cache cleanup happens in `unregisterMainWindow()` and `discardOrphanedMainWindowContext()` via `removeSavedDisplayWindowFrames(forWindowId:)`.

## Test plan

### E2E test (CI)
- [x] `DisplayReconnectionUITests.testWindowRestoresToExternalDisplayAfterReconnection` — creates a virtual display, moves the window to it, destroys it (verifies no sliver), recreates it (verifies window returns). Run via `gh workflow run test-e2e.yml`.

### Manual testing performed
- [x] Move window to external monitor → unplug → window restores to last-known laptop position with correct size
- [x] Plug monitor back in → window restores to last-known external monitor position
- [x] Repeated plug/unplug cycles → positions retained on both displays across cycles
- [x] Window size preserved (no proportional shrinking from larger to smaller display)
- [x] Autosave snapshots preserve correct per-display coordinates (verified via debug log)
- [x] Existing unit tests pass (41 tests, 0 new failures)

### Why no new unit tests
The new runtime logic (`handleScreenParametersDidChange`, `savedFrameForDisplacedWindow`, `updateSavedDisplayWindowFrames`) requires live `NSWindow` and `NSScreen` objects — mocking these would violate the [test quality policy](https://github.com/manaflow-ai/cmux/blob/main/CLAUDE.md#test-quality-policy) which requires tests to "verify observable runtime behavior through executable paths, not implementation shape." The core frame resolution logic (`resolvedWindowFrame`, `clampFrame`, `centeredFrame`) is already thoroughly covered by existing `SessionPersistenceTests` (13 tests). The E2E test covers the full behavioral contract.

### Note on brief sliver flash
When a display disconnects, macOS moves the window before the notification fires, so there is a brief (~0.25s) flash of the window in a bad position before our handler repositions it. This is standard macOS AppKit behavior — even Terminal.app exhibits it. Electron apps like Hyper avoid it because Chromium handles display changes at the framework level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes windows not restoring to external displays after disconnect/reconnect. Caches per-display window positions, restores them on reconnect (ID or geometry match), and prevents sliver windows and autosave overwrites.

- **Bug Fixes**
  - Cache per-display window frames at startup and during autosave; track display IDs; debounce screen-change notifications (0.25s).
  - On disconnect: move windows to last-known position on the fallback display (or center); preserve size; avoid slivers.
  - On reconnect: restore windows to saved position; if the display ID changed, match by frame + visibleFrame (±1px), remove the window entry only from the matched stale disconnected-display bucket, then re-save under the new display ID.
  - Autosave/snapshots use cached pre-disconnect frame/display instead of macOS-moved coordinates; skip cache writes for programmatically moved windows; persist a snapshot after handling screen changes.
  - Seed/update cache on window lifecycle; clean per-window cache entries on close.
  - Add E2E test using virtual displays that verifies the full disconnect/reconnect cycle; added to the test target.

Fixes #1331. Fixes #2135. Relates to #2666.

<sup>Written for commit 0413a417f8872694e2ba0abd395e0e05fd150cb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-window display reconnection: windows return to their original display and position when a monitor reconnects.

* **Bug Fixes**
  * Autosave and session snapshots now preserve displaced-window positions and avoid saving incorrect migrated frames, preventing lost or mispositioned windows after display changes.

* **Tests**
  * Added end-to-end UI tests that validate window restoration across display disconnect/reconnect cycles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->