### PR TITLE
release: harden signed app bundle layout

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -393,20 +393,13 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          ENTITLEMENTS="cmux.entitlements"
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
-            CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-            HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-            if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-            fi
-            if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-            fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-            /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+            ./scripts/sign-release-app.sh \
+              --app-path "$APP_PATH" \
+              --signing-identity "$APPLE_SIGNING_IDENTITY" \
+              --entitlements "cmux.entitlements"
           done
 
       - name: Notarize apps and dmgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -256,18 +256,10 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          ENTITLEMENTS="cmux.entitlements"
-          CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-          HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-          if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-          fi
-          if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-          fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-          /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          ./scripts/sign-release-app.sh \
+            --app-path "build-universal/Build/Products/Release/cmux.app" \
+            --signing-identity "$APPLE_SIGNING_IDENTITY" \
+            --entitlements "cmux.entitlements"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -107,7 +107,7 @@ jobs:
             depends_on macos: ">= :sonoma"
 
             app "cmux.app"
-            binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"
+            binary "#{appdir}/cmux.app/Contents/Helpers/cmux"
 
             zap trash: [
               "~/Library/Application Support/cmux",

--- a/.github/workflows/update-homebrew.yml
+++ b/.github/workflows/update-homebrew.yml
@@ -107,7 +107,7 @@ jobs:
             depends_on macos: ">= :sonoma"
 
             app "cmux.app"
-            binary "#{appdir}/cmux.app/Contents/Helpers/cmux"
+            binary File.exist?("#{appdir}/cmux.app/Contents/Helpers/cmux") ? "#{appdir}/cmux.app/Contents/Helpers/cmux" : "#{appdir}/cmux.app/Contents/Resources/bin/cmux"
 
             zap trash: [
               "~/Library/Application Support/cmux",

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -1127,20 +1127,37 @@ _cmux_install_prompt_command() {
     fi
 }
 
-# Ensure Resources/bin is at the front of PATH, and remove the app's
-# Contents/MacOS entry so the GUI cmux binary cannot shadow the CLI cmux.
+# Ensure bundled helper and wrapper directories are at the front of PATH, and
+# remove the app's Contents/MacOS entry so the GUI cmux binary cannot shadow
+# the CLI cmux.
 # Shell init (.bashrc/.bash_profile) may prepend other dirs after launch.
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
         local gui_dir="${GHOSTTY_BIN_DIR%/}"
-        local bin_dir="${gui_dir%/MacOS}/Resources/bin"
-        if [[ -d "$bin_dir" ]]; then
+        local bundle_dir="${gui_dir%/MacOS}"
+        local helper_dir="${bundle_dir}/Helpers"
+        local wrapper_dir="${bundle_dir}/Resources/bin"
+        local -a preferred_dirs=()
+
+        [[ -d "$helper_dir" ]] && preferred_dirs+=("$helper_dir")
+        [[ -d "$wrapper_dir" ]] && preferred_dirs+=("$wrapper_dir")
+
+        if [[ ${#preferred_dirs[@]} -gt 0 ]]; then
             local new_path=":${PATH}:"
-            new_path="${new_path//:${bin_dir}:/:}"
+            local dir
+            for dir in "${preferred_dirs[@]}"; do
+                new_path="${new_path//:${dir}:/:}"
+            done
             new_path="${new_path//:${gui_dir}:/:}"
             new_path="${new_path#:}"
             new_path="${new_path%:}"
-            PATH="${bin_dir}:${new_path}"
+            local preferred_path
+            preferred_path="$(IFS=:; printf '%s' "${preferred_dirs[*]}")"
+            if [[ -n "$new_path" ]]; then
+                PATH="${preferred_path}:${new_path}"
+            else
+                PATH="${preferred_path}"
+            fi
         fi
     fi
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -1259,20 +1259,35 @@ _cmux_precmd() {
     fi
 }
 
-# Ensure Resources/bin is at the front of PATH, and remove the app's
-# Contents/MacOS entry so the GUI cmux binary cannot shadow the CLI cmux.
+# Ensure bundled helper and wrapper directories are at the front of PATH, and
+# remove the app's Contents/MacOS entry so the GUI cmux binary cannot shadow
+# the CLI cmux.
 # Shell init (.zprofile/.zshrc) may prepend other dirs after launch.
 # We fix this once on first prompt (after all init files have run).
 _cmux_fix_path() {
     if [[ -n "${GHOSTTY_BIN_DIR:-}" ]]; then
         local gui_dir="${GHOSTTY_BIN_DIR%/}"
-        local bin_dir="${gui_dir%/MacOS}/Resources/bin"
-        if [[ -d "$bin_dir" ]]; then
-            # Remove existing entries and re-prepend the CLI bin dir.
+        local bundle_dir="${gui_dir%/MacOS}"
+        local helper_dir="${bundle_dir}/Helpers"
+        local wrapper_dir="${bundle_dir}/Resources/bin"
+        local -a preferred_dirs=()
+
+        [[ -d "$helper_dir" ]] && preferred_dirs+=("$helper_dir")
+        [[ -d "$wrapper_dir" ]] && preferred_dirs+=("$wrapper_dir")
+
+        if (( ${#preferred_dirs[@]} > 0 )); then
             local -a parts=("${(@s/:/)PATH}")
-            parts=("${(@)parts:#$bin_dir}")
             parts=("${(@)parts:#$gui_dir}")
-            PATH="${bin_dir}:${(j/:/)parts}"
+            for dir in "${preferred_dirs[@]}"; do
+                parts=("${(@)parts:#$dir}")
+            done
+
+            local preferred_path="${(j/:/)preferred_dirs}"
+            if (( ${#parts[@]} > 0 )); then
+                PATH="${preferred_path}:${(j/:/)parts}"
+            else
+                PATH="${preferred_path}"
+            fi
         fi
     fi
     add-zsh-hook -d precmd _cmux_fix_path

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -30,11 +30,7 @@ func cmuxBundledExecutableURL(named executableName: String, bundle: Bundle = .ma
         bundle.bundleURL.appendingPathComponent("\(cmuxBundledResourceBinDirectoryRelativePath)/\(executableName)", isDirectory: false),
     ]
 
-    if let executableCandidate = candidates.first(where: { fileManager.isExecutableFile(atPath: $0.path) }) {
-        return executableCandidate
-    }
-
-    return candidates.first(where: { fileManager.fileExists(atPath: $0.path) })
+    return candidates.first(where: { fileManager.isExecutableFile(atPath: $0.path) })
 }
 
 func cmuxBundledExecutableExpectedPath(named executableName: String, bundle: Bundle = .main) -> String {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -20,6 +20,51 @@ func cmuxJavaScriptStringLiteral(_ value: String?) -> String? {
     return String(arrayLiteral.dropFirst().dropLast())
 }
 
+private let cmuxBundledHelperDirectoryRelativePath = "Contents/Helpers"
+private let cmuxBundledResourceBinDirectoryRelativePath = "Contents/Resources/bin"
+
+func cmuxBundledExecutableURL(named executableName: String, bundle: Bundle = .main) -> URL? {
+    let fileManager = FileManager.default
+    let candidates = [
+        bundle.bundleURL.appendingPathComponent("\(cmuxBundledHelperDirectoryRelativePath)/\(executableName)", isDirectory: false),
+        bundle.bundleURL.appendingPathComponent("\(cmuxBundledResourceBinDirectoryRelativePath)/\(executableName)", isDirectory: false),
+    ]
+
+    if let executableCandidate = candidates.first(where: { fileManager.isExecutableFile(atPath: $0.path) }) {
+        return executableCandidate
+    }
+
+    return candidates.first(where: { fileManager.fileExists(atPath: $0.path) })
+}
+
+func cmuxBundledExecutableExpectedPath(named executableName: String, bundle: Bundle = .main) -> String {
+    cmuxBundledExecutableURL(named: executableName, bundle: bundle)?.path
+        ?? bundle.bundleURL
+            .appendingPathComponent("\(cmuxBundledHelperDirectoryRelativePath)/\(executableName)", isDirectory: false)
+            .path
+}
+
+func cmuxBundledBinDirectoryPaths(bundle: Bundle = .main) -> [String] {
+    let fileManager = FileManager.default
+    let candidateDirectories = [
+        bundle.bundleURL.appendingPathComponent(cmuxBundledHelperDirectoryRelativePath, isDirectory: true),
+        bundle.bundleURL.appendingPathComponent(cmuxBundledResourceBinDirectoryRelativePath, isDirectory: true),
+    ]
+
+    var resolvedDirectories: [String] = []
+    for candidate in candidateDirectories {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            continue
+        }
+        if !resolvedDirectories.contains(candidate.path) {
+            resolvedDirectories.append(candidate.path)
+        }
+    }
+
+    return resolvedDirectories
+}
+
 final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
 
@@ -1430,13 +1475,11 @@ struct CmuxCLIPathInstaller {
     }
 
     private static func defaultBundledCLIURL(bundle: Bundle = .main) -> URL? {
-        bundle.resourceURL?.appendingPathComponent("bin/cmux", isDirectory: false)
+        cmuxBundledExecutableURL(named: "cmux", bundle: bundle)
     }
 
     private static func defaultBundledCLIExpectedPath(bundle: Bundle = .main) -> String {
-        bundle.bundleURL
-            .appendingPathComponent("Contents/Resources/bin/cmux", isDirectory: false)
-            .path
+        cmuxBundledExecutableExpectedPath(named: "cmux", bundle: bundle)
     }
 
     private static func installWithAdministratorPrivileges(sourceURL: URL, destinationURL: URL) throws {
@@ -12655,8 +12698,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func observeDuplicateLaunches() {
         guard let bundleId = Bundle.main.bundleIdentifier else { return }
-        let embeddedCLIURL = Bundle.main.bundleURL
-            .appendingPathComponent("Contents/Resources/bin/cmux", isDirectory: false)
+        let embeddedCLIURL = URL(fileURLWithPath: cmuxBundledExecutableExpectedPath(named: "cmux"))
             .standardizedFileURL
             .resolvingSymlinksInPath()
         let currentPid = ProcessInfo.processInfo.processIdentifier

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4220,7 +4220,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         setManagedEnvironmentValue("CMUX_SOCKET_PATH", socketPath)
         // Backward-compatible alias expected by older scripts and third-party integrations.
         setManagedEnvironmentValue("CMUX_SOCKET", socketPath)
-        if let bundledCLIURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
+        if let bundledCLIURL = cmuxBundledExecutableURL(named: "cmux"),
            FileManager.default.isExecutableFile(atPath: bundledCLIURL.path) {
             setManagedEnvironmentValue("CMUX_BUNDLED_CLI_PATH", bundledCLIURL.path)
         }
@@ -4250,15 +4250,18 @@ final class TerminalSurface: Identifiable, ObservableObject {
             setManagedEnvironmentValue("CMUX_GEMINI_HOOKS_DISABLED", "1")
         }
 
-        if let cliBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+        let bundledBinDirectoryPaths = cmuxBundledBinDirectoryPaths()
+        if !bundledBinDirectoryPaths.isEmpty {
             let currentPath = env["PATH"]
                 ?? getenv("PATH").map { String(cString: $0) }
                 ?? ProcessInfo.processInfo.environment["PATH"]
                 ?? ""
-            if !currentPath.split(separator: ":").contains(Substring(cliBinPath)) {
-                let separator = currentPath.isEmpty ? "" : ":"
-                setManagedEnvironmentValue("PATH", "\(cliBinPath)\(separator)\(currentPath)")
-            }
+            let currentParts = currentPath
+                .split(separator: ":")
+                .map(String.init)
+            let filteredParts = currentParts.filter { !bundledBinDirectoryPaths.contains($0) }
+            let combinedParts = bundledBinDirectoryPaths + filteredParts
+            setManagedEnvironmentValue("PATH", combinedParts.joined(separator: ":"))
         }
 
         // Shell integration: inject ZDOTDIR wrapper for zsh shells.

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3000,7 +3000,7 @@ class TabManager: ObservableObject {
 
         appendSearchPath(environment["PATH"])
         appendSearchPath(getenv("PATH").map { String(cString: $0) })
-        if let bundledBinPath = Bundle.main.resourceURL?.appendingPathComponent("bin").path {
+        for bundledBinPath in cmuxBundledBinDirectoryPaths() {
             appendSearchPath(bundledBinPath)
         }
         fallbackDirectories.forEach { appendSearchPath($0) }

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -74,9 +74,9 @@ rm -rf build/
 xcodebuild -scheme cmux -configuration Release -derivedDataPath build CODE_SIGNING_ALLOWED=NO build 2>&1 | tail -5
 echo "Build succeeded"
 
-HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-if [ ! -x "$HELPER_PATH" ]; then
-  echo "Ghostty theme picker helper not found at $HELPER_PATH" >&2
+RAW_HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+if [ ! -x "$RAW_HELPER_PATH" ]; then
+  echo "Ghostty theme picker helper not found at $RAW_HELPER_PATH before release signing" >&2
   exit 1
 fi
 
@@ -92,15 +92,10 @@ echo "Sparkle keys injected"
 
 # --- Codesign ---
 echo "Codesigning..."
-CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-if [ -f "$CLI_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
-fi
-if [ -f "$HELPER_PATH" ]; then
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
-fi
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGN_HASH" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
-/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+./scripts/sign-release-app.sh \
+  --app-path "$APP_PATH" \
+  --signing-identity "$SIGN_HASH" \
+  --entitlements "$ENTITLEMENTS"
 echo "Codesign verified"
 
 # --- Notarize app ---
@@ -186,7 +181,7 @@ cask "cmux" do
   depends_on macos: ">= :ventura"
 
   app "cmux.app"
-  binary "#{appdir}/cmux.app/Contents/Resources/bin/cmux"
+  binary "#{appdir}/cmux.app/Contents/Helpers/cmux"
 
   zap trash: [
     "~/Library/Application Support/cmux",

--- a/scripts/harden-release-app-layout.sh
+++ b/scripts/harden-release-app-layout.sh
@@ -37,14 +37,13 @@ relocate_helper_executable() {
     return 0
   fi
 
-  if [[ -e "$destination_path" && ! "$source_path" -ef "$destination_path" ]]; then
-    echo "Refusing to overwrite existing helper executable at $destination_path while normalizing $APP_PATH" >&2
-    exit 1
-  fi
-
   if [[ ! -x "$source_path" ]]; then
     echo "Expected bundled helper executable $source_path to be executable before release signing" >&2
     exit 1
+  fi
+
+  if [[ -e "$destination_path" && ! "$source_path" -ef "$destination_path" ]]; then
+    rm -f "$destination_path"
   fi
 
   mv -f "$source_path" "$destination_path"

--- a/scripts/harden-release-app-layout.sh
+++ b/scripts/harden-release-app-layout.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/harden-release-app-layout.sh <app-path>
+
+Normalizes a built release app bundle into a Gatekeeper-friendlier layout by
+moving bundled helper executables out of Contents/Resources/bin and into
+Contents/Helpers before the app is signed.
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 1
+fi
+
+APP_PATH="$1"
+CONTENTS_DIR="$APP_PATH/Contents"
+RESOURCE_BIN_DIR="$CONTENTS_DIR/Resources/bin"
+HELPERS_DIR="$CONTENTS_DIR/Helpers"
+
+if [[ ! -d "$CONTENTS_DIR" ]]; then
+  echo "Release app bundle is missing its Contents directory at $CONTENTS_DIR" >&2
+  exit 1
+fi
+
+mkdir -p "$HELPERS_DIR"
+
+relocate_helper_executable() {
+  local executable_name="$1"
+  local source_path="$RESOURCE_BIN_DIR/$executable_name"
+  local destination_path="$HELPERS_DIR/$executable_name"
+
+  if [[ ! -e "$source_path" ]]; then
+    return 0
+  fi
+
+  if [[ -e "$destination_path" && ! "$source_path" -ef "$destination_path" ]]; then
+    echo "Refusing to overwrite existing helper executable at $destination_path while normalizing $APP_PATH" >&2
+    exit 1
+  fi
+
+  if [[ ! -x "$source_path" ]]; then
+    echo "Expected bundled helper executable $source_path to be executable before release signing" >&2
+    exit 1
+  fi
+
+  mv -f "$source_path" "$destination_path"
+  chmod 0755 "$destination_path"
+}
+
+relocate_helper_executable "cmux"
+relocate_helper_executable "ghostty"
+
+for helper_name in cmux ghostty; do
+  helper_path="$HELPERS_DIR/$helper_name"
+  if [[ -e "$helper_path" && ! -x "$helper_path" ]]; then
+    echo "Normalized helper executable $helper_path exists but is not executable" >&2
+    exit 1
+  fi
+done
+
+if [[ -d "$RESOURCE_BIN_DIR" ]]; then
+  resource_bin_entries=()
+  while IFS= read -r -d '' entry; do
+    resource_bin_entries+=("$entry")
+  done < <(find "$RESOURCE_BIN_DIR" -mindepth 1 -maxdepth 1 -print0)
+
+  if [[ ${#resource_bin_entries[@]} -eq 0 ]]; then
+    rmdir "$RESOURCE_BIN_DIR"
+  fi
+fi
+
+echo "Normalized release bundle layout for $APP_PATH"

--- a/scripts/harden-release-app-layout.sh
+++ b/scripts/harden-release-app-layout.sh
@@ -37,7 +37,7 @@ relocate_helper_executable() {
     return 0
   fi
 
-  if [[ ! -x "$source_path" ]]; then
+  if [[ ! -f "$source_path" || ! -x "$source_path" ]]; then
     echo "Expected bundled helper executable $source_path to be executable before release signing" >&2
     exit 1
   fi
@@ -50,12 +50,22 @@ relocate_helper_executable() {
   chmod 0755 "$destination_path"
 }
 
+install_legacy_resource_symlink() {
+  local executable_name="$1"
+  local legacy_path="$RESOURCE_BIN_DIR/$executable_name"
+  local relative_target="../../Helpers/$executable_name"
+
+  mkdir -p "$RESOURCE_BIN_DIR"
+  ln -sfn "$relative_target" "$legacy_path"
+}
+
 relocate_helper_executable "cmux"
 relocate_helper_executable "ghostty"
+install_legacy_resource_symlink "cmux"
 
 for helper_name in cmux ghostty; do
   helper_path="$HELPERS_DIR/$helper_name"
-  if [[ -e "$helper_path" && ! -x "$helper_path" ]]; then
+  if [[ -e "$helper_path" && ( ! -f "$helper_path" || ! -x "$helper_path" ) ]]; then
     echo "Normalized helper executable $helper_path exists but is not executable" >&2
     exit 1
   fi

--- a/scripts/harden-release-app-layout.sh
+++ b/scripts/harden-release-app-layout.sh
@@ -42,6 +42,11 @@ relocate_helper_executable() {
     exit 1
   fi
 
+  if [[ -e "$destination_path" && "$source_path" -ef "$destination_path" ]]; then
+    chmod 0755 "$destination_path"
+    return 0
+  fi
+
   if [[ -e "$destination_path" && ! "$source_path" -ef "$destination_path" ]]; then
     rm -f "$destination_path"
   fi

--- a/scripts/sign-release-app.sh
+++ b/scripts/sign-release-app.sh
@@ -59,12 +59,19 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 "$SCRIPT_DIR/harden-release-app-layout.sh" "$APP_PATH"
 
+CODESIGN_COMMON_ARGS=(--force --options runtime --sign "$SIGNING_IDENTITY")
+case "$SIGNING_IDENTITY" in
+  Developer\ ID\ Application:*|Apple\ Distribution:*)
+    CODESIGN_COMMON_ARGS+=(--timestamp)
+    ;;
+esac
+
 codesign_nested_path() {
   local nested_path="$1"
   if [[ ! -e "$nested_path" ]]; then
     return 0
   fi
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$nested_path"
+  /usr/bin/codesign "${CODESIGN_COMMON_ARGS[@]}" "$nested_path"
 }
 
 codesign_helper_executable() {
@@ -72,7 +79,7 @@ codesign_helper_executable() {
   if [[ ! -e "$helper_path" ]]; then
     return 0
   fi
-  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$helper_path"
+  /usr/bin/codesign "${CODESIGN_COMMON_ARGS[@]}" --entitlements "$ENTITLEMENTS" "$helper_path"
 }
 
 SIGNABLE_BUNDLES=()
@@ -103,7 +110,13 @@ if [[ -d "$APP_PATH/Contents/Resources/bin" ]]; then
   done < <(find "$APP_PATH/Contents/Resources/bin" -type f -perm -u+x -print0)
 fi
 
-/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$APP_PATH"
-/usr/bin/codesign --verify --strict --verbose=2 "$APP_PATH"
+if [[ -d "$APP_PATH/Contents/Frameworks" ]]; then
+  while IFS= read -r -d '' loose_dylib; do
+    codesign_nested_path "$loose_dylib"
+  done < <(find "$APP_PATH/Contents/Frameworks" -type f -name '*.dylib' ! -path '*.framework/*' -print0)
+fi
+
+/usr/bin/codesign "${CODESIGN_COMMON_ARGS[@]}" --entitlements "$ENTITLEMENTS" "$APP_PATH"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
 
 echo "Signed release app bundle at $APP_PATH"

--- a/scripts/sign-release-app.sh
+++ b/scripts/sign-release-app.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: ./scripts/sign-release-app.sh --app-path <path> --signing-identity <identity> --entitlements <plist>
+
+Normalizes the release app bundle layout, explicitly signs nested code in
+standard macOS bundle locations, signs bundled helper executables, then signs
+the app bundle without relying on codesign --deep.
+EOF
+}
+
+APP_PATH=""
+SIGNING_IDENTITY=""
+ENTITLEMENTS=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app-path)
+      APP_PATH="${2:-}"
+      shift 2
+      ;;
+    --signing-identity)
+      SIGNING_IDENTITY="${2:-}"
+      shift 2
+      ;;
+    --entitlements)
+      ENTITLEMENTS="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$APP_PATH" || -z "$SIGNING_IDENTITY" || -z "$ENTITLEMENTS" ]]; then
+  usage >&2
+  exit 1
+fi
+
+if [[ ! -d "$APP_PATH/Contents" ]]; then
+  echo "Cannot sign release app because $APP_PATH does not look like a macOS app bundle" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENTITLEMENTS" ]]; then
+  echo "Cannot sign release app because entitlements file $ENTITLEMENTS does not exist" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+"$SCRIPT_DIR/harden-release-app-layout.sh" "$APP_PATH"
+
+codesign_nested_path() {
+  local nested_path="$1"
+  if [[ ! -e "$nested_path" ]]; then
+    return 0
+  fi
+  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" "$nested_path"
+}
+
+codesign_helper_executable() {
+  local helper_path="$1"
+  if [[ ! -e "$helper_path" ]]; then
+    return 0
+  fi
+  /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$helper_path"
+}
+
+SIGNABLE_BUNDLES=()
+while IFS= read -r -d '' signable_path; do
+  SIGNABLE_BUNDLES+=("$signable_path")
+done < <(
+  find "$APP_PATH/Contents" \
+    -type d \
+    \( -name '*.framework' -o -name '*.app' -o -name '*.plugin' -o -name '*.appex' -o -name '*.xpc' \) \
+    ! -path "$APP_PATH" \
+    -print0 |
+    perl -0ne '
+      @items = split(/\0/, $_);
+      @items = grep { length $_ } @items;
+      @items = sort { () = $b =~ m{/}g <=> () = $a =~ m{/}g || $a cmp $b } @items;
+      print join("\0", @items), "\0" if @items;
+    '
+)
+
+for signable_bundle in "${SIGNABLE_BUNDLES[@]}"; do
+  codesign_nested_path "$signable_bundle"
+done
+
+for helper_name in cmux ghostty; do
+  codesign_helper_executable "$APP_PATH/Contents/Helpers/$helper_name"
+done
+
+/usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$APP_PATH"
+/usr/bin/codesign --verify --strict --verbose=2 "$APP_PATH"
+
+echo "Signed release app bundle at $APP_PATH"

--- a/scripts/sign-release-app.sh
+++ b/scripts/sign-release-app.sh
@@ -76,20 +76,17 @@ codesign_helper_executable() {
 }
 
 SIGNABLE_BUNDLES=()
-while IFS= read -r -d '' signable_path; do
-  SIGNABLE_BUNDLES+=("$signable_path")
+while IFS= read -r signable_record; do
+  [[ -z "$signable_record" ]] && continue
+  SIGNABLE_BUNDLES+=("${signable_record#*$'\t'}")
 done < <(
   find "$APP_PATH/Contents" \
     -type d \
     \( -name '*.framework' -o -name '*.app' -o -name '*.plugin' -o -name '*.appex' -o -name '*.xpc' \) \
     ! -path "$APP_PATH" \
-    -print0 |
-    perl -0ne '
-      @items = split(/\0/, $_);
-      @items = grep { length $_ } @items;
-      @items = sort { () = $b =~ m{/}g <=> () = $a =~ m{/}g || $a cmp $b } @items;
-      print join("\0", @items), "\0" if @items;
-    '
+    -print |
+    awk -F/ '{ print NF "\t" $0 }' |
+    sort -r -n -k1,1 -k2,2
 )
 
 for signable_bundle in "${SIGNABLE_BUNDLES[@]}"; do
@@ -99,6 +96,12 @@ done
 for helper_name in cmux ghostty; do
   codesign_helper_executable "$APP_PATH/Contents/Helpers/$helper_name"
 done
+
+if [[ -d "$APP_PATH/Contents/Resources/bin" ]]; then
+  while IFS= read -r -d '' resource_executable; do
+    codesign_helper_executable "$resource_executable"
+  done < <(find "$APP_PATH/Contents/Resources/bin" -type f -perm -u+x -print0)
+fi
 
 /usr/bin/codesign --force --options runtime --timestamp --sign "$SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$APP_PATH"
 /usr/bin/codesign --verify --strict --verbose=2 "$APP_PATH"


### PR DESCRIPTION
## Summary

- normalize release app bundles so shipped helper executables move from `Contents/Resources/bin` into `Contents/Helpers` before signing
- replace `codesign --deep` in release and nightly flows with a shared explicit nested-code signing script, and update shipped-path consumers to prefer the hardened layout while keeping debug/runtime fallbacks for the existing dev bundle shape
- harden the signing helper itself so rerunning release signing on a reused local build artifact works reliably and still signs executable remnants that remain under `Contents/Resources/bin`

## Testing

- `bash -n scripts/harden-release-app-layout.sh scripts/sign-release-app.sh scripts/build-sign-upload.sh`
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag gatekeeper-hardening`
- synthetic smoke test for `./scripts/harden-release-app-layout.sh` against a temporary app bundle in `/tmp`
- `xcodebuild -scheme cmux -configuration Release -derivedDataPath /tmp/cmux-gatekeeper-release CODE_SIGNING_ALLOWED=NO build`
- `./scripts/sign-release-app.sh --app-path /tmp/cmux-gatekeeper-release/Build/Products/Release/cmux.app --signing-identity 'Apple Development: Gale Williams (AMRC3N39SQ)' --entitlements cmux.entitlements`
- `codesign --verify --strict --verbose=2 /tmp/cmux-gatekeeper-release/Build/Products/Release/cmux.app`
- detached-`main` comparison build at `/tmp/cmux-wt-main-gatekeeper-compare` using `xcodebuild -scheme cmux -configuration Release -derivedDataPath /tmp/cmux-main-gatekeeper-release CODE_SIGNING_ALLOWED=NO build`
- old-style `main` signing comparison using resource-bin helper signing plus app-level `codesign --deep`

## Release Inspection

After seeing reports of gatekeeper issues in the Discord, I found a few issues with signing and the locations of bundled executables and plugin structure. A release build from main obscures expected feedback, whereas this hardened branch behaves as expected, reporting Notary Ticket Missing on a local build without Notarization.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened the macOS release bundle by moving helper executables (`cmux`, `ghostty`) to `Contents/Helpers` and replacing `codesign --deep` with a shared, explicit nested-signing script for release and nightly. This improves Gatekeeper behavior and makes signing safe to rerun, while dev/debug builds keep working via `Resources/bin` fallbacks.

- **Refactors**
  - Added `sign-release-app.sh` and `harden-release-app-layout.sh` for explicit nested signing; signs frameworks/plugins/loose dylibs and helpers, verifies the bundle, and is idempotent (keeps a legacy `Resources/bin/cmux` symlink and cleans empty dirs).
  - Updated CI (release/nightly) to use the signing script; removed ad‑hoc `codesign` steps.
  - Shell/App now prefer `Contents/Helpers` then `Contents/Resources/bin` on PATH and remove `Contents/MacOS`; centralized bundled executable and bin directory lookup in Swift.
  - Homebrew cask prefers `Contents/Helpers/cmux` with fallback to `Contents/Resources/bin/cmux`.

- **Migration**
  - Update any external scripts to use `Contents/Helpers/cmux` in signed releases; legacy `Resources/bin/cmux` remains as a fallback.
  - No changes needed for local development; existing `Resources/bin` paths still work in debug builds.

<sup>Written for commit 2c4f87ce65318fb488e04a89e246a9130f9046c0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Reorganized bundled helper binaries and normalized app bundle layout for predictable installs
  * Centralized and hardened release signing with a dedicated signing workflow for reliable notarization and verification
  * Updated shell integrations to prioritize bundled helper and wrapper directories on PATH
  * Adjusted Homebrew cask to prefer the packaged helper binary when present
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
