### PR TITLE
Local nightly build script + release.yml passkey signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,29 +296,18 @@ jobs:
             exit 1
           fi
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          # AuthenticationServices refuses restricted entitlements like
-          # WebAuthn with error 1004 unless the signed entitlements
-          # carry a matching com.apple.application-identifier. Inject
-          # it (and team-identifier) for the release bundle here.
-          RELEASE_ENT="$(mktemp /tmp/cmux-release-ent.XXXXXX.plist)"
-          trap 'rm -f "$RELEASE_ENT"' EXIT
-          cp cmux.entitlements "$RELEASE_ENT"
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$RELEASE_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$RELEASE_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app" "$RELEASE_ENT"
-          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$RELEASE_ENT"
+          ENTITLEMENTS="cmux.entitlements"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
           if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" "$CLI_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" "$HELPER_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
           fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" --deep "$APP_PATH"
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
-          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,45 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           security list-keychains -d user -s build.keychain
 
+      - name: Embed release provisioning profile
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          if [ -z "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" ]; then
+            echo "Missing APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 secret" >&2
+            exit 1
+          fi
+
+          APP_PATH="build-universal/Build/Products/Release/cmux.app"
+          PROFILE_PATH="$APP_PATH/Contents/embedded.provisionprofile"
+          TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
+          TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
+          trap 'rm -f "$TMP_PROFILE" "$TMP_PLIST"' EXIT
+
+          echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
+          security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
+
+          APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
+          if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then
+            echo "Release provisioning profile targets unexpected app ID: $APP_ID" >&2
+            exit 1
+          fi
+
+          WEBAUTHN_ENTITLEMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.web-browser.public-key-credential" "$TMP_PLIST")"
+          if [ "$WEBAUTHN_ENTITLEMENT" != "true" ]; then
+            echo "Release provisioning profile is missing WebAuthn browser entitlement" >&2
+            exit 1
+          fi
+
+          PROVISIONS_ALL_DEVICES="$(/usr/libexec/PlistBuddy -c "Print :ProvisionsAllDevices" "$TMP_PLIST")"
+          if [ "$PROVISIONS_ALL_DEVICES" != "true" ]; then
+            echo "Release provisioning profile is not a Developer ID all-devices profile" >&2
+            exit 1
+          fi
+
+          cp "$TMP_PROFILE" "$PROFILE_PATH"
+
       - name: Codesign app
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         env:
@@ -257,17 +296,29 @@ jobs:
             exit 1
           fi
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          ENTITLEMENTS="cmux.entitlements"
+          # AuthenticationServices refuses restricted entitlements like
+          # WebAuthn with error 1004 unless the signed entitlements
+          # carry a matching com.apple.application-identifier. Inject
+          # it (and team-identifier) for the release bundle here.
+          RELEASE_ENT="$(mktemp /tmp/cmux-release-ent.XXXXXX.plist)"
+          trap 'rm -f "$RELEASE_ENT"' EXIT
+          cp cmux.entitlements "$RELEASE_ENT"
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$RELEASE_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$RELEASE_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app" "$RELEASE_ENT"
+          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$RELEASE_ENT"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
           if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" "$HELPER_PATH"
           fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_ENT" --deep "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
+          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+build-local-nightly/

--- a/scripts/build-local-nightly.sh
+++ b/scripts/build-local-nightly.sh
@@ -79,21 +79,35 @@ mv "$SRC_APP" "$DEST_APP"
 echo "==> Embedding provisioning profile"
 cp "$PROFILE" "$DEST_APP/Contents/embedded.provisionprofile"
 
