### PR TITLE
Fix paste only pasting first character (#2805)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6398,12 +6398,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             let isPerformable = (bindingFlags.rawValue & GHOSTTY_BINDING_FLAGS_PERFORMABLE.rawValue) != 0
 
             // If the binding is consumed and not meant for the menu, allow menu first.
-            if isConsumed && !isAll && !isPerformable && keySequence.isEmpty && keyTables.isEmpty {
+            // Performable bindings (e.g. paste_from_clipboard) also need the menu
+            // path so that Edit > Paste handles Cmd+V instead of keyDown double-
+            // firing the clipboard request through both interpretKeyEvents and
+            // ghostty_surface_key.
+            if isConsumed && !isAll && keySequence.isEmpty && keyTables.isEmpty {
                 if let menu = NSApp.mainMenu, menu.performKeyEquivalent(with: event) {
                     return true
                 }
             }
 
+            // For performable bindings where the menu didn't handle the event,
+            // fall through to keyDown so Ghostty can perform the action directly
+            // (e.g. paste when no menu item exists).
             keyDown(with: event)
             return true
         }


### PR DESCRIPTION
## Summary

- Fixes #2805: Cmd+V paste was only pasting the first character
- Root cause: Ghostty upstream made `paste_from_clipboard` a **performable** binding, which caused `performKeyEquivalent` to skip the menu path (Edit > Paste) and fall through to `keyDown`, double-firing the clipboard request
- Fix: remove the `!isPerformable` guard in the menu-first condition so performable bindings like paste still route through the menu, restoring pre-upgrade behavior

## Changes

**`Sources/GhosttyTerminalView.swift`** — one condition change in `performKeyEquivalent`:
- Removed `!isPerformable` from the menu-first gate so consumed bindings (including performable ones) try the menu before falling through to `keyDown`
- Added comments explaining why performable bindings need the menu path

## Testing

- Built tagged debug app (`cmux DEV fix-paste.app`)
- Verified Cmd+V now pastes full clipboard contents correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+V only pasting the first character by sending performable paste through the Edit menu first to avoid double clipboard requests. Fixes #2805.

- **Bug Fixes**
  - In `performKeyEquivalent`, removed the `!isPerformable` check so Cmd+V routes through Edit > Paste; if the menu doesn’t handle it, it falls back to `keyDown`.

<sup>Written for commit 05ab5943118a77b05d46690ac10b01a258401435. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard binding behavior for terminal actions. Performable keybindings (such as paste_from_clipboard) now reliably execute through both menu routing and direct action dispatch, enhancing overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->