### PR TITLE
Add latest macOS launch crash smoke test

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -16,10 +16,12 @@ jobs:
             timeout: 30
             smoke: true
             skip_zig: false
+            launch_smoke_ui: false
           - os: warp-macos-26-arm64-6x
             timeout: 30
             smoke: false
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
+            launch_smoke_ui: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
@@ -162,6 +164,22 @@ jobs:
               exit 1
             fi
           fi
+
+      - name: Launch smoke test on latest macOS lane
+        if: matrix.launch_smoke_ui
+        env:
+          CMUX_SKIP_ZIG_BUILD: ${{ matrix.skip_zig && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+            CMUX_SKIP_ZIG_BUILD="$CMUX_SKIP_ZIG_BUILD" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            -maximum-test-execution-time-allowance 120 \
+            -only-testing:cmuxUITests/LatestMacOSLaunchSmokeUITests \
+            test
 
       - name: Create virtual display
         if: matrix.smoke

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,11 +17,13 @@ jobs:
             smoke: true
             skip_zig: false
             launch_smoke_ui: false
+            direct_startup_probe: false
           - os: warp-macos-26-arm64-6x
             timeout: 30
             smoke: false
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
             launch_smoke_ui: true
+            direct_startup_probe: true
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
@@ -180,6 +182,27 @@ jobs:
             -maximum-test-execution-time-allowance 120 \
             -only-testing:cmuxUITests/LatestMacOSLaunchSmokeUITests \
             test
+
+      - name: Build app for direct startup crash probe
+        if: matrix.direct_startup_probe
+        env:
+          CMUX_SKIP_ZIG_BUILD: ${{ matrix.skip_zig && '1' || '0' }}
+        run: |
+          set -euo pipefail
+          SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
+          xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug \
+            CMUX_SKIP_ZIG_BUILD="$CMUX_SKIP_ZIG_BUILD" \
+            -clonedSourcePackagesDirPath "$SOURCE_PACKAGES_DIR" \
+            -disableAutomaticPackageResolution \
+            -destination "platform=macOS" \
+            build
+
+      - name: Run direct startup crash probe
+        if: matrix.direct_startup_probe
+        run: |
+          set -euo pipefail
+          chmod +x scripts/startup-crash-probe-ci.sh
+          ITERATIONS=10 STABILITY_SECONDS=8 scripts/startup-crash-probe-ci.sh
 
       - name: Create virtual display
         if: matrix.smoke

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 			B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */; };
 			B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */; };
 			B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
+			B9100002A1B2C3D4E5F60719 /* LatestMacOSLaunchSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9100001A1B2C3D4E5F60719 /* LatestMacOSLaunchSmokeUITests.swift */; };
 			C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 			C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
 			E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
@@ -276,6 +277,7 @@
 		818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarResizeUITests.swift; sourceTree = "<group>"; };
 		B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHelpMenuUITests.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
+		B9100001A1B2C3D4E5F60719 /* LatestMacOSLaunchSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatestMacOSLaunchSmokeUITests.swift; sourceTree = "<group>"; };
 		C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillUITests.swift; sourceTree = "<group>"; };
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -567,6 +569,7 @@
 							818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */,
 							B8F266256A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift */,
 							B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
+							B9100001A1B2C3D4E5F60719 /* LatestMacOSLaunchSmokeUITests.swift */,
 							C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
 							E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */,
 							D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */,
@@ -867,6 +870,7 @@
 							B8F266236A1A3D9A45BD840F /* SidebarResizeUITests.swift in Sources */,
 							B8F266246A1A3D9A45BD840F /* SidebarHelpMenuUITests.swift in Sources */,
 							B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */,
+							B9100002A1B2C3D4E5F60719 /* LatestMacOSLaunchSmokeUITests.swift in Sources */,
 							C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */,
 							E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */,
 							D0E0F0B0A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift in Sources */,

--- a/cmuxUITests/LatestMacOSLaunchSmokeUITests.swift
+++ b/cmuxUITests/LatestMacOSLaunchSmokeUITests.swift
@@ -3,16 +3,32 @@ import Foundation
 
 final class LatestMacOSLaunchSmokeUITests: XCTestCase {
     private let launchTag = "ui-tests-latest-macos-launch-smoke"
+    private var launchHomeDirectory: URL?
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
+        launchHomeDirectory = makeIsolatedHomeDirectory()
     }
 
