### PR TITLE
Sign nested plugins and frameworks explicitly (post-PR #2905 fix-forward)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -459,12 +459,29 @@ jobs:
           do
             CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
             HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+            # 1. Sign CLI helpers with minimal entitlements.
             if [ -f "$CLI_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
             fi
             if [ -f "$HELPER_PATH" ]; then
               /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
             fi
+            # 2. Sign nested plugins with --deep, no entitlements. Without
+            #    this, removing --deep from the top-level sign leaves
+            #    PlugIns/*.plugin unsigned and codesign fails.
+            if [ -d "$APP_PATH/Contents/PlugIns" ]; then
+              while IFS= read -r -d '' plugin; do
+                /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --deep "$plugin"
+              done < <(find "$APP_PATH/Contents/PlugIns" -mindepth 1 -maxdepth 1 -print0)
+            fi
+            # 3. Sign frameworks with --deep, no entitlements. Handles
+            #    Sparkle's nested XPC services and Updater.app too.
+            if [ -d "$APP_PATH/Contents/Frameworks" ]; then
+              while IFS= read -r -d '' fw; do
+                /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --deep "$fw"
+              done < <(find "$APP_PATH/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
+            fi
+            # 4. Sign the main app bundle last with full entitlements, NO --deep.
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_APP_ENT" "$APP_PATH"
             /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
             /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,12 +307,26 @@ jobs:
           /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$RELEASE_APP_ENT"
           CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
           HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
+          # 1. CLI helpers with minimal entitlements.
           if [ -f "$CLI_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
           fi
           if [ -f "$HELPER_PATH" ]; then
             /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
           fi
+          # 2. Plugins with --deep, no entitlements.
+          if [ -d "$APP_PATH/Contents/PlugIns" ]; then
+            while IFS= read -r -d '' plugin; do
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --deep "$plugin"
+            done < <(find "$APP_PATH/Contents/PlugIns" -mindepth 1 -maxdepth 1 -print0)
+          fi
+          # 3. Frameworks with --deep, no entitlements.
+          if [ -d "$APP_PATH/Contents/Frameworks" ]; then
+            while IFS= read -r -d '' fw; do
+              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --deep "$fw"
+            done < <(find "$APP_PATH/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
+          fi
+          # 4. Main app bundle last with full entitlements, NO --deep.
           /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_APP_ENT" "$APP_PATH"
           /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
           /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"


### PR DESCRIPTION
## Summary

Nightly run after https://github.com/manaflow-ai/cmux/pull/2905 failed at the Codesign step with:

```
build-universal/.../cmux NIGHTLY.app: code object is not signed at all
In subcomponent: .../Contents/PlugIns/CmuxDockTilePlugin.plugin
```

PR 2905 dropped `--deep` from the top-level sign so the main app's entitlements wouldn't overwrite the CLI helpers. But `--deep` was also the only thing signing the nested plugin and the Sparkle / Sentry frameworks, so they're left unsigned and the top-level sign refuses.

Proper inside-out order per Apple's docs: sign every nested code item first (deepest out), outer containers last.

Changes (to both `nightly.yml` and `release.yml`):
1. CLI helpers signed with `cmux-helper.entitlements` (unchanged).
2. **New:** loop `Contents/PlugIns/*` and sign each with `--deep` (no custom entitlements).
3. **New:** loop `Contents/Frameworks/*` and sign each with `--deep` (no custom entitlements). Handles Sparkle's nested `XPCServices/*.xpc` and `Updater.app` too.
4. Main app bundle signed last with full entitlements, **no `--deep`** (unchanged).

## Test plan
- [ ] Nightly workflow succeeds through Codesign + Notarize.
- [ ] Published `cmux NIGHTLY.app` launches on macOS 26 Tahoe.
- [ ] `codesign -d --entitlements` on the published artifact still shows main app with `application-identifier` + `web-browser.public-key-credential`, helpers without `application-identifier`.
- [ ] Passkey registration + authentication on webauthn.io works in the new nightly's browser panel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS code signing process in CI/CD workflows to implement a structured signing sequence for nested bundle contents, ensuring proper security practices during the build and release pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix macOS codesigning by explicitly signing nested PlugIns and Frameworks before the app bundle, following Apple’s inside-out order. Nightly and release workflows now sign subcomponents so notarization and launch succeed after removing `--deep` from the top-level sign.

- **Bug Fixes**
  - Sign each `Contents/PlugIns/*` and `Contents/Frameworks/*` with `--deep` and no entitlements; includes `Sparkle`’s `XPCServices` and `Updater.app`.
  - Keep CLI helpers signed with `cmux-helper.entitlements`.
  - Sign the main app last with full entitlements, without `--deep`.

<sup>Written for commit 1b3b2a1a988954a4ac3585b0705a39306f1dd1e7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

