### PR TITLE
Fix Cmd+click links not working inside tmux sessions

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -120,7 +120,21 @@ tend to conflict together during rebases.
   - Wires `.apc_start`, `.apc_put`, and `.apc_end` through the shared APC parser in `TerminalStream`.
   - Restores kitty graphics execution and APC OK/error replies for the non-termio stream path used by cmux/libghostty integrations.
 
-Fork main now carries the section 8 APC handling fix plus later upstream merges;
+### 9) Cmd+click links through mouse capture (tmux)
+
+- Commit: `f915b291c` (Allow Cmd+click links when mouse reporting is active)
+- Files:
+  - `src/Surface.zig`
+- Summary:
+  - When a terminal application enables mouse reporting (e.g. tmux with `set -g mouse on`),
+    link hover detection and Cmd+click were completely disabled.
+  - Allows Ctrl/Super (Cmd on macOS) to bypass mouse capture for link detection, the same way
+    Shift already does, at three code paths: key event modifier handling, cursor position callback,
+    and link clearing.
+  - Also sets the `hyperlink_hover` dirty flag when leaving a link so the renderer clears the
+    underline immediately (pre-existing bug).
+
+Fork main now carries patches 1–9 plus later upstream merges;
 the current cmux pin is the head listed above.
 
 ## Upstreamed fork changes
@@ -183,5 +197,11 @@ These files change frequently upstream; be careful when rebasing the fork:
   - Keep the APC handler wired into `.apc_start`, `.apc_put`, `.apc_end`, and preserve the
     `apcEnd()` response path so kitty graphics still reach `Terminal.kittyGraphics()` and reply via
     `write_pty`.
+
+- `src/Surface.zig` (link detection)
+  - The `mouseModsWithCapture`, `linkAtPos`, `mouseRefreshLinks`, and `cursorPosCallback` functions
+    coordinate link detection. The Cmd bypass checks (`ctrlOrSuper()`) sit alongside the existing
+    Shift bypass. If upstream refactors mouse capture or link hover logic, re-check that both
+    Shift and Cmd still bypass mouse capture for link detection.
 
 If you resolve a conflict, update this doc with what changed.


### PR DESCRIPTION
## Summary

- Fix URLs not being clickable (Cmd+click) when running inside a tmux session with mouse mode enabled (`set -g mouse on`)
- Root cause: when tmux enables mouse reporting (`mouse_event != .none`), Ghostty's link hover detection was completely disabled — `over_link` was never set to `true`, so click handling never triggered
- Fix: allow Ctrl/Super (Cmd on macOS) to bypass mouse capture for link detection, the same way Shift already does, at three code paths in `Surface.zig`:
  1. **Key event handler**: pressing Cmd now refreshes link state instead of clearing it
  2. **Cursor position callback**: holding Cmd during mouse movement triggers link hover detection
  3. **Link clearing**: set `hyperlink_hover` dirty flag when leaving a link so the renderer removes the underline immediately (this was a pre-existing bug also visible outside tmux)

Closes #2896

## Linked submodule change

- Ghostty fork branch: [`fix/tmux-link-click`](https://github.com/TomerCohen95/ghostty/tree/fix/tmux-link-click)
- Single file changed: `src/Surface.zig` (+11, -4)

## Testing

- Built tagged debug app: `./scripts/reload.sh --tag local-dev --launch`
- Verified inside tmux with `set -g mouse on`:
  - Cmd+hover over URL → cursor changes to pointer, URL underlines ✓
  - Cmd+click URL → opens in browser ✓
  - Moving mouse away from URL with Cmd held → underline clears ✓
- Verified no regression outside tmux: Cmd+click links still work normally ✓

## Demo Video

N/A — text-only terminal behavior change

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved