### PR TITLE
feat: Shift+click to open links in system browser

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3257,6 +3257,15 @@ class GhosttyApp {
                 #endif
                 return false
             }
+            // Shift+click: bypass embedded browser, open in system default browser.
+            if NSEvent.modifierFlags.contains(.shift) {
+                #if DEBUG
+                dlog("link.openURL shift=true, forcing system browser url=\(target.url)")
+                #endif
+                return performOnMain {
+                    NSWorkspace.shared.open(target.url)
+                }
+            }
             if !BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowser() {
                 #if DEBUG
                 dlog("link.openURL cmuxBrowser=disabled, opening externally url=\(target.url)")
@@ -7044,7 +7053,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             var keyEvent = ghostty_input_key_s()
             keyEvent.action = action
             keyEvent.keycode = UInt32(event.keyCode)
-            keyEvent.mods = modsFromEvent(event)
+            keyEvent.mods = linkModsFromEvent(event)
             keyEvent.consumed_mods = GHOSTTY_MODS_NONE
             keyEvent.text = nil
             keyEvent.composing = false
@@ -7098,11 +7107,24 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return ghostty_surface_has_selection(surface)
     }
 
+    // Strip Shift when Cmd is held so Ghostty treats Cmd+Shift+click as a
+    // link click. The real Shift state is checked in the OPEN_URL handler.
+    private func linkModsFromEvent(_ event: NSEvent) -> ghostty_input_mods_e {
+        let flags = event.modifierFlags
+        if flags.contains(.command), flags.contains(.shift) {
+            return modsFromFlags(flags.subtracting(.shift))
+        }
+        return modsFromFlags(flags)
+    }
+
     private func hoverModsFromFlags(
         _ flags: NSEvent.ModifierFlags,
         suppressCommandPathHover: Bool
     ) -> ghostty_input_mods_e {
-        let effectiveFlags = suppressCommandPathHover ? flags.subtracting(.command) : flags
+        var effectiveFlags = suppressCommandPathHover ? flags.subtracting(.command) : flags
+        if effectiveFlags.contains(.command), effectiveFlags.contains(.shift) {
+            effectiveFlags = effectiveFlags.subtracting(.shift)
+        }
 #if DEBUG
         if suppressCommandPathHover, flags.contains(.command) {
             _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
@@ -7383,9 +7405,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Only update mouse position on the first click to prevent unwanted cursor
         // movement during double-click selection (issue #1698)
         if event.clickCount == 1 {
-            ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, modsFromEvent(event))
+            ghostty_surface_mouse_pos(surface, eventPoint.x, bounds.height - eventPoint.y, linkModsFromEvent(event))
         }
-        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, linkModsFromEvent(event))
     }
 
     override func mouseUp(with event: NSEvent) {
@@ -7394,7 +7416,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         #endif
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
-        let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+        let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, linkModsFromEvent(event))
         _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6171,6 +6171,18 @@ private class BrowserNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
+        // Shift+click: bypass embedded browser and open in system default browser.
+        if navigationAction.modifierFlags.contains(.shift),
+           navigationAction.navigationType == .linkActivated,
+           let url = navigationAction.request.url {
+            #if DEBUG
+            dlog("browser.nav.decidePolicy.action kind=shiftClickExternal url=\(url.absoluteString)")
+            #endif
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
+        }
+
         // Cmd+click and middle-click on regular links should always open in a new tab.
         if shouldOpenInNewTab,
            let url = navigationAction.request.url {

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -568,6 +568,17 @@ private class PopupNavigationDelegate: NSObject, WKNavigationDelegate {
             return
         }
 
+        // Shift+click: bypass embedded browser and open in system default browser.
+        if navigationAction.modifierFlags.contains(.shift),
+           navigationAction.navigationType == .linkActivated {
+            #if DEBUG
+            dlog("popup.nav.shiftClickExternal url=\(url.absoluteString)")
+            #endif
+            NSWorkspace.shared.open(url)
+            decisionHandler(.cancel)
+            return
+        }
+
         // Insecure HTTP → show same prompt as main browser
         if browserShouldBlockInsecureHTTPURL(url) {
             #if DEBUG


### PR DESCRIPTION
## Summary

- **Cmd+Shift+click** on terminal links opens them in the system default browser instead of the embedded browser
- **Shift+click** on links in the browser panel/popup also opens in system browser

## Approach

Ghostty only fires `OPEN_URL` when modifiers exactly match its link-mods config (Cmd on macOS). Adding Shift breaks both hover underline and the action. As a workaround, this PR strips Shift from the mods sent to Ghostty when Cmd is held — in `hoverModsFromFlags`, `flagsChanged`, `mouseDown`, and `mouseUp` — so Ghostty still sees plain Cmd. The real Shift state is then read via `NSEvent.modifierFlags` in the `OPEN_URL` handler to force system browser.

**Known concern:** This silently hides Shift from Ghostty for all mouse events when Cmd is held. A cleaner long-term approach would be a Ghostty C API like `ghostty_surface_link_url_at_pos()` to query the link under the cursor without triggering the action — then no modifier stripping is needed. Happy to rework if Ghostty exposes this.

## Test plan

- [ ] Cmd+click on a terminal link → opens in embedded browser (unchanged)
- [ ] Cmd+Shift+click on a terminal link → opens in system browser
- [ ] Hover underline stays visible when adding Shift to Cmd
- [ ] No flicker when pressing/releasing Shift while Cmd is held
- [ ] Shift+click on a link in the browser panel → opens in system browser
- [ ] Cmd+click on a browser panel link → opens in new tab (unchanged)
- [ ] Terminal text selection with Shift+click (no Cmd) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shift+click opens links in the system default browser: Cmd+Shift+click for terminal links, and Shift+click for links in the embedded browser. Cmd+click behavior is unchanged.

- **New Features**
  - Terminal: Cmd+Shift+click opens in the system browser while keeping hover underline and regular Cmd+click behavior.
  - Browser panel/popup: Shift+click opens externally; Cmd+click still opens in a new tab.

<sup>Written for commit bf290a5216c2deaaa011e8682c7f4eda9000298e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shift+clicking links now opens them in your system default browser instead of the app's embedded browser, providing direct access to your preferred browser.

* **Bug Fixes**
  * Enhanced keyboard modifier detection and normalization for more reliable link interaction behavior across all interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->