### PR TITLE
feat: RedisStreamEmitter v2 schema — 2-tier storage

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11,6 +11,174 @@ import Security
 import Sentry
 #endif
 
+// MARK: - Custom Build Identifier
+private let cmuxCustomBuildTag = "custom-redis-hooks"
+private let cmuxCustomBuildVersion = "1.0.0"
+
+// MARK: - Redis Stream Emitter
+
+/// Emits Claude Code hook events to a Redis Stream via raw RESP protocol.
+/// 2-tier storage: lightweight promoted fields in Stream, full raw_input in workspace-grouped Hash.
+/// Fire-and-forget: errors are silently ignored to avoid blocking the hook pipeline.
+private struct RedisStreamEmitter {
+    private let host: String
+    private let port: UInt16
+    private let streamKey: String
+    private let timeoutMs: Int
+    private let schemaVersion: Int
+
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.environment["CMUX_REDIS_ENABLED"] == "1"
+    }
+
+    init() {
+        let url = ProcessInfo.processInfo.environment["CMUX_REDIS_URL"] ?? "127.0.0.1"
+        let parts = url.replacingOccurrences(of: "redis://", with: "").split(separator: ":")
+        self.host = String(parts.first ?? "127.0.0.1")
+        self.port = parts.count > 1 ? UInt16(parts[1]) ?? 6379 : 6379
+        self.streamKey = ProcessInfo.processInfo.environment["CMUX_REDIS_STREAM"] ?? "cmux:hooks"
+        self.timeoutMs = Int(ProcessInfo.processInfo.environment["CMUX_REDIS_TIMEOUT_MS"] ?? "100") ?? 100
+        self.schemaVersion = Int(ProcessInfo.processInfo.environment["CMUX_REDIS_SCHEMA_VERSION"] ?? "2") ?? 2
+    }
+
+    /// Send a hook event to the Redis Stream. Fails silently.
+    /// Schema v2: XADD with promoted fields + HSET full data to workspace-grouped Hash (pipelined).
+    /// Schema v1: legacy XADD with raw_input inline (rollback mode).
+    func emit(
+        subcommand: String,
+        workspaceId: String?,
+        surfaceId: String?,
+        sessionId: String?,
+        cwd: String?,
+        rawInput: String,
+        promotedFields: [(String, String)] = []
+    ) {
+        let wid = workspaceId ?? ""
+        let sid = surfaceId ?? ""
+        let sessId = sessionId ?? ""
+        let cwdVal = cwd ?? ""
+        let ts = ISO8601DateFormatter().string(from: Date())
+        let hn = ProcessInfo.processInfo.hostName
+
+        var resp: String
+
+        if schemaVersion >= 2 {
+            // Schema v2: lightweight stream entry + Hash detail
+            let detailUUID = String(UUID().uuidString.lowercased().prefix(8))
+            let dateFormatter = DateFormatter()
+            dateFormatter.dateFormat = "yyyyMMdd"
+            let dateStr = dateFormatter.string(from: Date())
+            let detailHash = "cmux:ws:\(wid):events:\(dateStr)"
+
+            // Truncate rawInput for Hash storage (256KB limit)
+            let maxRawSize = 256 * 1024
+            let rawForHash: String
+            if rawInput.utf8.count > maxRawSize {
+                // Try to parse as JSON, add _truncated flag
+                let truncated = String(rawInput.prefix(maxRawSize))
+                rawForHash = truncated
+            } else {
+                rawForHash = rawInput
+            }
+
+            // Build XADD fields (promoted, no raw_input)
+            var fields: [(String, String)] = [
+                ("subcommand", subcommand),
+                ("workspace_id", wid),
+                ("surface_id", sid),
+                ("session_id", sessId),
+                ("cwd", String(cwdVal.suffix(100))),
+                ("timestamp", ts),
+                ("hostname", hn),
+                ("custom_build", cmuxCustomBuildTag),
+                ("detail_ref", detailUUID),
+                ("detail_hash", detailHash),
+                ("schema_version", "2"),
+            ]
+            fields.append(contentsOf: promotedFields)
+
+            // XADD command
+            let xaddArgCount = 3 + fields.count * 2
+            var xadd = "*\(xaddArgCount)\r\n"
+            xadd += encodeRESPBulkString("XADD")
+            xadd += encodeRESPBulkString(streamKey)
+            xadd += encodeRESPBulkString("*")
+            for (key, value) in fields {
+                xadd += encodeRESPBulkString(key)
+                xadd += encodeRESPBulkString(value)
+            }
+
+            // HSET command: HSET <detailHash> <detailUUID> <rawForHash>
+            var hset = "*4\r\n"
+            hset += encodeRESPBulkString("HSET")
+            hset += encodeRESPBulkString(detailHash)
+            hset += encodeRESPBulkString(detailUUID)
+            hset += encodeRESPBulkString(rawForHash)
+
+            // Pipeline both commands
+            resp = xadd + hset
+        } else {
+            // Schema v1: legacy mode with raw_input inline
+            let fields: [(String, String)] = [
+                ("subcommand", subcommand),
+                ("workspace_id", wid),
+                ("surface_id", sid),
+                ("session_id", sessId),
+                ("cwd", cwdVal),
+                ("raw_input", rawInput),
+                ("timestamp", ts),
+                ("hostname", hn),
+                ("custom_build", cmuxCustomBuildTag),
+            ]
+            let totalArgs = 3 + fields.count * 2
+            resp = "*\(totalArgs)\r\n"
+            resp += encodeRESPBulkString("XADD")
+            resp += encodeRESPBulkString(streamKey)
+            resp += encodeRESPBulkString("*")
+            for (key, value) in fields {
+                resp += encodeRESPBulkString(key)
+                resp += encodeRESPBulkString(value)
+            }
+        }
+
+        // TCP connect + send with timeout
+        let sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else { return }
+        defer { close(sock) }
+
+        var tv = timeval(tv_sec: 0, tv_usec: Int32(timeoutMs * 1000))
+        setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+        setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, socklen_t(MemoryLayout<timeval>.size))
+
+        var addr = sockaddr_in()
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = port.bigEndian
+        inet_pton(AF_INET, host, &addr.sin_addr)
+
+        let connectResult = withUnsafePointer(to: &addr) { ptr in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.connect(sock, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        guard connectResult == 0 else { return }
+
+        // Write pipelined commands as raw bytes to handle binary-safe content
+        let data = Array(resp.utf8)
+        data.withUnsafeBufferPointer { ptr in
+            _ = Darwin.write(sock, ptr.baseAddress!, data.count)
+        }
+
+        // Read responses (XADD returns stream ID, HSET returns integer; don't care about either)
+        var buf = [UInt8](repeating: 0, count: 512)
+        _ = Darwin.read(sock, &buf, buf.count)
+    }
+
+    private func encodeRESPBulkString(_ s: String) -> String {
+        let utf8 = s.utf8
+        return "$\(utf8.count)\r\n\(s)\r\n"
+    }
+}
+
 struct CLIError: Error, CustomStringConvertible {
     let message: String
 
@@ -12304,6 +12472,64 @@ struct CMUXCLI {
         let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore()
+
+        // Emit hook event to Redis Stream (fire-and-forget, errors silently ignored)
+        if RedisStreamEmitter.isEnabled {
+            // Extract promoted fields from parsed input for v2 schema
+            var promotedFields: [(String, String)] = []
+            if let object = parsedInput.object {
+                switch subcommand {
+                case "session-start", "active":
+                    if let model = firstString(in: object, keys: ["model"]) {
+                        promotedFields.append(("model", String(model.prefix(40))))
+                    }
+                    if let source = firstString(in: object, keys: ["source"]) {
+                        promotedFields.append(("source", String(source.prefix(20))))
+                    }
+                case "prompt-submit":
+                    if let preview = compactClaudeHookStringValue(object["prompt"], maxLength: 200) {
+                        promotedFields.append(("prompt_preview", preview))
+                    }
+                case "pre-tool-use":
+                    if let toolName = firstString(in: object, keys: ["tool_name"]) {
+                        promotedFields.append(("tool_name", String(toolName.prefix(60))))
+                    }
+                    if let toolSummary = describeToolUse(object) {
+                        promotedFields.append(("tool_summary", String(toolSummary.prefix(120))))
+                    }
+                case "stop", "idle":
+                    if let preview = compactClaudeHookStringValue(
+                        object["last_assistant_message"] ?? object["lastAssistantMessage"],
+                        maxLength: 200
+                    ) {
+                        promotedFields.append(("response_preview", preview))
+                    }
+                    if let reason = firstString(in: object, keys: ["reason"]) {
+                        promotedFields.append(("stop_reason", String(reason.prefix(40))))
+                    }
+                case "notification", "notify":
+                    let summary = summarizeClaudeHookNotification(parsedInput: parsedInput)
+                    promotedFields.append(("notify_type", summary.subtitle))
+                    promotedFields.append(("notify_message", String(summary.body.prefix(200))))
+                case "session-end":
+                    let reason = firstString(in: object, keys: ["reason"]) ?? "normal"
+                    promotedFields.append(("end_reason", String(reason.prefix(60))))
+                default:
+                    break
+                }
+            }
+
+            RedisStreamEmitter().emit(
+                subcommand: subcommand,
+                workspaceId: workspaceArg,
+                surfaceId: surfaceArg,
+                sessionId: parsedInput.sessionId,
+                cwd: parsedInput.cwd,
+                rawInput: rawInput,
+                promotedFields: promotedFields
+            )
+        }
+
         telemetry.breadcrumb(
             "claude-hook.input",
             data: [
@@ -13955,8 +14181,9 @@ struct CMUXCLI {
         } else {
             baseSummary = "cmux version unknown"
         }
-        guard let commit else { return baseSummary }
-        return "\(baseSummary) [\(commit)]"
+        let customSuffix = " [CUSTOM:\(cmuxCustomBuildTag) v\(cmuxCustomBuildVersion)]"
+        let base = commit != nil ? "\(baseSummary) [\(commit!)]" : baseSummary
+        return base + customSuffix
     }
 
     private func printWelcome() {

--- a/conv-logs/202604/11/conv-20260411-174654.md
+++ b/conv-logs/202604/11/conv-20260411-174654.md
@@ -1,0 +1,104 @@
+# Conversation Log — 2026-04-11 17:46
+
+# 참여자
+- Toby (사용자)
+- Claude (Opus 4.6)
+
+## 브랜치
+- `feature/tbkim-001`
+
+---
+
+## 1. cmux Claude hook Redis Stream 전송 로직 확인
+사용: Explore agent
+
+Toby: 현재 cmux claude hook을 socket에서 redis stream으로 전송하는 로직을 확인해달라.
+
+Claude: cmux의 RedisStreamEmitter 구현을 분석함:
+- `CLI/cmux.swift` lines 18-108: RedisStreamEmitter 구조체 (raw TCP RESP 프로토콜)
+- 9개 flat 필드 XADD: subcommand, workspace_id, surface_id, session_id, cwd, raw_input(JSON blob), timestamp, hostname, custom_build
+- fire-and-forget 패턴, 환경변수(`CMUX_REDIS_ENABLED`, `CMUX_REDIS_URL` 등)로 제어
+
+---
+
+## 2. Redis Stream 2-Tier 데이터 구조 설계 (브레인스토밍)
+사용: brainstorming skill, Plan agent, Explore agent, AskUserQuestion
+
+Toby: redis-chat-ui 프로젝트에 맞게 Redis stream 데이터 구조를 설계하고, 브레인스토밍을 통해 기능을 명확하게 명세하라.
+
+Claude: 4차례 질문을 통해 요구사항 확정:
+- 목적: 모니터링 + 간단한 인터랙션 (cmux CLI 실행), 추후 양방향 확장
+- 데이터 구조: 2-tier (Stream 경량 + Hash 상세), workspace별 날짜 파티셔닝
+- UI: 하이브리드 렌더링 (bubble/compact/badge/alert)
+- TTL: 없음 (영구 보존)
+- Hash 관리: 날짜별 파티셔닝 (`cmux:ws:{wid}:events:{YYYYMMDD}`)
+
+플랜 파일 작성: `/Users/brian/.claude/plans/snug-cuddling-lollipop.md`
+
+---
+
+## 3. cmux RedisStreamEmitter v2 스키마 구현
+사용: Edit, Bash
+
+Toby: 플랜 승인 후 구현 진행.
+
+Claude: `CLI/cmux.swift` 수정:
+- RedisStreamEmitter v2: XADD+HSET Redis 파이프라이닝, promoted 필드, detail_ref/detail_hash, schema_version
+- runClaudeHook() 호출부: subcommand별 promoted 필드 추출 (기존 헬퍼 함수 재활용)
+- v1 롤백 지원 (`CMUX_REDIS_SCHEMA_VERSION=1`)
+- cmux-cli 타겟 빌드 성공 확인
+
+---
+
+## 4. redis-chat-ui v2 스키마 대응 구현
+사용: Write, Edit
+
+Toby: redis-chat-ui 수정 내역은 별도로 저장하여 담당자에게 전달하겠다.
+
+Claude: `/Users/brian/works/agent/redis-chat-ui/` 프로젝트 파일 수정:
+- `lib/parser.js`: v1/v2 호환 파싱, deriveUIHints(), extractPromotedFromRaw()
+- `server.js`: GET /api/events/detail, POST /api/commands, WebSocket get_detail, Stream 트리밍
+- `public/app.js`: 하이브리드 렌더링, 접기/펼치기, detail 버튼, alert 배지
+- `public/style.css`: alert/detail/expand 스타일 추가
+- `docs/v2-schema-changes.md`: 담당자 전달용 변경 내역 문서
+
+---
+
+## 5. zig 재설치 및 빌드 환경 복구
+사용: Bash
+
+Toby: 기존에 빌드가 되었는데 왜 안 되는지 확인하라. zig 재설치하라.
+
+Claude: 원인 분석 — `ensure-ghosttykit.sh`가 `CMUX_SKIP_ZIG_BUILD` 플래그를 인식하지 않고 zig 존재를 무조건 체크. zig가 PATH에서 사라진 상태였음.
+- `brew install zig` 실행 → zig 0.15.2 설치 완료
+- 전체 앱 빌드는 metal 셰이더 컴파일 에러로 실패 (기존 환경 문제)
+
+---
+
+## 6. cmux CLI 빌드 및 배포
+사용: Bash
+
+Toby: 전체 빌드 필요 없음. cmux CLI만 빌드하고 배포하라.
+
+Claude: cmux-cli 스킴만 빌드 후 `~/.local/bin/cmux-custom`에 배포:
+- `xcodebuild -scheme cmux-cli` → BUILD SUCCEEDED
+- `~/.zshrc`의 `CMUX_BUNDLED_CLI_PATH=$HOME/.local/bin/cmux-custom` 설정 확인
+- 바이너리 복사 배포 완료
+
+---
+
+## 7. v2 스키마 동작 검증
+사용: Bash
+
+Toby: hook을 임의로 호출하고 redis 데이터를 확인하라.
+
+Claude: 4개 subcommand 테스트 (prompt-submit, session-start, stop, pre-tool-use):
+- Stream 엔트리: schema_version=2, promoted 필드 정상, raw_input 없음
+- Hash 저장: `cmux:ws:test-ws-001:events:20260411` 키에 전체 JSON 확인
+- TTL: -1 (영구 보존)
+- 실제 실행 중인 agent들의 hook도 v2로 정상 전송 확인
+
+---
+
+## 변경된 파일
+- `CLI/cmux.swift` (수정)


### PR DESCRIPTION
## Summary
- Redis Stream 엔트리를 경량 promoted 필드(~900 bytes)로 전환, raw_input 제거
- 전체 hook 데이터를 workspace별 Redis Hash(`cmux:ws:{wid}:events:{YYYYMMDD}`)에 XADD+HSET 파이프라이닝으로 영구 저장
- subcommand별 promoted 필드 추출 (prompt_preview, tool_name, tool_summary, response_preview, notify_type 등)
- `CMUX_REDIS_SCHEMA_VERSION=1`로 v1 즉시 롤백 지원

## Test plan
- [x] cmux-cli 타겟 빌드 성공
- [x] `~/.local/bin/cmux-custom`에 배포 완료
- [x] prompt-submit, session-start, stop, pre-tool-use hook 테스트 — Stream 엔트리 v2 확인
- [x] Hash 상세 데이터 저장 및 TTL=-1 (영구 보존) 확인
- [x] 실제 실행 중인 agent hook도 v2로 정상 전송 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Redis Stream emitter v2 with 2‑tier storage: lightweight stream entries and full hook payloads stored in per‑workspace/day Redis Hashes. This cuts stream size while keeping complete event data available, with quick rollback to v1 if needed.

- **New Features**
  - 2‑tier storage: XADD with promoted fields; full JSON saved to `cmux:ws:{wid}:events:{YYYYMMDD}` via pipelined XADD+HSET (no TTL).
  - Stream adds `schema_version=2`, `detail_ref`, `detail_hash`, plus subcommand‑specific fields (e.g., `prompt_preview`, `tool_name`, `tool_summary`, `response_preview`, `notify_type`, `stop_reason`, `end_reason`). No `raw_input` in Stream.
  - Non‑blocking emitter over raw RESP/TCP; configured via `CMUX_REDIS_ENABLED`, `CMUX_REDIS_URL`, `CMUX_REDIS_STREAM`, `CMUX_REDIS_TIMEOUT_MS`.
  - `cmux version` now shows a custom build tag suffix.

- **Migration**
  - Enable with `CMUX_REDIS_ENABLED=1` and set Redis URL/stream; consumers should read `schema_version` and, for v2, fetch details using `detail_hash` + `detail_ref`.
  - Roll back by setting `CMUX_REDIS_SCHEMA_VERSION=1` to restore legacy inline `raw_input` in Stream.

<sup>Written for commit 944ddd0e07c085f42ade48e22c4497d0a1b8d1b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added event tracking infrastructure to improve monitoring and system diagnostics
  * Enhanced version information display

<!-- end of auto-generated comment: release notes by coderabbit.ai -->