### PR TITLE
feat: file explorer sidebar panel

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -140,6 +140,10 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */; };
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */; };
+			FE0001B1 /* FileExplorerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0001A1 /* FileExplorerModel.swift */; };
+			FE0001B2 /* FileExplorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0001A2 /* FileExplorerView.swift */; };
+			FE0001B4 /* FileSystemWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0001A4 /* FileSystemWatcher.swift */; };
+			FE0001B5 /* SidebarModeStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE0001A5 /* SidebarModeStrip.swift */; };
 		/* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -344,6 +348,10 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
+				FE0001A1 /* FileExplorerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorer/FileExplorerModel.swift; sourceTree = "<group>"; };
+				FE0001A2 /* FileExplorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorer/FileExplorerView.swift; sourceTree = "<group>"; };
+				FE0001A4 /* FileSystemWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorer/FileSystemWatcher.swift; sourceTree = "<group>"; };
+				FE0001A5 /* SidebarModeStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorer/SidebarModeStrip.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -511,6 +519,10 @@
 				A5001419 /* MarkdownPanelView.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
+				FE0001A1 /* FileExplorerModel.swift */,
+				FE0001A2 /* FileExplorerView.swift */,
+				FE0001A4 /* FileSystemWatcher.swift */,
+				FE0001A5 /* SidebarModeStrip.swift */,
 				A5001211 /* UpdateController.swift */,
 				A5001212 /* UpdateDelegate.swift */,
 				A5001213 /* UpdateDriver.swift */,