+echo "==> Composing per-bundle entitlements (cmux.entitlements + application-identifier)"
+# AuthenticationServices refuses restricted entitlements like WebAuthn
+# with error 1004 unless the signed entitlements carry a valid
+# application-identifier that matches the embedded provisioning
+# profile. The checked-in cmux.entitlements omits it because it's
+# bundle-id specific; inject it here for the nightly bundle.
+NIGHTLY_ENT="$(mktemp -t cmux-nightly-ent.XXXXXX.plist)"
+trap 'rm -f "$TMP_PLIST" "$NIGHTLY_ENT"' EXIT
+cp "$ENTITLEMENTS" "$NIGHTLY_ENT"
+/usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$NIGHTLY_ENT" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$NIGHTLY_ENT" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app.nightly" "$NIGHTLY_ENT"
+/usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$NIGHTLY_ENT"
+
 echo "==> Codesigning helpers and app"
 CLI_PATH="$DEST_APP/Contents/Resources/bin/cmux"
 HELPER_PATH="$DEST_APP/Contents/Resources/bin/ghostty"
 
 if [[ -f "$CLI_PATH" ]]; then
   /usr/bin/codesign --force --options runtime --timestamp=none \
-    --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+    --sign "$IDENTITY" --entitlements "$NIGHTLY_ENT" "$CLI_PATH"
 fi
 if [[ -f "$HELPER_PATH" ]]; then
   /usr/bin/codesign --force --options runtime --timestamp=none \
-    --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+    --sign "$IDENTITY" --entitlements "$NIGHTLY_ENT" "$HELPER_PATH"
 fi
 
 /usr/bin/codesign --force --options runtime --timestamp=none \
-  --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$DEST_APP"
+  --sign "$IDENTITY" --entitlements "$NIGHTLY_ENT" --deep "$DEST_APP"
 /usr/bin/codesign --verify --deep --strict --verbose=2 "$DEST_APP"
 
 echo "==> Verifying WebAuthn entitlement present after signing"

--- a/scripts/build-local-nightly.sh
+++ b/scripts/build-local-nightly.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Build a locally-signed "cmux NIGHTLY" app that carries the real
+# Developer ID signature and an embedded provisioning profile. This is
+# required to exercise entitlements like
+# com.apple.developer.web-browser.public-key-credential (Passkey /
+# WebAuthn) which refuse to run on ad-hoc signed DEV builds.
+#
+# Produces: build-local-nightly/Build/Products/Release/cmux NIGHTLY.app
+#
+# Env overrides:
+#   CMUX_NIGHTLY_PROFILE    path to nightly .provisionprofile
+#                           (default: ~/.secrets/cmuxterm/cmux_nightly_Developer_ID.provisionprofile)
+#   CMUX_SIGNING_IDENTITY   codesign identity
+#                           (default: "Developer ID Application: Manaflow, Inc. (7WLXT3NR37)")
+#   CMUX_NIGHTLY_ARCHS      "arm64" (default) or "arm64 x86_64" for universal
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PROFILE="${CMUX_NIGHTLY_PROFILE:-$HOME/.secrets/cmuxterm/cmux_nightly_Developer_ID.provisionprofile}"
+IDENTITY="${CMUX_SIGNING_IDENTITY:-Developer ID Application: Manaflow, Inc. (7WLXT3NR37)}"
+ARCHS="${CMUX_NIGHTLY_ARCHS:-arm64}"
+ENTITLEMENTS="$REPO_ROOT/cmux.entitlements"
+BUILD_DIR="$REPO_ROOT/build-local-nightly"
+
+if [[ ! -f "$PROFILE" ]]; then
+  echo "error: provisioning profile not found at $PROFILE" >&2
+  echo "  download from https://developer.apple.com/account/resources/profiles/list" >&2
+  exit 1
+fi
+
+if ! /usr/bin/security find-identity -v -p codesigning | grep -q "$IDENTITY"; then
+  echo "error: signing identity not found in keychain: $IDENTITY" >&2
+  exit 1
+fi
+
+PROFILE_APP_ID="$(/usr/bin/security cms -D -i "$PROFILE" 2>/dev/null \
+  | /usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" /dev/stdin)"
+if [[ "$PROFILE_APP_ID" != "7WLXT3NR37.com.cmuxterm.app.nightly" ]]; then
+  echo "error: profile targets unexpected app id: $PROFILE_APP_ID" >&2
+  exit 1
+fi
+
+cd "$REPO_ROOT"
+
+echo "==> Building Release ($ARCHS) into $BUILD_DIR"
+xcodebuild -scheme cmux -configuration Release -derivedDataPath "$BUILD_DIR" \
+  -destination 'generic/platform=macOS' \
+  ARCHS="$ARCHS" \
+  ONLY_ACTIVE_ARCH=NO \
+  CODE_SIGNING_ALLOWED=NO \
+  ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly \
+  build
+
+APP_DIR="$BUILD_DIR/Build/Products/Release"
+SRC_APP="$APP_DIR/cmux.app"
+DEST_APP="$APP_DIR/cmux NIGHTLY.app"
+
+if [[ ! -d "$SRC_APP" ]]; then
+  echo "error: cmux.app not found at $SRC_APP" >&2
+  exit 1
+fi
+
+rm -rf "$DEST_APP"
+
+echo "==> Rewriting Info.plist for nightly bundle"
+PL="$SRC_APP/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName cmux NIGHTLY" "$PL"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName cmux NIGHTLY" "$PL"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.cmuxterm.app.nightly" "$PL"
+/usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$PL" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$PL" >/dev/null 2>&1 || true
+
+mv "$SRC_APP" "$DEST_APP"
+
+echo "==> Embedding provisioning profile"
+cp "$PROFILE" "$DEST_APP/Contents/embedded.provisionprofile"
+
+echo "==> Codesigning helpers and app"
+CLI_PATH="$DEST_APP/Contents/Resources/bin/cmux"
+HELPER_PATH="$DEST_APP/Contents/Resources/bin/ghostty"
+
+if [[ -f "$CLI_PATH" ]]; then
+  /usr/bin/codesign --force --options runtime --timestamp=none \
+    --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+fi
+if [[ -f "$HELPER_PATH" ]]; then
+  /usr/bin/codesign --force --options runtime --timestamp=none \
+    --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+fi
+
+/usr/bin/codesign --force --options runtime --timestamp=none \
+  --sign "$IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$DEST_APP"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$DEST_APP"
+
+echo "==> Verifying WebAuthn entitlement present after signing"
+if ! /usr/bin/codesign -d --entitlements :- "$DEST_APP" 2>&1 \
+    | grep -q "com.apple.developer.web-browser.public-key-credential"; then
+  echo "error: WebAuthn entitlement missing from signed binary" >&2
+  exit 1
+fi
+
+echo
+echo "App path:"
+echo "  $DEST_APP"

