### PR TITLE
Add sidebar branch directory display style setting

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -51882,13 +51882,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show the shortened working-directory path."
+            "value": "Show the full working-directory path (home abbreviated as ~)."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "短縮された作業ディレクトリのパスを表示します。"
+            "value": "作業ディレクトリの完全なパスを表示します（ホームは ~ で省略）。"
           }
         }
       }
@@ -51899,13 +51899,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show only the final directory name."
+            "value": "Show the repository name, or the final directory if not in a repo."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "最後のディレクトリ名のみを表示します。"
+            "value": "Git リポジトリ内ではリポジトリ名を、そうでない場合は最後のディレクトリ名を表示します。"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -51825,6 +51825,91 @@
         }
       }
     },
+    "settings.app.sidebarBranchDirectoryStyle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Branch Directory Style"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブランチディレクトリの表示形式"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarBranchDirectoryStyle.fullPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Full Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フルパス"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarBranchDirectoryStyle.repoName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Repository Name"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リポジトリ名"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarBranchDirectoryStyle.subtitleFullPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show the shortened working-directory path."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "短縮された作業ディレクトリのパスを表示します。"
+          }
+        }
+      }
+    },
+    "settings.app.sidebarBranchDirectoryStyle.subtitleRepoName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show only the final directory name."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "最後のディレクトリ名のみを表示します。"
+          }
+        }
+      }
+    },
     "settings.app.telemetry": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9959,6 +9959,7 @@ private struct SidebarTabItemSettingsSnapshot: Equatable {
     let alwaysShowShortcutHints: Bool
     let showsGitBranch: Bool
     let usesVerticalBranchLayout: Bool
+    let branchDirectoryStyle: SidebarBranchDirectoryStyle
     let showsGitBranchIcon: Bool
     let showsSSH: Bool
     let openPullRequestLinksInCmuxBrowser: Bool
@@ -9987,6 +9988,7 @@ private struct SidebarTabItemSettingsSnapshot: Equatable {
         )
         showsGitBranch = Self.bool(defaults: defaults, key: "sidebarShowGitBranch", defaultValue: true)
         usesVerticalBranchLayout = SidebarBranchLayoutSettings.usesVerticalLayout(defaults: defaults)
+        branchDirectoryStyle = SidebarBranchDirectoryStyleSettings.current(defaults: defaults)
         showsGitBranchIcon = Self.bool(defaults: defaults, key: "sidebarShowGitBranchIcon", defaultValue: false)
         showsSSH = Self.bool(defaults: defaults, key: "sidebarShowSSH", defaultValue: true)
         openPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser(
@@ -12499,6 +12501,19 @@ private struct SidebarEmptyArea: View {
 enum SidebarPathFormatter {
     static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
 
+    static func displayPath(
+        _ path: String,
+        style: SidebarBranchDirectoryStyle,
+        homeDirectoryPath: String = Self.homeDirectoryPath
+    ) -> String {
+        switch style {
+        case .fullPath:
+            return shortenedPath(path, homeDirectoryPath: homeDirectoryPath)
+        case .repoName:
+            return lastPathComponent(path)
+        }
+    }
+
     static func shortenedPath(
         _ path: String,
         homeDirectoryPath: String = Self.homeDirectoryPath
@@ -12512,6 +12527,13 @@ enum SidebarPathFormatter {
             return "~" + trimmed.dropFirst(homeDirectoryPath.count)
         }
         return trimmed
+    }
+
+    private static func lastPathComponent(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return path }
+        let component = (trimmed as NSString).lastPathComponent
+        return component.isEmpty ? trimmed : component
     }
 }
 
@@ -12678,6 +12700,10 @@ private struct TabItemView: View, Equatable {
 
     private var sidebarBranchVerticalLayout: Bool {
         settings.usesVerticalBranchLayout
+    }
+
+    private var sidebarBranchDirectoryStyle: SidebarBranchDirectoryStyle {
+        settings.branchDirectoryStyle
     }
 
     private var sidebarShowGitBranchIcon: Bool {
@@ -13911,8 +13937,12 @@ private struct TabItemView: View, Equatable {
 
             let directoryText: String? = {
                 guard let directory = entry.directory else { return nil }
-                let shortened = SidebarPathFormatter.shortenedPath(directory, homeDirectoryPath: home)
-                return shortened.isEmpty ? nil : shortened
+                let displayPath = SidebarPathFormatter.displayPath(
+                    directory,
+                    style: sidebarBranchDirectoryStyle,
+                    homeDirectoryPath: home
+                )
+                return displayPath.isEmpty ? nil : displayPath
             }()
 
             switch (branchText, directoryText) {
@@ -13931,8 +13961,12 @@ private struct TabItemView: View, Equatable {
     private func directorySummaryText(orderedPanelIds: [UUID]) -> String? {
         let home = SidebarPathFormatter.homeDirectoryPath
         let entries = tab.sidebarDirectoriesInDisplayOrder(orderedPanelIds: orderedPanelIds).compactMap { directory in
-            let shortened = SidebarPathFormatter.shortenedPath(directory, homeDirectoryPath: home)
-            return shortened.isEmpty ? nil : shortened
+            let displayPath = SidebarPathFormatter.displayPath(
+                directory,
+                style: sidebarBranchDirectoryStyle,
+                homeDirectoryPath: home
+            )
+            return displayPath.isEmpty ? nil : displayPath
         }
         return entries.isEmpty ? nil : entries.joined(separator: " | ")
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12510,7 +12510,7 @@ enum SidebarPathFormatter {
         case .fullPath:
             return shortenedPath(path, homeDirectoryPath: homeDirectoryPath)
         case .repoName:
-            return lastPathComponent(path)
+            return repositoryRootName(for: path) ?? lastPathComponent(path)
         }
     }
 
@@ -12534,6 +12534,32 @@ enum SidebarPathFormatter {
         guard !trimmed.isEmpty else { return path }
         let component = (trimmed as NSString).lastPathComponent
         return component.isEmpty ? trimmed : component
+    }
+
+    private static func repositoryRootName(for path: String) -> String? {
+        guard let gitRoot = gitRootPath(for: path) else { return nil }
+        let component = (gitRoot as NSString).lastPathComponent
+        return component.isEmpty ? gitRoot : component
+    }
+
+    private static func gitRootPath(for path: String) -> String? {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let fileManager = FileManager.default
+        var current = trimmed
+        while true {
+            let gitPath = (current as NSString).appendingPathComponent(".git")
+            if fileManager.fileExists(atPath: gitPath) {
+                return current
+            }
+
+            let parent = (current as NSString).deletingLastPathComponent
+            if parent == current { break }
+            current = parent
+        }
+
+        return nil
     }
 }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -47,6 +47,7 @@ final class CmuxSettingsFileStore {
         "notifications.command",
         "sidebar.hideAllDetails",
         "sidebar.branchLayout",
+        "sidebar.branchDirectoryStyle",
         "sidebar.showNotificationMessage",
         "sidebar.showBranchDirectory",
         "sidebar.showPullRequests",
@@ -492,6 +493,13 @@ final class CmuxSettingsFileStore {
                 snapshot.managedUserDefaults[SidebarBranchLayoutSettings.key] = .bool(false)
             default:
                 logInvalid("sidebar.branchLayout", sourcePath: sourcePath)
+            }
+        }
+        if let raw = jsonString(section["branchDirectoryStyle"]) {
+            if let style = SidebarBranchDirectoryStyle(rawValue: raw) {
+                snapshot.managedUserDefaults[SidebarBranchDirectoryStyleSettings.key] = .string(style.rawValue)
+            } else {
+                logInvalid("sidebar.branchDirectoryStyle", sourcePath: sourcePath)
             }
         }
         if let value = jsonBool(section["showNotificationMessage"]) {
@@ -1347,6 +1355,7 @@ final class CmuxSettingsFileStore {
                 "sidebar": [
                     "hideAllDetails": SidebarWorkspaceDetailSettings.defaultHideAllDetails,
                     "branchLayout": SidebarBranchLayoutSettings.defaultVerticalLayout ? "vertical" : "inline",
+                    "branchDirectoryStyle": SidebarBranchDirectoryStyleSettings.defaultStyle.rawValue,
                     "showNotificationMessage": SidebarWorkspaceDetailSettings.defaultShowNotificationMessage,
                     "showBranchDirectory": true,
                     "showPullRequests": true,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -106,12 +106,12 @@ enum SidebarBranchDirectoryStyle: String, CaseIterable, Identifiable {
         case .fullPath:
             return String(
                 localized: "settings.app.sidebarBranchDirectoryStyle.subtitleFullPath",
-                defaultValue: "Show the shortened working-directory path."
+                defaultValue: "Show the full working-directory path (home abbreviated as ~)."
             )
         case .repoName:
             return String(
                 localized: "settings.app.sidebarBranchDirectoryStyle.subtitleRepoName",
-                defaultValue: "Show only the final directory name."
+                defaultValue: "Show the repository name, or the final directory if not in a repo."
             )
         }
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -86,6 +86,50 @@ enum SidebarBranchLayoutSettings {
     }
 }
 
+enum SidebarBranchDirectoryStyle: String, CaseIterable, Identifiable {
+    case fullPath
+    case repoName
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .fullPath:
+            return String(localized: "settings.app.sidebarBranchDirectoryStyle.fullPath", defaultValue: "Full Path")
+        case .repoName:
+            return String(localized: "settings.app.sidebarBranchDirectoryStyle.repoName", defaultValue: "Repository Name")
+        }
+    }
+
+    var description: String {
+        switch self {
+        case .fullPath:
+            return String(
+                localized: "settings.app.sidebarBranchDirectoryStyle.subtitleFullPath",
+                defaultValue: "Show the shortened working-directory path."
+            )
+        case .repoName:
+            return String(
+                localized: "settings.app.sidebarBranchDirectoryStyle.subtitleRepoName",
+                defaultValue: "Show only the final directory name."
+            )
+        }
+    }
+}
+
+enum SidebarBranchDirectoryStyleSettings {
+    static let key = "sidebarBranchDirectoryStyle"
+    static let defaultStyle: SidebarBranchDirectoryStyle = .fullPath
+
+    static func current(defaults: UserDefaults = .standard) -> SidebarBranchDirectoryStyle {
+        guard let raw = defaults.string(forKey: key),
+              let style = SidebarBranchDirectoryStyle(rawValue: raw) else {
+            return defaultStyle
+        }
+        return style
+    }
+}
+
 enum SidebarWorkspaceDetailSettings {
     static let hideAllDetailsKey = "sidebarHideAllDetails"
     static let showNotificationMessageKey = "sidebarShowNotificationMessage"

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4253,6 +4253,8 @@ struct SettingsView: View {
     @AppStorage(SidebarWorkspaceDetailSettings.showNotificationMessageKey)
     private var sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
+    @AppStorage(SidebarBranchDirectoryStyleSettings.key)
+    private var sidebarBranchDirectoryStyle = SidebarBranchDirectoryStyleSettings.defaultStyle.rawValue
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
     @AppStorage("sidebarSelectionColorHex") private var sidebarSelectionColorHex: String?
@@ -5192,6 +5194,24 @@ struct SettingsView: View {
                                 .controlSize(.small)
                         }
                         .disabled(sidebarHideAllDetails)
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            configurationReview: .json("sidebar.branchDirectoryStyle"),
+                            String(localized: "settings.app.sidebarBranchDirectoryStyle", defaultValue: "Branch Directory Style"),
+                            subtitle: (
+                                SidebarBranchDirectoryStyle(rawValue: sidebarBranchDirectoryStyle)
+                                    ?? SidebarBranchDirectoryStyleSettings.defaultStyle
+                            ).description,
+                            controlWidth: pickerColumnWidth,
+                            selection: $sidebarBranchDirectoryStyle
+                        ) {
+                            ForEach(SidebarBranchDirectoryStyle.allCases) { style in
+                                Text(style.displayName).tag(style.rawValue)
+                            }
+                        }
+                        .disabled(sidebarHideAllDetails || !sidebarShowBranchDirectory)
 
                         SettingsCardDivider()
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6357,6 +6357,7 @@ struct SettingsView: View {
         sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
+        sidebarBranchDirectoryStyle = SidebarBranchDirectoryStyleSettings.defaultStyle.rawValue
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
         sidebarSelectionColorHex = nil
         sidebarNotificationBadgeColorHex = nil

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -39,6 +39,39 @@ final class SidebarPathFormatterTests: XCTestCase {
             "/tmp/cmux"
         )
     }
+
+    func testDisplayPathUsesShortenedPathForFullPathStyle() {
+        XCTAssertEqual(
+            SidebarPathFormatter.displayPath(
+                "/Users/example/projects/cmux",
+                style: .fullPath,
+                homeDirectoryPath: "/Users/example"
+            ),
+            "~/projects/cmux"
+        )
+    }
+
+    func testDisplayPathUsesLastComponentForRepoNameStyle() {
+        XCTAssertEqual(
+            SidebarPathFormatter.displayPath(
+                "/Users/example/projects/cmux",
+                style: .repoName,
+                homeDirectoryPath: "/Users/example"
+            ),
+            "cmux"
+        )
+    }
+
+    func testDisplayPathKeepsRootForRepoNameStyle() {
+        XCTAssertEqual(
+            SidebarPathFormatter.displayPath(
+                "/",
+                style: .repoName,
+                homeDirectoryPath: "/Users/example"
+            ),
+            "/"
+        )
+    }
 }
 
 final class GhosttyConfigTests: XCTestCase {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -72,6 +72,25 @@ final class SidebarPathFormatterTests: XCTestCase {
             "/"
         )
     }
+
+    func testDisplayPathUsesRepositoryRootForRepoNameStyle() throws {
+        let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let repoRoot = tempRoot.appendingPathComponent("cmux")
+        let nestedDirectory = repoRoot.appendingPathComponent("Sources/App")
+
+        try FileManager.default.createDirectory(at: nestedDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: repoRoot.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+        XCTAssertEqual(
+            SidebarPathFormatter.displayPath(
+                nestedDirectory.path,
+                style: .repoName,
+                homeDirectoryPath: "/Users/example"
+            ),
+            "cmux"
+        )
+    }
 }
 
 final class GhosttyConfigTests: XCTestCase {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -833,6 +833,52 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         )
     }
 
+    func testSettingsFileStoreParsesSidebarBranchDirectoryStyle() throws {
+        let defaults = UserDefaults.standard
+        let managedKey = SidebarBranchDirectoryStyleSettings.key
+        let previousValue = defaults.object(forKey: managedKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousValue {
+                defaults.set(previousValue, forKey: managedKey)
+            } else {
+                defaults.removeObject(forKey: managedKey)
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: managedKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "sidebar": {
+                "branchDirectoryStyle": "repoName"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(SidebarBranchDirectoryStyleSettings.current(defaults: defaults), .repoName)
+    }
+
     func testManagedUserDefaultSettingRestoresBackedUpValueWhenFileSettingIsRemoved() throws {
         let defaults = UserDefaults.standard
         let managedKey = WorkspaceAutoReorderSettings.key

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -156,6 +156,12 @@
           "default": "vertical",
           "description": "Show git branch details stacked vertically or inline."
         },
+        "branchDirectoryStyle": {
+          "type": "string",
+          "enum": ["fullPath", "repoName"],
+          "default": "fullPath",
+          "description": "Show the full working-directory path or only the final directory name in the branch + directory row."
+        },
         "showNotificationMessage": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
## Summary

- Add `sidebar.branchDirectoryStyle` with `fullPath` as the default and `repoName` for final-directory display
- Add a Settings > Sidebar picker, settings schema support, default settings output, and localized strings
- Apply the display style to both inline and vertical branch + directory sidebar rows
- Add formatter and settings-file regression coverage

Closes #2796

## Testing

- `git diff --check`
- `jq empty Resources/Localizable.xcstrings web/data/cmux-settings.schema.json`
- Native Swift rebuild and XCTest not run: this container does not have `swift` or `xcodebuild`

## Demo Video

Not recorded in this environment; native macOS app launch is unavailable here.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sidebar setting to choose how the branch directory is shown: full path (default) or repository name (falls back to the final directory if not in a repo). Applies to both inline and vertical rows. Closes #2796.

- **New Features**
  - Added `sidebar.branchDirectoryStyle` with `fullPath` and `repoName`.
  - Settings picker with localized labels/descriptions; disabled when the directory row is hidden.
  - New formatter abbreviates home as "~" and detects git roots to show the repo name.
  - Updated settings parsing, default output, and JSON schema; added tests for path display and settings parsing.

- **Bug Fixes**
  - Aligned the repository-name directory style in the sidebar.

<sup>Written for commit 471e33accd9c37a82ffcd092665bab8051ced550. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Branch Directory Style" setting letting users choose between showing the full working-directory path (with ~ abbreviation) or only the final repository/directory name in sidebar branch rows; settings UI includes a picker and respects related sidebar visibility options.
* **Localization**
  * Added English and Japanese strings for the new setting and its descriptions.
* **Tests**
  * Added unit and integration tests validating display behavior and settings import.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->