@@ -842,6 +854,10 @@
 				A5001421 /* MarkdownPanelView.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
+				FE0001B1 /* FileExplorerModel.swift in Sources */,
+				FE0001B2 /* FileExplorerView.swift in Sources */,
+				FE0001B4 /* FileSystemWatcher.swift in Sources */,
+				FE0001B5 /* SidebarModeStrip.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
 				A5001202 /* UpdateDelegate.swift in Sources */,
 				A5001203 /* UpdateDriver.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -89686,6 +89686,1434 @@
           }
         }
       }
+    },
+    "sidebar.mode.workspaces": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作區"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeitsbereiche"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espacios de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Espaces de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aree di lavoro"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbejdsområder"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arbeidsområder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przestrzenie robocze"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Áreas de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Рабочие области"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "พื้นที่ทำงาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Çalışma alanları"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Робочі області"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "مساحات العمل"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Radni prostori"
+          }
+        }
+      }
+    },
+    "sidebar.mode.files": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檔案"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Archivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fichiers"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pliki"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файлы"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไฟล์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyalar"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файли"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ملفات"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datoteke"
+          }
+        }
+      }
+    },
+    "fileExplorer.search.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filter files…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルを検索…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "筛选文件…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "篩選檔案…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 필터…"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateien filtern…"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar archivos…"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer les fichiers…"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtra file…"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer filer…"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrer filer…"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtruj pliki…"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtrar arquivos…"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фильтр файлов…"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "กรองไฟล์…"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosyaları filtrele…"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Фільтрувати файли…"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تصفية الملفات…"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filtriraj datoteke…"
+          }
+        }
+      }
+    },
+    "fileExplorer.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Refresh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更新"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "刷新"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "重新整理"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새로고침"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aktualisieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualizar"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Actualiser"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aggiorna"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opdater"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oppdater"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Odśwież"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Atualizar"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Обновить"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "รีเฟรช"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yenile"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Оновити"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تحديث"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Osvježi"
+          }
+        }
+      }
+    },
+    "fileExplorer.hideHidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Hidden Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠しファイルを非表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隐藏隐藏文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隱藏隱藏檔案"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숨김 파일 숨기기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versteckte Dateien ausblenden"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar archivos ocultos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Masquer les fichiers cachés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nascondi file nascosti"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skjul skjulte filer"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Skjul skjulte filer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ukryj ukryte pliki"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ocultar arquivos ocultos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Скрыть скрытые файлы"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ซ่อนไฟล์ที่ซ่อน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gizli dosyaları gizle"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сховати приховані файли"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إخفاء الملفات المخفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sakrij skrivene datoteke"
+          }
+        }
+      }
+    },
+    "fileExplorer.showHidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Hidden Files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠しファイルを表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示隐藏文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示隱藏檔案"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "숨김 파일 표시"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Versteckte Dateien anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar archivos ocultos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher les fichiers cachés"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra file nascosti"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis skjulte filer"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis skjulte filer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż ukryte pliki"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar arquivos ocultos"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать скрытые файлы"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงไฟล์ที่ซ่อน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gizli dosyaları göster"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати приховані файли"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار الملفات المخفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži skrivene datoteke"
+          }
+        }
+      }
+    },
+    "fileExplorer.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ファイルなし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有檔案"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "파일 없음"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine Dateien"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin archivos"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun fichier"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun file"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen filer"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen filer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak plików"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum arquivo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет файлов"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่มีไฟล์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dosya yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає файлів"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد ملفات"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nema datoteka"
+          }
+        }
+      }
+    },
+    "fileExplorer.noResults": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No matching files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するファイルなし"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有匹配的文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有相符的檔案"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일치하는 파일 없음"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine passenden Dateien"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sin archivos coincidentes"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aucun fichier correspondant"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nessun file corrispondente"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen matchende filer"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ingen matchende filer"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brak pasujących plików"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nenhum arquivo correspondente"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Нет подходящих файлов"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไม่พบไฟล์ที่ตรงกัน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Eşleşen dosya yok"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Немає відповідних файлів"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "لا توجد ملفات مطابقة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nema odgovarajućih datoteka"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.copyPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスをコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制路径"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷貝路徑"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "경로 복사"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pfad kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar ruta"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le chemin"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia percorso"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér sti"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier sti"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj ścieżkę"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar caminho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать путь"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกเส้นทาง"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yolu kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати шлях"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ المسار"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj putanju"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.copyRelativePath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Relative Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相対パスをコピー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制相对路径"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拷貝相對路徑"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "상대 경로 복사"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Relativen Pfad kopieren"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar ruta relativa"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copier le chemin relatif"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copia percorso relativo"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiér relativ sti"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopier relativ sti"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiuj ścieżkę względną"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copiar caminho relativo"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копировать относительный путь"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "คัดลอกเส้นทางสัมพัทธ์"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Göreceli yolu kopyala"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Копіювати відносний шлях"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "نسخ المسار النسبي"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kopiraj relativnu putanju"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.revealInFinder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在访达中显示"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Finder 中顯示"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder에서 보기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Finder anzeigen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar en Finder"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Afficher dans le Finder"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostra nel Finder"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis i Finder"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vis i Finder"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pokaż w Finderze"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mostrar no Finder"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показать в Finder"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "แสดงใน Finder"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finder'da göster"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Показати у Finder"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "إظهار في Finder"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Prikaži u Finderu"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.openInTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルで開く"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在终端中打开"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在終端機中開啟"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "터미널에서 열기"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Im Terminal öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir en terminal"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir dans le terminal"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri nel terminale"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åbn i terminal"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Åpne i terminal"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otwórz w terminalu"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir no terminal"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Открыть в терминале"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เปิดในเทอร์มินัล"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminalde aç"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Відкрити в терміналі"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "فتح في الطرفية"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Otvori u terminalu"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5768,6 +5768,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
         let firstResponder = window.firstResponder
+        // Don't steal focus from sidebar text fields (e.g. file explorer search).
+        // When a field editor is active for a FileExplorerNativeTextField, let
+        // normal AppKit key routing deliver keystrokes to the text field.
+        if let fieldEditor = firstResponder as? NSTextView,
+           fieldEditor.isFieldEditor,
+           fieldEditor.delegate is FileExplorerNativeTextField {
+            return
+        }
         if normalizedFlags.contains(.command) {
             let responderHasViableOwner = firstResponder.map { responderHasViableKeyRoutingOwner($0, in: window) } ?? false
             let commandEquivalentNeedsRepair = shouldRepairFocusedTerminalCommandEquivalentInputs(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5771,10 +5771,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Don't steal focus from sidebar text fields (e.g. file explorer search).
         // When a field editor is active for a FileExplorerNativeTextField, let
         // normal AppKit key routing deliver keystrokes to the text field.
+        // Walk the responder chain instead of accessing NSTextView.delegate
+        // (which is unsafe-unretained and can crash during teardown).
         if let fieldEditor = firstResponder as? NSTextView,
-           fieldEditor.isFieldEditor,
-           fieldEditor.delegate is FileExplorerNativeTextField {
-            return
+           fieldEditor.isFieldEditor {
+            var responder: NSResponder? = fieldEditor.nextResponder
+            while let current = responder {
+                if current is FileExplorerNativeTextField { return }
+                responder = current.nextResponder
+            }
         }
         if normalizedFlags.contains(.command) {
             let responderHasViableOwner = firstResponder.map { responderHasViableKeyRoutingOwner($0, in: window) } ?? false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10175,24 +10175,25 @@ struct VerticalTabsSidebar: View {
 
         VStack(spacing: 0) {
             GeometryReader { proxy in
-                ScrollView {
-                    VStack(spacing: 0) {
-                        // Space for traffic lights / fullscreen controls
-                        Spacer()
-                            .frame(height: trafficLightPadding)
+                VStack(spacing: 0) {
+                    // Space for traffic lights / fullscreen controls
+                    Spacer()
+                        .frame(height: trafficLightPadding)
 
-                        // Icon strip for switching sidebar content mode.
-                        SidebarModeStrip(mode: $sidebarPanelMode)
+                    // Icon strip for switching sidebar content mode — always sticky.
+                    SidebarModeStrip(mode: $sidebarPanelMode)
 
-                        if sidebarPanelMode == .files {
-                            FileExplorerView(
-                                model: fileExplorerModel,
-                                onOpenInTerminal: { url in
-                                    _ = tabManager.addWorkspace(workingDirectory: url.path)
-                                }
-                            )
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        } else {
+                    if sidebarPanelMode == .files {
+                        FileExplorerView(
+                            model: fileExplorerModel,
+                            onOpenInTerminal: { url in
+                                _ = tabManager.addWorkspace(workingDirectory: url.path)
+                            }
+                        )
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                    } else {
+                        ScrollView {
+                            VStack(spacing: 0) {
                             // Workspaces are bounded, so prefer a non-lazy stack here.
                             // LazyVStack + drag-state invalidations can recurse through layout.
                             VStack(spacing: tabRowSpacing) {
@@ -10283,16 +10284,17 @@ struct VerticalTabsSidebar: View {
                                 dropIndicator: $dropIndicator
                             )
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
-                        }
-                    }
-                    .frame(minHeight: proxy.size.height, alignment: .top)
-                }
-                .background(
-                    SidebarScrollViewResolver { scrollView in
-                        dragAutoScrollController.attach(scrollView: scrollView)
-                    }
-                    .frame(width: 0, height: 0)
-                )
+                        } // VStack(spacing: 0) inside ScrollView
+                        .frame(minHeight: proxy.size.height, alignment: .top)
+                        } // ScrollView
+                        .background(
+                            SidebarScrollViewResolver { scrollView in
+                                dragAutoScrollController.attach(scrollView: scrollView)
+                            }
+                            .frame(width: 0, height: 0)
+                        )
+                    } // else (workspaces)
+                } // VStack (sticky header)
                 .overlay(alignment: .top) {
                     SidebarTopScrim(height: trafficLightPadding + 20)
                         .allowsHitTesting(false)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10104,7 +10104,7 @@ struct VerticalTabsSidebar: View {
     @State private var dropIndicator: SidebarDropIndicator?
     @State private var frozenTabItemPresentation: SidebarTabItemPresentationSnapshot?
     @State private var terminalScrollBarVisibilityGeneration: UInt64 = 0
-    @State private var sidebarPanelMode: SidebarPanelMode = .workspaces
+    @AppStorage("sidebarPanelMode") private var sidebarPanelMode: SidebarPanelMode = .workspaces
     @StateObject private var fileExplorerModel = FileExplorerModel()
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10127,17 +10127,27 @@ struct VerticalTabsSidebar: View {
         return KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
     }
 
-    /// The current directory of the selected workspace, used to drive file explorer updates.
+    /// The selected workspace, used to drive file explorer updates.
+    private var selectedWorkspace: Workspace? {
+        guard let selectedId = tabManager.selectedTabId else { return nil }
+        return tabManager.tabs.first(where: { $0.id == selectedId })
+    }
+
     private var selectedWorkspaceCurrentDirectory: String {
-        guard let selectedId = tabManager.selectedTabId,
-              let workspace = tabManager.tabs.first(where: { $0.id == selectedId }) else { return "" }
-        return workspace.currentDirectory
+        selectedWorkspace?.currentDirectory ?? ""
     }
 
     private func updateFileExplorerRoot() {
         guard sidebarPanelMode == .files else { return }
-        let dir = selectedWorkspaceCurrentDirectory
-        guard !dir.isEmpty else { return }
+        guard let workspace = selectedWorkspace else {
+            fileExplorerModel.clearRoot()
+            return
+        }
+        let dir = workspace.currentDirectory
+        guard !dir.isEmpty, !workspace.isRemoteWorkspace else {
+            fileExplorerModel.clearRoot()
+            return
+        }
         fileExplorerModel.setRoot(URL(fileURLWithPath: dir))
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10104,6 +10104,8 @@ struct VerticalTabsSidebar: View {
     @State private var dropIndicator: SidebarDropIndicator?
     @State private var frozenTabItemPresentation: SidebarTabItemPresentationSnapshot?
     @State private var terminalScrollBarVisibilityGeneration: UInt64 = 0
+    @State private var sidebarPanelMode: SidebarPanelMode = .workspaces
+    @StateObject private var fileExplorerModel = FileExplorerModel()
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
 
@@ -10123,6 +10125,20 @@ struct VerticalTabsSidebar: View {
     private var workspaceNumberShortcut: StoredShortcut {
         let _ = keyboardShortcutSettingsObserver.revision
         return KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber)
+    }
+
+    /// The current directory of the selected workspace, used to drive file explorer updates.
+    private var selectedWorkspaceCurrentDirectory: String {
+        guard let selectedId = tabManager.selectedTabId,
+              let workspace = tabManager.tabs.first(where: { $0.id == selectedId }) else { return "" }
+        return workspace.currentDirectory
+    }
+
+    private func updateFileExplorerRoot() {
+        guard sidebarPanelMode == .files else { return }
+        let dir = selectedWorkspaceCurrentDirectory
+        guard !dir.isEmpty else { return }
+        fileExplorerModel.setRoot(URL(fileURLWithPath: dir))
     }
 
     var body: some View {
@@ -10155,96 +10171,109 @@ struct VerticalTabsSidebar: View {
                         Spacer()
                             .frame(height: trafficLightPadding)
 
-                        // Workspaces are bounded, so prefer a non-lazy stack here.
-                        // LazyVStack + drag-state invalidations can recurse through layout.
-                        VStack(spacing: tabRowSpacing) {
-                            ForEach(tabs, id: \.id) { tab in
-                                let index = tabIndexById[tab.id] ?? 0
-                                let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
-                                let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
-                                    ? selectedContextTargetIds
-                                    : [tab.id]
-                                let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
-                                    ? selectedRemoteContextMenuWorkspaceIds
-                                    : (tab.isRemoteWorkspace ? [tab.id] : [])
-                                let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
-                                    ? allSelectedRemoteContextMenuTargetsConnecting
-                                    : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
-                                let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
-                                    ? allSelectedRemoteContextMenuTargetsDisconnected
-                                    : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
-                                let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
-                                    contextMenuWorkspaceIds.allSatisfy { workspaceId in
-                                        workspaceTerminalScrollBarHiddenById[workspaceId] == true
-                                    }
-                                let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
-                                let liveLatestNotificationText: String? = {
-                                    guard showsSidebarNotificationMessage,
-                                          let notification = notificationStore.latestNotification(forTabId: tab.id) else {
-                                        return nil
-                                    }
-                                    let text = notification.body.isEmpty ? notification.title : notification.body
-                                    let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
-                                    return trimmed.isEmpty ? nil : trimmed
-                                }()
-                                let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
-                                let livePresentation = SidebarTabItemPresentationSnapshot(
-                                    tabId: tab.id,
-                                    unreadCount: liveUnreadCount,
-                                    latestNotificationText: liveLatestNotificationText,
-                                    showsModifierShortcutHints: liveShowsModifierShortcutHints
-                                )
-                                let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
-                                    ? frozenTabItemPresentation
-                                    : nil
-                                TabItemView(
-                                    tabManager: tabManager,
-                                    notificationStore: notificationStore,
-                                    tab: tab,
-                                    index: index,
-                                    isActive: tabManager.selectedTabId == tab.id,
-                                    workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
-                                        at: index,
-                                        workspaceCount: workspaceCount
-                                    ),
-                                    workspaceShortcutModifierSymbol: workspaceNumberShortcut.numberedDigitHintPrefix,
-                                    canCloseWorkspace: canCloseWorkspace,
-                                    accessibilityWorkspaceCount: workspaceCount,
-                                    unreadCount: frozenPresentation?.unreadCount ?? liveUnreadCount,
-                                    latestNotificationText: frozenPresentation?.latestNotificationText ?? liveLatestNotificationText,
-                                    rowSpacing: tabRowSpacing,
-                                    setSelectionToTabs: { selection = .tabs },
-                                    selectedTabIds: $selectedTabIds,
-                                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                                    showsModifierShortcutHints: frozenPresentation?.showsModifierShortcutHints ?? liveShowsModifierShortcutHints,
-                                    dragAutoScrollController: dragAutoScrollController,
-                                    draggedTabId: $draggedTabId,
-                                    dropIndicator: $dropIndicator,
-                                    contextMenuWorkspaceIds: contextMenuWorkspaceIds,
-                                    remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
-                                    allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
-                                    allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
-                                    allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
-                                    settings: tabItemSettings,
-                                    livePresentation: livePresentation,
-                                    frozenPresentation: $frozenTabItemPresentation
-                                )
-                                .equatable()
-                            }
-                        }
-                        .padding(.vertical, 8)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                        // Icon strip for switching sidebar content mode.
+                        SidebarModeStrip(mode: $sidebarPanelMode)
 
-                        SidebarEmptyArea(
-                            rowSpacing: tabRowSpacing,
-                            selection: $selection,
-                            selectedTabIds: $selectedTabIds,
-                            lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                            dragAutoScrollController: dragAutoScrollController,
-                            draggedTabId: $draggedTabId,
-                            dropIndicator: $dropIndicator
-                        )
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        if sidebarPanelMode == .files {
+                            FileExplorerView(
+                                model: fileExplorerModel,
+                                onOpenInTerminal: { url in
+                                    _ = tabManager.addWorkspace(workingDirectory: url.path)
+                                }
+                            )
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        } else {
+                            // Workspaces are bounded, so prefer a non-lazy stack here.
+                            // LazyVStack + drag-state invalidations can recurse through layout.
+                            VStack(spacing: tabRowSpacing) {
+                                ForEach(tabs, id: \.id) { tab in
+                                    let index = tabIndexById[tab.id] ?? 0
+                                    let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
+                                    let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
+                                        ? selectedContextTargetIds
+                                        : [tab.id]
+                                    let remoteContextMenuWorkspaceIds = usesSelectedContextMenuTargets
+                                        ? selectedRemoteContextMenuWorkspaceIds
+                                        : (tab.isRemoteWorkspace ? [tab.id] : [])
+                                    let allRemoteContextMenuTargetsConnecting = usesSelectedContextMenuTargets
+                                        ? allSelectedRemoteContextMenuTargetsConnecting
+                                        : (tab.isRemoteWorkspace && tab.remoteConnectionState == .connecting)
+                                    let allRemoteContextMenuTargetsDisconnected = usesSelectedContextMenuTargets
+                                        ? allSelectedRemoteContextMenuTargetsDisconnected
+                                        : (tab.isRemoteWorkspace && tab.remoteConnectionState == .disconnected)
+                                    let allContextMenuWorkspacesHideTerminalScrollBar = !contextMenuWorkspaceIds.isEmpty &&
+                                        contextMenuWorkspaceIds.allSatisfy { workspaceId in
+                                            workspaceTerminalScrollBarHiddenById[workspaceId] == true
+                                        }
+                                    let liveUnreadCount = notificationStore.unreadCount(forTabId: tab.id)
+                                    let liveLatestNotificationText: String? = {
+                                        guard showsSidebarNotificationMessage,
+                                              let notification = notificationStore.latestNotification(forTabId: tab.id) else {
+                                            return nil
+                                        }
+                                        let text = notification.body.isEmpty ? notification.title : notification.body
+                                        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+                                        return trimmed.isEmpty ? nil : trimmed
+                                    }()
+                                    let liveShowsModifierShortcutHints = modifierKeyMonitor.isModifierPressed
+                                    let livePresentation = SidebarTabItemPresentationSnapshot(
+                                        tabId: tab.id,
+                                        unreadCount: liveUnreadCount,
+                                        latestNotificationText: liveLatestNotificationText,
+                                        showsModifierShortcutHints: liveShowsModifierShortcutHints
+                                    )
+                                    let frozenPresentation = frozenTabItemPresentation?.tabId == tab.id
+                                        ? frozenTabItemPresentation
+                                        : nil
+                                    TabItemView(
+                                        tabManager: tabManager,
+                                        notificationStore: notificationStore,
+                                        tab: tab,
+                                        index: index,
+                                        isActive: tabManager.selectedTabId == tab.id,
+                                        workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                                            at: index,
+                                            workspaceCount: workspaceCount
+                                        ),
+                                        workspaceShortcutModifierSymbol: workspaceNumberShortcut.numberedDigitHintPrefix,
+                                        canCloseWorkspace: canCloseWorkspace,
+                                        accessibilityWorkspaceCount: workspaceCount,
+                                        unreadCount: frozenPresentation?.unreadCount ?? liveUnreadCount,
+                                        latestNotificationText: frozenPresentation?.latestNotificationText ?? liveLatestNotificationText,
+                                        rowSpacing: tabRowSpacing,
+                                        setSelectionToTabs: { selection = .tabs },
+                                        selectedTabIds: $selectedTabIds,
+                                        lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                        showsModifierShortcutHints: frozenPresentation?.showsModifierShortcutHints ?? liveShowsModifierShortcutHints,
+                                        dragAutoScrollController: dragAutoScrollController,
+                                        draggedTabId: $draggedTabId,
+                                        dropIndicator: $dropIndicator,
+                                        contextMenuWorkspaceIds: contextMenuWorkspaceIds,
+                                        remoteContextMenuWorkspaceIds: remoteContextMenuWorkspaceIds,
+                                        allRemoteContextMenuTargetsConnecting: allRemoteContextMenuTargetsConnecting,
+                                        allRemoteContextMenuTargetsDisconnected: allRemoteContextMenuTargetsDisconnected,
+                                        allContextMenuWorkspacesHideTerminalScrollBar: allContextMenuWorkspacesHideTerminalScrollBar,
+                                        settings: tabItemSettings,
+                                        livePresentation: livePresentation,
+                                        frozenPresentation: $frozenTabItemPresentation
+                                    )
+                                    .equatable()
+                                }
+                            }
+                            .padding(.vertical, 8)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+
+                            SidebarEmptyArea(
+                                rowSpacing: tabRowSpacing,
+                                selection: $selection,
+                                selectedTabIds: $selectedTabIds,
+                                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                                dragAutoScrollController: dragAutoScrollController,
+                                draggedTabId: $draggedTabId,
+                                dropIndicator: $dropIndicator
+                            )
+                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+                        }
                     }
                     .frame(minHeight: proxy.size.height, alignment: .top)
                 }
@@ -10298,6 +10327,7 @@ struct VerticalTabsSidebar: View {
                 tabId: nil,
                 reason: "sidebar_appear"
             )
+            updateFileExplorerRoot()
         }
         .onDisappear {
             modifierKeyMonitor.stop()
@@ -10305,10 +10335,17 @@ struct VerticalTabsSidebar: View {
             dragFailsafeMonitor.stop()
             draggedTabId = nil
             dropIndicator = nil
+            fileExplorerModel.stopWatching()
             SidebarDragLifecycleNotification.postStateDidChange(
                 tabId: nil,
                 reason: "sidebar_disappear"
             )
+        }
+        .onChange(of: selectedWorkspaceCurrentDirectory) { _ in
+            updateFileExplorerRoot()
+        }
+        .onChange(of: sidebarPanelMode) { newMode in
+            if newMode == .files { updateFileExplorerRoot() }
         }
         .onChange(of: draggedTabId) { newDraggedTabId in
             SidebarDragLifecycleNotification.postStateDidChange(

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -116,6 +116,14 @@ final class FileExplorerModel: ObservableObject {
         loadRootAsync()
     }
 
+    func clearRoot() {
+        watcher.stop()
+        rootURL = nil
+        rootItems = []
+        expandedDirectories.removeAll()
+        recomputeFlatItems()
+    }
+
     func stopWatching() {
         watcher.stop()
     }

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+// MARK: - FileExplorerItem
+
+/// A single node in the file explorer tree — either a file or a directory.
+struct FileExplorerItem: Identifiable, Hashable {
+    var id: URL { url }
+    let url: URL
+    let name: String
+    let isDirectory: Bool
+    let isHidden: Bool
+    var children: [FileExplorerItem]?
+
+    init(url: URL, isDirectory: Bool) {
+        self.url = url
+        self.name = url.lastPathComponent
+        self.isDirectory = isDirectory
+        self.isHidden = url.lastPathComponent.hasPrefix(".")
+    }
+
+    /// SF Symbol name appropriate for this item's type.
+    var iconName: String {
+        if isDirectory { return "folder.fill" }
+        switch url.pathExtension.lowercased() {
+        case "swift": return "swift"
+        case "json": return "curlybraces"
+        case "md", "markdown": return "doc.richtext"
+        case "sh", "zsh", "bash": return "terminal"
+        case "yml", "yaml", "toml", "plist", "xcconfig": return "gearshape"
+        case "png", "jpg", "jpeg", "gif", "svg", "webp", "ico": return "photo"
+        case "pdf": return "doc.text.image"
+        case "zip", "tar", "gz", "bz2": return "archivebox"
+        case "html", "htm", "css": return "globe"
+        case "xcodeproj", "xcworkspace", "pbxproj": return "hammer"
+        case "gitignore", "gitmodules": return "arrow.triangle.branch"
+        case "lock": return "lock"
+        case "log": return "doc.text.magnifyingglass"
+        case "js", "jsx", "ts", "tsx", "py", "rb", "c", "cpp", "h", "hpp",
+             "m", "mm", "rs", "go", "java", "kt":
+            return "doc.text"
+        default: return "doc"
+        }
+    }
+
+    /// Path relative to a root URL, for context menu "Copy Relative Path".
+    func relativePath(from root: URL?) -> String {
+        guard let root else { return url.path }
+        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        if url.path.hasPrefix(rootPath) {
+            return String(url.path.dropFirst(rootPath.count))
+        }
+        return url.path
+    }
+
+    static func == (lhs: FileExplorerItem, rhs: FileExplorerItem) -> Bool {
+        lhs.url == rhs.url
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(url)
+    }
+}
+
+// MARK: - FileExplorerModel
+
+/// Loads and manages the file tree for a directory, with expansion tracking,
+/// search filtering, and live FSEvents watching.
+@MainActor
+final class FileExplorerModel: ObservableObject {
+    @Published var rootURL: URL?
+    @Published var expandedDirectories: Set<URL> = []
+    @Published var searchQuery: String = "" { didSet { recomputeFlatItems() } }
+    @Published var showHiddenFiles: Bool = false { didSet { recomputeFlatItems() } }
+
+    /// Flattened visible items ready for rendering — computed from tree + filters + expansion.
+    @Published var flatDisplayItems: [FlatEntry] = []
+
+    struct FlatEntry: Identifiable {
+        let item: FileExplorerItem
+        let depth: Int
+        var id: URL { item.id }
+    }
+
+    private var rootItems: [FileExplorerItem] = []
+    private let watcher = FileSystemWatcher()
+
+    // MARK: - Public API
+
+    func setRoot(_ url: URL) {
+        guard url != rootURL else { return }
+        rootURL = url
+        expandedDirectories.removeAll()
+        loadRoot()
+        watcher.start(watching: url) { [weak self] in
+            self?.refresh()
+        }
+    }
+
+    func toggleExpansion(_ item: FileExplorerItem) {
+        guard item.isDirectory else { return }
+        if expandedDirectories.contains(item.url) {
+            expandedDirectories.remove(item.url)
+        } else {
+            expandedDirectories.insert(item.url)
+            loadChildrenIfNeeded(for: item.url)
+        }
+        recomputeFlatItems()
+    }
+
+    func isExpanded(_ item: FileExplorerItem) -> Bool {
+        expandedDirectories.contains(item.url)
+    }
+
+    func refresh() {
+        loadRoot()
+    }
+
+    func stopWatching() {
+        watcher.stop()
+    }
+
+    /// Display name for the root directory (e.g. "~/Projects/cmux").
+    var rootDisplayName: String {
+        guard let root = rootURL else { return "" }
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        if root.path.hasPrefix(home) {
+            return "~" + root.path.dropFirst(home.count)
+        }
+        return root.path
+    }
+
+    // MARK: - Loading
+
+    private func loadRoot() {
+        guard let rootURL else {
+            rootItems = []
+            recomputeFlatItems()
+            return
+        }
+        rootItems = loadDirectory(rootURL)
+        rootItems = rootItems.map { reloadAllExpanded(in: $0) }
+        recomputeFlatItems()
+    }
+
+    private func loadDirectory(_ url: URL) -> [FileExplorerItem] {
+        let fm = FileManager.default
+        guard let urls = try? fm.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: []
+        ) else { return [] }
+
+        return urls.compactMap { childURL in
+            let isDir = (try? childURL.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) ?? false
+            return FileExplorerItem(url: childURL, isDirectory: isDir)
+        }.sorted { a, b in
+            if a.isDirectory != b.isDirectory { return a.isDirectory }
+            if a.isHidden != b.isHidden { return !a.isHidden }
+            return a.name.localizedStandardCompare(b.name) == .orderedAscending
+        }
+    }
+
+    private func loadChildrenIfNeeded(for directoryURL: URL) {
+        rootItems = rootItems.map { updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
+    }
+
+    /// Single parameterized tree walk for both lazy-loading and reloading children.
+    private func updateChildren(in item: FileExplorerItem, targetURL: URL, forceReload: Bool) -> FileExplorerItem {
+        if item.url == targetURL && item.isDirectory && (forceReload || item.children == nil) {
+            var updated = item
+            updated.children = loadDirectory(targetURL)
+            return updated
+        }
+        guard item.isDirectory, let children = item.children else { return item }
+        var updated = item
+        updated.children = children.map { updateChildren(in: $0, targetURL: targetURL, forceReload: forceReload) }
+        return updated
+    }
+
+    /// Single-pass reload of all expanded directories — O(n) instead of O(E * N).
+    private func reloadAllExpanded(in item: FileExplorerItem) -> FileExplorerItem {
+        guard item.isDirectory else { return item }
+        var updated = item
+        if expandedDirectories.contains(item.url) {
+            updated.children = loadDirectory(item.url)
+        }
+        if let children = updated.children {
+            updated.children = children.map { reloadAllExpanded(in: $0) }
+        }
+        return updated
+    }
+
+    // MARK: - Filtering & flattening
+
+    private func recomputeFlatItems() {
+        var filtered = rootItems
+        if !showHiddenFiles {
+            filtered = filterHidden(filtered)
+        }
+        if !searchQuery.isEmpty {
+            filtered = filterByQuery(filtered, query: searchQuery.lowercased())
+        }
+        flatDisplayItems = flatten(filtered, depth: 0)
+    }
+
+    private func filterHidden(_ items: [FileExplorerItem]) -> [FileExplorerItem] {
+        items.compactMap { item in
+            guard !item.isHidden else { return nil }
+            guard item.isDirectory, let children = item.children else { return item }
+            var updated = item
+            updated.children = filterHidden(children)
+            return updated
+        }
+    }
+
+    private func filterByQuery(_ items: [FileExplorerItem], query: String) -> [FileExplorerItem] {
+        items.compactMap { item in
+            let nameMatches = item.name.lowercased().contains(query)
+            if item.isDirectory, let children = item.children {
+                let filteredChildren = filterByQuery(children, query: query)
+                if nameMatches || !filteredChildren.isEmpty {
+                    var updated = item
+                    updated.children = filteredChildren
+                    return updated
+                }
+                return nil
+            }
+            return nameMatches ? item : nil
+        }
+    }
+
+    private func flatten(_ items: [FileExplorerItem], depth: Int) -> [FlatEntry] {
+        var result: [FlatEntry] = []
+        for item in items {
+            result.append(FlatEntry(item: item, depth: depth))
+            if item.isDirectory && expandedDirectories.contains(item.url), let children = item.children {
+                result.append(contentsOf: flatten(children, depth: depth + 1))
+            }
+        }
+        return result
+    }
+}

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -101,11 +101,12 @@ final class FileExplorerModel: ObservableObject {
         guard item.isDirectory else { return }
         if expandedDirectories.contains(item.url) {
             expandedDirectories.remove(item.url)
+            recomputeFlatItems()
         } else {
             expandedDirectories.insert(item.url)
-            loadChildrenIfNeeded(for: item.url)
+            recomputeFlatItems()
+            loadChildrenAsync(for: item.url)
         }
-        recomputeFlatItems()
     }
 
     func isExpanded(_ item: FileExplorerItem) -> Bool {
@@ -161,8 +162,18 @@ final class FileExplorerModel: ObservableObject {
         }
     }
 
-    private func loadChildrenIfNeeded(for directoryURL: URL) {
-        rootItems = rootItems.map { Self.updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
+    private func loadChildrenAsync(for directoryURL: URL) {
+        loadGeneration &+= 1
+        let generation = loadGeneration
+        let currentItems = rootItems
+        Task.detached(priority: .utility) {
+            let updated = currentItems.map { Self.updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
+            await MainActor.run { [weak self] in
+                guard let self, self.loadGeneration == generation else { return }
+                self.rootItems = updated
+                self.recomputeFlatItems()
+            }
+        }
     }
 
     // MARK: - Static (nonisolated) directory I/O

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -90,7 +90,7 @@ final class FileExplorerModel: ObservableObject {
         guard url != rootURL else { return }
         rootURL = url
         expandedDirectories.removeAll()
-        loadRoot()
+        loadRootAsync()
         watcher.start(watching: url) { [weak self] in
             self?.refresh()
         }
@@ -112,7 +112,7 @@ final class FileExplorerModel: ObservableObject {
     }
 
     func refresh() {
-        loadRoot()
+        loadRootAsync()
     }
 
     func stopWatching() {
@@ -131,18 +131,31 @@ final class FileExplorerModel: ObservableObject {
 
     // MARK: - Loading
 
-    private func loadRoot() {
+    private func loadRootAsync() {
         guard let rootURL else {
             rootItems = []
             recomputeFlatItems()
             return
         }
-        rootItems = loadDirectory(rootURL)
-        rootItems = rootItems.map { reloadAllExpanded(in: $0) }
-        recomputeFlatItems()
+        let expanded = expandedDirectories
+        Task.detached(priority: .utility) {
+            let items = Self.loadDirectory(rootURL)
+            let reloaded = items.map { Self.reloadAllExpanded(in: $0, expanded: expanded) }
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.rootItems = reloaded
+                self.recomputeFlatItems()
+            }
+        }
     }
 
-    private func loadDirectory(_ url: URL) -> [FileExplorerItem] {
+    private func loadChildrenIfNeeded(for directoryURL: URL) {
+        rootItems = rootItems.map { Self.updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
+    }
+
+    // MARK: - Static (nonisolated) directory I/O
+
+    private nonisolated static func loadDirectory(_ url: URL) -> [FileExplorerItem] {
         let fm = FileManager.default
         guard let urls = try? fm.contentsOfDirectory(
             at: url,
@@ -160,12 +173,7 @@ final class FileExplorerModel: ObservableObject {
         }
     }
 
-    private func loadChildrenIfNeeded(for directoryURL: URL) {
-        rootItems = rootItems.map { updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
-    }
-
-    /// Single parameterized tree walk for both lazy-loading and reloading children.
-    private func updateChildren(in item: FileExplorerItem, targetURL: URL, forceReload: Bool) -> FileExplorerItem {
+    private nonisolated static func updateChildren(in item: FileExplorerItem, targetURL: URL, forceReload: Bool) -> FileExplorerItem {
         if item.url == targetURL && item.isDirectory && (forceReload || item.children == nil) {
             var updated = item
             updated.children = loadDirectory(targetURL)
@@ -177,15 +185,14 @@ final class FileExplorerModel: ObservableObject {
         return updated
     }
 
-    /// Single-pass reload of all expanded directories — O(n) instead of O(E * N).
-    private func reloadAllExpanded(in item: FileExplorerItem) -> FileExplorerItem {
+    private nonisolated static func reloadAllExpanded(in item: FileExplorerItem, expanded: Set<URL>) -> FileExplorerItem {
         guard item.isDirectory else { return item }
         var updated = item
-        if expandedDirectories.contains(item.url) {
+        if expanded.contains(item.url) {
             updated.children = loadDirectory(item.url)
         }
         if let children = updated.children {
-            updated.children = children.map { reloadAllExpanded(in: $0) }
+            updated.children = children.map { reloadAllExpanded(in: $0, expanded: expanded) }
         }
         return updated
     }

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -117,6 +117,7 @@ final class FileExplorerModel: ObservableObject {
     }
 
     func clearRoot() {
+        loadGeneration &+= 1
         watcher.stop()
         rootURL = nil
         rootItems = []

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -83,6 +83,7 @@ final class FileExplorerModel: ObservableObject {
 
     private var rootItems: [FileExplorerItem] = []
     private let watcher = FileSystemWatcher()
+    private var loadGeneration: UInt = 0
 
     // MARK: - Public API
 
@@ -132,6 +133,8 @@ final class FileExplorerModel: ObservableObject {
     // MARK: - Loading
 
     private func loadRootAsync() {
+        loadGeneration &+= 1
+        let generation = loadGeneration
         guard let rootURL else {
             rootItems = []
             recomputeFlatItems()
@@ -142,7 +145,7 @@ final class FileExplorerModel: ObservableObject {
             let items = Self.loadDirectory(rootURL)
             let reloaded = items.map { Self.reloadAllExpanded(in: $0, expanded: expanded) }
             await MainActor.run { [weak self] in
-                guard let self else { return }
+                guard let self, self.loadGeneration == generation else { return }
                 self.rootItems = reloaded
                 self.recomputeFlatItems()
             }

--- a/Sources/FileExplorer/FileExplorerModel.swift
+++ b/Sources/FileExplorer/FileExplorerModel.swift
@@ -163,13 +163,11 @@ final class FileExplorerModel: ObservableObject {
     }
 
     private func loadChildrenAsync(for directoryURL: URL) {
-        loadGeneration &+= 1
-        let generation = loadGeneration
         let currentItems = rootItems
         Task.detached(priority: .utility) {
             let updated = currentItems.map { Self.updateChildren(in: $0, targetURL: directoryURL, forceReload: false) }
             await MainActor.run { [weak self] in
-                guard let self, self.loadGeneration == generation else { return }
+                guard let self, self.expandedDirectories.contains(directoryURL) else { return }
                 self.rootItems = updated
                 self.recomputeFlatItems()
             }

--- a/Sources/FileExplorer/FileExplorerView.swift
+++ b/Sources/FileExplorer/FileExplorerView.swift
@@ -1,0 +1,275 @@
+import SwiftUI
+import AppKit
+
+/// File explorer tree view shown in the sidebar when the user selects the files mode.
+struct FileExplorerView: View {
+    @ObservedObject var model: FileExplorerModel
+    let onOpenInTerminal: ((URL) -> Void)?
+
+    private let rowHeight: CGFloat = 22
+    private let indentWidth: CGFloat = 16
+
+    var body: some View {
+        VStack(spacing: 0) {
+            searchBar
+            headerRow
+            fileTree
+        }
+    }
+
+    // MARK: - Search bar
+
+    private var searchBar: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 11))
+                .foregroundColor(.secondary)
+            FileExplorerSearchField(
+                text: $model.searchQuery,
+                placeholder: String(localized: "fileExplorer.search.placeholder", defaultValue: "Filter files…")
+            )
+            .frame(height: 18)
+            if !model.searchQuery.isEmpty {
+                Button {
+                    model.searchQuery = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .textBackgroundColor).opacity(0.3))
+        .cornerRadius(6)
+        .padding(.horizontal, 8)
+        .padding(.top, 4)
+        .padding(.bottom, 2)
+    }
+
+    // MARK: - Header
+
+    private var headerRow: some View {
+        HStack(spacing: 4) {
+            Text(model.rootDisplayName)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.secondary)
+                .lineLimit(1)
+                .truncationMode(.head)
+            Spacer()
+            Button {
+                model.refresh()
+            } label: {
+                Image(systemName: "arrow.clockwise")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help(String(localized: "fileExplorer.refresh", defaultValue: "Refresh"))
+
+            Button {
+                model.showHiddenFiles.toggle()
+            } label: {
+                Image(systemName: model.showHiddenFiles ? "eye" : "eye.slash")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .buttonStyle(.plain)
+            .help(
+                model.showHiddenFiles
+                    ? String(localized: "fileExplorer.hideHidden", defaultValue: "Hide Hidden Files")
+                    : String(localized: "fileExplorer.showHidden", defaultValue: "Show Hidden Files")
+            )
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 4)
+    }
+
+    // MARK: - File tree
+
+    private var fileTree: some View {
+        ScrollView {
+            LazyVStack(spacing: 0) {
+                if model.flatDisplayItems.isEmpty {
+                    emptyState
+                } else {
+                    ForEach(model.flatDisplayItems) { entry in
+                        FileExplorerRowView(
+                            item: entry.item,
+                            depth: entry.depth,
+                            isExpanded: model.isExpanded(entry.item),
+                            indentWidth: indentWidth,
+                            rowHeight: rowHeight,
+                            onToggle: { model.toggleExpansion(entry.item) }
+                        )
+                        .contextMenu {
+                            fileExplorerContextMenu(for: entry.item)
+                        }
+                    }
+                }
+            }
+            .padding(.vertical, 4)
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "folder")
+                .font(.system(size: 24))
+                .foregroundColor(.secondary.opacity(0.5))
+            Text(model.searchQuery.isEmpty
+                ? String(localized: "fileExplorer.empty", defaultValue: "No files")
+                : String(localized: "fileExplorer.noResults", defaultValue: "No matching files"))
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+    }
+
+    // MARK: - Context menu
+
+    @ViewBuilder
+    private func fileExplorerContextMenu(for item: FileExplorerItem) -> some View {
+        Button {
+            copyToPasteboard(item.url.path)
+        } label: {
+            Text(String(localized: "fileExplorer.contextMenu.copyPath", defaultValue: "Copy Path"))
+        }
+        Button {
+            copyToPasteboard(item.relativePath(from: model.rootURL))
+        } label: {
+            Text(String(localized: "fileExplorer.contextMenu.copyRelativePath", defaultValue: "Copy Relative Path"))
+        }
+        Divider()
+        Button {
+            NSWorkspace.shared.selectFile(item.url.path, inFileViewerRootedAtPath: item.url.deletingLastPathComponent().path)
+        } label: {
+            Text(String(localized: "fileExplorer.contextMenu.revealInFinder", defaultValue: "Reveal in Finder"))
+        }
+        if item.isDirectory, let onOpenInTerminal {
+            Button { onOpenInTerminal(item.url) } label: {
+                Text(String(localized: "fileExplorer.contextMenu.openInTerminal", defaultValue: "Open in Terminal"))
+            }
+        }
+    }
+
+    private func copyToPasteboard(_ text: String) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(text, forType: .string)
+    }
+}
+
+// MARK: - Row view
+
+private struct FileExplorerRowView: View {
+    let item: FileExplorerItem
+    let depth: Int
+    let isExpanded: Bool
+    let indentWidth: CGFloat
+    let rowHeight: CGFloat
+    let onToggle: () -> Void
+
+    @State private var isHovering = false
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if item.isDirectory {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(.secondary)
+                    .frame(width: 12)
+            } else {
+                Spacer().frame(width: 12)
+            }
+
+            Image(systemName: item.iconName)
+                .font(.system(size: 12))
+                .foregroundColor(item.isDirectory ? .accentColor : .secondary)
+                .frame(width: 16)
+
+            Text(item.name)
+                .font(.system(size: 12))
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .foregroundColor(.primary)
+
+            Spacer()
+        }
+        .padding(.leading, CGFloat(depth) * indentWidth + 8)
+        .padding(.trailing, 8)
+        .frame(height: rowHeight)
+        .background(isHovering ? Color.primary.opacity(0.06) : Color.clear)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if item.isDirectory { onToggle() }
+        }
+        .onHover { isHovering = $0 }
+    }
+}
+
+// MARK: - AppKit search field
+
+private struct FileExplorerSearchField: NSViewRepresentable {
+    @Binding var text: String
+    let placeholder: String
+
+    final class Coordinator: NSObject, NSTextFieldDelegate {
+        var parent: FileExplorerSearchField
+        var isProgrammatic = false
+
+        init(parent: FileExplorerSearchField) { self.parent = parent }
+
+        func controlTextDidChange(_ obj: Notification) {
+            guard !isProgrammatic, let field = obj.object as? NSTextField else { return }
+            parent.text = field.stringValue
+        }
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    func makeNSView(context: Context) -> FileExplorerNativeTextField {
+        let field = FileExplorerNativeTextField(frame: .zero)
+        field.font = .systemFont(ofSize: 12)
+        field.placeholderString = placeholder
+        field.isBordered = false
+        field.drawsBackground = false
+        field.focusRingType = .none
+        field.lineBreakMode = .byTruncatingTail
+        field.cell?.sendsActionOnEndEditing = false
+        field.delegate = context.coordinator
+        field.stringValue = text
+        field.setAccessibilityIdentifier("FileExplorerSearchField")
+        return field
+    }
+
+    func updateNSView(_ nsView: FileExplorerNativeTextField, context: Context) {
+        if nsView.stringValue != text {
+            context.coordinator.isProgrammatic = true
+            nsView.stringValue = text
+            context.coordinator.isProgrammatic = false
+        }
+    }
+}
+
+/// Custom NSTextField that claims first responder on mouse down, preventing
+/// the Ghostty terminal surface from intercepting keyboard events.
+final class FileExplorerNativeTextField: NSTextField {
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        if let window, window.firstResponder !== currentEditor() {
+            window.makeFirstResponder(self)
+        }
+        super.mouseDown(with: event)
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let result = super.becomeFirstResponder()
+        if result { currentEditor()?.selectAll(nil) }
+        return result
+    }
+}

--- a/Sources/FileExplorer/FileExplorerView.swift
+++ b/Sources/FileExplorer/FileExplorerView.swift
@@ -102,7 +102,8 @@ struct FileExplorerView: View {
                             isExpanded: model.isExpanded(entry.item),
                             indentWidth: indentWidth,
                             rowHeight: rowHeight,
-                            onToggle: { model.toggleExpansion(entry.item) }
+                            onToggle: { model.toggleExpansion(entry.item) },
+                            onOpenFile: { NSWorkspace.shared.open(entry.item.url) }
                         )
                         .contextMenu {
                             fileExplorerContextMenu(for: entry.item)
@@ -172,6 +173,7 @@ private struct FileExplorerRowView: View {
     let indentWidth: CGFloat
     let rowHeight: CGFloat
     let onToggle: () -> Void
+    let onOpenFile: () -> Void
 
     @State private var isHovering = false
 
@@ -205,7 +207,7 @@ private struct FileExplorerRowView: View {
         .background(isHovering ? Color.primary.opacity(0.06) : Color.clear)
         .contentShape(Rectangle())
         .onTapGesture {
-            if item.isDirectory { onToggle() }
+            if item.isDirectory { onToggle() } else { onOpenFile() }
         }
         .onHover { isHovering = $0 }
     }

--- a/Sources/FileExplorer/FileExplorerView.swift
+++ b/Sources/FileExplorer/FileExplorerView.swift
@@ -249,6 +249,7 @@ private struct FileExplorerSearchField: NSViewRepresentable {
     }
 
     func updateNSView(_ nsView: FileExplorerNativeTextField, context: Context) {
+        context.coordinator.parent = self
         if nsView.stringValue != text {
             context.coordinator.isProgrammatic = true
             nsView.stringValue = text

--- a/Sources/FileExplorer/FileSystemWatcher.swift
+++ b/Sources/FileExplorer/FileSystemWatcher.swift
@@ -81,7 +81,12 @@ final class FileSystemWatcher {
 
         self.stream = stream
         FSEventStreamSetDispatchQueue(stream, DispatchQueue.global(qos: .utility))
-        FSEventStreamStart(stream)
+        guard FSEventStreamStart(stream) else {
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+            self.stream = nil
+            return
+        }
     }
 
     private func stopStream() {

--- a/Sources/FileExplorer/FileSystemWatcher.swift
+++ b/Sources/FileExplorer/FileSystemWatcher.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Watches a directory recursively for file system changes using FSEvents.
+/// Debounces rapid changes and calls `onChange` on the main actor.
+@MainActor
+final class FileSystemWatcher {
+    private var stream: FSEventStreamRef?
+    private let debounceInterval: TimeInterval
+    private var debounceTask: Task<Void, Never>?
+    private var onChange: (() -> Void)?
+    private var watchedPath: String?
+
+    /// Context bridging `self` into the C callback.
+    private final class StreamContext {
+        weak var watcher: FileSystemWatcher?
+        init(_ watcher: FileSystemWatcher) { self.watcher = watcher }
+    }
+
+    init(debounceInterval: TimeInterval = 0.3) {
+        self.debounceInterval = debounceInterval
+    }
+
+    deinit {
+        if let stream {
+            FSEventStreamStop(stream)
+            FSEventStreamInvalidate(stream)
+            FSEventStreamRelease(stream)
+        }
+    }
+
+    func start(watching url: URL, onChange: @escaping () -> Void) {
+        let newPath = url.path
+        if newPath == watchedPath, stream != nil {
+            self.onChange = onChange
+            return
+        }
+        stopStream()
+        self.onChange = onChange
+        self.watchedPath = newPath
+        startStream(path: newPath)
+    }
+
+    func stop() {
+        stopStream()
+        debounceTask?.cancel()
+        debounceTask = nil
+        onChange = nil
+        watchedPath = nil
+    }
+
+    // MARK: - FSEvents
+
+    private func startStream(path: String) {
+        let contextPtr = Unmanaged.passRetained(StreamContext(self)).toOpaque()
+
+        var fsContext = FSEventStreamContext(
+            version: 0,
+            info: contextPtr,
+            retain: nil,
+            release: { info in
+                guard let info else { return }
+                Unmanaged<StreamContext>.fromOpaque(info).release()
+            },
+            copyDescription: nil
+        )
+
+        let paths = [path] as CFArray
+        let flags: FSEventStreamCreateFlags =
+            UInt32(kFSEventStreamCreateFlagUseCFTypes)
+            | UInt32(kFSEventStreamCreateFlagFileEvents)
+            | UInt32(kFSEventStreamCreateFlagNoDefer)
+
+        guard let stream = FSEventStreamCreate(
+            nil, Self.eventCallback, &fsContext, paths,
+            FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
+            0.2, flags
+        ) else { return }
+
+        self.stream = stream
+        FSEventStreamSetDispatchQueue(stream, DispatchQueue.global(qos: .utility))
+        FSEventStreamStart(stream)
+    }
+
+    private func stopStream() {
+        guard let stream else { return }
+        FSEventStreamStop(stream)
+        FSEventStreamInvalidate(stream)
+        FSEventStreamRelease(stream)
+        self.stream = nil
+    }
+
+    private static let eventCallback: FSEventStreamCallback = {
+        _, contextPtr, _, _, _, _ in
+        guard let contextPtr else { return }
+        let context = Unmanaged<StreamContext>.fromOpaque(contextPtr).takeUnretainedValue()
+        Task { @MainActor in context.watcher?.handleEvents() }
+    }
+
+    private func handleEvents() {
+        debounceTask?.cancel()
+        let interval = debounceInterval
+        debounceTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: UInt64(interval * 1_000_000_000))
+            guard !Task.isCancelled else { return }
+            self?.onChange?()
+        }
+    }
+}

--- a/Sources/FileExplorer/FileSystemWatcher.swift
+++ b/Sources/FileExplorer/FileSystemWatcher.swift
@@ -74,7 +74,10 @@ final class FileSystemWatcher {
             nil, Self.eventCallback, &fsContext, paths,
             FSEventStreamEventId(kFSEventStreamEventIdSinceNow),
             0.2, flags
-        ) else { return }
+        ) else {
+            Unmanaged<StreamContext>.fromOpaque(contextPtr).release()
+            return
+        }
 
         self.stream = stream
         FSEventStreamSetDispatchQueue(stream, DispatchQueue.global(qos: .utility))

--- a/Sources/FileExplorer/SidebarModeStrip.swift
+++ b/Sources/FileExplorer/SidebarModeStrip.swift
@@ -1,0 +1,51 @@
+import SwiftUI
+
+/// The sidebar's internal panel mode — controls which content the sidebar shows.
+enum SidebarPanelMode {
+    case workspaces
+    case files
+}
+
+/// Horizontal icon strip at the top of the sidebar for switching between
+/// workspace list and file explorer.
+struct SidebarModeStrip: View {
+    @Binding var mode: SidebarPanelMode
+
+    private let height: CGFloat = 28
+    private let iconSize: CGFloat = 13
+    private let buttonSize: CGFloat = 24
+
+    var body: some View {
+        HStack(spacing: 2) {
+            modeButton(
+                systemName: "rectangle.stack",
+                targetMode: .workspaces,
+                tooltip: String(localized: "sidebar.mode.workspaces", defaultValue: "Workspaces")
+            )
+            modeButton(
+                systemName: "folder",
+                targetMode: .files,
+                tooltip: String(localized: "sidebar.mode.files", defaultValue: "Files")
+            )
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .frame(height: height)
+    }
+
+    @ViewBuilder
+    private func modeButton(systemName: String, targetMode: SidebarPanelMode, tooltip: String) -> some View {
+        let isSelected = mode == targetMode
+        Button {
+            mode = targetMode
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: iconSize, weight: .medium))
+                .foregroundColor(isSelected ? .accentColor : .secondary)
+                .frame(width: buttonSize, height: buttonSize)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(tooltip)
+    }
+}

--- a/Sources/FileExplorer/SidebarModeStrip.swift
+++ b/Sources/FileExplorer/SidebarModeStrip.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// The sidebar's internal panel mode — controls which content the sidebar shows.
-enum SidebarPanelMode {
+enum SidebarPanelMode: String {
     case workspaces
     case files
 }

--- a/Sources/FileExplorer/SidebarModeStrip.swift
+++ b/Sources/FileExplorer/SidebarModeStrip.swift
@@ -47,5 +47,6 @@ struct SidebarModeStrip: View {
         }
         .buttonStyle(.plain)
         .help(tooltip)
+        .accessibilityLabel(Text(tooltip))
     }
 }


### PR DESCRIPTION
## Summary

- Add VS Code-style file explorer panel to sidebar with icon-based mode switching (workspaces ↔ files)
- Explorer tracks selected workspace's current directory, supports instant search filtering, hidden file toggling, and context menu operations (reveal in Finder, copy path, open in terminal)
- Fix keyboard focus stealing in AppDelegate so file explorer search field retains input

## Testing

- Built and launched tagged debug app (`reload.sh --tag file-explorer`)
- Verified mode switching between workspaces and files views
- Verified file tree loads from workspace CWD and updates on workspace switch
- Verified search filtering is instant (no debounce)
- Verified hidden file toggle is instant
- Verified search field retains keyboard focus (not stolen by terminal surface)

## Demo Video

https://github.com/user-attachments/assets/9b36fc23-794e-4ec9-b0d5-0b7b1a88a5e5

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a VS Code–style file explorer panel to the sidebar with icon-based switching between Workspaces and Files. It tracks the selected workspace directory with live updates, supports instant filtering, click-to-open files, and localized UI.

- **New Features**
  - Sidebar mode strip to switch between Workspaces and Files; selection persists across relaunches.
  - File Explorer synced to the selected workspace CWD with live refresh (FSEvents, async I/O), instant text filter, and toggle to show/hide dotfiles.
  - Click a file to open it with the default app; context menu: Reveal in Finder, Copy Path, Copy Relative Path, Open in Terminal.
  - Localized sidebar and explorer strings (19 languages).

- **Bug Fixes**
  - Keep search field focus by walking the responder chain for `FileExplorerNativeTextField`; keep the search binding in sync via coordinator updates.
  - Async loading: guard root reloads with a generation counter; use per-directory guards for folder expansions; move expansion I/O off the main thread; cancel in-flight loads on clear; skip empty/remote workspaces.
  - Keep the mode strip sticky by removing nested ScrollViews in files mode; add accessibility labels to mode buttons.
  - FSEvents robustness: release context on stream creation failure and clean up on start failure to avoid a stuck watcher.

<sup>Written for commit 2150e3b338d5aa373833ff4ee494981f7ff25b8a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File explorer sidebar panel with searchable file tree, hidden-file toggle, and per-item context menu (copy paths, reveal in Finder, open in Terminal)
  * Sidebar mode strip to persistently switch between workspaces and files
  * Live file-system change detection for real-time explorer updates
  * Added localization for new sidebar and file-explorer strings

* **Bug Fixes**
  * Sidebar text inputs retain keyboard focus correctly, preventing unexpected focus loss
<!-- end of auto-generated comment: release notes by coderabbit.ai -->