### PR TITLE
Render local images in the Markdown Viewer

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -41,6 +41,8 @@
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		A500LFI011 /* LocalFileImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI010 /* LocalFileImageLoader.swift */; };
+		A500LFI021 /* LocalFileImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI020 /* LocalFileImageProvider.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
@@ -138,6 +140,7 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
+			A500LFI031 /* LocalFileImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI030 /* LocalFileImageLoaderTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -249,6 +252,8 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		A500LFI010 /* LocalFileImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageLoader.swift; sourceTree = "<group>"; };
+		A500LFI020 /* LocalFileImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageProvider.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -340,6 +345,7 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
+			A500LFI030 /* LocalFileImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileImageLoaderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -504,6 +510,8 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				A500LFI010 /* LocalFileImageLoader.swift */,
+				A500LFI020 /* LocalFileImageProvider.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -624,6 +632,7 @@
 					C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
 					FE002001 /* FileExplorerRootResolverTests.swift */,
 					FE002002 /* FileExplorerStoreTests.swift */,
+					A500LFI030 /* LocalFileImageLoaderTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -833,6 +842,8 @@
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				A500LFI011 /* LocalFileImageLoader.swift in Sources */,
+				A500LFI021 /* LocalFileImageProvider.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
@@ -928,6 +939,7 @@
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 					FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 					FE002102 /* FileExplorerStoreTests.swift in Sources */,
+					A500LFI031 /* LocalFileImageLoaderTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -41,8 +41,8 @@
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
-		A500LFI011 /* LocalFileImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI010 /* LocalFileImageLoader.swift */; };
-		A500LFI021 /* LocalFileImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI020 /* LocalFileImageProvider.swift */; };
+		DE97B2925EF7873D31321334 /* LocalFileImageLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FD12E00DF7867EE7C27A601 /* LocalFileImageLoader.swift */; };
+		C604DB038A72572008162D29 /* LocalFileImageProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 724F4F1A7BB79B299C6229B2 /* LocalFileImageProvider.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
@@ -140,7 +140,7 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
-			A500LFI031 /* LocalFileImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500LFI030 /* LocalFileImageLoaderTests.swift */; };
+			859C91521F71537C9688630A /* LocalFileImageLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A88B120F2EC3383CFA6ECCC /* LocalFileImageLoaderTests.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -252,8 +252,8 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
-		A500LFI010 /* LocalFileImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageLoader.swift; sourceTree = "<group>"; };
-		A500LFI020 /* LocalFileImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageProvider.swift; sourceTree = "<group>"; };
+		7FD12E00DF7867EE7C27A601 /* LocalFileImageLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageLoader.swift; sourceTree = "<group>"; };
+		724F4F1A7BB79B299C6229B2 /* LocalFileImageProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/LocalFileImageProvider.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -345,7 +345,7 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
-			A500LFI030 /* LocalFileImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileImageLoaderTests.swift; sourceTree = "<group>"; };
+			3A88B120F2EC3383CFA6ECCC /* LocalFileImageLoaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocalFileImageLoaderTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -510,8 +510,8 @@
 				A5007421 /* BrowserPopupWindowController.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
-				A500LFI010 /* LocalFileImageLoader.swift */,
-				A500LFI020 /* LocalFileImageProvider.swift */,
+				7FD12E00DF7867EE7C27A601 /* LocalFileImageLoader.swift */,
+				724F4F1A7BB79B299C6229B2 /* LocalFileImageProvider.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -632,7 +632,7 @@
 					C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
 					FE002001 /* FileExplorerRootResolverTests.swift */,
 					FE002002 /* FileExplorerStoreTests.swift */,
-					A500LFI030 /* LocalFileImageLoaderTests.swift */,
+					3A88B120F2EC3383CFA6ECCC /* LocalFileImageLoaderTests.swift */,
 				);
 				path = cmuxTests;
 				sourceTree = "<group>";
@@ -842,8 +842,8 @@
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
-				A500LFI011 /* LocalFileImageLoader.swift in Sources */,
-				A500LFI021 /* LocalFileImageProvider.swift in Sources */,
+				DE97B2925EF7873D31321334 /* LocalFileImageLoader.swift in Sources */,
+				C604DB038A72572008162D29 /* LocalFileImageProvider.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
@@ -939,7 +939,7 @@
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 					FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 					FE002102 /* FileExplorerStoreTests.swift in Sources */,
-					A500LFI031 /* LocalFileImageLoaderTests.swift in Sources */,
+					859C91521F71537C9688630A /* LocalFileImageLoaderTests.swift in Sources */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -83933,6 +83933,23 @@
         }
       }
     },
