### PR TITLE
fix: allow symlinked Ghostty config files

### DIFF
--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -532,7 +532,8 @@ struct GhosttyConfig {
         guard fileManager.fileExists(atPath: path) else { return nil }
 
         if let attributes = try? fileManager.attributesOfItem(atPath: path) {
-            if let type = attributes[.type] as? FileAttributeType, type != .typeRegular {
+            if let type = attributes[.type] as? FileAttributeType,
+               type != .typeRegular && type != .typeSymbolicLink {
                 return nil
             }
             if let size = attributes[.size] as? NSNumber, size.intValue == 0 {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -125,7 +125,6 @@ final class GhosttyConfigTests: XCTestCase {
             withDestinationPath: targetConfig.path
         )
 
-        GhosttyConfig.invalidateLoadCache()
         let loaded = GhosttyConfig.load(preferredColorScheme: .dark, useCache: false)
 
         XCTAssertEqual(loaded.fontSize, CGFloat(15), accuracy: 0.0001)

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -92,6 +92,45 @@ final class GhosttyConfigTests: XCTestCase {
         XCTAssertTrue(paths.contains("\(pathB)/ghostty/themes/Solarized Light"))
     }
 
+    func testLoadReadsSymlinkedGhosttyConfigFile() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ghostty-config-symlink-\(UUID().uuidString)")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let originalFixedHome = getenv("CFFIXED_USER_HOME").map { String(cString: $0) }
+        setenv("CFFIXED_USER_HOME", root.path, 1)
+        defer {
+            if let originalFixedHome {
+                setenv("CFFIXED_USER_HOME", originalFixedHome, 1)
+            } else {
+                unsetenv("CFFIXED_USER_HOME")
+            }
+            GhosttyConfig.invalidateLoadCache()
+        }
+
+        let ghosttyConfigDir = root.appendingPathComponent(".config/ghostty", isDirectory: true)
+        try fileManager.createDirectory(at: ghosttyConfigDir, withIntermediateDirectories: true)
+
+        let dotfilesDir = root.appendingPathComponent("dotfiles/ghostty", isDirectory: true)
+        try fileManager.createDirectory(at: dotfilesDir, withIntermediateDirectories: true)
+
+        let targetConfig = dotfilesDir.appendingPathComponent("config", isDirectory: false)
+        try "font-size = 15\n".write(to: targetConfig, atomically: true, encoding: .utf8)
+
+        let symlinkedConfig = ghosttyConfigDir.appendingPathComponent("config", isDirectory: false)
+        try fileManager.createSymbolicLink(
+            atPath: symlinkedConfig.path,
+            withDestinationPath: targetConfig.path
+        )
+
+        GhosttyConfig.invalidateLoadCache()
+        let loaded = GhosttyConfig.load(preferredColorScheme: .dark, useCache: false)
+
+        XCTAssertEqual(loaded.fontSize, CGFloat(15), accuracy: 0.0001)
+    }
+
     func testLoadThemeResolvesPairedThemeValueByColorScheme() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-ghostty-theme-pair-\(UUID().uuidString)")


### PR DESCRIPTION
## Summary
- allow symlinked Ghostty config files in `GhosttyConfig.readConfigFile`
- add regression test covering symlinked `~/.config/ghostty/config` loading

Fixes #2812

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow symbolic links in `GhosttyConfig.readConfigFile` so symlinked `~/.config/ghostty/config` files load correctly. Add a regression test that loads a symlinked config and verifies the parsed value (font-size) is applied.

<sup>Written for commit 8eb745603934291a3940b588833d8ed4d1e7cf8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration file validation to properly handle symbolic links when loading configuration files from custom paths.

* **Tests**
  * Added test coverage to verify configuration loading behavior with symbolic link file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->