-    func testAppLaunchDoesNotCrashOnStartup() {
+    override func tearDown() {
+        if let launchHomeDirectory {
+            try? FileManager.default.removeItem(at: launchHomeDirectory)
+        }
+        launchHomeDirectory = nil
+        super.tearDown()
+    }
+
+    func testAppLaunchDoesNotCrashOnStartupWithManagedAppIconSettings() throws {
+        guard let launchHomeDirectory else {
+            XCTFail("Missing isolated HOME directory")
+            return
+        }
+        try writeManagedSettingsFixture(into: launchHomeDirectory)
+
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_TAG"] = launchTag
-        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["HOME"] = launchHomeDirectory.path
 
         launchAllowingHeadlessBackgroundState(app)
 
@@ -65,5 +81,35 @@ final class LatestMacOSLaunchSmokeUITests: XCTestCase {
 
     private func isRunning(_ app: XCUIApplication) -> Bool {
         app.state == .runningForeground || app.state == .runningBackground
+    }
+
+    private func makeIsolatedHomeDirectory() -> URL {
+        let path = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-ui-test-home-\(UUID().uuidString)", isDirectory: true)
+        try? FileManager.default.createDirectory(
+            at: path,
+            withIntermediateDirectories: true
+        )
+        return path
+    }
+
+    private func writeManagedSettingsFixture(into homeDirectory: URL) throws {
+        let configDirectory = homeDirectory
+            .appendingPathComponent(".config", isDirectory: true)
+            .appendingPathComponent("cmux", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: configDirectory,
+            withIntermediateDirectories: true
+        )
+        let settingsURL = configDirectory.appendingPathComponent("settings.json", isDirectory: false)
+        let settings = """
+        {
+          "schemaVersion": 1,
+          "app": {
+            "appIcon": "automatic"
+          }
+        }
+        """
+        try settings.write(to: settingsURL, atomically: true, encoding: .utf8)
     }
 }

--- a/cmuxUITests/LatestMacOSLaunchSmokeUITests.swift
+++ b/cmuxUITests/LatestMacOSLaunchSmokeUITests.swift
@@ -1,0 +1,69 @@
+import XCTest
+import Foundation
+
+final class LatestMacOSLaunchSmokeUITests: XCTestCase {
+    private let launchTag = "ui-tests-latest-macos-launch-smoke"
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+    }
+
+    func testAppLaunchDoesNotCrashOnStartup() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+
+        launchAllowingHeadlessBackgroundState(app)
+
+        XCTAssertTrue(
+            waitForAppToStart(app, timeout: 20.0),
+            "Expected cmux to start on latest macOS. state=\(app.state.rawValue)"
+        )
+
+        XCTAssertTrue(
+            waitForNoImmediateCrash(app, duration: 10.0),
+            "Expected cmux to remain running for startup stability window. state=\(app.state.rawValue)"
+        )
+
+        if isRunning(app) {
+            app.terminate()
+        }
+    }
+
+    private func launchAllowingHeadlessBackgroundState(_ app: XCUIApplication) {
+        // Some CI runners launch in background-only mode, which can emit an
+        // activation failure even when the process is healthy.
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            app.launch()
+        }
+    }
+
+    private func waitForAppToStart(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if isRunning(app) {
+                return true
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+        return isRunning(app)
+    }
+
+    private func waitForNoImmediateCrash(_ app: XCUIApplication, duration: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(duration)
+        while Date() < deadline {
+            if !isRunning(app) {
+                return false
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.2))
+        }
+        return true
+    }
+
+    private func isRunning(_ app: XCUIApplication) -> Bool {
+        app.state == .runningForeground || app.state == .runningBackground
+    }
+}

