### PR TITLE
Persist app icon mode on the app bundle

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2628,7 +2628,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         NSWindow.allowsAutomaticWindowTabbing = false
         disableNativeTabbingShortcut()
-        ensureApplicationIcon()
+        if !isRunningUnderXCTest {
+            ensureApplicationIcon()
+        }
         if !isRunningUnderXCTest {
             configureUserNotifications()
             installMenuBarVisibilityObserver()

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -12,10 +12,10 @@ private enum DockTileAppIconMode: String {
         self = Self(rawValue: defaultsValue ?? "") ?? .automatic
     }
 
-    var imageName: NSImage.Name? {
+    func imageName(isDarkAppearance: Bool) -> NSImage.Name? {
         switch self {
         case .automatic:
-            return nil
+            return isDarkAppearance ? NSImage.Name("AppIconDark") : NSImage.Name("AppIconLight")
         case .light:
             return NSImage.Name("AppIconLight")
         case .dark:
@@ -29,11 +29,13 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     // Keep the state minimal and derive everything from the enclosing app bundle.
     private let pluginBundle = Bundle(for: CmuxDockTilePlugin.self)
     private var iconChangeObserver: NSObjectProtocol?
+    private var appearanceObservation: NSKeyValueObservation?
 
     deinit {
         if let iconChangeObserver {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
         }
+        appearanceObservation?.invalidate()
     }
 
     func setDockTile(_ dockTile: NSDockTile?) {
@@ -41,6 +43,8 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
             self.iconChangeObserver = nil
         }
+        appearanceObservation?.invalidate()
+        appearanceObservation = nil
 
         guard let dockTile else { return }
         updateDockTile(dockTile)
@@ -52,6 +56,13 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         ) { [weak self] _ in
             guard let self else { return }
             self.updateDockTile(dockTile)
+        }
+
+        appearanceObservation = NSApp.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
+            DispatchQueue.main.async {
+                guard let self, self.appearanceObservation != nil else { return }
+                self.updateDockTile(dockTile)
+            }
         }
     }
 
@@ -71,12 +82,13 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
     private func updateDockTile(_ dockTile: NSDockTile) {
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
+        let isDarkAppearance = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
             dockTile.showDefaultAppIcon()
             return
         }
 
-        guard let imageName = mode.imageName,
+        guard let imageName = mode.imageName(isDarkAppearance: isDarkAppearance),
               let icon = appBundle?.image(forResource: imageName) else {
             NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
             NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -71,12 +71,21 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
     private func updateDockTile(_ dockTile: NSDockTile) {
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
-        guard let imageName = mode.imageName,
-              let icon = appBundle?.image(forResource: imageName) else {
+        guard let appBundleURL else {
             dockTile.showDefaultAppIcon()
             return
         }
 
+        guard let imageName = mode.imageName,
+              let icon = appBundle?.image(forResource: imageName) else {
+            NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
+            NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+            dockTile.showDefaultAppIcon()
+            return
+        }
+
+        NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
+        NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
         dockTile.showIcon(icon)
     }
 

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CoreServices
 
 private let cmuxAppIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
 private let cmuxAppIconModeKey = "appIconMode"
@@ -58,10 +59,12 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
             self.updateDockTile(dockTile)
         }
 
-        appearanceObservation = NSApp.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
-            DispatchQueue.main.async {
-                guard let self, self.appearanceObservation != nil else { return }
-                self.updateDockTile(dockTile)
+        if let app = NSApp {
+            appearanceObservation = app.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
+                DispatchQueue.main.async {
+                    guard let self, self.appearanceObservation != nil else { return }
+                    self.updateDockTile(dockTile)
+                }
             }
         }
     }
@@ -82,7 +85,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
     private func updateDockTile(_ dockTile: NSDockTile) {
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
-        let isDarkAppearance = NSApp.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
             dockTile.showDefaultAppIcon()
             return
@@ -92,12 +95,14 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
               let icon = appBundle?.image(forResource: imageName) else {
             NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
             NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+            _ = LSRegisterURL(appBundleURL as CFURL, true)
             dockTile.showDefaultAppIcon()
             return
         }
 
         NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
         NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+        _ = LSRegisterURL(appBundleURL as CFURL, true)
         dockTile.showIcon(icon)
     }
 

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -78,6 +78,13 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         return Bundle(url: appBundleURL)
     }
 
