### PR TITLE
Prune old nightly release assets before publish

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -536,6 +536,18 @@ jobs:
           git tag -f nightly "${{ needs.decide.outputs.head_sha }}"
           git push origin refs/tags/nightly --force
 
+      - name: Prune old nightly release assets
+        if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          python3 ./scripts/prune_nightly_release_assets.py \
+            --repo manaflow-ai/cmux \
+            --release-tag nightly \
+            --keep-builds 100 \
+            --execute
+
       - name: Publish nightly release assets
         if: needs.decide.outputs.should_publish == 'true' && steps.current_head_prebuild.outputs.still_current == 'true' && steps.current_head_postbuild.outputs.still_current == 'true'
         uses: softprops/action-gh-release@a06a81a03ee405af7f2048a818ed3f03bbf83c7b # v2

--- a/scripts/prune_nightly_release_assets.py
+++ b/scripts/prune_nightly_release_assets.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import subprocess
+import sys
+from collections import defaultdict
+from dataclasses import dataclass
+import re
+
+
+IMMUTABLE_ASSET_PATTERNS = [
+    re.compile(r"^cmux-nightly-macos-(?P<build>\d+)\.dmg$"),
+    re.compile(r"^cmux-nightly-universal-macos-(?P<build>\d+)\.dmg$"),
+    re.compile(r"^cmuxd-remote-(?:darwin-arm64|darwin-amd64|linux-arm64|linux-amd64)-(?P<build>\d+)$"),
+    re.compile(r"^cmuxd-remote-checksums-(?P<build>\d+)\.txt$"),
+    re.compile(r"^cmuxd-remote-manifest-(?P<build>\d+)\.json$"),
+]
+
+
+@dataclass(frozen=True)
+class ReleaseAsset:
+    asset_id: int
+    name: str
+    build: int
+
+
+def log(message: str) -> None:
+    print(message, flush=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Prune old immutable assets from the nightly GitHub release."
+    )
+    parser.add_argument("--repo", required=True, help="owner/repo, for example manaflow-ai/cmux")
+    parser.add_argument("--release-tag", default="nightly", help="GitHub release tag to prune")
+    parser.add_argument(
+        "--keep-builds",
+        type=int,
+        default=100,
+        help="Number of newest immutable nightly builds to keep",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Delete assets instead of printing a dry-run plan",
+    )
+    return parser.parse_args()
+
+
+def gh_json(*args: str) -> dict:
+    proc = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        stderr = (proc.stderr or proc.stdout).strip()
+        raise subprocess.CalledProcessError(proc.returncode, proc.args, output=proc.stdout, stderr=stderr)
+    return json.loads(proc.stdout)
+
+
+def load_release(repo: str, release_tag: str) -> dict | None:
+    try:
+        return gh_json("api", f"repos/{repo}/releases/tags/{release_tag}")
+    except subprocess.CalledProcessError as exc:
+        message = (exc.stderr or exc.output or "").lower()
+        if "404" in message or "not found" in message:
+            return None
+        raise
+
+
+def extract_build(name: str) -> int | None:
+    for pattern in IMMUTABLE_ASSET_PATTERNS:
+        match = pattern.match(name)
+        if match:
+            return int(match.group("build"))
+    return None
+
+
+def collect_immutable_assets(release: dict) -> tuple[list[ReleaseAsset], int]:
+    immutable_assets: list[ReleaseAsset] = []
+    ignored_assets = 0
+    for asset in release.get("assets", []):
+        build = extract_build(asset["name"])
+        if build is None:
+            ignored_assets += 1
+            continue
+        immutable_assets.append(
+            ReleaseAsset(
+                asset_id=asset["id"],
+                name=asset["name"],
+                build=build,
+            )
+        )
+    return immutable_assets, ignored_assets
+
+
+def partition_assets(assets: list[ReleaseAsset], keep_builds: int) -> tuple[list[ReleaseAsset], list[int]]:
+    assets_by_build: dict[int, list[ReleaseAsset]] = defaultdict(list)
+    for asset in assets:
+        assets_by_build[asset.build].append(asset)
+
+    ordered_builds = sorted(assets_by_build, reverse=True)
+    builds_to_keep = set(ordered_builds[:keep_builds])
+
+    to_delete: list[ReleaseAsset] = []
+    for build in ordered_builds[keep_builds:]:
+        to_delete.extend(sorted(assets_by_build[build], key=lambda asset: asset.name))
+
+    return to_delete, ordered_builds
+
+
+def delete_assets(repo: str, assets: list[ReleaseAsset]) -> None:
+    total = len(assets)
+    for index, asset in enumerate(assets, start=1):
+        log(f"[{index}/{total}] deleting {asset.name}")
+        subprocess.run(
+            [
+                "gh",
+                "api",
+                "-X",
+                "DELETE",
+                f"repos/{repo}/releases/assets/{asset.asset_id}",
+            ],
+            check=True,
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    if args.keep_builds < 1:
+        print("--keep-builds must be at least 1", file=sys.stderr)
+        return 2
+
+    release = load_release(args.repo, args.release_tag)
+    if release is None:
+        log(f"Release {args.release_tag!r} does not exist yet, nothing to prune.")
+        return 0
+
+    immutable_assets, ignored_assets = collect_immutable_assets(release)
+    to_delete, ordered_builds = partition_assets(immutable_assets, args.keep_builds)
+
+    total_assets = len(release.get("assets", []))
+    kept_builds = min(args.keep_builds, len(ordered_builds))
+    log(
+        f"Release {args.release_tag!r} has {total_assets} assets total, "
+        f"{len(immutable_assets)} immutable assets across {len(ordered_builds)} builds, "
+        f"and {ignored_assets} non-immutable alias assets."
+    )
+    log(
+        f"Keeping the newest {kept_builds} builds and "
+        f"{len(immutable_assets) - len(to_delete)} immutable assets."
+    )
+
+    if not to_delete:
+        log("Nothing to prune.")
+        return 0
+
+    oldest_deleted = min(asset.build for asset in to_delete)
+    newest_deleted = max(asset.build for asset in to_delete)
+    log(
+        f"{'Deleting' if args.execute else 'Would delete'} {len(to_delete)} immutable assets "
+        f"from builds {oldest_deleted} through {newest_deleted}."
+    )
+
+    preview = to_delete[:20]
+    for asset in preview:
+        log(f"  {asset.name}")
+    if len(to_delete) > len(preview):
+        log(f"  ... and {len(to_delete) - len(preview)} more")
+
+    if not args.execute:
+        log("Dry run only. Re-run with --execute to delete assets.")
+        return 0
+
+    delete_assets(args.repo, to_delete)
+    log("Prune complete.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a nightly-release pruning script that deletes old immutable nightly assets from the GitHub release
- run that prune step before uploading new nightly artifacts so the release stays below GitHub's 1000-asset cap
- manually prune the existing nightly release back under the cap and rerun the failed main nightly job

## Testing
- python3 -m py_compile scripts/prune_nightly_release_assets.py
- python3 scripts/prune_nightly_release_assets.py --repo manaflow-ai/cmux --release-tag nightly --keep-builds 100
- python3 scripts/prune_nightly_release_assets.py --repo manaflow-ai/cmux --release-tag nightly --keep-builds 100 --execute
- gh run rerun 24383368971 --repo manaflow-ai/cmux --failed

## Issues
- Related: nightly release asset cap failure on main after https://github.com/manaflow-ai/cmux/pull/2876 merged

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prune old nightly release assets before publishing to keep the nightly release under GitHub’s 1000-asset limit. Adds a Python script and wires it into the nightly workflow to keep only the newest 100 builds.

- **Bug Fixes**
  - New script `scripts/prune_nightly_release_assets.py` removes immutable assets matching nightly build patterns; dry-run by default, `--execute` to delete.
  - Keeps the newest 100 builds (configurable via `--keep-builds`) and ignores alias assets.
  - Runs in the nightly job only when publishing and the head is current, using `GH_TOKEN` with `gh api`.

<sup>Written for commit ab62846e992d8698c596597dd8fc5ef626d4255c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Automated cleanup workflow for nightly releases now removes older artifacts, retaining only the most recent 100 builds to optimize storage and prevent clutter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->