### PR TITLE
Add TCC usage descriptions for child processes

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -53,6 +53,10 @@
 	<string>A program running within cmux would like to use Bluetooth.</string>
 	<key>NSCalendarsUsageDescription</key>
 	<string>A program running within cmux would like to access your Calendar.</string>
+	<key>NSCalendarsFullAccessUsageDescription</key>
+	<string>A program running within cmux would like to have full access to your Calendar.</string>
+	<key>NSCalendarsWriteOnlyAccessUsageDescription</key>
+	<string>A program running within cmux would like to add events to your Calendar.</string>
 	<key>NSContactsUsageDescription</key>
 	<string>A program running within cmux would like to access your Contacts.</string>
 	<key>NSLocalNetworkUsageDescription</key>
@@ -68,7 +72,9 @@
 	<key>NSRemindersUsageDescription</key>
 	<string>A program running within cmux would like to access your reminders.</string>
 	<key>NSRemindersFullAccessUsageDescription</key>
-	<string>A program running within cmux would like to access your reminders.</string>
+	<string>A program running within cmux would like to have full access to your reminders.</string>
+	<key>NSRemindersWriteOnlyAccessUsageDescription</key>
+	<string>A program running within cmux would like to add reminders.</string>
 	<key>NSSpeechRecognitionUsageDescription</key>
 	<string>A program running within cmux would like to use speech recognition.</string>
 	<key>NSDesktopFolderUsageDescription</key>

--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -47,6 +47,42 @@
 	<string>A program running within cmux would like to use your microphone.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>A program running within cmux would like to use your camera.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>A program running within cmux would like to use AppleScript.</string>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>A program running within cmux would like to use Bluetooth.</string>
+	<key>NSCalendarsUsageDescription</key>
+	<string>A program running within cmux would like to access your Calendar.</string>
+	<key>NSContactsUsageDescription</key>
+	<string>A program running within cmux would like to access your Contacts.</string>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>A program running within cmux would like to access the local network.</string>
+	<key>NSLocationUsageDescription</key>
+	<string>A program running within cmux would like to access your location information.</string>
+	<key>NSLocationWhenInUseUsageDescription</key>
+	<string>A program running within cmux would like to access your location information.</string>
+	<key>NSMotionUsageDescription</key>
+	<string>A program running within cmux would like to access motion data.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>A program running within cmux would like to access your Photo Library.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>A program running within cmux would like to access your reminders.</string>
+	<key>NSRemindersFullAccessUsageDescription</key>
+	<string>A program running within cmux would like to access your reminders.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>A program running within cmux would like to use speech recognition.</string>
+	<key>NSDesktopFolderUsageDescription</key>
+	<string>A program running within cmux would like to access files in your Desktop folder.</string>
+	<key>NSDocumentsFolderUsageDescription</key>
+	<string>A program running within cmux would like to access files in your Documents folder.</string>
+	<key>NSDownloadsFolderUsageDescription</key>
+	<string>A program running within cmux would like to access files in your Downloads folder.</string>
+	<key>NSNetworkVolumesUsageDescription</key>
+	<string>A program running within cmux would like to access files on network volumes.</string>
+	<key>NSRemovableVolumesUsageDescription</key>
+	<string>A program running within cmux would like to access files on removable volumes.</string>
+	<key>NSSystemAdministrationUsageDescription</key>
+	<string>A program running within cmux would like to perform system administration tasks.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary

cmux is a terminal emulator, so almost every permission request actually comes from programs run *inside* cmux — CLIs, scripts, MCP servers, AI agents, etc. macOS TCC attributes those calls to the terminal app's bundle (`com.cmuxterm.app`) as the "responsible process", and **refuses to even show a permission prompt unless the matching `NS*UsageDescription` key is present in the terminal's `Info.plist`**.

