### PR TITLE
Add opt-in setting to open Cmd-clicked markdown files in cmux viewer

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -87714,6 +87714,124 @@
           }
         }
       }
+    },
+    "settings.app.openMarkdownInCmuxViewer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Markdown in cmux Viewer"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux ビューアで Markdown を開く"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 뷰어에서 Markdown 열기"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 查看器中打开 Markdown"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 檢視器中開啟 Markdown"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Markdown im cmux-Viewer öffnen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abrir Markdown en el visor cmux"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ouvrir Markdown dans la visionneuse cmux"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Apri Markdown nel visualizzatore cmux"
+          }
+        }
+      }
+    },
+    "settings.app.openMarkdownInCmuxViewer.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd-clicking .md/.markdown/.mkd/.mdx files opens the cmux markdown viewer panel instead of the preferred editor."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".md/.markdown/.mkd/.mdx ファイルを Cmd+クリックすると、優先エディタの代わりに cmux マークダウンビューアパネルが開きます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": ".md/.markdown/.mkd/.mdx 파일을 Cmd+클릭하면 기본 에디터 대신 cmux 마크다운 뷰어 패널이 열립니다."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+点击 .md/.markdown/.mkd/.mdx 文件将打开 cmux 标记查看器面板,而不是使用首选编辑器。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+點擊 .md/.markdown/.mkd/.mdx 檔案會開啟 cmux Markdown 檢視器面板,而不是使用偏好編輯器。"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd-Klick auf .md/.markdown/.mkd/.mdx-Dateien öffnet das cmux-Markdown-Viewer-Panel statt des bevorzugten Editors."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hacer Cmd+clic en archivos .md/.markdown/.mkd/.mdx abre el panel del visor de markdown de cmux en lugar del editor preferido."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+clic sur les fichiers .md/.markdown/.mkd/.mdx ouvre le panneau de la visionneuse markdown cmux au lieu de l'éditeur préféré."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cmd+clic sui file .md/.markdown/.mkd/.mdx apre il pannello del visualizzatore markdown cmux invece dell'editor preferito."
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3272,6 +3272,40 @@ class GhosttyApp {
                 #endif
                 return false
             }
+            // Route markdown file URLs into the cmux viewer when the toggle is
+            // on AND the link is local + has no anchor/query. Anything else
+            // (toggle off, hosted file URL, #fragment, ?query, non-markdown,
+            // remote workspace, unreadable file, split creation failure) falls
+            // through to the existing NSWorkspace path below so the default-off
+            // behavior and URL semantics are preserved.
+            let fileURLHost = target.url.host
+            if CmdClickMarkdownRouteSettings.isEnabled(),
+               target.url.isFileURL,
+               target.url.fragment == nil,
+               target.url.query == nil,
+               fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost",
+               CmdClickMarkdownRouteSettings.isMarkdownPath(target.url.path) {
+                let fileURL = target.url
+                let routed: Bool = performOnMain {
+                    // Remote-surface guard runs before shouldRoute so we never
+                    // stat a local path on the main thread for a remote workspace.
+                    guard let termSurface = surfaceView.terminalSurface,
+                          let workspace = termSurface.owningWorkspace(),
+                          !workspace.isRemoteTerminalSurface(termSurface.id),
+                          CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path) else {
+                        return false
+                    }
+                    return workspace.openOrFocusMarkdownSplit(
+                        from: termSurface.id,
+                        filePath: fileURL.path
+                    ) != nil
+                }
+                if routed {
+                    return true
+                }
+                // Fall through to the existing NSWorkspace path below.
+            }
+
             if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
                 #if DEBUG
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
@@ -7845,6 +7879,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             data: payload
         )
         #endif
