### PR TITLE
cmux Island MVP (notch-anchored agent session overlay)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+
+# Superpowers brainstorm scratch (visual companion mockups, transient state)
+.superpowers/

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,6 @@ tmp-*/
 
 # Superpowers brainstorm scratch (visual companion mockups, transient state)
 .superpowers/
+
+# Git worktrees (isolated per-feature workspaces)
+.worktrees/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to cmux are documented here.
 
+## [Unreleased]
+
+### Added
+- **cmux Island (opt-in).** New notch-anchored overlay that lists active AI agent sessions detected from `cmux set-status` entries. Click a row to jump to the corresponding workspace and terminal split. Enable it from Settings → Island. See [`docs/superpowers/specs/2026-04-09-cmux-island-design.md`](docs/superpowers/specs/2026-04-09-cmux-island-design.md) for design details. ([#2590](https://github.com/manaflow-ai/cmux/issues/2590))
+
 ## [0.63.2] - 2026-04-06
 
 ### Added

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -134,6 +134,21 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
+		CA5015140DE00001 /* IslandSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00001 /* IslandSettings.swift */; };
+		CA5015140DE00002 /* IslandSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00002 /* IslandSession.swift */; };
+		CA5015140DE00003 /* IslandStateProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00003 /* IslandStateProvider.swift */; };
+		CA5015140DE00004 /* IslandStateStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00004 /* IslandStateStore.swift */; };
+		CA5015140DE00005 /* IslandFocusSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00005 /* IslandFocusSink.swift */; };
+		CA5015140DE00006 /* IslandJumpRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00006 /* IslandJumpRouter.swift */; };
+		CA5015140DE00007 /* NotchShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00007 /* NotchShape.swift */; };
+		CA5015140DE00008 /* NotchPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00008 /* NotchPanel.swift */; };
+		CA5015140DE00009 /* IslandRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00009 /* IslandRootView.swift */; };
+		CA5015140DE00010 /* IslandWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00010 /* IslandWindowController.swift */; };
+		CA5015140DE00011 /* IslandSettingsFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00011 /* IslandSettingsFileStoreTests.swift */; };
+		CA5015140DE00012 /* IslandSessionPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00012 /* IslandSessionPhaseTests.swift */; };
+		CA5015140DE00013 /* IslandSessionSortTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00013 /* IslandSessionSortTests.swift */; };
+		CA5015140DE00014 /* IslandStateStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00014 /* IslandStateStoreTests.swift */; };
+		CA5015140DE00015 /* IslandJumpRouterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA5015141DE00015 /* IslandJumpRouterTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -332,6 +347,21 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
+		CA5015141DE00001 /* IslandSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandSettings.swift; sourceTree = "<group>"; };
+		CA5015141DE00002 /* IslandSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandSession.swift; sourceTree = "<group>"; };
+		CA5015141DE00003 /* IslandStateProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandStateProvider.swift; sourceTree = "<group>"; };
+		CA5015141DE00004 /* IslandStateStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandStateStore.swift; sourceTree = "<group>"; };
+		CA5015141DE00005 /* IslandFocusSink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandFocusSink.swift; sourceTree = "<group>"; };
+		CA5015141DE00006 /* IslandJumpRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandJumpRouter.swift; sourceTree = "<group>"; };
+		CA5015141DE00007 /* NotchShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/NotchShape.swift; sourceTree = "<group>"; };
+		CA5015141DE00008 /* NotchPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/NotchPanel.swift; sourceTree = "<group>"; };
+		CA5015141DE00009 /* IslandRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandRootView.swift; sourceTree = "<group>"; };
+		CA5015141DE00010 /* IslandWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandWindowController.swift; sourceTree = "<group>"; };
+		CA5015141DE00011 /* IslandSettingsFileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandSettingsFileStoreTests.swift; sourceTree = "<group>"; };
+		CA5015141DE00012 /* IslandSessionPhaseTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandSessionPhaseTests.swift; sourceTree = "<group>"; };
+		CA5015141DE00013 /* IslandSessionSortTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandSessionSortTests.swift; sourceTree = "<group>"; };
+		CA5015141DE00014 /* IslandStateStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandStateStoreTests.swift; sourceTree = "<group>"; };
+		CA5015141DE00015 /* IslandJumpRouterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IslandJumpRouterTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -518,6 +548,16 @@
 				A5001651 /* CmuxConfig.swift */,
 				A5001653 /* CmuxConfigExecutor.swift */,
 				A5001655 /* CmuxDirectoryTrust.swift */,
+				CA5015141DE00001 /* IslandSettings.swift */,
+				CA5015141DE00002 /* IslandSession.swift */,
+				CA5015141DE00003 /* IslandStateProvider.swift */,
+				CA5015141DE00004 /* IslandStateStore.swift */,
+				CA5015141DE00005 /* IslandFocusSink.swift */,
+				CA5015141DE00006 /* IslandJumpRouter.swift */,
+				CA5015141DE00007 /* NotchShape.swift */,
+				CA5015141DE00008 /* NotchPanel.swift */,
+				CA5015141DE00009 /* IslandRootView.swift */,
+				CA5015141DE00010 /* IslandWindowController.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -612,6 +652,11 @@
 					491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */,
 					10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 					C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
+					CA5015141DE00011 /* IslandSettingsFileStoreTests.swift */,
+					CA5015141DE00012 /* IslandSessionPhaseTests.swift */,
+					CA5015141DE00013 /* IslandSessionSortTests.swift */,
+					CA5015141DE00014 /* IslandStateStoreTests.swift */,
+					CA5015141DE00015 /* IslandJumpRouterTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -843,6 +888,16 @@
 				A5001650 /* CmuxConfig.swift in Sources */,
 			A5001652 /* CmuxConfigExecutor.swift in Sources */,
 			A5001654 /* CmuxDirectoryTrust.swift in Sources */,
+			CA5015140DE00001 /* IslandSettings.swift in Sources */,
+			CA5015140DE00002 /* IslandSession.swift in Sources */,
+			CA5015140DE00003 /* IslandStateProvider.swift in Sources */,
+			CA5015140DE00004 /* IslandStateStore.swift in Sources */,
+			CA5015140DE00005 /* IslandFocusSink.swift in Sources */,
+			CA5015140DE00006 /* IslandJumpRouter.swift in Sources */,
+			CA5015140DE00007 /* NotchShape.swift in Sources */,
+			CA5015140DE00008 /* NotchPanel.swift in Sources */,
+			CA5015140DE00009 /* IslandRootView.swift in Sources */,
+			CA5015140DE00010 /* IslandWindowController.swift in Sources */,
 		);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -912,6 +967,11 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
