### PR TITLE
Fix Cmd+click file path punctuation trimming

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -507,6 +507,10 @@ func cmuxResolveQuicklookPathForTesting(
         }
     )
 }
+
+func cmuxTrimTerminalPathTrailingPunctuationForTesting(_ token: String) -> String {
+    token
+}
 #endif
 
 private func cmuxResolveQuicklookPath(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -509,7 +509,7 @@ func cmuxResolveQuicklookPathForTesting(
 }
 
 func cmuxTrimTerminalPathTrailingPunctuationForTesting(_ token: String) -> String {
-    token
+    cmuxTrimTerminalPathTrailingPunctuation(token)
 }
 #endif
 
@@ -551,8 +551,18 @@ private func cmuxQuicklookPathCandidates(from rawText: String) -> [String] {
     func append(_ candidate: String?) {
         guard let candidate else { return }
         let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty, !candidates.contains(trimmed) else { return }
-        candidates.append(trimmed)
+        guard !trimmed.isEmpty else { return }
+
+        func appendUnique(_ value: String) {
+            guard !value.isEmpty, !candidates.contains(value) else { return }
+            candidates.append(value)
+        }
+
+        appendUnique(trimmed)
+        let punctuationTrimmed = cmuxTrimTerminalPathTrailingPunctuation(trimmed)
+        if punctuationTrimmed != trimmed {
+            appendUnique(punctuationTrimmed)
+        }
     }
 
     append(rawText)
@@ -571,6 +581,69 @@ private func cmuxQuicklookPathCandidates(from rawText: String) -> [String] {
     }
 
     return candidates
+}
+
+private let cmuxTerminalPathSentencePunctuation: Set<Character> = [
+    ".", ",", ";", ":", "!", "?"
+]
+
+private let cmuxTerminalPathTrailingQuotes: Set<Character> = [
+    "\"", "'", "”", "’", "»"
+]
+
+private let cmuxTerminalPathClosingPairs: [Character: Character] = [
+    ")": "(",
+    "]": "[",
+    "}": "{",
+    ">": "<"
+]
+
+/// Mirror smart-link terminals by trimming only the trailing punctuation run
+/// that is clearly outside the path itself.
+private func cmuxTrimTerminalPathTrailingPunctuation(_ token: String) -> String {
+    let characters = Array(token)
+    guard !characters.isEmpty else { return token }
+
+    var end = characters.count
+    while end > 0 {
+        let trailing = characters[end - 1]
+        if cmuxTerminalPathSentencePunctuation.contains(trailing) ||
+            cmuxTerminalPathTrailingQuotes.contains(trailing) {
+            end -= 1
+            continue
+        }
+
+        if let opener = cmuxTerminalPathClosingPairs[trailing],
+           !cmuxHasUnmatchedOpeningPathDelimiter(
+               in: characters[..<(end - 1)],
+               opener: opener,
+               closer: trailing
+           ) {
+            end -= 1
+            continue
+        }
+
+        break
+    }
+
+    guard end < characters.count else { return token }
+    return String(characters[..<end])
+}
+
+private func cmuxHasUnmatchedOpeningPathDelimiter(
+    in characters: ArraySlice<Character>,
+    opener: Character,
+    closer: Character
+) -> Bool {
+    var balance = 0
+    for character in characters {
+        if character == opener {
+            balance += 1
+        } else if character == closer, balance > 0 {
+            balance -= 1
+        }
+    }
+    return balance > 0
 }
 
 private func cmuxUnquoteShellToken(_ token: String) -> String? {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -3717,6 +3717,103 @@ final class TerminalOpenURLTargetResolutionTests: XCTestCase {
     }
 }
 
+final class TerminalCmdClickPathPunctuationTrimmingTests: XCTestCase {
+    func testTrimsTrailingPeriodAfterMarkdownFile() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "~/ClaudeCode/feature-spec-template.md."
+            ),
+            "~/ClaudeCode/feature-spec-template.md"
+        )
+    }
+
+    func testTrimsTrailingCommaInList() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "/tmp/fixtures/first.txt,"
+            ),
+            "/tmp/fixtures/first.txt"
+        )
+    }
+
+    func testTrimsTrailingCloseParenWhenNoBalancedOpenParen() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "/tmp/fixtures/notes.txt)"
+            ),
+            "/tmp/fixtures/notes.txt"
+        )
+    }
+
+    func testPreservesBalancedParensInMiddleOfPath() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "/tmp/fixtures/report (draft)/notes.txt"
+            ),
+            "/tmp/fixtures/report (draft)/notes.txt"
+        )
+    }
+
+    func testStripsMultipleTrailingPunctuationCharacters() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "/tmp/fixtures/report (draft).md).,!?\""
+            ),
+            "/tmp/fixtures/report (draft).md"
+        )
+    }
+
+    func testTrimsTrailingClosingQuote() {
+        XCTAssertEqual(
+            cmuxTrimTerminalPathTrailingPunctuationForTesting(
+                "/tmp/fixtures/notes.txt\""
+            ),
+            "/tmp/fixtures/notes.txt"
+        )
+    }
+
+    func testResolveQuicklookFallsBackToStrippedPathWhenLiteralPathIsMissing() {
+        let strippedPath = "/tmp/cmux-cmdclick-path.md"
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                "\(strippedPath).",
+                cwd: "/tmp",
+                existingPaths: [strippedPath]
+            ),
+            strippedPath
+        )
+    }
+
+    func testResolveQuicklookPrefersLiteralPathThatReallyEndsWithDot() {
+        let literalPath = "/tmp/cmux-cmdclick-literal-dot.md."
+        let strippedPath = "/tmp/cmux-cmdclick-literal-dot.md"
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                literalPath,
+                cwd: "/tmp",
+                existingPaths: [literalPath, strippedPath]
+            ),
+            literalPath
+        )
+    }
+
+    func testResolveQuicklookPrefersLiteralPathThatReallyEndsWithParen() {
+        let literalPath = "/tmp/cmux-cmdclick-literal-paren)"
+        let strippedPath = "/tmp/cmux-cmdclick-literal-paren"
+
+        XCTAssertEqual(
+            cmuxResolveQuicklookPathForTesting(
+                literalPath,
+                cwd: "/tmp",
+                existingPaths: [literalPath, strippedPath]
+            ),
+            literalPath
+        )
+    }
+}
+
 
 final class TerminalControllerSocketTextChunkTests: XCTestCase {
     func testSocketTextChunksReturnsSingleChunkForPlainText() {


### PR DESCRIPTION
## Summary
- trim trailing sentence punctuation from Cmd+click file-path candidates when the punctuation is not part of a balanced path token
- preserve legitimate trailing punctuation by trying the literal path first and only then the smart-trimmed fallback
- add focused regression coverage for periods, commas, unbalanced closers, balanced parens, multiple trailing punctuation characters, and literal filenames that really end with punctuation

## Testing
- not run locally (per repo policy)

Closes #2807

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Cmd+click file path candidate parsing and add regression tests; main risk is minor behavior changes in which path variant gets selected when filenames legitimately end with punctuation.
> 
> **Overview**
> Improves Cmd+click Quick Look path resolution by **adding a “smart” fallback candidate** that trims trailing sentence punctuation/quotes and certain unmatched closing delimiters (e.g., `)`, `]`) so paths followed by punctuation in terminal output still resolve.
> 
> Candidate ordering is updated to **try the literal token first** and only then try the punctuation-trimmed variant, reducing false negatives while preserving legitimate filenames that end with punctuation. Adds focused XCTest coverage for the trimming rules and resolution preference behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c77d2bdad9ce12976c5d704d39d22775eb941d14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smart-trims trailing punctuation on Cmd+click file paths so sentence-ending characters don’t break resolution. Keeps legitimate trailing punctuation by trying the literal path first, then a trimmed fallback.

- **Bug Fixes**
  - Trim trailing sentence punctuation, quotes, and unmatched closers while preserving balanced delimiters.
  - Add focused tests for periods, commas, unbalanced closers, balanced parens, multiple trailing characters, and literal filenames ending with punctuation.

<sup>Written for commit c77d2bdad9ce12976c5d704d39d22775eb941d14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cmd-click path detection in terminal output by intelligently trimming trailing punctuation (periods, commas, parentheses, quotes) that isn't part of the actual file path, while preserving balanced delimiters within paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->