### PR TITLE
Refactor cmux bundle signing: shared script + checked-in entitlements (competing with #2906)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -432,50 +432,13 @@ jobs:
             echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
             exit 1
           fi
-          # Inside-out signing with per-binary entitlements:
-          # - CLI helpers get a minimal hardened-runtime entitlements file
-          #   (no application-identifier). If we gave them the main app's
-          #   application-identifier, amfi rejects the bundle at launch on
-          #   macOS 26 Tahoe because the helper's signing identifier
-          #   ("cmux" / "ghostty") doesn't match the claimed app id
-          #   (7WLXT3NR37.com.cmuxterm.app.nightly).
-          # - Main app bundle gets the full entitlements including an
-          #   injected application-identifier, which AuthenticationServices
-          #   requires for passkey / WebAuthn ceremonies
-          #   (ASAuthorizationError 1004 otherwise).
-          # - No --deep on the top-level sign: it would overwrite the
-          #   helper signatures with the main entitlements and reintroduce
-          #   the mismatch.
-          HELPER_ENT="cmux-helper.entitlements"
-          NIGHTLY_APP_ENT="$(mktemp /tmp/cmux-nightly-app-ent.XXXXXX.plist)"
-          trap 'rm -f "$NIGHTLY_APP_ENT"' EXIT
-          cp cmux.entitlements "$NIGHTLY_APP_ENT"
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$NIGHTLY_APP_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$NIGHTLY_APP_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app.nightly" "$NIGHTLY_APP_ENT"
-          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$NIGHTLY_APP_ENT"
           for APP_PATH in \
             "build-universal/Build/Products/Release/cmux NIGHTLY.app"
           do
-            CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-            HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-            if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
-            fi
-            if [ -f "$HELPER_PATH" ]; then
-              /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
-            fi
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$NIGHTLY_APP_ENT" "$APP_PATH"
-            /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-            /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
-            /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app.nightly"
-            # Assert helpers do NOT carry the main app's application-identifier
-            if [ -f "$CLI_PATH" ]; then
-              /usr/bin/codesign -d --entitlements :- "$CLI_PATH" 2>&1 | grep -q "application-identifier" && {
-                echo "error: CLI helper unexpectedly carries application-identifier" >&2
-                exit 1
-              } || true
-            fi
+            ./scripts/sign-cmux-bundle.sh \
+              "$APP_PATH" \
+              cmux.nightly.entitlements \
+              "$APPLE_SIGNING_IDENTITY"
           done
 
       - name: Notarize apps and dmgs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -290,33 +290,10 @@ jobs:
             exit 1
           fi
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
-          # Inside-out signing (see docs/signing.md reasoning also in
-          # nightly.yml): CLI helpers get minimal hardened-runtime
-          # entitlements, main app bundle gets the full entitlements with
-          # application-identifier injected so AuthenticationServices can
-          # serve passkey / WebAuthn ceremonies. No --deep on the top
-          # sign: it would overwrite helper signatures and re-introduce
-          # the amfi launch rejection seen in the nightly.
-          HELPER_ENT="cmux-helper.entitlements"
-          RELEASE_APP_ENT="$(mktemp /tmp/cmux-release-app-ent.XXXXXX.plist)"
-          trap 'rm -f "$RELEASE_APP_ENT"' EXIT
-          cp cmux.entitlements "$RELEASE_APP_ENT"
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.application-identifier" "$RELEASE_APP_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Delete :com.apple.developer.team-identifier" "$RELEASE_APP_ENT" >/dev/null 2>&1 || true
-          /usr/libexec/PlistBuddy -c "Add :com.apple.application-identifier string 7WLXT3NR37.com.cmuxterm.app" "$RELEASE_APP_ENT"
-          /usr/libexec/PlistBuddy -c "Add :com.apple.developer.team-identifier string 7WLXT3NR37" "$RELEASE_APP_ENT"
-          CLI_PATH="$APP_PATH/Contents/Resources/bin/cmux"
-          HELPER_PATH="$APP_PATH/Contents/Resources/bin/ghostty"
-          if [ -f "$CLI_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$CLI_PATH"
-          fi
-          if [ -f "$HELPER_PATH" ]; then
-            /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$HELPER_ENT" "$HELPER_PATH"
-          fi
-          /usr/bin/codesign --force --options runtime --timestamp --sign "$APPLE_SIGNING_IDENTITY" --entitlements "$RELEASE_APP_ENT" "$APP_PATH"
-          /usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
-          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "com.apple.developer.web-browser.public-key-credential"
-          /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "7WLXT3NR37.com.cmuxterm.app"
+          ./scripts/sign-cmux-bundle.sh \
+            "$APP_PATH" \
+            cmux.release.entitlements \
+            "$APPLE_SIGNING_IDENTITY"
 
       - name: Notarize app
         if: steps.guard_release_assets.outputs.skip_all != 'true'

--- a/cmux.nightly.entitlements
+++ b/cmux.nightly.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.application-identifier</key>
+	<string>7WLXT3NR37.com.cmuxterm.app.nightly</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>7WLXT3NR37</string>
+	<key>com.apple.developer.web-browser.public-key-credential</key>
+	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>

--- a/cmux.release.entitlements
+++ b/cmux.release.entitlements
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.application-identifier</key>
+	<string>7WLXT3NR37.com.cmuxterm.app</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>7WLXT3NR37</string>
+	<key>com.apple.developer.web-browser.public-key-credential</key>
+	<true/>
+	<key>com.apple.security.automation.apple-events</key>
+	<true/>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+	<key>com.apple.security.device.audio-input</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+</dict>
+</plist>

--- a/scripts/sign-cmux-bundle.sh
+++ b/scripts/sign-cmux-bundle.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Inside-out codesign a cmux .app bundle for Developer ID + notarization.
+#
+# Usage:
+#   scripts/sign-cmux-bundle.sh <app-path> <app-entitlements> <signing-identity>
+#
+# Example:
+#   scripts/sign-cmux-bundle.sh \
+#     "build-universal/Build/Products/Release/cmux NIGHTLY.app" \
+#     cmux.nightly.entitlements \
+#     "Developer ID Application: Manaflow, Inc. (7WLXT3NR37)"
+#
+# Optional env:
+#   CMUX_HELPER_ENTITLEMENTS  (default: cmux-helper.entitlements)
+#   CMUX_TIMESTAMP             set to "none" for un-timestamped local sigs
+#
+# Signs in the Apple-documented inside-out order:
+#   1. CLI helpers under Contents/Resources/bin/* with minimal
+#      hardened-runtime entitlements (no application-identifier).
+#   2. Each nested plugin under Contents/PlugIns/* with --deep.
+#   3. Each nested framework under Contents/Frameworks/* with --deep
+#      (covers Sparkle's XPCServices and Updater.app).
+#   4. The main app bundle with the provided app-level entitlements,
+#      WITHOUT --deep. --deep here would overwrite helper/plugin
+#      signatures and re-introduce the app-id mismatch that amfi on
+#      notarized macOS 26 Tahoe rejects with errno 163.
+
+set -euo pipefail
+
+if [[ $# -lt 3 ]]; then
+  echo "usage: $0 <app-path> <app-entitlements> <signing-identity>" >&2
+  exit 2
+fi
+
+APP_PATH="$1"
+APP_ENTITLEMENTS="$2"
+IDENTITY="$3"
+HELPER_ENTITLEMENTS="${CMUX_HELPER_ENTITLEMENTS:-cmux-helper.entitlements}"
+
+if [[ ! -d "$APP_PATH" ]]; then
+  echo "error: app bundle not found at $APP_PATH" >&2
+  exit 1
+fi
+if [[ ! -f "$APP_ENTITLEMENTS" ]]; then
+  echo "error: app entitlements not found at $APP_ENTITLEMENTS" >&2
+  exit 1
+fi
+if [[ ! -f "$HELPER_ENTITLEMENTS" ]]; then
+  echo "error: helper entitlements not found at $HELPER_ENTITLEMENTS" >&2
+  exit 1
+fi
+
+if [[ "${CMUX_TIMESTAMP:-}" == "none" ]]; then
+  TS_FLAG=(--timestamp=none)
+else
+  TS_FLAG=(--timestamp)
+fi
+
+COMMON=(--force --options runtime "${TS_FLAG[@]}" --sign "$IDENTITY")
+
+# 1. CLI helpers
+for helper in "$APP_PATH/Contents/Resources/bin"/*; do
+  [[ -f "$helper" && -x "$helper" ]] || continue
+  echo "==> signing helper $(basename "$helper")"
+  /usr/bin/codesign "${COMMON[@]}" --entitlements "$HELPER_ENTITLEMENTS" "$helper"
+done
+
+# 2. Plugins
+if [[ -d "$APP_PATH/Contents/PlugIns" ]]; then
+  while IFS= read -r -d '' plugin; do
+    echo "==> signing plugin $(basename "$plugin")"
+    /usr/bin/codesign "${COMMON[@]}" --deep "$plugin"
+  done < <(find "$APP_PATH/Contents/PlugIns" -mindepth 1 -maxdepth 1 -print0)
+fi
+
+# 3. Frameworks
+if [[ -d "$APP_PATH/Contents/Frameworks" ]]; then
+  while IFS= read -r -d '' framework; do
+    echo "==> signing framework $(basename "$framework")"
+    /usr/bin/codesign "${COMMON[@]}" --deep "$framework"
+  done < <(find "$APP_PATH/Contents/Frameworks" -mindepth 1 -maxdepth 1 -print0)
+fi
+
+# 4. Main app bundle (no --deep).
+echo "==> signing main bundle"
+/usr/bin/codesign "${COMMON[@]}" --entitlements "$APP_ENTITLEMENTS" "$APP_PATH"
+
+echo "==> verifying"
+/usr/bin/codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+
+APP_ID="$(/usr/libexec/PlistBuddy -c "Print :com.apple.application-identifier" \
+  /dev/stdin <<<"$(plutil -convert xml1 -o - "$APP_ENTITLEMENTS")" 2>/dev/null || true)"
+
+if [[ -n "$APP_ID" ]]; then
+  /usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 | grep -q "$APP_ID" || {
+    echo "error: signed app missing application-identifier $APP_ID" >&2
+    exit 1
+  }
+fi
+/usr/bin/codesign -d --entitlements :- "$APP_PATH" 2>&1 \
+  | grep -q "com.apple.developer.web-browser.public-key-credential" || {
+    echo "error: signed app missing web-browser entitlement" >&2
+    exit 1
+  }
+
+# Helpers must NOT carry the main app's application-identifier.
+for helper in "$APP_PATH/Contents/Resources/bin"/*; do
+  [[ -f "$helper" && -x "$helper" ]] || continue
+  if /usr/bin/codesign -d --entitlements :- "$helper" 2>&1 \
+       | grep -q "application-identifier"; then
+    echo "error: helper $(basename "$helper") unexpectedly carries application-identifier" >&2
+    exit 1
+  fi
+done
+
+echo "==> signing OK: $APP_PATH"


### PR DESCRIPTION
## Summary

Competes with https://github.com/manaflow-ai/cmux/pull/2906. Same signing behavior, cleaner structure:

- **Checked in:** `cmux.release.entitlements` and `cmux.nightly.entitlements`, each with the right `application-identifier` and `team-identifier` baked in. Replaces the PlistBuddy-at-sign-time injection that mutates a copy of `cmux.entitlements`.
- **Extracted:** `scripts/sign-cmux-bundle.sh` does the inside-out signing (helpers, plugins, frameworks, main bundle, verification) in one place. Both `nightly.yml` and `release.yml` shrink to a single line that calls it with the right entitlements file.

### Why not fully Xcode-native

A fully Xcode-project-driven approach (manual signing config + provisioning-profile specifier + `xcconfig` per configuration + remove manual `codesign` loops from CI) is a cleaner endgame but requires pbxproj surgery and re-verifying Sparkle appcast / bundle-id plumbing. Worth doing as a follow-up when signing stabilizes.

### Competing with #2906

| | #2906 | #2907 (this PR) |
|---|---|---|
| Approach | YAML-inline signing loops in each workflow | Shared `scripts/sign-cmux-bundle.sh` |
| Entitlements | `cmux.entitlements` copied + PlistBuddy-mutated at sign time | `cmux.{release,nightly}.entitlements` checked in |
| Nightly.yml Codesign step LOC | ~50 lines | ~10 lines |
| Release.yml Codesign step LOC | ~40 lines | ~10 lines |
| Duplication between workflows | high (logic mirrored) | none (one script) |
| Future framework/plugin additions | edit both workflows | works automatically via `find` in script |

## Test plan
- [ ] Nightly workflow triggered on this branch passes Codesign + Notarize.
- [ ] Produced `cmux NIGHTLY.app` launches on macOS 26 Tahoe.
- [ ] `codesign -d --entitlements` confirms main app has `application-identifier=7WLXT3NR37.com.cmuxterm.app.nightly`, helpers do not.
- [ ] Passkey ceremony works on webauthn.io in the produced nightly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates macOS app signing into a shared script and checks in release/nightly entitlements to remove CI duplication. No behavior change; same signing order and entitlements with shorter workflows.

- **Refactors**
  - Added `cmux.release.entitlements` and `cmux.nightly.entitlements` with baked app/team identifiers, replacing PlistBuddy mutations.
  - Introduced `scripts/sign-cmux-bundle.sh` to sign inside-out (helpers → plugins → frameworks → main app without --deep), verify entitlements, and fail if helpers carry `application-identifier`.
  - Updated `nightly.yml` and `release.yml` to call the script, reducing ~70 LOC and auto-covering future plugins/frameworks.

<sup>Written for commit 6a3b1067e45d48bbe207fcc341303f47fb36ed47. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored application signing process in build workflows to use a dedicated script for improved consistency and maintainability across nightly and release builds.
  * Added entitlements configuration files to define security permissions and capabilities for signed releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->