### PR TITLE
Inside-out signing with per-binary entitlements for passkeys on notarized Developer ID

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -432,21 +432,50 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          ENTITLEMENTS="cmux.entitlements"
+          # Inside-out signing with per-binary entitlements:
+          # - CLI helpers get a minimal hardened-runtime entitlements file
+          #   (no application-identifier). If we gave them the main app's
+          #   application-identifier, amfi rejects the bundle at launch on
+          #   macOS 26 Tahoe because the helper's signing identifier
+          #   ("cmux" / "ghostty") doesn't match the claimed app id
+          #   (7WLXT3NR37.com.cmuxterm.app.nightly).
+          # - Main app bundle gets the full entitlements including an
+          #   injected application-identifier, which AuthenticationServices
+          #   requires for passkey / WebAuthn ceremonies
+          #   (ASAuthorizationError 1004 otherwise).
+          # - No --deep on the top-level sign: it would overwrite the
+          #   helper signatures with the main entitlements and reintroduce
+          #   the mismatch.
+          HELPER_ENT="cmux-helper.entitlements"
+          NIGHTLY_APP_ENT="$(mktemp /tmp/cmux-nightly-app-ent.XXXXXX.plist)"
+          trap 'rm -f "$NIGHTLY_APP_ENT"' EXIT
+          cp cmux.entitlements "$NIGHTLY_APP_ENT"
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$NIGHTLY_APP_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$NIGHTLY_APP_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app.nightly" "$NIGHTLY_APP_ENT"
+          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$NIGHTLY_APP_ENT"
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
             if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
             fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_APP_ENT" "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
             /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
+            /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app.nightly"
+            # Assert helpers do NOT carry the main app's application-identifier
+            if [ -f "$CLI_PATH" ]; then
+              /usr/bin/codesign -d --entitlements :- "$CLI_PATH" 2>&1 | grep -q "application-identifier" && {
+                echo "error: CLI helper unexpectedly carries application-identifier" >&2
+                exit 1
+              } || true
+            fi
           done
 
       - name: Notarize apps and dmgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -247,6 +247,39 @@ jobs:
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           security list-keychains -d user -s build.keychain
 
+      - name: Embed release provisioning profile
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          if [ -z "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" ]; then
+            echo "Missing APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 secret" >&2
+            exit 1
+          fi
+          APP_PATH="build-universal/Build/Products/Release/cmux.app"
+          PROFILE_PATH="$APP_PATH/Contents/embedded.provisionprofile"
+          TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
+          TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
+          trap 'rm -f "$TMP_PROFILE" "$TMP_PLIST"' EXIT
+          echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
+          security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
+          APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
+          if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then
+            echo "Release provisioning profile targets unexpected app ID: $APP_ID" >&2
+            exit 1
+          fi
+          WEBAUTHN_ENTITLEMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.web-browser.public-key-credential" "$TMP_PLIST")"
+          if [ "$WEBAUTHN_ENTITLEMENT" != "true" ]; then
+            echo "Release provisioning profile missing WebAuthn browser entitlement" >&2
+            exit 1
+          fi
+          PROVISIONS_ALL_DEVICES="$(/usr/libexec/PlistBuddy -c "Print :ProvisionsAllDevices" "$TMP_PLIST")"
+          if [ "$PROVISIONS_ALL_DEVICES" != "true" ]; then
+            echo "Release provisioning profile is not a Developer ID all-devices profile" >&2
+            exit 1
+          fi
+          cp "$TMP_PROFILE" "$PROFILE_PATH"
+
       - name: Codesign app
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         env:
@@ -257,17 +290,33 @@ jobs:
             exit 1
           fi
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          ENTITLEMENTS="cmux.entitlements"
+          # Inside-out signing (see docs/signing.md reasoning also in
+          # nightly.yml): CLI helpers get minimal hardened-runtime
+          # entitlements, main app bundle gets the full entitlements with
+          # application-identifier injected so AuthenticationServices can
+          # serve passkey / WebAuthn ceremonies. No --deep on the top
+          # sign: it would overwrite helper signatures and re-introduce
+          # the amfi launch rejection seen in the nightly.
+          HELPER_ENT="cmux-helper.entitlements"
+          RELEASE_APP_ENT="$(mktemp /tmp/cmux-release-app-ent.XXXXXX.plist)"
+          trap 'rm -f "$RELEASE_APP_ENT"' EXIT
+          cp cmux.entitlements "$RELEASE_APP_ENT"
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$RELEASE_APP_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$RELEASE_APP_ENT" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app" "$RELEASE_APP_ENT"
+          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$RELEASE_APP_ENT"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
           if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$CLI_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" "$HELPER_PATH"