+    "markdown.image.missing.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Image not found"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "画像が見つかりません"
+          }
+        }
+      }
+    },
     "settings.section.sidebarAppearance": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/LocalFileImageLoader.swift
+++ b/Sources/Panels/LocalFileImageLoader.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Classifies swift-markdown-ui image destinations so `LocalFileImageProvider`
+/// can dispatch to the right loader (local disk, remote fetch, or placeholder).
+enum LocalFileImageLoader {
+    enum Kind: Equatable {
+        case local(URL)
+        case remote(URL)
+        case unsupported
+    }
+
+    static func classify(_ url: URL) -> Kind {
+        // swift-markdown-ui hands us relative URLs resolved against `imageBaseURL`;
+        // normalize to absolute so scheme/path checks don't fall through to cwd.
+        let resolved = url.absoluteURL
+
+        if let scheme = resolved.scheme?.lowercased() {
+            switch scheme {
+            case "http", "https":
+                return .remote(resolved)
+            case "file":
+                // `URL.path` excludes query/fragment and percent-decodes, so
+                // rebuilding via `fileURLWithPath` yields a canonical file URL.
+                return .local(URL(fileURLWithPath: resolved.path))
+            default:
+                return .unsupported
+            }
+        }
+
+        // Defensive: the library normally normalizes scheme-less inputs before
+        // they reach us.
+        if resolved.path.hasPrefix("/") {
+            return .local(URL(fileURLWithPath: resolved.path))
+        }
+
+        return .unsupported
+    }
+}

