### PR TITLE
Fix appIcon=automatic crash on macOS Tahoe

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -14,11 +14,13 @@ jobs:
         include:
           - os: warp-macos-15-arm64-6x
             timeout: 30
-            smoke: true
+            startup_smoke: true
+            virtual_display: true
             skip_zig: false
           - os: warp-macos-26-arm64-6x
             timeout: 30
-            smoke: false
+            startup_smoke: true
+            virtual_display: false
             skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
@@ -164,7 +166,7 @@ jobs:
           fi
 
       - name: Create virtual display
-        if: matrix.smoke
+        if: matrix.virtual_display
         run: |
           set -euo pipefail
           echo "=== Display before ==="
@@ -180,7 +182,9 @@ jobs:
           system_profiler SPDisplaysDataType 2>/dev/null || echo "(no display info)"
 
       - name: Build app for smoke test
-        if: matrix.smoke
+        if: matrix.startup_smoke
+        env:
+          CMUX_SKIP_ZIG_BUILD: ${{ matrix.skip_zig && '1' || '0' }}
         run: |
           set -euo pipefail
           SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages"
@@ -190,7 +194,7 @@ jobs:
             -destination "platform=macOS" build
 
       - name: Smoke test
-        if: matrix.smoke
+        if: matrix.startup_smoke
         run: |
           set -euo pipefail
           chmod +x scripts/smoke-test-ci.sh

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2484,6 +2484,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
         let telemetryEnabled = TelemetrySettings.enabledForCurrentLaunch
+        AppIconLaunchState.markDidFinishLaunching()
 
         DistributedNotificationCenter.default().addObserver(
             self,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3727,20 +3727,74 @@ enum AppIconSettings {
     }
 }
 