--- a/scripts/startup-crash-probe-ci.sh
+++ b/scripts/startup-crash-probe-ci.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ITERATIONS="${ITERATIONS:-8}"
+STABILITY_SECONDS="${STABILITY_SECONDS:-8}"
+APP_ICON_MODES="${APP_ICON_MODES:-automatic light dark}"
+LOG_DIR="${TMPDIR:-/tmp}/cmux-startup-crash-probe-logs"
+
+mkdir -p "$LOG_DIR"
+
+APP_PATH="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Debug/cmux DEV.app" -print -quit 2>/dev/null || true)"
+if [[ -z "$APP_PATH" ]]; then
+  echo "ERROR: could not find built cmux DEV.app in DerivedData" >&2
+  exit 1
+fi
+
+BINARY_PATH="$APP_PATH/Contents/MacOS/cmux DEV"
+if [[ ! -x "$BINARY_PATH" ]]; then
+  echo "ERROR: missing executable at $BINARY_PATH" >&2
+  exit 1
+fi
+
+HOST_HOME="$HOME"
+
+write_settings_fixture() {
+  local target_home="$1"
+  local mode="$2"
+  local config_dir="$target_home/.config/cmux"
+  local fallback_dir="$target_home/Library/Application Support/com.cmuxterm.app"
+
+  mkdir -p "$config_dir" "$fallback_dir"
+
+  cat > "$config_dir/settings.json" <<EOF
+{
+  "schemaVersion": 1,
+  "app": {
+    "appIcon": "$mode"
+  }
+}
+EOF
+
+  # Also write the fallback path that CmuxSettingsFileStore knows about.
+  cp "$config_dir/settings.json" "$fallback_dir/settings.json"
+}
+
+print_crash_diagnostics() {
+  local test_home="$1"
+
+  echo "=== Recent DiagnosticReports in test HOME ==="
+  ls -lt "$test_home/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || echo "(none)"
+
+  echo "=== Recent DiagnosticReports in host HOME ==="
+  ls -lt "$HOST_HOME/Library/Logs/DiagnosticReports" 2>/dev/null | head -n 5 || echo "(none)"
+
+  local latest
+  latest="$(
+    ls -t \
+      "$test_home"/Library/Logs/DiagnosticReports/*cmux* \
+      "$HOST_HOME"/Library/Logs/DiagnosticReports/*cmux* 2>/dev/null | head -n 1 || true
+  )"
+  if [[ -n "$latest" ]]; then
+    echo "=== Crash excerpt ($latest) ==="
+    sed -n '1,120p' "$latest" || true
+  fi
+}
+
+echo "=== Startup crash probe ==="
+echo "App path: $APP_PATH"
+echo "Iterations: $ITERATIONS"
+echo "Modes: $APP_ICON_MODES"
+echo "Stability seconds per launch: $STABILITY_SECONDS"
+
+for iteration in $(seq 1 "$ITERATIONS"); do
+  for mode in $APP_ICON_MODES; do
+    probe_home="$(mktemp -d "${TMPDIR:-/tmp}/cmux-startup-probe-home.${iteration}.${mode}.XXXXXX")"
+    write_settings_fixture "$probe_home" "$mode"
+
+    tag="startup-probe-${mode}-${iteration}-${RANDOM}"
+    log_file="$LOG_DIR/${iteration}-${mode}.log"
+
+    echo "--- Launch iteration=$iteration mode=$mode tag=$tag ---"
+    HOME="$probe_home" CMUX_TAG="$tag" CMUX_SOCKET_MODE=allowAll "$BINARY_PATH" >"$log_file" 2>&1 &
+    app_pid=$!
+
+    launch_failed=0
+    deadline=$((SECONDS + STABILITY_SECONDS))
+    while [[ $SECONDS -lt $deadline ]]; do
+      if ! kill -0 "$app_pid" 2>/dev/null; then
+        launch_failed=1
+        break
+      fi
+      sleep 0.25
+    done
+
+    if [[ "$launch_failed" -eq 1 ]]; then
+      echo "ERROR: app exited early for iteration=$iteration mode=$mode tag=$tag" >&2
+      echo "=== App log ($log_file) ==="
+      tail -n 200 "$log_file" || true
+      print_crash_diagnostics "$probe_home"
+      rm -rf "$probe_home"
+      exit 1
+    fi
+
+    if kill -0 "$app_pid" 2>/dev/null; then
+      kill "$app_pid" 2>/dev/null || true
+      wait "$app_pid" 2>/dev/null || true
+    fi
+
+    rm -rf "$probe_home"
+  done
+done
+
+echo "=== Startup crash probe passed ==="


### PR DESCRIPTION
## Summary
- add `LatestMacOSLaunchSmokeUITests`, a startup smoke test that launches cmux and verifies it stays alive through startup on latest macOS CI runners
- seed an isolated HOME with managed `~/.config/cmux/settings.json` (`app.appIcon = automatic`) before launch so the test exercises the same managed app-icon startup path reported in https://github.com/manaflow-ai/cmux/issues/2763
- run the launch smoke class in `.github/workflows/ci-macos-compat.yml` on the macOS 26 lane (latest 26.x)

## Testing
- `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=task-latest-macos-launch-crash-smoke -f test_filter=LatestMacOSLaunchSmokeUITests -f runner=depot-macos-latest -f record_video=false -f test_timeout=120` (pass): https://github.com/manaflow-ai/cmux/actions/runs/24219770310
- same command after managed-settings extension (pass): https://github.com/manaflow-ai/cmux/actions/runs/24220152178
- `compat-tests (warp-macos-26-arm64-6x, 30, false, true, true)` for latest commit: pending at https://github.com/manaflow-ai/cmux/actions/runs/24220149171/job/70709620736

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/2763


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added UI smoke tests to validate app launch stability on latest macOS versions.
  * Added automated startup crash detection probes to catch launch issues across multiple configurations.

* **Chores**
  * Updated CI workflow configuration to run additional test suites on different macOS versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->