--- a/Sources/Panels/LocalFileImageProvider.swift
+++ b/Sources/Panels/LocalFileImageProvider.swift
@@ -13,12 +13,11 @@ struct LocalFileImageProvider: ImageProvider {
 private struct LocalFileImageView: View {
     let url: URL?
 
-    @State private var loadState: LoadState = .idle
+    @State private var outcome: LoadOutcome?
 
-    private enum LoadState {
-        case idle
-        case loaded(NSImage)
-        case failed
+    private enum LoadOutcome {
+        case loaded(URL, NSImage)
+        case failed(URL)
     }
 
     var body: some View {
@@ -29,7 +28,7 @@ private struct LocalFileImageView: View {
             DefaultImageProvider().makeImage(url: remoteURL)
 
         case .local(let fileURL)?:
-            localStateView
+            localStateView(for: fileURL)
                 .task(id: fileURL) { await load(fileURL: fileURL) }
 
         case .unsupported?, nil:
@@ -38,9 +37,11 @@ private struct LocalFileImageView: View {
     }
 
     @ViewBuilder
-    private var localStateView: some View {
-        switch loadState {
-        case .loaded(let image):
+    private func localStateView(for fileURL: URL) -> some View {
+        // Gate the render on a URL match so a stale outcome from a previous
+        // `fileURL` can't flash through during a URL transition before the
+        // new load task starts.
+        if case .loaded(let url, let image) = outcome, url == fileURL {
             // Match upstream's shrink-only layout: render at natural size
             // when it fits, otherwise scale down proportionally.
             Image(nsImage: image)
@@ -51,31 +52,41 @@ private struct LocalFileImageView: View {
                     maxHeight: image.size.height,
                     alignment: .leading
                 )
-        case .failed:
+        } else if case .failed(let url) = outcome, url == fileURL {
             placeholder
-        case .idle:
+        } else {
             Color.clear
         }
     }
 
     private func load(fileURL: URL) async {
-        loadState = .idle
-
-        let loaded = await Task.detached(priority: .userInitiated) { () -> NSImage? in
+        let task = Task.detached(priority: .userInitiated) { () -> NSImage? in
+            if Task.isCancelled { return nil }
             let cacheKey = LocalFileImageCache.key(for: fileURL)
+            if Task.isCancelled { return nil }
             if let cacheKey, let cached = LocalFileImageCache.shared.object(forKey: cacheKey) {
                 return cached
             }
+            if Task.isCancelled { return nil }
             guard let image = NSImage(contentsOf: fileURL) else { return nil }
             if let cacheKey {
                 LocalFileImageCache.shared.setObject(image, forKey: cacheKey)
             }
             return image
-        }.value
+        }
+
+        // Forward the parent `.task(id:)` cancellation into the detached task
+        // so an in-flight stat + NSImage load can short-circuit when the view
+        // moves on to a new URL instead of running to completion.
+        let decoded = await withTaskCancellationHandler {
+            await task.value
+        } onCancel: {
+            task.cancel()
+        }
 
         if Task.isCancelled { return }
 
-        loadState = loaded.map(LoadState.loaded) ?? .failed
+        outcome = decoded.map { .loaded(fileURL, $0) } ?? .failed(fileURL)
     }
 
     private var placeholder: some View {

--- a/Sources/Panels/LocalFileImageProvider.swift
+++ b/Sources/Panels/LocalFileImageProvider.swift
@@ -1,0 +1,117 @@
+import AppKit
+import MarkdownUI
+import SwiftUI
+
+/// swift-markdown-ui image provider that renders local files in addition to
+/// the remote-only behavior of the default provider.
+struct LocalFileImageProvider: ImageProvider {
+    func makeImage(url: URL?) -> some View {
+        LocalFileImageView(url: url)
+    }
+}
+
+private struct LocalFileImageView: View {
+    let url: URL?
+
+    @State private var loadState: LoadState = .idle
+
+    private enum LoadState {
+        case idle
+        case loaded(NSImage)
+        case failed
+    }
+
+    var body: some View {
+        switch url.map(LocalFileImageLoader.classify) {
+        case .remote(let remoteURL)?:
+            // Delegate to the upstream default so remote images keep their
+            // original shrink-only sizing via swift-markdown-ui's ResizeToFit.
+            DefaultImageProvider().makeImage(url: remoteURL)
+
+        case .local(let fileURL)?:
+            localStateView
+                .task(id: fileURL) { await load(fileURL: fileURL) }
+
+        case .unsupported?, nil:
+            placeholder
+        }
+    }
+
+    @ViewBuilder
+    private var localStateView: some View {
+        switch loadState {
+        case .loaded(let image):
+            // Match upstream's shrink-only layout: render at natural size
+            // when it fits, otherwise scale down proportionally.
+            Image(nsImage: image)
+                .resizable()
+                .aspectRatio(image.size, contentMode: .fit)
+                .frame(
+                    maxWidth: image.size.width,
+                    maxHeight: image.size.height,
+                    alignment: .leading
+                )
+        case .failed:
+            placeholder
+        case .idle:
+            Color.clear
+        }
+    }
+
+    private func load(fileURL: URL) async {
+        loadState = .idle
+
+        let loaded = await Task.detached(priority: .userInitiated) { () -> NSImage? in
+            let cacheKey = LocalFileImageCache.key(for: fileURL)
+            if let cacheKey, let cached = LocalFileImageCache.shared.object(forKey: cacheKey) {
+                return cached
+            }
+            guard let image = NSImage(contentsOf: fileURL) else { return nil }
+            if let cacheKey {
+                LocalFileImageCache.shared.setObject(image, forKey: cacheKey)
+            }
+            return image
+        }.value
+
+        if Task.isCancelled { return }
+
+        loadState = loaded.map(LoadState.loaded) ?? .failed
+    }
+
+    private var placeholder: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "photo")
+                .font(.system(size: 20))
+                .foregroundColor(.secondary)
+            Text(String(
+                localized: "markdown.image.missing.label",
+                defaultValue: "Image not found"
+            ))
+            .font(.caption)
+            .foregroundColor(.secondary)
+        }
+        .padding(8)
+    }
+}
+
+/// Shared cache keyed by path + file mtime. The mtime qualifier ensures that
+/// a remounted image view (e.g. panel closed and reopened after the file was
+/// edited) hits a cache miss and reloads rather than reusing a stale bitmap
+/// under the same path. Same-URL re-renders within a single mounted view are
+/// governed by SwiftUI's `.task(id:)` identity and don't re-stat.
+enum LocalFileImageCache {
+    static let shared: NSCache<NSString, NSImage> = {
+        let cache = NSCache<NSString, NSImage>()
+        cache.name = "cmux.markdown.localFileImage"
+        cache.countLimit = 64
+        return cache
+    }()
+
+    static func key(for fileURL: URL) -> NSString? {
+        let attrs = try? FileManager.default.attributesOfItem(atPath: fileURL.path)
+        guard let mtime = attrs?[.modificationDate] as? Date else {
+            return nil
+        }
+        return "\(fileURL.path)|\(mtime.timeIntervalSinceReferenceDate)" as NSString
+    }
+}

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -14,6 +14,13 @@ struct MarkdownPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @Environment(\.colorScheme) private var colorScheme
 
+    /// Directory swift-markdown-ui uses to resolve relative image references
+    /// in `panel.content`. Scoped to images so regular markdown link resolution
+    /// stays unchanged.
+    private var imageBaseURL: URL {
+        URL(fileURLWithPath: panel.filePath).deletingLastPathComponent()
+    }
+
     var body: some View {
         Group {
             if panel.isFileUnavailable {
@@ -58,7 +65,8 @@ struct MarkdownPanelView: View {
                     .padding(.horizontal, 16)
 
                 // Rendered markdown
-                Markdown(panel.content)
+                Markdown(panel.content, imageBaseURL: imageBaseURL)
+                    .markdownImageProvider(LocalFileImageProvider())
                     .markdownTheme(cmuxMarkdownTheme)
                     .textSelection(.enabled)
                     .padding(.horizontal, 24)

--- a/cmuxTests/LocalFileImageLoaderTests.swift
+++ b/cmuxTests/LocalFileImageLoaderTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class LocalFileImageLoaderTests: XCTestCase {
+    func testHttpIsRemote() {
+        let url = URL(string: "http://example.com/foo.png")!
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .remote(url))
+    }
+
+    func testHttpsIsRemote() {
+        let url = URL(string: "https://example.com/foo.png")!
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .remote(url))
+    }
+
+    func testFileURLIsLocal() {
+        let url = URL(string: "file:///Users/u/foo.png")!
+        let expected = URL(fileURLWithPath: "/Users/u/foo.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+
+    func testFileURLFragmentIsDropped() {
+        let url = URL(string: "file:///Users/u/foo.png#gh-dark-mode-only")!
+        let expected = URL(fileURLWithPath: "/Users/u/foo.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+
+    func testFileURLQueryIsDropped() {
+        let url = URL(string: "file:///Users/u/foo.png?v=1")!
+        let expected = URL(fileURLWithPath: "/Users/u/foo.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+
+    func testFileURLPercentEncodedSpaceIsDecoded() {
+        let url = URL(string: "file:///Users/u/has%20space.png")!
+        let expected = URL(fileURLWithPath: "/Users/u/has space.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+
+    func testFileURLPercentEncodedUnicodeIsDecoded() {
+        let url = URL(string: "file:///Users/u/%E6%97%A5%E6%9C%AC%E8%AA%9E.png")!
+        let expected = URL(fileURLWithPath: "/Users/u/日本語.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+
+    func testMailtoIsUnsupported() {
+        let url = URL(string: "mailto:foo@bar")!
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .unsupported)
+    }
+
+    func testDataURLIsUnsupported() {
+        let url = URL(string: "data:image/png;base64,AAAA")!
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .unsupported)
+    }
+
+    func testRelativeURLAgainstFileBaseResolvesToAbsoluteLocal() {
+        // swift-markdown-ui hands the provider the result of
+        // `URL(string: "./images/plain.png", relativeTo: imageBaseURL)`.
+        // The classifier must normalize that to an absolute file URL instead
+        // of passing the relative path through to `URL(fileURLWithPath:)`,
+        // which would join it against the shell's current working directory.
+        let base = URL(fileURLWithPath: "/tmp/md-test/edge.md").deletingLastPathComponent()
+        let relative = URL(string: "./images/plain.png", relativeTo: base)!
+        let expected = URL(fileURLWithPath: "/tmp/md-test/images/plain.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(relative), .local(expected))
+    }
+
+    func testRelativeURLWithParentTraversalResolvesAgainstBase() {
+        let base = URL(fileURLWithPath: "/tmp/md-test/edge.md").deletingLastPathComponent()
+        let relative = URL(string: "../md-test/images/plain.png", relativeTo: base)!
+        let expected = URL(fileURLWithPath: "/tmp/md-test/images/plain.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(relative), .local(expected))
+    }
+
+    func testBareRelativeURLResolvesAgainstBase() {
+        let base = URL(fileURLWithPath: "/tmp/md-test/edge.md").deletingLastPathComponent()
+        let relative = URL(string: "images/plain.png", relativeTo: base)!
+        let expected = URL(fileURLWithPath: "/tmp/md-test/images/plain.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(relative), .local(expected))
+    }
+
+    func testSchemelessAbsolutePathIsLocal() {
+        // Scheme-less absolute paths normally get normalized by the library
+        // before they reach us, but verify the defensive branch in the
+        // classifier.
+        var components = URLComponents()
+        components.path = "/Users/u/foo.png"
+        let url = components.url!
+        let expected = URL(fileURLWithPath: "/Users/u/foo.png")
+        XCTAssertEqual(LocalFileImageLoader.classify(url), .local(expected))
+    }
+}
+
+final class LocalFileImageCacheKeyTests: XCTestCase {
+    private var tempDirectoryURL: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectoryURL = URL(
+            fileURLWithPath: NSTemporaryDirectory(),
+            isDirectory: true
+        ).appendingPathComponent("cmux-LocalFileImageCacheTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempDirectoryURL,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectoryURL {
+            try? FileManager.default.removeItem(at: tempDirectoryURL)
+        }
+        tempDirectoryURL = nil
+        try super.tearDownWithError()
+    }
+
+    func testKeyReturnsNilForMissingFile() {
+        let missing = tempDirectoryURL.appendingPathComponent("missing.png")
+        XCTAssertNil(LocalFileImageCache.key(for: missing))
+    }
+
+    func testKeyChangesWhenFileModificationDateChanges() throws {
+        let fileURL = tempDirectoryURL.appendingPathComponent("image.png")
+        try Data([0x00]).write(to: fileURL)
+
+        let firstKey = try XCTUnwrap(LocalFileImageCache.key(for: fileURL))
+
+        // Bump mtime to a time that is definitely distinguishable from the
+        // initial write so the composite key must change.
+        let future = Date().addingTimeInterval(2)
+        try FileManager.default.setAttributes(
+            [.modificationDate: future],
+            ofItemAtPath: fileURL.path
+        )
+
+        let secondKey = try XCTUnwrap(LocalFileImageCache.key(for: fileURL))
+        XCTAssertNotEqual(firstKey, secondKey)
+    }
+
+    func testKeyIsStableAcrossCallsWhenFileUnchanged() throws {
+        let fileURL = tempDirectoryURL.appendingPathComponent("stable.png")
+        try Data([0x00, 0x01]).write(to: fileURL)
+
+        let first = try XCTUnwrap(LocalFileImageCache.key(for: fileURL))
+        let second = try XCTUnwrap(LocalFileImageCache.key(for: fileURL))
+        XCTAssertEqual(first, second)
+    }
+}


### PR DESCRIPTION
## Summary
- add `LocalFileImageProvider` that loads local images via `NSImage` and delegates
  remote URLs to swift-markdown-ui's `DefaultImageProvider` so remote sizing stays
  on the upstream `ResizeToFit` path
- add `LocalFileImageLoader`, a pure URL classifier that normalizes relative URLs
  via `absoluteURL`; for local file loads it ignores `?query` / `#fragment` and
  handles percent-encoded paths cleanly
- wire `imageBaseURL` (the `.md` file's parent directory) into `Markdown(...)` so
  relative image destinations resolve against it — regular markdown link
  resolution is untouched, `baseURL` is left at the default
- cache decoded `NSImage`s in an `NSCache` keyed by path + file mtime, bounded
  at 64 entries, so a remounted image view (panel closed and reopened after an
  edit) picks up the new bytes instead of reusing a stale entry
- run the cache stat and image load off the main thread so the markdown panel
  re-render path stays free of blocking file I/O
- render a localized "Image not found" placeholder for missing files and
  unsupported schemes

Addresses the local-image portion of #2069. Mermaid rendering is out of
scope and is being tracked separately in #2463.

## Demo

![cmux-markdown-local-images](https://github.com/user-attachments/assets/1c572370-625f-43c8-b2f2-fd9fb8093f42)


## Test plan
- [x] relative paths (`./images/foo.png`, `images/foo.png`, `../foo.png`) render
- [x] absolute paths and `file://` URLs render
- [x] percent-encoded filenames (spaces, unicode) round-trip cleanly
- [x] `?query` / `#fragment` suffixes are stripped before load
- [x] missing files show the localized placeholder, no crash
- [x] https URLs keep rendering via `DefaultImageProvider` (no regression)
- [x] unit coverage in `cmuxTests/LocalFileImageLoaderTests.swift` for the
      URL classifier and the path+mtime cache key

## Testing
- No local unit/xcodebuild test run per repo policy; manual verification only
- Built tagged Debug app: `./scripts/reload.sh --tag fix-md-local-images`
- Manual verification on the tagged Debug build with `/tmp/md-test/edge.md`
  fixture covering every case in the plan above

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Markdown panels now display local file images; relative paths resolve from the markdown file location
  * Local and remote images supported with caching to improve load performance and reduce reloads

* **Bug Fixes**
  * Failed or missing images show a user-friendly "Image not found" placeholder; stale image flashes prevented

* **Localization**
  * Added English and Japanese strings for the missing-image message

* **Tests**
  * Added tests covering URL classification, relative resolution, and cache key behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->