--- a/scripts/build-local-nightly.sh
+++ b/scripts/build-local-nightly.sh
@@ -44,13 +44,15 @@ fi
 
 cd "$REPO_ROOT"
 
-echo "==> Building Release ($ARCHS) into $BUILD_DIR"
+echo "==> Building Release with DEBUG conditionals ($ARCHS) into $BUILD_DIR"
 xcodebuild -scheme cmux -configuration Release -derivedDataPath "$BUILD_DIR" \
   -destination 'generic/platform=macOS' \
   ARCHS="$ARCHS" \
   ONLY_ACTIVE_ARCH=NO \
   CODE_SIGNING_ALLOWED=NO \
   ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly \
+  SWIFT_ACTIVE_COMPILATION_CONDITIONS="DEBUG" \
+  GCC_PREPROCESSOR_DEFINITIONS="DEBUG=1 \$(inherited)" \
   build
 
 APP_DIR="$BUILD_DIR/Build/Products/Release"

--- a/scripts/build-local-nightly.sh
+++ b/scripts/build-local-nightly.sh
@@ -33,8 +33,10 @@ if ! /usr/bin/security find-identity -v -p codesigning | grep -q "$IDENTITY"; th
   exit 1
 fi
 
-PROFILE_APP_ID="$(/usr/bin/security cms -D -i "$PROFILE" 2>/dev/null \
-  | /usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" /dev/stdin)"
+TMP_PLIST="$(mktemp -t cmux-profile.XXXXXX.plist)"
+trap 'rm -f "$TMP_PLIST"' EXIT
+/usr/bin/security cms -D -i "$PROFILE" > "$TMP_PLIST"
+PROFILE_APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
 if [[ "$PROFILE_APP_ID" != "7WLXT3NR37.com.cmuxterm.app.nightly" ]]; then
   echo "error: profile targets unexpected app id: $PROFILE_APP_ID" >&2
   exit 1