+    private var shouldPersistBundleIcon: Bool {
+        guard let appBundleURL else { return false }
+        // The default untagged Debug app is rebuilt and re-signed in place during CI.
+        // Persisting a custom icon there leaves Finder metadata behind and breaks codesign.
+        return appBundleURL.lastPathComponent != "cmux DEV.app"
+    }
+
     private var appDefaults: UserDefaults? {
         guard let bundleIdentifier = appBundle?.bundleIdentifier else { return nil }
         return UserDefaults(suiteName: bundleIdentifier)
@@ -93,16 +100,20 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
         guard let imageName = mode.imageName(isDarkAppearance: isDarkAppearance),
               let icon = appBundle?.image(forResource: imageName) else {
-            NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
-            NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
-            _ = LSRegisterURL(appBundleURL as CFURL, true)
+            if shouldPersistBundleIcon {
+                NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
+                NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+                _ = LSRegisterURL(appBundleURL as CFURL, true)
+            }
             dockTile.showDefaultAppIcon()
             return
         }
 
-        NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
-        NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
-        _ = LSRegisterURL(appBundleURL as CFURL, true)
+        if shouldPersistBundleIcon {
+            NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
+            NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+            _ = LSRegisterURL(appBundleURL as CFURL, true)
+        }
         dockTile.showIcon(icon)
     }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3787,6 +3787,8 @@ enum AppIconSettings {
     struct Environment {
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
+        let setBundleIcon: (NSImage?) -> Bool
+        let notifyBundleIconSystem: () -> Void
         let startAppearanceObservation: () -> Void
         let stopAppearanceObservation: () -> Void
         let notifyDockTilePlugin: () -> Void
@@ -3799,6 +3801,17 @@ enum AppIconSettings {
                 },
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
+                },
+                setBundleIcon: { icon in
+                    NSWorkspace.shared.setIcon(icon, forFile: Bundle.main.bundlePath, options: [])
+                },
+                notifyBundleIconSystem: {
+                    let bundlePath = Bundle.main.bundlePath
+                    NSWorkspace.shared.noteFileSystemChanged(bundlePath)
+                    let bundleURL = Bundle.main.bundleURL.standardizedFileURL
+                    DispatchQueue.global(qos: .utility).async {
+                        _ = LSRegisterURL(bundleURL as CFURL, true)
+                    }
                 },
                 startAppearanceObservation: {
                     AppIconAppearanceObserver.shared.startObserving()
@@ -3829,15 +3842,24 @@ enum AppIconSettings {
     static func applyIcon(_ mode: AppIconMode, environment: Environment = .live()) {
         switch mode {
         case .automatic:
+            if environment.setBundleIcon(nil) {
+                environment.notifyBundleIconSystem()
+            }
             environment.startAppearanceObservation()
         case .light:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.light) else { return }
             environment.setApplicationIconImage(icon)
+            if environment.setBundleIcon(icon) {
+                environment.notifyBundleIconSystem()
+            }
         case .dark:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.dark) else { return }
             environment.setApplicationIconImage(icon)
+            if environment.setBundleIcon(icon) {
+                environment.notifyBundleIconSystem()
+            }
         }
 
         environment.notifyDockTilePlugin()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3784,6 +3784,17 @@ enum AppIconSettings {
     static let defaultMode: AppIconMode = .automatic
     private static let dockTileIconDidChangeNotification = Notification.Name("com.cmuxterm.appIconDidChange")
 
+    private static func isRunningUnderXCTest(_ env: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        if env["XCTestConfigurationFilePath"] != nil { return true }
+        if env["XCTestBundlePath"] != nil { return true }
+        if env["XCTestSessionIdentifier"] != nil { return true }
+        if env["XCInjectBundle"] != nil { return true }
+        if env["XCInjectBundleInto"] != nil { return true }
+        if env["DYLD_INSERT_LIBRARIES"]?.contains("libXCTest") == true { return true }
+        if env.keys.contains(where: { $0.hasPrefix("CMUX_UI_TEST_") }) { return true }
+        return false
+    }
+
     struct Environment {
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
@@ -3807,6 +3818,7 @@ enum AppIconSettings {
                     AppIconAppearanceObserver.shared.stopObserving()
                 },
                 notifyDockTilePlugin: {
+                    guard !AppIconSettings.isRunningUnderXCTest() else { return }
                     DistributedNotificationCenter.default().postNotificationName(
                         AppIconSettings.dockTileIconDidChangeNotification,
                         object: nil,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -3787,8 +3787,6 @@ enum AppIconSettings {
     struct Environment {
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
-        let setBundleIcon: (NSImage?) -> Bool
-        let notifyBundleIconSystem: () -> Void
         let startAppearanceObservation: () -> Void
         let stopAppearanceObservation: () -> Void
         let notifyDockTilePlugin: () -> Void
@@ -3801,17 +3799,6 @@ enum AppIconSettings {
                 },
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
-                },
-                setBundleIcon: { icon in
-                    NSWorkspace.shared.setIcon(icon, forFile: Bundle.main.bundlePath, options: [])
-                },
-                notifyBundleIconSystem: {
-                    let bundlePath = Bundle.main.bundlePath
-                    NSWorkspace.shared.noteFileSystemChanged(bundlePath)
-                    let bundleURL = Bundle.main.bundleURL.standardizedFileURL
-                    DispatchQueue.global(qos: .utility).async {
-                        _ = LSRegisterURL(bundleURL as CFURL, true)
-                    }
                 },
                 startAppearanceObservation: {
                     AppIconAppearanceObserver.shared.startObserving()
@@ -3842,24 +3829,15 @@ enum AppIconSettings {
     static func applyIcon(_ mode: AppIconMode, environment: Environment = .live()) {
         switch mode {
         case .automatic:
-            if environment.setBundleIcon(nil) {
-                environment.notifyBundleIconSystem()
-            }
             environment.startAppearanceObservation()
         case .light:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.light) else { return }
             environment.setApplicationIconImage(icon)
-            if environment.setBundleIcon(icon) {
-                environment.notifyBundleIconSystem()
-            }
         case .dark:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.dark) else { return }
             environment.setApplicationIconImage(icon)
-            if environment.setBundleIcon(icon) {
-                environment.notifyBundleIconSystem()
-            }
         }
 
         environment.notifyDockTilePlugin()

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -30,6 +30,8 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
+            setBundleIcon: { _ in true },
+            notifyBundleIconSystem: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
@@ -62,6 +64,8 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 XCTFail("Automatic mode should delegate live updates to the appearance observer")
             },
+            setBundleIcon: { _ in true },
+            notifyBundleIconSystem: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -30,8 +30,6 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
-            setBundleIcon: { _ in true },
-            notifyBundleIconSystem: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
@@ -64,8 +62,6 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { _ in
                 XCTFail("Automatic mode should delegate live updates to the appearance observer")
             },
-            setBundleIcon: { _ in true },
-            notifyBundleIconSystem: {},
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },


### PR DESCRIPTION
## Summary
- keep runtime icon swaps in the app process for immediate feedback while the app is running
- move persistent light and dark icon writes into `CmuxDockTilePlugin`, which is the Dock-side source of truth
- clear the custom bundle icon from the plugin when returning to Automatic so stale overrides do not survive

## Verification
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-fix-app-icon-persistence`
- `killall Dock` once to make Dock load the updated plugin binary
- `defaults write com.cmuxterm.app.debug.task.fix.app.icon.persistence appIconMode -string dark`
- launch tagged app, verify the built `.app` gains `Icon`
- `defaults write com.cmuxterm.app.debug.task.fix.app.icon.persistence appIconMode -string automatic`
- relaunch tagged app, verify the built `.app` no longer has `Icon`

## Notes
- The previous app-process `NSWorkspace.setIcon` path was removed. The plugin now owns persistence because Dock icon state after force-kill is resolved from the Dock side, not the app process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dock icon now respects light/dark appearance and updates automatically when appearance changes.
  * Properly observes and stops observing appearance changes to ensure timely updates and cleanup.
  * More reliable fallback to the default Dock icon when app resources are missing or cannot be loaded.
  * Finder/application icon handling and system registration improved so icon changes are reflected promptly.
  * Suppress dock-tile updates and skip icon initialization during XCTest runs to avoid test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->