### PR TITLE
feat: add --pane and --no-focus flags to markdown open

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2992,8 +2992,7 @@ struct CMUXCLI {
             }
         }
         if let paneRaw = paneOpt {
-            let wsHandle = workspaceOpt ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
-            if let pane = try normalizePaneHandle(paneRaw, client: client, workspaceHandle: wsHandle) {
+            if let pane = try normalizePaneHandle(paneRaw, client: client, workspaceHandle: workspaceRaw) {
                 params["pane_id"] = pane
             }
         }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2922,7 +2922,9 @@ struct CMUXCLI {
         let (windowOpt, argsAfterWindow) = parseOption(argsAfterWorkspace, name: "--window")
         let (surfaceOpt, argsAfterSurface) = parseOption(argsAfterWindow, name: "--surface")
         let (directionOpt, argsAfterDirection) = parseOption(argsAfterSurface, name: "--direction")
-        args = argsAfterDirection
+        let (paneOpt, argsAfterPane) = parseOption(argsAfterDirection, name: "--pane")
+        let noFocus = argsAfterPane.contains("--no-focus")
+        args = argsAfterPane.filter { $0 != "--no-focus" }
 
         // Determine subcommand. Explicit "open" is supported, otherwise treat
         // a single positional argument as shorthand path.
@@ -2937,7 +2939,7 @@ struct CMUXCLI {
             if let first = args.first, first.hasPrefix("-") {
                 throw CLIError(
                     message:
-                        "markdown open: unknown flag '\(first)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up]"
+                        "markdown open: unknown flag '\(first)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up] [--pane <id|ref|index>] [--no-focus]"
                 )
             } else if let first = args.first, looksLikePath(first) || first.contains(".") {
                 subArgs = args
@@ -2955,13 +2957,13 @@ struct CMUXCLI {
         if let unknownFlag = trailingArgs.first(where: { $0.hasPrefix("-") }) {
             throw CLIError(
                 message:
-                    "markdown open: unknown flag '\(unknownFlag)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up]"
+                    "markdown open: unknown flag '\(unknownFlag)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up] [--pane <id|ref|index>] [--no-focus]"
             )
         }
         if let extraArg = trailingArgs.first {
             throw CLIError(
                 message:
-                    "markdown open: unexpected argument '\(extraArg)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up]"
+                    "markdown open: unexpected argument '\(extraArg)'. Usage: cmux markdown open <path> [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--direction right|down|left|up] [--pane <id|ref|index>] [--no-focus]"
             )
         }
 
@@ -2970,6 +2972,9 @@ struct CMUXCLI {
         // Build params
         let direction = directionOpt ?? "right"
         var params: [String: Any] = ["path": absolutePath, "direction": direction]
+        if noFocus {
+            params["focus"] = false
+        }
         if let surfaceRaw = surfaceOpt {
             if let surface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
                 params["surface_id"] = surface
@@ -2984,6 +2989,12 @@ struct CMUXCLI {
         if let windowRaw = windowOpt {
             if let window = try normalizeWindowHandle(windowRaw, client: client) {
                 params["window_id"] = window
+            }
+        }
+        if let paneRaw = paneOpt {
+            let wsHandle = workspaceOpt ?? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
+            if let pane = try normalizePaneHandle(paneRaw, client: client, workspaceHandle: wsHandle) {
+                params["pane_id"] = pane
             }
         }
 
@@ -8094,12 +8105,16 @@ struct CMUXCLI {
               --surface <id|ref|index>     Source surface to split from (default: focused surface)
               --window <id|ref|index>      Target window
               --direction <left|right|up|down>  Split direction (default: right)
+              --pane <id|ref|index>        Add as tab in existing pane instead of splitting
+              --no-focus                   Open without focusing the new panel
 
             Examples:
               cmux markdown open plan.md
               cmux markdown ~/project/CHANGELOG.md
               cmux markdown open ./docs/design.md --workspace 0
               cmux markdown open plan.md --direction down
+              cmux markdown open plan.md --pane pane:5
+              cmux markdown open plan.md --no-focus
             """
         default:
             return nil

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -7615,35 +7615,58 @@ class TerminalController {
             v2MaybeFocusWindow(for: tabManager)
             v2MaybeSelectWorkspace(tabManager, workspace: ws)
 
-            let sourceSurfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
-            guard let sourceSurfaceId else {
-                result = .err(code: "not_found", message: "No focused surface to split", data: nil)
-                return
+            let focus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? true)
+            let requestedPaneUUID = v2UUID(params, "pane_id")
+
+            let markdownPanelId: UUID?
+            let sourceSurfaceId: UUID?
+            let sourcePaneUUID: UUID?
+
+            if let requestedPaneUUID {
+                // --pane mode: add as tab in existing pane
+                guard let paneId = ws.bonsplitController.allPaneIds.first(where: { $0.id == requestedPaneUUID }) else {
+                    result = .err(code: "not_found", message: "Pane not found", data: ["pane_id": requestedPaneUUID.uuidString])
+                    return
+                }
+                sourceSurfaceId = nil
+                sourcePaneUUID = paneId.id
+                markdownPanelId = ws.newMarkdownSurface(
+                    inPane: paneId,
+                    filePath: filePath,
+                    focus: focus
+                )?.id
+            } else {
+                // Default: split from source surface
+                let resolvedSourceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+                guard let resolvedSourceId else {
+                    result = .err(code: "not_found", message: "No focused surface to split", data: nil)
+                    return
+                }
+                guard ws.panels[resolvedSourceId] != nil else {
+                    result = .err(code: "not_found", message: "Source surface not found", data: ["surface_id": resolvedSourceId.uuidString])
+                    return
+                }
+                sourceSurfaceId = resolvedSourceId
+                sourcePaneUUID = ws.paneId(forPanelId: resolvedSourceId)?.id
+
+                let directionStr = v2String(params, "direction") ?? "right"
+                guard let direction = parseSplitDirection(directionStr) else {
+                    result = .err(code: "invalid_params", message: "Invalid direction '\(directionStr)' (left|right|up|down)", data: nil)
+                    return
+                }
+                let orientation: SplitOrientation = direction.isHorizontal ? .horizontal : .vertical
+                let insertFirst = (direction == .left || direction == .up)
+
+                markdownPanelId = ws.newMarkdownSplit(
+                    from: resolvedSourceId,
+                    orientation: orientation,
+                    insertFirst: insertFirst,
+                    filePath: filePath,
+                    focus: focus
+                )?.id
             }
-            guard ws.panels[sourceSurfaceId] != nil else {
-                result = .err(code: "not_found", message: "Source surface not found", data: ["surface_id": sourceSurfaceId.uuidString])
-                return
-            }
 
-            let sourcePaneUUID = ws.paneId(forPanelId: sourceSurfaceId)?.id
-
-            let directionStr = v2String(params, "direction") ?? "right"
-            guard let direction = parseSplitDirection(directionStr) else {
-                result = .err(code: "invalid_params", message: "Invalid direction '\(directionStr)' (left|right|up|down)", data: nil)
-                return
-            }
-            let orientation: SplitOrientation = direction.isHorizontal ? .horizontal : .vertical
-            let insertFirst = (direction == .left || direction == .up)
-
-            let createdPanel = ws.newMarkdownSplit(
-                from: sourceSurfaceId,
-                orientation: orientation,
-                insertFirst: insertFirst,
-                filePath: filePath,
-                focus: v2FocusAllowed()
-            )
-
-            guard let markdownPanelId = createdPanel?.id else {
+            guard let markdownPanelId else {
                 result = .err(code: "internal_error", message: "Failed to create markdown panel", data: nil)
                 return
             }
@@ -7659,7 +7682,7 @@ class TerminalController {
                 "pane_ref": v2Ref(kind: .pane, uuid: targetPaneUUID),
                 "surface_id": markdownPanelId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: markdownPanelId),
-                "source_surface_id": sourceSurfaceId.uuidString,
+                "source_surface_id": v2OrNull(sourceSurfaceId?.uuidString),
                 "source_surface_ref": v2Ref(kind: .surface, uuid: sourceSurfaceId),
                 "source_pane_id": v2OrNull(sourcePaneUUID?.uuidString),
                 "source_pane_ref": v2Ref(kind: .pane, uuid: sourcePaneUUID),


### PR DESCRIPTION
## Summary

- **`--pane <id|ref|index>`**: Open a markdown file as a new tab in an existing pane instead of always splitting. Calls the existing `Workspace.newMarkdownSurface(inPane:)` — the method was already implemented (used by session restore) but not exposed through the socket API or CLI.
- **`--no-focus`**: Open the markdown panel without stealing focus from the current surface. Wires through the existing `v2FocusAllowed(requested:)` pattern used by `break-pane`, `join-pane`, and `surface.move`.
- Both flags compose: `cmux markdown open plan.md --pane pane:5 --no-focus`

Closes #1457
Addresses #2770, #2820

## Motivation

The current `markdown open` always creates a split, which makes it hard to use programmatically (e.g., agent hooks that preview markdown alongside terminals). The common pattern is opening markdown as a tab in a pane that already holds other markdown/browser panels, without disrupting the user's focused terminal. The workaround today requires `markdown open` → `surface move` → `pane focus`, which flickers and steals OS focus.

## Changes

**`CLI/cmux.swift`** (`runMarkdownCommand`):
- Parse `--pane` via `parseOption` and `--no-focus` as a boolean flag
- Pass `pane_id` and `focus: false` in socket params
- Normalize pane handle with `normalizePaneHandle` (supports UUID, ref, index)
- Update usage strings and help text with new options and examples

**`Sources/TerminalController.swift`** (`v2MarkdownOpen`):
- When `pane_id` is present: resolve the pane and call `ws.newMarkdownSurface(inPane:)` 
- When absent: existing split behavior (unchanged)
- Wire `focus` through `v2FocusAllowed(requested: v2Bool(params, "focus") ?? true)` — same pattern as other commands
- Handle `source_surface_id` being null in `--pane` mode (no source surface to split from)

## Test plan

- [x] `cmux markdown open plan.md` — creates split (existing behavior, unchanged)
- [x] `cmux markdown open plan.md --direction down` — creates split downward (unchanged)
- [x] `cmux markdown open plan.md --pane pane:0` — adds tab to pane 0
- [x] `cmux markdown open plan.md --pane pane:0 --no-focus` — adds tab without stealing focus
- [x] `cmux markdown open plan.md --no-focus` — creates split without stealing focus
- [x] `cmux markdown --help` — shows new options and examples
- [x] Build passes: `./scripts/reload.sh --tag markdown-pane`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `--pane` and `--no-focus` to `cmux markdown open` to open markdown in an existing pane and avoid stealing focus, while keeping the default split behavior. Also fixes pane resolution to respect `--window` scoping.

- **New Features**
  - `--pane <id|ref|index>`: open markdown as a new tab in an existing pane.
  - `--no-focus`: open without focusing the new panel; works with split and `--pane`.
  - Updated CLI help/usage with new options and examples; flags compose.

- **Bug Fixes**
  - `--pane` workspace scoping now respects `--window`; no fallback to `CMUX_WORKSPACE_ID` when `--window` is set.

<sup>Written for commit 18c6b775f1fdb6c7da98bf1ac686c36c10116b6c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--pane` flag to target which pane receives opened markdown content.
  * Added `--no-focus` flag to prevent focusing the new markdown panel.
  * Improved command usage/error messages and help text with examples for the new flags.
  * Markdown open now supports opening directly into a specified pane and consistently respects focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->