+            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
           fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$ENTITLEMENTS" --deep "$APP_PATH"
+          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_APP_ENT" "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
+          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/cmux-helper.entitlements
+++ b/cmux-helper.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Restores passkey / WebAuthn on the released and nightly builds after the failed attempts in https://github.com/manaflow-ai/cmux/pull/2727 (launch-broken) and https://github.com/manaflow-ai/cmux/pull/2902 (launch works but no passkeys).

### Root cause

`AuthenticationServices` requires `com.apple.application-identifier` in the *codesigned* entitlements blob of the calling process. It does not fall back to the embedded provisioning profile and does not derive the app id from `team-identifier` + bundle id, so without that key the passkey ceremony fails with `AuthorizationError 1004 "The calling process does not have an application identifier"`.

PR https://github.com/manaflow-ai/cmux/pull/2727 signed every binary inside the bundle (main app plus `Contents/Resources/bin/cmux` and `Contents/Resources/bin/ghostty`) with the same `cmux.entitlements`, then the follow-up injected `application-identifier` into that shared file and re-applied it with `--deep`. That pushed the main app's app id onto the CLI helpers, whose code-sign identifiers are `cmux` and `ghostty` (not the main bundle id). amfi on notarized macOS 26 Tahoe rejects this mismatch with `RBSRequestErrorDomain Code=5 / NSPOSIXErrorDomain Code=163 Launchd job spawn failed`. Local un-notarized Developer-ID builds survived because amfi applies weaker checks on those.

### Fix: inside-out signing

Two entitlements files, two signing passes:

- **`cmux-helper.entitlements`** (new): minimal hardened runtime only. Used for CLI helpers, which don't need app-id, WebAuthn, camera, mic, or AppleEvents.
- **`cmux.entitlements`** (unchanged in the repo): shared base, no app-id. At sign time the workflow copies it and injects `application-identifier` + `team-identifier` for the specific bundle (`com.cmuxterm.app` for release, `com.cmuxterm.app.nightly` for nightly).

Sign order:
1. CLI helpers with `cmux-helper.entitlements`.
2. Main app bundle last, full injected entitlements, **no `--deep`**. Deep would overwrite the helper signatures and put the mismatch back.

`release.yml` also picks up the same embedded provisioning profile step the nightly already has (`APPLE_RELEASE_PROVISIONING_PROFILE_BASE64` secret already uploaded), so the shipped `com.cmuxterm.app` build gets a profile authorizing the WebAuthn browser entitlement.

### Verification

Confirmed locally on macOS 26.3.1: re-signed the broken nightly bundle using exactly this scheme (see PR commits). `codesign -d --entitlements` now shows:

- Main app: `application-identifier`, `team-identifier`, `web-browser.public-key-credential` present.
- CLI helpers: only hardened-runtime exceptions, no `application-identifier`.

App launches and the WebAuthn bridge reaches `ASAuthorizationController.performRequests` without the `1004` error.

## Test plan
- [ ] Nightly workflow run green, resulting `cmux NIGHTLY.app` launches on macOS 26.
- [ ] In the new nightly's browser panel, register and authenticate a passkey on webauthn.io end-to-end.
- [ ] Run `release.yml` via `workflow_dispatch` on this branch to exercise release-signing path without cutting a tag; verify the `codesign -d --entitlements` greps succeed and notarization is accepted.

Closes https://github.com/manaflow-ai/cmux/issues/1739 (same error signature).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced macOS app signing and provisioning for nightly and release builds with improved credential separation and validation. Added security checks to ensure proper signing configuration and entitlements during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores passkey/WebAuthn on notarized Developer ID builds (closes #1739). Uses inside-out signing so the app carries `application-identifier` and helpers don’t, preventing AMFI launch failures.

- **Bug Fixes**
  - Split entitlements: new `cmux-helper.entitlements` for CLI helpers (minimal hardened runtime); main app uses `cmux.entitlements` with injected `application-identifier` and `team-identifier` at sign time.
  - Sign order: helpers first, app last, and no `--deep` to avoid overwriting helper signatures.
  - CI updates: `nightly.yml` and `release.yml` implement this flow; `release.yml` embeds and validates the Developer ID provisioning profile from `APPLE_RELEASE_PROVISIONING_PROFILE_BASE64`, and both workflows assert WebAuthn entitlement and correct app ID on the app while ensuring helpers lack `application-identifier`.

<sup>Written for commit bb9f9afe58cfb45a97831caec094789491c0c766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

