### PR TITLE
Preserve focus for claude-teams pane spawns

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -1049,6 +1049,15 @@ func tmuxWaitForSignalPath(name string) string {
 	return fmt.Sprintf("/tmp/cmux-wait-for-%s.sig", sanitized.String())
 }
 
+func tmuxShouldBackgroundAgentTeamSplits() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv("CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS"))) {
+	case "1", "true", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
 // --- Main dispatch ---
 
 func dispatchTmuxCommand(rc *rpcContext, command string, args []string) error {
@@ -1216,6 +1225,9 @@ func tmuxSplitWindow(rc *rpcContext, args []string) error {
 	}
 
 	focusNewPane := !p.hasFlag("-d")
+	if tmuxShouldBackgroundAgentTeamSplits() {
+		focusNewPane = false
+	}
 	created, err := rc.call("surface.split", map[string]any{
 		"workspace_id": targetWs,
 		"surface_id":   targetSurface,

--- a/tests/test_cli_claude_teams_tmux_sequence.py
+++ b/tests/test_cli_claude_teams_tmux_sequence.py
@@ -38,6 +38,7 @@ class FakeCmuxState:
     def __init__(self) -> None:
         self.lock = threading.Lock()
         self.requests: list[str] = []
+        self.split_calls: list[dict[str, object]] = []
         self.workspace = {
             "id": INITIAL_WORKSPACE_ID,
             "ref": "workspace:1",
@@ -161,6 +162,13 @@ class FakeCmuxState:
                     ]
                 }
             if method == "surface.split":
+                self.split_calls.append(
+                    {
+                        "surface_id": str(params.get("surface_id") or ""),
+                        "direction": str(params.get("direction") or ""),
+                        "focus": params.get("focus"),
+                    }
+                )
                 self.panes.append(
                     {
                         "id": NEW_PANE_ID,
@@ -334,6 +342,19 @@ tmux list-panes -t "$window_target" -F '#{pane_id}' > "$FAKE_PANE_LIST_LOG"
         split_pane = read_text(split_pane_log)
         if split_pane != f"%{NEW_PANE_ID}":
             print(f"FAIL: expected split-window to print %{NEW_PANE_ID}, got {split_pane!r}")
+            return 1
+
+        if len(state.split_calls) != 1:
+            print(f"FAIL: expected exactly one split call, got {len(state.split_calls)}")
+            print(f"split_calls={state.split_calls!r}")
+            return 1
+
+        split_call = state.split_calls[0]
+        if split_call["focus"] is not False:
+            print(
+                "FAIL: expected teammate split to open in background, "
+                f"got focus={split_call['focus']!r}"
+            )
             return 1
 
         pane_lines = pane_list_log.read_text(encoding="utf-8").splitlines()


### PR DESCRIPTION
## Summary
- keep claude-teams tmux-compat splits in the background instead of requesting focus for each new teammate pane
- add regression coverage that fails if the teammate split path ever requests focus again

## Testing
- not run (per repo policy; CI only)

Closes #2806

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes focus behavior for `tmux split-window` in tmux-compat when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is enabled, which can affect user interaction/UX in terminal sessions. Risk is limited by being behind an env-flag and covered by a regression test.
> 
> **Overview**
> When `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is enabled, tmux-compat `split-window` now forces `surface.split` to run with `focus=false`, preserving focus on the leader pane even if tmux would normally focus the new split.
> 
> Adds regression coverage in `tests/test_cli_claude_teams_tmux_sequence.py` that records `surface.split` params and fails if the teammate split path ever requests focus again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae46de084445d7210cb6eac7dbeac833b9d8ee73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep focus in the current pane when agent teams spawn a teammate split in tmux-compat, instead of stealing focus. Adds a regression test to ensure new teammate panes open in the background.

- **Bug Fixes**
  - Force teammate splits to open in the background when `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS` is enabled (sets `focus=false`).
  - Add test to assert a single split call with `focus is False`.

<sup>Written for commit ae46de084445d7210cb6eac7dbeac833b9d8ee73. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental feature to enable agent team splits to open in the background instead of taking focus. This behavior can be controlled via environment variable configuration for flexible workflow management.

* **Tests**
  * Enhanced test coverage to verify split-pane focus behavior and confirm that agent team splits correctly open in the background with appropriate focus settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->