### PR TITLE
Distinguish idle_prompt from real 'Needs input' in Claude hooks

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12600,9 +12600,9 @@ struct CMUXCLI {
                     icon: "pause.circle",
                     color: "#8E8E93"
                 )
-            case .none:
-                // auth_success and other non-status events should not clobber
-                // the existing running/idle state.
+            case .noStatus:
+                // auth_success, completion, and other non-attention events
+                // should not clobber the existing running/idle pill state.
                 break
             }
             print(response)
@@ -13301,7 +13301,7 @@ struct CMUXCLI {
     enum ClaudeNotificationStatusKind {
         case needsInput  // permission_prompt, elicitation_dialog, unknown attention-class messages
         case idle        // idle_prompt — session parked, no action required
-        case none        // auth_success and other non-status events
+        case noStatus    // auth_success, completion, and other events that should not clobber the existing pill
     }
 
     private func summarizeClaudeHookNotification(parsedInput: ClaudeHookParsedInput) -> (subtitle: String, body: String, statusKind: ClaudeNotificationStatusKind) {
@@ -13316,10 +13316,13 @@ struct CMUXCLI {
         // The authoritative Notification hook type field per Claude Code docs.
         let notificationType = firstString(in: object, keys: ["notification_type"])
             ?? firstString(in: nested, keys: ["notification_type"])
+        // Include notification_type in signalParts so unknown-but-classifiable
+        // type values (e.g. future values not yet enumerated below) still
+        // influence the keyword-based fallback instead of being dropped.
         let signalParts = [
             firstString(in: object, keys: ["event", "event_name", "hook_event_name", "type", "kind"]),
-            firstString(in: object, keys: ["matcher", "reason"]),
-            firstString(in: nested, keys: ["type", "kind", "reason"])
+            firstString(in: object, keys: ["notification_type", "matcher", "reason"]),
+            firstString(in: nested, keys: ["notification_type", "type", "kind", "reason"])
         ]
         let messageCandidates = [
             firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
@@ -13354,7 +13357,7 @@ struct CMUXCLI {
             case "idle_prompt":
                 return ("Idle", message.isEmpty ? "Session idle" : message, .idle)
             case "auth_success":
-                return ("Auth", message.isEmpty ? "Authentication successful" : message, .none)
+                return ("Auth", message.isEmpty ? "Authentication successful" : message, .noStatus)
             default:
                 break  // fall through to keyword-based classification
             }
@@ -13368,7 +13371,10 @@ struct CMUXCLI {
             return ("Error", message.isEmpty ? "Claude reported an error" : message, .needsInput)
         }
         if lower.contains("complet") || lower.contains("finish") || lower.contains("done") || lower.contains("success") {
-            return ("Completed", message.isEmpty ? "Task completed" : message, .needsInput)
+            // Completion events should not clobber the current status with a
+            // blue "Needs input" bell; the Stop hook is responsible for moving
+            // the pill to Idle.
+            return ("Completed", message.isEmpty ? "Task completed" : message, .noStatus)
         }
         if lower.contains("idle_prompt") || lower.contains("idle prompt") {
             return ("Idle", message.isEmpty ? "Session idle" : message, .idle)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13328,7 +13328,12 @@ struct CMUXCLI {
             firstString(in: object, keys: ["message", "body", "text", "prompt", "error", "description"]),
             firstString(in: nested, keys: ["message", "body", "text", "prompt", "error", "description"])
         ]
-        let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
+        // Keep the message empty when the payload doesn't supply one, so the
+        // per-type body defaults below ("Session idle", "Authentication
+        // successful", etc.) are chosen instead of the generic needs-input
+        // placeholder. Only fall back to the placeholder when the classifier
+        // actually produces a needs-input event with no body of its own.
+        let message = messageCandidates.compactMap { $0 }.first ?? ""
         let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
         var classified = classifyClaudeNotification(
@@ -13336,6 +13341,10 @@ struct CMUXCLI {
             signal: signal,
             message: normalizedMessage
         )
+
+        if classified.statusKind == .needsInput, classified.body.isEmpty {
+            classified.body = "Claude needs your input"
+        }
 
         classified.body = truncate(classified.body, maxLength: 180)
         return classified

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12552,7 +12552,11 @@ struct CMUXCLI {
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
-                summary = (subtitle: mappedSession.lastSubtitle ?? summary.subtitle, body: savedBody)
+                summary = (
+                    subtitle: mappedSession.lastSubtitle ?? summary.subtitle,
+                    body: savedBody,
+                    statusKind: summary.statusKind
+                )
             }
 
             let surfaceId = try resolvePreferredSurfaceIdForClaudeHook(
@@ -12579,13 +12583,28 @@ struct CMUXCLI {
             }
 
             let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
-            _ = try? setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Needs input",
-                icon: "bell.fill",
-                color: "#4C8DFF"
-            )
+            switch summary.statusKind {
+            case .needsInput:
+                _ = try? setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Needs input",
+                    icon: "bell.fill",
+                    color: "#4C8DFF"
+                )
+            case .idle:
+                _ = try? setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Idle",
+                    icon: "pause.circle",
+                    color: "#8E8E93"
+                )
+            case .none:
+                // auth_success and other non-status events should not clobber
+                // the existing running/idle state.
+                break
+            }
             print(response)
 
         case "session-end":
@@ -13273,18 +13292,33 @@ struct CMUXCLI {
         return nil
     }
 
-    private func summarizeClaudeHookNotification(parsedInput: ClaudeHookParsedInput) -> (subtitle: String, body: String) {
+    /// Sidebar status implied by a Claude Notification hook.
+    ///
+    /// Claude Code's `Notification` hook fires for multiple reasons; only some
+    /// actually require user input. Treating them all as "Needs input" causes
+    /// false positives (e.g. `idle_prompt` is emitted after the session sits
+    /// idle for a while, not because Claude is blocked on the user).
+    enum ClaudeNotificationStatusKind {
+        case needsInput  // permission_prompt, elicitation_dialog, unknown attention-class messages
+        case idle        // idle_prompt — session parked, no action required
+        case none        // auth_success and other non-status events
+    }
+
+    private func summarizeClaudeHookNotification(parsedInput: ClaudeHookParsedInput) -> (subtitle: String, body: String, statusKind: ClaudeNotificationStatusKind) {
         guard let object = parsedInput.object else {
             if let fallback = parsedInput.rawFallback, !fallback.isEmpty {
-                return classifyClaudeNotification(signal: fallback, message: fallback)
+                return classifyClaudeNotification(notificationType: nil, signal: fallback, message: fallback)
             }
-            return ("Waiting", "Claude is waiting for your input")
+            return ("Waiting", "Claude is waiting for your input", .needsInput)
         }
 
         let nested = (object["notification"] as? [String: Any]) ?? (object["data"] as? [String: Any]) ?? [:]
+        // The authoritative Notification hook type field per Claude Code docs.
+        let notificationType = firstString(in: object, keys: ["notification_type"])
+            ?? firstString(in: nested, keys: ["notification_type"])
         let signalParts = [
             firstString(in: object, keys: ["event", "event_name", "hook_event_name", "type", "kind"]),
-            firstString(in: object, keys: ["notification_type", "matcher", "reason"]),
+            firstString(in: object, keys: ["matcher", "reason"]),
             firstString(in: nested, keys: ["type", "kind", "reason"])
         ]
         let messageCandidates = [
@@ -13294,35 +13328,59 @@ struct CMUXCLI {
         let message = messageCandidates.compactMap { $0 }.first ?? "Claude needs your input"
         let normalizedMessage = normalizedSingleLine(message)
         let signal = signalParts.compactMap { $0 }.joined(separator: " ")
-        var classified = classifyClaudeNotification(signal: signal, message: normalizedMessage)
+        var classified = classifyClaudeNotification(
+            notificationType: notificationType,
+            signal: signal,
+            message: normalizedMessage
+        )
 
         classified.body = truncate(classified.body, maxLength: 180)
         return classified
     }
 
-    private func classifyClaudeNotification(signal: String, message: String) -> (subtitle: String, body: String) {
+    private func classifyClaudeNotification(
+        notificationType: String?,
+        signal: String,
+        message: String
+    ) -> (subtitle: String, body: String, statusKind: ClaudeNotificationStatusKind) {
+        // Prefer the authoritative notification_type field when Claude Code
+        // provides one — it distinguishes states that the message text cannot.
+        if let normalizedType = notificationType?.lowercased(), !normalizedType.isEmpty {
+            switch normalizedType {
+            case "permission_prompt":
+                return ("Permission", message.isEmpty ? "Approval needed" : message, .needsInput)
+            case "elicitation_dialog":
+                return ("Waiting", message.isEmpty ? "Waiting for input" : message, .needsInput)
+            case "idle_prompt":
+                return ("Idle", message.isEmpty ? "Session idle" : message, .idle)
+            case "auth_success":
+                return ("Auth", message.isEmpty ? "Authentication successful" : message, .none)
+            default:
+                break  // fall through to keyword-based classification
+            }
+        }
+
         let lower = "\(signal) \(message)".lowercased()
         if lower.contains("permission") || lower.contains("approve") || lower.contains("approval") || lower.contains("permission_prompt") {
-            let body = message.isEmpty ? "Approval needed" : message
-            return ("Permission", body)
+            return ("Permission", message.isEmpty ? "Approval needed" : message, .needsInput)
         }
         if lower.contains("error") || lower.contains("failed") || lower.contains("exception") {
-            let body = message.isEmpty ? "Claude reported an error" : message
-            return ("Error", body)
+            return ("Error", message.isEmpty ? "Claude reported an error" : message, .needsInput)
         }
         if lower.contains("complet") || lower.contains("finish") || lower.contains("done") || lower.contains("success") {
-            let body = message.isEmpty ? "Task completed" : message
-            return ("Completed", body)
+            return ("Completed", message.isEmpty ? "Task completed" : message, .needsInput)
         }
-        if lower.contains("idle") || lower.contains("wait") || lower.contains("input") || lower.contains("idle_prompt") {
-            let body = message.isEmpty ? "Waiting for input" : message
-            return ("Waiting", body)
+        if lower.contains("idle_prompt") || lower.contains("idle prompt") {
+            return ("Idle", message.isEmpty ? "Session idle" : message, .idle)
+        }
+        if lower.contains("wait") || lower.contains("input") {
+            return ("Waiting", message.isEmpty ? "Waiting for input" : message, .needsInput)
         }
         // Use the message directly if it's meaningful (not a generic placeholder).
         if !message.isEmpty, message != "Claude needs your input" {
-            return ("Attention", message)
+            return ("Attention", message, .needsInput)
         }
-        return ("Attention", "Claude needs your attention")
+        return ("Attention", "Claude needs your attention", .needsInput)
     }
 
     private func firstString(in object: [String: Any], keys: [String]) -> String? {


### PR DESCRIPTION
## Summary

Claude Code's \`Notification\` hook fires for multiple reasons per the [official docs](https://code.claude.com/docs/en/hooks#notification):

- \`permission_prompt\` — Claude needs user approval
- \`elicitation_dialog\` — MCP server requests user input
- \`idle_prompt\` — session has been idle for a while (fires ~5 minutes of inactivity)
- \`auth_success\` — authentication completed

The existing hook handler hardcoded every fired \`Notification\` as \"Needs input\", so after Claude finished a task and sat idle, the \`idle_prompt\` event re-raised a false \"Needs input\" badge in the sidebar. This is the root cause reported in several issues.

This PR parses the authoritative \`notification_type\` field and routes each case correctly:
- \`permission_prompt\` / \`elicitation_dialog\` → \"Needs input\" (bell, blue)
- \`idle_prompt\` → \"Idle\" (pause, gray)
- \`auth_success\` → no status change
- Unknown types → fall back to keyword classification (existing behavior)

Also tightens the keyword fallback so bare \`idle_prompt\` mentions no longer bleed into the \"Waiting\" bucket.

## Test plan

Manual reproduction against the released 0.63.1 CLI:

\`\`\`bash
# idle_prompt — should NOT trigger \"Needs input\" but does on 0.63.1
echo '{\"hook_event_name\":\"Notification\",\"notification_type\":\"idle_prompt\",\"message\":\"Claude waited for your input\",\"session_id\":\"test\"}' \\
  | /Applications/cmux.app/Contents/Resources/bin/cmux claude-hook notification --workspace 1
# -> Before this PR: sidebar shows \"Needs input\" (bug)
# -> After this PR:  sidebar shows \"Idle\"

# permission_prompt — should still trigger \"Needs input\"
echo '{\"hook_event_name\":\"Notification\",\"notification_type\":\"permission_prompt\",\"message\":\"Permission needed\",\"session_id\":\"test\"}' \\
  | cmux claude-hook notification --workspace 1
# -> Sidebar shows \"Needs input\" (correct, unchanged)
\`\`\`

Verified locally by comparing the 0.63.1 installed CLI against a debug build with this patch against the same running app.

## Related issues

- Relates to #1027 (Running/Needs Input indicators flaky)
- Relates to #1492 (inconsistent Idle vs Needs Input)
- Closes #2576 (distinguish Needs Input vs Idle states)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes false “Needs input” badges by using `notification_type` in Claude `Notification` hooks. Sidebar shows “Idle” after inactivity, keeps the current pill on completion/auth, and only asks for input when action is required.

- **Bug Fixes**
  - Map `permission_prompt`/`elicitation_dialog` → “Needs input”; `idle_prompt` → “Idle”; `auth_success` and completion → no status change; preserve the existing pill and reuse a saved message body.
  - Defer the “needs input” placeholder until after classification so idle/auth/completion don’t get conflicting generic bodies.
  - Improve fallback: include `notification_type` in the signal and tighten keywords so idle text doesn’t trigger “Needs input”.

- **Refactors**
  - Rename status kind from `.none` to `.noStatus` for clarity.

<sup>Written for commit 80234f87ed2ffa1afb8b4504cfdfe9dc5b9df641. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Notification classification now prefers authoritative notification fields with a reliable keyword fallback, mapping notifications to "Needs input", "Idle", or default states.
  * Detected status is preserved when reusing saved session content.
  * Visuals updated: "Needs input" (bell), "Idle" (pause), or default.

* **Bug Fixes**
  * Sidebar status is only updated for actionable states, preventing unintended overwrites.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->