### PR TITLE
Fix Cmd+Shift+V paste in browser pane

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9,6 +9,17 @@ import Combine
 import ObjectiveC.runtime
 import Darwin
 
+func cmuxJavaScriptStringLiteral(_ value: String?) -> String? {
+    guard let value else { return nil }
+    // Serialize as a JSON array, then strip the outer brackets to get a quoted JS string literal.
+    guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+          let arrayLiteral = String(data: data, encoding: .utf8),
+          arrayLiteral.count >= 2 else {
+        return nil
+    }
+    return String(arrayLiteral.dropFirst().dropLast())
+}
+
 final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
 
@@ -9041,16 +9052,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         Task { @MainActor in evaluate() }
     }
 
-    private func javaScriptLiteral(_ value: String?) -> String {
-        guard let value else { return "null" }
-        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
-              let arrayLiteral = String(data: data, encoding: .utf8),
-              arrayLiteral.count >= 2 else {
-            return "null"
-        }
-        return String(arrayLiteral.dropFirst().dropLast())
-    }
-
     private func setupFocusedInputForGotoSplitUITest(panel: BrowserPanel) {
         let script = """
         (() => {
@@ -9344,7 +9345,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         awaitingInputId: String? = nil,
         completion: @escaping ([String: String]) -> Void
     ) {
-        let expectedInputIdLiteral = javaScriptLiteral(awaitingInputId)
+        let expectedInputIdLiteral = cmuxJavaScriptStringLiteral(awaitingInputId) ?? "null"
         let script = """
         (() => {
           const expectedInputId = \(expectedInputIdLiteral);

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2548,6 +2548,15 @@ final class BrowserPanel: Panel, ObservableObject {
                 forMainFrameOnly: true
             )
         )
+        // Keep a native cache of whether the focused page element can currently accept
+        // plain-text paste so Cmd+Shift+V is only consumed when the browser can use it.
+        configuration.userContentController.addUserScript(
+            WKUserScript(
+                source: CmuxWebView.pasteAsPlainTextFocusTrackingBootstrapScriptSource,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+        )
     }
 
     private func bindWebView(_ webView: CmuxWebView) {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -124,7 +124,21 @@ final class CmuxWebView: WKWebView {
       const existing = window.__cmuxPasteAsPlainTextHelpers;
       if (existing) return existing;
 
-      const supportedTextInputTypes = new Set(["", "text", "search", "tel", "url", "email", "password"]);
+      const supportedTextInputTypes = new Set([
+        "",
+        "text",
+        "search",
+        "tel",
+        "url",
+        "email",
+        "password",
+        "number",
+        "date",
+        "datetime-local",
+        "month",
+        "time",
+        "week"
+      ]);
 
       const deepestActiveElement = (root) => {
         let active = root?.activeElement ?? null;
@@ -162,6 +176,17 @@ final class CmuxWebView: WKWebView {
         return supportedTextInputTypes.has(type);
       };
 
+      const isFocusedCrossOriginFrameElement = (el) => {
+        const tagName = typeof el?.tagName === "string" ? el.tagName.toUpperCase() : "";
+        if (tagName !== "IFRAME") return false;
+        try {
+          void el.contentDocument;
+          return false;
+        } catch (_) {
+          return true;
+        }
+      };
+
       const resolvedCandidateElement = (el) => {
         if (!el) return deepestActiveElement(document);
 
@@ -184,6 +209,7 @@ final class CmuxWebView: WKWebView {
         const candidate = resolvedCandidateElement(el);
         if (!candidate) return null;
         if (isPlainTextTextControl(candidate)) return candidate;
+        if (isFocusedCrossOriginFrameElement(candidate)) return candidate;
         if (candidate.isContentEditable) return candidate;
         return candidate.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null;
       };
@@ -191,6 +217,7 @@ final class CmuxWebView: WKWebView {
       const helpers = {
         deepestActiveElement,
         isPlainTextTextControl,
+        isFocusedCrossOriginFrameElement,
         resolvedCandidateElement,
         editableTarget,
         canPasteAsPlainTextInto(el) {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -547,7 +547,8 @@ final class CmuxWebView: WKWebView {
 
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard(_ sender: Any? = nil) -> Bool {
-        guard NSPasteboard.general.string(forType: .string) != nil,
+        guard pasteAsPlainTextTargetAvailable,
+              NSPasteboard.general.string(forType: .string) != nil,
               pageCanAcceptPlainTextPaste() else {
             return false
         }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -348,21 +348,11 @@ final class CmuxWebView: WKWebView {
         return event.keyCode == pasteAsPlainTextKeyCode && normalizedFlags == [.command, .shift]
     }
 
-    private static func javaScriptLiteral(_ value: String) -> String? {
-        // Serialize as a JSON array, then strip the outer brackets to get a quoted JS string literal.
-        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
-              let arrayLiteral = String(data: data, encoding: .utf8),
-              arrayLiteral.count >= 2 else {
-            return nil
-        }
-        return String(arrayLiteral.dropFirst().dropLast())
-    }
-
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard() -> Bool {
         guard pasteAsPlainTextTargetAvailable,
               let text = NSPasteboard.general.string(forType: .string),
-              let textLiteral = Self.javaScriptLiteral(text) else {
+              let textLiteral = cmuxJavaScriptStringLiteral(text) else {
             return false
         }
 

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -333,6 +333,7 @@ final class CmuxWebView: WKWebView {
     var allowsFirstResponderAcquisition: Bool = true
     private var pointerFocusAllowanceDepth: Int = 0
     private var pasteAsPlainTextTargetAvailable = false
+    private var lastPasteAsPlainTextPerformKeyEventTimestamp: TimeInterval?
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
     }
@@ -508,6 +509,15 @@ final class CmuxWebView: WKWebView {
         return canPaste
     }
 
+    private func shouldSkipRepeatedPasteAsPlainTextPreflight(for event: NSEvent) -> Bool {
+        guard event.timestamp > 0,
+              let lastTimestamp = lastPasteAsPlainTextPerformKeyEventTimestamp else {
+            return false
+        }
+        lastPasteAsPlainTextPerformKeyEventTimestamp = nil
+        return lastTimestamp == event.timestamp
+    }
+
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard(_ sender: Any? = nil) -> Bool {
         guard NSPasteboard.general.string(forType: .string) != nil,
@@ -571,7 +581,15 @@ final class CmuxWebView: WKWebView {
         }
 
         if Self.isPasteAsPlainTextCommandEquivalent(event) {
+            if event.timestamp > 0 {
+                lastPasteAsPlainTextPerformKeyEventTimestamp = event.timestamp
+            } else {
+                lastPasteAsPlainTextPerformKeyEventTimestamp = nil
+            }
             let result = performPasteAsPlainTextFromPasteboard() || super.performKeyEquivalent(with: event)
+            if result {
+                lastPasteAsPlainTextPerformKeyEventTimestamp = nil
+            }
 #if DEBUG
             handled = result
 #endif
@@ -647,12 +665,18 @@ final class CmuxWebView: WKWebView {
         }
 #endif
         if Self.isPasteAsPlainTextCommandEquivalent(event) {
-            let didPaste = performPasteAsPlainTextFromPasteboard()
+            if shouldSkipRepeatedPasteAsPlainTextPreflight(for: event) {
 #if DEBUG
-            route = didPaste ? "pasteAsPlainText" : "super"
+                route = "super"
 #endif
-            if didPaste {
-                return
+            } else {
+                let didPaste = performPasteAsPlainTextFromPasteboard()
+#if DEBUG
+                route = didPaste ? "pasteAsPlainText" : "super"
+#endif
+                if didPaste {
+                    return
+                }
             }
         }
 

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -118,6 +118,7 @@ final class CmuxWebView: WKWebView {
     private static var lastMiddleClickIntent: MiddleClickIntent?
     private static let middleClickIntentMaxAge: TimeInterval = 0.8
     private static let pasteAsPlainTextFocusMessageHandlerName = "cmuxPasteAsPlainTextFocus"
+    private static var pasteAsPlainTextFocusHandlerInstalledKey: UInt8 = 0
     static let pasteAsPlainTextFocusTrackingBootstrapScriptSource = """
     (() => {
       try {
@@ -132,13 +133,68 @@ final class CmuxWebView: WKWebView {
           }
         })();
 
-        const canPasteAsPlainTextInto = (el) => {
-          if (!el) return false;
-          if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
-            return !(el.disabled || el.readOnly);
+        const supportedTextInputTypes = new Set(["", "text", "search", "tel", "url", "email", "password"]);
+
+        const deepestActiveElement = (root) => {
+          let active = root?.activeElement ?? null;
+          while (active) {
+            const shadowActive = active.shadowRoot?.activeElement ?? null;
+            if (shadowActive && shadowActive !== active) {
+              active = shadowActive;
+              continue;
+            }
+
+            const tagName = typeof active.tagName === "string" ? active.tagName.toUpperCase() : "";
+            if (tagName === "IFRAME") {
+              try {
+                const frameActive = active.contentDocument?.activeElement ?? null;
+                if (frameActive && frameActive !== active) {
+                  active = frameActive;
+                  continue;
+                }
+              } catch (_) {}
+            }
+
+            break;
           }
-          if (el.isContentEditable) return true;
-          return !!(el.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null);
+          return active;
+        };
+
+        const isPlainTextTextControl = (el) => {
+          if (!el || el.disabled || el.readOnly) return false;
+
+          const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+          if (tagName === "TEXTAREA") return true;
+          if (tagName !== "INPUT") return false;
+
+          const type = typeof el.type === "string" ? el.type.toLowerCase() : "text";
+          return supportedTextInputTypes.has(type);
+        };
+
+        const resolvedCandidateElement = (el) => {
+          if (!el) return deepestActiveElement(document);
+
+          const shadowActive = el.shadowRoot?.activeElement ?? null;
+          if (shadowActive && shadowActive !== el) {
+            return deepestActiveElement(el.shadowRoot) ?? shadowActive;
+          }
+
+          const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+          if (tagName === "IFRAME") {
+            try {
+              return deepestActiveElement(el.contentDocument) ?? el;
+            } catch (_) {}
+          }
+
+          return el;
+        };
+
+        const canPasteAsPlainTextInto = (el) => {
+          const candidate = resolvedCandidateElement(el);
+          if (!candidate) return false;
+          if (isPlainTextTextControl(candidate)) return true;
+          if (candidate.isContentEditable) return true;
+          return !!(candidate.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null);
         };
 
         const publish = (canPaste) => {
@@ -149,7 +205,7 @@ final class CmuxWebView: WKWebView {
         };
 
         const publishForElement = (el) => {
-          publish(canPasteAsPlainTextInto(el ?? document.activeElement));
+          publish(canPasteAsPlainTextInto(el));
         };
 
         document.addEventListener("focusin", (ev) => {
@@ -186,16 +242,13 @@ final class CmuxWebView: WKWebView {
     """
 
     private final class PasteAsPlainTextFocusMessageHandler: NSObject, WKScriptMessageHandler {
-        weak var webView: CmuxWebView?
-
-        init(webView: CmuxWebView) {
-            self.webView = webView
-        }
-
         func userContentController(
             _ userContentController: WKUserContentController,
             didReceive message: WKScriptMessage
         ) {
+            guard let webView = message.webView as? CmuxWebView else {
+                return
+            }
             guard let body = message.body as? [String: Any],
                   let canPaste = body["canPaste"] as? Bool else {
                 return
@@ -205,6 +258,8 @@ final class CmuxWebView: WKWebView {
             }
         }
     }
+
+    private static let sharedPasteAsPlainTextFocusMessageHandler = PasteAsPlainTextFocusMessageHandler()
 
     static func hasRecentMiddleClickIntent(for webView: WKWebView) -> Bool {
         guard let webView = webView as? CmuxWebView else { return false }
@@ -250,7 +305,6 @@ final class CmuxWebView: WKWebView {
     var allowsFirstResponderAcquisition: Bool = true
     private var pointerFocusAllowanceDepth: Int = 0
     private var pasteAsPlainTextTargetAvailable = false
-    private var pasteAsPlainTextFocusMessageHandler: PasteAsPlainTextFocusMessageHandler?
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
     }
@@ -266,16 +320,25 @@ final class CmuxWebView: WKWebView {
         installPasteAsPlainTextFocusTracking()
     }
 
-    deinit {
-        configuration.userContentController.removeScriptMessageHandler(
-            forName: Self.pasteAsPlainTextFocusMessageHandlerName
-        )
-    }
-
     private func installPasteAsPlainTextFocusTracking() {
-        let handler = PasteAsPlainTextFocusMessageHandler(webView: self)
-        pasteAsPlainTextFocusMessageHandler = handler
-        configuration.userContentController.add(handler, name: Self.pasteAsPlainTextFocusMessageHandlerName)
+        let userContentController = configuration.userContentController
+        if objc_getAssociatedObject(
+            userContentController,
+            &Self.pasteAsPlainTextFocusHandlerInstalledKey
+        ) != nil {
+            return
+        }
+
+        userContentController.add(
+            Self.sharedPasteAsPlainTextFocusMessageHandler,
+            name: Self.pasteAsPlainTextFocusMessageHandlerName
+        )
+        objc_setAssociatedObject(
+            userContentController,
+            &Self.pasteAsPlainTextFocusHandlerInstalledKey,
+            NSNumber(value: true),
+            .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+        )
     }
 
     private func updatePasteAsPlainTextTargetAvailable(_ available: Bool) {
@@ -348,6 +411,35 @@ final class CmuxWebView: WKWebView {
         return event.keyCode == pasteAsPlainTextKeyCode && normalizedFlags == [.command, .shift]
     }
 
+    private func evaluateJavaScriptSynchronously(
+        _ script: String,
+        timeout: TimeInterval = 0.25
+    ) -> (completed: Bool, result: Any?, error: Error?) {
+        var completed = false
+        var result: Any?
+        var error: Error?
+
+        evaluateJavaScript(script) { jsResult, jsError in
+            result = jsResult
+            error = jsError
+            completed = true
+        }
+
+        let deadline = ProcessInfo.processInfo.systemUptime + timeout
+        while !completed {
+            let remaining = deadline - ProcessInfo.processInfo.systemUptime
+            guard remaining > 0 else { break }
+
+            let sliceEnd = Date(timeIntervalSinceNow: min(remaining, 0.01))
+            _ = RunLoop.current.run(mode: .default, before: sliceEnd)
+            if !completed {
+                _ = RunLoop.current.run(mode: .eventTracking, before: sliceEnd)
+            }
+        }
+
+        return (completed, result, error)
+    }
+
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard() -> Bool {
         guard pasteAsPlainTextTargetAvailable,
@@ -359,104 +451,149 @@ final class CmuxWebView: WKWebView {
         let script = """
         (() => {
             const text = \(textLiteral);
-            const active = document.activeElement;
-            const makeInputEvent = () => {
-                try {
-                    return new InputEvent('input', {
-                        bubbles: true,
-                        inputType: 'insertFromPaste',
-                        data: text
-                    });
-                } catch (_) {
-                    return new Event('input', { bubbles: true });
-                }
-            };
+            const supportedTextInputTypes = new Set(['', 'text', 'search', 'tel', 'url', 'email', 'password']);
+            const deepestActiveElement = (root) => {
+                let active = root?.activeElement ?? null;
+                while (active) {
+                    const shadowActive = active.shadowRoot?.activeElement ?? null;
+                    if (shadowActive && shadowActive !== active) {
+                        active = shadowActive;
+                        continue;
+                    }
 
+                    const tagName = typeof active.tagName === 'string' ? active.tagName.toUpperCase() : '';
+                    if (tagName === 'IFRAME') {
+                        try {
+                            const frameActive = active.contentDocument?.activeElement ?? null;
+                            if (frameActive && frameActive !== active) {
+                                active = frameActive;
+                                continue;
+                            }
+                        } catch (_) {}
+                    }
+
+                    break;
+                }
+                return active;
+            };
+            const isPlainTextTextControl = (el) => {
+                if (!el || el.disabled || el.readOnly) return false;
+
+                const tagName = typeof el.tagName === 'string' ? el.tagName.toUpperCase() : '';
+                if (tagName === 'TEXTAREA') return true;
+                if (tagName !== 'INPUT') return false;
+
+                const type = typeof el.type === 'string' ? el.type.toLowerCase() : 'text';
+                return supportedTextInputTypes.has(type);
+            };
+            const active = deepestActiveElement(document);
             const editableTarget = (() => {
                 if (!active) return null;
-                if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
-                    if (active.disabled || active.readOnly) return null;
-                    return active;
-                }
+                if (isPlainTextTextControl(active)) return active;
                 if (active.isContentEditable) return active;
                 return active.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null;
             })();
-
             if (!editableTarget) return false;
 
-            if (editableTarget instanceof HTMLInputElement || editableTarget instanceof HTMLTextAreaElement) {
-                const hasSelection = (() => {
-                    try {
-                        return typeof editableTarget.selectionStart === 'number'
-                            && typeof editableTarget.selectionEnd === 'number';
-                    } catch (_) {
-                        return false;
+            const ownerDocument = editableTarget.ownerDocument ?? document;
+            const ownerWindow = ownerDocument.defaultView ?? window;
+            const makeInputEvent = () => {
+                try {
+                    const InputEventCtor = ownerWindow.InputEvent;
+                    if (typeof InputEventCtor === 'function') {
+                        return new InputEventCtor('input', {
+                            bubbles: true,
+                            inputType: 'insertFromPaste',
+                            data: text
+                        });
                     }
-                })();
-                const start = hasSelection ? editableTarget.selectionStart : editableTarget.value.length;
-                const end = hasSelection ? editableTarget.selectionEnd : start;
+                } catch (_) {}
 
                 try {
-                    if (hasSelection && typeof editableTarget.setRangeText === 'function') {
+                    const EventCtor = ownerWindow.Event;
+                    if (typeof EventCtor === 'function') {
+                        return new EventCtor('input', { bubbles: true });
+                    }
+                } catch (_) {}
+
+                return null;
+            };
+
+            if (isPlainTextTextControl(editableTarget)) {
+                const value = typeof editableTarget.value === 'string' ? editableTarget.value : '';
+                const start = typeof editableTarget.selectionStart === 'number'
+                    ? editableTarget.selectionStart
+                    : value.length;
+                const end = typeof editableTarget.selectionEnd === 'number'
+                    ? editableTarget.selectionEnd
+                    : start;
+
+                try {
+                    if (typeof editableTarget.setRangeText === 'function') {
                         editableTarget.setRangeText(text, start, end, 'end');
-                    } else if (hasSelection) {
-                        const value = editableTarget.value;
+                    } else {
                         editableTarget.value = value.slice(0, start) + text + value.slice(end);
                         if (typeof editableTarget.setSelectionRange === 'function') {
                             const caret = start + text.length;
                             editableTarget.setSelectionRange(caret, caret);
                         }
-                    } else {
-                        editableTarget.value = text;
                     }
                 } catch (_) {
                     return false;
                 }
 
-                editableTarget.dispatchEvent(makeInputEvent());
+                const inputEvent = makeInputEvent();
+                if (inputEvent) {
+                    editableTarget.dispatchEvent(inputEvent);
+                }
                 return true;
             }
 
-            if (typeof document.execCommand === 'function') {
+            if (typeof ownerDocument.execCommand === 'function') {
                 try {
-                    if (document.execCommand('insertText', false, text)) {
+                    if (ownerDocument.execCommand('insertText', false, text)) {
                         return true;
                     }
                 } catch (_) {}
             }
 
-            const selection = window.getSelection();
+            const selection = typeof ownerWindow.getSelection === 'function'
+                ? ownerWindow.getSelection()
+                : null;
             if (!selection || selection.rangeCount === 0) return false;
 
             const range = selection.getRangeAt(0);
             range.deleteContents();
-            const node = document.createTextNode(text);
+            const node = ownerDocument.createTextNode(text);
             range.insertNode(node);
             range.setStartAfter(node);
             range.setEndAfter(node);
             selection.removeAllRanges();
             selection.addRange(range);
-            editableTarget.dispatchEvent(makeInputEvent());
+
+            const inputEvent = makeInputEvent();
+            if (inputEvent) {
+                editableTarget.dispatchEvent(inputEvent);
+            }
             return true;
         })();
         """
 
-        evaluateJavaScript(script) { result, error in
+        // NSResponder key-equivalent handling is synchronous. Wait briefly so failed page-side
+        // insertion can fall through to WebKit/page handlers instead of being consumed here.
+        let evaluation = evaluateJavaScriptSynchronously(script)
+        let inserted = evaluation.completed && ((evaluation.result as? Bool) ?? false)
 #if DEBUG
-            let inserted = (result as? Bool) ?? false
-            dlog(
-                "browser.pasteAsPlainText " +
-                "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
-                "error=\(error?.localizedDescription ?? "nil")"
-            )
-#else
-            _ = result
-            _ = error
+        let errorDescription = evaluation.completed
+            ? (evaluation.error?.localizedDescription ?? "nil")
+            : "timeout"
+        dlog(
+            "browser.pasteAsPlainText " +
+            "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
+            "error=\(errorDescription)"
+        )
 #endif
-        }
-        // The editable-target cache is kept in sync from the page, so consuming the
-        // shortcut here avoids double-routing while JS performs the paste asynchronously.
-        return true
+        return inserted
     }
 
     @IBAction func pasteAsPlainText(_ sender: Any?) {
@@ -502,12 +639,12 @@ final class CmuxWebView: WKWebView {
             return result
         }
 
-        if Self.isPasteAsPlainTextCommandEquivalent(event),
-           performPasteAsPlainTextFromPasteboard() {
+        if Self.isPasteAsPlainTextCommandEquivalent(event) {
+            let result = performPasteAsPlainTextFromPasteboard() || super.performKeyEquivalent(with: event)
 #if DEBUG
-            handled = true
+            handled = result
 #endif
-            return true
+            return result
         }
 
         var replayedBrowserFindShortcutIntoWebContent = false
@@ -578,12 +715,14 @@ final class CmuxWebView: WKWebView {
             )
         }
 #endif
-        if Self.isPasteAsPlainTextCommandEquivalent(event),
-           performPasteAsPlainTextFromPasteboard() {
+        if Self.isPasteAsPlainTextCommandEquivalent(event) {
+            let didPaste = performPasteAsPlainTextFromPasteboard()
 #if DEBUG
-            route = "pasteAsPlainText"
+            route = didPaste ? "pasteAsPlainText" : "super"
 #endif
-            return
+            if didPaste {
+                return
+            }
         }
 
         // Some Cmd-based key paths in WebKit don't consistently invoke performKeyEquivalent.

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -149,6 +149,7 @@ final class CmuxWebView: WKWebView {
     }
 
     private static var contextMenuFallbackKey: UInt8 = 0
+    private static let pasteAsPlainTextKeyCode: UInt16 = 9
 
     var onContextMenuDownloadStateChanged: ((Bool) -> Void)?
     /// Called when "Open Link in New Tab" context menu is selected.
@@ -218,6 +219,130 @@ final class CmuxWebView: WKWebView {
         return body()
     }
 
+    private static func isPasteAsPlainTextCommandEquivalent(_ event: NSEvent) -> Bool {
+        let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
+        return event.keyCode == pasteAsPlainTextKeyCode && normalizedFlags == [.command, .shift]
+    }
+
+    private static func javaScriptLiteral(_ value: String) -> String? {
+        guard let data = try? JSONSerialization.data(withJSONObject: [value]),
+              let arrayLiteral = String(data: data, encoding: .utf8),
+              arrayLiteral.count >= 2 else {
+            return nil
+        }
+        return String(arrayLiteral.dropFirst().dropLast())
+    }
+
+    @discardableResult
+    private func performPasteAsPlainTextFromPasteboard() -> Bool {
+        guard let text = NSPasteboard.general.string(forType: .string),
+              let textLiteral = Self.javaScriptLiteral(text) else {
+            return false
+        }
+
+        let script = """
+        (() => {
+            const text = \(textLiteral);
+            const active = document.activeElement;
+            const makeInputEvent = () => {
+                try {
+                    return new InputEvent('input', {
+                        bubbles: true,
+                        inputType: 'insertFromPaste',
+                        data: text
+                    });
+                } catch (_) {
+                    return new Event('input', { bubbles: true });
+                }
+            };
+
+            const editableTarget = (() => {
+                if (!active) return null;
+                if (active instanceof HTMLInputElement || active instanceof HTMLTextAreaElement) {
+                    if (active.disabled || active.readOnly) return null;
+                    return active;
+                }
+                if (active.isContentEditable) return active;
+                return active.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null;
+            })();
+
+            if (!editableTarget) return false;
+
+            if (editableTarget instanceof HTMLInputElement || editableTarget instanceof HTMLTextAreaElement) {
+                const hasSelection =
+                    typeof editableTarget.selectionStart === 'number'
+                    && typeof editableTarget.selectionEnd === 'number';
+                const start = hasSelection ? editableTarget.selectionStart : editableTarget.value.length;
+                const end = hasSelection ? editableTarget.selectionEnd : start;
+
+                if (typeof editableTarget.setRangeText === 'function') {
+                    editableTarget.setRangeText(text, start, end, 'end');
+                } else {
+                    const value = editableTarget.value;
+                    editableTarget.value = value.slice(0, start) + text + value.slice(end);
+                    if (typeof editableTarget.setSelectionRange === 'function') {
+                        const caret = start + text.length;
+                        editableTarget.setSelectionRange(caret, caret);
+                    }
+                }
+
+                editableTarget.dispatchEvent(makeInputEvent());
+                return true;
+            }
+
+            if (typeof document.execCommand === 'function') {
+                try {
+                    if (document.execCommand('insertText', false, text)) {
+                        return true;
+                    }
+                } catch (_) {}
+            }
+
+            const selection = window.getSelection();
+            if (!selection || selection.rangeCount === 0) return false;
+
+            const range = selection.getRangeAt(0);
+            range.deleteContents();
+            const node = document.createTextNode(text);
+            range.insertNode(node);
+            range.setStartAfter(node);
+            range.setEndAfter(node);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            editableTarget.dispatchEvent(makeInputEvent());
+            return true;
+        })();
+        """
+
+        evaluateJavaScript(script) { result, error in
+#if DEBUG
+            let inserted = (result as? Bool) ?? false
+            dlog(
+                "browser.pasteAsPlainText " +
+                "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
+                "error=\(error?.localizedDescription ?? "nil")"
+            )
+#else
+            _ = result
+            _ = error
+#endif
+        }
+        return true
+    }
+
+    @IBAction func pasteAsPlainText(_ sender: Any?) {
+        _ = sender
+        _ = performPasteAsPlainTextFromPasteboard()
+    }
+
+    override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(pasteAsPlainText(_:)) {
+            return NSPasteboard.general.string(forType: .string) != nil
+        }
+        return super.validateUserInterfaceItem(item)
+    }
+
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
 #if DEBUG
         let typingTimingStart = CmuxTypingTiming.start()
@@ -246,6 +371,14 @@ final class CmuxWebView: WKWebView {
             handled = result
 #endif
             return result
+        }
+
+        if Self.isPasteAsPlainTextCommandEquivalent(event),
+           performPasteAsPlainTextFromPasteboard() {
+#if DEBUG
+            handled = true
+#endif
+            return true
         }
 
         var replayedBrowserFindShortcutIntoWebContent = false
@@ -316,6 +449,14 @@ final class CmuxWebView: WKWebView {
             )
         }
 #endif
+        if Self.isPasteAsPlainTextCommandEquivalent(event),
+           performPasteAsPlainTextFromPasteboard() {
+#if DEBUG
+            route = "pasteAsPlainText"
+#endif
+            return
+        }
+
         // Some Cmd-based key paths in WebKit don't consistently invoke performKeyEquivalent.
         // Route them through the same app-level shortcut handler as a fallback.
         if event.modifierFlags.intersection(.deviceIndependentFlagsMask).contains(.command),

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -119,6 +119,88 @@ final class CmuxWebView: WKWebView {
     private static let middleClickIntentMaxAge: TimeInterval = 0.8
     private static let pasteAsPlainTextFocusMessageHandlerName = "cmuxPasteAsPlainTextFocus"
     private static var pasteAsPlainTextFocusHandlerInstalledKey: UInt8 = 0
+    private static let pasteAsPlainTextSharedHelpersScriptSource = """
+    const __cmuxPasteAsPlainTextHelpers = (() => {
+      const existing = window.__cmuxPasteAsPlainTextHelpers;
+      if (existing) return existing;
+
+      const supportedTextInputTypes = new Set(["", "text", "search", "tel", "url", "email", "password"]);
+
+      const deepestActiveElement = (root) => {
+        let active = root?.activeElement ?? null;
+        while (active) {
+          const shadowActive = active.shadowRoot?.activeElement ?? null;
+          if (shadowActive && shadowActive !== active) {
+            active = shadowActive;
+            continue;
+          }
+
+          const tagName = typeof active.tagName === "string" ? active.tagName.toUpperCase() : "";
+          if (tagName === "IFRAME") {
+            try {
+              const frameActive = active.contentDocument?.activeElement ?? null;
+              if (frameActive && frameActive !== active) {
+                active = frameActive;
+                continue;
+              }
+            } catch (_) {}
+          }
+
+          break;
+        }
+        return active;
+      };
+
+      const isPlainTextTextControl = (el) => {
+        if (!el || el.disabled || el.readOnly) return false;
+
+        const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+        if (tagName === "TEXTAREA") return true;
+        if (tagName !== "INPUT") return false;
+
+        const type = typeof el.type === "string" ? el.type.toLowerCase() : "text";
+        return supportedTextInputTypes.has(type);
+      };
+
+      const resolvedCandidateElement = (el) => {
+        if (!el) return deepestActiveElement(document);
+
+        const shadowActive = el.shadowRoot?.activeElement ?? null;
+        if (shadowActive && shadowActive !== el) {
+          return deepestActiveElement(el.shadowRoot) ?? shadowActive;
+        }
+
+        const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
+        if (tagName === "IFRAME") {
+          try {
+            return deepestActiveElement(el.contentDocument) ?? el;
+          } catch (_) {}
+        }
+
+        return el;
+      };
+
+      const editableTarget = (el) => {
+        const candidate = resolvedCandidateElement(el);
+        if (!candidate) return null;
+        if (isPlainTextTextControl(candidate)) return candidate;
+        if (candidate.isContentEditable) return candidate;
+        return candidate.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null;
+      };
+
+      const helpers = {
+        deepestActiveElement,
+        isPlainTextTextControl,
+        resolvedCandidateElement,
+        editableTarget,
+        canPasteAsPlainTextInto(el) {
+          return !!editableTarget(el);
+        }
+      };
+      window.__cmuxPasteAsPlainTextHelpers = helpers;
+      return helpers;
+    })();
+    """
     static let pasteAsPlainTextFocusTrackingBootstrapScriptSource = """
     (() => {
       try {
@@ -133,79 +215,25 @@ final class CmuxWebView: WKWebView {
           }
         })();
 
-        const supportedTextInputTypes = new Set(["", "text", "search", "tel", "url", "email", "password"]);
+        \(pasteAsPlainTextSharedHelpersScriptSource)
 
-        const deepestActiveElement = (root) => {
-          let active = root?.activeElement ?? null;
-          while (active) {
-            const shadowActive = active.shadowRoot?.activeElement ?? null;
-            if (shadowActive && shadowActive !== active) {
-              active = shadowActive;
-              continue;
-            }
-
-            const tagName = typeof active.tagName === "string" ? active.tagName.toUpperCase() : "";
-            if (tagName === "IFRAME") {
-              try {
-                const frameActive = active.contentDocument?.activeElement ?? null;
-                if (frameActive && frameActive !== active) {
-                  active = frameActive;
-                  continue;
-                }
-              } catch (_) {}
-            }
-
-            break;
-          }
-          return active;
-        };
-
-        const isPlainTextTextControl = (el) => {
-          if (!el || el.disabled || el.readOnly) return false;
-
-          const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
-          if (tagName === "TEXTAREA") return true;
-          if (tagName !== "INPUT") return false;
-
-          const type = typeof el.type === "string" ? el.type.toLowerCase() : "text";
-          return supportedTextInputTypes.has(type);
-        };
-
-        const resolvedCandidateElement = (el) => {
-          if (!el) return deepestActiveElement(document);
-
-          const shadowActive = el.shadowRoot?.activeElement ?? null;
-          if (shadowActive && shadowActive !== el) {
-            return deepestActiveElement(el.shadowRoot) ?? shadowActive;
-          }
-
-          const tagName = typeof el.tagName === "string" ? el.tagName.toUpperCase() : "";
-          if (tagName === "IFRAME") {
-            try {
-              return deepestActiveElement(el.contentDocument) ?? el;
-            } catch (_) {}
-          }
-
-          return el;
-        };
-
-        const canPasteAsPlainTextInto = (el) => {
-          const candidate = resolvedCandidateElement(el);
-          if (!candidate) return false;
-          if (isPlainTextTextControl(candidate)) return true;
-          if (candidate.isContentEditable) return true;
-          return !!(candidate.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null);
-        };
+        const publishState = { lastCanPaste: null };
 
         const publish = (canPaste) => {
+          if (publishState.lastCanPaste === canPaste) return;
+          publishState.lastCanPaste = canPaste;
           window.__cmuxPasteAsPlainTextTargetAvailable = canPaste;
           try {
             handler?.postMessage({ canPaste });
           } catch (_) {}
         };
 
+        window.__cmuxCanPasteAsPlainTextIntoCurrentFocus = () => {
+          return __cmuxPasteAsPlainTextHelpers.canPasteAsPlainTextInto(document.activeElement);
+        };
+
         const publishForElement = (el) => {
-          publish(canPasteAsPlainTextInto(el));
+          publish(__cmuxPasteAsPlainTextHelpers.canPasteAsPlainTextInto(el));
         };
 
         document.addEventListener("focusin", (ev) => {
@@ -411,6 +439,19 @@ final class CmuxWebView: WKWebView {
         return event.keyCode == pasteAsPlainTextKeyCode && normalizedFlags == [.command, .shift]
     }
 
+    private func webKitPasteAsPlainTextFallback(_ sender: Any?) {
+        let selector = NSSelectorFromString("pasteAsPlainText:")
+        guard let method = class_getInstanceMethod(WKWebView.self, selector) else {
+            return
+        }
+
+        typealias PasteAsPlainTextFn = @convention(c) (AnyObject, Selector, Any?) -> Void
+        let implementation = method_getImplementation(method)
+        unsafeBitCast(implementation, to: PasteAsPlainTextFn.self)(self, selector, sender)
+    }
+
+    // Key-equivalent handling is synchronous, so this bounded preflight pumps the main run loop.
+    // Keep callers limited to fast, side-effect-free reads from page-owned state.
     private func evaluateJavaScriptSynchronously(
         _ script: String,
         timeout: TimeInterval = 0.25
@@ -440,59 +481,46 @@ final class CmuxWebView: WKWebView {
         return (completed, result, error)
     }
 
+    private func pageCanAcceptPlainTextPaste() -> Bool {
+        let script = """
+        (() => {
+            try {
+                const fn = window.__cmuxCanPasteAsPlainTextIntoCurrentFocus;
+                return typeof fn === 'function' ? !!fn() : false;
+            } catch (_) {
+                return false;
+            }
+        })();
+        """
+
+        let evaluation = evaluateJavaScriptSynchronously(script)
+        let canPaste = evaluation.completed && ((evaluation.result as? Bool) ?? false)
+#if DEBUG
+        let errorDescription = evaluation.completed
+            ? (evaluation.error?.localizedDescription ?? "nil")
+            : "timeout"
+        dlog(
+            "browser.pasteAsPlainText.preflight " +
+            "web=\(ObjectIdentifier(self)) canPaste=\(canPaste ? 1 : 0) " +
+            "error=\(errorDescription)"
+        )
+#endif
+        return canPaste
+    }
+
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard() -> Bool {
-        guard pasteAsPlainTextTargetAvailable,
-              let text = NSPasteboard.general.string(forType: .string),
-              let textLiteral = cmuxJavaScriptStringLiteral(text) else {
+        guard let text = NSPasteboard.general.string(forType: .string),
+              pageCanAcceptPlainTextPaste() else {
             return false
         }
+        let textLiteral = "\"\(BrowserFindJavaScript.jsStringEscape(text))\""
 
         let script = """
         (() => {
             const text = \(textLiteral);
-            const supportedTextInputTypes = new Set(['', 'text', 'search', 'tel', 'url', 'email', 'password']);
-            const deepestActiveElement = (root) => {
-                let active = root?.activeElement ?? null;
-                while (active) {
-                    const shadowActive = active.shadowRoot?.activeElement ?? null;
-                    if (shadowActive && shadowActive !== active) {
-                        active = shadowActive;
-                        continue;
-                    }
-
-                    const tagName = typeof active.tagName === 'string' ? active.tagName.toUpperCase() : '';
-                    if (tagName === 'IFRAME') {
-                        try {
-                            const frameActive = active.contentDocument?.activeElement ?? null;
-                            if (frameActive && frameActive !== active) {
-                                active = frameActive;
-                                continue;
-                            }
-                        } catch (_) {}
-                    }
-
-                    break;
-                }
-                return active;
-            };
-            const isPlainTextTextControl = (el) => {
-                if (!el || el.disabled || el.readOnly) return false;
-
-                const tagName = typeof el.tagName === 'string' ? el.tagName.toUpperCase() : '';
-                if (tagName === 'TEXTAREA') return true;
-                if (tagName !== 'INPUT') return false;
-
-                const type = typeof el.type === 'string' ? el.type.toLowerCase() : 'text';
-                return supportedTextInputTypes.has(type);
-            };
-            const active = deepestActiveElement(document);
-            const editableTarget = (() => {
-                if (!active) return null;
-                if (isPlainTextTextControl(active)) return active;
-                if (active.isContentEditable) return active;
-                return active.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null;
-            })();
+            \(Self.pasteAsPlainTextSharedHelpersScriptSource)
+            const editableTarget = __cmuxPasteAsPlainTextHelpers.editableTarget(document.activeElement);
             if (!editableTarget) return false;
 
             const ownerDocument = editableTarget.ownerDocument ?? document;
@@ -519,7 +547,7 @@ final class CmuxWebView: WKWebView {
                 return null;
             };
 
-            if (isPlainTextTextControl(editableTarget)) {
+            if (__cmuxPasteAsPlainTextHelpers.isPlainTextTextControl(editableTarget)) {
                 const value = typeof editableTarget.value === 'string' ? editableTarget.value : '';
                 const start = typeof editableTarget.selectionStart === 'number'
                     ? editableTarget.selectionStart
@@ -579,26 +607,30 @@ final class CmuxWebView: WKWebView {
         })();
         """
 
-        // NSResponder key-equivalent handling is synchronous. Wait briefly so failed page-side
-        // insertion can fall through to WebKit/page handlers instead of being consumed here.
-        let evaluation = evaluateJavaScriptSynchronously(script)
-        let inserted = evaluation.completed && ((evaluation.result as? Bool) ?? false)
+        evaluateJavaScript(script) { [weak self] result, error in
+            guard let self else { return }
 #if DEBUG
-        let errorDescription = evaluation.completed
-            ? (evaluation.error?.localizedDescription ?? "nil")
-            : "timeout"
-        dlog(
-            "browser.pasteAsPlainText " +
-            "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
-            "error=\(errorDescription)"
-        )
+            let inserted = (result as? Bool) ?? false
+            dlog(
+                "browser.pasteAsPlainText " +
+                "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
+                "error=\(error?.localizedDescription ?? "nil")"
+            )
+#else
+            _ = result
+            _ = error
 #endif
-        return inserted
+        }
+        // Key-equivalent routing cannot await the page-side insertion result. Once the
+        // preflight confirms a live editable target, dispatch the insertion and consume.
+        return true
     }
 
     @IBAction func pasteAsPlainText(_ sender: Any?) {
         _ = sender
-        _ = performPasteAsPlainTextFromPasteboard()
+        if !performPasteAsPlainTextFromPasteboard() {
+            webKitPasteAsPlainTextFallback(sender)
+        }
     }
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -117,6 +117,94 @@ final class CmuxWebView: WKWebView {
 
     private static var lastMiddleClickIntent: MiddleClickIntent?
     private static let middleClickIntentMaxAge: TimeInterval = 0.8
+    private static let pasteAsPlainTextFocusMessageHandlerName = "cmuxPasteAsPlainTextFocus"
+    static let pasteAsPlainTextFocusTrackingBootstrapScriptSource = """
+    (() => {
+      try {
+        if (window.__cmuxPasteAsPlainTextFocusTrackerInstalled) return true;
+        window.__cmuxPasteAsPlainTextFocusTrackerInstalled = true;
+
+        const handler = (() => {
+          try {
+            return window.webkit?.messageHandlers?.\(pasteAsPlainTextFocusMessageHandlerName) ?? null;
+          } catch (_) {
+            return null;
+          }
+        })();
+
+        const canPasteAsPlainTextInto = (el) => {
+          if (!el) return false;
+          if (el instanceof HTMLInputElement || el instanceof HTMLTextAreaElement) {
+            return !(el.disabled || el.readOnly);
+          }
+          if (el.isContentEditable) return true;
+          return !!(el.closest?.('[contenteditable]:not([contenteditable="false"])') ?? null);
+        };
+
+        const publish = (canPaste) => {
+          window.__cmuxPasteAsPlainTextTargetAvailable = canPaste;
+          try {
+            handler?.postMessage({ canPaste });
+          } catch (_) {}
+        };
+
+        const publishForElement = (el) => {
+          publish(canPasteAsPlainTextInto(el ?? document.activeElement));
+        };
+
+        document.addEventListener("focusin", (ev) => {
+          publishForElement(ev && ev.target ? ev.target : document.activeElement);
+        }, true);
+        document.addEventListener("focusout", () => {
+          requestAnimationFrame(() => publishForElement(document.activeElement));
+        }, true);
+        document.addEventListener("selectionchange", () => {
+          publishForElement(document.activeElement);
+        }, true);
+        document.addEventListener("input", () => {
+          publishForElement(document.activeElement);
+        }, true);
+        document.addEventListener("change", () => {
+          publishForElement(document.activeElement);
+        }, true);
+        document.addEventListener("mousedown", (ev) => {
+          const target = ev && ev.target ? ev.target : null;
+          if (!canPasteAsPlainTextInto(target)) {
+            publish(false);
+          }
+        }, true);
+        window.addEventListener("beforeunload", () => {
+          publish(false);
+        }, true);
+
+        publishForElement(document.activeElement);
+        return true;
+      } catch (_) {
+        return false;
+      }
+    })();
+    """
+
+    private final class PasteAsPlainTextFocusMessageHandler: NSObject, WKScriptMessageHandler {
+        weak var webView: CmuxWebView?
+
+        init(webView: CmuxWebView) {
+            self.webView = webView
+        }
+
+        func userContentController(
+            _ userContentController: WKUserContentController,
+            didReceive message: WKScriptMessage
+        ) {
+            guard let body = message.body as? [String: Any],
+                  let canPaste = body["canPaste"] as? Bool else {
+                return
+            }
+            Task { @MainActor [weak webView] in
+                webView?.updatePasteAsPlainTextTargetAvailable(canPaste)
+            }
+        }
+    }
 
     static func hasRecentMiddleClickIntent(for webView: WKWebView) -> Bool {
         guard let webView = webView as? CmuxWebView else { return false }
@@ -149,7 +237,7 @@ final class CmuxWebView: WKWebView {
     }
 
     private static var contextMenuFallbackKey: UInt8 = 0
-    private static let pasteAsPlainTextKeyCode: UInt16 = 9
+    private static let pasteAsPlainTextKeyCode: UInt16 = 9 // V key (hardware position, layout-independent)
 
     var onContextMenuDownloadStateChanged: ((Bool) -> Void)?
     /// Called when "Open Link in New Tab" context menu is selected.
@@ -161,10 +249,45 @@ final class CmuxWebView: WKWebView {
     /// BrowserPanelView updates this as pane focus state changes.
     var allowsFirstResponderAcquisition: Bool = true
     private var pointerFocusAllowanceDepth: Int = 0
+    private var pasteAsPlainTextTargetAvailable = false
+    private var pasteAsPlainTextFocusMessageHandler: PasteAsPlainTextFocusMessageHandler?
     var allowsFirstResponderAcquisitionEffective: Bool {
         allowsFirstResponderAcquisition || pointerFocusAllowanceDepth > 0
     }
     var debugPointerFocusAllowanceDepth: Int { pointerFocusAllowanceDepth }
+
+    override init(frame: NSRect, configuration: WKWebViewConfiguration) {
+        super.init(frame: frame, configuration: configuration)
+        installPasteAsPlainTextFocusTracking()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        installPasteAsPlainTextFocusTracking()
+    }
+
+    deinit {
+        configuration.userContentController.removeScriptMessageHandler(
+            forName: Self.pasteAsPlainTextFocusMessageHandlerName
+        )
+    }
+
+    private func installPasteAsPlainTextFocusTracking() {
+        let handler = PasteAsPlainTextFocusMessageHandler(webView: self)
+        pasteAsPlainTextFocusMessageHandler = handler
+        configuration.userContentController.add(handler, name: Self.pasteAsPlainTextFocusMessageHandlerName)
+    }
+
+    private func updatePasteAsPlainTextTargetAvailable(_ available: Bool) {
+        guard pasteAsPlainTextTargetAvailable != available else { return }
+        pasteAsPlainTextTargetAvailable = available
+#if DEBUG
+        dlog(
+            "browser.pasteAsPlainText.target " +
+            "web=\(ObjectIdentifier(self)) available=\(available ? 1 : 0)"
+        )
+#endif
+    }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
         PaneFirstClickFocusSettings.isEnabled()
@@ -226,6 +349,7 @@ final class CmuxWebView: WKWebView {
     }
 
     private static func javaScriptLiteral(_ value: String) -> String? {
+        // Serialize as a JSON array, then strip the outer brackets to get a quoted JS string literal.
         guard let data = try? JSONSerialization.data(withJSONObject: [value]),
               let arrayLiteral = String(data: data, encoding: .utf8),
               arrayLiteral.count >= 2 else {
@@ -236,7 +360,8 @@ final class CmuxWebView: WKWebView {
 
     @discardableResult
     private func performPasteAsPlainTextFromPasteboard() -> Bool {
-        guard let text = NSPasteboard.general.string(forType: .string),
+        guard pasteAsPlainTextTargetAvailable,
+              let text = NSPasteboard.general.string(forType: .string),
               let textLiteral = Self.javaScriptLiteral(text) else {
             return false
         }
@@ -270,21 +395,32 @@ final class CmuxWebView: WKWebView {
             if (!editableTarget) return false;
 
             if (editableTarget instanceof HTMLInputElement || editableTarget instanceof HTMLTextAreaElement) {
-                const hasSelection =
-                    typeof editableTarget.selectionStart === 'number'
-                    && typeof editableTarget.selectionEnd === 'number';
+                const hasSelection = (() => {
+                    try {
+                        return typeof editableTarget.selectionStart === 'number'
+                            && typeof editableTarget.selectionEnd === 'number';
+                    } catch (_) {
+                        return false;
+                    }
+                })();
                 const start = hasSelection ? editableTarget.selectionStart : editableTarget.value.length;
                 const end = hasSelection ? editableTarget.selectionEnd : start;
 
-                if (typeof editableTarget.setRangeText === 'function') {
-                    editableTarget.setRangeText(text, start, end, 'end');
-                } else {
-                    const value = editableTarget.value;
-                    editableTarget.value = value.slice(0, start) + text + value.slice(end);
-                    if (typeof editableTarget.setSelectionRange === 'function') {
-                        const caret = start + text.length;
-                        editableTarget.setSelectionRange(caret, caret);
+                try {
+                    if (hasSelection && typeof editableTarget.setRangeText === 'function') {
+                        editableTarget.setRangeText(text, start, end, 'end');
+                    } else if (hasSelection) {
+                        const value = editableTarget.value;
+                        editableTarget.value = value.slice(0, start) + text + value.slice(end);
+                        if (typeof editableTarget.setSelectionRange === 'function') {
+                            const caret = start + text.length;
+                            editableTarget.setSelectionRange(caret, caret);
+                        }
+                    } else {
+                        editableTarget.value = text;
                     }
+                } catch (_) {
+                    return false;
                 }
 
                 editableTarget.dispatchEvent(makeInputEvent());
@@ -328,6 +464,8 @@ final class CmuxWebView: WKWebView {
             _ = error
 #endif
         }
+        // The editable-target cache is kept in sync from the page, so consuming the
+        // shortcut here avoids double-routing while JS performs the paste asynchronously.
         return true
     }
 
@@ -338,7 +476,8 @@ final class CmuxWebView: WKWebView {
 
     override func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
         if item.action == #selector(pasteAsPlainText(_:)) {
-            return NSPasteboard.general.string(forType: .string) != nil
+            return pasteAsPlainTextTargetAvailable
+                && NSPasteboard.general.string(forType: .string) != nil
         }
         return super.validateUserInterfaceItem(item)
     }

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -253,7 +253,7 @@ final class CmuxWebView: WKWebView {
         }, true);
         document.addEventListener("mousedown", (ev) => {
           const target = ev && ev.target ? ev.target : null;
-          if (!canPasteAsPlainTextInto(target)) {
+          if (!__cmuxPasteAsPlainTextHelpers.canPasteAsPlainTextInto(target)) {
             publish(false);
           }
         }, true);
@@ -509,126 +509,25 @@ final class CmuxWebView: WKWebView {
     }
 
     @discardableResult
-    private func performPasteAsPlainTextFromPasteboard() -> Bool {
-        guard let text = NSPasteboard.general.string(forType: .string),
+    private func performPasteAsPlainTextFromPasteboard(_ sender: Any? = nil) -> Bool {
+        guard NSPasteboard.general.string(forType: .string) != nil,
               pageCanAcceptPlainTextPaste() else {
             return false
         }
-        let textLiteral = "\"\(BrowserFindJavaScript.jsStringEscape(text))\""
 
-        let script = """
-        (() => {
-            const text = \(textLiteral);
-            \(Self.pasteAsPlainTextSharedHelpersScriptSource)
-            const editableTarget = __cmuxPasteAsPlainTextHelpers.editableTarget(document.activeElement);
-            if (!editableTarget) return false;
-
-            const ownerDocument = editableTarget.ownerDocument ?? document;
-            const ownerWindow = ownerDocument.defaultView ?? window;
-            const makeInputEvent = () => {
-                try {
-                    const InputEventCtor = ownerWindow.InputEvent;
-                    if (typeof InputEventCtor === 'function') {
-                        return new InputEventCtor('input', {
-                            bubbles: true,
-                            inputType: 'insertFromPaste',
-                            data: text
-                        });
-                    }
-                } catch (_) {}
-
-                try {
-                    const EventCtor = ownerWindow.Event;
-                    if (typeof EventCtor === 'function') {
-                        return new EventCtor('input', { bubbles: true });
-                    }
-                } catch (_) {}
-
-                return null;
-            };
-
-            if (__cmuxPasteAsPlainTextHelpers.isPlainTextTextControl(editableTarget)) {
-                const value = typeof editableTarget.value === 'string' ? editableTarget.value : '';
-                const start = typeof editableTarget.selectionStart === 'number'
-                    ? editableTarget.selectionStart
-                    : value.length;
-                const end = typeof editableTarget.selectionEnd === 'number'
-                    ? editableTarget.selectionEnd
-                    : start;
-
-                try {
-                    if (typeof editableTarget.setRangeText === 'function') {
-                        editableTarget.setRangeText(text, start, end, 'end');
-                    } else {
-                        editableTarget.value = value.slice(0, start) + text + value.slice(end);
-                        if (typeof editableTarget.setSelectionRange === 'function') {
-                            const caret = start + text.length;
-                            editableTarget.setSelectionRange(caret, caret);
-                        }
-                    }
-                } catch (_) {
-                    return false;
-                }
-
-                const inputEvent = makeInputEvent();
-                if (inputEvent) {
-                    editableTarget.dispatchEvent(inputEvent);
-                }
-                return true;
-            }
-
-            if (typeof ownerDocument.execCommand === 'function') {
-                try {
-                    if (ownerDocument.execCommand('insertText', false, text)) {
-                        return true;
-                    }
-                } catch (_) {}
-            }
-
-            const selection = typeof ownerWindow.getSelection === 'function'
-                ? ownerWindow.getSelection()
-                : null;
-            if (!selection || selection.rangeCount === 0) return false;
-
-            const range = selection.getRangeAt(0);
-            range.deleteContents();
-            const node = ownerDocument.createTextNode(text);
-            range.insertNode(node);
-            range.setStartAfter(node);
-            range.setEndAfter(node);
-            selection.removeAllRanges();
-            selection.addRange(range);
-
-            const inputEvent = makeInputEvent();
-            if (inputEvent) {
-                editableTarget.dispatchEvent(inputEvent);
-            }
-            return true;
-        })();
-        """
-
-        evaluateJavaScript(script) { [weak self] result, error in
-            guard let self else { return }
+        webKitPasteAsPlainTextFallback(sender)
 #if DEBUG
-            let inserted = (result as? Bool) ?? false
-            dlog(
-                "browser.pasteAsPlainText " +
-                "web=\(ObjectIdentifier(self)) inserted=\(inserted ? 1 : 0) " +
-                "error=\(error?.localizedDescription ?? "nil")"
-            )
-#else
-            _ = result
-            _ = error
+        dlog(
+            "browser.pasteAsPlainText " +
+            "web=\(ObjectIdentifier(self)) routedNative=1"
+        )
 #endif
-        }
-        // Key-equivalent routing cannot await the page-side insertion result. Once the
-        // preflight confirms a live editable target, dispatch the insertion and consume.
         return true
     }
 
     @IBAction func pasteAsPlainText(_ sender: Any?) {
         _ = sender
-        if !performPasteAsPlainTextFromPasteboard() {
+        if !performPasteAsPlainTextFromPasteboard(sender) {
             webKitPasteAsPlainTextFallback(sender)
         }
     }


### PR DESCRIPTION
## Summary
- handle `Cmd+Shift+V` directly in `CmuxWebView` for browser panes
- track whether the focused web element can accept plain-text paste before consuming the shortcut
- share one page-side helper for eligibility checks and insertion so the tracker and injected paste path stay aligned
- escape pasted JavaScript text with `BrowserFindJavaScript.jsStringEscape` and fall back to WebKit when the custom path cannot run

## Testing
- not run locally per repo policy
- built with `./scripts/reload.sh --tag issue-2766-cmd-shift-v-paste`
- built and launched with `./scripts/reload.sh --tag issue-2766-cmd-shift-v-paste --launch`
- rebuilt after review fixes with `./scripts/reload.sh --tag issue-2766-cmd-shift-v-paste`
- rebuilt after GitHub review follow-ups with `./scripts/reload.sh --tag issue-2766-cmd-shift-v-paste`

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: not recorded in this PR update

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

Fixes #2766

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Paste as Plain Text" shortcut (Cmd+Shift+V) to paste plain text into inputs, textareas, and contenteditable regions.

* **Improvements**
  * Shortcut is enabled only when clipboard text is available and the focused page element accepts plain-text insertion, using a page-side preflight check.
  * Includes improved key routing, a fallback paste path when preflight fails, and additional diagnostic logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes keyboard event routing and injects new page scripts/message handlers into `WKWebView`, which can affect input focus/shortcuts and has some risk of regressions across diverse sites.
> 
> **Overview**
> Fixes `Cmd+Shift+V` in browser panes by adding a native `pasteAsPlainText` path in `CmuxWebView` that preflights paste eligibility against the currently focused page element and falls back to WebKit when it can’t safely handle the shortcut.
> 
> Adds a document-start script + `WKScriptMessageHandler` to continuously track whether the focused element can accept plain-text paste, uses that state to validate/consume the menu item and shortcut, and centralizes safe JS string literal serialization via `cmuxJavaScriptStringLiteral` for UI-test script injection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f1aee645af74f6809823d8599488ab3885ce17c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->