-final class AppIconAppearanceObserver: NSObject {
-    static let shared = AppIconAppearanceObserver()
-    private var observation: NSKeyValueObservation?
+protocol AppIconAppearanceObservation: AnyObject {
+    func invalidate()
+}
 
-    private override init() { super.init() }
+extension NSKeyValueObservation: AppIconAppearanceObservation {}
+
+final class AppIconAppearanceObserver: NSObject {
+    struct Environment {
+        let isApplicationFinishedLaunching: () -> Bool
+        let startEffectiveAppearanceObservation: (@escaping () -> Void) -> AppIconAppearanceObservation?
+        let addDidFinishLaunchingObserver: (@escaping () -> Void) -> NSObjectProtocol
+        let removeObserver: (NSObjectProtocol) -> Void
+        let currentAppearanceIsDark: () -> Bool?
+        let imageForName: (String) -> NSImage?
+        let setApplicationIconImage: (NSImage) -> Void
+
+        static func live() -> Self {
+            Self(
+                isApplicationFinishedLaunching: { NSRunningApplication.current.isFinishedLaunching },
+                startEffectiveAppearanceObservation: { handler in
+                    guard let app = NSApp else { return nil }
+                    return app.observe(\.effectiveAppearance, options: []) { _, _ in
+                        DispatchQueue.main.async {
+                            handler()
+                        }
+                    }
+                },
+                addDidFinishLaunchingObserver: { handler in
+                    NotificationCenter.default.addObserver(
+                        forName: NSApplication.didFinishLaunchingNotification,
+                        object: nil,
+                        queue: .main
+                    ) { _ in
+                        handler()
+                    }
+                },
+                removeObserver: { observer in
+                    NotificationCenter.default.removeObserver(observer)
+                },
+                currentAppearanceIsDark: {
+                    guard let app = NSApp else { return nil }
+                    return app.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+                },
+                imageForName: { imageName in
+                    NSImage(named: imageName)
+                },
+                setApplicationIconImage: { icon in
+                    NSApplication.shared.applicationIconImage = icon
+                }
+            )
+        }
+    }
+
+    static let shared = AppIconAppearanceObserver()
+    private let environment: Environment
+    private var observation: AppIconAppearanceObservation?
+
+    init(environment: Environment = .live()) {
+        self.environment = environment
+        super.init()
+    }
 
     func startObserving() {
         applyIconForCurrentAppearance()
         guard observation == nil else { return }
-        observation = NSApp.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
-            DispatchQueue.main.async {
-                guard let self, self.observation != nil else { return }
-                self.applyIconForCurrentAppearance()
-            }
+        observation = environment.startEffectiveAppearanceObservation { [weak self] in
+            guard let self, self.observation != nil else { return }
+            self.applyIconForCurrentAppearance()
         }
     }
 
@@ -3750,10 +3804,10 @@ final class AppIconAppearanceObserver: NSObject {
     }
 
     private func applyIconForCurrentAppearance() {
-        let isDark = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        guard let isDark = environment.currentAppearanceIsDark() else { return }
         let imageName = isDark ? "AppIconDark" : "AppIconLight"
-        if let icon = NSImage(named: imageName) {
-            NSApplication.shared.applicationIconImage = icon
+        if let icon = environment.imageForName(imageName) {
+            environment.setApplicationIconImage(icon)
         }
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3783,6 +3783,8 @@ final class AppIconAppearanceObserver: NSObject {
     static let shared = AppIconAppearanceObserver()
     private let environment: Environment
     private var observation: AppIconAppearanceObservation?
+    private var launchObserver: NSObjectProtocol?
+    private var hasDeferredStartPending = false
 
     init(environment: Environment = .live()) {
         self.environment = environment
@@ -3790,6 +3792,14 @@ final class AppIconAppearanceObserver: NSObject {
     }
 
     func startObserving() {
+        // Tahoe crashes if effectiveAppearance is touched during App.init(),
+        // so defer the first automatic-icon apply until launch completes.
+        if !environment.isApplicationFinishedLaunching() {
+            deferStartUntilLaunchIfNeeded()
+            return
+        }
+
+        cancelDeferredStart()
         applyIconForCurrentAppearance()
         guard observation == nil else { return }
         observation = environment.startEffectiveAppearanceObservation { [weak self] in
@@ -3801,9 +3811,28 @@ final class AppIconAppearanceObserver: NSObject {
     func stopObserving() {
         observation?.invalidate()
         observation = nil
+        cancelDeferredStart()
+    }
+
+    private func deferStartUntilLaunchIfNeeded() {
+        hasDeferredStartPending = true
+        guard launchObserver == nil else { return }
+        launchObserver = environment.addDidFinishLaunchingObserver { [weak self] in
+            guard let self, self.hasDeferredStartPending else { return }
+            self.cancelDeferredStart()
+            self.startObserving()
+        }
+    }
+
+    private func cancelDeferredStart() {
+        hasDeferredStartPending = false
+        guard let launchObserver else { return }
+        environment.removeObserver(launchObserver)
+        self.launchObserver = nil
     }
 
     private func applyIconForCurrentAppearance() {
+        guard environment.isApplicationFinishedLaunching() else { return }
         guard let isDark = environment.currentAppearanceIsDark() else { return }
         let imageName = isDark ? "AppIconDark" : "AppIconLight"
         if let icon = environment.imageForName(imageName) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3662,12 +3662,32 @@ enum AppIconMode: String, CaseIterable, Identifiable {
     }
 }
 
+enum AppIconLaunchState {
+    private static let lock = NSLock()
+    private static var didFinishLaunching = false
+
+    static func markDidFinishLaunching() {
+        lock.lock()
+        defer { lock.unlock() }
+        didFinishLaunching = true
+    }
+
+    static func isApplicationFinishedLaunching() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        let hasFinishedLaunching = didFinishLaunching
+        return hasFinishedLaunching
+    }
+}
+
 enum AppIconSettings {
     static let modeKey = "appIconMode"
     static let defaultMode: AppIconMode = .automatic
     private static let dockTileIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
+    private static var liveEnvironmentProvider: () -> Environment = { .live() }
 
     struct Environment {
+        let isApplicationFinishedLaunching: () -> Bool
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
         let startAppearanceObservation: () -> Void
@@ -3676,6 +3696,9 @@ enum AppIconSettings {
 
         static func live() -> Self {
             Self(
+                isApplicationFinishedLaunching: {
+                    AppIconLaunchState.isApplicationFinishedLaunching()
+                },
                 imageForMode: { mode in
                     guard let imageName = mode.imageName else { return nil }
                     return NSImage(named: imageName)
@@ -3709,7 +3732,13 @@ enum AppIconSettings {
         return mode
     }
 
-    static func applyIcon(_ mode: AppIconMode, environment: Environment = .live()) {
+    static func applyIcon(_ mode: AppIconMode, environment: Environment? = nil) {
+        let environment = environment ?? liveEnvironmentProvider()
+        // Tahoe can crash or wedge when app icon work runs during App.init(),
+        // so leave settings replay to update defaults only and let AppDelegate
+        // apply the resolved icon once didFinishLaunching begins.
+        guard environment.isApplicationFinishedLaunching() else { return }
+
         switch mode {
         case .automatic:
             environment.startAppearanceObservation()
@@ -3724,6 +3753,14 @@ enum AppIconSettings {
         }
 
         environment.notifyDockTilePlugin()
+    }
+
+    static func setLiveEnvironmentProviderForTesting(_ provider: @escaping () -> Environment) {
+        liveEnvironmentProvider = provider
+    }
+
+    static func resetLiveEnvironmentProviderForTesting() {
+        liveEnvironmentProvider = { .live() }
     }
 }
 
@@ -3745,7 +3782,9 @@ final class AppIconAppearanceObserver: NSObject {
 
         static func live() -> Self {
             Self(
-                isApplicationFinishedLaunching: { NSRunningApplication.current.isFinishedLaunching },
+                isApplicationFinishedLaunching: {
+                    AppIconLaunchState.isApplicationFinishedLaunching()
+                },
                 startEffectiveAppearanceObservation: { handler in
                     guard let app = NSApp else { return nil }
                     return app.observe(\.effectiveAppearance, options: []) { _, _ in

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -23,6 +23,7 @@ final class AppIconSettingsTests: XCTestCase {
         var stopObservationCallCount = 0
 
         let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
             imageForMode: { mode in
                 XCTAssertEqual(mode, .dark)
                 return expectedIcon
@@ -55,6 +56,7 @@ final class AppIconSettingsTests: XCTestCase {
         var stopObservationCallCount = 0
 
         let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { true },
             imageForMode: { mode in
                 XCTFail("Automatic mode should not request a manual icon image: \(mode.rawValue)")
                 return nil
@@ -77,6 +79,42 @@ final class AppIconSettingsTests: XCTestCase {
 
         XCTAssertEqual(dockTileNotificationCount, 1)
         XCTAssertEqual(startObservationCallCount, 1)
+        XCTAssertEqual(stopObservationCallCount, 0)
+    }
+
+    func testApplyDarkBeforeLaunchDoesNotTouchRuntimeIconState() {
+        var imageRequestCount = 0
+        var runtimeIconSetCount = 0
+        var dockTileNotificationCount = 0
+        var startObservationCallCount = 0
+        var stopObservationCallCount = 0
+
+        let environment = AppIconSettings.Environment(
+            isApplicationFinishedLaunching: { false },
+            imageForMode: { _ in
+                imageRequestCount += 1
+                return NSImage(size: NSSize(width: 16, height: 16))
+            },
+            setApplicationIconImage: { _ in
+                runtimeIconSetCount += 1
+            },
+            startAppearanceObservation: {
+                startObservationCallCount += 1
+            },
+            stopAppearanceObservation: {
+                stopObservationCallCount += 1
+            },
+            notifyDockTilePlugin: {
+                dockTileNotificationCount += 1
+            }
+        )
+
+        AppIconSettings.applyIcon(.dark, environment: environment)
+
+        XCTAssertEqual(imageRequestCount, 0)
+        XCTAssertEqual(runtimeIconSetCount, 0)
+        XCTAssertEqual(dockTileNotificationCount, 0)
+        XCTAssertEqual(startObservationCallCount, 0)
         XCTAssertEqual(stopObservationCallCount, 0)
     }
 }

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -192,3 +192,102 @@ final class TitlebarControlsHoverPolicyTests: XCTestCase {
         XCTAssertFalse(titlebarControlsShouldTrackButtonHover(config: TitlebarControlsStyle.softButtons.config))
     }
 }
+
+final class AppIconAppearanceObserverTests: XCTestCase {
+    private final class ObservationToken: AppIconAppearanceObservation {
+        private(set) var invalidateCallCount = 0
+
+        func invalidate() {
+            invalidateCallCount += 1
+        }
+    }
+
+    private final class Harness {
+        var isFinishedLaunching = false
+        var startObservationCallCount = 0
+        var currentAppearanceIsDarkCallCount = 0
+        var imageRequests: [String] = []
+        var appliedIconCount = 0
+        var didFinishLaunchingObserverCount = 0
+        private(set) var didFinishLaunchingHandler: (() -> Void)?
+        let observation = ObservationToken()
+
+        lazy var environment = AppIconAppearanceObserver.Environment(
+            isApplicationFinishedLaunching: { [unowned self] in
+                self.isFinishedLaunching
+            },
+            startEffectiveAppearanceObservation: { [unowned self] _ in
+                self.startObservationCallCount += 1
+                return self.observation
+            },
+            addDidFinishLaunchingObserver: { [unowned self] handler in
+                self.didFinishLaunchingObserverCount += 1
+                self.didFinishLaunchingHandler = handler
+                return NSObject()
+            },
+            removeObserver: { _ in },
+            currentAppearanceIsDark: { [unowned self] in
+                self.currentAppearanceIsDarkCallCount += 1
+                return false
+            },
+            imageForName: { [unowned self] imageName in
+                self.imageRequests.append(imageName)
+                return NSImage(size: NSSize(width: 1, height: 1))
+            },
+            setApplicationIconImage: { [unowned self] _ in
+                self.appliedIconCount += 1
+            }
+        )
+
+        func fireDidFinishLaunching() {
+            didFinishLaunchingHandler?()
+        }
+    }
+
+    func testStartObservingDefersInitialApplyUntilLaunch() {
+        let harness = Harness()
+        let observer = AppIconAppearanceObserver(environment: harness.environment)
+
+        observer.startObserving()
+
+        XCTAssertEqual(harness.didFinishLaunchingObserverCount, 1)
+        XCTAssertEqual(harness.startObservationCallCount, 0)
+        XCTAssertEqual(harness.currentAppearanceIsDarkCallCount, 0)
+        XCTAssertTrue(harness.imageRequests.isEmpty)
+
+        harness.isFinishedLaunching = true
+        harness.fireDidFinishLaunching()
+
+        XCTAssertEqual(harness.startObservationCallCount, 1)
+        XCTAssertEqual(harness.currentAppearanceIsDarkCallCount, 1)
+        XCTAssertEqual(harness.imageRequests, ["AppIconLight"])
+        XCTAssertEqual(harness.appliedIconCount, 1)
+    }
+
+    func testStopObservingCancelsDeferredLaunchApply() {
+        let harness = Harness()
+        let observer = AppIconAppearanceObserver(environment: harness.environment)
+
+        observer.startObserving()
+        observer.stopObserving()
+        harness.isFinishedLaunching = true
+        harness.fireDidFinishLaunching()
+
+        XCTAssertEqual(harness.startObservationCallCount, 0)
+        XCTAssertEqual(harness.currentAppearanceIsDarkCallCount, 0)
+        XCTAssertTrue(harness.imageRequests.isEmpty)
+        XCTAssertEqual(harness.appliedIconCount, 0)
+    }
+
+    func testStopObservingInvalidatesActiveObservation() {
+        let harness = Harness()
+        harness.isFinishedLaunching = true
+        let observer = AppIconAppearanceObserver(environment: harness.environment)
+
+        observer.startObserving()
+        observer.stopObserving()
+
+        XCTAssertEqual(harness.startObservationCallCount, 1)
+        XCTAssertEqual(harness.observation.invalidateCallCount, 1)
+    }
+}

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -333,6 +333,7 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
 
     override func tearDown() {
         KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+        AppIconSettings.resetLiveEnvironmentProviderForTesting()
         KeyboardShortcutSettings.resetAll()
         super.tearDown()
     }
@@ -374,6 +375,165 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
             StoredShortcut(key: "b", command: false, shift: false, option: false, control: true, chordKey: "1")
         )
         XCTAssertEqual(store.activeSourcePath, settingsFileURL.path)
+    }
+
+    func testSettingsFileStoreDoesNotApplyAutomaticAppIconDuringStartupReplay() throws {
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: AppIconSettings.modeKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: AppIconSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: AppIconSettings.modeKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: AppIconSettings.modeKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "app": {
+                "appIcon": "automatic"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        var startObservationCallCount = 0
+        var stopObservationCallCount = 0
+        var imageRequestCount = 0
+        var runtimeIconSetCount = 0
+        var dockTileNotificationCount = 0
+        AppIconSettings.setLiveEnvironmentProviderForTesting {
+            AppIconSettings.Environment(
+                isApplicationFinishedLaunching: { false },
+                imageForMode: { _ in
+                    imageRequestCount += 1
+                    return nil
+                },
+                setApplicationIconImage: { _ in
+                    runtimeIconSetCount += 1
+                },
+                startAppearanceObservation: {
+                    startObservationCallCount += 1
+                },
+                stopAppearanceObservation: {
+                    stopObservationCallCount += 1
+                },
+                notifyDockTilePlugin: {
+                    dockTileNotificationCount += 1
+                }
+            )
+        }
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(defaults.string(forKey: AppIconSettings.modeKey), AppIconMode.automatic.rawValue)
+        XCTAssertEqual(startObservationCallCount, 0)
+        XCTAssertEqual(stopObservationCallCount, 0)
+        XCTAssertEqual(imageRequestCount, 0)
+        XCTAssertEqual(runtimeIconSetCount, 0)
+        XCTAssertEqual(dockTileNotificationCount, 0)
+    }
+
+    func testSettingsFileStoreCanReplayAutomaticAppIconSettingTwiceWithoutTouchingAppKit() throws {
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: AppIconSettings.modeKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: AppIconSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: AppIconSettings.modeKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: AppIconSettings.modeKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "app": {
+                "appIcon": "automatic"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        var startObservationCallCount = 0
+        var stopObservationCallCount = 0
+        var imageRequestCount = 0
+        var runtimeIconSetCount = 0
+        var dockTileNotificationCount = 0
+        AppIconSettings.setLiveEnvironmentProviderForTesting {
+            AppIconSettings.Environment(
+                isApplicationFinishedLaunching: { false },
+                imageForMode: { _ in
+                    imageRequestCount += 1
+                    return nil
+                },
+                setApplicationIconImage: { _ in
+                    runtimeIconSetCount += 1
+                },
+                startAppearanceObservation: {
+                    startObservationCallCount += 1
+                },
+                stopAppearanceObservation: {
+                    stopObservationCallCount += 1
+                },
+                notifyDockTilePlugin: {
+                    dockTileNotificationCount += 1
+                }
+            )
+        }
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(defaults.string(forKey: AppIconSettings.modeKey), AppIconMode.automatic.rawValue)
+        XCTAssertEqual(startObservationCallCount, 0)
+        XCTAssertEqual(stopObservationCallCount, 0)
+        XCTAssertEqual(imageRequestCount, 0)
+        XCTAssertEqual(runtimeIconSetCount, 0)
+        XCTAssertEqual(dockTileNotificationCount, 0)
     }
 
     func testSettingsFileStoreRejectsModifierFreeFirstStroke() throws {


### PR DESCRIPTION
## Summary
- root cause: `CmuxSettingsFileStore` replays managed `app.appIcon` during `cmuxApp.init`, and Tahoe can crash or wedge if any app icon work touches `NSApplication` / `NSImage` before `applicationDidFinishLaunching`
- gate all app icon work behind an explicit launch-state check, and mark that state at the start of `applicationDidFinishLaunching` so the actual icon apply and automatic appearance observation begin only after launch starts
- keep settings-file replay limited to updating `UserDefaults` during startup, which fixes the broken post-crash recovery path where a second launch could come up with no windows and no socket until `settings.json` was emptied
- add regression coverage for startup replay with `appIcon = automatic`, including repeated settings-file loads, plus a prelaunch guard test for manual icon modes

## Notes
- local tests were not run per repo policy

Closes #2763
Closes #2775

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes app startup behavior around AppKit icon/appearance observation to avoid pre-launch crashes, which can impact launch-time UI state if the gating or deferral logic is incorrect. CI smoke-test matrix changes are low risk but may alter coverage expectations across macOS runners.
> 
> **Overview**
> Prevents `appIcon=automatic` (and other icon modes) from touching AppKit before launch completes by introducing `AppIconLaunchState`, marking it at the start of `applicationDidFinishLaunching`, and gating `AppIconSettings.applyIcon` plus `AppIconAppearanceObserver` to *defer icon application/observation until launch*.
> 
> Refactors the appearance observer to use an injectable environment and adds regression tests covering pre-launch no-op behavior, deferred automatic-icon application, and repeated settings-file replays without triggering AppKit calls. Updates macOS compat CI to split `startup_smoke` vs `virtual_display` and to pass `CMUX_SKIP_ZIG_BUILD` through the smoke build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1b9e609ec5e461aeddb16689a425cd1d5c3a4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash/hang on macOS Tahoe when `app.appIcon` is set to `automatic` by deferring all app icon work until after `applicationDidFinishLaunching`. Also restores clean recovery after a crash by avoiding pre-launch icon operations. Fixes #2763 and #2775.

- **Bug Fixes**
  - Gate all app icon operations behind a launch-state check; mark launch at the start of `applicationDidFinishLaunching`.
  - During startup replay, only update `UserDefaults`; apply the resolved icon and start appearance observation after launch begins.
  - Add a deferred, safe `AppIconAppearanceObserver` that avoids touching `NSApplication`/`NSImage` before launch.
  - Add regression tests for pre-launch guards and repeated settings-file loads with `appIcon = automatic`.
  - CI: add startup smoke test and virtual display toggle; run on macOS 15 and 26 runners.

<sup>Written for commit 0f1b9e609ec5e461aeddb16689a425cd1d5c3a4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed app icon initialization timing to prevent state inconsistencies during early startup phases.

* **Refactor**
  * Enhanced app icon management to defer operations until application launch completes, improving startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->