@@ -53,7 +55,7 @@ xcodebuild -scheme cmux -configuration Release -derivedDataPath "$BUILD_DIR" \
 
 APP_DIR="$BUILD_DIR/Build/Products/Release"
 SRC_APP="$APP_DIR/cmux.app"
-DEST_APP="$APP_DIR/cmux NIGHTLY.app"
+DEST_APP="$APP_DIR/cmux NIGHTLY local.app"
 
 if [[ ! -d "$SRC_APP" ]]; then
   echo "error: cmux.app not found at $SRC_APP" >&2
@@ -64,8 +66,8 @@ rm -rf "$DEST_APP"
 
 echo "==> Rewriting Info.plist for nightly bundle"
 PL="$SRC_APP/Contents/Info.plist"
-/usr/libexec/PlistBuddy -c "Set :CFBundleName cmux NIGHTLY" "$PL"
-/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName cmux NIGHTLY" "$PL"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName cmux NIGHTLY local" "$PL"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName cmux NIGHTLY local" "$PL"
 /usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.cmuxterm.app.nightly" "$PL"
 /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$PL" >/dev/null 2>&1 || true
 /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$PL" >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary

Two related pieces around getting passkey/WebAuthn working on signed cmux builds:

### `scripts/build-local-nightly.sh`
Mirrors the nightly CI signing flow on a Mac so devs can dogfood passkey changes without waiting for CI:
- Builds Release (arm64 by default, override with `CMUX_NIGHTLY_ARCHS="arm64 x86_64"`).
- Rewrites `Info.plist` to the `cmux NIGHTLY local` bundle (renamed from `cmux NIGHTLY` so it doesn't collide with a real nightly install).
- Embeds the nightly provisioning profile from `~/.secrets/cmuxterm/cmux_nightly_Developer_ID.provisionprofile` (override with `CMUX_NIGHTLY_PROFILE`).
- Generates a per-bundle entitlements copy that injects `com.apple.application-identifier` (required for restricted entitlements like WebAuthn — without it AuthenticationServices fails with error 1004 even when the profile is embedded).
- Compiles in `DEBUG` conditionals so `dlog()` writes to `/tmp/cmux-debug.log` for diagnosing the local Release-config build.

### `.github/workflows/release.yml`
Same pattern as PR https://github.com/manaflow-ai/cmux/pull/2727 added for nightly:
- Embed the release provisioning profile from `APPLE_RELEASE_PROVISIONING_PROFILE_BASE64`.
- Inject `com.apple.application-identifier=7WLXT3NR37.com.cmuxterm.app` into the codesigned entitlements blob.
- Verify both `web-browser.public-key-credential` and the app id are present in the final signed bundle via `codesign -d --entitlements`.

Without this, the production `com.cmuxterm.app` build (after PR 2727 lands) would still fail passkey ceremonies even though the Swift bridge and entitlements file are in place.

## Verification (no actual release)
Trigger release.yml manually on this branch:

```bash
gh workflow run release.yml --repo manaflow-ai/cmux --ref feat-build-local-nightly
```

`workflow_dispatch` on a non-tag ref runs the build/sign/notarize/verify steps; the release upload step (`softprops/action-gh-release`) only fires for tag refs, so nothing is published. Confirmation of success comes from the `codesign -d --entitlements` greps inside the Codesign step, plus successful notarization.

## Test plan
- [x] Local: `./scripts/build-local-nightly.sh`, launch the produced app, register and authenticate a passkey on webauthn.io.
- [ ] CI: workflow_dispatch run of release.yml on this branch passes the codesign verification greps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds the ability to produce a locally-signed "cmux NIGHTLY" macOS app for testing, with automated signing and entitlement validation.

* **Chores**
  * Build tooling and CI updated to embed provisioning profiles and verify signing entitlements during release/nightly builds.
  * Repository ignore rules updated to exclude local nightly build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->