### PR TITLE
Revert application-identifier injection from nightly signing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -432,34 +432,21 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          # AuthenticationServices refuses restricted entitlements like
-          # WebAuthn with error 1004 unless the signed entitlements
-          # carry a matching com.apple.application-identifier. The
-          # checked-in cmux.entitlements omits it because the value is
-          # bundle-id specific; inject it (and team-identifier) for the
-          # nightly bundle here.
-          NIGHTLY_ENT="$(mktemp /tmp/cmux-nightly-ent.XXXXXX.plist)"
-          trap 'rm -f "$NIGHTLY_ENT"' EXIT
-          cp cmux.entitlements "$NIGHTLY_ENT"
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$NIGHTLY_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$NIGHTLY_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app.nightly" "$NIGHTLY_ENT"
-          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$NIGHTLY_ENT"
+          ENTITLEMENTS="cmux.entitlements"
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
             if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_ENT" "$CLI_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_ENT" "$HELPER_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
             fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_ENT" --deep "$APP_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
             /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
-            /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app.nightly"
           done
 
       - name: Notarize apps and dmgs


### PR DESCRIPTION
## Summary

PR https://github.com/manaflow-ai/cmux/pull/2727 added `com.apple.application-identifier` to the codesigned entitlements blob of the nightly bundle to fix passkey error 1004. That works for ad-hoc / un-notarized local Developer-ID-signed builds, but on the **notarized** nightly produced by CI, amfi rejects the binary on launch with `RBSRequestErrorDomain Code=5 / NSPOSIXErrorDomain Code=163` (Launchd job spawn failed / EAUTH).

The currently-published `cmux NIGHTLY` build can't be opened at all.

The `application-identifier` entitlement is intended for App Store / sandboxed iOS-style apps. On Developer ID Mac apps, AuthenticationServices reads the application-identifier at runtime from the **embedded provisioning profile**, not from the codesigned entitlements blob. The embedded profile was already added in PR 2727 and already carries the right value (`7WLXT3NR37.com.cmuxterm.app.nightly`). The application-identifier injection is therefore unnecessary and actively breaks notarized launch.

## Test plan
- [ ] After merge, run nightly workflow: `gh workflow run nightly.yml --repo manaflow-ai/cmux -f force=true`
- [ ] Sparkle-update or download the new `cmux NIGHTLY.app` and verify it launches.
- [ ] In the new nightly's browser panel, register and authenticate a passkey on webauthn.io. The embedded profile should provide the application-identifier to AuthenticationServices.
- [ ] If 1004 returns, we'll need a different workaround (maybe a per-bundle entitlements file with only application-identifier outside the codesign blob, or convince the runtime to read the profile differently).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts entitlement injection in the nightly signing step to fix notarized launch failures. The nightly app now launches, and passkeys still work via the embedded provisioning profile.

- **Bug Fixes**
  - Removed injection of `com.apple.application-identifier` and team ID into signed entitlements; use `cmux.entitlements` as-is in `.github/workflows/nightly.yml`.
  - Rely on the embedded provisioning profile for the application identifier, preventing amfi EAUTH (163) on launch.

<sup>Written for commit 08383c2f64bb22c45da84fbbe8ac4fc5d8b76da4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the macOS app codesigning workflow in nightly builds to use the standard entitlements configuration file directly instead of generating nightly-specific temporary entitlements, streamlining the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->