### PR TITLE
fix: prefer UTF-8 plain text in pasteboard to avoid Mac OS Roman loss

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -264,7 +264,22 @@ enum GhosttyPasteboardHelper {
     }
 
     private static func plainTextContents(from pasteboard: NSPasteboard) -> String? {
-        for type in pasteboard.types ?? [] {
+        let allTypes = pasteboard.types ?? []
+
+        // Prefer UTF-8 plain text whenever available. Some apps — notably
+        // Qt-based ones like Telegram Desktop — register
+        // `com.apple.traditional-mac-plain-text` (Mac OS Roman, which cannot
+        // represent non-Latin scripts) *before* the UTF-8 variants. Iterating
+        // `pasteboard.types` in order then returns a lossy value where every
+        // non-Latin character becomes "?". Fixes #2818.
+        for preferred in [utf8PlainTextType, NSPasteboard.PasteboardType.string] {
+            guard allTypes.contains(preferred) else { continue }
+            guard let value = pasteboard.string(forType: preferred), !value.isEmpty else { continue }
+            return value
+        }
+
+        for type in allTypes {
+            if type == utf8PlainTextType || type == .string { continue }
             guard isPlainTextType(type) else { continue }
             guard let value = pasteboard.string(forType: type), !value.isEmpty else { continue }
             return value

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -49,6 +49,49 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         )
     }
 
+    /// Regression test for https://github.com/manaflow-ai/cmux/issues/2818 —
+    /// Qt-based apps (Telegram Desktop, etc.) register the legacy
+    /// `com.apple.traditional-mac-plain-text` type (Mac OS Roman encoding,
+    /// no CJK/Cyrillic/Arabic support) *before* UTF-8. Iterating the
+    /// pasteboard types in order used to return the lossy legacy value,
+    /// mangling every non-Latin character into "?". The helper must
+    /// prefer UTF-8 whenever it is also present on the pasteboard.
+    func testPrefersUTF8PlainTextOverLegacyMacRomanType() {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-utf8-priority-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+
+        let koreanText = "삼성전자 거래량 미충족"
+        let legacyType = NSPasteboard.PasteboardType("com.apple.traditional-mac-plain-text")
+        let utf8Type = NSPasteboard.PasteboardType("public.utf8-plain-text")
+
+        // Order matters: declare legacy FIRST to mirror Qt's behaviour.
+        pasteboard.declareTypes([legacyType, utf8Type], owner: nil)
+        pasteboard.setString("?? ??? ???", forType: legacyType)
+        pasteboard.setString(koreanText, forType: utf8Type)
+
+        XCTAssertEqual(
+            cmuxPasteboardStringContentsForTesting(pasteboard),
+            koreanText
+        )
+    }
+
+    /// Fallback-loop coverage: when *only* a legacy / unknown plain-text
+    /// type is present and no UTF-8 variant exists, the helper should still
+    /// return whatever string the pasteboard does expose (best-effort).
+    func testFallsBackWhenOnlyNonPreferredPlainTextTypePresent() {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-only-legacy-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+
+        let legacyType = NSPasteboard.PasteboardType("com.apple.traditional-mac-plain-text")
+        pasteboard.declareTypes([legacyType], owner: nil)
+        pasteboard.setString("plain ascii", forType: legacyType)
+
+        XCTAssertEqual(
+            cmuxPasteboardStringContentsForTesting(pasteboard),
+            "plain ascii"
+        )
+    }
+
     func testEmptyPlainTextFallsBackToRichTextPayload() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-empty-plain-rich-fallback-\(UUID().uuidString)"))
         pasteboard.clearContents()


### PR DESCRIPTION
## Summary

Fixes #2818 — Cmd+V replaces non-Latin characters (Korean, Chinese, Japanese, Cyrillic, Arabic, …) with `?` when pasting from Qt-based apps such as Telegram Desktop.

## Root Cause

`GhosttyPasteboardHelper.plainTextContents(from:)` iterated `pasteboard.types` in declaration order and returned the first value that satisfied `isPlainTextType(_:)`.

Qt on macOS registers pasteboard types in this order:

1. `com.apple.traditional-mac-plain-text` ← **Mac OS Roman encoding** (no support for non-Latin scripts)
2. `public.utf8-plain-text`
3. `public.utf16-external-plain-text`

The helper therefore read the Mac OS Roman value, converting every non-Latin character to `?`.

## Fix

Explicitly probe `public.utf8-plain-text` and `.string` (UTF-8 on modern macOS) **first** before falling back to the general loop. The fallback loop is preserved so apps that publish only a non-preferred plain-text UTType (e.g. `public.plain-text`, `NSFilenamesPboardType`) keep working — the existing `testAlternatePlainTextUTIExtractsPlainText` case still passes.

```swift
private static func plainTextContents(from pasteboard: NSPasteboard) -> String? {
    let allTypes = pasteboard.types ?? []

    for preferred in [utf8PlainTextType, NSPasteboard.PasteboardType.string] {
        guard allTypes.contains(preferred) else { continue }
        guard let value = pasteboard.string(forType: preferred), !value.isEmpty else { continue }
        return value
    }

    for type in allTypes {
        if type == utf8PlainTextType || type == .string { continue }
        guard isPlainTextType(type) else { continue }
        guard let value = pasteboard.string(forType: type), !value.isEmpty else { continue }
        return value
    }

    return nil
}
```

## Tests

Two new regression cases in `GhosttyPasteboardHelperTests`:

- **`testPrefersUTF8PlainTextOverLegacyMacRomanType`** — builds a pasteboard that declares `com.apple.traditional-mac-plain-text` **before** `public.utf8-plain-text` (mirroring Qt), writes a mangled ASCII value to the legacy slot and the correct Korean string `삼성전자 거래량 미충족` to the UTF-8 slot, and asserts `cmuxPasteboardStringContentsForTesting` returns the Korean original.
- **`testFallsBackWhenOnlyNonPreferredPlainTextTypePresent`** — declares only the legacy Mac OS Roman type and asserts the helper still returns the string (fallback-loop coverage, no regression for legacy-only pasteboards).

All existing tests in the file are unchanged.

## Out of scope

This PR only fixes the read path. The write path (`writeString`) already uses `.string`, which is UTF-8 on modern macOS, so no change is needed there. The Ghostty submodule is not touched.

## Test plan

- [ ] CI passes (new regression tests + existing suite)
- [ ] Manually verify: copy Korean text from Telegram Desktop → paste into a cmux pane → characters arrive intact
- [ ] Manually verify: copy from Safari / VS Code / Notes (non-Qt apps) → paste still works (they don't publish the legacy type, fallback path unchanged)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefer UTF‑8 plain text from the macOS pasteboard to avoid Mac OS Roman corruption when pasting from Qt-based apps (e.g., Telegram Desktop). Non‑Latin characters now paste correctly. Fixes #2818.

- **Bug Fixes**
  - Update `GhosttyPasteboardHelper.plainTextContents(from:)` to read `public.utf8-plain-text` and `.string` first, then fall back to other plain-text types.
  - Keep fallback so legacy-only types still work.
  - Add regression tests for preferring UTF‑8 over `com.apple.traditional-mac-plain-text` and for legacy-only fallback.

<sup>Written for commit 4d49a7bae5781271a33b4d5e4849c9c4e07b6909. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced text paste functionality to correctly prioritize UTF-8 plain text formats, improving how text is handled when multiple text types are available on the clipboard.

* **Tests**
  * Added regression tests for clipboard plain-text format selection, including coverage for scenarios with both modern UTF-8 and legacy text format types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->