### PR TITLE
Fix PortScanner subprocess pipe fd leak

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -104,6 +104,7 @@
 					F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */; };
 					F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */; };
+					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */; };
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 					FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */; };
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
@@ -302,6 +303,7 @@
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UpdatePillReleaseVisibilityTests.swift; sourceTree = "<group>"; };
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
+				F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerTests.swift; sourceTree = "<group>"; };
 				F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserImportMappingTests.swift; sourceTree = "<group>"; };
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
@@ -585,6 +587,7 @@
 					F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 					F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 					F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
+					F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
 					F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
@@ -885,6 +888,7 @@
 					F2000000A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift in Sources */,
 					F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */,
 					F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,
+					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */,
 					F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -448,6 +448,46 @@ final class PortScanner: @unchecked Sendable {
 
     // MARK: - Process helpers
 
+    static func captureStandardOutput(
+        executablePath: String,
+        arguments: [String]
+    ) -> String? {
+        autoreleasepool {
+            let process = Process()
+            let stdoutPipe = Pipe()
+            let stdoutReadHandle = stdoutPipe.fileHandleForReading
+            let stdoutWriteHandle = stdoutPipe.fileHandleForWriting
+
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = stdoutPipe
+            process.standardError = FileHandle.nullDevice
+
+            defer {
+                try? stdoutReadHandle.close()
+                try? stdoutWriteHandle.close()
+            }
+
+            do {
+                try process.run()
+            } catch {
+                return nil
+            }
+
+            // Force prompt fd teardown on this long-lived utility queue instead of
+            // waiting for ARC/autorelease to eventually release the pipe.
+            try? stdoutWriteHandle.close()
+            let data = stdoutReadHandle.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            guard let output = String(data: data, encoding: .utf8) else {
+                return nil
+            }
+            return output
+        }
+    }
+
     private func expandAgentProcessTree(agentPIDsByWorkspace: [UUID: Set<Int>]) -> [Int: Set<UUID>] {
         let normalizedRoots = agentPIDsByWorkspace.reduce(into: [UUID: Set<Int>]()) { partial, item in
             let valid = Set(item.value.filter { $0 > 0 })
@@ -491,23 +531,12 @@ final class PortScanner: @unchecked Sendable {
 
     private func runPS(ttyList: String) -> [Int: String] {
         // `ps -t tty1,tty2,... -o pid=,tty=` — targeted scan, much cheaper than -ax.
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-t", ttyList, "-o", "pid=,tty="]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-        } catch {
+        guard let output = Self.captureStandardOutput(
+            executablePath: "/bin/ps",
+            arguments: ["-t", ttyList, "-o", "pid=,tty="]
+        ) else {
             return [:]
         }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard let output = String(data: data, encoding: .utf8) else { return [:] }
 
         var mapping: [Int: String] = [:]
         for line in output.split(separator: "\n") {
@@ -520,23 +549,12 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func runAllProcesses() -> [Int: Int] {
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/bin/ps")
-        process.arguments = ["-ax", "-o", "pid=,ppid="]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-        } catch {
+        guard let output = Self.captureStandardOutput(
+            executablePath: "/bin/ps",
+            arguments: ["-ax", "-o", "pid=,ppid="]
+        ) else {
             return [:]
         }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard let output = String(data: data, encoding: .utf8) else { return [:] }
 
         var mapping: [Int: Int] = [:]
         for line in output.split(separator: "\n") {
@@ -551,23 +569,12 @@ final class PortScanner: @unchecked Sendable {
 
     private func runLsof(pidsCsv: String) -> [Int: Set<Int>] {
         // `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -F pn`
-        let process = Process()
-        let pipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: "/usr/sbin/lsof")
-        process.arguments = ["-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"]
-        process.standardOutput = pipe
-        process.standardError = FileHandle.nullDevice
-
-        do {
-            try process.run()
-        } catch {
+        guard let output = Self.captureStandardOutput(
+            executablePath: "/usr/sbin/lsof",
+            arguments: ["-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"]
+        ) else {
             return [:]
         }
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard let output = String(data: data, encoding: .utf8) else { return [:] }
 
         // Parse lsof -F output: lines starting with 'p' = PID, 'n' = name (host:port).
         var result: [Int: Set<Int>] = [:]

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -475,8 +475,12 @@ final class PortScanner: @unchecked Sendable {
                 return nil
             }
 
-            // Force prompt fd teardown on this long-lived utility queue instead of
-            // waiting for ARC/autorelease to eventually release the pipe.
+            // Close the parent's write end before reading. This is required:
+            // readDataToEndOfFile() blocks until EOF, which only occurs when every
+            // write-fd holder (parent + child) has closed its copy. Keeping the
+            // parent's copy open would deadlock the read. The defer below is a
+            // safety net for the error path (process.run() throws), not a
+            // substitute for this explicit close.
             try? stdoutWriteHandle.close()
             let data = stdoutReadHandle.readDataToEndOfFile()
             process.waitUntilExit()

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4000,34 +4000,3 @@ final class BrowserImportScopeTests: XCTestCase {
         XCTAssertNil(scope)
     }
 }
-
-final class PortScannerProcessCaptureTests: XCTestCase {
-    private func openFDCount() -> Int? {
-        try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count
-    }
-
-    func testCaptureStandardOutputDoesNotLeakPipeFDs() throws {
-        guard let baseline = openFDCount() else {
-            throw XCTSkip("Unable to inspect /dev/fd on this runner")
-        }
-
-        var maxCount = baseline
-        for _ in 0..<200 {
-            let output = PortScanner.captureStandardOutput(
-                executablePath: "/usr/bin/printf",
-                arguments: ["cmux"]
-            )
-            XCTAssertEqual(output, "cmux")
-            if let current = openFDCount() {
-                maxCount = max(maxCount, current)
-            }
-        }
-
-        guard let finalCount = openFDCount() else {
-            throw XCTSkip("Unable to inspect final /dev/fd count on this runner")
-        }
-
-        XCTAssertLessThanOrEqual(maxCount - baseline, 8)
-        XCTAssertLessThanOrEqual(finalCount - baseline, 8)
-    }
-}

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -4000,3 +4000,34 @@ final class BrowserImportScopeTests: XCTestCase {
         XCTAssertNil(scope)
     }
 }
+
+final class PortScannerProcessCaptureTests: XCTestCase {
+    private func openFDCount() -> Int? {
+        try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count
+    }
+
+    func testCaptureStandardOutputDoesNotLeakPipeFDs() throws {
+        guard let baseline = openFDCount() else {
+            throw XCTSkip("Unable to inspect /dev/fd on this runner")
+        }
+
+        var maxCount = baseline
+        for _ in 0..<200 {
+            let output = PortScanner.captureStandardOutput(
+                executablePath: "/usr/bin/printf",
+                arguments: ["cmux"]
+            )
+            XCTAssertEqual(output, "cmux")
+            if let current = openFDCount() {
+                maxCount = max(maxCount, current)
+            }
+        }
+
+        guard let finalCount = openFDCount() else {
+            throw XCTSkip("Unable to inspect final /dev/fd count on this runner")
+        }
+
+        XCTAssertLessThanOrEqual(maxCount - baseline, 8)
+        XCTAssertLessThanOrEqual(finalCount - baseline, 8)
+    }
+}

--- a/cmuxTests/PortScannerTests.swift
+++ b/cmuxTests/PortScannerTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class PortScannerProcessCaptureTests: XCTestCase {
+    private func openFDCount() -> Int? {
+        try? FileManager.default.contentsOfDirectory(atPath: "/dev/fd").count
+    }
+
+    func testCaptureStandardOutputDoesNotLeakPipeFDs() throws {
+        guard let baseline = openFDCount() else {
+            throw XCTSkip("Unable to inspect /dev/fd on this runner")
+        }
+
+        var maxCount = baseline
+        for _ in 0..<200 {
+            let output = PortScanner.captureStandardOutput(
+                executablePath: "/usr/bin/printf",
+                arguments: ["cmux"]
+            )
+            XCTAssertEqual(output, "cmux")
+            if let current = openFDCount() {
+                maxCount = max(maxCount, current)
+            }
+        }
+
+        guard let finalCount = openFDCount() else {
+            throw XCTSkip("Unable to inspect final /dev/fd count on this runner")
+        }
+
+        XCTAssertLessThanOrEqual(maxCount - baseline, 8)
+        XCTAssertLessThanOrEqual(finalCount - baseline, 8)
+    }
+}


### PR DESCRIPTION
Closes #2890

## Summary
- add a regression test that repeatedly captures subprocess output and asserts the app process does not accumulate open PIPE file descriptors
- fix PortScanner's repeated `ps`/`lsof` subprocess helpers to use a shared output-capture path that closes both pipe ends deterministically
- wrap the capture helper in `autoreleasepool` so long-lived utility-queue scans do not rely on delayed ARC/autorelease cleanup for PIPE fd teardown

## Root Cause
`PortScanner` shells out on a long-lived utility queue for panel and agent port scans. Its one-pipe `Process` helpers matched the leaking Foundation pattern reproduced outside the app: repeated `Process` + `Pipe` usage could leave one-sided PIPE fds open until a distant autorelease-pool drain, which caused steady fd growth over long uptimes.

## Verification
- added a unit regression test for repeated subprocess capture without fd growth
- reproduced the Foundation leak pattern locally with a standalone Swift loop, then verified the deterministic-close helper keeps fd count flat
- attempted `./scripts/reload.sh --tag fix-2890-pipe-fd-leak`, but local `xcodebuild` stalled in Xcode infrastructure before compile output or an `App path:` line was produced

## Notes
- local test suites were not run per repo policy
- commits are split as test first, fix second so CI can show the regression coverage structure clearly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `PortScanner` shells out to `ps`/`lsof` by centralizing `Process`/`Pipe` handling; mistakes here could regress port discovery or hang on output reads. Added a regression test to detect file-descriptor leaks, reducing long-uptime risk.
> 
> **Overview**
> Fixes a `PortScanner` file-descriptor leak by introducing a shared `captureStandardOutput` helper that runs subprocesses inside an `autoreleasepool` and explicitly closes both pipe ends to avoid `Pipe` FD accumulation.
> 
> Updates the `ps` and `lsof` helpers to use this shared capture path, and adds `PortScannerTests` to repeatedly execute the capture and assert `/dev/fd` stays within a small delta. The Xcode project is updated to include the new unit test file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae784f5c4bc691c116c46faee78eafa6eddf65e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a pipe file descriptor leak in `PortScanner` subprocess helpers that caused FD growth over time. Adds a safer, deterministic output-capture helper and a regression test to keep FD counts stable on long uptimes.

- **Bug Fixes**
  - Introduced `PortScanner.captureStandardOutput(...)` that runs in `autoreleasepool`, routes stdin/stderr to `FileHandle.nullDevice`, explicitly closes the parent write end before reading, and closes both pipe ends deterministically.
  - Updated `ps` and `lsof` helpers to use the shared capture path, avoiding ARC-delayed pipe cleanup.
  - Added a regression test that loops 200 times (using `/usr/bin/printf`) and verifies `/dev/fd` stays within a small delta.

<sup>Written for commit ae784f5c4bc691c116c46faee78eafa6eddf65e5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal process execution logic into a reusable helper to improve code maintainability and reduce duplication.

* **Tests**
  * Added tests verifying proper resource cleanup during process execution to prevent file descriptor leaks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->