Before this PR, `Resources/Info.plist` only declared `NSMicrophoneUsageDescription` and `NSCameraUsageDescription`. So child processes trying to access Reminders, Calendars, Contacts, the local network, or the user's Desktop/Documents/Downloads folders fail with cryptic errors and — crucially — **cmux never appears in the corresponding panel under System Settings > Privacy & Security at all**, because the OS won't list apps that cannot legally request the permission. There is no way for the user to grant access even if they want to.

### Concrete example

Running the [`remi`](https://github.com/mattheworiordan/remi) CLI (a Rust wrapper around EventKit) to list Reminders from inside cmux:

```
$ remi lists --json
{"success": true, "data": {"error": "Reminders access denied. Grant in System Settings > Privacy & Security > Reminders.", "success": false}}

$ remi doctor
...
✗ Reminders access: Not granted (0 lists returned)
  Run: remi authorize
```

`remi authorize` then opens System Settings → Reminders, which shows only Ghostty, iTerm, Terminal — **cmux is not in the list**, and there is no `+` button because cmux has never been able to trigger a prompt. The same flow inside Ghostty works fine on first run because Ghostty ships with `NSRemindersUsageDescription`.

## Fix

Add the set of usage descriptions that Ghostty (which cmux is based on) already declares, plus:

- `NSRemindersFullAccessUsageDescription` — macOS 14+ full-access variant for Reminders (EventKit split write-only vs full access in macOS 14).
- Desktop / Documents / Downloads / Network volumes / Removable volumes — macOS 10.15+ file-location TCC.
- System Administration — for tools that use `SMJobBless` / authorization services.

All strings follow cmux's existing pattern: *"A program running within cmux would like to …"*.

**No runtime behaviour changes — only Info.plist strings.** No new entitlements, no new code. The app doesn't request any of these at launch; they only take effect when a child process invokes the underlying macOS API, at which point the user sees a standard, attributed TCC prompt and can allow/deny.

## Test plan

- [x] `plutil -lint Resources/Info.plist` → OK
- [ ] Build a local signed cmux with this branch
- [ ] Launch cmux fresh, run `remi lists` → verify macOS shows a Reminders prompt attributed to cmux
- [ ] Allow the prompt, verify cmux appears in **System Settings → Privacy & Security → Reminders**
- [ ] Re-run `remi doctor` → `Reminders access: granted`
- [ ] Spot-check one other resource (e.g. `osascript -e 'tell application "Calendar" to return count of calendars'`) to confirm the Calendar key also prompts correctly

## Why this matters

cmux is targeted specifically at AI coding agents — and agent tooling is increasingly integrating with user data (Reminders/Calendar for planning, local network for dev servers, Desktop/Documents/Downloads for file operations). Without this fix, those integrations silently fail inside cmux while working in every other terminal, which makes cmux feel broken compared to Ghostty/iTerm/Terminal for a growing class of workflows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add missing macOS TCC `NS*UsageDescription` entries to `Resources/Info.plist` so programs run inside cmux can trigger permission prompts and cmux appears in Privacy settings. Also adds macOS 14+ EventKit split keys for Calendars and Reminders to prevent silent failures.

- New Features
  - Added usage descriptions for Apple Events, Bluetooth, Calendars (incl. macOS 14+ full access and write-only), Contacts, Local Network, Location (when-in-use), Motion, Photos, Reminders (incl. macOS 14+ full and write-only access), Speech Recognition, Desktop/Documents/Downloads, Network/Removable volumes, and System Administration.
  - Prompts now appear when a child process requests these resources; approvals persist and cmux shows in the relevant Privacy panel.
  - No new entitlements or code changes; Info.plist strings only.

<sup>Written for commit d741d33925fb9a2fd8bf29931cef4da80bbfb815. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added and clarified system permission prompts for a wide range of features: Apple Events/AppleScript, Bluetooth (always), Calendars (including full and write-only), Contacts, Local Network, Location (general and when‑in‑use), Motion, Photo Library, Reminders (including full and write-only), Speech Recognition, Desktop/Documents/Downloads folders, Network and Removable Volumes, and System Administration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->