### PR TITLE
fix: prefer UTF-8 pasteboard type over MacRoman for paste

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -203,7 +203,22 @@ enum GhosttyPasteboardHelper {
     }
 
     private static func plainTextContents(from pasteboard: NSPasteboard) -> String? {
-        for type in pasteboard.types ?? [] {
+        let types = pasteboard.types ?? []
+
+        // Prefer known Unicode-safe types first. Types like
+        // "com.apple.traditional-mac-plain-text" conform to UTType.plainText
+        // but use MacRoman encoding, which corrupts non-ASCII text (e.g. Cyrillic).
+        // Qt-based apps such as Telegram may advertise that type before the
+        // UTF-8 variant, so we must check Unicode types before falling back to
+        // the generic conformance check.
+        for type in [NSPasteboard.PasteboardType.string, utf8PlainTextType] {
+            guard types.contains(type) else { continue }
+            if let value = pasteboard.string(forType: type), !value.isEmpty {
+                return value
+            }
+        }
+
+        for type in types {
             guard isPlainTextType(type) else { continue }
             guard let value = pasteboard.string(forType: type), !value.isEmpty else { continue }
             return value

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -205,17 +205,15 @@ enum GhosttyPasteboardHelper {
     private static func plainTextContents(from pasteboard: NSPasteboard) -> String? {
         let types = pasteboard.types ?? []
 
-        // Prefer known Unicode-safe types first. Types like
-        // "com.apple.traditional-mac-plain-text" conform to UTType.plainText
-        // but use MacRoman encoding, which corrupts non-ASCII text (e.g. Cyrillic).
-        // Qt-based apps such as Telegram may advertise that type before the
-        // UTF-8 variant, so we must check Unicode types before falling back to
-        // the generic conformance check.
-        for type in [NSPasteboard.PasteboardType.string, utf8PlainTextType] {
-            guard types.contains(type) else { continue }
-            if let value = pasteboard.string(forType: type), !value.isEmpty {
-                return value
-            }
+        // Prefer UTF-8 first. Types like "com.apple.traditional-mac-plain-text"
+        // conform to UTType.plainText but use MacRoman encoding, which corrupts
+        // non-ASCII text (e.g. Cyrillic). Qt-based apps such as Telegram may
+        // advertise that type before the UTF-8 variant, so we must check the
+        // Unicode-safe type before falling back to the generic conformance check.
+        // Note: .string == "public.utf8-plain-text" on modern macOS.
+        if types.contains(.string),
+           let value = pasteboard.string(forType: .string), !value.isEmpty {
+            return value
         }
 
         for type in types {


### PR DESCRIPTION
## Summary

Fixes a regression from #2467 where pasting non-ASCII text (Cyrillic, CJK, emoji) from Qt-based apps like Telegram produces `?` characters instead of the actual content.

**Root cause:** Qt apps advertise `com.apple.traditional-mac-plain-text` (MacRoman encoding) before `public.utf8-plain-text` in their pasteboard type order. The generic `UTType.plainText` conformance loop introduced in #2467 picks MacRoman first, which cannot represent non-ASCII characters.

**Fix:** Add a first-pass check for `NSPasteboardType.string` and `public.utf8-plain-text` before the generic conformance iteration. This preserves the Raycast fix from #2467 while ensuring Unicode content is always preferred when available.

Fixes #2756

## Test plan

- [ ] Copy Cyrillic text from Telegram Desktop, Cmd+V into cmux → should paste correctly
- [ ] Copy text from Raycast clipboard history → should still work (no regression from #2467 fix)
- [ ] Copy text from browser → should paste correctly
- [ ] Copy emoji from any app → should paste correctly
- [ ] `printf "Кириллица\n"` in terminal → should render correctly (unrelated to paste, sanity check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer UTF‑8/plain string pasteboard types when pasting to stop non‑ASCII text becoming `?` from Qt apps like Telegram. Keeps the Raycast clipboard behavior from #2467. Fixes #2756.

- **Bug Fixes**
  - Check `NSPasteboard.PasteboardType.string` (maps to `public.utf8-plain-text`) before iterating `UTType.plainText` types; remove redundant second UTF‑8 check.
  - Avoid selecting `com.apple.traditional-mac-plain-text` (MacRoman) when UTF‑8 is available.

<sup>Written for commit f1721b4323054229effdb984423c9925109a196f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plain-text extraction from the clipboard by prioritizing UTF‑8-capable text formats first, then falling back to other plain-text types. This reduces misinterpreted characters and makes paste operations more reliable across different text sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->