+
+        // Remote-surface guard runs before shouldRoute so we never stat a local
+        // path on the main thread for a remote workspace. When the viewer path
+        // is applicable but split creation fails, fall back to the preferred
+        // editor so the click never silently no-ops.
+        if let termSurface = terminalSurface,
+           let workspace = termSurface.owningWorkspace(),
+           !workspace.isRemoteTerminalSurface(termSurface.id),
+           CmdClickMarkdownRouteSettings.shouldRoute(path: resolution.path),
+           workspace.openOrFocusMarkdownSplit(from: termSurface.id, filePath: resolution.path) != nil {
+            return resolution
+        }
 
         PreferredEditorSettings.open(URL(fileURLWithPath: resolution.path))
         return resolution

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -33,6 +33,7 @@ final class CmuxSettingsFileStore {
         "app.keepWorkspaceOpenWhenClosingLastSurface",
         "app.focusPaneOnFirstClick",
         "app.preferredEditor",
+        "app.openMarkdownInCmuxViewer",
         "app.reorderOnNotification",
         "app.sendAnonymousTelemetry",
         "app.warnBeforeQuit",
@@ -429,6 +430,9 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonString(section["preferredEditor"]) {
             snapshot.managedUserDefaults[PreferredEditorSettings.key] = .string(value)
+        }
+        if let value = jsonBool(section["openMarkdownInCmuxViewer"]) {
+            snapshot.managedUserDefaults[CmdClickMarkdownRouteSettings.key] = .bool(value)
         }
         if let value = jsonBool(section["reorderOnNotification"]) {
             snapshot.managedUserDefaults[WorkspaceAutoReorderSettings.key] = .bool(value)
@@ -1357,6 +1361,7 @@ final class CmuxSettingsFileStore {
                     "keepWorkspaceOpenWhenClosingLastSurface": !LastSurfaceCloseShortcutSettings.defaultValue,
                     "focusPaneOnFirstClick": PaneFirstClickFocusSettings.defaultEnabled,
                     "preferredEditor": "",
+                    "openMarkdownInCmuxViewer": CmdClickMarkdownRouteSettings.defaultValue,
                     "reorderOnNotification": WorkspaceAutoReorderSettings.defaultValue,
                     "sendAnonymousTelemetry": TelemetrySettings.defaultSendAnonymousTelemetry,
                     "warnBeforeQuit": QuitWarningSettings.defaultWarnBeforeQuit,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9178,6 +9178,34 @@ final class Workspace: Identifiable, ObservableObject {
         return browserPanel
     }
 
+    /// Open the markdown viewer for `filePath`, reusing an existing
+    /// `MarkdownPanel` in this workspace that already shows the same file.
+    /// Paths are compared after symlink resolution so `./README.md` and a
+    /// symlink pointing at the same file focus the same viewer.
+    /// Returns `nil` when no existing viewer matches and split creation
+    /// fails, so callers can fall back to the preferred editor / system opener.
+    @discardableResult
+    func openOrFocusMarkdownSplit(
+        from panelId: UUID,
+        filePath: String
+    ) -> MarkdownPanel? {
+        let canonical = (filePath as NSString).resolvingSymlinksInPath
+        for (existingId, panel) in panels {
+            guard let md = panel as? MarkdownPanel else { continue }
+            if (md.filePath as NSString).resolvingSymlinksInPath == canonical {
+                focusPanel(existingId)
+                return md
+            }
+        }
+        return newMarkdownSplit(
+            from: panelId,
+            orientation: .horizontal,
+            insertFirst: false,
+            filePath: filePath,
+            focus: true
+        )
+    }
+
     func newMarkdownSplit(
         from panelId: UUID,
         orientation: SplitOrientation,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4128,6 +4128,37 @@ enum TelemetrySettings {
     static let enabledForCurrentLaunch = isEnabled()
 }
 
+enum CmdClickMarkdownRouteSettings {
+    static let key = "openMarkdownInCmuxViewer"
+    static let defaultValue = false
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: key) == nil ? defaultValue : defaults.bool(forKey: key)
+    }
+
+    /// Cheap extension check. Safe to call off the main thread before any
+    /// filesystem probe so remote/non-markdown paths can be filtered early.
+    static func isMarkdownPath(_ path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return ext == "md" || ext == "markdown" || ext == "mkd" || ext == "mdx"
+    }
+
+    static func shouldRoute(path: String) -> Bool {
+        guard isEnabled(), isMarkdownPath(path) else { return false }
+        // Match the `markdown.open` socket path: only route real, readable
+        // files. Rejects FIFOs, device nodes, sockets, symlinks to non-regular
+        // targets, and permission-denied paths so the viewer never opens into
+        // an unavailable state.
+        let resolved = (path as NSString).resolvingSymlinksInPath
+        guard FileManager.default.isReadableFile(atPath: resolved),
+              let attrs = try? FileManager.default.attributesOfItem(atPath: resolved),
+              (attrs[.type] as? FileAttributeType) == .typeRegular else {
+            return false
+        }
+        return true
+    }
+}
+
 enum PreferredEditorSettings {
     static let key = "preferredEditorCommand"
 
@@ -4362,6 +4393,7 @@ struct SettingsView: View {
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
+    @AppStorage(CmdClickMarkdownRouteSettings.key) private var openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
     @AppStorage("cmuxPortRange") private var cmuxPortRange = 10
     @AppStorage(BrowserSearchSettings.searchEngineKey) private var browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
@@ -5064,6 +5096,21 @@ struct SettingsView: View {
                             )
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.openMarkdownInCmuxViewer"),
+                            String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer"),
+                            subtitle: String(localized: "settings.app.openMarkdownInCmuxViewer.subtitle", defaultValue: "Cmd-clicking .md/.markdown/.mkd/.mdx files opens the cmux markdown viewer panel instead of the preferred editor.")
+                        ) {
+                            Toggle("", isOn: $openMarkdownInCmuxViewer)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityLabel(
+                                    String(localized: "settings.app.openMarkdownInCmuxViewer", defaultValue: "Open Markdown in cmux Viewer")
+                                )
                         }
 
                         SettingsCardDivider()
@@ -6479,6 +6526,7 @@ struct SettingsView: View {
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         preferredEditorCommand = ""
+        openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue
         browserSearchSuggestionsEnabled = BrowserSearchSettings.defaultSearchSuggestionsEnabled
         browserThemeMode = BrowserThemeSettings.defaultMode.rawValue

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -26,7 +26,27 @@
       "properties": {
         "language": {
           "type": "string",
-          "enum": ["system", "en", "ar", "bs", "zh-Hans", "zh-Hant", "da", "de", "es", "fr", "it", "ja", "ko", "nb", "pl", "pt-BR", "ru", "th", "tr"],
+          "enum": [
+            "system",
+            "en",
+            "ar",
+            "bs",
+            "zh-Hans",
+            "zh-Hant",
+            "da",
+            "de",
+            "es",
+            "fr",
+            "it",
+            "ja",
+            "ko",
+            "nb",
+            "pl",
+            "pt-BR",
+            "ru",
+            "th",
+            "tr"
+          ],
           "default": "system",
           "description": "Preferred app language."
         },
@@ -67,6 +87,11 @@
           "type": "string",
           "default": "",
           "description": "Custom editor command used by cmux where applicable. Leave empty to use the default."
+        },
+        "openMarkdownInCmuxViewer": {
+          "type": "boolean",
+          "default": false,
+          "description": "When enabled, Cmd-clicking .md/.markdown/.mkd/.mdx files in the terminal opens them in the cmux markdown viewer panel (with live reload) instead of the preferred editor."
         },
         "reorderOnNotification": {
           "type": "boolean",
@@ -136,7 +161,25 @@
         },
         "sound": {
           "type": "string",
-          "enum": ["default", "Basso", "Blow", "Bottle", "Frog", "Funk", "Glass", "Hero", "Morse", "Ping", "Pop", "Purr", "Sosumi", "Submarine", "Tink", "custom_file", "none"],
+          "enum": [
+            "default",
+            "Basso",
+            "Blow",
+            "Bottle",
+            "Frog",
+            "Funk",
+            "Glass",
+            "Hero",
+            "Morse",
+            "Ping",
+            "Pop",
+            "Purr",
+            "Sosumi",
+            "Submarine",
+            "Tink",
+            "custom_file",
+            "none"
+          ],
           "default": "default",
           "description": "Notification sound preset."
         },
@@ -229,7 +272,17 @@
       "properties": {
         "indicatorStyle": {
           "type": "string",
-          "enum": ["leftRail", "solidFill", "rail", "border", "wash", "lift", "typography", "washRail", "blueWashColorRail"],
+          "enum": [
+            "leftRail",
+            "solidFill",
+            "rail",
+            "border",
+            "wash",
+            "lift",
+            "typography",
+            "washRail",
+            "blueWashColorRail"
+          ],
           "default": "leftRail",
           "description": "Active workspace indicator style. Legacy aliases are accepted and normalized."
         },
@@ -313,7 +366,17 @@
       "properties": {
         "socketControlMode": {
           "type": "string",
-          "enum": ["off", "cmuxOnly", "automation", "password", "allowAll", "openAccess", "fullOpenAccess", "notifications", "full"],
+          "enum": [
+            "off",
+            "cmuxOnly",
+            "automation",
+            "password",
+            "allowAll",
+            "openAccess",
+            "fullOpenAccess",
+            "notifications",
+            "full"
+          ],
           "default": "cmuxOnly",
           "description": "Socket control mode. Legacy aliases are accepted and normalized."
         },
@@ -423,7 +486,13 @@
           "items": {
             "type": "string"
           },
-          "default": ["localhost", "127.0.0.1", "::1", "0.0.0.0", "*.localtest.me"],
+          "default": [
+            "localhost",
+            "127.0.0.1",
+            "::1",
+            "0.0.0.0",
+            "*.localtest.me"
+          ],
           "description": "HTTP hosts allowed in the embedded browser without a warning prompt."
         },
         "showImportHintOnBlankTabs": {


### PR DESCRIPTION
## Summary

- **What:** Adds an opt-in setting (`app.openMarkdownInCmuxViewer`, default **off**) that routes Cmd-clicked markdown paths (`.md`, `.markdown`, `.mkd`, `.mdx`) in the terminal to the built-in cmux markdown viewer panel (with live reload) instead of the preferred editor. Reuses an existing viewer panel when one already shows the same file.
- **Why:** Closes #1778. Agent workflows (Claude Code, etc.) reference a lot of markdown files in terminal output — piping them into the formatted live-reload viewer is a much better experience than opening raw markdown in an editor.

### Behavior

| Toggle | Target | Result |
|--------|--------|--------|
| Off (default) | any path | Preserves existing `PreferredEditorSettings.open` / `NSWorkspace.open` behavior |
| On | local, readable, regular `.md*` file | Splits a viewer panel to the right (or focuses an existing viewer for the same path) |
| On | same file already displayed in a viewer | Focuses the existing panel (mirrors browser-link reuse) |
| On | remote workspace, missing file, directory, non-regular file, unreadable file | Falls back to preferred editor / system opener |
| On | `file://host/...` (non-local), or URL with `#fragment` / `?query` | Falls through to system opener so the host / anchor is preserved |

### Implementation notes

- New `CmdClickMarkdownRouteSettings` enum in `Sources/cmuxApp.swift`:
  - `isMarkdownPath(_:)` — cheap extension check, safe off main thread.
  - `shouldRoute(path:)` — full readiness check (toggle + extension + readable + regular file via `attributesOfItem`). Mirrors the existing `markdown.open` socket path's `isReadableFile` guard.
- Two integration points — both reuse the existing `Workspace.newMarkdownSplit` API that powers `cmux markdown open`:
  - `GHOSTTY_ACTION_OPEN_URL` in `GhosttyTerminalView.swift` for Ghostty-consumed clicks (URL-formed targets, OSC-8 hyperlinks). Runs **before** the browser-link early return so the setting works regardless of `browser.openTerminalLinksInCmuxBrowser`.
  - `handleCommandClickRelease` fallback path for word-under-cursor resolutions.
- Both sites check the remote-workspace guard **before** any filesystem probe, so remote terminals never stat local paths on the main thread.
- Settings plumbing: new key registered in `CmuxSettingsFileStore.supportedSettingsJSONPaths`, parsed from `settings.json`, included in the default settings template, and published in `web/data/cmux-settings.schema.json`.
- Settings UI: a toggle row beneath **Open Files With** in the App section.
- Localizations added for the title and subtitle in `Localizable.xcstrings` (en / ja / ko / zh-Hans / zh-Hant / de / es / fr / it).

## Testing

- **How:** Manually exercised the feature in a Debug build (`reload.sh --tag pr-1778 --launch`) — toggled the setting off/on and Cmd-clicked the paths below in a terminal panel.
- **What was verified:**
  - Toggle off (default): `.md` Cmd-click opens in the preferred editor — no regression.
  - Toggle on, local `.md`: splits a viewer panel to the right with live reload.
  - Toggle on, same `.md` clicked again: second click focuses the existing panel (no duplicate split).
  - Toggle on, different `.md`: new split is created.
  - Toggle on, non-md (`.zshrc`, etc.): opens in preferred editor (no false-positive routing).
  - Settings UI toggle renders under **Open Files With** and persists across restarts.
  - Settings > App crash from precondition failure on an unknown JSON path was caught during development and fixed by registering the new key in `supportedSettingsJSONPaths` + parser + default template.
- **Not exercised locally** (would need a more involved harness / remote VM):
  - Remote workspace fallback — covered by the code path but not manually reproduced.
  - `file://` URLs with `#fragment` / `?query` — covered by the guard.
  - Non-regular / unreadable files — covered by the `isReadableFile` + `typeRegular` check.

Happy to expand coverage or add an automated test if there's a harness suggestion for the cmd-click fallback paths.

## Demo Video

I don't have a suitable recording setup here — happy to add a short clip if it helps. In the meantime, the behavior is reproducible in any Debug build by toggling **Settings > App > Open Markdown in cmux Viewer** and Cmd-clicking an `.md` path in a terminal.

- Video URL or attachment:

https://github.com/user-attachments/assets/f9e8dd8c-44ec-4820-bbf6-b31d512d5e12



## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Open Markdown in cmux Viewer" toggle: when enabled, Cmd-clicking Markdown files opens (or focuses) a built-in markdown viewer panel instead of the preferred editor. Disabled by default.
* **Configuration**
  * New persistent setting exposed in app settings and schema.
* **Localization**
  * Added localized title and subtitle strings for the new setting across supported locales.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->