### PR TITLE
Load standalone Ghostty app support config at runtime

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1211,6 +1211,7 @@ class GhosttyApp {
     }
 
     static let shared = GhosttyApp()
+    private static let standaloneGhosttyBundleIdentifier = "com.mitchellh.ghostty"
     private static let releaseBundleIdentifier = "com.cmuxterm.app"
     private static let backgroundLogTimestampFormatter: ISO8601DateFormatter = {
         let formatter = ISO8601DateFormatter()
@@ -1733,9 +1734,8 @@ class GhosttyApp {
 
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
         ghostty_config_load_default_files(config)
-        loadLegacyGhosttyConfigIfNeeded(config)
+        loadAdditionalAppSupportGhosttyConfigFilesIfNeeded(config)
         ghostty_config_load_recursive_files(config)
-        loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         loadCJKFontFallbackIfNeeded(config)
         let useHostLayerBackground = !hasConfiguredBackgroundImage(config)
         usesHostLayerBackground = useHostLayerBackground
@@ -2053,33 +2053,17 @@ class GhosttyApp {
               !bundleId.isEmpty,
               let appSupportDirectory else { return paths }
 
+        paths.append(contentsOf: standaloneGhosttyAppSupportConfigURLs(
+            appSupportDirectory: appSupportDirectory
+        ).map(\.path))
+
         let appSupportConfigURLs = cmuxAppSupportConfigURLs(
             currentBundleIdentifier: bundleId,
             appSupportDirectory: appSupportDirectory
         )
         paths.append(contentsOf: appSupportConfigURLs.map(\.path))
 
-        let releaseDir = appSupportDirectory.appendingPathComponent(releaseBundleIdentifier, isDirectory: true)
-        let releaseLegacyConfig = releaseDir.appendingPathComponent("config", isDirectory: false)
-        let releaseConfig = releaseDir.appendingPathComponent("config.ghostty", isDirectory: false)
-
-        let releaseConfigSize = configFileSize(at: releaseConfig)
-        let releaseLegacyConfigSize = configFileSize(at: releaseLegacyConfig)
-
-        if shouldLoadLegacyGhosttyConfig(
-            newConfigFileSize: releaseConfigSize,
-            legacyConfigFileSize: releaseLegacyConfigSize
-        ), !paths.contains(releaseLegacyConfig.path) {
-            paths.append(releaseLegacyConfig.path)
-        }
-
         return paths
-    }
-
-    private static func configFileSize(at url: URL) -> Int? {
-        guard let attrs = try? FileManager.default.attributesOfItem(atPath: url.path),
-              let size = attrs[.size] as? NSNumber else { return nil }
-        return size.intValue
     }
 
     /// Scans a single config file for font settings relevant to cmux's
@@ -2180,6 +2164,37 @@ class GhosttyApp {
         return true
     }
 
+    private static func appSupportConfigURLs(
+        bundleIdentifier: String,
+        appSupportDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        let directory = appSupportDirectory.appendingPathComponent(bundleIdentifier, isDirectory: true)
+        return [
+            directory.appendingPathComponent("config", isDirectory: false),
+            directory.appendingPathComponent("config.ghostty", isDirectory: false)
+        ].filter { url in
+            guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
+                  let type = attrs[.type] as? FileAttributeType,
+                  type == .typeRegular,
+                  let size = attrs[.size] as? NSNumber else {
+                return false
+            }
+            return size.intValue > 0
+        }
+    }
+
+    static func standaloneGhosttyAppSupportConfigURLs(
+        appSupportDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        appSupportConfigURLs(
+            bundleIdentifier: standaloneGhosttyBundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        )
+    }
+
     static func cmuxAppSupportConfigURLs(
         currentBundleIdentifier: String?,
         appSupportDirectory: URL,
@@ -2187,28 +2202,20 @@ class GhosttyApp {
     ) -> [URL] {
         guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else { return [] }
 
-        func existingConfigURLs(for bundleIdentifier: String) -> [URL] {
-            let directory = appSupportDirectory.appendingPathComponent(bundleIdentifier, isDirectory: true)
-            return [
-                directory.appendingPathComponent("config", isDirectory: false),
-                directory.appendingPathComponent("config.ghostty", isDirectory: false)
-            ].filter { url in
-                guard let attrs = try? fileManager.attributesOfItem(atPath: url.path),
-                      let type = attrs[.type] as? FileAttributeType,
-                      type == .typeRegular,
-                      let size = attrs[.size] as? NSNumber else {
-                    return false
-                }
-                return size.intValue > 0
-            }
-        }
-
-        let currentURLs = existingConfigURLs(for: currentBundleIdentifier)
+        let currentURLs = appSupportConfigURLs(
+            bundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        )
         if !currentURLs.isEmpty {
             return currentURLs
         }
         if SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
-            let releaseURLs = existingConfigURLs(for: releaseBundleIdentifier)
+            let releaseURLs = appSupportConfigURLs(
+                bundleIdentifier: releaseBundleIdentifier,
+                appSupportDirectory: appSupportDirectory,
+                fileManager: fileManager
+            )
             if !releaseURLs.isEmpty {
                 return releaseURLs
             }
@@ -2253,14 +2260,42 @@ class GhosttyApp {
         return true
     }
 
-    private func loadCmuxAppSupportGhosttyConfigIfNeeded(_ config: ghostty_config_t) {
+    /// Standalone Ghostty's macOS config should apply in cmux as the shared
+    /// baseline, with cmux-specific app-support config layered on top.
+    private static func supplementalAppSupportConfigURLsForRuntime(
+        currentBundleIdentifier: String?,
+        appSupportDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        var urls = standaloneGhosttyAppSupportConfigURLs(
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        )
+        guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else { return urls }
+        guard currentBundleIdentifier != releaseBundleIdentifier else { return urls }
+
+        let currentURLs = appSupportConfigURLs(
+            bundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
+            fileManager: fileManager
+        )
+        if currentURLs.isEmpty && SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
+            urls.append(contentsOf: appSupportConfigURLs(
+                bundleIdentifier: releaseBundleIdentifier,
+                appSupportDirectory: appSupportDirectory,
+                fileManager: fileManager
+            ))
+        }
+
+        return urls
+    }
+
+    private func loadAdditionalAppSupportGhosttyConfigFilesIfNeeded(_ config: ghostty_config_t) {
         #if os(macOS)
         let fm = FileManager.default
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
-        guard let currentBundleIdentifier = Bundle.main.bundleIdentifier,
-              !currentBundleIdentifier.isEmpty else { return }
-        let urls = Self.cmuxAppSupportConfigURLs(
-            currentBundleIdentifier: currentBundleIdentifier,
+        let urls = Self.supplementalAppSupportConfigURLsForRuntime(
+            currentBundleIdentifier: Bundle.main.bundleIdentifier,
             appSupportDirectory: appSupport,
             fileManager: fm
         )
@@ -2274,41 +2309,9 @@ class GhosttyApp {
 
 #if DEBUG
         dlog(
-            "loaded cmux app support ghostty config from: \(urls.map(\.path).joined(separator: ", "))"
+            "loaded supplemental ghostty app support config from: \(urls.map(\.path).joined(separator: ", "))"
         )
 #endif
-        #endif
-    }
-
-    private func loadLegacyGhosttyConfigIfNeeded(_ config: ghostty_config_t) {
-        #if os(macOS)
-        // Ghostty 1.3+ prefers `config.ghostty`, but some users still have their real
-        // settings in the legacy `config` file. If the new file exists but is empty,
-        // load the legacy file as a compatibility fallback.
-        let fm = FileManager.default
-        guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
-        let ghosttyDir = appSupport.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
-        let configNew = ghosttyDir.appendingPathComponent("config.ghostty", isDirectory: false)
-        let configLegacy = ghosttyDir.appendingPathComponent("config", isDirectory: false)
-
-        func fileSize(_ url: URL) -> Int? {
-            guard let attrs = try? fm.attributesOfItem(atPath: url.path),
-                  let size = attrs[.size] as? NSNumber else { return nil }
-            return size.intValue
-        }
-
-        guard Self.shouldLoadLegacyGhosttyConfig(
-            newConfigFileSize: fileSize(configNew),
-            legacyConfigFileSize: fileSize(configLegacy)
-        ) else { return }
-
-        configLegacy.path.withCString { path in
-            ghostty_config_load_file(config, path)
-        }
-
-        #if DEBUG
-        Self.initLog("loaded legacy ghostty config because config.ghostty was empty: \(configLegacy.path)")
-        #endif
         #endif
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1858,6 +1858,11 @@ class GhosttyApp {
         }
     }
 
+    private struct UserFontConfigScanPlan {
+        var topLevelConfigPaths: [String]
+        var overrideConfigPaths: [String]
+    }
+
     /// Returns (range, font) pairs for CJK font fallback based on the system's
     /// preferred languages, or nil if no CJK language is detected. Each language
     /// only maps its own script ranges to avoid assigning glyphs to a font that
@@ -1904,12 +1909,21 @@ class GhosttyApp {
     /// primary font family.
     static func autoInjectedCJKFontMappings(
         preferredLanguages: [String] = Locale.preferredLanguages,
-        configPaths: [String] = loadedCJKScanPaths(),
+        configPaths: [String]? = nil,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first,
         rangeCoverageProbe: ((String, String) -> Bool)? = nil
     ) -> [(String, String)]? {
         guard var mappings = cjkFontMappings(preferredLanguages: preferredLanguages) else { return nil }
 
-        let summary = userFontConfigSummary(configPaths: configPaths)
+        let summary = userFontConfigSummary(
+            configPaths: configPaths,
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        )
         if summary.containsCodepointMap || summary.hasExplicitFontFamilyFallbackChain {
             return nil
         }
@@ -1935,25 +1949,50 @@ class GhosttyApp {
     /// a `font-codepoint-map` entry covering CJK ranges. Also checks
     /// application-support config paths that cmux may load at runtime.
     static func userConfigContainsCJKCodepointMap(
-        configPaths: [String] = loadedCJKScanPaths()
+        configPaths: [String]? = nil,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
     ) -> Bool {
-        userFontConfigSummary(configPaths: configPaths).containsCodepointMap
+        userFontConfigSummary(
+            configPaths: configPaths,
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        ).containsCodepointMap
     }
 
     static func userConfigHasExplicitFontFamilyFallbackChain(
-        configPaths: [String] = loadedCJKScanPaths()
+        configPaths: [String]? = nil,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
     ) -> Bool {
-        userFontConfigSummary(configPaths: configPaths).hasExplicitFontFamilyFallbackChain
+        userFontConfigSummary(
+            configPaths: configPaths,
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        ).hasExplicitFontFamilyFallbackChain
     }
 
     static func shouldInjectCJKFontFallback(
         preferredLanguages: [String] = Locale.preferredLanguages,
-        configPaths: [String] = loadedCJKScanPaths(),
+        configPaths: [String]? = nil,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first,
         rangeCoverageProbe: ((String, String) -> Bool)? = nil
     ) -> Bool {
         autoInjectedCJKFontMappings(
             preferredLanguages: preferredLanguages,
             configPaths: configPaths,
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory,
             rangeCoverageProbe: rangeCoverageProbe
         ) != nil
     }
@@ -2003,18 +2042,70 @@ class GhosttyApp {
     }
 
     private static func userFontConfigSummary(
-        configPaths: [String] = loadedCJKScanPaths()
+        configPaths: [String]? = nil,
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> UserFontConfigSummary {
+        if let configPaths {
+            return userFontConfigSummary(topLevelConfigPaths: configPaths)
+        }
+
+        return userFontConfigSummary(
+            scanPlan: userFontConfigScanPlan(
+                currentBundleIdentifier: currentBundleIdentifier,
+                appSupportDirectory: appSupportDirectory
+            )
+        )
+    }
+
+    private static func userFontConfigSummary(
+        topLevelConfigPaths: [String]
     ) -> UserFontConfigSummary {
         var summary = UserFontConfigSummary()
+        scanFontConfigFiles(
+            atPaths: topLevelConfigPaths,
+            summary: &summary,
+            loadRecursiveIncludes: true
+        )
+        return summary
+    }
+
+    private static func userFontConfigSummary(
+        scanPlan: UserFontConfigScanPlan
+    ) -> UserFontConfigSummary {
+        var summary = UserFontConfigSummary()
+        scanFontConfigFiles(
+            atPaths: scanPlan.topLevelConfigPaths,
+            summary: &summary,
+            loadRecursiveIncludes: true
+        )
+        scanFontConfigFiles(
+            atPaths: scanPlan.overrideConfigPaths,
+            summary: &summary,
+            loadRecursiveIncludes: false
+        )
+        return summary
+    }
+
+    private static func scanFontConfigFiles(
+        atPaths paths: [String],
+        summary: inout UserFontConfigSummary,
+        loadRecursiveIncludes: Bool
+    ) {
         var recursiveConfigPaths: [String] = []
 
-        for path in configPaths.map({ NSString(string: $0).expandingTildeInPath }) {
+        for path in paths.map({ NSString(string: $0).expandingTildeInPath }) {
             scanFontConfigFile(
                 atPath: path,
                 summary: &summary,
                 recursiveConfigPaths: &recursiveConfigPaths
             )
         }
+
+        guard loadRecursiveIncludes else { return }
 
         var loadedRecursivePaths = Set<String>()
         var index = 0
@@ -2031,12 +2122,11 @@ class GhosttyApp {
                 recursiveConfigPaths: &recursiveConfigPaths
             )
         }
-
-        return summary
     }
 
-    /// Returns the top-level config paths that cmux will actually load before
-    /// recursive `config-file` processing.
+    /// Returns the top-level config paths that can affect cmux's CJK scan.
+    /// Standalone Ghostty config participates in recursive `config-file`
+    /// loading before cmux's bundle-specific override layer is applied last.
     static func loadedCJKScanPaths(
         currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = FileManager.default.urls(
@@ -2044,26 +2134,47 @@ class GhosttyApp {
             in: .userDomainMask
         ).first
     ) -> [String] {
-        var paths = [
+        let scanPlan = userFontConfigScanPlan(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        )
+        return scanPlan.topLevelConfigPaths + scanPlan.overrideConfigPaths
+    }
+
+    private static func userFontConfigScanPlan(
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> UserFontConfigScanPlan {
+        var topLevelConfigPaths = [
             "~/.config/ghostty/config",
             "~/.config/ghostty/config.ghostty",
         ]
+        var overrideConfigPaths: [String] = []
 
         guard let bundleId = currentBundleIdentifier,
               !bundleId.isEmpty,
-              let appSupportDirectory else { return paths }
+              let appSupportDirectory else {
+            return UserFontConfigScanPlan(
+                topLevelConfigPaths: topLevelConfigPaths,
+                overrideConfigPaths: overrideConfigPaths
+            )
+        }
 
-        paths.append(contentsOf: standaloneGhosttyAppSupportConfigURLs(
+        topLevelConfigPaths.append(contentsOf: standaloneGhosttyAppSupportConfigURLs(
+            appSupportDirectory: appSupportDirectory
+        ).map(\.path))
+        overrideConfigPaths.append(contentsOf: cmuxAppSupportConfigURLs(
+            currentBundleIdentifier: bundleId,
             appSupportDirectory: appSupportDirectory
         ).map(\.path))
 
-        let appSupportConfigURLs = cmuxAppSupportConfigURLs(
-            currentBundleIdentifier: bundleId,
-            appSupportDirectory: appSupportDirectory
+        return UserFontConfigScanPlan(
+            topLevelConfigPaths: topLevelConfigPaths,
+            overrideConfigPaths: overrideConfigPaths
         )
-        paths.append(contentsOf: appSupportConfigURLs.map(\.path))
-
-        return paths
     }
 
     /// Scans a single config file for font settings relevant to cmux's
@@ -2153,15 +2264,6 @@ class GhosttyApp {
             ? expanded
             : (parentDir as NSString).appendingPathComponent(expanded)
         recursiveConfigPaths.append(absolute)
-    }
-
-    static func shouldLoadLegacyGhosttyConfig(
-        newConfigFileSize: Int?,
-        legacyConfigFileSize: Int?
-    ) -> Bool {
-        guard let newConfigFileSize, newConfigFileSize == 0 else { return false }
-        guard let legacyConfigFileSize, legacyConfigFileSize > 0 else { return false }
-        return true
     }
 
     private static func appSupportConfigURLs(
@@ -2266,6 +2368,11 @@ class GhosttyApp {
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
         guard let currentBundleIdentifier = Bundle.main.bundleIdentifier,
               !currentBundleIdentifier.isEmpty else { return }
+        // Ghostty's default-file pass already loaded its normal XDG and
+        // app-support roots, and `ghostty_config_load_recursive_files`
+        // has already consumed any queued `config-file` includes from those
+        // sources. This late pass is only for cmux's bundle-specific
+        // app-support override layer.
         let urls = Self.cmuxAppSupportConfigURLs(
             currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupport,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1734,8 +1734,8 @@ class GhosttyApp {
 
     private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) {
         ghostty_config_load_default_files(config)
-        loadAdditionalAppSupportGhosttyConfigFilesIfNeeded(config)
         ghostty_config_load_recursive_files(config)
+        loadCmuxAppSupportGhosttyConfigIfNeeded(config)
         loadCJKFontFallbackIfNeeded(config)
         let useHostLayerBackground = !hasConfiguredBackgroundImage(config)
         usesHostLayerBackground = useHostLayerBackground
@@ -2260,42 +2260,14 @@ class GhosttyApp {
         return true
     }
 
-    /// Standalone Ghostty's macOS config should apply in cmux as the shared
-    /// baseline, with cmux-specific app-support config layered on top.
-    private static func supplementalAppSupportConfigURLsForRuntime(
-        currentBundleIdentifier: String?,
-        appSupportDirectory: URL,
-        fileManager: FileManager = .default
-    ) -> [URL] {
-        var urls = standaloneGhosttyAppSupportConfigURLs(
-            appSupportDirectory: appSupportDirectory,
-            fileManager: fileManager
-        )
-        guard let currentBundleIdentifier, !currentBundleIdentifier.isEmpty else { return urls }
-        guard currentBundleIdentifier != releaseBundleIdentifier else { return urls }
-
-        let currentURLs = appSupportConfigURLs(
-            bundleIdentifier: currentBundleIdentifier,
-            appSupportDirectory: appSupportDirectory,
-            fileManager: fileManager
-        )
-        if currentURLs.isEmpty && SocketControlSettings.isDebugLikeBundleIdentifier(currentBundleIdentifier) {
-            urls.append(contentsOf: appSupportConfigURLs(
-                bundleIdentifier: releaseBundleIdentifier,
-                appSupportDirectory: appSupportDirectory,
-                fileManager: fileManager
-            ))
-        }
-
-        return urls
-    }
-
-    private func loadAdditionalAppSupportGhosttyConfigFilesIfNeeded(_ config: ghostty_config_t) {
+    private func loadCmuxAppSupportGhosttyConfigIfNeeded(_ config: ghostty_config_t) {
         #if os(macOS)
         let fm = FileManager.default
         guard let appSupport = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first else { return }
-        let urls = Self.supplementalAppSupportConfigURLsForRuntime(
-            currentBundleIdentifier: Bundle.main.bundleIdentifier,
+        guard let currentBundleIdentifier = Bundle.main.bundleIdentifier,
+              !currentBundleIdentifier.isEmpty else { return }
+        let urls = Self.cmuxAppSupportConfigURLs(
+            currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupport,
             fileManager: fm
         )
@@ -2309,7 +2281,7 @@ class GhosttyApp {
 
 #if DEBUG
         dlog(
-            "loaded supplemental ghostty app support config from: \(urls.map(\.path).joined(separator: ", "))"
+            "loaded cmux app support ghostty config from: \(urls.map(\.path).joined(separator: ", "))"
         )
 #endif
         #endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2050,6 +2050,9 @@ class GhosttyApp {
         ).first
     ) -> UserFontConfigSummary {
         if let configPaths {
+            // Explicit config paths model Ghostty's pre-recursive top-level
+            // inputs. Runtime cmux override files are applied afterward and
+            // must not have their own `config-file` directives recursed here.
             return userFontConfigSummary(topLevelConfigPaths: configPaths)
         }
 
@@ -2124,9 +2127,9 @@ class GhosttyApp {
         }
     }
 
-    /// Returns the top-level config paths that can affect cmux's CJK scan.
-    /// Standalone Ghostty config participates in recursive `config-file`
-    /// loading before cmux's bundle-specific override layer is applied last.
+    /// Returns the pre-recursive top-level config paths that can affect cmux's
+    /// CJK scan. cmux's bundle-specific override layer is applied afterward
+    /// and exposed separately via `loadedCJKOverrideConfigPaths`.
     static func loadedCJKScanPaths(
         currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = FileManager.default.urls(
@@ -2134,11 +2137,24 @@ class GhosttyApp {
             in: .userDomainMask
         ).first
     ) -> [String] {
-        let scanPlan = userFontConfigScanPlan(
+        userFontConfigScanPlan(
             currentBundleIdentifier: currentBundleIdentifier,
             appSupportDirectory: appSupportDirectory
-        )
-        return scanPlan.topLevelConfigPaths + scanPlan.overrideConfigPaths
+        ).topLevelConfigPaths
+    }
+
+    /// Returns cmux's post-recursive application-support override config paths.
+    static func loadedCJKOverrideConfigPaths(
+        currentBundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first
+    ) -> [String] {
+        userFontConfigScanPlan(
+            currentBundleIdentifier: currentBundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        ).overrideConfigPaths
     }
 
     private static func userFontConfigScanPlan(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -276,42 +276,6 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertEqual(second.fontFamily, "reload-2")
     }
 
-    func testLegacyConfigFallbackUsesLegacyFileWhenConfigGhosttyIsEmpty() {
-        XCTAssertTrue(
-            GhosttyApp.shouldLoadLegacyGhosttyConfig(
-                newConfigFileSize: 0,
-                legacyConfigFileSize: 42
-            )
-        )
-    }
-
-    func testLegacyConfigFallbackSkipsWhenNewFileMissingOrLegacyEmpty() {
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadLegacyGhosttyConfig(
-                newConfigFileSize: nil,
-                legacyConfigFileSize: 42
-            )
-        )
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadLegacyGhosttyConfig(
-                newConfigFileSize: 10,
-                legacyConfigFileSize: 42
-            )
-        )
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadLegacyGhosttyConfig(
-                newConfigFileSize: 0,
-                legacyConfigFileSize: 0
-            )
-        )
-        XCTAssertFalse(
-            GhosttyApp.shouldLoadLegacyGhosttyConfig(
-                newConfigFileSize: 0,
-                legacyConfigFileSize: nil
-            )
-        )
-    }
-
     func testCmuxAppSupportConfigURLsUseReleaseConfigForDebugBundleWithoutCurrentConfig() throws {
         try withTemporaryAppSupportDirectory { appSupportDirectory in
             let releaseConfigURL = try writeAppSupportConfig(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -392,6 +392,35 @@ final class GhosttyConfigTests: XCTestCase {
         }
     }
 
+    func testLoadedCJKScanPathsIncludeStandaloneGhosttyAppSupportBeforeCmuxOverrides() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let ghosttyConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.mitchellh.ghostty",
+                filename: "config.ghostty",
+                contents: "font-feature = calt\n"
+            )
+            let cmuxConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: "font-family = JetBrains Mono\n"
+            )
+
+            let paths = GhosttyApp.loadedCJKScanPaths(
+                currentBundleIdentifier: "com.cmuxterm.app.debug",
+                appSupportDirectory: appSupportDirectory
+            )
+
+            XCTAssertTrue(paths.contains(ghosttyConfigURL.path))
+            XCTAssertTrue(paths.contains(cmuxConfigURL.path))
+
+            let ghosttyIndex = try XCTUnwrap(paths.firstIndex(of: ghosttyConfigURL.path))
+            let cmuxIndex = try XCTUnwrap(paths.firstIndex(of: cmuxConfigURL.path))
+            XCTAssertLessThan(ghosttyIndex, cmuxIndex)
+        }
+    }
+
     func testDefaultBackgroundUpdateScopePrioritizesSurfaceOverAppAndUnscoped() {
         XCTAssertTrue(
             GhosttyApp.shouldApplyDefaultBackgroundUpdate(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2705,9 +2705,9 @@ final class GhosttyMouseFocusTests: XCTestCase {
         try "font-family = JetBrains Mono\n"
             .write(to: taggedConfig, atomically: true, encoding: .utf8)
 
-        let releaseDir = appSupport.appendingPathComponent("com.mitchellh.ghostty", isDirectory: true)
-        try FileManager.default.createDirectory(at: releaseDir, withIntermediateDirectories: true)
-        let releaseConfig = releaseDir.appendingPathComponent("config", isDirectory: false)
+        let cmuxReleaseDir = appSupport.appendingPathComponent("com.cmuxterm.app", isDirectory: true)
+        try FileManager.default.createDirectory(at: cmuxReleaseDir, withIntermediateDirectories: true)
+        let releaseConfig = cmuxReleaseDir.appendingPathComponent("config", isDirectory: false)
         try "font-family = LXGW WenKai Mono TC\n"
             .write(to: releaseConfig, atomically: true, encoding: .utf8)
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -2624,6 +2624,46 @@ final class GhosttyMouseFocusTests: XCTestCase {
         }
     }
 
+    func testShouldInjectCJKFontFallbackKeepsCmuxOverridesAfterStandaloneRecursiveIncludes() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let sharedConfigURL = appSupportDirectory
+                .appendingPathComponent("shared-fonts.conf", isDirectory: false)
+            try "font-family = LXGW WenKai Mono TC\n"
+                .write(to: sharedConfigURL, atomically: true, encoding: .utf8)
+
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.mitchellh.ghostty",
+                filename: "config.ghostty",
+                contents: """
+                font-family = JetBrains Mono
+                config-file = \(sharedConfigURL.path)
+                """
+            )
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: """
+                font-family =
+                font-family = JetBrains Mono
+                """
+            )
+
+            XCTAssertTrue(
+                GhosttyApp.shouldInjectCJKFontFallback(
+                    preferredLanguages: ["zh-Hans-CN"],
+                    currentBundleIdentifier: "com.cmuxterm.app",
+                    appSupportDirectory: appSupportDirectory,
+                    rangeCoverageProbe: { fontFamily, _ in
+                        XCTAssertEqual(fontFamily, "JetBrains Mono")
+                        return false
+                    }
+                )
+            )
+        }
+    }
+
     func testLoadedCJKScanPathsSkipsReleaseAppSupportWhenTaggedConfigExists() throws {
         let appSupport = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-test-cjk-app-support-\(UUID().uuidString)")

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -331,6 +331,25 @@ final class GhosttyConfigTests: XCTestCase {
         }
     }
 
+    func testCmuxAppSupportConfigURLsUseReleaseConfigForReleaseBundle() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let releaseConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: "font-feature = calt\n"
+            )
+
+            XCTAssertEqual(
+                GhosttyApp.cmuxAppSupportConfigURLs(
+                    currentBundleIdentifier: "com.cmuxterm.app",
+                    appSupportDirectory: appSupportDirectory
+                ),
+                [releaseConfigURL]
+            )
+        }
+    }
+
     func testCmuxAppSupportConfigURLsPreferCurrentBundleConfigWhenPresent() throws {
         try withTemporaryAppSupportDirectory { appSupportDirectory in
             _ = try writeAppSupportConfig(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -9,6 +9,33 @@ import Darwin
 @testable import cmux
 #endif
 
+private func withTemporaryAppSupportDirectory(
+    _ body: (URL) throws -> Void
+) throws {
+    let fileManager = FileManager.default
+    let directory = fileManager.temporaryDirectory
+        .appendingPathComponent("cmux-app-support-\(UUID().uuidString)", isDirectory: true)
+    try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? fileManager.removeItem(at: directory) }
+    try body(directory)
+}
+
+private func writeAppSupportConfig(
+    appSupportDirectory: URL,
+    bundleIdentifier: String,
+    filename: String,
+    contents: String
+) throws -> URL {
+    let fileManager = FileManager.default
+    let bundleDirectory = appSupportDirectory
+        .appendingPathComponent(bundleIdentifier, isDirectory: true)
+    try fileManager.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+
+    let configURL = bundleDirectory.appendingPathComponent(filename, isDirectory: false)
+    try contents.write(to: configURL, atomically: true, encoding: .utf8)
+    return configURL
+}
+
 final class SidebarPathFormatterTests: XCTestCase {
     func testShortenedPathReplacesExactHomeDirectory() {
         XCTAssertEqual(
@@ -375,7 +402,7 @@ final class GhosttyConfigTests: XCTestCase {
         }
     }
 
-    func testLoadedCJKScanPathsIncludeStandaloneGhosttyAppSupportBeforeCmuxOverrides() throws {
+    func testLoadedCJKPathOrderIncludesStandaloneGhosttyAppSupportBeforeCmuxOverrides() throws {
         try withTemporaryAppSupportDirectory { appSupportDirectory in
             let ghosttyConfigURL = try writeAppSupportConfig(
                 appSupportDirectory: appSupportDirectory,
@@ -390,10 +417,15 @@ final class GhosttyConfigTests: XCTestCase {
                 contents: "font-family = JetBrains Mono\n"
             )
 
-            let paths = GhosttyApp.loadedCJKScanPaths(
-                currentBundleIdentifier: "com.cmuxterm.app.debug",
-                appSupportDirectory: appSupportDirectory
-            )
+            let paths =
+                GhosttyApp.loadedCJKScanPaths(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug",
+                    appSupportDirectory: appSupportDirectory
+                ) +
+                GhosttyApp.loadedCJKOverrideConfigPaths(
+                    currentBundleIdentifier: "com.cmuxterm.app.debug",
+                    appSupportDirectory: appSupportDirectory
+                )
 
             XCTAssertTrue(paths.contains(ghosttyConfigURL.path))
             XCTAssertTrue(paths.contains(cmuxConfigURL.path))
@@ -401,6 +433,31 @@ final class GhosttyConfigTests: XCTestCase {
             let ghosttyIndex = try XCTUnwrap(paths.firstIndex(of: ghosttyConfigURL.path))
             let cmuxIndex = try XCTUnwrap(paths.firstIndex(of: cmuxConfigURL.path))
             XCTAssertLessThan(ghosttyIndex, cmuxIndex)
+        }
+    }
+
+    func testLoadedCJKScanPathsIncludeOnlyPreRecursiveInputs() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let standaloneConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.mitchellh.ghostty",
+                filename: "config.ghostty",
+                contents: "font-feature = calt\n"
+            )
+            let cmuxConfigURL = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: "font-family = JetBrains Mono\n"
+            )
+
+            let scanPaths = GhosttyApp.loadedCJKScanPaths(
+                currentBundleIdentifier: "com.cmuxterm.app.debug",
+                appSupportDirectory: appSupportDirectory
+            )
+
+            XCTAssertTrue(scanPaths.contains(standaloneConfigURL.path))
+            XCTAssertFalse(scanPaths.contains(cmuxConfigURL.path))
         }
     }
 
@@ -611,32 +668,6 @@ final class GhosttyConfigTests: XCTestCase {
         )
     }
 
-    private func withTemporaryAppSupportDirectory(
-        _ body: (URL) throws -> Void
-    ) throws {
-        let fileManager = FileManager.default
-        let directory = fileManager.temporaryDirectory
-            .appendingPathComponent("cmux-app-support-\(UUID().uuidString)", isDirectory: true)
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-        defer { try? fileManager.removeItem(at: directory) }
-        try body(directory)
-    }
-
-    private func writeAppSupportConfig(
-        appSupportDirectory: URL,
-        bundleIdentifier: String,
-        filename: String,
-        contents: String
-    ) throws -> URL {
-        let fileManager = FileManager.default
-        let bundleDirectory = appSupportDirectory
-            .appendingPathComponent(bundleIdentifier, isDirectory: true)
-        try fileManager.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
-
-        let configURL = bundleDirectory.appendingPathComponent(filename, isDirectory: false)
-        try contents.write(to: configURL, atomically: true, encoding: .utf8)
-        return configURL
-    }
 }
 
 final class WorkspaceChromeThemeTests: XCTestCase {
@@ -2628,7 +2659,41 @@ final class GhosttyMouseFocusTests: XCTestCase {
         }
     }
 
-    func testLoadedCJKScanPathsSkipsReleaseAppSupportWhenTaggedConfigExists() throws {
+    func testShouldInjectCJKFontFallbackIgnoresConfigFileIncludesInsideCmuxOverrides() throws {
+        try withTemporaryAppSupportDirectory { appSupportDirectory in
+            let overrideIncludeURL = appSupportDirectory
+                .appendingPathComponent("override-fonts.conf", isDirectory: false)
+            try "font-family = LXGW WenKai Mono TC\n"
+                .write(to: overrideIncludeURL, atomically: true, encoding: .utf8)
+
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.mitchellh.ghostty",
+                filename: "config.ghostty",
+                contents: "font-family = JetBrains Mono\n"
+            )
+            _ = try writeAppSupportConfig(
+                appSupportDirectory: appSupportDirectory,
+                bundleIdentifier: "com.cmuxterm.app",
+                filename: "config.ghostty",
+                contents: "config-file = \(overrideIncludeURL.path)\n"
+            )
+
+            XCTAssertTrue(
+                GhosttyApp.shouldInjectCJKFontFallback(
+                    preferredLanguages: ["zh-Hans-CN"],
+                    currentBundleIdentifier: "com.cmuxterm.app",
+                    appSupportDirectory: appSupportDirectory,
+                    rangeCoverageProbe: { fontFamily, _ in
+                        XCTAssertEqual(fontFamily, "JetBrains Mono")
+                        return false
+                    }
+                )
+            )
+        }
+    }
+
+    func testLoadedCJKPathOrderSkipsReleaseAppSupportWhenTaggedConfigExists() throws {
         let appSupport = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-test-cjk-app-support-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: appSupport, withIntermediateDirectories: true)
@@ -2646,17 +2711,23 @@ final class GhosttyMouseFocusTests: XCTestCase {
         try "font-family = LXGW WenKai Mono TC\n"
             .write(to: releaseConfig, atomically: true, encoding: .utf8)
 
-        let paths = GhosttyApp.loadedCJKScanPaths(
-            currentBundleIdentifier: "com.example.cmux-dev",
-            appSupportDirectory: appSupport
-        )
+        let paths =
+            GhosttyApp.loadedCJKScanPaths(
+                currentBundleIdentifier: "com.example.cmux-dev",
+                appSupportDirectory: appSupport
+            ) +
+            GhosttyApp.loadedCJKOverrideConfigPaths(
+                currentBundleIdentifier: "com.example.cmux-dev",
+                appSupportDirectory: appSupport
+            )
 
         XCTAssertTrue(paths.contains(taggedConfig.path))
         XCTAssertFalse(paths.contains(releaseConfig.path))
         XCTAssertTrue(
             GhosttyApp.shouldInjectCJKFontFallback(
                 preferredLanguages: ["zh-Hans-CN"],
-                configPaths: paths
+                currentBundleIdentifier: "com.example.cmux-dev",
+                appSupportDirectory: appSupport
             )
         )
     }


### PR DESCRIPTION
Fixes #2781.

## Summary

- load standalone Ghostty app-support config files before cmux-specific app-support overrides during runtime so Ghostty font-feature settings like ligatures carry into cmux
- consolidate app-support config discovery so both `config` and `config.ghostty` are considered only when they exist as non-empty regular files
- add a regression test that verifies standalone Ghostty app-support config is scanned before cmux overrides for config-driven font fallback behavior

## Testing

- Not run locally in this turn; repo policy says not to run tests locally
- Added regression coverage in `cmuxTests/GhosttyConfigTests.swift`

## Demo Video

- Video URL or attachment: N/A (runtime config-loading change)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime Ghostty config load order and CJK font-fallback scanning behavior, which can alter effective font/rendering settings for users depending on their config files. Risk is moderate due to precedence/recursion edge cases, but covered by new regression tests.
> 
> **Overview**
> Ensures cmux loads the standalone Ghostty app-support configs (`com.mitchellh.ghostty`) as part of the *pre-recursive* config inputs, so settings like `font-feature` (e.g. ligatures) carry into cmux before cmux’s own app-support override layer is applied.
> 
> Refactors CJK font-fallback config scanning into a two-phase plan: recurse `config-file` includes for top-level inputs, then apply cmux app-support override files **without** recursing their includes, matching runtime load semantics. Also consolidates app-support config discovery to only consider non-empty regular `config`/`config.ghostty` files and removes the legacy Ghostty `config` fallback path.
> 
> Adds/updates tests to validate app-support config selection (debug-like bundle falling back to release), scan/override ordering, and that override-layer `config-file` directives do not affect the CJK scan.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b6922718ba7b8c128b37756950d279ad89fee1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load standalone Ghostty Application Support config at runtime before cmux overrides so ligature and font settings carry into cmux, and match the CJK font-fallback scan to the same two-phase order. CJK helpers now separate pre-recursive inputs from post-recursive overrides to preserve cmux’s precedence.

- **Bug Fixes**
  - Two-phase order for CJK scan and runtime load: standalone `com.mitchellh.ghostty` top-level configs (with recursive includes) first; cmux App Support overrides (no recursive includes) last. Helpers accept optional bundle/app-support inputs and expose explicit override paths to mirror runtime order.
  - Unified discovery to only non-empty regular `config`/`config.ghostty` files; include standalone App Support in the top-level scan. Release uses `com.cmuxterm.app`; debug-like bundles fall back to release only if their own config is missing. Removed the legacy `config` fallback loader.
  - Added tests for load/scan order, pre-recursive vs override separation, ignoring `config-file` includes inside overrides, and preserving cmux override precedence. Fixed the tagged CJK regression fixture.

<sup>Written for commit 3b6922718ba7b8c128b37756950d279ad89fee1b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable config discovery and ordering so standalone and app‑support configs are detected consistently; CJK font-fallback now respects explicit and app‑support overrides.

* **Refactor**
  * CJK config scanning reorganized into distinct “top-level” and “override” phases and legacy compatibility fallbacks removed; public APIs now accept optional config inputs and compute scan inputs when unspecified.

* **Tests**
  * Expanded tests covering config resolution, precedence, scan-path behavior, and CJK font-fallback scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->