### PR TITLE
Fix command-hold shortcut hints and prevent sidebar truncation

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10154,8 +10154,6 @@ enum ShortcutHintModifierPolicy {
         for modifierFlags: NSEvent.ModifierFlags,
         defaults: UserDefaults = .standard
     ) -> Bool {
-        let shortcut = KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
-        guard !shortcut.hasChord else { return false }
         let normalized = modifierFlags.intersection(.deviceIndependentFlagsMask)
             .subtracting([.numericPad, .function, .capsLock])
         guard normalized == [.command] else {
@@ -12378,18 +12376,8 @@ enum SidebarTrailingAccessoryWidthPolicy {
     static let closeButtonWidth: CGFloat = 16
 
     static func width(
-        canCloseWorkspace: Bool,
-        showsWorkspaceShortcutHint: Bool,
-        workspaceShortcutLabel: String?,
-        debugXOffset: Double
+        canCloseWorkspace: Bool
     ) -> CGFloat {
-        if showsWorkspaceShortcutHint, let workspaceShortcutLabel {
-            return SidebarWorkspaceShortcutHintMetrics.slotWidth(
-                label: workspaceShortcutLabel,
-                debugXOffset: debugXOffset
-            )
-        }
-
         return canCloseWorkspace ? closeButtonWidth : 0
     }
 }
@@ -12601,10 +12589,7 @@ private struct TabItemView: View, Equatable {
 
     private var trailingAccessoryWidth: CGFloat {
         SidebarTrailingAccessoryWidthPolicy.width(
-            canCloseWorkspace: canCloseWorkspace,
-            showsWorkspaceShortcutHint: showsWorkspaceShortcutHint,
-            workspaceShortcutLabel: workspaceShortcutLabel,
-            debugXOffset: sidebarShortcutHintXOffset
+            canCloseWorkspace: canCloseWorkspace
         )
     }
 

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -797,6 +797,37 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
         }
     }
 
+    func testShortcutHintStaysCommandOnlyWhenWorkspaceShortcutUsesChord() {
+        let action = KeyboardShortcutSettings.Action.selectWorkspaceByNumber
+        let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
+        defer {
+            KeyboardShortcutSettings.setShortcut(originalShortcut, for: action)
+        }
+
+        KeyboardShortcutSettings.setShortcut(
+            StoredShortcut(
+                key: "1",
+                command: false,
+                shift: false,
+                option: false,
+                control: true,
+                chordKey: "2",
+                chordCommand: true,
+                chordShift: false,
+                chordOption: false,
+                chordControl: false
+            ),
+            for: action
+        )
+
+        withDefaultsSuite { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+        }
+    }
+
     func testShortcutHintUsesIntentionalHoldDelay() {
         XCTAssertEqual(ShortcutHintModifierPolicy.intentionalHoldDelay, 0.30, accuracy: 0.001)
     }


### PR DESCRIPTION
## Summary
- make command-hold hint reveal independent of workspace-number shortcut shape (including chorded remaps)
- keep control-hold behavior scoped to control-relevant pane hints
- stop reserving extra sidebar row width for shortcut hint pills so command-hold no longer forces title ellipsis
- add regression coverage for the chorded-remap command-hold policy
- update bonsplit submodule for pane-hint command-hold reveal policy and tests

## Linked submodule PR
- https://github.com/manaflow-ai/bonsplit/pull/93

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Command-hold shortcut hints so they always show, even when workspace-by-number uses a chorded remap. Also prevents sidebar title truncation by removing extra hint-pill width, while keeping Control-hold scoped to control-only hints.

- **Bug Fixes**
  - Show hints on Command-hold regardless of workspace-number shortcut shape (including chords).
  - Limit Control-hold to control-relevant pane hints.
  - Stop reserving sidebar width for hint pills to avoid title ellipsis on Command-hold.
  - Add regression test for the chorded-remap Command-hold policy.

- **Dependencies**
  - Update `vendor/bonsplit` to include the new hint-reveal policy and tests.

<sup>Written for commit f8dfdefa8620cfa5b9deefffeef509f5a590ce55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut hint display logic to ensure consistent behavior across different modifier key configurations, particularly for workspace shortcuts with chord modifiers.

* **Tests**
  * Added test coverage for keyboard shortcut hint behavior when using chord modifier combinations.

* **Chores**
  * Updated internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->