### PR TITLE
Fix Intel second-surface inheritance crash

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -99,6 +99,10 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
+    guard cmuxPointerAppearsLive(quicklookFont) else {
+        return nil
+    }
+
     let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
@@ -117,7 +121,7 @@ func cmuxSurfaceForInheritance(_ terminalPanel: TerminalPanel) -> ghostty_surfac
         return override(terminalPanel)
     }
 #endif
-    return terminalPanel.surface.surface
+    return terminalPanel.surface.liveSurfaceForGhosttyAccess(reason: "workspace.inheritance")
 }
 
 func cmuxInheritedSurfaceConfig(
@@ -130,22 +134,14 @@ func cmuxInheritedSurfaceConfig(
 #else
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
 #endif
-    var config = CmuxSurfaceConfigTemplate(cConfig: inherited)
-
-    // Make runtime zoom inheritance explicit, even when Ghostty's
-    // inherit-font-size config is disabled.
-    let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
-    if let points = runtimePoints {
-        config.fontSize = points
-    }
+    let config = CmuxSurfaceConfigTemplate(cConfig: inherited)
 
 #if DEBUG
     let inheritedText = String(format: "%.2f", inherited.font_size)
-    let runtimeText = runtimePoints.map { String(format: "%.2f", $0) } ?? "nil"
     let finalText = String(format: "%.2f", config.fontSize)
     dlog(
         "zoom.inherit context=\(cmuxSurfaceContextName(context)) " +
-        "inherited=\(inheritedText) runtime=\(runtimeText) final=\(finalText)"
+        "inherited=\(inheritedText) runtime=nil final=\(finalText)"
     )
 #endif
 
@@ -8654,34 +8650,26 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func resolvedTerminalInheritanceFontPoints(
         for terminalPanel: TerminalPanel,
-        sourceSurface: ghostty_surface_t,
         inheritedConfig: CmuxSurfaceConfigTemplate
     ) -> Float? {
-        let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface)
         if let rooted = terminalInheritanceFontPointsByPanelId[terminalPanel.id], rooted > 0 {
-            if let runtimePoints, abs(runtimePoints - rooted) > 0.05 {
-                // Runtime zoom changed after lineage was seeded (manual zoom on descendant);
-                // treat runtime as the new root for future descendants.
-                return runtimePoints
+            if inheritedConfig.fontSize > 0,
+               abs(inheritedConfig.fontSize - rooted) > 0.05 {
+                return inheritedConfig.fontSize
             }
             return rooted
         }
         if inheritedConfig.fontSize > 0 {
             return inheritedConfig.fontSize
         }
-        return runtimePoints
+        return nil
     }
 
     private func rememberTerminalConfigInheritanceSource(_ terminalPanel: TerminalPanel) {
         lastTerminalConfigInheritancePanelId = terminalPanel.id
-        if let sourceSurface = terminalPanel.surface.surface,
-           let runtimePoints = cmuxCurrentSurfaceFontSizePoints(sourceSurface) {
-            let existing = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
-            if existing == nil || abs((existing ?? runtimePoints) - runtimePoints) > 0.05 {
-                terminalInheritanceFontPointsByPanelId[terminalPanel.id] = runtimePoints
-            }
-            lastTerminalConfigInheritanceFontPoints =
-                terminalInheritanceFontPointsByPanelId[terminalPanel.id] ?? runtimePoints
+        if let rootedFontPoints = terminalInheritanceFontPointsByPanelId[terminalPanel.id],
+           rootedFontPoints > 0 {
+            lastTerminalConfigInheritanceFontPoints = rootedFontPoints
         }
     }
 
@@ -8766,33 +8754,35 @@ final class Workspace: Identifiable, ObservableObject {
         preferredPanelId: UUID? = nil,
         inPane preferredPaneId: PaneID? = nil
     ) -> CmuxSurfaceConfigTemplate? {
-        // Walk candidates in priority order and use the first panel that still exposes
-        // a runtime surface pointer.
+        var staleRootedFontFallback: Float?
+
+        // Walk candidates in priority order and use the first panel with a live surface.
+        // If a preferred candidate is already torn down, retain its rooted font as a
+        // fallback instead of probing through stale native font state.
         for terminalPanel in terminalPanelConfigInheritanceCandidates(
             preferredPanelId: preferredPanelId,
             inPane: preferredPaneId
         ) {
-            // Pin the panel and its TerminalSurface wrapper for the duration of
-            // this iteration. The raw ghostty_surface_t extracted below is owned
-            // by `surface` (the TerminalSurface) — ARC must not release it while
-            // ghostty_surface_inherited_config or cmuxCurrentSurfaceFontSizePoints
-            // is still reading through the pointer.
-            let surface = terminalPanel.surface
-            guard let sourceSurface = cmuxSurfaceForInheritance(terminalPanel) else { continue }
+            let rootedFontFallback = terminalInheritanceFontPointsByPanelId[terminalPanel.id]
+            guard let sourceSurface = cmuxSurfaceForInheritance(terminalPanel) else {
+                if staleRootedFontFallback == nil,
+                   let rootedFontFallback,
+                   rootedFontFallback > 0 {
+                    staleRootedFontFallback = rootedFontFallback
+                }
+                continue
+            }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT
             )
             if let rootedFontPoints = resolvedTerminalInheritanceFontPoints(
                 for: terminalPanel,
-                sourceSurface: sourceSurface,
                 inheritedConfig: config
             ), rootedFontPoints > 0 {
                 config.fontSize = rootedFontPoints
                 terminalInheritanceFontPointsByPanelId[terminalPanel.id] = rootedFontPoints
             }
-            // Prevent ARC from releasing panel/surface before the C calls above complete.
-            withExtendedLifetime((terminalPanel, surface)) {}
             rememberTerminalConfigInheritanceSource(terminalPanel)
             if config.fontSize > 0 {
                 lastTerminalConfigInheritanceFontPoints = config.fontSize
@@ -8800,12 +8790,13 @@ final class Workspace: Identifiable, ObservableObject {
             return config
         }
 
-        if let fallbackFontPoints = lastTerminalConfigInheritanceFontPoints {
+        if let fallbackFontPoints = staleRootedFontFallback ?? lastTerminalConfigInheritanceFontPoints {
             var config = CmuxSurfaceConfigTemplate()
             config.fontSize = fallbackFontPoints
 #if DEBUG
+            let fallbackSource = staleRootedFontFallback != nil ? "quarantinedRootedFont" : "lastKnownFont"
             dlog(
-                "zoom.inherit fallback=lastKnownFont context=split font=\(String(format: "%.2f", fallbackFontPoints))"
+                "zoom.inherit fallback=\(fallbackSource) context=split font=\(String(format: "%.2f", fallbackFontPoints))"
             )
 #endif
             return config

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -86,6 +86,11 @@ func cmuxSurfacePointerAppearsLive(_ surface: ghostty_surface_t) -> Bool {
 }
 
 func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
+#if DEBUG
+    if let override = cmuxCurrentSurfaceFontSizePointsOverride {
+        return override(surface)
+    }
+#endif
     guard cmuxSurfacePointerAppearsLive(surface) else {
         return nil
     }
@@ -100,11 +105,31 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
     return points
 }
 
+#if DEBUG
+var cmuxCurrentSurfaceFontSizePointsOverride: ((ghostty_surface_t) -> Float?)?
+var cmuxGhosttyInheritedSurfaceConfigOverride: ((ghostty_surface_t, ghostty_surface_context_e) -> ghostty_surface_config_s)?
+var cmuxSurfaceForInheritanceOverride: ((TerminalPanel) -> ghostty_surface_t?)?
+#endif
+
+func cmuxSurfaceForInheritance(_ terminalPanel: TerminalPanel) -> ghostty_surface_t? {
+#if DEBUG
+    if let override = cmuxSurfaceForInheritanceOverride {
+        return override(terminalPanel)
+    }
+#endif
+    return terminalPanel.surface.surface
+}
+
 func cmuxInheritedSurfaceConfig(
     sourceSurface: ghostty_surface_t,
     context: ghostty_surface_context_e
 ) -> CmuxSurfaceConfigTemplate {
+#if DEBUG
+    let inherited = cmuxGhosttyInheritedSurfaceConfigOverride?(sourceSurface, context)
+        ?? ghostty_surface_inherited_config(sourceSurface, context)
+#else
     let inherited = ghostty_surface_inherited_config(sourceSurface, context)
+#endif
     var config = CmuxSurfaceConfigTemplate(cConfig: inherited)
 
     // Make runtime zoom inheritance explicit, even when Ghostty's
@@ -8753,7 +8778,7 @@ final class Workspace: Identifiable, ObservableObject {
             // ghostty_surface_inherited_config or cmuxCurrentSurfaceFontSizePoints
             // is still reading through the pointer.
             let surface = terminalPanel.surface
-            guard let sourceSurface = surface.surface else { continue }
+            guard let sourceSurface = cmuxSurfaceForInheritance(terminalPanel) else { continue }
             var config = cmuxInheritedSurfaceConfig(
                 sourceSurface: sourceSurface,
                 context: GHOSTTY_SURFACE_CONTEXT_SPLIT

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2614,6 +2614,56 @@ final class WorkspaceTerminalConfigInheritanceSelectionTests: XCTestCase {
             "Expected inheritance to prefer last focused terminal when browser is focused in another pane"
         )
     }
+
+    func testNewTerminalSplitDoesNotProbeRuntimeFontOnSourceSurfaceDuringInheritance() {
+        let workspace = Workspace()
+        guard let sourcePanelId = workspace.focusedPanelId,
+              let sourcePanel = workspace.terminalPanel(for: sourcePanelId) else {
+            XCTFail("Expected initial focused terminal panel")
+            return
+        }
+
+        let fakeSurfaceStorage = UnsafeMutableRawPointer.allocate(byteCount: 1, alignment: 1)
+        let fakeSurface = unsafeBitCast(fakeSurfaceStorage, to: ghostty_surface_t.self)
+        let originalFontOverride = cmuxCurrentSurfaceFontSizePointsOverride
+        let originalInheritedOverride = cmuxGhosttyInheritedSurfaceConfigOverride
+        let originalSurfaceOverride = cmuxSurfaceForInheritanceOverride
+        var runtimeProbeCount = 0
+        cmuxSurfaceForInheritanceOverride = { panel in
+            panel.id == sourcePanel.id ? fakeSurface : nil
+        }
+        cmuxGhosttyInheritedSurfaceConfigOverride = { _, _ in
+            var config = ghostty_surface_config_new()
+            config.font_size = 17
+            return config
+        }
+        cmuxCurrentSurfaceFontSizePointsOverride = { _ in
+            runtimeProbeCount += 1
+            return 23
+        }
+        defer {
+            cmuxCurrentSurfaceFontSizePointsOverride = originalFontOverride
+            cmuxGhosttyInheritedSurfaceConfigOverride = originalInheritedOverride
+            cmuxSurfaceForInheritanceOverride = originalSurfaceOverride
+            fakeSurfaceStorage.deallocate()
+        }
+
+        guard let splitPanel = workspace.newTerminalSplit(
+            from: sourcePanel.id,
+            orientation: .horizontal,
+            focus: false
+        ) else {
+            XCTFail("Expected split terminal panel to be created")
+            return
+        }
+
+        XCTAssertNotNil(workspace.panels[splitPanel.id])
+        XCTAssertEqual(
+            runtimeProbeCount,
+            0,
+            "Split inheritance should not probe runtime font state from the source surface"
+        )
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add a regression seam/test for Intel second-surface inheritance
- stop probing live Ghostty font state while building inherited surface config
- fall back to rooted cached font values when the source terminal is already tearing down

## Why
Fixes #2047. Intel second-surface creation was still reading runtime font state from the source Ghostty surface during split/new-surface inheritance. That path can hand back stale CoreText pointers on x86_64, which turns second-surface creation into an EXC_BAD_ACCESS.

## Test plan
- not run locally by policy
- ran `./scripts/setup.sh`
- dispatch the existing `Repro Intel release split shortcuts` GitHub workflow against this branch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal split config inheritance and raw surface-pointer access, which could impact font/zoom inheritance behavior across panels if edge cases are missed. Mitigated by added debug seams and a regression unit test targeting the crash scenario.
> 
> **Overview**
> Prevents split/new-surface config inheritance from probing live CoreText font state on the source `ghostty_surface_t`, instead relying on `ghostty_surface_inherited_config` plus cached (“rooted”) font sizes and returning `nil` when no safe font value is available.
> 
> Adds debug-only override seams (`cmuxSurfaceForInheritance`, `cmuxGhosttyInheritedSurfaceConfigOverride`, `cmuxCurrentSurfaceFontSizePointsOverride`) and a new unit test asserting that split inheritance does not call the runtime font probe, plus extra liveness checks on the quicklook font pointer and a fallback path that uses cached rooted font sizes when the preferred source surface is already torn down.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5253b60701cce9c2d87efc70e029ce191c501c61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an Intel crash when creating a split/second surface by avoiding runtime font probes during inheritance and using safe, rooted font values instead. Prevents EXC_BAD_ACCESS from stale CoreText pointers and adds a regression test. Fixes #2047.

- **Bug Fixes**
  - Stop probing live font state during split/new-surface inheritance; rely on `ghostty_surface_inherited_config` and cached rooted font.
  - Select a live source via `cmuxSurfaceForInheritance`; if the preferred panel is torn down, fall back to the rooted font instead of touching stale native pointers.
  - Add a unit test to ensure split inheritance never probes runtime font state.

<sup>Written for commit 5253b60701cce9c2d87efc70e029ce191c501c61. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved reliability of configuration inheritance during terminal split creation
  * Enhanced fallback handling for inherited font configurations when terminal panels are closed
  * Optimized font resolution to reduce unnecessary runtime checks

* **Tests**
  * Added test coverage for terminal split configuration inheritance scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->