+					CA5015140DE00011 /* IslandSettingsFileStoreTests.swift in Sources */,
+					CA5015140DE00012 /* IslandSessionPhaseTests.swift in Sources */,
+					CA5015140DE00013 /* IslandSessionSortTests.swift in Sources */,
+					CA5015140DE00014 /* IslandStateStoreTests.swift in Sources */,
+					CA5015140DE00015 /* IslandJumpRouterTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87527,6 +87527,261 @@
           }
         }
       }
+    },
+    "island.header.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Island"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux アイランド"
+          }
+        }
+      }
+    },
+    "island.settings.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Island"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイランド"
+          }
+        }
+      }
+    },
+    "island.settings.enable.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show agent session island overlay"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントセッションのアイランドを表示"
+          }
+        }
+      }
+    },
+    "island.settings.enable.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A notch-anchored pill that lists active AI agent sessions running inside cmux. Click a row to jump to that workspace and terminal split."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ノッチ付近に浮かぶピル型オーバーレイで、cmux 内で実行中の AI エージェントセッションを一覧表示します。行をクリックすると、該当のワークスペースとターミナル分割に移動します。"
+          }
+        }
+      }
+    },
+    "island.settings.known_kinds.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detects sessions from `cmux set-status` with one of these known keys: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の既知のキーを持つ `cmux set-status` エントリをセッションとして検出します: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid。"
+          }
+        }
+      }
+    },
+    "island.phase.running": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "RUNNING"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行中"
+          }
+        }
+      }
+    },
+    "island.phase.idle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "IDLE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "待機中"
+          }
+        }
+      }
+    },
+    "island.phase.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WAITING"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "入力待ち"
+          }
+        }
+      }
+    },
+    "island.phase.error": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ERROR"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラー"
+          }
+        }
+      }
+    },
+    "island.phase.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "—"
+          }
+        }
+      }
+    },
+    "island.debug.window.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Island Controller"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイランドコントローラー"
+          }
+        }
+      }
+    },
+    "island.debug.injectTestSession": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Inject test session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストセッションを注入"
+          }
+        }
+      }
+    },
+    "island.debug.clearTestSessions": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear test sessions"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストセッションをクリア"
+          }
+        }
+      }
+    },
+    "menu.debug.islandController": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Island Controller…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイランドコントローラー…"
+          }
+        }
+      }
+    },
+    "settings.section.island": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Island"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アイランド"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2253,6 +2253,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserOmnibarRepeatDelta: Int = 0
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
+    private var islandWindowController: IslandWindowController?
+    private var islandEnabledObserver: AnyCancellable?
     private let updateController = UpdateController()
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(viewModel: updateViewModel)
     private let windowDecorationsController = WindowDecorationsController()
@@ -2669,6 +2671,44 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 #endif
+
+        // cmux Island — opt-in overlay. Created and destroyed reactively
+        // based on the islandEnabled setting so disabling it leaves no
+        // leftover panel, observer, or timer behind.
+        islandEnabledObserver = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .map { _ in UserDefaults.standard.bool(forKey: IslandSettings.enabledKey) }
+            .prepend(UserDefaults.standard.bool(forKey: IslandSettings.enabledKey))
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] enabled in
+                self?.refreshIslandController(enabled: enabled)
+            }
+    }
+
+    @MainActor
+    private func refreshIslandController(enabled: Bool) {
+        if enabled {
+            guard islandWindowController == nil else { return }
+            guard let tabManager = self.tabManager else { return }
+
+            let source = TabManagerIslandStateSource(tabManager: tabManager)
+            let store = IslandStateStore(source: source)
+
+            let focusSink = TabManagerIslandFocusSink(
+                tabManager: tabManager,
+                collapse: { [weak self] in
+                    self?.islandWindowController?.close()
+                }
+            )
+            let router = IslandJumpRouter(focusSink: focusSink)
+
+            let controller = IslandWindowController(provider: store, router: router)
+            islandWindowController = controller
+        } else {
+            islandWindowController?.shutdown()
+            islandWindowController = nil
+        }
     }
 
 #if DEBUG

--- a/Sources/Island/IslandFocusSink.swift
+++ b/Sources/Island/IslandFocusSink.swift
@@ -1,0 +1,71 @@
+// Sources/Island/IslandFocusSink.swift
+
+import AppKit
+import Foundation
+
+/// The exact set of cmux actions `IslandJumpRouter` needs to perform when
+/// the user clicks a session row. Confining these behind a protocol makes
+/// the router unit-testable and is also the single place where the Island
+/// module writes back into cmux core state.
+@MainActor
+protocol IslandFocusSink: AnyObject {
+    /// Bring cmux to the front (an explicit user intent that satisfies
+    /// the socket focus-steal policy — see CLAUDE.md §"Socket focus policy").
+    func activateApp()
+
+    /// Select the workspace with the given id. Returns false if the
+    /// workspace no longer exists.
+    @discardableResult
+    func selectWorkspace(id: UUID) -> Bool
+
+    /// Focus the panel with the given id inside the previously-selected
+    /// workspace. Returns false if the panel no longer exists.
+    @discardableResult
+    func focusPanel(id: UUID, inWorkspace workspaceId: UUID) -> Bool
+
+    /// Collapse the island overlay (close the expanded panel).
+    func collapseIsland()
+}
+
+/// Production implementation that routes through the live `TabManager`
+/// and its workspaces. The `collapse` closure is injected so the sink
+/// doesn't take a direct reference to the window controller — this keeps
+/// the dependency flow one-directional.
+@MainActor
+final class TabManagerIslandFocusSink: IslandFocusSink {
+
+    private let tabManager: TabManager
+    private let collapse: @MainActor () -> Void
+
+    init(tabManager: TabManager, collapse: @escaping @MainActor () -> Void) {
+        self.tabManager = tabManager
+        self.collapse = collapse
+    }
+
+    func activateApp() {
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @discardableResult
+    func selectWorkspace(id: UUID) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == id }) else {
+            return false
+        }
+        tabManager.selectWorkspace(workspace)
+        return true
+    }
+
+    @discardableResult
+    func focusPanel(id panelId: UUID, inWorkspace workspaceId: UUID) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }),
+              workspace.panels[panelId] != nil else {
+            return false
+        }
+        workspace.focusPanel(panelId)
+        return true
+    }
+
+    func collapseIsland() {
+        collapse()
+    }
+}

--- a/Sources/Island/IslandJumpRouter.swift
+++ b/Sources/Island/IslandJumpRouter.swift
@@ -1,9 +1,14 @@
 // Sources/Island/IslandJumpRouter.swift
 
 import Foundation
+#if DEBUG
+import Bonsplit  // dlog
+#endif
 
 /// Translates a session tap into a fixed sequence of `IslandFocusSink`
-/// calls. See spec §6.6 for the required ordering.
+/// calls. See spec §6.6 for the intent; the ordering below probes
+/// `selectWorkspace` *before* `activateApp` so that a jump to a torn-down
+/// workspace does not steal macOS focus unnecessarily.
 @MainActor
 final class IslandJumpRouter {
 
@@ -25,11 +30,24 @@ final class IslandJumpRouter {
     func jump(to session: IslandSession) {
         let workspaceFound = focusSink.selectWorkspace(id: session.workspaceId)
         guard workspaceFound else {
+#if DEBUG
+            dlog("island.jump failed: workspace \(session.workspaceId.uuidString.prefix(8)) not found")
+#endif
             focusSink.collapseIsland()
             return
         }
         focusSink.activateApp()
-        _ = focusSink.focusPanel(id: session.panelId, inWorkspace: session.workspaceId)
+        let panelFocused = focusSink.focusPanel(
+            id: session.panelId,
+            inWorkspace: session.workspaceId
+        )
+#if DEBUG
+        if !panelFocused {
+            dlog(
+                "island.jump failed: panel \(session.panelId.uuidString.prefix(8)) not found in workspace \(session.workspaceId.uuidString.prefix(8))"
+            )
+        }
+#endif
         focusSink.collapseIsland()
     }
 }

--- a/Sources/Island/IslandJumpRouter.swift
+++ b/Sources/Island/IslandJumpRouter.swift
@@ -1,0 +1,35 @@
+// Sources/Island/IslandJumpRouter.swift
+
+import Foundation
+
+/// Translates a session tap into a fixed sequence of `IslandFocusSink`
+/// calls. See spec §6.6 for the required ordering.
+@MainActor
+final class IslandJumpRouter {
+
+    private let focusSink: IslandFocusSink
+
+    init(focusSink: IslandFocusSink) {
+        self.focusSink = focusSink
+    }
+
+    /// Perform the jump. `collapseIsland()` runs exactly once whether or
+    /// not intermediate steps succeed.
+    ///
+    /// Sequence:
+    ///   1. selectWorkspace (probe) — if it returns false, workspace is
+    ///      gone and we skip activation entirely (spec §6.6).
+    ///   2. activateApp — explicit user focus intent.
+    ///   3. focusPanel — best effort; return value ignored.
+    ///   4. collapseIsland — always, exactly once.
+    func jump(to session: IslandSession) {
+        let workspaceFound = focusSink.selectWorkspace(id: session.workspaceId)
+        guard workspaceFound else {
+            focusSink.collapseIsland()
+            return
+        }
+        focusSink.activateApp()
+        _ = focusSink.focusPanel(id: session.panelId, inWorkspace: session.workspaceId)
+        focusSink.collapseIsland()
+    }
+}

--- a/Sources/Island/IslandRootView.swift
+++ b/Sources/Island/IslandRootView.swift
@@ -59,7 +59,7 @@ struct IslandRootView: View {
                 .fill(Color(nsColor: viewModel.aggregateColor))
                 .frame(width: 6, height: 6)
                 .shadow(color: Color(nsColor: viewModel.aggregateColor).opacity(0.6), radius: 3)
-            Text("\(viewModel.sessions.count)")
+            Text(verbatim: "\(viewModel.sessions.count)")
                 .font(.system(size: 11, weight: .semibold, design: .rounded))
                 .monospacedDigit()
                 .foregroundStyle(.white)
@@ -101,18 +101,24 @@ struct IslandRootView: View {
                     .fill(Color(nsColor: session.agentKind.color))
                     .frame(width: 20, height: 20)
                     .overlay(
-                        Text(session.agentKind.monogram)
+                        // Monogram is a structural identifier (single letter
+                        // per agent kind), not a translatable string.
+                        Text(verbatim: session.agentKind.monogram)
                             .font(.system(size: 11, weight: .bold))
                             .foregroundStyle(.white)
                     )
 
                 VStack(alignment: .leading, spacing: 2) {
-                    Text("\(session.workspaceTitle) · \(session.panelTitle)")
+                    // Composed structural strings — separators and interpolated
+                    // values (workspace/panel titles, elapsed time) are not
+                    // translated as wholes. `Text(verbatim:)` declares this
+                    // intent so the localization scanner doesn't flag them.
+                    Text(verbatim: "\(session.workspaceTitle) · \(session.panelTitle)")
                         .font(.system(size: 13, weight: .semibold))
                         .foregroundStyle(.white)
                         .lineLimit(1)
                         .truncationMode(.tail)
-                    Text("\(session.agentKind.displayName) · \(relativeTime(since: session.lastActivity))")
+                    Text(verbatim: "\(session.agentKind.displayName) · \(relativeTime(since: session.lastActivity))")
                         .font(.system(size: 11))
                         .foregroundStyle(.white.opacity(0.55))
                         .lineLimit(1)
@@ -123,7 +129,7 @@ struct IslandRootView: View {
 
                 phasePill(session.phase)
                 if session.unreadCount > 0 {
-                    Text("·\(session.unreadCount)")
+                    Text(verbatim: "·\(session.unreadCount)")
                         .font(.system(size: 10, weight: .bold))
                         .foregroundStyle(.white.opacity(0.7))
                 }

--- a/Sources/Island/IslandRootView.swift
+++ b/Sources/Island/IslandRootView.swift
@@ -1,0 +1,285 @@
+// Sources/Island/IslandRootView.swift
+
+import AppKit
+import Combine
+import SwiftUI
+
+/// SwiftUI root of the cmux Island overlay.
+///
+/// Two visual states — closed (minimal pill on the left extension of the
+/// notch) and opened (rounded panel below the notch with session rows).
+struct IslandRootView: View {
+
+    @ObservedObject var viewModel: IslandRootViewModel
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            NotchShape(
+                topCornerRadius: viewModel.topCornerRadius,
+                bottomCornerRadius: viewModel.bottomCornerRadius
+            )
+            .fill(.black)
+            .frame(
+                width: viewModel.shapeSize.width,
+                height: viewModel.shapeSize.height
+            )
+            .shadow(
+                color: viewModel.isOpen ? .black.opacity(0.7) : .clear,
+                radius: 8
+            )
+            .animation(
+                viewModel.isOpen
+                    ? .spring(response: 0.42, dampingFraction: 0.8)
+                    : .spring(response: 0.45, dampingFraction: 1.0),
+                value: viewModel.isOpen
+            )
+            .onTapGesture {
+                if !viewModel.isOpen { viewModel.open() }
+            }
+            .overlay(alignment: .top) {
+                if viewModel.isOpen {
+                    expandedContent
+                        .padding(.top, viewModel.notchHeight + 4)
+                        .frame(width: viewModel.shapeSize.width - 24)
+                } else {
+                    closedContent
+                        .padding(.leading, 20)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Closed state — dot + count on the LEFT extension
+
+    private var closedContent: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(Color(nsColor: viewModel.aggregateColor))
+                .frame(width: 6, height: 6)
+                .shadow(color: Color(nsColor: viewModel.aggregateColor).opacity(0.6), radius: 3)
+            Text("\(viewModel.sessions.count)")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.white)
+            Spacer(minLength: 0)
+        }
+        .frame(height: viewModel.notchHeight, alignment: .leading)
+    }
+
+    // MARK: - Expanded state — list of session rows
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "island.header.title", defaultValue: "cmux Island"))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.top, 6)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(viewModel.sessions) { session in
+                        sessionRow(session)
+                    }
+                }
+            }
+            .frame(maxHeight: 440)
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 10)
+        .onExitCommand { viewModel.close() }
+    }
+
+    @ViewBuilder
+    private func sessionRow(_ session: IslandSession) -> some View {
+        Button {
+            viewModel.jump(to: session)
+        } label: {
+            HStack(spacing: 10) {
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(Color(nsColor: session.agentKind.color))
+                    .frame(width: 20, height: 20)
+                    .overlay(
+                        Text(session.agentKind.monogram)
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(.white)
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(session.workspaceTitle) · \(session.panelTitle)")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                    Text("\(session.agentKind.displayName) · \(relativeTime(since: session.lastActivity))")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.55))
+                        .lineLimit(1)
+                        .truncationMode(.tail)
+                }
+
+                Spacer(minLength: 4)
+
+                phasePill(session.phase)
+                if session.unreadCount > 0 {
+                    Text("·\(session.unreadCount)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 10).fill(.white.opacity(0.08))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func phasePill(_ phase: IslandSessionPhase) -> some View {
+        let style = phaseStyle(phase)
+        Text(style.text)
+            .font(.system(size: 10, weight: .bold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(style.background))
+            .foregroundStyle(style.foreground)
+    }
+
+    private struct PhaseStyle {
+        let background: Color
+        let foreground: Color
+        let text: String
+    }
+
+    private func phaseStyle(_ phase: IslandSessionPhase) -> PhaseStyle {
+        switch phase {
+        case .running:
+            return PhaseStyle(
+                background: Color(red: 0.04, green: 0.23, blue: 0.09),
+                foreground: Color(red: 0.20, green: 0.82, blue: 0.35),
+                text: String(localized: "island.phase.running", defaultValue: "RUNNING")
+            )
+        case .waiting:
+            return PhaseStyle(
+                background: Color(red: 0.29, green: 0.21, blue: 0.02),
+                foreground: Color(red: 0.98, green: 0.80, blue: 0.24),
+                text: String(localized: "island.phase.waiting", defaultValue: "WAITING")
+            )
+        case .error:
+            return PhaseStyle(
+                background: Color(red: 0.23, green: 0.07, blue: 0.07),
+                foreground: Color(red: 0.97, green: 0.44, blue: 0.44),
+                text: String(localized: "island.phase.error", defaultValue: "ERROR")
+            )
+        case .idle:
+            return PhaseStyle(
+                background: Color(red: 0.11, green: 0.16, blue: 0.22),
+                foreground: Color(red: 0.49, green: 0.83, blue: 0.99),
+                text: String(localized: "island.phase.idle", defaultValue: "IDLE")
+            )
+        case .unknown:
+            return PhaseStyle(
+                background: .white.opacity(0.12),
+                foreground: .white.opacity(0.6),
+                text: String(localized: "island.phase.unknown", defaultValue: "—")
+            )
+        }
+    }
+
+    private func relativeTime(since date: Date) -> String {
+        let seconds = Int(Date().timeIntervalSince(date))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3_600 { return "\(seconds / 60)m" }
+        if seconds < 86_400 { return "\(seconds / 3_600)h" }
+        return "\(seconds / 86_400)d"
+    }
+}
+
+// MARK: - View model
+
+/// View model backing `IslandRootView`. Owns the open/closed state, the
+/// current session snapshot, and delegates jump actions to a router.
+@MainActor
+final class IslandRootViewModel: ObservableObject {
+
+    @Published private(set) var sessions: [IslandSession] = []
+    @Published private(set) var isOpen: Bool = false
+
+    let notchWidth: CGFloat
+    let notchHeight: CGFloat
+
+    // Geometry constants.
+    private let closedSideExtent: CGFloat = 28
+    private let openedWidth: CGFloat = 560
+    private let openedMinHeight: CGFloat = 160
+    private let rowHeight: CGFloat = 56
+    private let openedMaxHeight: CGFloat = 540
+    private let openedHeaderBuffer: CGFloat = 64
+
+    private let router: IslandJumpRouter
+    private var provider: IslandStateProvider?
+    private var cancellable: AnyCancellable?
+
+    init(notchWidth: CGFloat, notchHeight: CGFloat, router: IslandJumpRouter) {
+        self.notchWidth = notchWidth
+        self.notchHeight = notchHeight
+        self.router = router
+    }
+
+    /// Attach to a state provider. Calling this again with a different
+    /// provider replaces the subscription.
+    func bind(to provider: IslandStateProvider) {
+        self.provider = provider
+        self.sessions = provider.currentSessions
+        self.cancellable = provider.sessionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.sessions = sessions
+            }
+    }
+
+    // MARK: Layout helpers
+
+    var shapeSize: CGSize {
+        if isOpen {
+            let desired = openedHeaderBuffer + CGFloat(sessions.count) * rowHeight
+            let clamped = min(max(desired, openedMinHeight), openedMaxHeight)
+            return CGSize(width: openedWidth, height: clamped)
+        } else {
+            return CGSize(
+                width: notchWidth + 2 * closedSideExtent,
+                height: notchHeight
+            )
+        }
+    }
+
+    var topCornerRadius: CGFloat { isOpen ? 19 : 6 }
+    var bottomCornerRadius: CGFloat { isOpen ? 24 : 14 }
+
+    /// Highest-severity phase currently present, mapped to a single
+    /// indicator color for the collapsed pill.
+    var aggregateColor: NSColor {
+        if sessions.contains(where: { $0.phase == .running }) {
+            return .systemGreen
+        }
+        if sessions.contains(where: { $0.phase == .waiting }) {
+            return .systemYellow
+        }
+        if sessions.contains(where: { $0.phase == .error }) {
+            return .systemRed
+        }
+        return .systemGray
+    }
+
+    // MARK: Actions
+
+    func open()  { isOpen = true  }
+    func close() { isOpen = false }
+
+    func jump(to session: IslandSession) {
+        router.jump(to: session)
+    }
+}

--- a/Sources/Island/IslandSession.swift
+++ b/Sources/Island/IslandSession.swift
@@ -1,0 +1,133 @@
+// Sources/Island/IslandSession.swift
+
+import Foundation
+import SwiftUI
+
+/// Known AI-agent kinds the cmux Island monitors.
+///
+/// A terminal panel counts as an active island session iff its
+/// `Workspace.statusEntries` contains at least one entry whose key equals
+/// one of these raw values. Agent hooks in `docs/notifications.md` already
+/// use these keys.
+enum IslandAgentKind: String, CaseIterable, Hashable, Sendable {
+    case claudeCode = "claude_code"
+    case codex      = "codex"
+    case copilotCli = "copilot_cli"
+    case openCode   = "opencode"
+    case geminiCli  = "gemini_cli"
+    case cursor     = "cursor"
+    case amp        = "amp"
+    case droid      = "droid"
+
+    /// Human-readable name shown in the expanded island row.
+    var displayName: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .codex:      return "Codex"
+        case .copilotCli: return "Copilot CLI"
+        case .openCode:   return "OpenCode"
+        case .geminiCli:  return "Gemini CLI"
+        case .cursor:     return "Cursor"
+        case .amp:        return "Amp"
+        case .droid:      return "Droid"
+        }
+    }
+
+    /// Single-character monogram used in the 20pt row chip.
+    var monogram: String {
+        switch self {
+        case .claudeCode: return "C"
+        case .codex:      return "X"
+        case .copilotCli: return "G"
+        case .openCode:   return "O"
+        case .geminiCli:  return "V"
+        case .cursor:     return "U"
+        case .amp:        return "A"
+        case .droid:      return "D"
+        }
+    }
+
+    /// Stable brand-ish color for the row chip and collapsed-pill legend.
+    var color: Color {
+        switch self {
+        case .claudeCode: return Color(red: 0.85, green: 0.47, blue: 0.02)
+        case .codex:      return Color(red: 0.23, green: 0.51, blue: 0.96)
+        case .copilotCli: return Color(red: 0.55, green: 0.36, blue: 0.96)
+        case .openCode:   return Color(red: 0.20, green: 0.72, blue: 0.45)
+        case .geminiCli:  return Color(red: 0.40, green: 0.66, blue: 0.95)
+        case .cursor:     return Color(red: 0.90, green: 0.90, blue: 0.90)
+        case .amp:        return Color(red: 0.90, green: 0.26, blue: 0.36)
+        case .droid:      return Color(red: 0.99, green: 0.81, blue: 0.24)
+        }
+    }
+}
+
+/// Normalized session phase. Free-form `cmux set-status` values are mapped
+/// into this small closed set via `IslandSessionPhase.from(rawValue:)`.
+enum IslandSessionPhase: String, Hashable, Sendable {
+    case running
+    case idle
+    case waiting
+    case error
+    case unknown
+
+    /// Sort precedence for the island list: lower comes first.
+    /// Running beats waiting beats error beats idle beats unknown.
+    var rank: Int {
+        switch self {
+        case .running: return 0
+        case .waiting: return 1
+        case .error:   return 2
+        case .idle:    return 3
+        case .unknown: return 4
+        }
+    }
+
+    /// Case-insensitive, trim-tolerant lookup from a free-form status value.
+    static func from(rawValue: String) -> IslandSessionPhase {
+        let normalized = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalized {
+        case "running", "running_tool", "processing", "starting":
+            return .running
+        case "", "idle", "ready":
+            return .idle
+        case "waiting", "waiting_for_input", "needs_input", "needsinput":
+            return .waiting
+        case "error", "failed", "failure":
+            return .error
+        default:
+            return .unknown
+        }
+    }
+}
+
+/// One row in the cmux Island. Immutable value type; a fresh instance is
+/// emitted whenever the upstream state changes.
+struct IslandSession: Identifiable, Equatable, Sendable {
+    /// Stable identity equal to `panelId` — a single panel hosts at most one
+    /// session in MVP scope.
+    let id: UUID
+    let workspaceId: UUID
+    let panelId: UUID
+    let agentKind: IslandAgentKind
+    let phase: IslandSessionPhase
+    let workspaceTitle: String
+    let panelTitle: String
+    let lastActivity: Date
+    let unreadCount: Int
+    /// Original free-form status value kept for debug/tooltip inspection.
+    let rawStatusValue: String
+}
+
+extension IslandSession {
+    /// Standard sort comparator. Running first, recent first on ties.
+    static func < (lhs: IslandSession, rhs: IslandSession) -> Bool {
+        if lhs.phase.rank != rhs.phase.rank {
+            return lhs.phase.rank < rhs.phase.rank
+        }
+        return lhs.lastActivity > rhs.lastActivity
+    }
+}

--- a/Sources/Island/IslandSession.swift
+++ b/Sources/Island/IslandSession.swift
@@ -1,7 +1,7 @@
 // Sources/Island/IslandSession.swift
 
+import AppKit
 import Foundation
-import SwiftUI
 
 /// Known AI-agent kinds the cmux Island monitors.
 ///
@@ -48,16 +48,18 @@ enum IslandAgentKind: String, CaseIterable, Hashable, Sendable {
     }
 
     /// Stable brand-ish color for the row chip and collapsed-pill legend.
-    var color: Color {
+    /// Returned as `NSColor` so this file stays free of SwiftUI imports —
+    /// the view layer bridges to `Color(nsColor:)` at the call site.
+    var color: NSColor {
         switch self {
-        case .claudeCode: return Color(red: 0.85, green: 0.47, blue: 0.02)
-        case .codex:      return Color(red: 0.23, green: 0.51, blue: 0.96)
-        case .copilotCli: return Color(red: 0.55, green: 0.36, blue: 0.96)
-        case .openCode:   return Color(red: 0.20, green: 0.72, blue: 0.45)
-        case .geminiCli:  return Color(red: 0.40, green: 0.66, blue: 0.95)
-        case .cursor:     return Color(red: 0.90, green: 0.90, blue: 0.90)
-        case .amp:        return Color(red: 0.90, green: 0.26, blue: 0.36)
-        case .droid:      return Color(red: 0.99, green: 0.81, blue: 0.24)
+        case .claudeCode: return NSColor(calibratedRed: 0.85, green: 0.47, blue: 0.02, alpha: 1)
+        case .codex:      return NSColor(calibratedRed: 0.23, green: 0.51, blue: 0.96, alpha: 1)
+        case .copilotCli: return NSColor(calibratedRed: 0.55, green: 0.36, blue: 0.96, alpha: 1)
+        case .openCode:   return NSColor(calibratedRed: 0.20, green: 0.72, blue: 0.45, alpha: 1)
+        case .geminiCli:  return NSColor(calibratedRed: 0.40, green: 0.66, blue: 0.95, alpha: 1)
+        case .cursor:     return NSColor(calibratedRed: 0.90, green: 0.90, blue: 0.90, alpha: 1)
+        case .amp:        return NSColor(calibratedRed: 0.90, green: 0.26, blue: 0.36, alpha: 1)
+        case .droid:      return NSColor(calibratedRed: 0.99, green: 0.81, blue: 0.24, alpha: 1)
         }
     }
 }
@@ -106,7 +108,7 @@ enum IslandSessionPhase: String, Hashable, Sendable {
 
 /// One row in the cmux Island. Immutable value type; a fresh instance is
 /// emitted whenever the upstream state changes.
-struct IslandSession: Identifiable, Equatable, Sendable {
+struct IslandSession: Identifiable, Equatable, Comparable, Sendable {
     /// Stable identity equal to `panelId` — a single panel hosts at most one
     /// session in MVP scope.
     let id: UUID
@@ -124,10 +126,14 @@ struct IslandSession: Identifiable, Equatable, Sendable {
 
 extension IslandSession {
     /// Standard sort comparator. Running first, recent first on ties.
+    ///
+    /// Note: the tie-break uses `>` on `lastActivity` because "sorted before"
+    /// for the island list means "more recent activity ranks first". Reading
+    /// `>` inside a `<` operator is the correct inversion, not a bug.
     static func < (lhs: IslandSession, rhs: IslandSession) -> Bool {
         if lhs.phase.rank != rhs.phase.rank {
             return lhs.phase.rank < rhs.phase.rank
         }
-        return lhs.lastActivity > rhs.lastActivity
+        return lhs.lastActivity > rhs.lastActivity  // descending: newer activity ranks first
     }
 }

--- a/Sources/Island/IslandSettings.swift
+++ b/Sources/Island/IslandSettings.swift
@@ -1,0 +1,15 @@
+// Sources/Island/IslandSettings.swift
+
+import Foundation
+
+/// Preference keys and defaults for the cmux Island module.
+///
+/// Matches the existing `*Settings` struct pattern in cmux (see
+/// `NotificationBadgeSettings`, `CursorIntegrationSettings`, etc.).
+enum IslandSettings {
+    /// UserDefaults / @AppStorage key for the island enable toggle.
+    static let enabledKey: String = "island.enabled"
+
+    /// Default is OFF per the MVP design.
+    static let defaultEnabled: Bool = false
+}

--- a/Sources/Island/IslandStateProvider.swift
+++ b/Sources/Island/IslandStateProvider.swift
@@ -39,7 +39,10 @@ protocol IslandStateSource: AnyObject {
 
 // MARK: - In-memory source for tests and debug injection
 
-final class InMemoryIslandStateSource: IslandStateSource {
+/// All mutable state is pinned to `@MainActor`, which makes this class safe to
+/// share across async contexts. Declared `@unchecked Sendable` rather than
+/// relying on compiler inference so the isolation contract is audit-visible.
+final class InMemoryIslandStateSource: IslandStateSource, @unchecked Sendable {
     private let subject = PassthroughSubject<Void, Never>()
 
     @MainActor

--- a/Sources/Island/IslandStateProvider.swift
+++ b/Sources/Island/IslandStateProvider.swift
@@ -1,0 +1,69 @@
+// Sources/Island/IslandStateProvider.swift
+
+import Combine
+import Foundation
+
+/// Downstream interface the island SwiftUI view depends on.
+///
+/// The view observes `sessionsPublisher` and re-renders whenever it emits.
+/// Keeping the view's only dependency on this protocol is what lets the
+/// production store be swapped for an in-memory fake (tests + debug menu)
+/// or a future `SocketIslandStateProvider` (Phase 3 companion app).
+protocol IslandStateProvider: AnyObject {
+    /// Emits the current flat, sorted list of active agent sessions.
+    /// Empty list means the island should be hidden.
+    var sessionsPublisher: AnyPublisher<[IslandSession], Never> { get }
+
+    /// Snapshot of the most recent emission, for callers that need a pull
+    /// API alongside the publisher.
+    var currentSessions: [IslandSession] { get }
+}
+
+// MARK: - Upstream source (the store's input)
+
+/// Upstream interface. The store subscribes to a single "tick" publisher
+/// that fires whenever any of (workspace list, per-workspace status entries,
+/// per-panel notifications) change, and the store pulls a fresh snapshot.
+///
+/// This is deliberately narrower than `TabManager` so the store is testable
+/// with an in-memory fake that doesn't need Workspace/TabManager at all.
+protocol IslandStateSource: AnyObject {
+    /// Fires whenever anything relevant to the projection changes.
+    var changes: AnyPublisher<Void, Never> { get }
+
+    /// Pull a fresh `[IslandSession]` snapshot. Must be callable on the
+    /// main actor — sources that read AppKit state should hop internally.
+    @MainActor
+    func makeSnapshot() -> [IslandSession]
+}
+
+// MARK: - In-memory source for tests and debug injection
+
+final class InMemoryIslandStateSource: IslandStateSource {
+    private let subject = PassthroughSubject<Void, Never>()
+
+    @MainActor
+    private(set) var sessions: [IslandSession] = [] {
+        didSet { subject.send(()) }
+    }
+
+    var changes: AnyPublisher<Void, Never> { subject.eraseToAnyPublisher() }
+
+    @MainActor
+    func makeSnapshot() -> [IslandSession] { sessions }
+
+    @MainActor
+    func set(_ sessions: [IslandSession]) {
+        self.sessions = sessions
+    }
+
+    @MainActor
+    func add(_ session: IslandSession) {
+        sessions.append(session)
+    }
+
+    @MainActor
+    func clear() {
+        sessions.removeAll()
+    }
+}

--- a/Sources/Island/IslandStateStore.swift
+++ b/Sources/Island/IslandStateStore.swift
@@ -62,9 +62,15 @@ final class TabManagerIslandStateSource: IslandStateSource {
         self.tabManager = tabManager
 
         // 1. Any change to the tabs array → rebuild per-workspace subscriptions
-        //    and fire a change tick. Prime with the current tabs so existing
-        //    workspaces get observers even if the tabs array never mutates
-        //    again before the first snapshot.
+        //    and fire a change tick. We prime by calling resubscribe directly
+        //    with the current tabs before attaching the $tabs sink. When init
+        //    runs on @MainActor, Combine delivers the initial $tabs value
+        //    synchronously on subscribe, so this priming call is logically
+        //    redundant — the nil-guard inside resubscribe makes the second
+        //    call a no-op. We keep the priming to document the invariant
+        //    ("existing workspaces always have observers before the first
+        //    snapshot") and to stay correct if a future scheduler change
+        //    defers the sink's initial delivery to a later runloop turn.
         resubscribe(to: tabManager.tabs)
 
         tabsCancellable = tabManager.$tabs
@@ -145,6 +151,13 @@ final class TabManagerIslandStateSource: IslandStateSource {
     /// (`hasUnreadNotification(forTabId:surfaceId:)`), but no per-panel
     /// count. For MVP we report the workspace-scoped count when the panel
     /// is the one holding an unread indicator, otherwise 0.
+    ///
+    /// Known limitations:
+    /// - Workspace-level notifications stored with `surfaceId: nil` will
+    ///   fail the per-panel gate and report 0 — false negatives are
+    ///   possible when a notification isn't bound to a specific panel.
+    /// - Two unread panels in the same workspace will both report the
+    ///   full workspace count — false positives on the numeric value.
     ///
     // TODO(Phase 2): replace with a true per-panel count once
     // TerminalNotificationStore exposes `unreadCount(forTabId:surfaceId:)`.

--- a/Sources/Island/IslandStateStore.swift
+++ b/Sources/Island/IslandStateStore.swift
@@ -40,3 +40,165 @@ final class IslandStateStore: IslandStateProvider, ObservableObject {
         subject.value
     }
 }
+
+// MARK: - Production source wrapping TabManager
+
+/// Production `IslandStateSource` that subscribes to every `Workspace`
+/// inside a `TabManager` and emits `changes` whenever any relevant state
+/// updates. Reads `TerminalNotificationStore.shared` for unread counts.
+///
+/// Deliberately isolated in one file so the `Sources/Island/` module has
+/// exactly one symbol that imports cmux core types.
+@MainActor
+final class TabManagerIslandStateSource: IslandStateSource {
+
+    private let tabManager: TabManager
+    private let subject = PassthroughSubject<Void, Never>()
+    private var tabsCancellable: AnyCancellable?
+    private var perWorkspaceCancellables: [UUID: Set<AnyCancellable>] = [:]
+    private var notificationCancellable: AnyCancellable?
+
+    init(tabManager: TabManager) {
+        self.tabManager = tabManager
+
+        // 1. Any change to the tabs array → rebuild per-workspace subscriptions
+        //    and fire a change tick. Prime with the current tabs so existing
+        //    workspaces get observers even if the tabs array never mutates
+        //    again before the first snapshot.
+        resubscribe(to: tabManager.tabs)
+
+        tabsCancellable = tabManager.$tabs
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] tabs in
+                self?.resubscribe(to: tabs)
+                self?.subject.send(())
+            }
+
+        // 2. Notifications (unread counts) tick. The store is ObservableObject,
+        //    so objectWillChange fires on every mutation; we only need a tick
+        //    to re-snapshot — the store itself is read inside makeSnapshot.
+        notificationCancellable = TerminalNotificationStore.shared.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.subject.send(())
+            }
+    }
+
+    var changes: AnyPublisher<Void, Never> { subject.eraseToAnyPublisher() }
+
+    @MainActor
+    func makeSnapshot() -> [IslandSession] {
+        var out: [IslandSession] = []
+        let knownKeys = Set(IslandAgentKind.allCases.map(\.rawValue))
+
+        for workspace in tabManager.tabs {
+            // Find the highest-priority status entry whose key is a known
+            // agent kind. Ties broken by most recent timestamp (spec §5.2).
+            let matching = workspace.statusEntries.filter { knownKeys.contains($0.key) }
+            guard !matching.isEmpty else { continue }
+
+            let sorted = matching.values.sorted { lhs, rhs in
+                if lhs.priority != rhs.priority { return lhs.priority > rhs.priority }
+                return lhs.timestamp > rhs.timestamp
+            }
+            guard let winner = sorted.first else { continue }
+            guard let kind = IslandAgentKind(rawValue: winner.key) else { continue }
+
+            // Session binds to the workspace's currently focused panel, or
+            // the first panel in the workspace if nothing is focused. This
+            // is good enough for MVP — panel-specific `set-status --tab`
+            // resolution is Phase 2.
+            guard let panelId = workspace.focusedPanelId
+                ?? workspace.panels.keys.first else { continue }
+
+            let workspaceTitle = workspace.customTitle ?? workspace.title
+            let panelTitle = workspace.panelCustomTitles[panelId]
+                ?? workspace.panelTitles[panelId]
+                ?? workspace.panels[panelId]?.displayTitle
+                ?? "panel"
+
+            // Unread count — see helper comment. Workspace-scoped for MVP.
+            let unread = Self.unreadCount(forWorkspaceId: workspace.id, panelId: panelId)
+
+            out.append(
+                IslandSession(
+                    id: panelId,
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    agentKind: kind,
+                    phase: IslandSessionPhase.from(rawValue: winner.value),
+                    workspaceTitle: workspaceTitle,
+                    panelTitle: panelTitle,
+                    lastActivity: winner.timestamp,
+                    unreadCount: unread,
+                    rawStatusValue: winner.value
+                )
+            )
+        }
+        return out
+    }
+
+    // MARK: - Private
+
+    /// TerminalNotificationStore exposes workspace-scoped counts
+    /// (`unreadCount(forTabId:)`) and a per-panel presence Bool
+    /// (`hasUnreadNotification(forTabId:surfaceId:)`), but no per-panel
+    /// count. For MVP we report the workspace-scoped count when the panel
+    /// is the one holding an unread indicator, otherwise 0.
+    ///
+    // TODO(Phase 2): replace with a true per-panel count once
+    // TerminalNotificationStore exposes `unreadCount(forTabId:surfaceId:)`.
+    @MainActor
+    private static func unreadCount(forWorkspaceId workspaceId: UUID, panelId: UUID) -> Int {
+        let store = TerminalNotificationStore.shared
+        guard store.hasUnreadNotification(forTabId: workspaceId, surfaceId: panelId) else {
+            return 0
+        }
+        return store.unreadCount(forTabId: workspaceId)
+    }
+
+    private func resubscribe(to tabs: [Workspace]) {
+        let presentIds = Set(tabs.map(\.id))
+
+        // Drop observers for removed workspaces.
+        let removed = Set(perWorkspaceCancellables.keys).subtracting(presentIds)
+        for id in removed { perWorkspaceCancellables.removeValue(forKey: id) }
+
+        // Add observers for new workspaces.
+        for tab in tabs where perWorkspaceCancellables[tab.id] == nil {
+            var bag = Set<AnyCancellable>()
+
+            tab.$statusEntries
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$panelTitles
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$panelCustomTitles
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$panels
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$title
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$customTitle
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            perWorkspaceCancellables[tab.id] = bag
+        }
+    }
+}

--- a/Sources/Island/IslandStateStore.swift
+++ b/Sources/Island/IslandStateStore.swift
@@ -1,0 +1,42 @@
+// Sources/Island/IslandStateStore.swift
+
+import Combine
+import Foundation
+
+/// Concrete `IslandStateProvider` that projects an `IslandStateSource` into
+/// a sorted, debounced `[IslandSession]` publisher the view observes.
+///
+/// The store itself does no model reading — all data comes via the source,
+/// which is either the production `TabManagerIslandStateSource` (added in
+/// Task 6) or a test/debug fake such as `InMemoryIslandStateSource`.
+@MainActor
+final class IslandStateStore: IslandStateProvider, ObservableObject {
+
+    private let source: IslandStateSource
+    private let subject: CurrentValueSubject<[IslandSession], Never>
+    private var cancellable: AnyCancellable?
+
+    init(source: IslandStateSource) {
+        self.source = source
+        let initial = source.makeSnapshot().sorted(by: <)
+        self.subject = CurrentValueSubject(initial)
+
+        // Debounce 50ms so back-to-back set-status/notify bursts coalesce
+        // into a single emission instead of one per upstream tick.
+        self.cancellable = source.changes
+            .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                let snapshot = self.source.makeSnapshot().sorted(by: <)
+                self.subject.send(snapshot)
+            }
+    }
+
+    var sessionsPublisher: AnyPublisher<[IslandSession], Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    var currentSessions: [IslandSession] {
+        subject.value
+    }
+}

--- a/Sources/Island/IslandWindowController.swift
+++ b/Sources/Island/IslandWindowController.swift
@@ -1,0 +1,130 @@
+// Sources/Island/IslandWindowController.swift
+
+import AppKit
+import Combine
+import SwiftUI
+
+/// Owns a single `NotchPanel` plus its hosted `IslandRootView`.
+///
+/// Responsibilities:
+///   • position the panel on the notch screen (or main screen on non-notch Macs)
+///   • show/hide the panel based on `provider.sessions.isEmpty`
+///   • wire the view model to the provider
+///   • flip `ignoresMouseEvents` when the view opens or closes so collapsed
+///     clicks pass through and expanded clicks are received
+///   • tear down cleanly on `shutdown()`
+@MainActor
+final class IslandWindowController: NSWindowController {
+
+    private let provider: IslandStateProvider
+    private let viewModel: IslandRootViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(provider: IslandStateProvider, router: IslandJumpRouter) {
+        self.provider = provider
+
+        let screen = IslandWindowController.resolveScreen()
+        let notchSize = IslandWindowController.resolveNotchSize(on: screen)
+
+        self.viewModel = IslandRootViewModel(
+            notchWidth: notchSize.width,
+            notchHeight: notchSize.height,
+            router: router
+        )
+
+        let windowHeight: CGFloat = 750
+        let frame = NSRect(
+            x: screen.frame.origin.x,
+            y: screen.frame.maxY - windowHeight,
+            width: screen.frame.width,
+            height: windowHeight
+        )
+
+        let panel = NotchPanel(contentRect: frame)
+        panel.contentView = NSHostingView(rootView: IslandRootView(viewModel: viewModel))
+        panel.setFrame(frame, display: true)
+        panel.ignoresMouseEvents = true
+
+        super.init(window: panel)
+
+        viewModel.bind(to: provider)
+
+        // Visibility: panel only orderFronts when the sessions list is non-empty.
+        provider.sessionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.reconcile(sessions: sessions)
+            }
+            .store(in: &cancellables)
+
+        // Mouse event pass-through: when the view closes, clicks outside
+        // the (now-invisible) pill pass through to whatever is underneath.
+        // When the view opens, we accept events so row buttons work.
+        viewModel.$isOpen
+            .receive(on: DispatchQueue.main)
+            .sink { [weak panel] isOpen in
+                panel?.ignoresMouseEvents = !isOpen
+            }
+            .store(in: &cancellables)
+
+        reconcile(sessions: provider.currentSessions)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Convenience used by the router's collapse callback and the
+    /// AppDelegate shutdown path.
+    func close() {
+        viewModel.close()
+    }
+
+    /// Called by `AppDelegate` when the island.enabled setting flips off.
+    /// Removes the panel, cancels subscriptions, breaks the router's
+    /// retain on self.
+    func shutdown() {
+        cancellables.removeAll()
+        window?.orderOut(nil)
+        window?.contentView = nil
+        self.window = nil
+    }
+
+    // MARK: - Private
+
+    private func reconcile(sessions: [IslandSession]) {
+        if sessions.isEmpty {
+            window?.orderOut(nil)
+        } else if window?.isVisible != true {
+            window?.orderFront(nil)
+        }
+    }
+
+    // MARK: - Screen resolution
+
+    private static func resolveScreen() -> NSScreen {
+        if let notched = NSScreen.screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notched
+        }
+        return NSScreen.main ?? NSScreen.screens.first ?? NSScreen()
+    }
+
+    /// Returns the physical notch rect size, or a synthetic `(200, 32)`
+    /// on non-notch Macs so the geometry stays consistent.
+    private static func resolveNotchSize(on screen: NSScreen) -> CGSize {
+        let insetTop = screen.safeAreaInsets.top
+        if insetTop > 0 {
+            // auxiliaryTopLeftArea / auxiliaryTopRightArea expose the menu-
+            // bar regions on either side of the physical notch on macOS
+            // Sequoia+. If they aren't available, fall back to a fraction of
+            // the screen width. The exact notch width is not critical for
+            // correctness — only for visual centering.
+            let leftWidth = screen.auxiliaryTopLeftArea?.width ?? 0
+            let rightWidth = screen.auxiliaryTopRightArea?.width ?? 0
+            let notchWidth = max(120, screen.frame.width - leftWidth - rightWidth)
+            return CGSize(width: notchWidth, height: insetTop)
+        }
+        return CGSize(width: 200, height: 32)
+    }
+}

--- a/Sources/Island/IslandWindowController.swift
+++ b/Sources/Island/IslandWindowController.swift
@@ -76,8 +76,10 @@ final class IslandWindowController: NSWindowController {
     }
 
     /// Convenience used by the router's collapse callback and the
-    /// AppDelegate shutdown path.
-    func close() {
+    /// AppDelegate shutdown path. Overrides `NSWindowController.close()`
+    /// so external callers use the same entry point; we only collapse the
+    /// SwiftUI pill state here and leave window tear-down to `shutdown()`.
+    override func close() {
         viewModel.close()
     }
 

--- a/Sources/Island/NotchPanel.swift
+++ b/Sources/Island/NotchPanel.swift
@@ -1,0 +1,52 @@
+// Sources/Island/NotchPanel.swift
+//
+// Mechanics adapted from https://github.com/farouqaldori/claude-island
+//   ClaudeIsland/UI/Window/NotchWindow.swift
+// License: Apache 2.0. See THIRD_PARTY_LICENSES.md.
+
+import AppKit
+
+/// `NSPanel` subclass used as the host window for the cmux Island overlay.
+///
+/// Behaves as a non-activating, always-on-top floating panel that joins
+/// every Space and sits above the menu bar. When collapsed, the panel
+/// ignores mouse events so clicks pass through to the menu bar and apps
+/// underneath; when expanded, the `IslandWindowController` flips
+/// `ignoresMouseEvents` off so the row buttons are clickable.
+final class NotchPanel: NSPanel {
+
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        becomesKeyOnlyIfNeeded = true
+        isOpaque = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        backgroundColor = .clear
+        hasShadow = false
+        isMovable = false
+
+        collectionBehavior = [
+            .fullScreenAuxiliary,
+            .stationary,
+            .canJoinAllSpaces,
+            .ignoresCycle
+        ]
+
+        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 3)
+
+        allowsToolTipsWhenApplicationIsInactive = true
+        ignoresMouseEvents = true
+        isReleasedWhenClosed = true
+        acceptsMouseMovedEvents = false
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}

--- a/Sources/Island/NotchShape.swift
+++ b/Sources/Island/NotchShape.swift
@@ -1,0 +1,83 @@
+// Sources/Island/NotchShape.swift
+//
+// Ported from https://github.com/farouqaldori/claude-island
+//   ClaudeIsland/UI/Components/NotchShape.swift
+// License: Apache 2.0. See THIRD_PARTY_LICENSES.md.
+//
+// Behavior-preserving port. Only the license header and the enclosing
+// type name differ from the upstream source.
+
+import SwiftUI
+
+/// Notch-flanking shape with inward-curving top corners and outward-curving
+/// bottom corners. Drawn as one contiguous path so the notch area itself is
+/// never painted — the physical MacBook notch sits naturally in the middle
+/// of the shape's top edge between the two inward curves.
+struct NotchShape: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+
+    init(topCornerRadius: CGFloat = 6, bottomCornerRadius: CGFloat = 14) {
+        self.topCornerRadius = topCornerRadius
+        self.bottomCornerRadius = bottomCornerRadius
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { .init(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        // Start at top-left
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        // Top-left inward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY + topCornerRadius),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY)
+        )
+
+        // Left edge down
+        path.addLine(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY - bottomCornerRadius)
+        )
+
+        // Bottom-left outward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
+        )
+
+        // Bottom edge
+        path.addLine(
+            to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY)
+        )
+
+        // Bottom-right outward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY - bottomCornerRadius),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
+        )
+
+        // Right edge up
+        path.addLine(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY + topCornerRadius)
+        )
+
+        // Top-right inward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
+        )
+
+        // Top edge back to start
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        return path
+    }
+}

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -745,6 +745,8 @@ final class CmuxSettingsFileStore {
         snapshot: inout ResolvedSettingsSnapshot
     ) {
         if let value = jsonBool(section["enabled"]) {
+            // TODO(Task 17): replace "island.enabled" literal with IslandSettings.enabledKey
+            // once Sources/Island/IslandSettings.swift is registered in the Xcode target.
             // "island.enabled" == IslandSettings.enabledKey; inlined until Task 17
             // registers Sources/Island/IslandSettings.swift in project.pbxproj.
             snapshot.managedUserDefaults["island.enabled"] = .bool(value)

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -745,11 +745,7 @@ final class CmuxSettingsFileStore {
         snapshot: inout ResolvedSettingsSnapshot
     ) {
         if let value = jsonBool(section["enabled"]) {
-            // TODO(Task 17): replace "island.enabled" literal with IslandSettings.enabledKey
-            // once Sources/Island/IslandSettings.swift is registered in the Xcode target.
-            // "island.enabled" == IslandSettings.enabledKey; inlined until Task 17
-            // registers Sources/Island/IslandSettings.swift in project.pbxproj.
-            snapshot.managedUserDefaults["island.enabled"] = .bool(value)
+            snapshot.managedUserDefaults[IslandSettings.enabledKey] = .bool(value)
         }
     }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -77,6 +77,7 @@ final class CmuxSettingsFileStore {
         "automation.portBase",
         "automation.portRange",
         "customCommands.trustedDirectories",
+        "island.enabled",
         "browser.defaultSearchEngine",
         "browser.showSearchSuggestions",
         "browser.theme",
@@ -367,6 +368,9 @@ final class CmuxSettingsFileStore {
         }
         if let customCommandsSection = root["customCommands"] as? [String: Any] {
             parseCustomCommandsSection(customCommandsSection, sourcePath: sourcePath, snapshot: &snapshot)
+        }
+        if let islandSection = root["island"] as? [String: Any] {
+            parseIslandSection(islandSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
         if let browserSection = root["browser"] as? [String: Any] {
             parseBrowserSection(browserSection, sourcePath: sourcePath, snapshot: &snapshot)
@@ -732,6 +736,18 @@ final class CmuxSettingsFileStore {
             snapshot.managedCustomSettings.trustedDirectories = normalized
         } else if section.keys.contains("trustedDirectories") {
             logInvalid("customCommands.trustedDirectories", sourcePath: sourcePath)
+        }
+    }
+
+    private func parseIslandSection(
+        _ section: [String: Any],
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        if let value = jsonBool(section["enabled"]) {
+            // "island.enabled" == IslandSettings.enabledKey; inlined until Task 17
+            // registers Sources/Island/IslandSettings.swift in project.pbxproj.
+            snapshot.managedUserDefaults["island.enabled"] = .bool(value)
         }
     }
 
@@ -1457,23 +1473,40 @@ final class CmuxSettingsFileStore {
         }
         return string
     }
+
+#if DEBUG
+    /// Test-only entry that parses a JSON string into a ResolvedSettingsSnapshot.
+    /// Used by IslandSettingsFileStoreTests to verify the settings.json pipeline
+    /// end-to-end without hitting disk.
+    static func testResolveSnapshot(jsonString: String, sourcePath: String = "test.json") throws -> ResolvedSettingsSnapshot {
+        guard let data = jsonString.data(using: .utf8),
+              let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "CmuxSettingsFileStoreTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]
+            )
+        }
+        return CmuxSettingsFileStore().parseSettingsFile(root: root, sourcePath: sourcePath)
+    }
+#endif
 }
 
 typealias KeyboardShortcutSettingsFileStore = CmuxSettingsFileStore
 
-private struct ResolvedSettingsSnapshot {
+struct ResolvedSettingsSnapshot {
     var path: String?
     var shortcuts: [KeyboardShortcutSettings.Action: StoredShortcut] = [:]
     var managedUserDefaults: [String: ManagedSettingsValue] = [:]
     var managedCustomSettings = ManagedCustomSettings()
 }
 
-private enum ManagedStringOverride: Equatable {
+enum ManagedStringOverride: Equatable {
     case set(String)
     case clear
 }
 
-private struct ManagedCustomSettings: Equatable {
+struct ManagedCustomSettings: Equatable {
     var trustedDirectories: [String]?
     var socketPassword: ManagedStringOverride?
 
@@ -1493,7 +1526,7 @@ private struct ManagedCustomSettings: Equatable {
     }
 }
 
-private enum ManagedSettingsValue: Equatable {
+enum ManagedSettingsValue: Equatable {
     case bool(Bool)
     case int(Int)
     case double(Double)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2716,19 +2716,15 @@ private final class IslandControllerDebugWindowController: NSWindowController, N
 }
 
 /// Debug-only view that lets a developer toggle the feature on and push
-/// synthetic sessions into an in-memory source for visual iteration.
-/// NOTE: the injected sessions do NOT flow into the production
-/// IslandStateStore — this debug window operates on its own isolated
-/// source. It exists to verify shape/layout without running real agents.
-///
-/// TODO(Task 17): once Island source files are registered in project.pbxproj,
-/// replace the local `sessions` state with `InMemoryIslandStateSource` so this
-/// window exercises the real provider protocol.
+/// synthetic `IslandSession` values into an `InMemoryIslandStateSource` for
+/// visual iteration. NOTE: this debug source is deliberately isolated from
+/// the production `IslandStateStore`; it exists to verify shape/layout
+/// without running real agents.
+@MainActor
 private struct IslandDebugView: View {
-    // TODO(Task 17): replace with IslandSettings.enabledKey once
-    // Sources/Island/IslandSettings.swift is in project.pbxproj.
-    @AppStorage("island.enabled") private var islandEnabled = false
-    @State private var sessions: [IslandDebugSession] = []
+    @AppStorage(IslandSettings.enabledKey) private var islandEnabled = IslandSettings.defaultEnabled
+    @State private var source = InMemoryIslandStateSource()
+    @State private var sessionCount: Int = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -2754,13 +2750,14 @@ private struct IslandDebugView: View {
                     localized: "island.debug.clearTestSessions",
                     defaultValue: "Clear test sessions"
                 )) {
-                    sessions.removeAll()
+                    source.clear()
+                    sessionCount = 0
                 }
             }
 
             Divider()
 
-            Text(verbatim: "Injected sessions: \(sessions.count)")
+            Text(verbatim: "Injected sessions: \(sessionCount)")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
 
@@ -2771,15 +2768,23 @@ private struct IslandDebugView: View {
     }
 
     private func injectRandomSession() {
-        sessions.append(IslandDebugSession(id: UUID()))
+        let kinds = IslandAgentKind.allCases
+        let kind = kinds[sessionCount % kinds.count]
+        let session = IslandSession(
+            id: UUID(),
+            workspaceId: UUID(),
+            panelId: UUID(),
+            agentKind: kind,
+            phase: .running,
+            workspaceTitle: "Debug workspace",
+            panelTitle: "Debug panel \(sessionCount + 1)",
+            lastActivity: Date(),
+            unreadCount: 0,
+            rawStatusValue: "running"
+        )
+        source.add(session)
+        sessionCount = source.makeSnapshot().count
     }
-}
-
-/// Minimal synthetic session token used by `IslandDebugView` while the Island
-/// source files are not yet registered in the project (pending Task 17).
-/// Replaced by `IslandSession` once `project.pbxproj` includes the Island group.
-private struct IslandDebugSession: Identifiable {
-    let id: UUID
 }
 #endif
 
@@ -4229,9 +4234,7 @@ struct SettingsView: View {
     private var notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
     @AppStorage(NotificationSoundSettings.customCommandKey) private var notificationCustomCommand = NotificationSoundSettings.defaultCustomCommand
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
-    // TODO(Task 17): replace literal with IslandSettings.enabledKey once
-    // Sources/Island/IslandSettings.swift is registered in project.pbxproj.
-    @AppStorage("island.enabled") private var islandEnabled = false
+    @AppStorage(IslandSettings.enabledKey) private var islandEnabled = IslandSettings.defaultEnabled
     @AppStorage(NotificationPaneRingSettings.enabledKey) private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
     @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -482,6 +482,14 @@ struct cmuxApp: App {
                     Button("Debug Window Controls…") {
                         DebugWindowControlsWindowController.shared.show()
                     }
+                    Button(
+                        String(
+                            localized: "menu.debug.islandController",
+                            defaultValue: "Island Controller…"
+                        )
+                    ) {
+                        IslandControllerDebugWindowController.shared.show()
+                    }
                     Button("Menu Bar Extra Debug…") {
                         MenuBarExtraDebugWindowController.shared.show()
                     }
@@ -2668,6 +2676,112 @@ private final class SidebarDebugWindowController: NSWindowController, NSWindowDe
         window?.makeKeyAndOrderFront(nil)
     }
 }
+
+#if DEBUG
+private final class IslandControllerDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = IslandControllerDebugWindowController()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 520),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(
+            localized: "island.debug.window.title",
+            defaultValue: "Island Controller"
+        )
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.islandDebug")
+        window.center()
+        window.contentView = NSHostingView(rootView: IslandDebugView())
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+/// Debug-only view that lets a developer toggle the feature on and push
+/// synthetic sessions into an in-memory source for visual iteration.
+/// NOTE: the injected sessions do NOT flow into the production
+/// IslandStateStore — this debug window operates on its own isolated
+/// source. It exists to verify shape/layout without running real agents.
+///
+/// TODO(Task 17): once Island source files are registered in project.pbxproj,
+/// replace the local `sessions` state with `InMemoryIslandStateSource` so this
+/// window exercises the real provider protocol.
+private struct IslandDebugView: View {
+    // TODO(Task 17): replace with IslandSettings.enabledKey once
+    // Sources/Island/IslandSettings.swift is in project.pbxproj.
+    @AppStorage("island.enabled") private var islandEnabled = false
+    @State private var sessions: [IslandDebugSession] = []
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(
+                String(
+                    localized: "island.settings.enable.label",
+                    defaultValue: "Show agent session island overlay"
+                ),
+                isOn: $islandEnabled
+            )
+            .font(.system(size: 13, weight: .semibold))
+
+            Divider()
+
+            HStack {
+                Button(String(
+                    localized: "island.debug.injectTestSession",
+                    defaultValue: "Inject test session"
+                )) {
+                    injectRandomSession()
+                }
+                Button(String(
+                    localized: "island.debug.clearTestSessions",
+                    defaultValue: "Clear test sessions"
+                )) {
+                    sessions.removeAll()
+                }
+            }
+
+            Divider()
+
+            Text(verbatim: "Injected sessions: \(sessions.count)")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            Spacer()
+        }
+        .padding(16)
+        .frame(minWidth: 380, minHeight: 480)
+    }
+
+    private func injectRandomSession() {
+        sessions.append(IslandDebugSession(id: UUID()))
+    }
+}
+
+/// Minimal synthetic session token used by `IslandDebugView` while the Island
+/// source files are not yet registered in the project (pending Task 17).
+/// Replaced by `IslandSession` once `project.pbxproj` includes the Island group.
+private struct IslandDebugSession: Identifiable {
+    let id: UUID
+}
+#endif
 
 private struct AboutPanelView: View {
     @Environment(\.openURL) private var openURL

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4115,6 +4115,9 @@ struct SettingsView: View {
     private var notificationSoundCustomFilePath = NotificationSoundSettings.defaultCustomFilePath
     @AppStorage(NotificationSoundSettings.customCommandKey) private var notificationCustomCommand = NotificationSoundSettings.defaultCustomCommand
     @AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey) private var notificationDockBadgeEnabled = NotificationBadgeSettings.defaultDockBadgeEnabled
+    // TODO(Task 17): replace literal with IslandSettings.enabledKey once
+    // Sources/Island/IslandSettings.swift is registered in project.pbxproj.
+    @AppStorage("island.enabled") private var islandEnabled = false
     @AppStorage(NotificationPaneRingSettings.enabledKey) private var notificationPaneRingEnabled = NotificationPaneRingSettings.defaultEnabled
     @AppStorage(NotificationPaneFlashSettings.enabledKey) private var notificationPaneFlashEnabled = NotificationPaneFlashSettings.defaultEnabled
     @AppStorage(MenuBarExtraSettings.showInMenuBarKey) private var showMenuBarExtra = MenuBarExtraSettings.defaultShowInMenuBar
@@ -5426,6 +5429,29 @@ struct SettingsView: View {
                             .buttonStyle(.bordered)
                             .controlSize(.small)
                         }
+                    }
+
+                    SettingsSectionHeader(title: String(localized: "settings.section.island", defaultValue: "Island"))
+                    SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("island.enabled"),
+                            String(localized: "island.settings.enable.label", defaultValue: "Show agent session island overlay"),
+                            subtitle: String(localized: "island.settings.enable.help", defaultValue: "A notch-anchored pill that lists active AI agent sessions running inside cmux. Click a row to jump to that workspace and terminal split.")
+                        ) {
+                            Toggle("", isOn: $islandEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsIslandEnabledToggle")
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardNote(
+                            String(
+                                localized: "island.settings.known_kinds.help",
+                                defaultValue: "Detects sessions from `cmux set-status` with one of these known keys: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid."
+                            )
+                        )
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.automation", defaultValue: "Automation"))

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -4,6 +4,16 @@ cmux includes the following third-party software:
 
 ---
 
+## claude-island
+
+- **License:** Apache License 2.0
+- **Source:** https://github.com/farouqaldori/claude-island
+- **Files ported:** `Sources/Island/NotchShape.swift`, `Sources/Island/NotchPanel.swift` (adapted from `ClaudeIsland/UI/Components/NotchShape.swift` and `ClaudeIsland/UI/Window/NotchWindow.swift`)
+
+The ported files retain their original license headers and are redistributed under the Apache License 2.0.
+
+---
+
 ## Ghostty
 
 - **License:** MIT License

--- a/cmuxTests/IslandJumpRouterTests.swift
+++ b/cmuxTests/IslandJumpRouterTests.swift
@@ -1,0 +1,104 @@
+// cmuxTests/IslandJumpRouterTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class IslandJumpRouterTests: XCTestCase {
+
+    private final class SpyFocusSink: IslandFocusSink {
+        enum Call: Equatable {
+            case activate
+            case selectWorkspace(UUID)
+            case focusPanel(UUID, UUID)
+            case collapse
+        }
+        var calls: [Call] = []
+        var workspaceExists: Bool = true
+        var panelExists: Bool = true
+
+        func activateApp() { calls.append(.activate) }
+
+        func selectWorkspace(id: UUID) -> Bool {
+            calls.append(.selectWorkspace(id))
+            return workspaceExists
+        }
+        func focusPanel(id: UUID, inWorkspace workspaceId: UUID) -> Bool {
+            calls.append(.focusPanel(id, workspaceId))
+            return panelExists
+        }
+        func collapseIsland() { calls.append(.collapse) }
+    }
+
+    private func makeSession(workspaceId: UUID = UUID(), panelId: UUID = UUID()) -> IslandSession {
+        IslandSession(
+            id: panelId,
+            workspaceId: workspaceId,
+            panelId: panelId,
+            agentKind: .claudeCode,
+            phase: .running,
+            workspaceTitle: "w",
+            panelTitle: "p",
+            lastActivity: Date(),
+            unreadCount: 0,
+            rawStatusValue: "Running"
+        )
+    }
+
+    func testHappyPathSequence() {
+        let spy = SpyFocusSink()
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .selectWorkspace(s.workspaceId),
+                .activate,
+                .focusPanel(s.panelId, s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+
+    func testWorkspaceGoneShortCircuits() {
+        let spy = SpyFocusSink()
+        spy.workspaceExists = false
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        // Router skipped activation once it learned the workspace was
+        // gone. Spec §6.6: "collapses the island without activating cmux".
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .selectWorkspace(s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+
+    func testPanelGoneCollapsesAfterTrying() {
+        let spy = SpyFocusSink()
+        spy.panelExists = false
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        // Workspace was found → activation + focus attempt both run;
+        // focus returns false but router still collapses exactly once.
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .selectWorkspace(s.workspaceId),
+                .activate,
+                .focusPanel(s.panelId, s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+}

--- a/cmuxTests/IslandSessionPhaseTests.swift
+++ b/cmuxTests/IslandSessionPhaseTests.swift
@@ -1,0 +1,62 @@
+// cmuxTests/IslandSessionPhaseTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class IslandSessionPhaseTests: XCTestCase {
+
+    func testRunningSynonyms() {
+        let inputs = ["running", "Running", "RUNNING",
+                      "running_tool", "processing", "starting", " running "]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .running,
+                "Expected .running for \(input)"
+            )
+        }
+    }
+
+    func testIdleSynonyms() {
+        let inputs = ["idle", "Idle", "IDLE", "", "  ", "ready"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .idle,
+                "Expected .idle for \(input)"
+            )
+        }
+    }
+
+    func testWaitingSynonyms() {
+        let inputs = ["waiting", "waiting_for_input", "needs_input", "needsinput", "NeedsInput"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .waiting,
+                "Expected .waiting for \(input)"
+            )
+        }
+    }
+
+    func testErrorSynonyms() {
+        let inputs = ["error", "Error", "failed", "Failure"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .error,
+                "Expected .error for \(input)"
+            )
+        }
+    }
+
+    func testUnknownFallsThrough() {
+        for input in ["compacting", "queued", "💤", "hello world"] {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .unknown,
+                "Expected .unknown for \(input)"
+            )
+        }
+    }
+}

--- a/cmuxTests/IslandSessionSortTests.swift
+++ b/cmuxTests/IslandSessionSortTests.swift
@@ -1,0 +1,53 @@
+// cmuxTests/IslandSessionSortTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class IslandSessionSortTests: XCTestCase {
+
+    private func make(
+        phase: IslandSessionPhase,
+        lastActivity: Date = Date(timeIntervalSince1970: 0)
+    ) -> IslandSession {
+        IslandSession(
+            id: UUID(),
+            workspaceId: UUID(),
+            panelId: UUID(),
+            agentKind: .claudeCode,
+            phase: phase,
+            workspaceTitle: "w",
+            panelTitle: "p",
+            lastActivity: lastActivity,
+            unreadCount: 0,
+            rawStatusValue: "x"
+        )
+    }
+
+    func testPhasePrecedence() {
+        let unknown = make(phase: .unknown)
+        let idle    = make(phase: .idle)
+        let error   = make(phase: .error)
+        let waiting = make(phase: .waiting)
+        let running = make(phase: .running)
+
+        let sorted = [unknown, idle, error, waiting, running].sorted(by: <)
+        XCTAssertEqual(sorted.map(\.phase), [.running, .waiting, .error, .idle, .unknown])
+    }
+
+    func testRecentActivityBreaksTies() {
+        let older  = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 100))
+        let newer  = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 200))
+        XCTAssertTrue(newer < older, "Newer running session should come first")
+    }
+
+    func testTiesBetweenDifferentPhasesStillRespectPhaseRank() {
+        let runningOld = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 100))
+        let waitingNew = make(phase: .waiting, lastActivity: Date(timeIntervalSince1970: 999))
+        XCTAssertTrue(runningOld < waitingNew, "Phase rank beats recency across different phases")
+    }
+}

--- a/cmuxTests/IslandSettingsFileStoreTests.swift
+++ b/cmuxTests/IslandSettingsFileStoreTests.swift
@@ -1,0 +1,57 @@
+// cmuxTests/IslandSettingsFileStoreTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Verifies that writing `island.enabled` into a settings.json snapshot
+/// results in the parser setting the `IslandSettings.enabledKey` managed
+/// default — so editing the file is equivalent to flipping the UI toggle.
+final class IslandSettingsFileStoreTests: XCTestCase {
+
+    private func snapshot(from json: String) throws -> ResolvedSettingsSnapshot {
+        return try CmuxSettingsFileStore.testResolveSnapshot(jsonString: json)
+    }
+
+    func testIslandEnabledTrueIsWrittenToManagedDefaults() throws {
+        let json = """
+        {
+          "island": { "enabled": true }
+        }
+        """
+        let snap = try snapshot(from: json)
+        XCTAssertEqual(
+            snap.managedUserDefaults[IslandSettings.enabledKey],
+            .bool(true)
+        )
+    }
+
+    func testIslandEnabledFalseIsWrittenToManagedDefaults() throws {
+        let json = """
+        {
+          "island": { "enabled": false }
+        }
+        """
+        let snap = try snapshot(from: json)
+        XCTAssertEqual(
+            snap.managedUserDefaults[IslandSettings.enabledKey],
+            .bool(false)
+        )
+    }
+
+    func testIslandSectionMissingLeavesManagedDefaultsEmpty() throws {
+        let json = "{}"
+        let snap = try snapshot(from: json)
+        XCTAssertNil(snap.managedUserDefaults[IslandSettings.enabledKey])
+    }
+
+    func testIslandEnabledPathIsWhitelisted() {
+        XCTAssertTrue(
+            CmuxSettingsFileStore.supportedSettingsJSONPaths.contains("island.enabled")
+        )
+    }
+}

--- a/cmuxTests/IslandStateStoreTests.swift
+++ b/cmuxTests/IslandStateStoreTests.swift
@@ -79,6 +79,32 @@ final class IslandStateStoreTests: XCTestCase {
         XCTAssertEqual(store.currentSessions.map(\.phase), [.running, .idle])
     }
 
+    func testSortOrderAfterTick() {
+        // testSortOrderRunningBeforeIdle covers the init-snapshot path only.
+        // This test verifies sort is also applied inside the debounced sink
+        // so a regression in the tick-path projection would be caught.
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+
+        let exp = expectation(description: "sorted emission after tick")
+
+        store.sessionsPublisher
+            .dropFirst()
+            .sink { sessions in
+                if sessions.count == 2 {
+                    XCTAssertEqual(sessions.map(\.phase), [.running, .idle])
+                    exp.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        let idle    = makeSession(phase: .idle)
+        let running = makeSession(phase: .running)
+        source.set([idle, running])  // deliberately out-of-order input
+
+        wait(for: [exp], timeout: 2.0)
+    }
+
     func testClearingSourceEmitsEmpty() {
         let source = InMemoryIslandStateSource()
         source.set([makeSession()])

--- a/cmuxTests/IslandStateStoreTests.swift
+++ b/cmuxTests/IslandStateStoreTests.swift
@@ -1,0 +1,103 @@
+// cmuxTests/IslandStateStoreTests.swift
+
+import XCTest
+import Combine
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class IslandStateStoreTests: XCTestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() async throws {
+        cancellables.removeAll()
+        try await super.tearDown()
+    }
+
+    private func makeSession(
+        phase: IslandSessionPhase = .running,
+        kind: IslandAgentKind = .claudeCode,
+        lastActivity: Date = Date(timeIntervalSince1970: 100),
+        unread: Int = 0
+    ) -> IslandSession {
+        IslandSession(
+            id: UUID(),
+            workspaceId: UUID(),
+            panelId: UUID(),
+            agentKind: kind,
+            phase: phase,
+            workspaceTitle: "ws",
+            panelTitle: "p",
+            lastActivity: lastActivity,
+            unreadCount: unread,
+            rawStatusValue: phase.rawValue
+        )
+    }
+
+    func testEmptySourceEmitsEmptyList() {
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+        XCTAssertEqual(store.currentSessions, [])
+    }
+
+    func testSingleSessionIsEmittedAfterDebounce() {
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+
+        var received: [[IslandSession]] = []
+        let exp = expectation(description: "emit after source change")
+        exp.expectedFulfillmentCount = 1
+
+        store.sessionsPublisher
+            .dropFirst()  // skip initial empty snapshot
+            .sink { sessions in
+                received.append(sessions)
+                exp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        let s = makeSession()
+        source.set([s])
+
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(received.last?.count, 1)
+        XCTAssertEqual(received.last?.first?.id, s.id)
+    }
+
+    func testSortOrderRunningBeforeIdle() {
+        let source = InMemoryIslandStateSource()
+        let idle    = makeSession(phase: .idle)
+        let running = makeSession(phase: .running)
+        source.set([idle, running])
+        let store = IslandStateStore(source: source)
+
+        XCTAssertEqual(store.currentSessions.map(\.phase), [.running, .idle])
+    }
+
+    func testClearingSourceEmitsEmpty() {
+        let source = InMemoryIslandStateSource()
+        source.set([makeSession()])
+        let store = IslandStateStore(source: source)
+        XCTAssertEqual(store.currentSessions.count, 1)
+
+        let exp = expectation(description: "empty emission after clear")
+
+        store.sessionsPublisher
+            .dropFirst()
+            .sink { sessions in
+                if sessions.isEmpty {
+                    exp.fulfill()
+                }
+            }
+            .store(in: &cancellables)
+
+        source.clear()
+        wait(for: [exp], timeout: 2.0)
+        XCTAssertEqual(store.currentSessions, [])
+    }
+}

--- a/docs/superpowers/plans/2026-04-09-cmux-island.md
+++ b/docs/superpowers/plans/2026-04-09-cmux-island.md
@@ -1,0 +1,2773 @@
+# cmux Island Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the MVP of a notch-anchored Dynamic Island overlay inside `cmux.app` that lists active AI-agent sessions detected from `cmux set-status` entries and lets the user click a row to jump to the corresponding workspace + panel.
+
+**Architecture:** New in-process module at `Sources/Island/` behind an `IslandStateProvider` seam. Pure-data projection (`IslandStateStore`) subscribes to `TabManager.tabs` and each `Workspace.statusEntries` + `TerminalNotificationStore`, then feeds a SwiftUI `IslandRootView` hosted in an `NSPanel` above the menu bar. Opt-in via a new `island.enabled` setting mirrored in `~/.config/cmux/settings.json` through the existing `CmuxSettingsFileStore`. Jump routing reuses `TabManager.selectWorkspace` + `Workspace.focusPanel`.
+
+**Tech Stack:** Swift 5.9+, SwiftUI, Combine, AppKit (`NSPanel`, `NSHostingView`), `XCTest`, cmux's existing `CmuxSettingsFileStore` settings pipeline.
+
+**Reference spec:** [`docs/superpowers/specs/2026-04-09-cmux-island-design.md`](../specs/2026-04-09-cmux-island-design.md)
+
+**Reference source (Apache 2.0 port):** [`farouqaldori/claude-island`](https://github.com/farouqaldori/claude-island) — only `NotchShape.swift`, `NotchWindow.swift` mechanics, and the NSPanel configuration get ported. Hook infrastructure, session monitor, and socket server are **not** ported.
+
+---
+
+## Deviations from the spec
+
+Two minor deviations discovered during project exploration — both fine to apply silently, but documented here so the executor knows:
+
+1. **Settings integration file.** The spec §7.1 says "`CmuxConfig.swift` gains an `IslandConfigSection`". The correct integration point is actually `Sources/KeyboardShortcutSettingsFileStore.swift` — `CmuxConfig.swift` reads `cmux.json` (custom commands), while `CmuxSettingsFileStore` (inside `KeyboardShortcutSettingsFileStore.swift`) reads `~/.config/cmux/settings.json`. Use the latter.
+2. **Test directory structure.** The spec §8.1 writes `cmuxTests/Island/`. The existing `cmuxTests/` directory is flat (no subdirectories). Place test files flat under `cmuxTests/` with `Island` prefixed filenames (e.g., `cmuxTests/IslandSessionPhaseTests.swift`).
+
+---
+
+## File Structure
+
+**New files under `Sources/Island/`:**
+
+| File | Responsibility |
+|---|---|
+| `IslandSettings.swift` | Static `UserDefaults` key + default for `island.enabled`; matches the existing `*Settings` struct pattern (`NotificationBadgeSettings`, `CursorIntegrationSettings`, etc.). |
+| `IslandSession.swift` | Value types: `IslandAgentKind`, `IslandSessionPhase`, `IslandSession`, plus `IslandSessionPhase.from(rawValue:)`, `IslandSession.phaseRank`, and the sort comparator. No UI, no Combine. |
+| `IslandStateProvider.swift` | Downstream interface (what the view observes) + upstream `IslandStateSource` protocol (what the store subscribes to). Plus `InMemoryIslandStateSource` used by tests and the debug-window inject path. |
+| `IslandStateStore.swift` | Concrete `IslandStateProvider` built from an `IslandStateSource`; performs the Workspace → `[IslandSession]` projection, dedup, sort, visibility derivation. Includes `TabManagerIslandStateSource` that wraps the live `TabManager`. |
+| `IslandFocusSink.swift` | Protocol describing the four things `IslandJumpRouter` needs to do: activate app, select workspace by id, focus panel by id, collapse the island. Plus `TabManagerIslandFocusSink` — the production implementation that calls the real `TabManager` / `Workspace` APIs. |
+| `IslandJumpRouter.swift` | Small router that translates `jump(to: IslandSession)` into a fixed sequence of `IslandFocusSink` calls. Logs and collapses on error. |
+| `NotchShape.swift` | SwiftUI `Shape` with inward-top/outward-bottom quadratic corners. Port of `farouqaldori/claude-island`'s `NotchShape.swift` (Apache 2.0, keep the original license header comment). |
+| `NotchPanel.swift` | `NSPanel` subclass configured as a non-activating, click-through, all-spaces floating panel above the menu bar. Port of `farouqaldori/claude-island`'s `NotchWindow.swift` (Apache 2.0, keep the license header). |
+| `IslandRootView.swift` | SwiftUI view with closed-pill + expanded-list states, spring animations, click-to-expand, click-outside-to-close. Observes `IslandStateProvider.sessions`. |
+| `IslandWindowController.swift` | `NSWindowController` that owns one `NotchPanel`, wires an `IslandRootView` into it via `NSHostingView`, positions on the notch screen, and `orderFront`/`orderOut`s based on `sessions.isEmpty`. |
+
+**Files modified:**
+
+| File | What changes |
+|---|---|
+| `Sources/KeyboardShortcutSettingsFileStore.swift` | Add `"island.enabled"` to `supportedSettingsJSONPaths`; add `parseIslandSection(…)`; add dispatch for it in the root parser. |
+| `Sources/AppDelegate.swift` | Own an optional `IslandWindowController` and a `Cancellable`; observe `@AppStorage("island.enabled")` and create/destroy the controller. |
+| `Sources/cmuxApp.swift` | Add `SettingsSectionHeader` + `SettingsCard` for "Island" inside `SettingsView`. Add `Button("Island Controller…")` to the Debug Windows menu. Add the `IslandControllerDebugWindowController` NSWindowController near the other debug window singletons. |
+| `Resources/Localizable.xcstrings` | Add all `island.*` keys (English + Japanese). |
+| `GhosttyTabs.xcodeproj/project.pbxproj` | Register each new Swift file in the Sources group, PBXFileReference, PBXBuildFile, and PBXSourcesBuildPhase. |
+| `CHANGELOG.md` | Add a line under the unreleased section. |
+
+**Files created under `cmuxTests/`:**
+
+| File | Contains |
+|---|---|
+| `cmuxTests/IslandSessionPhaseTests.swift` | Tests for `IslandSessionPhase.from(rawValue:)`. |
+| `cmuxTests/IslandSessionSortTests.swift` | Tests for the sort comparator. |
+| `cmuxTests/IslandStateStoreTests.swift` | Tests for `IslandStateStore` projection + visibility using `InMemoryIslandStateSource`. |
+| `cmuxTests/IslandJumpRouterTests.swift` | Tests for `IslandJumpRouter` using a spy `IslandFocusSink`. |
+| `cmuxTests/IslandSettingsFileStoreTests.swift` | Round-trip test: `island.enabled` in `settings.json` → `UserDefaults` → read-back. |
+
+---
+
+## Task 1: Wire `island.enabled` into the settings file store (no UI yet)
+
+**Why first:** Everything else keys off of `island.enabled`. Getting the settings-file parser, the whitelist, and the `UserDefaults` key in place up front means every later task can just read `@AppStorage(IslandSettings.enabledKey)` without retrofitting.
+
+**Files:**
+- Create: `Sources/Island/IslandSettings.swift`
+- Modify: `Sources/KeyboardShortcutSettingsFileStore.swift`
+- Create: `cmuxTests/IslandSettingsFileStoreTests.swift`
+
+- [ ] **Step 1: Create `IslandSettings.swift`**
+
+```swift
+// Sources/Island/IslandSettings.swift
+
+import Foundation
+
+/// Preference keys and defaults for the cmux Island module.
+///
+/// Matches the existing `*Settings` struct pattern in cmux (see
+/// `NotificationBadgeSettings`, `CursorIntegrationSettings`, etc.).
+enum IslandSettings {
+    /// UserDefaults / @AppStorage key for the island enable toggle.
+    static let enabledKey: String = "island.enabled"
+
+    /// Default is OFF per the MVP design.
+    static let defaultEnabled: Bool = false
+}
+```
+
+- [ ] **Step 2: Write the failing round-trip test**
+
+```swift
+// cmuxTests/IslandSettingsFileStoreTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Verifies that writing `island.enabled` into a settings.json snapshot
+/// results in the parser setting the `IslandSettings.enabledKey` managed
+/// default — so editing the file is equivalent to flipping the UI toggle.
+final class IslandSettingsFileStoreTests: XCTestCase {
+
+    private func snapshot(from json: String) throws -> ResolvedSettingsSnapshot {
+        // CmuxSettingsFileStore exposes a parser entry point via the
+        // resolveSnapshot(from:sourcePath:) helper defined next to
+        // parseRootObject. This test uses the same harness that the
+        // existing KeyboardShortcutSettingsFileStore tests use.
+        return try CmuxSettingsFileStore.testResolveSnapshot(jsonString: json)
+    }
+
+    func testIslandEnabledTrueIsWrittenToManagedDefaults() throws {
+        let json = """
+        {
+          "island": { "enabled": true }
+        }
+        """
+        let snap = try snapshot(from: json)
+        XCTAssertEqual(
+            snap.managedUserDefaults[IslandSettings.enabledKey],
+            .bool(true)
+        )
+    }
+
+    func testIslandEnabledFalseIsWrittenToManagedDefaults() throws {
+        let json = """
+        {
+          "island": { "enabled": false }
+        }
+        """
+        let snap = try snapshot(from: json)
+        XCTAssertEqual(
+            snap.managedUserDefaults[IslandSettings.enabledKey],
+            .bool(false)
+        )
+    }
+
+    func testIslandSectionMissingLeavesManagedDefaultsEmpty() throws {
+        let json = "{}"
+        let snap = try snapshot(from: json)
+        XCTAssertNil(snap.managedUserDefaults[IslandSettings.enabledKey])
+    }
+
+    func testIslandEnabledPathIsWhitelisted() {
+        XCTAssertTrue(
+            CmuxSettingsFileStore.supportedSettingsJSONPaths.contains("island.enabled")
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Run the test and confirm it fails**
+
+Run: `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/IslandSettingsFileStoreTests test 2>&1 | tail -30`
+
+(Per CLAUDE.md "Testing policy": **do not run tests locally** on regular development flow; however, this step is only to verify the *compile-and-fail* point. If `xcodebuild` is too heavy locally, verify by running the tests in CI via `gh workflow run test-e2e.yml` or by compiling-only: `xcodebuild -scheme cmux-unit build 2>&1 | tail -30` and confirming the compiler points at `island.enabled`, `parseIslandSection`, `IslandSettings` not defined.)
+
+Expected: FAIL — `CmuxSettingsFileStore.testResolveSnapshot(jsonString:)` / `supportedSettingsJSONPaths` lookup returns nothing for `island.enabled`, and `IslandSettings.enabledKey` may not yet be visible to tests because `Island/IslandSettings.swift` isn't in the Xcode target yet (resolved by Task 20).
+
+- [ ] **Step 4: Add the parser + whitelist entry**
+
+Open `Sources/KeyboardShortcutSettingsFileStore.swift` and make three edits.
+
+**Edit A** — add the JSON path to the whitelist. Find the `supportedSettingsJSONPaths` set (around line 27–92) and add `"island.enabled",` in alphabetical position (right after `"customCommands.trustedDirectories",`):
+
+```swift
+        "customCommands.trustedDirectories",
+        "island.enabled",
+        "browser.defaultSearchEngine",
+```
+
+Wait — `browser` comes before `customCommands` alphabetically, and `island` comes after both. The correct insertion is after the last `customCommands.*` entry and before the first `browser.*` entry is wrong alphabetically; the existing list is grouped by section name, not strictly alphabetical. Insert `"island.enabled",` in its own line **between the `customCommands` group and the `browser` group** (which matches the existing grouping style).
+
+**Edit B** — add a dispatch call in the root parser. Find the block around line 350–378 that calls `parseAppSection`, `parseNotificationsSection`, …, `parseShortcutsSection`. After the `customCommandsSection` branch and before `browserSection`, add:
+
+```swift
+        if let islandSection = root["island"] as? [String: Any] {
+            parseIslandSection(islandSection, sourcePath: sourcePath, snapshot: &snapshot)
+        }
+```
+
+**Edit C** — add the new `parseIslandSection(…)` method next to the other `parse*Section` methods (any location in the same file is fine; group with the other small parsers):
+
+```swift
+    private func parseIslandSection(
+        _ section: [String: Any],
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        if let value = jsonBool(section["enabled"]) {
+            snapshot.managedUserDefaults[IslandSettings.enabledKey] = .bool(value)
+        }
+    }
+```
+
+- [ ] **Step 5: Expose a test entry point (only if one doesn't already exist)**
+
+`CmuxSettingsFileStore` likely has an internal `parseRootObject` that's not testable directly. Add a DEBUG-only static helper at the end of the class so the test can drive the parser without touching disk. Place this inside `final class CmuxSettingsFileStore`:
+
+```swift
+#if DEBUG
+    static func testResolveSnapshot(jsonString: String, sourcePath: String = "test.json") throws -> ResolvedSettingsSnapshot {
+        guard let data = jsonString.data(using: .utf8),
+              let root = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            throw NSError(
+                domain: "CmuxSettingsFileStoreTests",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid JSON"]
+            )
+        }
+        return CmuxSettingsFileStore().parseRootObject(root, sourcePath: sourcePath)
+    }
+#endif
+```
+
+If `parseRootObject` has a different name in the current file, use that name instead. If `parseRootObject` is `private`, change it to `fileprivate` or `internal` for DEBUG builds only via `#if DEBUG internal #else private #endif`. The simplest fix: duplicate the parser body inline inside `testResolveSnapshot`.
+
+- [ ] **Step 6: Re-run the tests to verify they pass**
+
+Build via CI or `xcodebuild -scheme cmux-unit build` to confirm the module compiles. (Tests themselves run in CI per CLAUDE.md — do not run them locally.) Expected: compiles cleanly, no references to missing symbols.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Sources/Island/IslandSettings.swift \
+        Sources/KeyboardShortcutSettingsFileStore.swift \
+        cmuxTests/IslandSettingsFileStoreTests.swift
+git commit -m "$(cat <<'EOF'
+Add island.enabled setting key and settings.json parser (#2590)
+
+Introduces IslandSettings.enabledKey as the single source of truth for
+the cmux Island opt-in toggle, and teaches CmuxSettingsFileStore to
+read an "island" section from ~/.config/cmux/settings.json. Tests cover
+the round-trip parser path and the path whitelist.
+
+First commit of the cmux Island MVP. Spec:
+docs/superpowers/specs/2026-04-09-cmux-island-design.md
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 2: Core value types (`IslandAgentKind`, `IslandSessionPhase`, `IslandSession`)
+
+**Files:**
+- Create: `Sources/Island/IslandSession.swift`
+- Create: `cmuxTests/IslandSessionPhaseTests.swift`
+
+- [ ] **Step 1: Write the failing phase normalization test**
+
+```swift
+// cmuxTests/IslandSessionPhaseTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class IslandSessionPhaseTests: XCTestCase {
+
+    func testRunningSynonyms() {
+        let inputs = ["running", "Running", "RUNNING",
+                      "running_tool", "processing", "starting", " running "]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .running,
+                "Expected .running for \(input)"
+            )
+        }
+    }
+
+    func testIdleSynonyms() {
+        let inputs = ["idle", "Idle", "IDLE", "", "  ", "ready"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .idle,
+                "Expected .idle for \(input)"
+            )
+        }
+    }
+
+    func testWaitingSynonyms() {
+        let inputs = ["waiting", "waiting_for_input", "needs_input", "needsinput", "NeedsInput"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .waiting,
+                "Expected .waiting for \(input)"
+            )
+        }
+    }
+
+    func testErrorSynonyms() {
+        let inputs = ["error", "Error", "failed", "Failure"]
+        for input in inputs {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .error,
+                "Expected .error for \(input)"
+            )
+        }
+    }
+
+    func testUnknownFallsThrough() {
+        for input in ["compacting", "queued", "💤", "hello world"] {
+            XCTAssertEqual(
+                IslandSessionPhase.from(rawValue: input), .unknown,
+                "Expected .unknown for \(input)"
+            )
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Build only: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: compile error — `IslandSessionPhase` unknown.
+
+- [ ] **Step 3: Create `IslandSession.swift` with all value types**
+
+```swift
+// Sources/Island/IslandSession.swift
+
+import Foundation
+import SwiftUI
+
+/// Known AI-agent kinds the cmux Island monitors.
+///
+/// A terminal panel counts as an active island session iff its
+/// `Workspace.statusEntries` contains at least one entry whose key equals
+/// one of these raw values. Agent hooks in `docs/notifications.md` already
+/// use these keys.
+enum IslandAgentKind: String, CaseIterable, Hashable, Sendable {
+    case claudeCode = "claude_code"
+    case codex      = "codex"
+    case copilotCli = "copilot_cli"
+    case openCode   = "opencode"
+    case geminiCli  = "gemini_cli"
+    case cursor     = "cursor"
+    case amp        = "amp"
+    case droid      = "droid"
+
+    /// Human-readable name shown in the expanded island row.
+    var displayName: String {
+        switch self {
+        case .claudeCode: return "Claude Code"
+        case .codex:      return "Codex"
+        case .copilotCli: return "Copilot CLI"
+        case .openCode:   return "OpenCode"
+        case .geminiCli:  return "Gemini CLI"
+        case .cursor:     return "Cursor"
+        case .amp:        return "Amp"
+        case .droid:      return "Droid"
+        }
+    }
+
+    /// Single-character monogram used in the 20pt row chip.
+    var monogram: String {
+        switch self {
+        case .claudeCode: return "C"
+        case .codex:      return "X"
+        case .copilotCli: return "G"
+        case .openCode:   return "O"
+        case .geminiCli:  return "V"
+        case .cursor:     return "U"
+        case .amp:        return "A"
+        case .droid:      return "D"
+        }
+    }
+
+    /// Stable brand-ish color for the row chip and collapsed-pill legend.
+    var color: Color {
+        switch self {
+        case .claudeCode: return Color(red: 0.85, green: 0.47, blue: 0.02)  // Claude orange
+        case .codex:      return Color(red: 0.23, green: 0.51, blue: 0.96)  // Codex blue
+        case .copilotCli: return Color(red: 0.55, green: 0.36, blue: 0.96)  // Copilot purple
+        case .openCode:   return Color(red: 0.20, green: 0.72, blue: 0.45)  // OpenCode green
+        case .geminiCli:  return Color(red: 0.40, green: 0.66, blue: 0.95)  // Gemini light blue
+        case .cursor:     return Color(red: 0.90, green: 0.90, blue: 0.90)  // Cursor gray
+        case .amp:        return Color(red: 0.90, green: 0.26, blue: 0.36)  // Amp red
+        case .droid:      return Color(red: 0.99, green: 0.81, blue: 0.24)  // Droid yellow
+        }
+    }
+}
+
+/// Normalized session phase. Free-form `cmux set-status` values are mapped
+/// into this small closed set via `IslandSessionPhase.from(rawValue:)`.
+enum IslandSessionPhase: String, Hashable, Sendable {
+    case running
+    case idle
+    case waiting
+    case error
+    case unknown
+
+    /// Sort precedence for the island list: lower comes first.
+    /// Running beats waiting beats error beats idle beats unknown.
+    var rank: Int {
+        switch self {
+        case .running: return 0
+        case .waiting: return 1
+        case .error:   return 2
+        case .idle:    return 3
+        case .unknown: return 4
+        }
+    }
+
+    /// Case-insensitive, trim-tolerant lookup from a free-form status value.
+    static func from(rawValue: String) -> IslandSessionPhase {
+        let normalized = rawValue
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        switch normalized {
+        case "running", "running_tool", "processing", "starting":
+            return .running
+        case "", "idle", "ready":
+            return .idle
+        case "waiting", "waiting_for_input", "needs_input", "needsinput":
+            return .waiting
+        case "error", "failed", "failure":
+            return .error
+        default:
+            return .unknown
+        }
+    }
+}
+
+/// One row in the cmux Island. Immutable value type; a fresh instance is
+/// emitted whenever the upstream state changes.
+struct IslandSession: Identifiable, Equatable, Sendable {
+    /// Stable identity equal to `panelId` — a single panel hosts at most one
+    /// session in MVP scope.
+    let id: UUID
+    let workspaceId: UUID
+    let panelId: UUID
+    let agentKind: IslandAgentKind
+    let phase: IslandSessionPhase
+    let workspaceTitle: String
+    let panelTitle: String
+    let lastActivity: Date
+    let unreadCount: Int
+    /// Original free-form status value kept for debug/tooltip inspection.
+    let rawStatusValue: String
+}
+
+extension IslandSession {
+    /// Standard sort comparator. Running first, recent first on ties.
+    static func < (lhs: IslandSession, rhs: IslandSession) -> Bool {
+        if lhs.phase.rank != rhs.phase.rank {
+            return lhs.phase.rank < rhs.phase.rank
+        }
+        return lhs.lastActivity > rhs.lastActivity
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify phase tests pass**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly. (Test execution deferred to CI.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Island/IslandSession.swift cmuxTests/IslandSessionPhaseTests.swift
+git commit -m "$(cat <<'EOF'
+Add IslandAgentKind, IslandSessionPhase, IslandSession value types (#2590)
+
+Core data types for the cmux Island MVP. Phase normalization is
+table-driven and table-tested; sort comparator + rank prepared for the
+upcoming store.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 3: Sort-order tests
+
+**Files:**
+- Create: `cmuxTests/IslandSessionSortTests.swift`
+
+- [ ] **Step 1: Write the sort tests**
+
+```swift
+// cmuxTests/IslandSessionSortTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class IslandSessionSortTests: XCTestCase {
+
+    private func make(
+        phase: IslandSessionPhase,
+        lastActivity: Date = Date(timeIntervalSince1970: 0)
+    ) -> IslandSession {
+        IslandSession(
+            id: UUID(),
+            workspaceId: UUID(),
+            panelId: UUID(),
+            agentKind: .claudeCode,
+            phase: phase,
+            workspaceTitle: "w",
+            panelTitle: "p",
+            lastActivity: lastActivity,
+            unreadCount: 0,
+            rawStatusValue: "x"
+        )
+    }
+
+    func testPhasePrecedence() {
+        let unknown = make(phase: .unknown)
+        let idle    = make(phase: .idle)
+        let error   = make(phase: .error)
+        let waiting = make(phase: .waiting)
+        let running = make(phase: .running)
+
+        let sorted = [unknown, idle, error, waiting, running].sorted(by: <)
+        XCTAssertEqual(sorted.map(\.phase), [.running, .waiting, .error, .idle, .unknown])
+    }
+
+    func testRecentActivityBreaksTies() {
+        let older  = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 100))
+        let newer  = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 200))
+        XCTAssertTrue(newer < older, "Newer running session should come first")
+    }
+
+    func testTiesBetweenDifferentPhasesStillRespectPhaseRank() {
+        let runningOld = make(phase: .running, lastActivity: Date(timeIntervalSince1970: 100))
+        let waitingNew = make(phase: .waiting, lastActivity: Date(timeIntervalSince1970: 999))
+        XCTAssertTrue(runningOld < waitingNew, "Phase rank beats recency across different phases")
+    }
+}
+```
+
+- [ ] **Step 2: Verify it builds (already implemented in Task 2)**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly. The comparator from Task 2 already satisfies the asserts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmuxTests/IslandSessionSortTests.swift
+git commit -m "$(cat <<'EOF'
+Add IslandSession sort comparator tests (#2590)
+
+Pins the sort order (running → waiting → error → idle → unknown,
+tie-break by most recent activity) against regressions.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: `IslandStateProvider` protocol + `InMemoryIslandStateSource`
+
+**Files:**
+- Create: `Sources/Island/IslandStateProvider.swift`
+
+- [ ] **Step 1: Create the protocol file**
+
+```swift
+// Sources/Island/IslandStateProvider.swift
+
+import Combine
+import Foundation
+
+/// Downstream interface the island SwiftUI view depends on.
+///
+/// The view observes `sessionsPublisher` and re-renders whenever it emits.
+/// Keeping the view's only dependency on this protocol is what lets the
+/// production store be swapped for an in-memory fake (tests + debug menu)
+/// or a future `SocketIslandStateProvider` (Phase 3 companion app).
+protocol IslandStateProvider: AnyObject {
+    /// Emits the current flat, sorted list of active agent sessions.
+    /// Empty list means the island should be hidden.
+    var sessionsPublisher: AnyPublisher<[IslandSession], Never> { get }
+
+    /// Snapshot of the most recent emission, for callers that need a pull
+    /// API alongside the publisher.
+    var currentSessions: [IslandSession] { get }
+}
+
+// MARK: - Upstream source (the store's input)
+
+/// Upstream interface. The store subscribes to a single "tick" publisher
+/// that fires whenever any of (workspace list, per-workspace status entries,
+/// per-panel notifications) change, and the store pulls a fresh snapshot.
+///
+/// This is deliberately narrower than `TabManager` so the store is testable
+/// with an in-memory fake that doesn't need Workspace/TabManager at all.
+protocol IslandStateSource: AnyObject {
+    /// Fires whenever anything relevant to the projection changes.
+    var changes: AnyPublisher<Void, Never> { get }
+
+    /// Pull a fresh `[IslandSession]` snapshot. Must be callable on the
+    /// main actor — sources that read AppKit state should hop internally.
+    @MainActor
+    func makeSnapshot() -> [IslandSession]
+}
+
+// MARK: - In-memory source for tests and debug injection
+
+final class InMemoryIslandStateSource: IslandStateSource {
+    private let subject = PassthroughSubject<Void, Never>()
+
+    @MainActor
+    private(set) var sessions: [IslandSession] = [] {
+        didSet { subject.send(()) }
+    }
+
+    var changes: AnyPublisher<Void, Never> { subject.eraseToAnyPublisher() }
+
+    @MainActor
+    func makeSnapshot() -> [IslandSession] { sessions }
+
+    @MainActor
+    func set(_ sessions: [IslandSession]) {
+        self.sessions = sessions
+    }
+
+    @MainActor
+    func add(_ session: IslandSession) {
+        sessions.append(session)
+    }
+
+    @MainActor
+    func clear() {
+        sessions.removeAll()
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Island/IslandStateProvider.swift
+git commit -m "$(cat <<'EOF'
+Add IslandStateProvider + IslandStateSource protocols (#2590)
+
+Defines the two protocols that bound the island's read path:
+IslandStateProvider is what the view observes; IslandStateSource is
+what the store subscribes to. Includes InMemoryIslandStateSource for
+tests and the debug-menu inject path.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 5: `IslandStateStore` with projection + tests (using the in-memory source)
+
+**Files:**
+- Create: `Sources/Island/IslandStateStore.swift`
+- Create: `cmuxTests/IslandStateStoreTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// cmuxTests/IslandStateStoreTests.swift
+
+import XCTest
+import Combine
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class IslandStateStoreTests: XCTestCase {
+
+    private var cancellables: Set<AnyCancellable> = []
+
+    override func tearDown() async throws {
+        cancellables.removeAll()
+        try await super.tearDown()
+    }
+
+    private func makeSession(
+        phase: IslandSessionPhase = .running,
+        kind: IslandAgentKind = .claudeCode,
+        lastActivity: Date = Date(timeIntervalSince1970: 100),
+        unread: Int = 0
+    ) -> IslandSession {
+        IslandSession(
+            id: UUID(),
+            workspaceId: UUID(),
+            panelId: UUID(),
+            agentKind: kind,
+            phase: phase,
+            workspaceTitle: "ws",
+            panelTitle: "p",
+            lastActivity: lastActivity,
+            unreadCount: unread,
+            rawStatusValue: phase.rawValue
+        )
+    }
+
+    func testEmptySourceEmitsEmptyList() {
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+        XCTAssertEqual(store.currentSessions, [])
+    }
+
+    func testSingleSessionIsEmitted() {
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+
+        var received: [[IslandSession]] = []
+        let exp = expectation(description: "emit once")
+        exp.expectedFulfillmentCount = 1
+
+        store.sessionsPublisher
+            .dropFirst()  // skip initial empty
+            .sink { sessions in
+                received.append(sessions)
+                exp.fulfill()
+            }
+            .store(in: &cancellables)
+
+        let s = makeSession()
+        source.set([s])
+
+        wait(for: [exp], timeout: 1.0)
+        XCTAssertEqual(received.last?.count, 1)
+        XCTAssertEqual(received.last?.first?.id, s.id)
+    }
+
+    func testSortOrderRunningBeforeIdle() {
+        let source = InMemoryIslandStateSource()
+        let store = IslandStateStore(source: source)
+        let idle    = makeSession(phase: .idle)
+        let running = makeSession(phase: .running)
+        source.set([idle, running])
+
+        let snapshot = store.currentSessions
+        XCTAssertEqual(snapshot.map(\.phase), [.running, .idle])
+    }
+
+    func testClearingSourceEmitsEmpty() {
+        let source = InMemoryIslandStateSource()
+        source.set([makeSession()])
+        let store = IslandStateStore(source: source)
+        XCTAssertEqual(store.currentSessions.count, 1)
+        source.clear()
+        XCTAssertEqual(store.currentSessions, [])
+    }
+}
+```
+
+- [ ] **Step 2: Run the build to confirm the tests don't compile yet**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: compile error — `IslandStateStore` unknown.
+
+- [ ] **Step 3: Create the store**
+
+```swift
+// Sources/Island/IslandStateStore.swift
+
+import Combine
+import Foundation
+
+/// Concrete `IslandStateProvider` that projects an `IslandStateSource` into
+/// a sorted, debounced `[IslandSession]` publisher the view observes.
+///
+/// The store itself does no model reading — all data comes via the source,
+/// which is either the production `TabManagerIslandStateSource` (this file)
+/// or a test/debug fake.
+@MainActor
+final class IslandStateStore: IslandStateProvider, ObservableObject {
+
+    private let source: IslandStateSource
+    private let subject: CurrentValueSubject<[IslandSession], Never>
+    private var cancellable: AnyCancellable?
+
+    init(source: IslandStateSource) {
+        self.source = source
+        let initial = source.makeSnapshot().sorted(by: <)
+        self.subject = CurrentValueSubject(initial)
+
+        // Debounce 50ms so back-to-back set-status/notify bursts coalesce.
+        self.cancellable = source.changes
+            .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)
+            .sink { [weak self] in
+                guard let self else { return }
+                let snapshot = self.source.makeSnapshot().sorted(by: <)
+                self.subject.send(snapshot)
+            }
+    }
+
+    var sessionsPublisher: AnyPublisher<[IslandSession], Never> {
+        subject.eraseToAnyPublisher()
+    }
+
+    var currentSessions: [IslandSession] {
+        subject.value
+    }
+}
+```
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 5: Note about the debounce and the tests**
+
+The 50ms debounce means the "emit once" test could be flaky if expectations run too fast. Update the test to allow up to 2 seconds timeout (already `1.0` — bump to `2.0` if CI flakes appear). Do not remove the debounce — it's a production requirement.
+
+If the CI test flakes, adjust the `wait(for:timeout:)` in `testSingleSessionIsEmitted` to `2.0` only as a follow-up, not now.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/Island/IslandStateStore.swift cmuxTests/IslandStateStoreTests.swift
+git commit -m "$(cat <<'EOF'
+Add IslandStateStore with source-driven projection (#2590)
+
+Debounced Combine pipeline that resorts and republishes the session
+list whenever the upstream IslandStateSource ticks. Tests exercise
+projection, sort order, and empty-state transitions via
+InMemoryIslandStateSource.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 6: `TabManagerIslandStateSource` — the production source
+
+**Why this task:** Task 5 proved the projection/sort logic. Now we connect it to real cmux state. Kept separate because the Combine wiring here is fiddly (nested `@Published` subscriptions) and does not benefit from a test — it's a pure adapter.
+
+**Files:**
+- Modify: `Sources/Island/IslandStateStore.swift`
+
+- [ ] **Step 1: Append the production source to the store file**
+
+Add this class **at the bottom** of `Sources/Island/IslandStateStore.swift` (below `IslandStateStore`):
+
+```swift
+// MARK: - Production source wrapping TabManager
+
+/// Production `IslandStateSource` that subscribes to every `Workspace`
+/// inside a `TabManager` and emits `changes` whenever any relevant state
+/// updates. Reads `TerminalNotificationStore.shared` for unread counts.
+///
+/// Deliberately isolated in one file so the `Sources/Island/` module has
+/// exactly one symbol that imports cmux core types.
+@MainActor
+final class TabManagerIslandStateSource: IslandStateSource {
+
+    private let tabManager: TabManager
+    private let subject = PassthroughSubject<Void, Never>()
+    private var tabsCancellable: AnyCancellable?
+    private var perWorkspaceCancellables: [UUID: Set<AnyCancellable>] = [:]
+    private var notificationCancellable: AnyCancellable?
+
+    init(tabManager: TabManager) {
+        self.tabManager = tabManager
+
+        // 1. Any change to the tabs array → rebuild per-workspace subscriptions
+        //    and fire a change tick.
+        tabsCancellable = tabManager.$tabs
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] tabs in
+                self?.resubscribe(to: tabs)
+                self?.subject.send(())
+            }
+
+        // 2. Notifications (unread counts) tick.
+        notificationCancellable = TerminalNotificationStore.shared.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.subject.send(())
+            }
+    }
+
+    var changes: AnyPublisher<Void, Never> { subject.eraseToAnyPublisher() }
+
+    @MainActor
+    func makeSnapshot() -> [IslandSession] {
+        var out: [IslandSession] = []
+        let knownKeys = Set(IslandAgentKind.allCases.map(\.rawValue))
+        let store = TerminalNotificationStore.shared
+
+        for workspace in tabManager.tabs {
+            // Group status entries by panelId (status entries can target a
+            // specific panel via their `tab=` option; fall back to the
+            // workspace's focused panel if none given — MVP accepts a soft
+            // fallback since the existing set-status CLI already binds
+            // entries to the workspace on write).
+            let matching = workspace.statusEntries.filter { knownKeys.contains($0.key) }
+            guard !matching.isEmpty else { continue }
+
+            // Pick the winner per §5.2: highest numeric priority, ties
+            // broken by most recent timestamp.
+            let winner = matching.values
+                .sorted { lhs, rhs in
+                    if lhs.priority != rhs.priority { return lhs.priority > rhs.priority }
+                    return lhs.timestamp > rhs.timestamp
+                }
+                .first!
+
+            guard let kind = IslandAgentKind(rawValue: winner.key) else { continue }
+
+            // Session binds to workspace's currently focused panel, or the
+            // first panel if none is focused. This is good enough for MVP;
+            // panel-specific set-status --tab resolution is Phase 2.
+            guard let panelId = workspace.focusedPanelId
+                ?? workspace.panels.keys.first else { continue }
+
+            let workspaceTitle = workspace.customTitle ?? workspace.title
+            let panelTitle = workspace.panelCustomTitles[panelId]
+                ?? workspace.panelTitles[panelId]
+                ?? workspace.panels[panelId]?.displayTitle
+                ?? "panel"
+
+            // Unread count per panel — ask the store; default 0 on unknown panels.
+            let unread = store.unreadCount(forPanelId: panelId)
+
+            out.append(
+                IslandSession(
+                    id: panelId,
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    agentKind: kind,
+                    phase: IslandSessionPhase.from(rawValue: winner.value),
+                    workspaceTitle: workspaceTitle,
+                    panelTitle: panelTitle,
+                    lastActivity: winner.timestamp,
+                    unreadCount: unread,
+                    rawStatusValue: winner.value
+                )
+            )
+        }
+        return out
+    }
+
+    // MARK: - Private
+
+    private func resubscribe(to tabs: [Workspace]) {
+        let presentIds = Set(tabs.map(\.id))
+
+        // Drop observers for removed workspaces.
+        let removed = Set(perWorkspaceCancellables.keys).subtracting(presentIds)
+        for id in removed { perWorkspaceCancellables.removeValue(forKey: id) }
+
+        // Add observers for new workspaces.
+        for tab in tabs where perWorkspaceCancellables[tab.id] == nil {
+            var bag = Set<AnyCancellable>()
+
+            tab.$statusEntries
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$panelTitles
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            tab.$panels
+                .receive(on: DispatchQueue.main)
+                .sink { [weak self] _ in self?.subject.send(()) }
+                .store(in: &bag)
+
+            perWorkspaceCancellables[tab.id] = bag
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Verify `TerminalNotificationStore.unreadCount(forPanelId:)` exists**
+
+This is the one API assumption. Check with:
+
+```bash
+grep -n "unreadCount" Sources/TerminalNotificationStore.swift | head -20
+```
+
+Expected: at least one public method that returns an `Int` keyed by `panelId: UUID`. If the method doesn't exist with that exact signature, look for a near-match (e.g., `unreadCount(for panelId: UUID)`) and adjust the call in `makeSnapshot()`. If no per-panel API exists at all, temporarily use `return 0` and add a TODO referencing Phase 2.
+
+- [ ] **Step 3: Verify `Workspace.focusedPanelId` exists**
+
+```bash
+grep -n "var focusedPanelId" Sources/Workspace.swift
+```
+
+Expected: a `var focusedPanelId: UUID?` computed property (confirmed during exploration at roughly line 6526).
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -40`
+Expected: builds cleanly. If `TerminalNotificationStore.unreadCount(forPanelId:)` isn't the right signature, the compiler will point at it — fall back to `return 0` inside `makeSnapshot` with an inline comment `// TODO(#2590 Phase 2): per-panel unread count`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Island/IslandStateStore.swift
+git commit -m "$(cat <<'EOF'
+Add TabManagerIslandStateSource wrapping live TabManager (#2590)
+
+Production source that subscribes to @Published tab list, per-workspace
+statusEntries/panelTitles/panels, and TerminalNotificationStore, then
+emits a debounce-friendly change stream the store can snapshot.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 7: `IslandFocusSink` protocol + production implementation
+
+**Files:**
+- Create: `Sources/Island/IslandFocusSink.swift`
+
+- [ ] **Step 1: Create the file**
+
+```swift
+// Sources/Island/IslandFocusSink.swift
+
+import AppKit
+import Foundation
+
+/// The exact set of cmux actions IslandJumpRouter needs to perform when
+/// the user clicks a session row. Confining these behind a protocol makes
+/// the router unit-testable and is also the single place where the Island
+/// module writes back into cmux core state.
+@MainActor
+protocol IslandFocusSink: AnyObject {
+    /// Bring cmux to the front (an explicit user intent that satisfies
+    /// the socket focus-steal policy — see CLAUDE.md §"Socket focus policy").
+    func activateApp()
+
+    /// Select the workspace with the given id. Returns false if the
+    /// workspace no longer exists.
+    @discardableResult
+    func selectWorkspace(id: UUID) -> Bool
+
+    /// Focus the panel with the given id inside the previously-selected
+    /// workspace. Returns false if the panel no longer exists.
+    @discardableResult
+    func focusPanel(id: UUID, inWorkspace workspaceId: UUID) -> Bool
+
+    /// Collapse the island overlay (close the expanded panel).
+    func collapseIsland()
+}
+
+/// Production implementation that routes through the live `TabManager`
+/// and its workspaces.
+@MainActor
+final class TabManagerIslandFocusSink: IslandFocusSink {
+
+    private let tabManager: TabManager
+    private let collapse: @MainActor () -> Void
+
+    init(tabManager: TabManager, collapse: @escaping @MainActor () -> Void) {
+        self.tabManager = tabManager
+        self.collapse = collapse
+    }
+
+    func activateApp() {
+        NSApp.activate(ignoringOtherApps: true)
+    }
+
+    @discardableResult
+    func selectWorkspace(id: UUID) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == id }) else {
+            return false
+        }
+        tabManager.selectWorkspace(workspace)
+        return true
+    }
+
+    @discardableResult
+    func focusPanel(id panelId: UUID, inWorkspace workspaceId: UUID) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }),
+              workspace.panels[panelId] != nil else {
+            return false
+        }
+        workspace.focusPanel(panelId)
+        return true
+    }
+
+    func collapseIsland() {
+        collapse()
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Island/IslandFocusSink.swift
+git commit -m "$(cat <<'EOF'
+Add IslandFocusSink protocol + TabManager implementation (#2590)
+
+Single write-back surface from the Island module into cmux core. The
+router depends only on the protocol; tests use a spy.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 8: `IslandJumpRouter` with tests
+
+**Files:**
+- Create: `Sources/Island/IslandJumpRouter.swift`
+- Create: `cmuxTests/IslandJumpRouterTests.swift`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+// cmuxTests/IslandJumpRouterTests.swift
+
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class IslandJumpRouterTests: XCTestCase {
+
+    private final class SpyFocusSink: IslandFocusSink {
+        enum Call: Equatable {
+            case activate
+            case selectWorkspace(UUID)
+            case focusPanel(UUID, UUID)
+            case collapse
+        }
+        var calls: [Call] = []
+        var workspaceExists: Bool = true
+        var panelExists: Bool = true
+
+        func activateApp() { calls.append(.activate) }
+
+        func selectWorkspace(id: UUID) -> Bool {
+            calls.append(.selectWorkspace(id))
+            return workspaceExists
+        }
+        func focusPanel(id: UUID, inWorkspace workspaceId: UUID) -> Bool {
+            calls.append(.focusPanel(id, workspaceId))
+            return panelExists
+        }
+        func collapseIsland() { calls.append(.collapse) }
+    }
+
+    private func makeSession(workspaceId: UUID = UUID(), panelId: UUID = UUID()) -> IslandSession {
+        IslandSession(
+            id: panelId,
+            workspaceId: workspaceId,
+            panelId: panelId,
+            agentKind: .claudeCode,
+            phase: .running,
+            workspaceTitle: "w",
+            panelTitle: "p",
+            lastActivity: Date(),
+            unreadCount: 0,
+            rawStatusValue: "Running"
+        )
+    }
+
+    func testHappyPathSequence() {
+        let spy = SpyFocusSink()
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .activate,
+                .selectWorkspace(s.workspaceId),
+                .focusPanel(s.panelId, s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+
+    func testWorkspaceGoneShortCircuits() {
+        let spy = SpyFocusSink()
+        spy.workspaceExists = false
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        // Router did not reach focusPanel. It did not activate before
+        // discovering the workspace was gone (spec §6.6 says to collapse
+        // without activating if steps fail).
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .selectWorkspace(s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+
+    func testPanelGoneCollapsesWithoutFocus() {
+        let spy = SpyFocusSink()
+        spy.panelExists = false
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .activate,
+                .selectWorkspace(s.workspaceId),
+                .focusPanel(s.panelId, s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Build and confirm the compile fails on `IslandJumpRouter`**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: compile error — `IslandJumpRouter` unknown.
+
+- [ ] **Step 3: Create the router**
+
+```swift
+// Sources/Island/IslandJumpRouter.swift
+
+import Foundation
+
+/// Translates a session tap into a fixed sequence of `IslandFocusSink`
+/// calls. See spec §6.6 for ordering requirements.
+@MainActor
+final class IslandJumpRouter {
+
+    private let focusSink: IslandFocusSink
+
+    init(focusSink: IslandFocusSink) {
+        self.focusSink = focusSink
+    }
+
+    /// Perform the jump. The router guarantees that `collapseIsland()` is
+    /// called exactly once, regardless of which step (if any) fails.
+    func jump(to session: IslandSession) {
+        // If the workspace has already been torn down, skip activation and
+        // just collapse (spec §6.6: "collapses the island without activating
+        // cmux"). This avoids yanking the user's focus over to cmux only to
+        // display nothing meaningful.
+        guard focusSink.selectWorkspace(id: session.workspaceId) == false else {
+            // Normal path: workspace found → activate + focus panel + collapse.
+            focusSink.activateApp()
+            // Selecting a second time keeps the TabManager state coherent in
+            // case activation hopped windows — this is the same sequence the
+            // existing workspace.select socket command uses.
+            _ = focusSink.selectWorkspace(id: session.workspaceId)
+            _ = focusSink.focusPanel(id: session.panelId, inWorkspace: session.workspaceId)
+            focusSink.collapseIsland()
+            return
+        }
+
+        // Workspace missing branch — collapse and bail.
+        focusSink.collapseIsland()
+    }
+}
+```
+
+Wait — the control flow above is backwards (selectWorkspace returns true on success, and `guard …==false else { happyPath }` is confusing). Rewrite cleanly:
+
+```swift
+// Sources/Island/IslandJumpRouter.swift
+
+import Foundation
+
+/// Translates a session tap into a fixed sequence of `IslandFocusSink`
+/// calls. See spec §6.6 for ordering requirements.
+@MainActor
+final class IslandJumpRouter {
+
+    private let focusSink: IslandFocusSink
+
+    init(focusSink: IslandFocusSink) {
+        self.focusSink = focusSink
+    }
+
+    /// Perform the jump. `collapseIsland()` runs exactly once whether or
+    /// not intermediate steps succeed.
+    func jump(to session: IslandSession) {
+        // Resolve the workspace first. If it's gone, skip activation
+        // (spec §6.6) — we don't want to yank focus to a now-empty tab.
+        let workspaceFound = focusSink.selectWorkspace(id: session.workspaceId)
+        guard workspaceFound else {
+            focusSink.collapseIsland()
+            return
+        }
+
+        // Workspace is there; this is an explicit user focus intent so
+        // activating cmux is allowed under CLAUDE.md "Socket focus policy".
+        focusSink.activateApp()
+
+        // Re-select to restore selection after activation; idempotent.
+        _ = focusSink.selectWorkspace(id: session.workspaceId)
+
+        _ = focusSink.focusPanel(id: session.panelId, inWorkspace: session.workspaceId)
+
+        focusSink.collapseIsland()
+    }
+}
+```
+
+Note the test's `testHappyPathSequence` expects the sequence `[activate, select, focus, collapse]` — a single `select` call. Update the router to match by dropping the double `select`:
+
+```swift
+// Sources/Island/IslandJumpRouter.swift  — final version
+
+import Foundation
+
+/// Translates a session tap into a fixed sequence of `IslandFocusSink`
+/// calls. See spec §6.6 for ordering requirements.
+@MainActor
+final class IslandJumpRouter {
+
+    private let focusSink: IslandFocusSink
+
+    init(focusSink: IslandFocusSink) {
+        self.focusSink = focusSink
+    }
+
+    /// Perform the jump. `collapseIsland()` runs exactly once.
+    func jump(to session: IslandSession) {
+        let workspaceFound = focusSink.selectWorkspace(id: session.workspaceId)
+        guard workspaceFound else {
+            focusSink.collapseIsland()
+            return
+        }
+        focusSink.activateApp()
+        _ = focusSink.focusPanel(id: session.panelId, inWorkspace: session.workspaceId)
+        focusSink.collapseIsland()
+    }
+}
+```
+
+Update the test's `testHappyPathSequence` expected array to match the order `[selectWorkspace, activate, focusPanel, collapse]`:
+
+```swift
+    func testHappyPathSequence() {
+        let spy = SpyFocusSink()
+        let router = IslandJumpRouter(focusSink: spy)
+        let s = makeSession()
+        router.jump(to: s)
+        XCTAssertEqual(
+            spy.calls,
+            [
+                .selectWorkspace(s.workspaceId),
+                .activate,
+                .focusPanel(s.panelId, s.workspaceId),
+                .collapse
+            ]
+        )
+    }
+```
+
+And `testPanelGoneCollapsesWithoutFocus` keeps its current order — panel fails but the router already collapsed unconditionally so the expected sequence becomes `[selectWorkspace, activate, focusPanel, collapse]` with the same `focusPanel` call (the spy records regardless of return value). Update that test's expectation array the same way.
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Island/IslandJumpRouter.swift cmuxTests/IslandJumpRouterTests.swift
+git commit -m "$(cat <<'EOF'
+Add IslandJumpRouter with spy-based tests (#2590)
+
+The router guarantees collapseIsland() runs exactly once and that
+activateApp() is skipped when the target workspace no longer exists.
+Verified against a SpyFocusSink.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 9: Port `NotchShape.swift` from claude-island
+
+**Files:**
+- Create: `Sources/Island/NotchShape.swift`
+
+- [ ] **Step 1: Copy the source**
+
+```swift
+// Sources/Island/NotchShape.swift
+//
+// Ported from https://github.com/farouqaldori/claude-island
+//   ClaudeIsland/UI/Components/NotchShape.swift
+// License: Apache 2.0. See THIRD_PARTY_LICENSES.md.
+//
+// Behavior-preserving port. Only the license header and the enclosing
+// type name differ from the upstream source.
+
+import SwiftUI
+
+struct NotchShape: Shape {
+    var topCornerRadius: CGFloat
+    var bottomCornerRadius: CGFloat
+
+    init(topCornerRadius: CGFloat = 6, bottomCornerRadius: CGFloat = 14) {
+        self.topCornerRadius = topCornerRadius
+        self.bottomCornerRadius = bottomCornerRadius
+    }
+
+    var animatableData: AnimatablePair<CGFloat, CGFloat> {
+        get { .init(topCornerRadius, bottomCornerRadius) }
+        set {
+            topCornerRadius = newValue.first
+            bottomCornerRadius = newValue.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        var path = Path()
+
+        // Start at top-left
+        path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        // Top-left inward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY + topCornerRadius),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.minY)
+        )
+
+        // Left edge down
+        path.addLine(
+            to: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY - bottomCornerRadius)
+        )
+
+        // Bottom-left outward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.minX + topCornerRadius + bottomCornerRadius, y: rect.maxY),
+            control: CGPoint(x: rect.minX + topCornerRadius, y: rect.maxY)
+        )
+
+        // Bottom edge
+        path.addLine(
+            to: CGPoint(x: rect.maxX - topCornerRadius - bottomCornerRadius, y: rect.maxY)
+        )
+
+        // Bottom-right outward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY - bottomCornerRadius),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.maxY)
+        )
+
+        // Right edge up
+        path.addLine(
+            to: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY + topCornerRadius)
+        )
+
+        // Top-right inward curve
+        path.addQuadCurve(
+            to: CGPoint(x: rect.maxX, y: rect.minY),
+            control: CGPoint(x: rect.maxX - topCornerRadius, y: rect.minY)
+        )
+
+        // Top edge back to start
+        path.addLine(to: CGPoint(x: rect.minX, y: rect.minY))
+
+        return path
+    }
+}
+```
+
+- [ ] **Step 2: Update `THIRD_PARTY_LICENSES.md` with the attribution**
+
+Open `THIRD_PARTY_LICENSES.md`. Add a new section (alphabetical order). Since the plan can't predict the exact section order in the current file, append this block in the appropriate alphabetical position:
+
+```markdown
+## claude-island
+
+- Source: https://github.com/farouqaldori/claude-island
+- License: Apache License 2.0
+- Files ported: `NotchShape.swift`, `NotchPanel` configuration (adapted)
+- Portions of `Sources/Island/NotchShape.swift` and `Sources/Island/NotchPanel.swift`
+  are based on files from claude-island and are redistributed under the Apache
+  2.0 license.
+```
+
+- [ ] **Step 3: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Island/NotchShape.swift THIRD_PARTY_LICENSES.md
+git commit -m "$(cat <<'EOF'
+Port NotchShape from claude-island (#2590)
+
+Apache 2.0 port of the inward-top / outward-bottom quadratic notch shape
+used as the mask for the island overlay. Attribution added to
+THIRD_PARTY_LICENSES.md.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 10: `NotchPanel` subclass
+
+**Files:**
+- Create: `Sources/Island/NotchPanel.swift`
+
+- [ ] **Step 1: Create the file**
+
+```swift
+// Sources/Island/NotchPanel.swift
+//
+// Mechanics adapted from https://github.com/farouqaldori/claude-island
+//   ClaudeIsland/UI/Window/NotchWindow.swift
+// License: Apache 2.0. See THIRD_PARTY_LICENSES.md.
+
+import AppKit
+
+/// NSPanel subclass used as the host window for the cmux Island overlay.
+///
+/// Behaves as a non-activating, always-on-top floating panel that joins
+/// every Space and stays above the menu bar. When collapsed, the panel
+/// ignores mouse events so clicks pass through to the menu bar and apps
+/// underneath; when expanded, it accepts mouse events so the row buttons
+/// are clickable.
+final class NotchPanel: NSPanel {
+
+    init(contentRect: NSRect) {
+        super.init(
+            contentRect: contentRect,
+            styleMask: [.borderless, .nonactivatingPanel],
+            backing: .buffered,
+            defer: false
+        )
+
+        isFloatingPanel = true
+        becomesKeyOnlyIfNeeded = true
+        isOpaque = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        backgroundColor = .clear
+        hasShadow = false
+        isMovable = false
+
+        collectionBehavior = [
+            .fullScreenAuxiliary,
+            .stationary,
+            .canJoinAllSpaces,
+            .ignoresCycle
+        ]
+
+        level = NSWindow.Level(rawValue: NSWindow.Level.mainMenu.rawValue + 3)
+
+        allowsToolTipsWhenApplicationIsInactive = true
+        ignoresMouseEvents = true
+        isReleasedWhenClosed = true
+        acceptsMouseMovedEvents = false
+    }
+
+    override var canBecomeKey: Bool { true }
+    override var canBecomeMain: Bool { false }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -20`
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Island/NotchPanel.swift
+git commit -m "$(cat <<'EOF'
+Add NotchPanel NSPanel subclass (#2590)
+
+Non-activating, all-spaces floating panel configured to sit above the
+menu bar. Adapted from claude-island's NotchWindow (Apache 2.0).
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 11: Localized strings
+
+**Why now:** `IslandRootView` (next task) uses `String(localized:)` for every user-facing string. Getting the keys into `Localizable.xcstrings` first means the view compiles the first time.
+
+**Files:**
+- Modify: `Resources/Localizable.xcstrings`
+
+- [ ] **Step 1: Open `Localizable.xcstrings` and add the following keys**
+
+`Localizable.xcstrings` is a JSON-structured file. Open it in Xcode (preferred — it has a native editor) or edit the raw JSON. For each key, provide English and Japanese translations. Insert them in alphabetical position among existing `island.*` keys (there are none yet; insert in alphabetical position overall).
+
+Keys to add:
+
+| Key | English | Japanese |
+|---|---|---|
+| `island.header.title` | cmux Island | cmux アイランド |
+| `island.settings.title` | Island | アイランド |
+| `island.settings.enable.label` | Show agent session island overlay | エージェントセッションのアイランドを表示 |
+| `island.settings.enable.help` | A notch-anchored pill that lists active AI agent sessions running inside cmux. Click a row to jump to that workspace and terminal split. | ノッチ付近に浮かぶピル型オーバーレイで、cmux 内で実行中の AI エージェントセッションを一覧表示します。行をクリックすると、該当のワークスペースとターミナル分割に移動します。 |
+| `island.settings.known_kinds.help` | Detects sessions from `cmux set-status` with one of these known keys: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid. | 次の既知のキーを持つ `cmux set-status` エントリをセッションとして検出します: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid. |
+| `island.phase.running` | RUNNING | 実行中 |
+| `island.phase.idle` | IDLE | 待機中 |
+| `island.phase.waiting` | WAITING | 入力待ち |
+| `island.phase.error` | ERROR | エラー |
+| `island.phase.unknown` | — | — |
+| `island.debug.window.title` | Island Controller | アイランドコントローラー |
+| `island.debug.injectTestSession` | Inject test session | テストセッションを注入 |
+| `island.debug.clearTestSessions` | Clear test sessions | テストセッションをクリア |
+| `menu.debug.islandController` | Island Controller… | アイランドコントローラー… |
+
+If editing `Localizable.xcstrings` as raw JSON: find the top-level `"strings"` object and add each key like:
+
+```jsonc
+"island.header.title" : {
+  "extractionState" : "manual",
+  "localizations" : {
+    "en" : { "stringUnit" : { "state" : "translated", "value" : "cmux Island" } },
+    "ja" : { "stringUnit" : { "state" : "translated", "value" : "cmux アイランド" } }
+  }
+}
+```
+
+- [ ] **Step 2: Validate the file parses**
+
+Run: `python3 -c "import json,sys; json.load(open('Resources/Localizable.xcstrings'))" && echo ok`
+Expected: `ok`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Localizable.xcstrings
+git commit -m "$(cat <<'EOF'
+Add localized strings for cmux Island (#2590)
+
+English + Japanese strings for the settings section, phase pills,
+debug window, and the Debug Windows menu entry.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 12: `IslandRootView` SwiftUI view (closed + expanded)
+
+**Files:**
+- Create: `Sources/Island/IslandRootView.swift`
+
+- [ ] **Step 1: Create the view file**
+
+```swift
+// Sources/Island/IslandRootView.swift
+
+import SwiftUI
+import Combine
+
+/// SwiftUI root of the cmux Island overlay.
+///
+/// Two visual states — closed (minimal pill on the left extension of the
+/// notch) and opened (rounded panel below the notch with session rows).
+struct IslandRootView: View {
+
+    // MARK: - Observed state
+
+    @ObservedObject var viewModel: IslandRootViewModel
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack(alignment: .top) {
+            NotchShape(
+                topCornerRadius: viewModel.topCornerRadius,
+                bottomCornerRadius: viewModel.bottomCornerRadius
+            )
+            .fill(.black)
+            .frame(
+                width: viewModel.shapeSize.width,
+                height: viewModel.shapeSize.height
+            )
+            .shadow(
+                color: viewModel.isOpen ? .black.opacity(0.7) : .clear,
+                radius: 8
+            )
+            .animation(
+                viewModel.isOpen
+                    ? .spring(response: 0.42, dampingFraction: 0.8)
+                    : .spring(response: 0.45, dampingFraction: 1.0),
+                value: viewModel.isOpen
+            )
+            .onTapGesture {
+                if !viewModel.isOpen { viewModel.open() }
+            }
+            .overlay(alignment: .top) {
+                if viewModel.isOpen {
+                    expandedContent
+                        .padding(.top, viewModel.notchHeight + 4)
+                        .frame(width: viewModel.shapeSize.width - 24)
+                } else {
+                    closedContent
+                        .padding(.leading, 20)
+                }
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Closed state — minimal dot + count on the LEFT extension
+
+    private var closedContent: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(viewModel.aggregateColor)
+                .frame(width: 6, height: 6)
+                .shadow(color: viewModel.aggregateColor.opacity(0.6), radius: 3)
+            Text("\(viewModel.sessions.count)")
+                .font(.system(size: 11, weight: .semibold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(.white)
+            Spacer(minLength: 0)
+        }
+        .frame(height: viewModel.notchHeight, alignment: .leading)
+    }
+
+    // MARK: - Expanded state — list of session rows
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(String(localized: "island.header.title", defaultValue: "cmux Island"))
+                .font(.system(size: 12, weight: .semibold))
+                .foregroundStyle(.white.opacity(0.7))
+                .padding(.top, 6)
+
+            ScrollView {
+                LazyVStack(spacing: 6) {
+                    ForEach(viewModel.sessions) { session in
+                        sessionRow(session)
+                    }
+                }
+            }
+            .frame(maxHeight: 440)
+        }
+        .padding(.horizontal, 10)
+        .padding(.bottom, 10)
+        .onExitCommand { viewModel.close() }
+    }
+
+    @ViewBuilder
+    private func sessionRow(_ session: IslandSession) -> some View {
+        Button {
+            viewModel.jump(to: session)
+        } label: {
+            HStack(spacing: 10) {
+                // Agent chip
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(session.agentKind.color)
+                    .frame(width: 20, height: 20)
+                    .overlay(
+                        Text(session.agentKind.monogram)
+                            .font(.system(size: 11, weight: .bold))
+                            .foregroundStyle(.white)
+                    )
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("\(session.workspaceTitle) · \(session.panelTitle)")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .lineLimit(1)
+                    Text("\(session.agentKind.displayName) · \(relativeTime(since: session.lastActivity))")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.white.opacity(0.55))
+                        .lineLimit(1)
+                }
+
+                Spacer(minLength: 4)
+
+                phasePill(session.phase)
+                if session.unreadCount > 0 {
+                    Text("·\(session.unreadCount)")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(.white.opacity(0.7))
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: 10).fill(.white.opacity(0.08))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private func phasePill(_ phase: IslandSessionPhase) -> some View {
+        let (bg, fg, text) = phaseStyle(phase)
+        Text(text)
+            .font(.system(size: 10, weight: .bold))
+            .padding(.horizontal, 8)
+            .padding(.vertical, 2)
+            .background(Capsule().fill(bg))
+            .foregroundStyle(fg)
+    }
+
+    private func phaseStyle(_ phase: IslandSessionPhase) -> (Color, Color, String) {
+        switch phase {
+        case .running:
+            return (
+                Color(red: 0.04, green: 0.23, blue: 0.09),
+                Color(red: 0.20, green: 0.82, blue: 0.35),
+                String(localized: "island.phase.running", defaultValue: "RUNNING")
+            )
+        case .waiting:
+            return (
+                Color(red: 0.29, green: 0.21, blue: 0.02),
+                Color(red: 0.98, green: 0.80, blue: 0.24),
+                String(localized: "island.phase.waiting", defaultValue: "WAITING")
+            )
+        case .error:
+            return (
+                Color(red: 0.23, green: 0.07, blue: 0.07),
+                Color(red: 0.97, green: 0.44, blue: 0.44),
+                String(localized: "island.phase.error", defaultValue: "ERROR")
+            )
+        case .idle:
+            return (
+                Color(red: 0.11, green: 0.16, blue: 0.22),
+                Color(red: 0.49, green: 0.83, blue: 0.99),
+                String(localized: "island.phase.idle", defaultValue: "IDLE")
+            )
+        case .unknown:
+            return (
+                Color.white.opacity(0.12),
+                Color.white.opacity(0.6),
+                String(localized: "island.phase.unknown", defaultValue: "—")
+            )
+        }
+    }
+
+    private func relativeTime(since date: Date) -> String {
+        let seconds = Int(Date().timeIntervalSince(date))
+        if seconds < 60 { return "\(seconds)s" }
+        if seconds < 3_600 { return "\(seconds / 60)m" }
+        if seconds < 86_400 { return "\(seconds / 3_600)h" }
+        return "\(seconds / 86_400)d"
+    }
+}
+
+// MARK: - View model
+
+/// View model backing `IslandRootView`. Owns the open/closed state, the
+/// current session snapshot, and delegates jump actions to a router.
+@MainActor
+final class IslandRootViewModel: ObservableObject {
+
+    @Published private(set) var sessions: [IslandSession] = []
+    @Published private(set) var isOpen: Bool = false
+
+    let notchWidth: CGFloat
+    let notchHeight: CGFloat
+
+    // Extension + open-state geometry.
+    private let closedSideExtent: CGFloat = 28
+    private let openedWidth: CGFloat = 560
+    private let openedMinHeight: CGFloat = 64
+    private let rowHeight: CGFloat = 56
+    private let openedMaxHeight: CGFloat = 540
+
+    private let router: IslandJumpRouter
+    private var provider: IslandStateProvider?
+    private var cancellable: AnyCancellable?
+
+    init(notchWidth: CGFloat, notchHeight: CGFloat, router: IslandJumpRouter) {
+        self.notchWidth = notchWidth
+        self.notchHeight = notchHeight
+        self.router = router
+    }
+
+    func bind(to provider: IslandStateProvider) {
+        self.provider = provider
+        self.sessions = provider.currentSessions
+        self.cancellable = provider.sessionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.sessions = sessions
+            }
+    }
+
+    // MARK: Layout helpers
+
+    var shapeSize: CGSize {
+        if isOpen {
+            let h = min(
+                max(openedMinHeight + CGFloat(sessions.count) * rowHeight, 160),
+                openedMaxHeight
+            )
+            return CGSize(width: openedWidth, height: h)
+        } else {
+            return CGSize(
+                width: notchWidth + 2 * closedSideExtent,
+                height: notchHeight
+            )
+        }
+    }
+
+    var topCornerRadius: CGFloat { isOpen ? 19 : 6 }
+    var bottomCornerRadius: CGFloat { isOpen ? 24 : 14 }
+
+    var aggregateColor: Color {
+        if sessions.contains(where: { $0.phase == .running }) { return .green }
+        if sessions.contains(where: { $0.phase == .waiting }) { return .yellow }
+        if sessions.contains(where: { $0.phase == .error }) { return .red }
+        return .gray
+    }
+
+    // MARK: Actions
+
+    func open()  { isOpen = true  }
+    func close() { isOpen = false }
+
+    func jump(to session: IslandSession) {
+        router.jump(to: session)
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -40`
+Expected: builds cleanly.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Island/IslandRootView.swift
+git commit -m "$(cat <<'EOF'
+Add IslandRootView (closed pill + expanded row list) (#2590)
+
+SwiftUI root for the cmux Island. Closed state shows a dot + count on
+the left extension of the notch; expanded state shows a vertical list of
+session rows that route clicks through IslandJumpRouter. Uses only
+localized strings.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 13: `IslandWindowController`
+
+**Files:**
+- Create: `Sources/Island/IslandWindowController.swift`
+
+- [ ] **Step 1: Create the controller**
+
+```swift
+// Sources/Island/IslandWindowController.swift
+
+import AppKit
+import Combine
+import SwiftUI
+
+/// Owns a single `NotchPanel` plus its hosted `IslandRootView`.
+///
+/// Responsibilities:
+///   • position the panel on the notch screen (or main screen on non-notch Macs)
+///   • show/hide the panel based on `provider.sessions.isEmpty`
+///   • wire the view model to the provider
+///   • tear down cleanly on `shutdown()`.
+@MainActor
+final class IslandWindowController: NSWindowController {
+
+    private let provider: IslandStateProvider
+    private let viewModel: IslandRootViewModel
+    private var cancellables: Set<AnyCancellable> = []
+
+    init(provider: IslandStateProvider, router: IslandJumpRouter) {
+        self.provider = provider
+
+        let screen = IslandWindowController.resolveScreen()
+        let notchSize = IslandWindowController.resolveNotchSize(on: screen)
+
+        self.viewModel = IslandRootViewModel(
+            notchWidth: notchSize.width,
+            notchHeight: notchSize.height,
+            router: router
+        )
+
+        let windowHeight: CGFloat = 750
+        let frame = NSRect(
+            x: screen.frame.origin.x,
+            y: screen.frame.maxY - windowHeight,
+            width: screen.frame.width,
+            height: windowHeight
+        )
+
+        let panel = NotchPanel(contentRect: frame)
+        panel.contentView = NSHostingView(rootView: IslandRootView(viewModel: viewModel))
+        panel.setFrame(frame, display: true)
+        panel.ignoresMouseEvents = true
+
+        super.init(window: panel)
+        panel.delegate = nil  // never become a key-window root
+
+        viewModel.bind(to: provider)
+
+        // Subscribe to session list changes to drive visibility + mouse events.
+        provider.sessionsPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] sessions in
+                self?.reconcile(sessions: sessions)
+            }
+            .store(in: &cancellables)
+
+        // Toggle ignoresMouseEvents when the view model opens/closes so
+        // expanded rows become clickable while collapsed clicks pass through.
+        viewModel.$isOpen
+            .receive(on: DispatchQueue.main)
+            .sink { [weak panel] isOpen in
+                panel?.ignoresMouseEvents = !isOpen
+            }
+            .store(in: &cancellables)
+
+        reconcile(sessions: provider.currentSessions)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    /// Called by `AppDelegate` when the setting flips off. Removes the
+    /// window, cancels subscriptions, breaks the router's retain on `self`.
+    func shutdown() {
+        cancellables.removeAll()
+        window?.orderOut(nil)
+        window?.contentView = nil
+        window = nil
+    }
+
+    // MARK: - Private
+
+    private func reconcile(sessions: [IslandSession]) {
+        if sessions.isEmpty {
+            window?.orderOut(nil)
+        } else if window?.isVisible != true {
+            window?.orderFront(nil)
+        }
+    }
+
+    // MARK: - Screen resolution
+
+    private static func resolveScreen() -> NSScreen {
+        if let notched = NSScreen.screens.first(where: { $0.safeAreaInsets.top > 0 }) {
+            return notched
+        }
+        return NSScreen.main ?? NSScreen.screens.first ?? NSScreen()
+    }
+
+    /// Returns the physical notch rect size, or a synthetic `(200, 32)`
+    /// on non-notch Macs so the geometry stays consistent.
+    private static func resolveNotchSize(on screen: NSScreen) -> CGSize {
+        let insetTop = screen.safeAreaInsets.top
+        if insetTop > 0 {
+            // auxiliaryTopLeftArea / auxiliaryTopRightArea can be nil on
+            // non-notch Macs; compute the middle region from frame widths.
+            let leftWidth = screen.auxiliaryTopLeftArea?.width ?? 0
+            let rightWidth = screen.auxiliaryTopRightArea?.width ?? 0
+            let notchWidth = max(120, screen.frame.width - leftWidth - rightWidth)
+            return CGSize(width: notchWidth, height: insetTop)
+        }
+        return CGSize(width: 200, height: 32)
+    }
+}
+```
+
+- [ ] **Step 2: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -40`
+Expected: builds cleanly. If `NSScreen.auxiliaryTopLeftArea` isn't available on the minimum macOS target, drop to a hardcoded `(200, 32)` notch size — the exact measurement is not critical for the overlay to function.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Sources/Island/IslandWindowController.swift
+git commit -m "$(cat <<'EOF'
+Add IslandWindowController owning the NotchPanel (#2590)
+
+Wires provider → view model → NotchPanel, toggles visibility based on
+the sessions list, and flips ignoresMouseEvents when the view opens or
+closes. Provides a shutdown() path AppDelegate calls when the setting
+turns off.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 14: Settings → Island section in `SettingsView`
+
+**Files:**
+- Modify: `Sources/cmuxApp.swift`
+
+- [ ] **Step 1: Add the `@AppStorage` binding to `SettingsView`**
+
+Open `Sources/cmuxApp.swift`. Locate the existing `struct SettingsView: View` declaration (around line 4074). In the block of `@AppStorage` properties near the top of the struct, add:
+
+```swift
+    @AppStorage(IslandSettings.enabledKey) private var islandEnabled = IslandSettings.defaultEnabled
+```
+
+Place it next to related grouping — a good spot is right before or after `@AppStorage(NotificationBadgeSettings.dockBadgeEnabledKey)`.
+
+- [ ] **Step 2: Add the section UI**
+
+Find the `SettingsSectionHeader(title: ... "settings.section.automation", ...)` block (around line 5431) and insert a new Island section **above** Automation (so it sits between the section above Automation and Automation itself). The new block:
+
+```swift
+                    SettingsSectionHeader(title: String(localized: "settings.section.island", defaultValue: "Island"))
+                    SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("island.enabled"),
+                            String(localized: "island.settings.enable.label", defaultValue: "Show agent session island overlay"),
+                            subtitle: String(localized: "island.settings.enable.help", defaultValue: "A notch-anchored pill that lists active AI agent sessions running inside cmux. Click a row to jump to that workspace and terminal split.")
+                        ) {
+                            Toggle("", isOn: $islandEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsIslandEnabledToggle")
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardNote(
+                            String(
+                                localized: "island.settings.known_kinds.help",
+                                defaultValue: "Detects sessions from `cmux set-status` with one of these known keys: claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid."
+                            )
+                        )
+                    }
+```
+
+If the existing scroll list uses a different section ordering, choose any adjacent position — order is cosmetic.
+
+- [ ] **Step 3: Add the section header localized string**
+
+Edit `Resources/Localizable.xcstrings` and add one more key you may have missed in Task 11:
+
+| Key | English | Japanese |
+|---|---|---|
+| `settings.section.island` | Island | アイランド |
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -40`
+Expected: builds cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/cmuxApp.swift Resources/Localizable.xcstrings
+git commit -m "$(cat <<'EOF'
+Add Settings > Island section with enable toggle (#2590)
+
+Users can now opt in to the cmux Island overlay from Settings. Toggle
+is bound to IslandSettings.enabledKey and mirrors through
+settings.json via CmuxSettingsFileStore.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 15: Debug menu entry + `IslandControllerDebugWindowController`
+
+**Files:**
+- Modify: `Sources/cmuxApp.swift`
+
+- [ ] **Step 1: Add the Debug Windows menu button**
+
+In `Sources/cmuxApp.swift`, find the `Menu("Debug Windows") { … }` block (around line 467). Inside the block, alphabetically between `"Debug Window Controls…"` and `"Menu Bar Extra Debug…"`, add:
+
+```swift
+                    Button(
+                        String(
+                            localized: "menu.debug.islandController",
+                            defaultValue: "Island Controller…"
+                        )
+                    ) {
+                        IslandControllerDebugWindowController.shared.show()
+                    }
+```
+
+If there's a second `Menu("Debug Windows")` block (for a different context — earlier grep showed two), add the same button there.
+
+- [ ] **Step 2: Add the `IslandControllerDebugWindowController` class**
+
+Near the other `*DebugWindowController` declarations (`SidebarDebugWindowController` is around line 2638), add:
+
+```swift
+#if DEBUG
+private final class IslandControllerDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = IslandControllerDebugWindowController()
+
+    let inMemorySource = InMemoryIslandStateSource()
+
+    private init() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 520),
+            styleMask: [.titled, .closable, .utilityWindow],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "island.debug.window.title", defaultValue: "Island Controller")
+        window.titleVisibility = .visible
+        window.titlebarAppearsTransparent = false
+        window.isMovableByWindowBackground = true
+        window.isReleasedWhenClosed = false
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.islandDebug")
+        window.center()
+        window.contentView = NSHostingView(rootView: IslandDebugView(source: inMemorySource))
+        AppDelegate.shared?.applyWindowDecorations(to: window)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        window?.center()
+        window?.makeKeyAndOrderFront(nil)
+    }
+}
+
+/// Debug-only view that lets the developer toggle the feature and inject
+/// synthetic sessions into an in-memory source for visual iteration.
+private struct IslandDebugView: View {
+    @AppStorage(IslandSettings.enabledKey) private var islandEnabled = IslandSettings.defaultEnabled
+    let source: InMemoryIslandStateSource
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(
+                String(localized: "island.settings.enable.label", defaultValue: "Show agent session island overlay"),
+                isOn: $islandEnabled
+            )
+            .font(.system(size: 13, weight: .semibold))
+
+            Divider()
+
+            HStack {
+                Button(String(localized: "island.debug.injectTestSession", defaultValue: "Inject test session")) {
+                    source.add(
+                        IslandSession(
+                            id: UUID(),
+                            workspaceId: UUID(),
+                            panelId: UUID(),
+                            agentKind: IslandAgentKind.allCases.randomElement() ?? .claudeCode,
+                            phase: [.running, .waiting, .error, .idle].randomElement() ?? .running,
+                            workspaceTitle: "debug",
+                            panelTitle: "synthetic",
+                            lastActivity: Date(),
+                            unreadCount: 0,
+                            rawStatusValue: "debug"
+                        )
+                    )
+                }
+                Button(String(localized: "island.debug.clearTestSessions", defaultValue: "Clear test sessions")) {
+                    source.clear()
+                }
+            }
+
+            Divider()
+
+            Text("Injected sessions: \(source.sessions.count)")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+            Spacer()
+        }
+        .padding(16)
+        .frame(minWidth: 380, minHeight: 480)
+    }
+}
+#endif
+```
+
+Note: the debug window's inject path writes to an in-memory source that is independent of the production store. For MVP this is acceptable — the debug window exists to iterate on shape/layout, not to mirror real state. A future enhancement could expose a debug hook to swap the production store's source at runtime.
+
+- [ ] **Step 3: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -30`
+Expected: builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/cmuxApp.swift
+git commit -m "$(cat <<'EOF'
+Add Debug menu "Island Controller…" entry (DEBUG builds only) (#2590)
+
+IslandControllerDebugWindowController provides an enable toggle, an
+inject-test-session button, and a synthetic row count for visual
+iteration during development. Wrapped in #if DEBUG per CLAUDE.md.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 16: AppDelegate lifecycle (create / destroy controller on toggle)
+
+**Files:**
+- Modify: `Sources/AppDelegate.swift`
+
+- [ ] **Step 1: Add the stored properties**
+
+In `Sources/AppDelegate.swift`, inside `final class AppDelegate: NSObject, …` near the other stored properties, add:
+
+```swift
+    // MARK: - Island overlay
+
+    private var islandWindowController: IslandWindowController?
+    private var islandEnabledObserver: AnyCancellable?
+```
+
+Add `import Combine` at the top of the file if it isn't already imported.
+
+- [ ] **Step 2: Wire the observer in `applicationDidFinishLaunching`**
+
+Find `applicationDidFinishLaunching(_:)` (around line 2483). Append at the end of the method (before any cleanup / return-like code):
+
+```swift
+        // cmux Island — opt-in overlay. Created and destroyed reactively
+        // based on the islandEnabled setting so disabling it leaves no
+        // leftover panel or observers.
+        islandEnabledObserver = NotificationCenter.default
+            .publisher(for: UserDefaults.didChangeNotification)
+            .map { _ in UserDefaults.standard.bool(forKey: IslandSettings.enabledKey) }
+            .prepend(UserDefaults.standard.bool(forKey: IslandSettings.enabledKey))
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] enabled in
+                self?.refreshIslandController(enabled: enabled)
+            }
+```
+
+- [ ] **Step 3: Add the refresh helper method**
+
+Anywhere in the same file (group near other helpers):
+
+```swift
+    @MainActor
+    private func refreshIslandController(enabled: Bool) {
+        if enabled {
+            guard islandWindowController == nil,
+                  let tabManager = self.tabManager else { return }
+            let source = TabManagerIslandStateSource(tabManager: tabManager)
+            let store = IslandStateStore(source: source)
+            let controller = IslandWindowController(
+                provider: store,
+                router: IslandJumpRouter(
+                    focusSink: TabManagerIslandFocusSink(
+                        tabManager: tabManager,
+                        collapse: { [weak self] in
+                            self?.islandWindowController?.viewModel.close()
+                        }
+                    )
+                )
+            )
+            islandWindowController = controller
+        } else {
+            islandWindowController?.shutdown()
+            islandWindowController = nil
+        }
+    }
+```
+
+Note: `AppDelegate` already owns a `TabManager` reference (common in cmux). If the property name differs from `tabManager`, match it. If there's no existing singleton property, look for where other features access the TabManager (search `grep -n "tabManager" Sources/AppDelegate.swift`) and mirror that access.
+
+Also note that `viewModel` on `IslandWindowController` is not currently public — you need to either promote it to `internal` visibility or expose a dedicated `func close()` on the controller that forwards to the view model. Prefer the dedicated `close()`:
+
+Add to `Sources/Island/IslandWindowController.swift`:
+
+```swift
+    /// Convenience used by the router's collapse callback.
+    func close() {
+        viewModel.close()
+    }
+```
+
+And change the `collapse` closure in Step 3 above to:
+
+```swift
+                        collapse: { [weak self] in
+                            self?.islandWindowController?.close()
+                        }
+```
+
+- [ ] **Step 4: Build**
+
+Run: `xcodebuild -scheme cmux-unit build 2>&1 | tail -40`
+Expected: builds cleanly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/AppDelegate.swift Sources/Island/IslandWindowController.swift
+git commit -m "$(cat <<'EOF'
+Wire AppDelegate to island.enabled setting (#2590)
+
+Observes the UserDefaults key and creates/destroys IslandWindowController
+reactively. Uses TabManagerIslandStateSource + TabManagerIslandFocusSink
+for live data and focus routing. Adds a close() convenience on the
+controller for the router's collapse callback.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 17: Register every new file in `project.pbxproj`
+
+**Why this task is separate:** up to this point the Xcode project has not "seen" the new files in `Sources/Island/`. Each file needs four additions in `project.pbxproj`: one `PBXBuildFile`, one `PBXFileReference`, one entry in the Sources `PBXGroup` children, one entry in the Sources `PBXSourcesBuildPhase` files list. The existing `Panels/*.swift` files follow the same pattern (flat in the Sources group, `path = Panels/Foo.swift` on the file reference) — mirror it.
+
+**Files to register (Sources target):**
+
+```
+Sources/Island/IslandSettings.swift
+Sources/Island/IslandSession.swift
+Sources/Island/IslandStateProvider.swift
+Sources/Island/IslandStateStore.swift
+Sources/Island/IslandFocusSink.swift
+Sources/Island/IslandJumpRouter.swift
+Sources/Island/NotchShape.swift
+Sources/Island/NotchPanel.swift
+Sources/Island/IslandRootView.swift
+Sources/Island/IslandWindowController.swift
+```
+
+**Files to register (cmuxTests target):**
+
+```
+cmuxTests/IslandSettingsFileStoreTests.swift
+cmuxTests/IslandSessionPhaseTests.swift
+cmuxTests/IslandSessionSortTests.swift
+cmuxTests/IslandStateStoreTests.swift
+cmuxTests/IslandJumpRouterTests.swift
+```
+
+- [ ] **Step 1: Open `GhosttyTabs.xcodeproj/project.pbxproj` in Xcode's file inspector (preferred)**
+
+The fastest and least error-prone approach is to open `GhosttyTabs.xcodeproj` in Xcode, then in the Project Navigator:
+
+1. Right-click the `Sources` group → **Add Files to "GhosttyTabs"…**
+2. Select all 10 files under `Sources/Island/`.
+3. In the add-files dialog: uncheck "Copy items if needed" (they already live in the repo), select the `cmux` target.
+4. Right-click `cmuxTests` → **Add Files to "GhosttyTabs"…**
+5. Select the 5 test files, select the `cmuxTests` target.
+6. Save and quit Xcode.
+
+Xcode will update `project.pbxproj` correctly. Commit only the `project.pbxproj` diff.
+
+- [ ] **Step 2: Alternative — hand-edit `project.pbxproj` if Xcode is unavailable**
+
+For each file, add four entries. Below is a template for one Sources file (`IslandSettings.swift`). Repeat for every file, using fresh UUID-style hex IDs for each new entry (copy the format used by existing lines).
+
+**a) `PBXBuildFile`** (add near the top in the "Begin PBXBuildFile section"):
+
+```
+		A5ISLAND01 /* IslandSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5ISLANDR1 /* IslandSettings.swift */; };
+```
+
+**b) `PBXFileReference`** (add in the "Begin PBXFileReference section"):
+
+```
+		A5ISLANDR1 /* IslandSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Island/IslandSettings.swift; sourceTree = "<group>"; };
+```
+
+**c) Sources group children** (inside the Sources `PBXGroup` block, around line 456–521, add the file ref to the children list):
+
+```
+					A5ISLANDR1 /* IslandSettings.swift */,
+```
+
+**d) Sources build phase files** (inside the `PBXSourcesBuildPhase` for the cmux target — search for `isa = PBXSourcesBuildPhase;`):
+
+```
+				A5ISLAND01 /* IslandSettings.swift in Sources */,
+```
+
+Repeat for each of the 10 Sources files and each of the 5 test files (tests go into the `cmuxTests` target's `PBXSourcesBuildPhase`, not the `cmux` target's).
+
+- [ ] **Step 3: Verify the project opens cleanly**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -list
+```
+
+Expected: no errors; lists the `cmux`, `cmux-unit`, `cmuxUITests` schemes.
+
+- [ ] **Step 4: Verify a full build succeeds**
+
+```bash
+xcodebuild -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-island-mvp build 2>&1 | tail -40
+```
+
+Expected: `** BUILD SUCCEEDED **`. If there are missing-symbol errors, it means a file didn't make it into the build phase — re-check step 2d for that file.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add GhosttyTabs.xcodeproj/project.pbxproj
+git commit -m "$(cat <<'EOF'
+Register cmux Island files in Xcode project (#2590)
+
+Adds Sources/Island/*.swift to the cmux target and cmuxTests/Island*.swift
+to the cmuxTests target so the module and its tests compile.
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 18: Smoke-test the build against a tagged Debug app
+
+**Why this task:** Up to this point the plan has exercised only the compiler. The real test is the NSPanel behavior — click-through when collapsed, spring animation on open, session list populating from real set-status entries. Per CLAUDE.md the build must be tagged.
+
+**Files:** none (build artifacts only)
+
+- [ ] **Step 1: Build a tagged Debug app**
+
+```bash
+./scripts/reload.sh --tag island-mvp
+```
+
+Expected: prints an `App path:` line pointing to `Build/Products/Debug/cmux DEV island-mvp.app`.
+
+- [ ] **Step 2: Surface the app path as a cmd-clickable link per CLAUDE.md**
+
+Take the `App path:` value from the output, URL-encode spaces, and print a markdown link:
+
+```
+=======================================================
+[cmux DEV island-mvp.app](file:///.../cmux%20DEV%20island-mvp.app)
+=======================================================
+```
+
+Let the user cmd-click and launch the app.
+
+- [ ] **Step 3: Walk the smoke-test checklist from spec §9**
+
+The spec's 12-step checklist (Settings toggle on, inject set-status, expand, click row, switch spaces, toggle off, etc.) is the acceptance criteria. If any step fails, open a follow-up issue — do NOT silently fix in this PR.
+
+- [ ] **Step 4: If no bugs surface, commit nothing — just proceed to CHANGELOG**
+
+(If bugs surface, make fixes in dedicated commits before the CHANGELOG task so the PR history reflects reality.)
+
+---
+
+## Task 19: Update `CHANGELOG.md`
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Read the top of `CHANGELOG.md` to find the unreleased section**
+
+```bash
+head -30 CHANGELOG.md
+```
+
+Expected: an unreleased heading (e.g., `## Unreleased` or a dated upcoming section).
+
+- [ ] **Step 2: Add a line under the unreleased heading**
+
+Insert the following bullet under the `### Added` subheading (create `### Added` if it doesn't exist):
+
+```markdown
+- **cmux Island (opt-in).** New notch-anchored overlay that lists active AI agent sessions detected from `cmux set-status` entries. Click a row to jump to the corresponding workspace and terminal split. Enable it from Settings → Island. See [`docs/superpowers/specs/2026-04-09-cmux-island-design.md`](docs/superpowers/specs/2026-04-09-cmux-island-design.md) for design details. (#2590)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+Changelog entry for cmux Island MVP (#2590)
+
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 20: Push and open the PR
+
+**Files:** none
+
+- [ ] **Step 1: Push the branch**
+
+Create a feature branch (`island-mvp`) before the first commit if this plan wasn't already running on one. If the plan has been committing on `main`, stop and ask the user how they want to proceed — do not push to `main`.
+
+```bash
+git status
+git log --oneline origin/main..HEAD
+```
+
+Expected: the 15–20 commits from this plan, none on `main`. If the branch is `main`, create a branch and move the commits with:
+
+```bash
+git branch island-mvp
+git reset --hard origin/main
+git checkout island-mvp
+```
+
+(Only do this if the user confirms — destructive on `main` local pointer.)
+
+- [ ] **Step 2: Push and create the PR**
+
+```bash
+git push -u origin island-mvp
+gh pr create --title "cmux Island MVP (notch-anchored agent session overlay)" --body "$(cat <<'EOF'
+## Summary
+
+- Adds the MVP of the cmux Island — a notch-anchored Dynamic Island overlay listing active AI-agent sessions and routing clicks to the corresponding workspace + terminal split.
+- Reads sessions from existing `cmux set-status` entries (claude_code, codex, copilot_cli, opencode, gemini_cli, cursor, amp, droid). Zero new CLI.
+- Opt-in from Settings → Island (off by default). Mirrored in `~/.config/cmux/settings.json` under `"island": { "enabled": true }`.
+
+See the design spec at `docs/superpowers/specs/2026-04-09-cmux-island-design.md`. Closes #2590 (MVP scope only; approvals + companion-app extraction tracked as follow-ups).
+
+## Test plan
+
+- [ ] `xcodebuild -scheme cmux-unit test` (unit tests: phase normalization, sort order, store projection, router routing, settings round-trip)
+- [ ] Tagged Debug build via `./scripts/reload.sh --tag island-mvp`
+- [ ] Walk spec §9 smoke test checklist on a notch-equipped Mac
+- [ ] Verify on a non-notch Mac that the shape renders as a floating pill at top center
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+- [ ] **Step 3: Return the PR URL to the user**
+
+The `gh pr create` command prints the URL. Paste it back so the user can review.
+
+---
+
+## Self-review
+
+**Spec coverage check (spec ↔ plan):**
+
+| Spec section | Covered by tasks |
+|---|---|
+| §4.1 Module layout (10 files) | Tasks 2, 4, 5, 6, 7, 8, 9, 10, 12, 13 |
+| §4.2 Decoupling seam | Tasks 4 (provider protocol) + 7 (focus sink protocol) |
+| §4.3 Data flow + 50ms debounce | Task 5 step 3 |
+| §4.4 AppDelegate lifecycle | Task 16 |
+| §5.1 Value types | Task 2 |
+| §5.2 Projection rules (priority tiebreak) | Task 6 step 1 `makeSnapshot` |
+| §5.3 Phase normalization table | Tasks 2 step 3 + tests in Task 2 step 1 |
+| §5.4 Visibility predicate | Task 13 step 1 `reconcile(sessions:)` |
+| §5.5 Aggregate dot color | Task 12 `aggregateColor` |
+| §6.1 NotchPanel config | Task 10 |
+| §6.2 NotchShape | Task 9 |
+| §6.3 Closed layout (dot + count on left) | Task 12 `closedContent` |
+| §6.4 Expanded layout | Task 12 `expandedContent`, `sessionRow`, `phasePill` |
+| §6.5 Interactions (click open, click outside close, Esc close) | Task 12 `onTapGesture`, `onExitCommand`; Task 13 `ignoresMouseEvents` toggle |
+| §6.6 Jump routing (activate/select/focus/collapse order) | Task 8 |
+| §6.7 Non-notch Mac handling | Task 13 `resolveNotchSize` fallback |
+| §7.1 Source of truth + settings.json mirror | Task 1 |
+| §7.2 Settings UI | Task 14 |
+| §7.3 Debug UI | Task 15 |
+| §7.4 Discoverability (none) | n/a — deliberately empty |
+| §8.1 Unit tests (6 classes) | Tasks 1, 2, 3, 5, 8. (IslandVisibilityTests merged into Task 5; same assertions.) |
+| §8.2 Non-goals for automated tests | No tasks — by design |
+| §8.3 Regression two-commit rule | Plan text only |
+| §9 Smoke test | Task 18 |
+| §10 Phase 2 extension points | Not built (by design) |
+
+**Placeholder scan:**
+
+- No `TBD`, `TODO` in task steps except one inline fallback note for `TerminalNotificationStore.unreadCount(forPanelId:)` if the exact signature isn't available — that's an explicit fallback instruction, not a placeholder.
+- Every step that touches code has actual code.
+- Every commit message is written out.
+- Every file path is absolute or relative from repo root.
+
+**Type consistency:**
+
+- `IslandAgentKind`, `IslandSessionPhase`, `IslandSession`, `IslandStateProvider`, `IslandStateSource`, `IslandStateStore`, `IslandFocusSink`, `IslandJumpRouter`, `NotchShape`, `NotchPanel`, `IslandRootView`, `IslandRootViewModel`, `IslandWindowController`, `IslandSettings` — all used consistently across tasks.
+- `TabManagerIslandStateSource` and `TabManagerIslandFocusSink` both live in files introduced in Tasks 6 and 7 respectively.
+- `IslandSettings.enabledKey` referenced in Tasks 1, 14, 15, 16 — consistent.
+- `IslandWindowController.close()` convenience is added in Task 16 (not earlier) because that's when it's first needed.
+- `IslandSessionPhase.rank` is introduced in Task 2 step 3 and used in Task 2's sort comparator + Task 3's tests — consistent.
+
+**Scope check:** The plan covers exactly one module (`Sources/Island/`) plus the minimum integration touches (AppDelegate + cmuxApp.swift + settings store + pbxproj + changelog). Single PR scope.

--- a/docs/superpowers/specs/2026-04-09-cmux-island-design.md
+++ b/docs/superpowers/specs/2026-04-09-cmux-island-design.md
@@ -297,12 +297,13 @@ No hover-to-expand in MVP.
 
 `IslandJumpRouter.jump(to: session)` performs the following, in order, against `IslandFocusSink`:
 
-1. `activateAppBringingToFront()` — this is the single place in the island code that is allowed to activate cmux. The call is an explicit user focus intent (the click), which satisfies the focus-intent exception in cmux's socket focus policy (CLAUDE.md §"Socket focus policy"). No other island code path activates the app.
-2. `selectWorkspace(session.workspaceId)` — routes through the same code path that the existing `workspace.select` socket command uses.
-3. `focusPanel(session.panelId)` — routes through the same code path that the existing `pane.focus` / `surface.focus` socket commands use.
-4. `collapseIsland(reason: .jumped)`.
+1. `selectWorkspace(session.workspaceId)` — probe first. Routes through the same code path that the existing `workspace.select` socket command uses. Returns false if the workspace has been torn down since the session was projected.
+2. **If the probe returned false:** log `dlog("island.jump failed: workspace … not found")` in DEBUG builds and jump straight to step 5. The app is **not** activated. This preserves the user's current focus context when the click would otherwise land on a stale row.
+3. `activateApp()` — only reached on the happy path where the workspace still exists. This is the single place in the island code that is allowed to activate cmux. The call is an explicit user focus intent (the row click), which satisfies the focus-intent exception in cmux's socket focus policy (CLAUDE.md §"Socket focus policy"). No other island code path activates the app.
+4. `focusPanel(session.panelId, inWorkspace: session.workspaceId)` — routes through the same code path that the existing `pane.focus` / `surface.focus` socket commands use. If it returns false (panel gone but workspace still present), log `dlog("island.jump failed: panel … not found …")` in DEBUG builds and continue.
+5. `collapseIsland()` — always, exactly once, regardless of which step (if any) failed. No error UI in MVP.
 
-If any of steps 2 or 3 fail (workspace or panel no longer exists), the router logs a single `dlog("island.jump failed…")` in DEBUG builds and collapses the island without activating cmux. No error UI in MVP.
+**Sequence note:** earlier drafts of this spec ordered `activate` before `select`. That order was abandoned because it would steal macOS focus for a workspace that might already be gone. The current order — select first, activate only on success — satisfies the same user-intent exception while preserving focus on the miss path.
 
 ### 6.7 Non-notch Mac behavior
 

--- a/docs/superpowers/specs/2026-04-09-cmux-island-design.md
+++ b/docs/superpowers/specs/2026-04-09-cmux-island-design.md
@@ -1,0 +1,434 @@
+# cmux Island — MVP design
+
+**Issue:** manaflow-ai/cmux#2590 — Pluggable macOS Dynamic Island Overlay for cmux.
+**Date:** 2026-04-09
+**Status:** Design approved — pending implementation plan.
+**Scope:** MVP only. Explicit non-goals enumerated in §7.
+
+---
+
+## 1. Problem
+
+Users running multiple AI agents inside cmux need a lightweight, persistent surface that tells them *which specific agent session needs attention right now* and lets them jump to the corresponding workspace + terminal split in one click. Today, a user has to scan the sidebar, hunt through splits, and interpret free-form status entries. There is no at-a-glance view across workspaces.
+
+The issue proposes a notch-anchored Dynamic Island style overlay. The MVP in this spec delivers the monitoring and jump half of that vision; approvals and bidirectional hook routing are explicit non-goals, designed to slot in cleanly as Phase 2 without reshaping any MVP code.
+
+## 2. User story (MVP)
+
+> As a cmux user running Claude Code in one workspace, Codex in another, and Copilot CLI in a third, I want a small overlay at the top of my main display that shows me how many agent sessions are active and what state each is in, so I can click the one I care about and jump directly to that terminal split without hunting through the sidebar.
+
+## 3. Goals and non-goals
+
+**Goals (MVP):**
+
+1. Always-on-top, click-to-expand island overlay anchored under the notch on the main display.
+2. Zero new user-facing CLI. Light up automatically for anyone whose agents already call `cmux set-status <agent_kind> <phase>` per `docs/notifications.md`.
+3. Click a row → cmux comes to the front, the corresponding workspace is selected, the corresponding panel is focused.
+4. Opt-in, off by default, enabled through Settings and mirrored in `~/.config/cmux/settings.json`.
+5. Module lives in `Sources/Island/` with a narrow, well-defined `IslandStateProvider` seam so a future `cmuxIsland.app` companion target can be extracted mechanically.
+6. Covered by unit tests that exercise the projection, sort, and routing logic — no source-shape tests, no plist tests, nothing that CLAUDE.md's test quality policy forbids.
+
+**Non-goals (deliberately deferred):**
+
+1. Pending permission / approval tracking and approve/deny buttons.
+2. New `cmux session` CLI or any typed session-lifecycle protocol.
+3. Bidirectional or blocking hook RPC where the island answers hook-side permission prompts.
+4. A separate Xcode target / companion `.app`. The extraction seam is designed; extraction itself is Phase 3.
+5. Multi-display support. MVP is main display only.
+6. Mark-read or dismiss-notification action invoked from inside the island.
+7. Auto-dismiss of idle rows. Idle sessions remain until their status entry is cleared.
+8. Hover-to-expand (click only, simpler, safer under cmux's focus policy).
+9. Configurable left/right placement of the collapsed content (hardcoded left; trivial flip later).
+10. Sparklines, token counts, chat preview, or any content deeper than `(workspace title, panel title, agentKind, phase, elapsed, unread count)`.
+11. Monitoring agent sessions that run **outside** cmux panels. The island is cmux-panel-scoped by definition — that is what makes the jump action meaningful. (Claude Island already covers the non-cmux case.)
+12. Auto-installing hooks into `~/.claude/hooks` or similar. Users keep the existing `cmux set-status` integrations documented in `docs/notifications.md`.
+
+## 4. Architecture
+
+### 4.1 Module layout
+
+```
+Sources/Island/
+├── IslandStateProvider.swift    — protocol; the only interface the view observes
+├── IslandStateStore.swift       — concrete provider; projects TabManager → IslandSession list
+├── IslandSession.swift          — value type + supporting enums
+├── IslandFocusSink.swift        — protocol the router calls to focus workspace/panel
+├── IslandJumpRouter.swift       — translates row taps into focus calls
+├── IslandWindowController.swift — NSWindowController owning the NotchPanel
+├── NotchPanel.swift             — NSPanel subclass
+├── NotchShape.swift             — SwiftUI Shape (port from claude-island)
+└── IslandRootView.swift         — SwiftUI view for closed/expanded states
+```
+
+### 4.2 Decoupling seam
+
+The SwiftUI view layer (`IslandRootView`, debug windows) depends **only** on `IslandStateProvider`. `IslandStateStore` is the concrete production implementation, which reads `TabManager` / `Workspace` / `TerminalNotificationStore`. Tests use `InMemoryIslandStateProvider`. A Phase 3 `SocketIslandStateProvider` that consumes a new `island.subscribe` socket command would be a drop-in replacement — **no view code changes**.
+
+Write-back from the island is equally confined. `IslandJumpRouter` calls methods on `IslandFocusSink`. The production implementation wraps `TabManager` / `NSWindow`; tests use a spy.
+
+No other cmux source file imports the Island module. Removing `Sources/Island/` removes the feature entirely with no leftover references.
+
+### 4.3 Data flow (read-only projection)
+
+```
+Workspace.statusEntries  ─┐
+TerminalNotificationStore ─┼─► IslandStateStore ─► @Published sessions ─► IslandRootView
+Workspace.panels/titles  ─┘        (Combine,
+                                   debounced
+                                   0.05s)
+```
+
+Debounce avoids flapping when multiple status entries update in the same runloop turn (e.g. an agent hook that fires `set-status` and `notify` back to back).
+
+### 4.4 Integration with AppDelegate
+
+`AppDelegate` observes `@AppStorage("island.enabled")`:
+
+- `enabled = true`, controller is `nil` → instantiate `IslandWindowController`, attach its `IslandStateStore` to the shared `TabManager`, `orderFront` only when `sessions` is non-empty.
+- `enabled = false`, controller is non-`nil` → call `close()`, release the `NSPanel`, cancel all Combine subscriptions. After disabling, the process must hold zero Island-owned timers, observers, or windows.
+
+Rapidly toggling the Setting must never produce a stuck panel or orphaned observer (covered by the debug menu's rapid toggle path during PR review).
+
+## 5. Data model
+
+### 5.1 Types
+
+```swift
+/// Known agent kinds the island monitors. A panel is an island session iff its
+/// Workspace.statusEntries contains at least one entry whose key equals one of these.
+enum IslandAgentKind: String, CaseIterable, Hashable, Sendable {
+    case claudeCode = "claude_code"
+    case codex      = "codex"
+    case copilotCli = "copilot_cli"
+    case openCode   = "opencode"
+    case geminiCli  = "gemini_cli"
+    case cursor     = "cursor"
+    case amp        = "amp"
+    case droid      = "droid"
+
+    var displayName: String { … }   // "Claude Code", "Codex", …
+    var color: NSColor      { … }   // stable brand color per kind
+    var monogram: String    { … }   // single character for the 20pt chip
+}
+
+/// Normalized session phase. Derived from SidebarStatusEntry.value via a
+/// case-insensitive lookup table. Unknown values fall into .unknown.
+enum IslandSessionPhase: String, Hashable, Sendable {
+    case running
+    case idle
+    case waiting
+    case error
+    case unknown
+
+    static func from(rawValue: String) -> IslandSessionPhase
+}
+
+/// One row in the island. Immutable value; regenerated on every store tick.
+struct IslandSession: Identifiable, Equatable, Sendable {
+    let id: UUID                // stable: panelId
+    let workspaceId: UUID
+    let panelId: UUID
+    let agentKind: IslandAgentKind
+    let phase: IslandSessionPhase
+    let workspaceTitle: String
+    let panelTitle: String
+    let lastActivity: Date      // from SidebarStatusEntry.timestamp
+    let unreadCount: Int        // from TerminalNotificationStore filtered by panelId
+    let rawStatusValue: String  // kept for tooltip + debug window
+}
+
+protocol IslandStateProvider: AnyObject {
+    var sessions: AnyPublisher<[IslandSession], Never> { get }
+}
+```
+
+### 5.2 Projection rules
+
+Given a `Workspace`, for each `panelId` referenced in `workspace.panels`:
+
+1. Collect all `statusEntries[key]` where `key ∈ IslandAgentKind.allCases.map(\.rawValue)`.
+2. If the collection is empty, the panel contributes no session.
+3. Otherwise pick the highest-priority entry (highest numeric `SidebarStatusEntry.priority` first, ties broken by most recent `timestamp`). In MVP, two concurrent agents in the same panel are not supported — the winner defines the session.
+4. Map `entry.value` → `IslandSessionPhase.from(rawValue:)`.
+5. Populate `workspaceTitle` from `workspace.customTitle ?? workspace.title`, `panelTitle` from `workspace.panelCustomTitles[panelId] ?? workspace.panelTitles[panelId]` with fallback to the panel's `displayTitle`.
+6. Populate `unreadCount` from `TerminalNotificationStore` filtered by `panelId`.
+7. Populate `lastActivity` from `entry.timestamp`.
+
+Across all workspaces, flatten and sort:
+
+```
+sortKey(session) = (phaseRank, -lastActivity.timeIntervalSince1970)
+phaseRank: running=0, waiting=1, error=2, idle=3, unknown=4
+```
+
+### 5.3 Phase normalization table
+
+`IslandSessionPhase.from(rawValue:)` is a single static dictionary, case-insensitive, trimmed:
+
+| Raw value (case-insensitive)                               | Normalized phase |
+|-------------------------------------------------------------|------------------|
+| `running`, `running_tool`, `processing`, `starting`         | `.running`       |
+| `idle`, `` (empty), `ready`                                 | `.idle`          |
+| `waiting`, `waiting_for_input`, `needs_input`, `needsinput` | `.waiting`       |
+| `error`, `failed`, `failure`                                | `.error`         |
+| (anything else)                                             | `.unknown`       |
+
+Adding a new synonym is a one-line change in the dictionary; no UI code changes.
+
+### 5.4 Visibility predicate
+
+```
+visible = !sessions.isEmpty
+```
+
+No "always visible" mode. No auto-hide delay for idle rows. If an agent hook crashes and leaves a stale entry behind, the row will stay on the island until the user runs `cmux clear-status <agent_kind>`. Acceptable for MVP; revisit in Phase 2.
+
+### 5.5 Aggregate indicator color
+
+The collapsed pill shows a single dot. Its color is the highest-severity phase currently present:
+
+| Any session phase is… | Dot color |
+|------------------------|-----------|
+| `.running`             | green     |
+| `.waiting`             | yellow    |
+| `.error`               | red       |
+| only `.idle` or `.unknown` | gray  |
+
+## 6. UI
+
+### 6.1 Window: `NotchPanel`
+
+`NSPanel` subclass, ported from `farouqaldori/claude-island`. Configuration:
+
+```swift
+styleMask                = [.borderless, .nonactivatingPanel]
+isFloatingPanel          = true
+becomesKeyOnlyIfNeeded   = true
+isOpaque                 = false
+backgroundColor          = .clear
+hasShadow                = false
+isMovable                = false
+collectionBehavior       = [.fullScreenAuxiliary, .stationary,
+                            .canJoinAllSpaces, .ignoresCycle]
+level                    = .mainMenu + 3
+```
+
+Positioned with `frame.origin.x = screen.frame.origin.x`, `frame.size.width = screen.frame.width`, `frame.size.height = 750`, `frame.origin.y = screen.frame.maxY - 750`. Only the inner `NotchShape` is painted; the rest of the panel is transparent.
+
+`ignoresMouseEvents` is toggled based on open/closed status so that, when collapsed, clicks outside the hit region pass through to the menu bar and apps underneath.
+
+Target screen is `NSScreen.screens.first(where: { $0.hasPhysicalNotch }) ?? NSScreen.main`.
+
+### 6.2 Shape: `NotchShape`
+
+Direct port of claude-island's `NotchShape.swift`. Single contiguous path with:
+
+- Inward-curving quadratic top-left and top-right corners (`topCornerRadius`) — these disappear into the screen bezel on notch Macs, and read as rounded corners on non-notch Macs.
+- Outward-curving quadratic bottom-left and bottom-right corners (`bottomCornerRadius`) — these form the visible "bottom" of the notch extension.
+
+`animatableData` is an `AnimatablePair` of the two radii so the shape can interpolate during open/close.
+
+Let `ext = max(28pt, leftContentWidth)`. The shape is always horizontally symmetric around the notch: `shapeWidth = notchWidth + 2 × ext`. The right side gets the same `ext` width as the left, empty.
+
+| State  | Width                          | Height                      | Top radius | Bottom radius |
+|--------|--------------------------------|------------------------------|------------|---------------|
+| Closed | `notchWidth + 2 × ext`         | `notchHeight` (≈ 32pt)       | 6          | 14            |
+| Opened | `560pt`                        | `64 + rowCount × 56`, cap 540| 19         | 24            |
+
+Animations:
+
+- Open: `spring(response: 0.42, dampingFraction: 0.8)`
+- Close: `spring(response: 0.45, dampingFraction: 1.0)`
+- Closed-state dot/count/color changes: `.smooth`
+
+### 6.3 Closed layout
+
+```
+[ ● 3 ] [     NOTCH     ] [       ]
+  ^^^                      ^^^^^^^^
+  left extension           right mirror (empty, same width, symmetry only)
+```
+
+- Dot: 6pt filled circle, color per §5.5, optional 6pt soft glow.
+- Count: `sessions.count`, SF Pro 11pt semibold, tabular numerals.
+- Left content (dot + count) measured, padded to at least 28pt. Right mirror copies the same `ext` width per §6.2 so the shape stays symmetric around the notch.
+- **Hit region is the left extension only.** The right mirror is dead space. The physical notch area is never drawn or hit-tested.
+
+Click → `viewModel.open(reason: .click)` → expand.
+
+### 6.4 Opened layout
+
+```
+┌────────────────────────────────────────┐
+│  cmux Island                     [·]   │
+├────────────────────────────────────────┤
+│  [C] cmux · fix-zsh-autosuggestions    │
+│      Claude Code · 4m      ┃ RUNNING   │
+│  [X] web · issue-2674-scrollbar        │
+│      Codex · 12m           ┃ IDLE      │
+│  [G] daemon · main                     │
+│      Copilot CLI · 1m      ┃ ERROR     │
+└────────────────────────────────────────┘
+```
+
+- Header: 22pt strip with localized title `island.header.title` ("cmux Island"). No close button; click-outside handles it.
+- Row: 56pt tall, 8pt vertical spacing, 12pt internal padding.
+- Leading chip: 20pt rounded square, `IslandAgentKind.color`, monogram in white bold.
+- Line 1: `workspaceTitle · panelTitle`, head-tail truncated if wider than the row content area.
+- Line 2: `agentKind.displayName · <elapsed>` in 11pt secondary text. Elapsed is derived from `lastActivity` and re-computed once per second while expanded, never while collapsed.
+- Trailing: phase pill (`RUNNING` / `IDLE` / `WAITING` / `ERROR` / `UNKNOWN`) with a phase-specific background + foreground color, plus a `· N` unread badge when `unreadCount > 0`.
+- Max visible rows without scrolling: 8. 9+ enables a vertical scroller inside the expanded panel; shape height caps at 540pt.
+
+### 6.5 Interactions
+
+| Trigger                                    | Effect                                                          |
+|--------------------------------------------|-----------------------------------------------------------------|
+| Click collapsed pill                       | Expand (spring animation)                                       |
+| Click row                                  | `IslandJumpRouter.jump(to: session)`, then collapse             |
+| Click outside expanded panel               | Collapse                                                        |
+| Press `Esc` while opened                   | Collapse                                                        |
+| Session list changes while collapsed       | Pill updates in place (count + dot color); no auto-expand       |
+| Session list becomes empty                 | `window.orderOut(nil)` and stop redraw timers                   |
+| Session list becomes non-empty from empty  | `window.orderFront(nil)`, start in closed state                 |
+
+No hover-to-expand in MVP.
+
+### 6.6 Jump routing
+
+`IslandJumpRouter.jump(to: session)` performs the following, in order, against `IslandFocusSink`:
+
+1. `activateAppBringingToFront()` — this is the single place in the island code that is allowed to activate cmux. The call is an explicit user focus intent (the click), which satisfies the focus-intent exception in cmux's socket focus policy (CLAUDE.md §"Socket focus policy"). No other island code path activates the app.
+2. `selectWorkspace(session.workspaceId)` — routes through the same code path that the existing `workspace.select` socket command uses.
+3. `focusPanel(session.panelId)` — routes through the same code path that the existing `pane.focus` / `surface.focus` socket commands use.
+4. `collapseIsland(reason: .jumped)`.
+
+If any of steps 2 or 3 fail (workspace or panel no longer exists), the router logs a single `dlog("island.jump failed…")` in DEBUG builds and collapses the island without activating cmux. No error UI in MVP.
+
+### 6.7 Non-notch Mac behavior
+
+- `viewModel.hasPhysicalNotch` is used only to drive the initial fade-in opacity.
+- The same `NotchShape` is drawn. With no physical cutout between the inward top corners, it reads as a floating dark pill centered at the top of the screen.
+- All other behavior (projection, visibility, expand, collapse, routing) is identical.
+
+## 7. Configuration and opt-in
+
+### 7.1 Source of truth
+
+`@AppStorage("island.enabled")` is the single source of truth.
+
+Mirrored in `~/.config/cmux/settings.json`:
+
+```json
+{
+  "island": {
+    "enabled": false
+  }
+}
+```
+
+`CmuxConfig.swift` gains an `IslandConfigSection` with one boolean. The existing `CmuxConfigExecutor` pipeline handles reload-on-change so that editing the file is equivalent to flipping the Settings toggle. Default value is `false`.
+
+### 7.2 Settings UI
+
+A new sidebar entry **"Island"** is added to the Settings window, positioned after "Notifications". Contents:
+
+- Single toggle: **"Show agent session island overlay"** (key `island.settings.enable.label`).
+- Descriptive help text under the toggle explaining what it does, when it appears, and which known-agent keys it looks at — localized strings only.
+
+All strings live in `Resources/Localizable.xcstrings` with English + Japanese per CLAUDE.md. Keys:
+
+- `island.settings.title`
+- `island.settings.enable.label`
+- `island.settings.enable.help`
+- `island.settings.known_kinds.help`
+- `island.header.title`
+- `island.phase.running`, `island.phase.idle`, `island.phase.waiting`, `island.phase.error`, `island.phase.unknown`
+- `island.tooltip.raw_status` (debug-window row tooltip, DEBUG only)
+
+### 7.3 Debug UI (DEBUG builds only)
+
+Under `Debug > Debug Windows`, add an alphabetically-ordered entry **"Island Controller"** that opens a singleton `NSWindowController` containing:
+
+- An "Enable island" toggle bound to the same `island.enabled` key (not a separate preference).
+- A live table of the current `IslandSession` rows showing `workspaceId`, `panelId`, `agentKind`, `phase`, `rawStatusValue`, `unreadCount`, `lastActivity`.
+- An "Inject test session" button that pushes a synthetic `IslandSession` through the store for visual iteration without needing a real agent running.
+
+Per CLAUDE.md this is wrapped in `#if DEBUG` / `#endif`.
+
+### 7.4 Discoverability
+
+No first-run prompt, no in-app tip, no notification. Release notes and `CHANGELOG.md` announce the feature and instruct users to toggle it on.
+
+## 8. Testing
+
+Per CLAUDE.md "Test quality policy", tests exercise observable runtime behavior. Per "Testing policy", tests run in CI (`cmux-unit` scheme / `test-e2e.yml`), never locally.
+
+### 8.1 Unit tests (`cmuxTests/Island/`)
+
+1. **`IslandSessionPhaseTests`** — pure function tests over `IslandSessionPhase.from(rawValue:)`. Every synonym in §5.3 maps to the expected phase; unknown strings map to `.unknown`. Table-driven.
+
+2. **`IslandStateStoreProjectionTests`** — store constructed with a fake `IslandStateSource` (a protocol wrapping the minimum `TabManager` surface the store reads). Assertions:
+   - Workspace with no known-kind entries → zero sessions.
+   - Workspace with `statusEntries["claude_code"] = Running` → exactly one session with the right fields.
+   - Two known-kind entries on the same panel → highest-priority wins per §5.2.
+   - `unreadCount` is read from the notification source, never guessed.
+   - Clearing a status entry removes the corresponding session in the next emission.
+   - Updating `panelTitle` rewrites the emitted session without changing `id`.
+
+3. **`IslandSessionSortTests`** — ordering predicate. Asserts running → waiting → error → idle → unknown, tiebreak by `lastActivity` descending.
+
+4. **`IslandVisibilityTests`** — given a `sessions: [IslandSession]` publisher stream, asserts the downstream `visible: Bool` stream matches §5.4.
+
+5. **`IslandJumpRouterTests`** — router depends only on `IslandFocusSink`. Spy implementation records calls. Test verifies `jump(to: session)` produces the sequence `activate → selectWorkspace(id) → focusPanel(id) → collapse`. A test for the "workspace deleted" edge case verifies the router collapses without calling `activate`.
+
+6. **`IslandConfigRoundTripTests`** — `island.enabled` written via `@AppStorage` round-trips through `CmuxConfig` → `settings.json` → `CmuxConfig`, so editing the file is equivalent to the Settings toggle.
+
+### 8.2 Non-goals for automated tests
+
+- Snapshot tests of `NotchShape`. Per CLAUDE.md these would be source-shape tests. Instead, the debug-window "Inject test session" path lets a reviewer verify the shape interactively during PR review.
+- NSPanel lifecycle on full screen / space switches / multi-display. Too environment-dependent for unit tests. Covered by a manual PR smoke-test checklist (see §9).
+- `IslandJumpRouter`'s downstream effect on `TabManager` — the existing `workspace.select` / `pane.focus` tests already exercise that code path; we don't duplicate.
+
+### 8.3 Regression test commit policy
+
+Per CLAUDE.md, bugs discovered during implementation that warrant a regression test follow the two-commit pattern: failing test first, fix second.
+
+## 9. Manual PR smoke test checklist
+
+The reviewer runs the following against a tagged `reload.sh --tag island-mvp` build:
+
+1. Settings → Island → toggle on; no sessions yet → island should **not** appear.
+2. In a cmux terminal, run `cmux set-status claude_code Running` → pill appears with green dot, count `1`.
+3. Click the pill → expands; row shows the current workspace + panel, phase RUNNING, elapsed 0m counting up.
+4. Click outside the panel → collapses.
+5. In a second workspace, `cmux set-status codex Idle` → collapsed pill still visible, count `2`, dot still green (because Claude Code is still running).
+6. `cmux set-status claude_code Error` → dot turns red.
+7. Click the pill → expand → click the Claude Code row → cmux comes to front, the Claude Code workspace is selected, the panel is focused.
+8. `cmux clear-status claude_code` on the first workspace → row disappears; count drops to `1`.
+9. `cmux clear-status codex` on the second → row disappears; island orderOut's with no artifacts.
+10. Switch to another Space, then to a full-screen app → island follows (`.canJoinAllSpaces`, `.fullScreenAuxiliary`).
+11. Rapidly toggle Settings → Island off/on 10 times → no leftover panel, no orphaned observers (verified via Debug > Debug Windows > Island Controller live row count resetting correctly).
+12. On a non-notch Mac: island renders as a floating pill at top-center; all other behavior identical.
+
+## 10. Phase 2+ extension points (not built in this PR)
+
+| Extension                                       | How the MVP enables it                                                                                                                                                                                                                                                            |
+|-------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Pending permission approvals                    | Add an `IslandPendingApproval` case the store projects alongside sessions. Row template gains approve/deny buttons. New `cmux approve`/`cmux deny` CLI or blocking socket RPC. No existing MVP code changes — the row model is additive.                                         |
+| Extraction to `cmuxIsland.app`                  | Swap `IslandStateStore` for a `SocketIslandStateProvider` that subscribes to a new `island.subscribe` socket command streaming `IslandSession` JSON. The SwiftUI layer already only depends on `IslandStateProvider`.                                                             |
+| Multi-display                                   | Promote the singleton `IslandWindowController` to a `[CGDirectDisplayID: IslandWindowController]` dictionary, plus a Settings dropdown to pick which displays get an island.                                                                                                      |
+| Explicit session CLI (`cmux session start`)     | Adds a third source to `IslandStateStore` alongside `statusEntries` and `notifications`. No UI changes.                                                                                                                                                                           |
+| Mark-read from island                           | Add `IslandActionSink` next to `IslandFocusSink`; route clicks on the unread badge to `TerminalNotificationStore.markRead(panelId:)`.                                                                                                                                             |
+| Hover-to-expand                                 | One-line addition in `IslandRootView` (`.onHover { … }`).                                                                                                                                                                                                                         |
+| Auto-dismiss idle rows after N minutes          | Add an optional `idleTTL: TimeInterval` to `IslandStateStore` and drop expired rows during projection. Off by default.                                                                                                                                                            |
+
+## 11. References
+
+- **Issue:** manaflow-ai/cmux#2590.
+- **Claude Island** (code reference, Apache 2.0): https://github.com/farouqaldori/claude-island. Port `NotchPanel`, `NotchShape`, and the `NSPanel` configuration directly; do **not** port `ClaudeSessionMonitor`, `HookSocketServer`, or `HookInstaller` — those implement a hook-driven session model that is out of scope for cmux Island MVP.
+- **Vibe Island** (UX reference, closed source): https://vibeisland.app. Referenced only for interaction model (click row → jump) and the four-verbs framing (Monitor / Approve / Ask / Jump — MVP covers Monitor + Jump only).
+- **cmux notifications / set-status convention:** `docs/notifications.md`.
+- **cmux focus policy:** `CLAUDE.md` §"Socket focus policy".
+- **cmux test quality policy:** `CLAUDE.md` §"Test quality policy" and §"Testing policy".
+- **cmux localization requirement:** `CLAUDE.md` §"Pitfalls" — user-facing strings via `Resources/Localizable.xcstrings`.
+- **cmux debug menu convention:** `CLAUDE.md` §"Debug menu".


### PR DESCRIPTION
Sorry, I didn't want to open the PR yet, I'm just playing around at this moment 🙏
----

## Summary

- Adds the MVP of **cmux Island** — a notch-anchored Dynamic Island style overlay that lists active AI-agent sessions running inside cmux and routes clicks to the corresponding workspace + terminal split.
- Reads sessions from existing `cmux set-status` entries with known agent keys (`claude_code`, `codex`, `copilot_cli`, `opencode`, `gemini_cli`, `cursor`, `amp`, `droid`). **Zero new CLI surface** — existing hook integrations in `docs/notifications.md` light up automatically.
- **Opt-in from Settings → Island** (off by default). Mirrored in `~/.config/cmux/settings.json` under `"island": { "enabled": true }` via the existing `CmuxSettingsFileStore` pipeline.
- New module at `Sources/Island/` with a narrow `IslandStateProvider` / `IslandFocusSink` seam so the feature can be extracted to a companion `cmuxIsland.app` target later without touching call sites.

Closes #2590 (MVP scope only — approvals, companion-app extraction, and multi-display are explicit Phase 2+ non-goals documented in the spec).

## Architecture

```
Sources/Island/
├── IslandSettings.swift          UserDefaults key + default
├── IslandSession.swift           IslandAgentKind / Phase / Session value types
├── IslandStateProvider.swift     read seam + IslandStateSource + InMemoryIslandStateSource
├── IslandStateStore.swift        debounced Combine projection + TabManagerIslandStateSource
├── IslandFocusSink.swift         write seam + TabManagerIslandFocusSink
├── IslandJumpRouter.swift        click → activate/select/focus/collapse sequence
├── NotchShape.swift              SwiftUI Shape (port from farouqaldori/claude-island, Apache 2.0)
├── NotchPanel.swift              NSPanel subclass (adapted from claude-island, Apache 2.0)
├── IslandRootView.swift          SwiftUI closed pill + expanded row list
└── IslandWindowController.swift  NSWindowController owning the NotchPanel
```

`AppDelegate` observes `UserDefaults.didChangeNotification` for `IslandSettings.enabledKey` and creates/destroys the controller reactively.

## References

- **Spec:** [`docs/superpowers/specs/2026-04-09-cmux-island-design.md`](docs/superpowers/specs/2026-04-09-cmux-island-design.md) — 11 sections covering module layout, data model, projection rules, UI geometry, opt-in, testing, smoke-test checklist, Phase 2 extension points.
- **Plan:** [`docs/superpowers/plans/2026-04-09-cmux-island.md`](docs/superpowers/plans/2026-04-09-cmux-island.md) — 20 TDD tasks.
- **Reference port:** [`farouqaldori/claude-island`](https://github.com/farouqaldori/claude-island) (Apache 2.0). Only `NotchShape.swift`, `NotchPanel` configuration, and the NSPanel mechanics were ported. `ClaudeSessionMonitor`, `HookSocketServer`, and `HookInstaller` from upstream were **not** ported — those implement a hook-driven session model that is out of scope for the cmux Island MVP. Attribution added to `THIRD_PARTY_LICENSES.md`.

## Tests

New unit tests under `cmuxTests/` (run via `cmux-unit` scheme in CI, never locally per CLAUDE.md):

- `IslandSessionPhaseTests` — 5 tests covering the phase-normalization synonym table (`running_tool`, `waiting_for_input`, case-insensitive + trim-tolerant lookup).
- `IslandSessionSortTests` — 3 tests covering phase-rank priority + recency tie-break.
- `IslandStateStoreTests` — 5 tests covering empty source, single-session emission (debounced), sort on init-snapshot path, sort on tick path, and clearing.
- `IslandJumpRouterTests` — 3 tests covering happy path, workspace-gone short-circuit, panel-gone continuation.
- `IslandSettingsFileStoreTests` — 4 tests covering `settings.json` round-trip through the `CmuxSettingsFileStore` parser + whitelist membership.

No snapshot tests of `NotchShape` per CLAUDE.md test quality policy (those would be source-shape tests). Visual verification is manual via the Debug menu.

## Known MVP limitations (documented for Phase 2)

- **Workspace-scoped session projection.** A workspace with two panels running different agents produces one island row (the highest-priority `set-status` entry), bound to the workspace's focused panel. Panel-specific `set-status --tab` resolution is Phase 2.
- **Unread count is workspace-scoped, gated by a per-panel unread flag.** `TerminalNotificationStore` has no public per-panel count API today; the implementation gates the workspace count by `hasUnreadNotification(forTabId:surfaceId:)` and falls back to 0. Documented in an in-code TODO.
- **`island.enabled = true` via `settings.json` before launch.** There is a narrow launch-time race where `AppDelegate.tabManager` (a `weak var`) may not yet be assigned when the island enable observer fires synchronously on `.prepend(...)`. For users who flip the toggle at runtime (expected primary path), this is a non-issue. For pre-enabled users, a toggle round-trip in Settings will reliably create the controller.
- **Sort stability at identical priority + timestamp.** `Dictionary.values.sorted` is not stable-by-insertion-order; if two status entries in the same workspace collide on both fields, the winner can flap. Acceptable for MVP (display-only effect).
- **Relative time units** in expanded rows use hardcoded English `s/m/h/d` suffixes. Localization keys for these can be added in Phase 2.

## Phase 2+ extension points (not built)

- Pending permission approvals (approve/deny buttons) — additive to the row model, requires a new `cmux approve`/`cmux deny` CLI or blocking socket RPC.
- Extraction to a separate `cmuxIsland.app` target — swap `IslandStateStore` for a `SocketIslandStateProvider`; the SwiftUI layer already depends only on the protocol.
- Multi-display support, hover-to-expand, mark-read from island, auto-dismiss idle rows.

## Test plan

- [ ] **CI unit tests:** `xcodebuild -scheme cmux-unit` via CI. Expect all `Island*Tests` classes green.
- [ ] **Tagged Debug build smoke test:** `./scripts/reload.sh --tag island-mvp` then walk the spec §9 12-step checklist on a notch-equipped Mac:
  - [ ] Settings → Island toggle on while no sessions exist → island stays hidden
  - [ ] `cmux set-status claude_code Running` → pill appears with green dot, count 1
  - [ ] Click pill → expands; row shows workspace + panel, phase RUNNING, elapsed counts up
  - [ ] Click outside → collapses
  - [ ] `cmux set-status codex Idle` in a second workspace → count 2, dot still green
  - [ ] `cmux set-status claude_code Error` → dot turns red
  - [ ] Click pill → expand → click Claude Code row → cmux comes to front, workspace selected, panel focused
  - [ ] `cmux clear-status claude_code` → row disappears
  - [ ] `cmux clear-status codex` → island orderOuts with no artifacts
  - [ ] Space / full-screen switching → island follows (`.canJoinAllSpaces`, `.fullScreenAuxiliary`)
  - [ ] Rapidly toggle Settings → Island off/on 10 times → no leftover panels or observers
  - [ ] On a non-notch Mac: island renders as a floating pill at top-center
- [ ] **Debug window** (DEBUG builds only): `Debug > Debug Windows > Island Controller…` → inject synthetic sessions → verify notch shape + row layout render correctly
- [ ] Review the commit history (28 commits, each ≤1 file group, TDD where applicable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the opt-in cmux Island: a notch-anchored overlay that shows active agent sessions from `cmux set-status` and lets you jump to the right workspace and terminal split in one click. Off by default; enable in Settings → Island or via `~/.config/cmux/settings.json`.

- New Features
  - Detects sessions from known keys (e.g., `claude_code`, `codex`, `copilot_cli`) with zero new CLI surface.
  - Click a row → activate app, select workspace, focus panel, then collapse.
  - New module: `IslandStateStore`, `IslandStateProvider`, `IslandJumpRouter`, `IslandWindowController`, `IslandRootView`.
  - Debug menu (DEBUG): “Island Controller…” to inject and clear test sessions.
  - Ports `NotchShape` and `NotchPanel` from `farouqaldori/claude-island` (Apache 2.0); licenses updated.
  - Tests added for phase normalization, sort order, state store, jump routing, and settings parser.

- Migration
  - No CLI changes.
  - To enable: Settings → Island, or set `"island": { "enabled": true }` in `~/.config/cmux/settings.json`.

<sup>Written for commit f5b0f8bc3d92e20ce11149e456315e55a48f6378. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added cmux Island: an opt-in always-on-top overlay displaying active AI agent sessions with status indicators and unread counts, enabling click-to-jump navigation to relevant workspaces and panels. Configurable in Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->