### PR TITLE
build: skip Ghostty app bundle during setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,7 @@ xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -des
 When rebuilding GhosttyKit.xcframework, always use Release optimizations:
 
 ```bash
-cd ghostty && zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 ```
 
 When rebuilding cmuxd for release/bundling, always use ReleaseFast:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you make changes to the ghostty submodule, rebuild the xcframework:
 
 ```bash
 cd ghostty
-zig build -Demit-xcframework=true -Doptimize=ReleaseFast
+zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 ```
 
 ## Running Tests

--- a/scripts/ensure-ghosttykit.sh
+++ b/scripts/ensure-ghosttykit.sh
@@ -120,7 +120,9 @@ else
     echo "==> Building GhosttyKit.xcframework (this may take a few minutes)..."
     (
       cd ghostty
-      zig build -Demit-xcframework=true -Dxcframework-target=universal -Doptimize=ReleaseFast
+      # Ghostty's xcframework build implicitly enables the macOS app bundle
+      # unless we turn it off explicitly, which causes avoidable app-side effects.
+      zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
     )
     echo "$GHOSTTY_KEY" > "$LOCAL_KEY_STAMP"
     echo "$GHOSTTY_SHA" > "$LEGACY_LOCAL_SHA_STAMP"


### PR DESCRIPTION
## Summary

- What changed?
  - `scripts/ensure-ghosttykit.sh` now passes `-Demit-macos-app=false` when building GhosttyKit during setup.
- Why?
  - Ghostty's xcframework build implicitly enables the macOS app bundle unless it is disabled explicitly.
  - That means `./scripts/setup.sh` was building `Ghostty.app` as a side effect even though cmux setup only needs `GhosttyKit.xcframework`.
  - Skipping the app bundle avoids the Dock tile plugin side effect and trimmed the measured cold setup path from `159.41s` to `126.54s` in local runs, about `32.87s` faster (`20.6%`).

## Testing

- How did you test this change?
  - Ran `./scripts/setup.sh` in a fresh sibling worktree after temporarily moving the matching `~/.cache/cmux/ghosttykit/<sha>` entry aside to force a rebuild.
  - Ran `./scripts/reload.sh --tag setup-no-ghostty-app` afterward to verify the cmux Debug app still builds cleanly.
- What did you verify manually?
  - Verified the patched setup path completed successfully and regenerated `GhosttyKit.xcframework`.
  - Verified `ghostty/macos/build/ReleaseLocal/Ghostty.app` was not produced by setup in the worktree.
  - Verified the tagged Debug cmux build succeeded.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:
  - N/A (build/setup-only change)

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip building the Ghostty macOS app during setup by passing `-Demit-macos-app=false` when producing `GhosttyKit.xcframework`, avoiding Dock tile plugin side effects and cutting cold setup from 159.41s to 126.54s (~20.6%). Also synced rebuild instructions in `CLAUDE.md` and `CONTRIBUTING.md` to use the same flags (disable app; universal xcframework).

<sup>Written for commit 5dd2d4244a06add5413fdc299221ad54c2a624dc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the framework build process to explicitly disable producing a macOS app bundle, streamlining xcframework generation and release builds.
* **Documentation**
  * Updated contributor instructions to reflect the new build steps for generating the xcframework in Release mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->