### PR TITLE
Fix shell integration (report_pwd) not injected — ZDOTDIR override

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1204,6 +1204,7 @@ class GhosttyApp {
     private(set) var defaultBackgroundColor: NSColor = .windowBackgroundColor
     private(set) var defaultBackgroundOpacity: Double = 1.0
     private(set) var usesHostLayerBackground = true
+    private(set) var userGhosttyShellIntegrationMode: String = "detect"
     private static func resolveBackgroundLogURL(
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> URL {
@@ -1624,6 +1625,12 @@ class GhosttyApp {
                 prefix: "cmux-layer-bg",
                 logLabel: "layer background (fallback)"
             )
+            loadInlineGhosttyConfig(
+                "shell-integration = none",
+                into: fallbackConfig,
+                prefix: "cmux-shell-integration-override",
+                logLabel: "shell integration override (fallback)"
+            )
             usesHostLayerBackground = true
             ghostty_config_finalize(fallbackConfig)
             updateDefaultBackground(from: fallbackConfig, source: "initialize.fallbackConfig")
@@ -1740,6 +1747,26 @@ class GhosttyApp {
                 logLabel: "layer background"
             )
         }
+        // Save the user's preference before we force it to none.
+        userGhosttyShellIntegrationMode = "detect"
+        do {
+            var value: UnsafePointer<Int8>?
+            let key = "shell-integration"
+            if ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))),
+               let value {
+                userGhosttyShellIntegrationMode = String(cString: value)
+            }
+        }
+
+        // Prevent Ghostty from overriding ZDOTDIR — cmux handles shell
+        // integration itself via the .zshenv bootstrap (#2594).
+        loadInlineGhosttyConfig(
+            "shell-integration = none",
+            into: config,
+            prefix: "cmux-shell-integration-override",
+            logLabel: "shell integration override"
+        )
+
         ghostty_config_finalize(config)
     }
 
@@ -2490,17 +2517,6 @@ class GhosttyApp {
         let key = "macos-applescript"
         _ = ghostty_config_get(config, &enabled, key, UInt(key.lengthOfBytes(using: .utf8)))
         return enabled
-    }
-
-    fileprivate func shellIntegrationMode() -> String {
-        guard let config else { return "detect" }
-        var value: UnsafePointer<Int8>?
-        let key = "shell-integration"
-        guard ghostty_config_get(config, &value, key, UInt(key.lengthOfBytes(using: .utf8))),
-              let value else {
-            return "detect"
-        }
-        return String(cString: value)
     }
 
     private func bellFeatures() -> CUnsignedInt {
@@ -4157,7 +4173,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 ?? "/bin/zsh"
             let shellName = URL(fileURLWithPath: shell).lastPathComponent
             if shellName == "zsh" {
-                if GhosttyApp.shared.shellIntegrationMode() != "none" {
+                if GhosttyApp.shared.userGhosttyShellIntegrationMode != "none" {
                     setManagedEnvironmentValue("CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION", "1")
                 }
                 let candidateZdotdir = (env["ZDOTDIR"]?.isEmpty == false ? env["ZDOTDIR"] : nil)
@@ -4181,7 +4197,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
                 setManagedEnvironmentValue("ZDOTDIR", integrationDir)
             } else if shellName == "bash" {
-                if GhosttyApp.shared.shellIntegrationMode() != "none" {
+                if GhosttyApp.shared.userGhosttyShellIntegrationMode != "none" {
                     setManagedEnvironmentValue("CMUX_LOAD_GHOSTTY_BASH_INTEGRATION", "1")
                 }
                 // macOS ships /bin/bash 3.2, where Ghostty's automatic bash


### PR DESCRIPTION
## Summary

- Ghostty's `shell-integration=detect` (default) overrides `ZDOTDIR` inside `ghostty_surface_new`, clobbering the value cmux sets for its `.zshenv` bootstrap. This prevents `_cmux_precmd` from being registered, so `report_pwd` never fires and the sidebar cwd goes stale.
- Force `shell-integration=none` in the Ghostty config so Ghostty doesn't touch `ZDOTDIR`. cmux already loads Ghostty's integration manually via `CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION`.
- Save the user's original `shell-integration` preference before the override so `CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION` is still gated correctly.

Closes #2594

## Test plan

- [x] Open cmux, create a workspace
- [x] `cd ~/some-other-dir` — sidebar updates to show new cwd
- [x] `typeset -f _cmux_precmd` — function is defined
- [x] Open a new tab — inherits the current working directory
- [x] Verified with `shell-integration=detect` (default) in ghostty config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and handling of user shell-integration preference to ensure correct behavior with zsh and bash.
  * Ensured shell-integration is explicitly disabled when needed during all initialization paths so integration settings are applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->