### PR TITLE
fix: Find Next / Find Previous search for "next"/"previous" instead of navigating

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1854,7 +1854,7 @@ class TabManager: ObservableObject {
 
     func findNext() {
         if let panel = selectedTerminalPanel {
-            _ = panel.performBindingAction("search:next")
+            _ = panel.performBindingAction("navigate_search:next")
             return
         }
 
@@ -1863,7 +1863,7 @@ class TabManager: ObservableObject {
 
     func findPrevious() {
         if let panel = selectedTerminalPanel {
-            _ = panel.performBindingAction("search:previous")
+            _ = panel.performBindingAction("navigate_search:previous")
             return
         }
 


### PR DESCRIPTION
## Summary
- `TabManager.findNext()` and `findPrevious()` used the `search:` binding action, which starts a new search with the given text as the needle. `search:next` literally searched for the string "next".
- Changed to `navigate_search:next` / `navigate_search:previous`, which correctly navigates to the next/previous match (consistent with `SurfaceSearchOverlay`).

## Test plan
- [ ] Open a terminal, Cmd-F to search, type a query, confirm matches are highlighted
- [ ] Press Cmd-G — should jump to the next match without changing the search query or count
- [ ] Press Cmd-Shift-G — should jump to the previous match

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd-G and Cmd-Shift-G so they navigate to the next/previous match instead of searching for the words "next" or "previous". The search query and results now stay intact while moving between matches.

- **Bug Fixes**
  - Switched from `search:next/previous` to `navigate_search:next/previous` in `TabManager`.
  - Cmd-G moves to the next match; Cmd-Shift-G moves to the previous, without changing the query or counts.
  - Matches the behavior used by `SurfaceSearchOverlay`.

<sup>Written for commit 563fa06f6a67f80e26c21aa4675912b1e4003f8d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard navigation behavior for the find functionality in the terminal pane.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->