### PR TITLE
Fix blank terminal when creating a new workspace

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9201,6 +9201,25 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
+    /// Nudge AppKit/CoreAnimation to composite the selected surface once the portal sync lands.
+    /// This is only used on structural transitions like new-workspace insertion, not typing paths.
+    func requestVisibleSurfaceDisplayIfNeeded() {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestVisibleSurfaceDisplayIfNeeded()
+            }
+            return
+        }
+
+        guard window != nil else { return }
+        surfaceView.layoutSubtreeIfNeeded()
+        if let metalLayer = surfaceView.layer as? CAMetalLayer {
+            metalLayer.setNeedsDisplay()
+        } else {
+            surfaceView.layer?.setNeedsDisplay()
+        }
+    }
+
     @discardableResult
     private func synchronizeGeometryAndContent() -> Bool {
         CATransaction.begin()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8611,6 +8611,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
+    private var pendingVisibleSurfaceDisplayOnWindowAttach = false
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
@@ -9211,7 +9212,12 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
-        guard window != nil else { return }
+        guard window != nil else {
+            pendingVisibleSurfaceDisplayOnWindowAttach = true
+            return
+        }
+
+        pendingVisibleSurfaceDisplayOnWindowAttach = false
         surfaceView.layoutSubtreeIfNeeded()
         if let metalLayer = surfaceView.layer as? CAMetalLayer {
             metalLayer.setNeedsDisplay()
@@ -9404,6 +9410,11 @@ final class GhosttySurfaceScrollView: NSView {
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         windowObservers.removeAll()
         guard let window else { return }
+        if pendingVisibleSurfaceDisplayOnWindowAttach {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestVisibleSurfaceDisplayIfNeeded()
+            }
+        }
         windowObservers.append(NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: window,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2041,6 +2041,9 @@ class TabManager: ObservableObject {
                     object: nil,
                     userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
                 )
+                newWorkspace.scheduleInitialSelectedTerminalRenderRefresh(
+                    reason: "tabManager.addWorkspace"
+                )
             }
 #if DEBUG
             UITestRecorder.incrementInt("addTabInvocations")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10913,6 +10913,42 @@ final class Workspace: Identifiable, ObservableObject {
         runRefreshPass(0.03)
     }
 
+    func scheduleInitialSelectedTerminalRenderRefresh(reason: String = "workspace.create.initialSelection") {
+        guard let terminalPanel = focusedTerminalPanel else { return }
+        let panelId = terminalPanel.id
+
+        // New-workspace insertion can saturate the current layout turn before the freshly
+        // selected terminal gets the same portal sync/reveal path that a tab re-present does.
+        terminalPanel.requestViewReattach()
+        scheduleTerminalGeometryReconcile()
+
+        let runRefreshPass: (TimeInterval) -> Void = { [weak self] delay in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                guard let self,
+                      self.owningTabManager?.selectedTabId == self.id,
+                      self.focusedPanelId == panelId,
+                      let panel = self.terminalPanel(for: panelId) else { return }
+
+                if let window = panel.hostedView.window {
+                    TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                } else {
+                    TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                }
+
+                panel.hostedView.reconcileGeometryNow()
+                if panel.surface.surface != nil {
+                    panel.surface.forceRefresh(reason: reason)
+                } else {
+                    panel.surface.requestBackgroundSurfaceStartIfNeeded()
+                }
+                panel.hostedView.requestVisibleSurfaceDisplayIfNeeded()
+            }
+        }
+
+        runRefreshPass(0)
+        runRefreshPass(0.03)
+    }
+
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) {
         for tabId in tabIds {
             if skipPinned,

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -2,6 +2,21 @@ import XCTest
 import Foundation
 
 final class AutomationSocketUITests: XCTestCase {
+    private struct RenderStatsSnapshot: CustomStringConvertible {
+        let panelId: String
+        let layerContentsKey: String
+        let inWindow: Bool
+        let presentCount: Int
+
+        var hasPresentedFirstFrame: Bool {
+            inWindow && layerContentsKey != "nil"
+        }
+
+        var description: String {
+            "panelId=\(panelId) inWindow=\(inWindow) presentCount=\(presentCount) layerContentsKey=\(layerContentsKey)"
+        }
+    }
+
     private var socketPath = ""
     private let defaultsDomain = "com.cmuxterm.app.debug"
     private let modeKey = "socketControlMode"
@@ -45,9 +60,60 @@ final class AutomationSocketUITests: XCTestCase {
         app.terminate()
     }
 
+    func testRapidWorkspaceCreationPresentsFirstFrameWithoutWorkspaceSwitch() {
+        let app = configuredApp(mode: "cmuxOnly")
+        app.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for workspace first-frame test. state=\(app.state.rawValue)"
+        )
+
+        guard let resolvedPath = resolveSocketPath(timeout: 5.0) else {
+            XCTFail("Expected control socket to exist for workspace first-frame test")
+            return
+        }
+        socketPath = resolvedPath
+
+        XCTAssertTrue(
+            waitForSocketPong(timeout: 8.0),
+            "Expected control socket to respond to ping at \(socketPath)"
+        )
+
+        var seenWorkspaceIds: Set<String> = []
+        var seenPanelIds: Set<String> = []
+
+        for index in 0..<10 {
+            guard let workspaceId = okUUID(from: socketCommand("new_workspace")) else {
+                XCTFail(
+                    "Expected new_workspace to return a workspace ID on iteration \(index).\n\(debugWorkspaceCreationState())"
+                )
+                return
+            }
+            seenWorkspaceIds.insert(workspaceId)
+
+            guard let stats = waitForSelectedWorkspaceFirstFrame(timeout: 5.0) else {
+                XCTFail(
+                    "Expected newly created workspace to present its first frame on iteration \(index).\n" +
+                    "workspaceId=\(workspaceId)\n\(debugWorkspaceCreationState())"
+                )
+                return
+            }
+
+            XCTAssertTrue(
+                stats.hasPresentedFirstFrame,
+                "Expected selected workspace to have a visible IOSurface-backed first frame. stats=\(stats)"
+            )
+            seenPanelIds.insert(stats.panelId)
+        }
+
+        XCTAssertEqual(seenWorkspaceIds.count, 10, "Expected each new_workspace call to create a distinct workspace")
+        XCTAssertEqual(seenPanelIds.count, 10, "Expected each created workspace to expose a distinct focused terminal panel")
+        app.terminate()
+    }
+
     private func configuredApp(mode: String) -> XCUIApplication {
         let app = XCUIApplication()
-        app.launchArguments += ["-\(modeKey)", mode]
+        app.launchArguments += ["-\(modeKey)", mode, "-cmuxWelcomeShown", "YES"]
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
         // Debug launches require a tag outside reload.sh; provide one in UITests so CI
@@ -66,6 +132,14 @@ final class AutomationSocketUITests: XCTestCase {
             return app.wait(for: .runningForeground, timeout: 6.0)
         }
         return false
+    }
+
+    private func waitForCondition(timeout: TimeInterval, predicate: @escaping () -> Bool) -> Bool {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in predicate() },
+            object: nil
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
     }
 
     private func waitForSocket(exists: Bool, timeout: TimeInterval) -> Bool {
@@ -115,6 +189,81 @@ final class AutomationSocketUITests: XCTestCase {
         return nil
     }
 
+    private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            self.socketCommand("ping") == "PONG"
+        }
+    }
+
+    private func waitForSelectedWorkspaceFirstFrame(timeout: TimeInterval) -> RenderStatsSnapshot? {
+        let deadline = Date().addingTimeInterval(timeout)
+        var latest: RenderStatsSnapshot?
+
+        while Date() < deadline {
+            if let stats = currentRenderStats() {
+                latest = stats
+                if stats.hasPresentedFirstFrame {
+                    return stats
+                }
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+
+        return latest
+    }
+
+    private func currentRenderStats() -> RenderStatsSnapshot? {
+        guard let response = socketCommand("render_stats"),
+              response.hasPrefix("OK ") else {
+            return nil
+        }
+        let payload = String(response.dropFirst(3))
+        guard let data = payload.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let panelId = object["panelId"] as? String,
+              let layerContentsKey = object["layerContentsKey"] as? String,
+              let inWindow = object["inWindow"] as? Bool else {
+            return nil
+        }
+
+        return RenderStatsSnapshot(
+            panelId: panelId,
+            layerContentsKey: layerContentsKey,
+            inWindow: inWindow,
+            presentCount: object["presentCount"] as? Int ?? 0
+        )
+    }
+
+    private func socketCommand(_ command: String) -> String? {
+        ControlSocketClient(path: socketPath, responseTimeout: 2.0).sendLine(command)
+    }
+
+    private func okUUID(from response: String?) -> String? {
+        guard let response,
+              response.hasPrefix("OK ") else {
+            return nil
+        }
+        let value = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard UUID(uuidString: value) != nil else { return nil }
+        return value
+    }
+
+    private func debugWorkspaceCreationState() -> String {
+        let currentWorkspace = socketCommand("current_workspace") ?? "<nil>"
+        let workspaces = socketCommand("list_workspaces") ?? "<nil>"
+        let surfaces = socketCommand("list_surfaces") ?? "<nil>"
+        let health = socketCommand("surface_health") ?? "<nil>"
+        let renderStats = socketCommand("render_stats") ?? "<nil>"
+
+        return [
+            "current_workspace: \(currentWorkspace)",
+            "list_workspaces: \(workspaces)",
+            "list_surfaces: \(surfaces)",
+            "surface_health: \(health)",
+            "render_stats: \(renderStats)",
+        ].joined(separator: "\n")
+    }
+
     private func resetSocketDefaults() {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
@@ -138,5 +287,100 @@ final class AutomationSocketUITests: XCTestCase {
 
     private func removeSocketFile() {
         try? FileManager.default.removeItem(atPath: socketPath)
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+#if os(macOS)
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
+            }
+#endif
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let bytes = Array(path.utf8CString)
+            guard bytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { ptr in
+                let raw = UnsafeMutableRawPointer(ptr).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
+                for index in 0..<bytes.count {
+                    raw[index] = bytes[index]
+                }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + bytes.count)
+#if os(macOS)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+#endif
+
+            let connected = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, addrLen)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = line + "\n"
+            let wrote: Bool = payload.withCString { cString in
+                var remaining = strlen(cString)
+                var pointer = UnsafeRawPointer(cString)
+                while remaining > 0 {
+                    let written = write(fd, pointer, remaining)
+                    if written <= 0 { return false }
+                    remaining -= written
+                    pointer = pointer.advanced(by: written)
+                }
+                return true
+            }
+            guard wrote else { return nil }
+
+            let deadline = Date().addingTimeInterval(responseTimeout)
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            var accumulator = ""
+            while Date() < deadline {
+                var pollDescriptor = pollfd(fd: fd, events: Int16(POLLIN), revents: 0)
+                let ready = poll(&pollDescriptor, 1, 100)
+                if ready < 0 {
+                    return nil
+                }
+                if ready == 0 {
+                    continue
+                }
+                let count = read(fd, &buffer, buffer.count)
+                if count <= 0 { break }
+                if let chunk = String(bytes: buffer[0..<count], encoding: .utf8) {
+                    accumulator.append(chunk)
+                    if let newline = accumulator.firstIndex(of: "\n") {
+                        return String(accumulator[..<newline])
+                    }
+                }
+            }
+
+            return accumulator.isEmpty ? nil : accumulator.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 }

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -9,7 +9,7 @@ final class AutomationSocketUITests: XCTestCase {
         let presentCount: Int
 
         var hasPresentedFirstFrame: Bool {
-            inWindow && layerContentsKey != "nil"
+            inWindow && layerContentsKey != "nil" && presentCount > 0
         }
 
         var description: String {
@@ -80,7 +80,12 @@ final class AutomationSocketUITests: XCTestCase {
         )
 
         var seenWorkspaceIds: Set<String> = []
-        var seenPanelIds: Set<String> = []
+        var excludedPanelIds: Set<String> = []
+        var createdPanelIds: Set<String> = []
+
+        if let baselineStats = currentRenderStats() {
+            excludedPanelIds.insert(baselineStats.panelId)
+        }
 
         for index in 0..<10 {
             guard let workspaceId = okUUID(from: socketCommand("new_workspace")) else {
@@ -91,7 +96,10 @@ final class AutomationSocketUITests: XCTestCase {
             }
             seenWorkspaceIds.insert(workspaceId)
 
-            guard let stats = waitForSelectedWorkspaceFirstFrame(timeout: 5.0) else {
+            guard let stats = waitForSelectedWorkspaceFirstFrame(
+                timeout: 5.0,
+                excludingPanelIds: excludedPanelIds
+            ) else {
                 XCTFail(
                     "Expected newly created workspace to present its first frame on iteration \(index).\n" +
                     "workspaceId=\(workspaceId)\n\(debugWorkspaceCreationState())"
@@ -103,11 +111,12 @@ final class AutomationSocketUITests: XCTestCase {
                 stats.hasPresentedFirstFrame,
                 "Expected selected workspace to have a visible IOSurface-backed first frame. stats=\(stats)"
             )
-            seenPanelIds.insert(stats.panelId)
+            excludedPanelIds.insert(stats.panelId)
+            createdPanelIds.insert(stats.panelId)
         }
 
         XCTAssertEqual(seenWorkspaceIds.count, 10, "Expected each new_workspace call to create a distinct workspace")
-        XCTAssertEqual(seenPanelIds.count, 10, "Expected each created workspace to expose a distinct focused terminal panel")
+        XCTAssertEqual(createdPanelIds.count, 10, "Expected each created workspace to expose a distinct focused terminal panel")
         app.terminate()
     }
 
@@ -195,14 +204,17 @@ final class AutomationSocketUITests: XCTestCase {
         }
     }
 
-    private func waitForSelectedWorkspaceFirstFrame(timeout: TimeInterval) -> RenderStatsSnapshot? {
+    private func waitForSelectedWorkspaceFirstFrame(
+        timeout: TimeInterval,
+        excludingPanelIds: Set<String>
+    ) -> RenderStatsSnapshot? {
         let deadline = Date().addingTimeInterval(timeout)
         var latest: RenderStatsSnapshot?
 
         while Date() < deadline {
             if let stats = currentRenderStats() {
                 latest = stats
-                if stats.hasPresentedFirstFrame {
+                if !excludingPanelIds.contains(stats.panelId), stats.hasPresentedFirstFrame {
                     return stats
                 }
             }


### PR DESCRIPTION
## Summary
- add a UI regression test that creates 10 workspaces over the automation socket and waits for each selected terminal to present its first frame
- schedule a post-insertion terminal portal refresh after `TabManager.addWorkspace()` selects the new workspace
- mirror the re-present path by reattaching, synchronizing portal geometry, forcing a surface refresh, and nudging the selected surface layer to display

Closes #2555

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal rendering/portal synchronization and CoreAnimation display triggers during workspace insertion, which could introduce visual regressions or extra redraw work. Scope is limited to post-selection refresh paths and adds a UI regression test to catch failures.
> 
> **Overview**
> Prevents newly created workspaces from showing a blank terminal by scheduling an immediate post-selection render/geometry sync when `TabManager.addWorkspace()` selects the new workspace.
> 
> Adds `Workspace.scheduleInitialSelectedTerminalRenderRefresh()` to reattach the focused panel, reconcile portal geometry, force/start the surface, and request a layer display pass via the new `GhosttyTerminalView.requestVisibleSurfaceDisplayIfNeeded()` (including deferred execution until the view has a window).
> 
> Adds an automation-socket UI regression test that rapidly creates 10 workspaces and asserts each selected terminal presents its first IOSurface-backed frame using new `render_stats` polling helpers and a lightweight UNIX-domain socket client.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0561f1565d03dafd47db359ce1ea985652a55eb1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2555: new workspaces now show the selected terminal’s first frame immediately, preventing a blank terminal. Adds a regression UI test that creates 10 workspaces and confirms first-frame rendering without switching tabs.

- **Bug Fixes**
  - After `TabManager.addWorkspace()`, schedule an initial render refresh on the newly selected terminal: reattach the view, reconcile geometry and portal sync (per-window when possible), start the surface if needed, force a refresh, and request a visible-surface display with a window-attach fallback; run this pass twice (now and ~30ms later) to cover layout/composition races.
  - UI regression test (automation socket) creates 10 workspaces and asserts the selected terminal presents its first IOSurface-backed frame using `render_stats`; bypasses onboarding with `-cmuxWelcomeShown YES`.

<sup>Written for commit 0561f1565d03dafd47db359ce1ea985652a55eb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable initial rendering and display updates when workspaces or tabs are created/selected, ensuring terminal content appears promptly even when windows attach or views are not yet ready.

* **Tests**
  * Added UI tests that validate rapid workspace creation still presents the first frame for each new workspace and focused terminal panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->