### PR TITLE
Fix flaky FileExplorerStoreTests (macOS Compatibility)

### DIFF
--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -43,7 +43,31 @@ private final class MockFileExplorerProvider: FileExplorerProvider {
 
 // MARK: - Store Tests
 
+/// The store's `@Published` state is driven by unstructured `Task { ... }` calls that
+/// hop to `@MainActor`. Pinning the test class to `@MainActor` keeps observations on
+/// the same actor as the mutations, so reads see a consistent snapshot.
+@MainActor
 final class FileExplorerStoreTests: XCTestCase {
+
+    /// Poll on the main actor until `condition` holds or `timeout` elapses.
+    /// Replaces fixed `Task.sleep` delays that were flaky on slow CI runners
+    /// (warp-macos-15) where the spawned load Task hadn't run inside 100ms.
+    private func waitFor(
+        _ description: String,
+        timeout: TimeInterval = 5.0,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: () -> Bool
+    ) async {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !condition() {
+            if Date() >= deadline {
+                XCTFail("Timed out waiting for: \(description)", file: file, line: line)
+                return
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+    }
 
     // MARK: - Basic loading
 
@@ -58,10 +82,8 @@ final class FileExplorerStoreTests: XCTestCase {
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
 
-        // Wait for async load
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("root nodes loaded") { store.rootNodes.count == 2 }
 
-        XCTAssertEqual(store.rootNodes.count, 2)
         // Directories should sort before files
         XCTAssertEqual(store.rootNodes[0].name, "src")
         XCTAssertTrue(store.rootNodes[0].isDirectory)
@@ -91,12 +113,11 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider1)
         store.setRootPath("/home/user/project")
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 
-        // Expand src/
         let srcNode = store.rootNodes.first { $0.name == "src" }!
         store.expand(node: srcNode)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("src expanded") { srcNode.children?.count == 1 }
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/src"))
 
@@ -110,28 +131,26 @@ final class FileExplorerStoreTests: XCTestCase {
             FileExplorerEntry(name: "lib.swift", path: "/home/user/project/src/lib.swift", isDirectory: false),
         ])
         store.setProvider(provider2)
-        try await Task.sleep(nanoseconds: 200_000_000)
 
-        // Expanded paths should still be tracked
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/src"))
 
-        // The src node should have been auto-expanded with the new provider's data
+        await waitFor("src re-hydrated with 2 children") {
+            (store.rootNodes.first { $0.name == "src" }?.children?.count ?? 0) == 2
+        }
         let newSrcNode = store.rootNodes.first { $0.name == "src" }
         XCTAssertNotNil(newSrcNode)
-        XCTAssertNotNil(newSrcNode?.children)
         XCTAssertEqual(newSrcNode?.children?.count, 2)
     }
 
     // MARK: - SSH hydration
 
     func testExpandedRemoteNodesHydrateWhenProviderBecomesAvailable() async throws {
-        // Start with unavailable provider
         let provider = MockFileExplorerProvider(isAvailable: false)
 
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("initial root load finished") { store.isRootLoading == false }
 
         // Root load fails because provider unavailable
         XCTAssertTrue(store.rootNodes.isEmpty)
@@ -150,20 +169,16 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         store.hydrateExpandedNodes()
-        try await Task.sleep(nanoseconds: 200_000_000)
 
-        // Root should now be loaded
-        XCTAssertFalse(store.rootNodes.isEmpty)
+        await waitFor("src hydrated") {
+            (store.rootNodes.first { $0.name == "src" }?.children?.count ?? 0) == 1
+        }
         let srcNode = store.rootNodes.first { $0.name == "src" }
         XCTAssertNotNil(srcNode)
-        // Since src was in expandedPaths, it should have been auto-expanded
-        XCTAssertNotNil(srcNode?.children)
-        XCTAssertEqual(srcNode?.children?.count, 1)
         XCTAssertEqual(srcNode?.children?.first?.name, "app.swift")
     }
 
     func testExpandedNodesSurviveStoreRecreation() async throws {
-        // Simulate: user expands nodes, then store/provider is recreated (e.g., workspace reconnect)
         let provider = MockFileExplorerProvider()
         provider.listings["/home/user/project"] = .success([
             FileExplorerEntry(name: "lib", path: "/home/user/project/lib", isDirectory: true),
@@ -175,15 +190,15 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "lib" } }
 
         let libNode = store.rootNodes.first { $0.name == "lib" }!
         store.expand(node: libNode)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("lib expanded") { libNode.children?.count == 1 }
 
         XCTAssertTrue(store.isExpanded(libNode))
 
-        // Simulate provider recreation: clear children, reload with new provider
+        // Simulate provider recreation
         let newProvider = MockFileExplorerProvider()
         newProvider.listings["/home/user/project"] = .success([
             FileExplorerEntry(name: "lib", path: "/home/user/project/lib", isDirectory: true),
@@ -194,14 +209,11 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         store.setProvider(newProvider)
-        try await Task.sleep(nanoseconds: 200_000_000)
 
-        // Expanded path should survive
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/lib"))
-        let newLibNode = store.rootNodes.first { $0.name == "lib" }
-        XCTAssertNotNil(newLibNode?.children)
-        // Should have the new provider's data
-        XCTAssertEqual(newLibNode?.children?.count, 2)
+        await waitFor("lib re-hydrated with 2 children") {
+            (store.rootNodes.first { $0.name == "lib" }?.children?.count ?? 0) == 2
+        }
     }
 
     // MARK: - Error clearing
@@ -211,7 +223,6 @@ final class FileExplorerStoreTests: XCTestCase {
         provider.listings["/home/user/project"] = .success([
             FileExplorerEntry(name: "src", path: "/home/user/project/src", isDirectory: true),
         ])
-        // src listing fails
         provider.listings["/home/user/project/src"] = .failure(
             FileExplorerError.sshCommandFailed("connection reset")
         )
@@ -219,24 +230,21 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 
         let srcNode = store.rootNodes.first { $0.name == "src" }!
         store.expand(node: srcNode)
-        try await Task.sleep(nanoseconds: 100_000_000)
-
-        XCTAssertNotNil(srcNode.error)
+        await waitFor("src error surfaced") { srcNode.error != nil }
 
         // Fix the listing and retry
         provider.listings["/home/user/project/src"] = .success([
             FileExplorerEntry(name: "main.swift", path: "/home/user/project/src/main.swift", isDirectory: false),
         ])
-        // Collapse then re-expand to trigger retry
         store.collapse(node: srcNode)
+        srcNode.children = nil
         store.expand(node: srcNode)
-        try await Task.sleep(nanoseconds: 100_000_000)
+        await waitFor("src retry loaded") { srcNode.children?.count == 1 }
 
-        // Error should be cleared
         XCTAssertNil(srcNode.error)
         XCTAssertNotNil(srcNode.children)
     }

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -49,21 +49,27 @@ private final class MockFileExplorerProvider: FileExplorerProvider {
 @MainActor
 final class FileExplorerStoreTests: XCTestCase {
 
+    struct WaitTimeout: Error, CustomStringConvertible {
+        let description: String
+    }
+
     /// Poll on the main actor until `condition` holds or `timeout` elapses.
     /// Replaces fixed `Task.sleep` delays that were flaky on slow CI runners
     /// (warp-macos-15) where the spawned load Task hadn't run inside 100ms.
+    /// Throws on timeout so the test function aborts instead of falling through
+    /// to force-unwraps that would crash the runner.
     private func waitFor(
         _ description: String,
         timeout: TimeInterval = 5.0,
         file: StaticString = #filePath,
         line: UInt = #line,
         _ condition: () -> Bool
-    ) async {
+    ) async throws {
         let deadline = Date().addingTimeInterval(timeout)
         while !condition() {
             if Date() >= deadline {
                 XCTFail("Timed out waiting for: \(description)", file: file, line: line)
-                return
+                throw WaitTimeout(description: description)
             }
             try? await Task.sleep(nanoseconds: 10_000_000)
         }
@@ -82,7 +88,7 @@ final class FileExplorerStoreTests: XCTestCase {
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
 
-        await waitFor("root nodes loaded") { store.rootNodes.count == 2 }
+        try await waitFor("root nodes loaded") { store.rootNodes.count == 2 }
 
         // Directories should sort before files
         XCTAssertEqual(store.rootNodes[0].name, "src")
@@ -113,11 +119,11 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider1)
         store.setRootPath("/home/user/project")
-        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
+        try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 
         let srcNode = store.rootNodes.first { $0.name == "src" }!
         store.expand(node: srcNode)
-        await waitFor("src expanded") { srcNode.children?.count == 1 }
+        try await waitFor("src expanded") { srcNode.children?.count == 1 }
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/src"))
 
@@ -134,7 +140,7 @@ final class FileExplorerStoreTests: XCTestCase {
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/src"))
 
-        await waitFor("src re-hydrated with 2 children") {
+        try await waitFor("src re-hydrated with 2 children") {
             (store.rootNodes.first { $0.name == "src" }?.children?.count ?? 0) == 2
         }
         let newSrcNode = store.rootNodes.first { $0.name == "src" }
@@ -150,7 +156,12 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        await waitFor("initial root load finished") { store.isRootLoading == false }
+        // Wait for the initial load attempt to actually reach the provider,
+        // not just for `isRootLoading` to drop (which may already be false
+        // before the unstructured Task runs).
+        try await waitFor("initial root load attempt finished") {
+            provider.listCallPaths.contains("/home/user/project") && store.isRootLoading == false
+        }
 
         // Root load fails because provider unavailable
         XCTAssertTrue(store.rootNodes.isEmpty)
@@ -170,7 +181,7 @@ final class FileExplorerStoreTests: XCTestCase {
 
         store.hydrateExpandedNodes()
 
-        await waitFor("src hydrated") {
+        try await waitFor("src hydrated") {
             (store.rootNodes.first { $0.name == "src" }?.children?.count ?? 0) == 1
         }
         let srcNode = store.rootNodes.first { $0.name == "src" }
@@ -190,11 +201,11 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "lib" } }
+        try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "lib" } }
 
         let libNode = store.rootNodes.first { $0.name == "lib" }!
         store.expand(node: libNode)
-        await waitFor("lib expanded") { libNode.children?.count == 1 }
+        try await waitFor("lib expanded") { libNode.children?.count == 1 }
 
         XCTAssertTrue(store.isExpanded(libNode))
 
@@ -211,7 +222,7 @@ final class FileExplorerStoreTests: XCTestCase {
         store.setProvider(newProvider)
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/lib"))
-        await waitFor("lib re-hydrated with 2 children") {
+        try await waitFor("lib re-hydrated with 2 children") {
             (store.rootNodes.first { $0.name == "lib" }?.children?.count ?? 0) == 2
         }
     }
@@ -230,20 +241,19 @@ final class FileExplorerStoreTests: XCTestCase {
         let store = FileExplorerStore()
         store.setProvider(provider)
         store.setRootPath("/home/user/project")
-        await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
+        try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 
         let srcNode = store.rootNodes.first { $0.name == "src" }!
         store.expand(node: srcNode)
-        await waitFor("src error surfaced") { srcNode.error != nil }
+        try await waitFor("src error surfaced") { srcNode.error != nil }
 
         // Fix the listing and retry
         provider.listings["/home/user/project/src"] = .success([
             FileExplorerEntry(name: "main.swift", path: "/home/user/project/src/main.swift", isDirectory: false),
         ])
         store.collapse(node: srcNode)
-        srcNode.children = nil
         store.expand(node: srcNode)
-        await waitFor("src retry loaded") { srcNode.children?.count == 1 }
+        try await waitFor("src retry loaded") { srcNode.children?.count == 1 }
 
         XCTAssertNil(srcNode.error)
         XCTAssertNotNil(srcNode.children)


### PR DESCRIPTION
## Summary
The `macOS Compatibility` workflow has been flaky on `warp-macos-15-arm64-6x` since PR #1963 was merged (commit 6d7bbd23, author: me). The failure surfaced again on main after PR #2875 and the user flagged it started failing around commit ab46c557 too.

Root cause: `cmuxTests/FileExplorerStoreTests.swift` used fixed `Task.sleep(nanoseconds: 100_000_000)` waits to let the unstructured `Task { ... }` started by `setRootPath`/`expand`/`setProvider` hop to `@MainActor` and mutate `@Published` state. On the slower macOS 15 warp runner, 100ms isn't enough — `rootNodes` is still empty, and `testExpandedNodesSurviveStoreRecreation` line 180 force-unwraps `store.rootNodes.first { \$0.name == \"lib\" }!` and crashes the test runner. macOS 26 always wins the race, so the older runner alone hangs until the 30m job timeout.

Fix: replace every fixed sleep with a polling `waitFor(...)` helper that returns as soon as the observable state (`rootNodes`, `children`, `error`, `isRootLoading`) matches the expected condition, with a 5s safety timeout. Also pin the test class to `@MainActor` so reads and writes of `@Published` state share an actor instead of racing across threads.

## Test plan
- [x] `cmux-unit` scheme builds locally
- [x] All 8 `FileExplorerStoreTests` pass locally in 0.34s total (vs. ~1.2s of sleeps before)
- [ ] `macOS Compatibility` passes on both `warp-macos-26-arm64-6x` and `warp-macos-15-arm64-6x` in CI

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes `FileExplorerStoreTests` by replacing fixed sleeps with a polling `waitFor(...)` that throws on timeout and marking the test class `@MainActor`. This removes race conditions on slower macOS runners and prevents force-unwrap crashes.

- **Bug Fixes**
  - `waitFor(...)` now throws on timeout to stop tests before unsafe fallthroughs.
  - Remote hydration test waits for the provider to be consulted, not just `isRootLoading == false`.
  - Removed redundant `srcNode.children = nil` in the stale error retry path.
  - Tests run reliably on CI and finish faster locally.

<sup>Written for commit 03dc50521e0033b71250e57151c11dca20e542bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved async test reliability by adding main-thread isolation for test execution.
  * Introduced a polling-based wait helper to replace fixed delays, gating assertions on observable state transitions.
  * Strengthened assertions to check state via polling (loading, expansion, remote hydration, retries) instead of timing-based sleeps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->