### PR TITLE
Fix blank split panes after portal reveal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9275,6 +9275,13 @@ final class GhosttySurfaceScrollView: NSView {
     /// Request an immediate terminal redraw after geometry updates so stale IOSurface
     /// contents do not remain stretched during live resize churn.
     func refreshSurfaceNow(reason: String = "portal.refreshSurfaceNow") {
+        // Portal reparent/reveal can settle geometry a tick before AppKit finishes
+        // realizing the terminal subtree's backing layer state. Flush display for the
+        // hosted subtree first so forceRefresh does not race a still-unrealized layer.
+        layoutSubtreeIfNeeded()
+        surfaceView.layoutSubtreeIfNeeded()
+        displayIfNeeded()
+        surfaceView.displayIfNeeded()
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 


### PR DESCRIPTION
Root cause: terminal panes could reach the portal refresh path after geometry had been reconciled but before AppKit had fully realized the hosted terminal subtree's backing and display state. In that window, forceRefresh could run against a still-unrealized subtree, leaving the new pane blank until a later focus or tab change forced another redraw.

Fix: in GhosttySurfaceScrollView.refreshSurfaceNow, flush layout and display for both the scroll view and its hosted surface view before calling terminalSurface.forceRefresh. This keeps the fix localized to the portal refresh path that reproduces the issue and avoids the broader workspace-level refresh scheduling that was explored during investigation.

Validation: rebuilt the app successfully with ./scripts/reload.sh --tag build-codex and reran the manual split-pane repro flow against the trimmed patch; the blank-pane issue no longer reproduced.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank split panes after portal reveal by flushing layout and display before forcing a terminal redraw. Panes now render immediately instead of staying blank until focus or tab changes.

- **Bug Fixes**
  - In `GhosttySurfaceScrollView.refreshSurfaceNow`, call `layoutSubtreeIfNeeded()` and `displayIfNeeded()` on the scroll view and hosted surface view before `terminalSurface.forceRefresh`.
  - Prevents a race with unrealized AppKit layers; verified with the split-pane repro flow where the issue no longer reproduces.

<sup>Written for commit c9d3c6b707188752c35e3e5b72c55faa50b92583. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal display reliability by fixing a synchronization issue that could cause rendering glitches during UI refresh operations, ensuring consistent and stable visual output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->