### PR TITLE
Fix bash async job notification regression

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -72,10 +72,9 @@ _cmux_relay_rpc_bg() {
     local relay_cli=""
     _cmux_socket_uses_remote_relay || return 1
     relay_cli="$(_cmux_relay_cli_path)" || return 1
-    {
+    (
         "$relay_cli" rpc "$method" "$params" >/dev/null 2>&1 || true
-    } >/dev/null 2>&1 &
-    disown 2>/dev/null || true
+    ) >/dev/null 2>&1 &
 }
 
 _cmux_relay_rpc() {
@@ -380,9 +379,9 @@ _cmux_report_tty_once() {
         payload="$(_cmux_report_tty_payload)"
         [[ -n "$payload" ]] || return 0
         _CMUX_TTY_REPORTED=1
-        {
+        (
             _cmux_send "$payload"
-        } >/dev/null 2>&1 & disown
+        ) >/dev/null 2>&1 &
     else
         [[ -n "$_CMUX_TTY_NAME" ]] || return 0
         # Keep the first relay TTY report synchronous so the server can resolve
@@ -400,9 +399,9 @@ _cmux_report_shell_activity_state() {
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
     [[ "$_CMUX_SHELL_ACTIVITY_LAST" == "$state" ]] && return 0
     _CMUX_SHELL_ACTIVITY_LAST="$state"
-    {
+    (
         _cmux_send "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-    } >/dev/null 2>&1 & disown
+    ) >/dev/null 2>&1 &
 }
 
 _cmux_ports_kick() {
@@ -416,9 +415,9 @@ _cmux_ports_kick() {
     fi
     _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
     if _cmux_socket_is_unix; then
-        {
+        (
             _cmux_send "ports_kick --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID --reason=$reason"
-        } >/dev/null 2>&1 & disown
+        ) >/dev/null 2>&1 &
     else
         _cmux_ports_kick_via_relay "$reason"
     fi
@@ -514,9 +513,9 @@ _cmux_emit_pr_command_hint() {
         local quoted_target="${_CMUX_LAST_PR_TARGET//\"/\\\"}"
         payload+=" --target=\"$quoted_target\""
     fi
-    {
+    (
         _cmux_send "$payload"
-    } >/dev/null 2>&1 & disown
+    ) >/dev/null 2>&1 &
     _CMUX_LAST_PR_ACTION=""
     _CMUX_LAST_PR_TARGET=""
 }
@@ -835,7 +834,7 @@ _cmux_start_pr_poll_loop() {
     fi
     _CMUX_PR_POLL_PWD="$watch_pwd"
 
-    {
+    (
         local signal_path=""
         signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
         while :; do
@@ -857,9 +856,8 @@ _cmux_start_pr_poll_loop() {
                 slept=$(( slept + 1 ))
             done
         done
-    } >/dev/null 2>&1 &
+    ) >/dev/null 2>&1 &
     _CMUX_PR_POLL_PID=$!
-    disown "$_CMUX_PR_POLL_PID" 2>/dev/null || disown
 }
 
 _cmux_bash_cleanup() {
@@ -1004,10 +1002,10 @@ _cmux_prompt_command() {
     # CWD: keep the app in sync with the actual shell directory.
     if [[ "$pwd" != "$_CMUX_PWD_LAST_PWD" ]]; then
         _CMUX_PWD_LAST_PWD="$pwd"
-        {
+        (
             local qpwd="${pwd//\"/\\\"}"
             _cmux_send "report_pwd \"${qpwd}\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-        } >/dev/null 2>&1 & disown
+        ) >/dev/null 2>&1 &
     fi
 
     # Branch can change via aliases/tools while an older probe is still in flight.
@@ -1051,7 +1049,7 @@ _cmux_prompt_command() {
     if [[ -z "$_CMUX_GIT_JOB_PID" ]] || ! kill -0 "$_CMUX_GIT_JOB_PID" 2>/dev/null; then
         _CMUX_GIT_LAST_PWD="$pwd"
         _CMUX_GIT_LAST_RUN=$now
-        {
+        (
             # Skip git operations if not in a git repository to avoid TCC prompts
             git rev-parse --git-dir >/dev/null 2>&1 || return 0
             local branch dirty_opt=""
@@ -1064,9 +1062,8 @@ _cmux_prompt_command() {
             else
                 _cmux_send "clear_git_branch --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
             fi
-        } >/dev/null 2>&1 &
+        ) >/dev/null 2>&1 &
         _CMUX_GIT_JOB_PID=$!
-        disown
         _CMUX_GIT_JOB_STARTED_AT=$now
     fi
 

--- a/tests/test_issue_1565_bash_job_notifications.py
+++ b/tests/test_issue_1565_bash_job_notifications.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""
+Regression guard for issue #1565.
+
+The shipped bash integration must keep cmux fire-and-forget async jobs in the
+backgrounded subshell form rather than reintroducing brace-group + disown
+launches for the known prompt-time call sites.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION_PATH = ROOT / "Resources" / "shell-integration" / "cmux-bash-integration.bash"
+
+EXPECTED_ASYNC_SUBSHELL_COUNTS = {
+    "_cmux_relay_rpc_bg": 1,
+    "_cmux_report_tty_once": 1,
+    "_cmux_report_shell_activity_state": 1,
+    "_cmux_ports_kick": 1,
+    "_cmux_emit_pr_command_hint": 1,
+    "_cmux_start_pr_poll_loop": 1,
+    "_cmux_prompt_command": 2,
+}
+
+ASYNC_BRACE_GROUP_RE = re.compile(r"^\s*}\s*>/dev/null 2>&1 &(?:\s*disown)?\s*$", re.MULTILINE)
+ASYNC_SUBSHELL_RE = re.compile(r"^\s*\)\s*>/dev/null 2>&1 &\s*$", re.MULTILINE)
+FUNCTION_BODY_RE_TEMPLATE = r"^{name}\(\) \{{\n(?P<body>.*?)^}}"
+
+
+def extract_function_body(script_text: str, function_name: str) -> str:
+    pattern = re.compile(
+        FUNCTION_BODY_RE_TEMPLATE.format(name=re.escape(function_name)),
+        re.MULTILINE | re.DOTALL,
+    )
+    match = pattern.search(script_text)
+    if match is None:
+        raise AssertionError(f"missing function definition for {function_name}")
+    return match.group("body")
+
+
+def main() -> int:
+    script_text = INTEGRATION_PATH.read_text(encoding="utf-8")
+    failures: list[str] = []
+
+    if "& disown" in script_text:
+        failures.append("cmux-bash-integration.bash still contains '& disown'")
+
+    for function_name, expected_count in EXPECTED_ASYNC_SUBSHELL_COUNTS.items():
+        body = extract_function_body(script_text, function_name)
+        brace_group_hits = len(ASYNC_BRACE_GROUP_RE.findall(body))
+        if brace_group_hits:
+            failures.append(
+                f"{function_name}: found {brace_group_hits} brace-group async launch(es)"
+            )
+
+        if "disown" in body:
+            failures.append(f"{function_name}: unexpected disown remains in function body")
+
+        subshell_hits = len(ASYNC_SUBSHELL_RE.findall(body))
+        if subshell_hits != expected_count:
+            failures.append(
+                f"{function_name}: expected {expected_count} async subshell launch(es), found {subshell_hits}"
+            )
+
+    if failures:
+        print("FAIL:")
+        for failure in failures:
+            print(failure)
+        return 1
+
+    print("PASS: bash integration async cmux jobs use backgrounded subshells without disown")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add an issue #1565 regression guard for the bash integration async launch form
- replace brace-group background jobs plus disown with backgrounded subshells in the bash shell integration
- keep PID-tracked async jobs using `$!` without disown

## Testing
- not run locally (per repo policy)
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `python3 -m py_compile tests/test_issue_1565_bash_job_notifications.py`

Closes #1565

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes prompt-time background job launching in the bash integration, which could affect job control behavior across different shell setups. Scope is limited and guarded by a new regression test.
> 
> **Overview**
> Fixes a bash integration regression by replacing several async `cmux` send/relay/background tasks from brace-group + `disown` to **backgrounded subshell** launches (and removes `disown` usage), including cases that track PIDs via `$!`.
> 
> Adds `tests/test_issue_1565_bash_job_notifications.py` to assert the integration contains no `& disown`, rejects brace-group async patterns in key functions, and verifies expected counts of subshell-based async launches to prevent the regression from returning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afe3158c0db3b7441733c2c2ba5773379a506c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore correct async job notifications in the Bash integration by running background tasks in subshells instead of brace groups with disown. Fixes #1565 and keeps PID tracking using `$!` where needed.

- **Bug Fixes**
  - Replaced `{ ... } >/dev/null 2>&1 & disown` with `( ... ) >/dev/null 2>&1 &` across async call sites; removed `disown` and captured `$!` for tracked jobs (e.g., PR poll loop, git probe).
  - Added `tests/test_issue_1565_bash_job_notifications.py` to enforce subshell launches and prevent reintroducing `disown`.

<sup>Written for commit afe3158c0db3b7441733c2c2ba5773379a506c21. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced bash shell integration to improve stability and reliability of background job management and tracking.

* **Tests**
  * Added regression test to validate asynchronous job behavior within bash shell integration and prevent future regressions in job handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->