### PR TITLE
fix: use physical key positions for Cmd shortcuts on alternative layouts

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -982,10 +982,14 @@ struct ShortcutStroke: Equatable {
     }
 
     static func from(event: NSEvent, requireModifier: Bool = true) -> ShortcutStroke? {
-        guard !isEscapeCancelEvent(event),
-              let key = storedKey(from: event) else { return nil }
-
+        guard !isEscapeCancelEvent(event) else { return nil }
         let flags = normalizedModifierFlags(from: event.modifierFlags)
+        let preferPhysicalKey = flags.contains(.command) || flags.contains(.control)
+        guard let key = storedKey(
+            keyCode: event.keyCode,
+            charactersIgnoringModifiers: event.charactersIgnoringModifiers,
+            preferPhysicalKey: preferPhysicalKey
+        ) else { return nil }
 
         let stroke = ShortcutStroke(
             key: key,
@@ -1034,6 +1038,16 @@ struct ShortcutStroke: Equatable {
             return keyCode == 36 || keyCode == 76
         }
 
+        // For Command-based shortcuts, match by physical key position (ANSI key
+        // code) first. macOS uses QWERTY positions for Cmd shortcuts regardless
+        // of the active keyboard layout. Without this, alternative Latin layouts
+        // (Dvorak, Colemak) produce false positives — e.g. physical W in Dvorak
+        // sends "," which incorrectly matches Cmd+, instead of Cmd+W.
+        if flags.contains(.command),
+           let expectedKeyCode = Self.keyCodeForShortcutKey(shortcutKey) {
+            return keyCode == expectedKeyCode
+        }
+
         if Self.shortcutCharacterMatches(
             eventCharacter: eventCharacter,
             shortcutKey: shortcutKey,
@@ -1052,13 +1066,6 @@ struct ShortcutStroke: Equatable {
            Self.digitForNumberKeyCode(keyCode) == nil {
             return false
         }
-        if hasEventChars,
-           eventCharsAreASCII,
-           flags.contains(.command),
-           !flags.contains(.control),
-           Self.shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey) {
-            return false
-        }
 
         let layoutCharacter = layoutCharacterProvider(keyCode, modifierFlags)
         if Self.shortcutCharacterMatches(
@@ -1070,15 +1077,7 @@ struct ShortcutStroke: Equatable {
             return true
         }
 
-        let allowANSIKeyCodeFallback = flags.contains(.control)
-            || (flags.contains(.command)
-                && !flags.contains(.control)
-                && (
-                    !Self.shouldRequireCharacterMatchForCommandShortcut(shortcutKey: shortcutKey)
-                        || (hasEventChars && !eventCharsAreASCII)
-                        || (!hasEventChars && (layoutCharacter?.isEmpty ?? true))
-                ))
-        if allowANSIKeyCodeFallback,
+        if flags.contains(.control),
            let expectedKeyCode = Self.keyCodeForShortcutKey(shortcutKey) {
             return keyCode == expectedKeyCode
         }
@@ -1086,38 +1085,19 @@ struct ShortcutStroke: Equatable {
         return false
     }
 
-    private static func storedKey(from event: NSEvent) -> String? {
-        storedKey(
-            keyCode: event.keyCode,
-            charactersIgnoringModifiers: event.charactersIgnoringModifiers
-        )
-    }
-
     private static func storedKey(
         keyCode: UInt16,
-        charactersIgnoringModifiers: String?
+        charactersIgnoringModifiers: String?,
+        preferPhysicalKey: Bool = false
     ) -> String? {
-        // Prefer keyCode mapping so shifted symbol keys (e.g. "}") record as "]".
-        switch keyCode {
-        case 123: return "←" // left arrow
-        case 124: return "→" // right arrow
-        case 125: return "↓" // down arrow
-        case 126: return "↑" // up arrow
-        case 48: return "\t" // tab
-        case 36, 76: return "\r" // return, keypad enter
-        case 33: return "["  // kVK_ANSI_LeftBracket
-        case 30: return "]"  // kVK_ANSI_RightBracket
-        case 27: return "-"  // kVK_ANSI_Minus
-        case 24: return "="  // kVK_ANSI_Equal
-        case 43: return ","  // kVK_ANSI_Comma
-        case 47: return "."  // kVK_ANSI_Period
-        case 44: return "/"  // kVK_ANSI_Slash
-        case 41: return ";"  // kVK_ANSI_Semicolon
-        case 39: return "'"  // kVK_ANSI_Quote
-        case 50: return "`"  // kVK_ANSI_Grave
-        case 42: return "\\" // kVK_ANSI_Backslash
-        default:
-            break
+        // For Command/Control shortcuts, use physical key position (QWERTY ANSI
+        // key code) so the stored key is layout-independent. This ensures
+        // shortcuts recorded on Dvorak, Colemak, or other alternative layouts
+        // match correctly via keyCode-first matching. Non-Command/Control
+        // shortcuts (Option-only, chord second strokes) keep character-based
+        // recording to match their character-based matching path.
+        if preferPhysicalKey, let physicalKey = shortcutKeyForKeyCode(keyCode) {
+            return physicalKey
         }
 
         guard let chars = charactersIgnoringModifiers?.lowercased(),
@@ -1165,13 +1145,6 @@ struct ShortcutStroke: Equatable {
         }
     }
 
-    private static func shouldRequireCharacterMatchForCommandShortcut(shortcutKey: String) -> Bool {
-        guard shortcutKey.count == 1, let scalar = shortcutKey.unicodeScalars.first else {
-            return false
-        }
-        return CharacterSet.letters.contains(scalar)
-    }
-
     private static func shortcutCharacterMatches(
         eventCharacter: String?,
         shortcutKey: String,
@@ -1184,6 +1157,66 @@ struct ShortcutStroke: Equatable {
             applyShiftSymbolNormalization: applyShiftSymbolNormalization,
             eventKeyCode: eventKeyCode
         ) == shortcutKey
+    }
+
+    static func shortcutKeyForKeyCode(_ keyCode: UInt16) -> String? {
+        switch keyCode {
+        case 0: return "a"
+        case 1: return "s"
+        case 2: return "d"
+        case 3: return "f"
+        case 4: return "h"
+        case 5: return "g"
+        case 6: return "z"
+        case 7: return "x"
+        case 8: return "c"
+        case 9: return "v"
+        case 11: return "b"
+        case 12: return "q"
+        case 13: return "w"
+        case 14: return "e"
+        case 15: return "r"
+        case 16: return "y"
+        case 17: return "t"
+        case 18: return "1"
+        case 19: return "2"
+        case 20: return "3"
+        case 21: return "4"
+        case 22: return "6"
+        case 23: return "5"
+        case 24: return "="
+        case 25: return "9"
+        case 26: return "7"
+        case 27: return "-"
+        case 28: return "8"
+        case 29: return "0"
+        case 30: return "]"
+        case 31: return "o"
+        case 32: return "u"
+        case 33: return "["
+        case 34: return "i"
+        case 35: return "p"
+        case 36: return "\r"
+        case 37: return "l"
+        case 38: return "j"
+        case 39: return "'"
+        case 40: return "k"
+        case 41: return ";"
+        case 42: return "\\"
+        case 43: return ","
+        case 44: return "/"
+        case 45: return "n"
+        case 46: return "m"
+        case 47: return "."
+        case 48: return "\t"
+        case 50: return "`"
+        case 76: return "\r"
+        case 123: return "←"
+        case 124: return "→"
+        case 125: return "↓"
+        case 126: return "↑"
+        default: return nil
+        }
     }
 
     private static func keyCodeForShortcutKey(_ key: String) -> UInt16? {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1160,25 +1160,90 @@ final class StoredShortcutMatchingTests: XCTestCase {
         )
     }
 
-    func testMatchingUsesRecordedCharacterForRemappedCommandLetter() {
-        let shortcut = StoredShortcut(key: "q", command: true, shift: false, option: false, control: false)
-
+    func testCommandShortcutMatchesByPhysicalKeyPosition() {
+        // Cmd+W (key "w") should match keyCode 13 (physical W) regardless of
+        // what character the layout produces. On Dvorak, physical W sends ",".
         XCTAssertTrue(
-            shortcut.matches(
-                keyCode: 13,
-                modifierFlags: [.command],
-                eventCharacter: "q",
-                layoutCharacterProvider: { _, _ in nil }
-            )
-        )
-        XCTAssertFalse(
             StoredShortcut(key: "w", command: true, shift: false, option: false, control: false).matches(
-                keyCode: 13,
+                keyCode: 13, // kVK_ANSI_W
+                modifierFlags: [.command],
+                eventCharacter: ",", // Dvorak character for physical W
+                layoutCharacterProvider: { _, _ in nil }
+            )
+        )
+        // Cmd+Q (key "q") should NOT match keyCode 13 (physical W) even if the
+        // event character happens to be "q" (impossible on standard layouts, but
+        // verifies that character matching does not override keyCode).
+        XCTAssertFalse(
+            StoredShortcut(key: "q", command: true, shift: false, option: false, control: false).matches(
+                keyCode: 13, // kVK_ANSI_W, not kVK_ANSI_Q (12)
                 modifierFlags: [.command],
                 eventCharacter: "q",
                 layoutCharacterProvider: { _, _ in nil }
             )
         )
+    }
+
+    func testDvorakCmdWDoesNotMatchOpenSettings() {
+        // On Dvorak, physical W (keyCode 13) produces ",". This must NOT match
+        // the Settings shortcut (Cmd+,) — it must match Close Tab (Cmd+W).
+        let settingsShortcut = StoredShortcut(key: ",", command: true, shift: false, option: false, control: false)
+        let closeTabShortcut = StoredShortcut(key: "w", command: true, shift: false, option: false, control: false)
+
+        // Physical W on Dvorak: keyCode 13, character ","
+        XCTAssertFalse(
+            settingsShortcut.matches(
+                keyCode: 13, // kVK_ANSI_W
+                modifierFlags: [.command],
+                eventCharacter: ",",
+                layoutCharacterProvider: { _, _ in nil }
+            ),
+            "Cmd+, must not match physical W (keyCode 13) on Dvorak"
+        )
+        XCTAssertTrue(
+            closeTabShortcut.matches(
+                keyCode: 13, // kVK_ANSI_W
+                modifierFlags: [.command],
+                eventCharacter: ",",
+                layoutCharacterProvider: { _, _ in nil }
+            ),
+            "Cmd+W must match physical W (keyCode 13) on Dvorak"
+        )
+
+        // Physical comma on Dvorak: keyCode 43, should match Settings
+        XCTAssertTrue(
+            settingsShortcut.matches(
+                keyCode: 43, // kVK_ANSI_Comma
+                modifierFlags: [.command],
+                eventCharacter: "w", // Dvorak character for physical comma position
+                layoutCharacterProvider: { _, _ in nil }
+            ),
+            "Cmd+, must match physical comma (keyCode 43) on Dvorak"
+        )
+    }
+
+    func testRecorderStoresPhysicalKeyOnAlternativeLayout() {
+        // On Dvorak, physical W (keyCode 13) produces ",". The recorder should
+        // store "w" (QWERTY position), not "," (layout character).
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: ",",
+            charactersIgnoringModifiers: ",",
+            isARepeat: false,
+            keyCode: 13 // kVK_ANSI_W
+        ) else {
+            XCTFail("Failed to construct Dvorak Cmd+W event")
+            return
+        }
+
+        let stroke = ShortcutStroke.from(event: event, requireModifier: false)
+        XCTAssertEqual(stroke?.key, "w", "Recorder must store physical key 'w', not Dvorak character ','")
+        XCTAssertTrue(stroke?.command ?? false)
     }
 
     func testMatchingTreatsKeypadEnterAsReturn() {


### PR DESCRIPTION
## Summary

- Cmd shortcuts on Dvorak, Colemak, and other alternative Latin layouts fire the wrong action because `ShortcutStroke.matches()` compares `event.charactersIgnoringModifiers` (which follows the active layout) against shortcut keys before checking the physical key code
- On Dvorak, physical W produces `,` — so Cmd+W matches Cmd+, (Settings) before reaching Cmd+W (Close Tab)
- Fix: for Command-modified shortcuts, match by ANSI key code (physical position) first, following the macOS convention that Cmd shortcuts bind to QWERTY positions regardless of layout

### Before

On Dvorak: Cmd+W (physical) → opens Settings (matches `cmd+,`)

### After

On Dvorak: Cmd+W (physical) → closes tab (matches `cmd+w` by keyCode 13 = kVK_ANSI_W)

## Details

The existing non-Latin layout fix (Russian, Korean, etc.) works because `charactersIgnoringModifiers` returns non-ASCII characters, triggering the keyCode fallback. Dvorak/Colemak produce ASCII characters that happen to match the *wrong* shortcut, so they never reach the fallback.

The fix adds a keyCode-first check for all Command shortcuts and simplifies the fallback chain:
1. Command shortcuts → match by ANSI key code (physical position)
2. Control shortcuts → match by ANSI key code (fallback, unchanged)
3. All others → match by character (unchanged)

## Test plan

- [ ] Dvorak: Cmd+W closes tab (not Settings), Cmd+, opens Settings
- [ ] Colemak: Cmd+W closes tab
- [ ] QWERTY: all shortcuts unchanged (keyCode and character agree)
- [ ] Russian/Korean: shortcuts still work (keyCode fallback still active)
- [ ] Existing unit tests pass

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd shortcuts on alternative Latin layouts by matching via physical key positions (ANSI) and records Cmd/Control shortcuts by physical key. Prevents collisions like Cmd+W opening Settings on Dvorak; QWERTY and non‑Latin layouts unchanged.

- **Bug Fixes**
  - Cmd shortcuts now match by ANSI key code first (character match only if no known key code), resolving Dvorak/Colemak collisions like Cmd+W vs Cmd+,.
  - Recording stores the physical QWERTY key for Cmd and Control shortcuts; others still record by character. Control matching behavior is unchanged.

- **Refactors**
  - Added reverse keyCode→key mapping and removed `shouldRequireCharacterMatchForCommandShortcut` and `storedKey(from:)`; expanded tests for physical-key-first matching and recorder behavior.

<sup>Written for commit e9a17fcbc81ad2dabd634914220df48d70347fac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command-key shortcuts now match by physical key position (layout-independent) and use simplified fallback rules for more consistent behavior across layouts.
  * Shortcut recording stores the physical key for Command shortcuts instead of the layout-produced character.

* **Tests**
  * Added/updated unit tests (including Dvorak scenarios) to validate physical-key matching and prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->