### PR TITLE
Fix up/down arrow keys in browser surface

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2253,6 +2253,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var browserOmnibarRepeatDelta: Int = 0
     private var browserAddressBarFocusObserver: NSObjectProtocol?
     private var browserAddressBarBlurObserver: NSObjectProtocol?
+    private var browserWebViewFirstResponderObserver: NSObjectProtocol?
     private let updateController = UpdateController()
     private lazy var titlebarAccessoryController = UpdateTitlebarAccessoryController(viewModel: updateViewModel)
     private let windowDecorationsController = WindowDecorationsController()
@@ -10881,14 +10882,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         // Chrome-like omnibar navigation while holding Cmd+N / Ctrl+N / Cmd+P / Ctrl+P.
-        if let delta = commandOmnibarSelectionDelta(flags: flags, chars: chars) {
+        if let delta = commandOmnibarSelectionDelta(
+            hasFocusedAddressBar: hasFocusedAddressBarInShortcutContext,
+            flags: flags,
+            chars: chars
+        ) {
             dispatchBrowserOmnibarSelectionMove(delta: delta)
             startBrowserOmnibarSelectionRepeatIfNeeded(keyCode: event.keyCode, delta: delta)
             return true
         }
 
         if let delta = browserOmnibarSelectionDeltaForArrowNavigation(
-            hasFocusedAddressBar: browserAddressBarFocusedPanelId != nil,
+            hasFocusedAddressBar: hasFocusedAddressBarInShortcutContext,
             flags: event.modifierFlags,
             keyCode: event.keyCode
         ) {
@@ -10905,7 +10910,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Let omnibar-local Emacs navigation (Cmd/Ctrl+N/P) win while the browser
         // address bar is focused. Without this, app-level Cmd+N can steal focus.
-        if shouldBypassAppShortcutForFocusedBrowserAddressBar(flags: flags, chars: chars) {
+        if hasFocusedAddressBarInShortcutContext,
+           shouldBypassAppShortcutForFocusedBrowserAddressBar(flags: flags, chars: chars) {
             return false
         }
 
@@ -11666,6 +11672,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func focusedBrowserAddressBarPanelIdForShortcutEvent(_ event: NSEvent) -> UUID? {
         guard let panelId = browserAddressBarFocusedPanelId else { return nil }
+        let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
+        let shortcutResponder = shortcutWindow?.firstResponder
+
+        guard isBrowserOmnibarResponder(shortcutResponder) else {
+#if DEBUG
+            dlog(
+                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "accepted=0 reason=responder_not_omnibar responder=\(shortcutResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
+                "event=\(NSWindow.keyDescription(event))"
+            )
+#endif
+            return nil
+        }
 
         guard let context = preferredMainWindowContextForShortcutRouting(event: event) else {
 #if DEBUG
@@ -11707,6 +11726,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return panelId
     }
 
+    private func isBrowserOmnibarResponder(_ responder: NSResponder?) -> Bool {
+        guard let ownerView = keyRoutingOwnerView(for: responder) else { return false }
+
+        var current: NSView? = ownerView
+        while let candidate = current {
+            if candidate.identifier == browserOmnibarTextFieldIdentifier {
+                return true
+            }
+            current = candidate.superview
+        }
+
+        return false
+    }
+
     @discardableResult
     func requestBrowserAddressBarFocus(panelId: UUID) -> Bool {
         focusBrowserAddressBar(panelId: panelId)
@@ -11734,11 +11767,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func commandOmnibarSelectionDelta(
+        hasFocusedAddressBar: Bool,
         flags: NSEvent.ModifierFlags,
         chars: String
     ) -> Int? {
         browserOmnibarSelectionDeltaForCommandNavigation(
-            hasFocusedAddressBar: browserAddressBarFocusedPanelId != nil,
+            hasFocusedAddressBar: hasFocusedAddressBar,
             flags: flags,
             chars: chars
         )
@@ -12651,7 +12685,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func installBrowserAddressBarFocusObservers() {
-        guard browserAddressBarFocusObserver == nil, browserAddressBarBlurObserver == nil else { return }
+        guard browserAddressBarFocusObserver == nil,
+              browserAddressBarBlurObserver == nil,
+              browserWebViewFirstResponderObserver == nil else { return }
 
         browserAddressBarFocusObserver = NotificationCenter.default.addObserver(
             forName: .browserDidFocusAddressBar,
@@ -12681,6 +12717,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 self.stopBrowserOmnibarSelectionRepeat()
 #if DEBUG
                 dlog("addressBar BLUR panelId=\(panelId.uuidString.prefix(8))")
+#endif
+            }
+        }
+
+        browserWebViewFirstResponderObserver = NotificationCenter.default.addObserver(
+            forName: .browserDidBecomeFirstResponderWebView,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            guard let webView = notification.object as? CmuxWebView,
+                  let panel = self.browserPanelOwning(webView) else { return }
+            panel.endSuppressWebViewFocusForAddressBar()
+            if self.browserAddressBarFocusedPanelId != nil {
+                self.browserAddressBarFocusedPanelId = nil
+                self.stopBrowserOmnibarSelectionRepeat()
+#if DEBUG
+                dlog(
+                    "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
+                    "reason=webViewFirstResponder"
+                )
 #endif
             }
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1587,6 +1587,25 @@ func shouldDispatchBrowserReturnViaFirstResponderKeyDown(
     return browserOmnibarShouldSubmitOnReturn(flags: flags)
 }
 
+func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsBrowser: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsBrowser else { return false }
+    guard !firstResponderHasMarkedText else { return false }
+    guard keyCode == 125 || keyCode == 126 else { return false }
+
+    // Keep this narrow to avoid stealing app/browser shortcuts that layer onto
+    // modified arrow keys. Plain up/down should always flow through keyDown so
+    // web content such as Google Docs receives the event directly.
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    return normalizedFlags.isEmpty
+}
+
 func shouldToggleMainWindowFullScreenForCommandControlFShortcut(
     flags: NSEvent.ModifierFlags,
     chars: String,
@@ -13898,6 +13917,7 @@ private var cmuxFirstResponderGuardCurrentEventContext: NSEvent?
 private var cmuxFirstResponderGuardHitViewContext: NSView?
 private var cmuxFirstResponderGuardContextWindowNumber: Int?
 private var cmuxBrowserReturnForwardingDepth = 0
+private var cmuxBrowserArrowForwardingDepth = 0
 private var cmuxWindowFirstResponderBypassDepth = 0
 private var cmuxFieldEditorOwningWebViewAssociationKey: UInt8 = 0
 
@@ -14283,6 +14303,32 @@ private extension NSWindow {
             defer { cmuxBrowserReturnForwardingDepth = max(0, cmuxBrowserReturnForwardingDepth - 1) }
 #if DEBUG
             dlog("  → browser Return/Enter routed to firstResponder.keyDown")
+#endif
+            self.firstResponder?.keyDown(with: event)
+            return true
+        }
+
+        // Some browser content (notably Google Docs) loses plain up/down when
+        // NSWindow.performKeyEquivalent claims the arrow before WebKit sees
+        // keyDown. Route those arrows directly to the first responder instead.
+        if shouldDispatchBrowserArrowViaFirstResponderKeyDown(
+            keyCode: event.keyCode,
+            firstResponderIsBrowser: firstResponderWebView != nil,
+            firstResponderHasMarkedText: firstResponderHasMarkedText,
+            flags: event.modifierFlags
+        ) {
+            // Match the Return/Enter forwarding guard: AppKit/WebKit can re-enter
+            // performKeyEquivalent while the synthesized keyDown is in flight.
+            if cmuxBrowserArrowForwardingDepth > 0 {
+#if DEBUG
+                dlog("  → browser Up/Down reentry; using normal dispatch")
+#endif
+                return false
+            }
+            cmuxBrowserArrowForwardingDepth += 1
+            defer { cmuxBrowserArrowForwardingDepth = max(0, cmuxBrowserArrowForwardingDepth - 1) }
+#if DEBUG
+            dlog("  → browser Up/Down routed to firstResponder.keyDown")
 #endif
             self.firstResponder?.keyDown(with: event)
             return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11749,8 +11749,38 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return panelId
     }
 
+    private func browserOmnibarOwnerView(for responder: NSResponder?) -> NSView? {
+        guard let responder else { return nil }
+
+        if let textView = responder as? NSTextView,
+           textView.isFieldEditor,
+           let delegateView = textView.delegate as? NSView,
+           delegateView.identifier == browserOmnibarTextFieldIdentifier {
+            return delegateView
+        }
+
+        let ownerView = keyRoutingOwnerView(for: responder)
+        guard ownerView?.identifier == browserOmnibarTextFieldIdentifier else { return nil }
+        return ownerView
+    }
+
     private func isBrowserOmnibarResponder(_ responder: NSResponder?) -> Bool {
-        keyRoutingOwnerView(for: responder)?.identifier == browserOmnibarTextFieldIdentifier
+        guard let ownerView = browserOmnibarOwnerView(for: responder) else { return false }
+
+        if let fieldEditor = responder as? NSTextView,
+           fieldEditor.isFieldEditor {
+            return (ownerView as? NSTextField)?.currentEditor() === fieldEditor
+        }
+
+        return true
+    }
+
+    private func shouldPreserveBrowserAddressBarTracking(for panel: BrowserPanel) -> Bool {
+        guard browserAddressBarFocusedPanelId == panel.id else { return false }
+        if isBrowserOmnibarResponder(panel.webView.window?.firstResponder) {
+            return true
+        }
+        return panel.preferredFocusIntent == .addressBar && panel.shouldSuppressWebViewFocus()
     }
 
     @discardableResult
@@ -12746,7 +12776,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if let trackedPanelId = self.browserAddressBarFocusedPanelId,
                trackedPanelId != panel.id,
                let trackedPanel = self.browserPanel(for: trackedPanelId),
-               !self.isBrowserOmnibarResponder(trackedPanel.webView.window?.firstResponder) {
+               !self.shouldPreserveBrowserAddressBarTracking(for: trackedPanel) {
                 trackedPanel.endSuppressWebViewFocusForAddressBar()
                 self.browserAddressBarFocusedPanelId = nil
                 self.stopBrowserOmnibarSelectionRepeat()
@@ -12758,12 +12788,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             }
 
-            guard panel.pendingAddressBarFocusRequestId == nil ||
-                    self.browserAddressBarFocusedPanelId != panel.id else {
+            guard !self.shouldPreserveBrowserAddressBarTracking(for: panel) else {
 #if DEBUG
                 dlog(
                     "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
-                    "reason=skip_pending_focus_handoff"
+                    "reason=skip_preserve_omnibar_handoff"
                 )
 #endif
                 return

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11725,12 +11725,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
         let shortcutResponder = shortcutWindow?.firstResponder
-        let responderIsOmnibar = isBrowserOmnibarResponder(shortcutResponder)
-        let pendingAddressBarHandoff =
-            panel.pendingAddressBarFocusRequestId != nil &&
-            workspace.focusedPanelId == panelId
 
-        guard responderIsOmnibar || pendingAddressBarHandoff else {
+        guard isBrowserOmnibarResponder(shortcutResponder) else {
 #if DEBUG
             let focusedPanel = workspace.focusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
             dlog(
@@ -11744,10 +11740,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
 #if DEBUG
-        let acceptReason = responderIsOmnibar ? "omnibar_responder" : "pending_handoff"
         dlog(
             "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
-            "accepted=1 reason=\(acceptReason) workspace=\(workspace.id.uuidString.prefix(5)) " +
+            "accepted=1 reason=omnibar_responder workspace=\(workspace.id.uuidString.prefix(5)) " +
             "event=\(NSWindow.keyDescription(event))"
         )
 #endif
@@ -11755,17 +11750,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func isBrowserOmnibarResponder(_ responder: NSResponder?) -> Bool {
-        guard let ownerView = keyRoutingOwnerView(for: responder) else { return false }
-
-        var current: NSView? = ownerView
-        while let candidate = current {
-            if candidate.identifier == browserOmnibarTextFieldIdentifier {
-                return true
-            }
-            current = candidate.superview
-        }
-
-        return false
+        keyRoutingOwnerView(for: responder)?.identifier == browserOmnibarTextFieldIdentifier
     }
 
     @discardableResult
@@ -12757,6 +12742,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self else { return }
             guard let webView = notification.object as? CmuxWebView,
                   let panel = self.browserPanelOwning(webView) else { return }
+
+            if let trackedPanelId = self.browserAddressBarFocusedPanelId,
+               trackedPanelId != panel.id,
+               let trackedPanel = self.browserPanel(for: trackedPanelId),
+               !self.isBrowserOmnibarResponder(trackedPanel.webView.window?.firstResponder) {
+                trackedPanel.endSuppressWebViewFocusForAddressBar()
+                self.browserAddressBarFocusedPanelId = nil
+                self.stopBrowserOmnibarSelectionRepeat()
+#if DEBUG
+                dlog(
+                    "addressBar CLEAR panelId=\(trackedPanelId.uuidString.prefix(8)) " +
+                    "reason=stale_other_panel_webViewFirstResponder"
+                )
+#endif
+            }
+
             guard panel.pendingAddressBarFocusRequestId == nil ||
                     self.browserAddressBarFocusedPanelId != panel.id else {
 #if DEBUG

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11691,19 +11691,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func focusedBrowserAddressBarPanelIdForShortcutEvent(_ event: NSEvent) -> UUID? {
         guard let panelId = browserAddressBarFocusedPanelId else { return nil }
-        let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
-        let shortcutResponder = shortcutWindow?.firstResponder
-
-        guard isBrowserOmnibarResponder(shortcutResponder) else {
-#if DEBUG
-            dlog(
-                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
-                "accepted=0 reason=responder_not_omnibar responder=\(shortcutResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
-                "event=\(NSWindow.keyDescription(event))"
-            )
-#endif
-            return nil
-        }
 
         guard let context = preferredMainWindowContextForShortcutRouting(event: event) else {
 #if DEBUG
@@ -11725,7 +11712,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return nil
         }
 
-        guard workspace.browserPanel(for: panelId) != nil else {
+        guard let panel = workspace.browserPanel(for: panelId) else {
 #if DEBUG
             dlog(
                 "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
@@ -11736,10 +11723,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return nil
         }
 
+        let shortcutWindow = resolvedShortcutEventWindow(event) ?? NSApp.keyWindow ?? NSApp.mainWindow
+        let shortcutResponder = shortcutWindow?.firstResponder
+        let responderIsOmnibar = isBrowserOmnibarResponder(shortcutResponder)
+        let pendingAddressBarHandoff =
+            panel.pendingAddressBarFocusRequestId != nil &&
+            workspace.focusedPanelId == panelId
+
+        guard responderIsOmnibar || pendingAddressBarHandoff else {
 #if DEBUG
+            let focusedPanel = workspace.focusedPanelId.map { String($0.uuidString.prefix(5)) } ?? "nil"
+            dlog(
+                "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
+                "accepted=0 reason=responder_not_omnibar responder=\(shortcutResponder.map { String(describing: type(of: $0)) } ?? "nil") " +
+                "pending=\(panel.pendingAddressBarFocusRequestId != nil ? 1 : 0) focusedPanel=\(focusedPanel) " +
+                "event=\(NSWindow.keyDescription(event))"
+            )
+#endif
+            return nil
+        }
+
+#if DEBUG
+        let acceptReason = responderIsOmnibar ? "omnibar_responder" : "pending_handoff"
         dlog(
             "browser.focus.addressBar.shortcutContext panel=\(panelId.uuidString.prefix(5)) " +
-            "accepted=1 workspace=\(workspace.id.uuidString.prefix(5)) event=\(NSWindow.keyDescription(event))"
+            "accepted=1 reason=\(acceptReason) workspace=\(workspace.id.uuidString.prefix(5)) " +
+            "event=\(NSWindow.keyDescription(event))"
         )
 #endif
         return panelId
@@ -12748,8 +12757,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self else { return }
             guard let webView = notification.object as? CmuxWebView,
                   let panel = self.browserPanelOwning(webView) else { return }
+            guard panel.pendingAddressBarFocusRequestId == nil ||
+                    self.browserAddressBarFocusedPanelId != panel.id else {
+#if DEBUG
+                dlog(
+                    "addressBar CLEAR panelId=\(panel.id.uuidString.prefix(8)) " +
+                    "reason=skip_pending_focus_handoff"
+                )
+#endif
+                return
+            }
             panel.endSuppressWebViewFocusForAddressBar()
-            if self.browserAddressBarFocusedPanelId != nil {
+            if self.browserAddressBarFocusedPanelId == panel.id {
                 self.browserAddressBarFocusedPanelId = nil
                 self.stopBrowserOmnibarSelectionRepeat()
 #if DEBUG
@@ -12763,7 +12782,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func browserPanel(for panelId: UUID) -> BrowserPanel? {
-        return tabManager?.selectedWorkspace?.browserPanel(for: panelId)
+        return workspaceContainingPanel(panelId: panelId)?.workspace.browserPanel(for: panelId)
     }
 
     fileprivate func browserFindBarIsVisible(for webView: CmuxWebView) -> Bool {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5,6 +5,7 @@ import AppKit
 import ObjectiveC
 
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
+let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
 
 private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
     guard let object else { return "nil" }
@@ -3953,6 +3954,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 
     func makeNSView(context: Context) -> OmnibarNativeTextField {
         let field = OmnibarNativeTextField(frame: .zero)
+        field.identifier = browserOmnibarTextFieldIdentifier
         field.font = .systemFont(ofSize: 12)
         field.placeholderString = placeholder
         field.delegate = context.coordinator

--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -12,10 +12,9 @@ When we change the fork, update this document and the parent submodule SHA.
 
 ## Current fork changes
 
-Fork rebased onto upstream `main` at `3509ccf78` (`v1.3.1-457-g3509ccf78`) on March 30, 2026.
-Current cmux pinned fork head: `ae3cc5d29` (`v1.3.1-473-gae3cc5d29`).
-Fork `main` keeps this pin reachable via merge commit `5c781d710`
-(`Retain layer-background pin ancestry on main`).
+Fork main has advanced beyond the March 30, 2026 rebase onto upstream `main`
+at `3509ccf78` (`v1.3.1-457-g3509ccf78`).
+Current cmux pinned fork head: `3b684a085` (`tip-1717-g3b684a085`).
 
 ### 1) macOS display link restart on display changes
 
@@ -112,7 +111,17 @@ tend to conflict together during rebases.
   - Allows the host app to provide the terminal background via `CALayer.backgroundColor` for instant coverage during view resizes, avoiding alpha double-stacking.
   - Replays the layer-background restore on top of the refreshed Ghostty base so cmux keeps the resize-coverage fix after the upstream sync.
 
-The fork branch HEAD is now the section 7 layer-background restore commit.
+### 8) TerminalStream kitty graphics APC handling
+
+- Commit: `a8e92c9c5` (terminal: add APC handler to stream_terminal)
+- Files:
+  - `src/terminal/stream_terminal.zig`
+- Summary:
+  - Wires `.apc_start`, `.apc_put`, and `.apc_end` through the shared APC parser in `TerminalStream`.
+  - Restores kitty graphics execution and APC OK/error replies for the non-termio stream path used by cmux/libghostty integrations.
+
+Fork main now carries the section 8 APC handling fix plus later upstream merges;
+the current cmux pin is the head listed above.
 
 ## Upstreamed fork changes
 
@@ -169,5 +178,10 @@ These files change frequently upstream; be careful when rebasing the fork:
 - `src/termio/stream_handler.zig`
   - Keep DECSET 1004 enablement side-effect free. xterm-compatible focus reporting should only emit
     `CSI I` / `CSI O` on actual focus transitions, not immediately when the mode is enabled.
+
+- `src/terminal/stream_terminal.zig`
+  - Keep the APC handler wired into `.apc_start`, `.apc_put`, `.apc_end`, and preserve the
+    `apcEnd()` response path so kitty graphics still reach `Terminal.kittyGraphics()` and reply via
+    `write_pty`.
 
 If you resolve a conflict, update this doc with what changed.


### PR DESCRIPTION
## Summary

- Route plain Up/Down arrow keys in browser content through `firstResponder.keyDown` so WebKit pages like Google Docs receive them instead of losing them in `performKeyEquivalent`.
- Tighten browser omnibar shortcut detection so app-level shortcut bypass only applies when the omnibar text field is actually the current responder.
- Clear tracked address-bar focus when the browser web view becomes first responder to keep omnibar navigation state in sync.
- Fixes #1146.

## Testing

- Not run locally in this session.
- Manual verification not run in this session.
- Repo policy notes that local testing is generally deferred to CI / tagged app runs for this project.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: Not included.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS key-equivalent routing and focus/shortcut tracking, which can subtly affect global shortcuts and text input behavior across browser/terminal panes. Changes are scoped to browser-specific paths but should be validated across common shortcuts and IME scenarios.
> 
> **Overview**
> Fixes browser panels losing plain Up/Down arrow key presses (e.g., in Google Docs) by forwarding unmodified up/down arrows from `NSWindow.performKeyEquivalent` to `firstResponder.keyDown`, with a re-entrancy guard similar to existing Return/Enter forwarding.
> 
> Tightens omnibar shortcut behavior by only treating the address bar as focused when the actual omnibar text field is the current responder (via `browserOmnibarTextFieldIdentifier`), and keeps `browserAddressBarFocusedPanelId` in sync by clearing stale tracking when a web view becomes first responder (including cross-panel transitions).
> 
> Updates `docs/ghostty-fork.md` to reflect the new pinned Ghostty fork head and document an added TerminalStream APC/kitty-graphics handling patch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ffe48649ed2b00af0b863b61d4489c8710b3faf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost Up/Down arrow handling in the browser surface so WebKit pages (like Google Docs) receive plain arrows. Tightens omnibar shortcut focus detection with field‑editor awareness and keeps address‑bar focus state in sync. Fixes #1146.

- **Bug Fixes**
  - Route plain Up/Down to `firstResponder.keyDown` when the browser web view is first responder, no marked text, and no modifiers; adds a re‑entrancy guard and prevents `performKeyEquivalent` from swallowing them.
  - Only bypass app shortcuts and apply omnibar selection when the omnibar text field or its field editor is the responder (via `browserOmnibarTextFieldIdentifier`), or during a pending address‑bar handoff; uses a unified shortcut context for command and arrow navigation.
  - Clear tracked address‑bar focus when the web view becomes first responder (including other panels) and stop omnibar selection repeat; preserve tracking during an omnibar handoff to avoid flicker.

- **Dependencies**
  - Update `vendor/bonsplit`; refresh `docs/ghostty-fork.md` with the new fork head and APC/kitty‑graphics stream handler notes.

<sup>Written for commit 1ffe48649ed2b00af0b863b61d4489c8710b3faf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable arrow-key navigation and shortcut handling between address bar and web content, avoiding dispatch loops and honoring IME/text composition.
  * Improved focus detection and stricter shortcut-context checks to prevent shortcut conflicts and inconsistent omnibar selection.
* **New Features**
  * Omnibar text field now has a stable identifier for more consistent interactions.
* **Documentation**
  * Updated fork/merge notes and terminal graphics handling documentation.
* **Chores**
  * Updated a vendored dependency pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->