### PR TITLE
Add --layout to workspace.create for programmatic split layouts

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2105,9 +2105,10 @@ struct CMUXCLI {
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
             let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
             let (nameOpt, rem2) = parseOption(rem1, name: "--name")
-            let (descriptionOpt, remaining) = parseOption(rem2, name: "--description")
+            let (descriptionOpt, rem3) = parseOption(rem2, name: "--description")
+            let (layoutOpt, remaining) = parseOption(rem3, name: "--layout")
             if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>")
+                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>, --layout <json>")
             }
             var params: [String: Any] = [:]
             if let cwdOpt {
@@ -2120,10 +2121,17 @@ struct CMUXCLI {
             if let descriptionOpt {
                 params["description"] = descriptionOpt
             }
+            if let layoutOpt {
+                guard let layoutData = layoutOpt.data(using: .utf8),
+                      let layoutObj = try? JSONSerialization.jsonObject(with: layoutData) else {
+                    throw CLIError(message: "new-workspace: --layout value must be valid JSON")
+                }
+                params["layout"] = layoutObj
+            }
             let response = try client.sendV2(method: "workspace.create", params: params)
             let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
             print("OK \(wsId)")
-            if let commandText = commandOpt, !wsId.isEmpty {
+            if layoutOpt == nil, let commandText = commandOpt, !wsId.isEmpty {
                 let text = unescapeSendText(commandText + "\\n")
                 let sendParams: [String: Any] = ["text": text, "workspace_id": wsId]
                 _ = try client.sendV2(method: "surface.send_text", params: sendParams)
@@ -7201,15 +7209,18 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>]
+            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>]
 
             Create a new workspace in the current window.
 
             Flags:
-              --name <title>     Set a custom name for the new workspace
+              --name <title>       Set a custom name for the new workspace
               --description <text> Set a custom description for the new workspace
-              --cwd <path>       Set the working directory for the new workspace
-              --command <text>   Send text+Enter to the new workspace after creation
+              --cwd <path>         Set the working directory for the new workspace
+              --command <text>     Send text+Enter to the new workspace after creation
+              --layout <json>      Create workspace with a predefined split layout (inline JSON).
+                                   Uses the same schema as cmux.json layout definitions.
+                                   When provided, --command is ignored (layout surfaces define their own commands).
 
             Example:
               cmux new-workspace
@@ -7217,6 +7228,7 @@ struct CMUXCLI {
               cmux new-workspace --name "Launch" --description "Ship checklist"
               cmux new-workspace --cwd ~/projects/myapp
               cmux new-workspace --cwd . --command "npm test"
+              cmux new-workspace --name "Dev" --layout '{"direction":"horizontal","split":0.5,"children":[{"pane":{"surfaces":[{"type":"terminal","command":"vim"}]}},{"pane":{"surfaces":[{"type":"terminal","command":"npm run start"}]}}]}'
             """
         case "list-workspaces":
             return """
@@ -14372,7 +14384,7 @@ struct CMUXCLI {
           reorder-workspace --workspace <id|ref|index> (--index <n> | --before <id|ref|index> | --after <id|ref|index>) [--window <id|ref|index>]
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>]
           list-workspaces
-          new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>]
+          new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2123,8 +2123,8 @@ struct CMUXCLI {
             }
             if let layoutOpt {
                 guard let layoutData = layoutOpt.data(using: .utf8),
-                      let layoutObj = try? JSONSerialization.jsonObject(with: layoutData) else {
-                    throw CLIError(message: "new-workspace: --layout value must be valid JSON")
+                      let layoutObj = try? JSONSerialization.jsonObject(with: layoutData) as? [String: Any] else {
+                    throw CLIError(message: "new-workspace: --layout value must be a valid JSON object")
                 }
                 params["layout"] = layoutObj
             }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3393,18 +3393,36 @@ class TerminalController {
         let title = (requestedTitle?.isEmpty == false) ? requestedTitle : nil
         let description = v2RawString(params, "description")
 
+        // Decode optional layout param (same JSON schema as cmux.json layout field).
+        // Validate before creating the workspace so malformed layouts fail fast.
+        var layoutNode: CmuxLayoutNode?
+        if let rawLayout = params["layout"] {
+            guard JSONSerialization.isValidJSONObject(rawLayout),
+                  let layoutData = try? JSONSerialization.data(withJSONObject: rawLayout) else {
+                return .err(code: "invalid_params", message: "layout must be a valid JSON object", data: nil)
+            }
+            do {
+                layoutNode = try JSONDecoder().decode(CmuxLayoutNode.self, from: layoutData)
+            } catch {
+                return .err(code: "invalid_params", message: "Invalid layout: \(error.localizedDescription)", data: nil)
+            }
+        }
+
         var newId: UUID?
         let shouldFocus = v2FocusAllowed()
         v2MainSync {
             let ws = tabManager.addWorkspace(
                 title: title,
                 workingDirectory: cwd,
-                initialTerminalCommand: initialCommand,
-                initialTerminalEnvironment: initialEnv,
+                initialTerminalCommand: layoutNode == nil ? initialCommand : nil,
+                initialTerminalEnvironment: layoutNode == nil ? initialEnv : [:],
                 select: shouldFocus,
                 eagerLoadTerminal: !shouldFocus
             )
             ws.setCustomDescription(description)
+            if let layoutNode {
+                ws.applyCustomLayout(layoutNode, baseCwd: cwd ?? ws.currentDirectory)
+            }
             newId = ws.id
         }
 

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -145,7 +145,10 @@ def test_env_vars(c: cmux) -> None:
             },
         })
         c.select_workspace(ws)
-        c.send(f"printf 'CHECK=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\"\\n")
+        surfaces = _surface_list(c, ws)
+        _must(len(surfaces) >= 1, f"expected at least 1 surface, got {len(surfaces)}")
+        surface_id = str(surfaces[0].get("id"))
+        c.send_surface(surface_id, f"printf 'CHECK=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\"\\n")
         text = _wait_for_text(c, ws, f"CHECK={token}")
         _must(f"CHECK={token}" in text, f"env var not found in output: {text!r}")
         c.select_workspace(baseline)

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -290,6 +290,17 @@ def test_layout_overrides_initial_command_and_env(c: cmux) -> None:
         text = _wait_for_text(c, ws, f"LAYOUT_CMD_{token}")
         _must(f"LAYOUT_CMD_{token}" in text, f"layout command missing: {text!r}")
         _must("SHOULD_NOT_RUN" not in text, f"initial_command unexpectedly ran: {text!r}")
+        # Verify initial_env was ignored and layout env was applied
+        surfaces = _surface_list(c, ws)
+        _must(len(surfaces) >= 1, f"expected at least 1 surface, got {len(surfaces)}")
+        surface_id = str(surfaces[0].get("id"))
+        c.send_surface(
+            surface_id,
+            "printf 'LAYOUT_ENV=%s INITIAL_ENV=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\" \"$SHOULD_NOT_EXIST\"\\n",
+        )
+        env_text = _wait_for_text(c, ws, f"LAYOUT_ENV={token}")
+        _must(f"LAYOUT_ENV={token}" in env_text, f"layout env missing: {env_text!r}")
+        _must("INITIAL_ENV=1" not in env_text, f"initial_env unexpectedly applied: {env_text!r}")
         c.select_workspace(baseline)
     finally:
         if ws:

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -51,6 +51,13 @@ def _surface_list(c: cmux, workspace_id: str) -> list:
     return list(payload.get("surfaces") or [])
 
 
+def _close_workspace_quietly(c: cmux, workspace_id: str) -> None:
+    try:
+        c.close_workspace(workspace_id)
+    except cmuxError as err:
+        print(f"  WARN: failed to close workspace {workspace_id}: {err}", file=sys.stderr)
+
+
 def _create_and_get_id(c: cmux, params: dict) -> str:
     payload = c._call("workspace.create", params) or {}
     ws_id = str(payload.get("workspace_id") or "")
@@ -84,10 +91,7 @@ def test_horizontal_split(c: cmux) -> None:
         c.select_workspace(baseline)
     finally:
         if ws:
-            try:
-                c.close_workspace(ws)
-            except Exception:
-                pass
+            _close_workspace_quietly(c, ws)
     print("  PASS: horizontal split creates 2 terminal panes")
 
 
@@ -119,10 +123,7 @@ def test_nested_splits(c: cmux) -> None:
         c.select_workspace(baseline)
     finally:
         if ws:
-            try:
-                c.close_workspace(ws)
-            except Exception:
-                pass
+            _close_workspace_quietly(c, ws)
     print("  PASS: nested splits create 3 panes")
 
 
@@ -150,10 +151,7 @@ def test_env_vars(c: cmux) -> None:
         c.select_workspace(baseline)
     finally:
         if ws:
-            try:
-                c.close_workspace(ws)
-            except Exception:
-                pass
+            _close_workspace_quietly(c, ws)
     print("  PASS: per-surface env vars are applied")
 
 
@@ -180,10 +178,7 @@ def test_surface_commands(c: cmux) -> None:
         c.select_workspace(baseline)
     finally:
         if ws:
-            try:
-                c.close_workspace(ws)
-            except Exception:
-                pass
+            _close_workspace_quietly(c, ws)
     print("  PASS: per-surface commands are executed")
 
 
@@ -210,10 +205,7 @@ def test_multi_surface_pane(c: cmux) -> None:
         c.select_workspace(baseline)
     finally:
         if ws:
-            try:
-                c.close_workspace(ws)
-            except Exception:
-                pass
+            _close_workspace_quietly(c, ws)
     print("  PASS: multi-surface pane creates tabs within one pane")
 
 

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -148,7 +148,7 @@ def test_env_vars(c: cmux) -> None:
         surfaces = _surface_list(c, ws)
         _must(len(surfaces) >= 1, f"expected at least 1 surface, got {len(surfaces)}")
         surface_id = str(surfaces[0].get("id"))
-        c.send_surface(surface_id, f"printf 'CHECK=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\"\\n")
+        c.send_surface(surface_id, "printf 'CHECK=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\"\\n")
         text = _wait_for_text(c, ws, f"CHECK={token}")
         _must(f"CHECK={token}" in text, f"env var not found in output: {text!r}")
         c.select_workspace(baseline)

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -266,6 +266,37 @@ def test_empty_surfaces_rejected(c: cmux) -> None:
     print("  PASS: empty surfaces array is rejected")
 
 
+def test_layout_overrides_initial_command_and_env(c: cmux) -> None:
+    """When layout is provided, initial_command and initial_env are ignored."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        token = f"layout_only_{int(time.time() * 1000)}"
+        ws = _create_and_get_id(c, {
+            "title": "test_precedence",
+            "initial_command": "echo SHOULD_NOT_RUN",
+            "initial_env": {"SHOULD_NOT_EXIST": "1"},
+            "layout": {
+                "pane": {
+                    "surfaces": [{
+                        "type": "terminal",
+                        "env": {"CMUX_LAYOUT_TEST_TOKEN": token},
+                        "command": f"echo LAYOUT_CMD_{token}",
+                    }],
+                },
+            },
+        })
+        c.select_workspace(ws)
+        text = _wait_for_text(c, ws, f"LAYOUT_CMD_{token}")
+        _must(f"LAYOUT_CMD_{token}" in text, f"layout command missing: {text!r}")
+        _must("SHOULD_NOT_RUN" not in text, f"initial_command unexpectedly ran: {text!r}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            _close_workspace_quietly(c, ws)
+    print("  PASS: layout overrides initial_command and initial_env")
+
+
 def main() -> int:
     with cmux(SOCKET_PATH) as c:
         print("test_workspace_create_layout:")
@@ -274,6 +305,7 @@ def main() -> int:
         test_env_vars(c)
         test_surface_commands(c)
         test_multi_surface_pane(c)
+        test_layout_overrides_initial_command_and_env(c)
         test_malformed_layout_rejected(c)
         test_empty_surfaces_rejected(c)
 

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""Test: workspace.create with layout parameter creates split panes and surfaces."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+import base64
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _wait_for_text(c: cmux, workspace_id: str, needle: str, timeout_s: float = 8.0) -> str:
+    deadline = time.time() + timeout_s
+    last_text = ""
+    while time.time() < deadline:
+        payload = c._call(
+            "surface.read_text",
+            {"workspace_id": workspace_id},
+        ) or {}
+        if "text" in payload:
+            last_text = str(payload.get("text") or "")
+        else:
+            b64 = str(payload.get("base64") or "")
+            raw = base64.b64decode(b64) if b64 else b""
+            last_text = raw.decode("utf-8", errors="replace")
+        if needle in last_text:
+            return last_text
+        time.sleep(0.1)
+    raise cmuxError(f"Timed out waiting for {needle!r} in panel text: {last_text!r}")
+
+
+def _pane_count(c: cmux, workspace_id: str) -> int:
+    payload = c._call("pane.list", {"workspace_id": workspace_id}) or {}
+    return len(payload.get("panes") or [])
+
+
+def _surface_list(c: cmux, workspace_id: str) -> list:
+    payload = c._call("surface.list", {"workspace_id": workspace_id}) or {}
+    return list(payload.get("surfaces") or [])
+
+
+def _create_and_get_id(c: cmux, params: dict) -> str:
+    payload = c._call("workspace.create", params) or {}
+    ws_id = str(payload.get("workspace_id") or "")
+    _must(bool(ws_id), f"workspace.create returned no workspace_id: {payload}")
+    return ws_id
+
+
+def test_horizontal_split(c: cmux) -> None:
+    """Two terminal panes side by side."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        ws = _create_and_get_id(c, {
+            "title": "test_hsplit",
+            "layout": {
+                "direction": "horizontal",
+                "split": 0.5,
+                "children": [
+                    {"pane": {"surfaces": [{"type": "terminal", "name": "Left"}]}},
+                    {"pane": {"surfaces": [{"type": "terminal", "name": "Right"}]}},
+                ],
+            },
+        })
+        _must(c.current_workspace() == baseline, "should not steal focus")
+        c.select_workspace(ws)
+        _must(_pane_count(c, ws) == 2, f"expected 2 panes, got {_pane_count(c, ws)}")
+        surfaces = _surface_list(c, ws)
+        _must(len(surfaces) == 2, f"expected 2 surfaces, got {len(surfaces)}")
+        types = {str(s.get("type")) for s in surfaces}
+        _must(types == {"terminal"}, f"expected all terminal surfaces, got {types}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+    print("  PASS: horizontal split creates 2 terminal panes")
+
+
+def test_nested_splits(c: cmux) -> None:
+    """Three panes: left terminal, top-right terminal, bottom-right terminal."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        ws = _create_and_get_id(c, {
+            "title": "test_nested",
+            "layout": {
+                "direction": "horizontal",
+                "split": 0.5,
+                "children": [
+                    {"pane": {"surfaces": [{"type": "terminal"}]}},
+                    {
+                        "direction": "vertical",
+                        "split": 0.5,
+                        "children": [
+                            {"pane": {"surfaces": [{"type": "terminal"}]}},
+                            {"pane": {"surfaces": [{"type": "terminal"}]}},
+                        ],
+                    },
+                ],
+            },
+        })
+        c.select_workspace(ws)
+        _must(_pane_count(c, ws) == 3, f"expected 3 panes, got {_pane_count(c, ws)}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+    print("  PASS: nested splits create 3 panes")
+
+
+def test_env_vars(c: cmux) -> None:
+    """Per-surface env vars are applied to terminal surfaces."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        token = f"tok_{int(time.time() * 1000)}"
+        ws = _create_and_get_id(c, {
+            "title": "test_env",
+            "layout": {
+                "pane": {
+                    "surfaces": [{
+                        "type": "terminal",
+                        "env": {"CMUX_LAYOUT_TEST_TOKEN": token},
+                    }],
+                },
+            },
+        })
+        c.select_workspace(ws)
+        c.send(f"printf 'CHECK=%s\\n' \"$CMUX_LAYOUT_TEST_TOKEN\"\\n")
+        text = _wait_for_text(c, ws, f"CHECK={token}")
+        _must(f"CHECK={token}" in text, f"env var not found in output: {text!r}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+    print("  PASS: per-surface env vars are applied")
+
+
+def test_surface_commands(c: cmux) -> None:
+    """Per-surface commands are executed in terminal surfaces."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        token = f"cmd_{int(time.time() * 1000)}"
+        ws = _create_and_get_id(c, {
+            "title": "test_cmd",
+            "layout": {
+                "pane": {
+                    "surfaces": [{
+                        "type": "terminal",
+                        "command": f"echo {token}",
+                    }],
+                },
+            },
+        })
+        c.select_workspace(ws)
+        text = _wait_for_text(c, ws, token)
+        _must(token in text, f"command output not found: {text!r}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+    print("  PASS: per-surface commands are executed")
+
+
+def test_multi_surface_pane(c: cmux) -> None:
+    """Multiple surfaces (tabs) in a single pane."""
+    baseline = c.current_workspace()
+    ws = ""
+    try:
+        ws = _create_and_get_id(c, {
+            "title": "test_multi",
+            "layout": {
+                "pane": {
+                    "surfaces": [
+                        {"type": "terminal", "name": "Tab1"},
+                        {"type": "terminal", "name": "Tab2"},
+                    ],
+                },
+            },
+        })
+        c.select_workspace(ws)
+        _must(_pane_count(c, ws) == 1, f"expected 1 pane, got {_pane_count(c, ws)}")
+        surfaces = _surface_list(c, ws)
+        _must(len(surfaces) == 2, f"expected 2 surfaces, got {len(surfaces)}")
+        c.select_workspace(baseline)
+    finally:
+        if ws:
+            try:
+                c.close_workspace(ws)
+            except Exception:
+                pass
+    print("  PASS: multi-surface pane creates tabs within one pane")
+
+
+def test_malformed_layout_rejected(c: cmux) -> None:
+    """Malformed layout returns an error and does not create a workspace."""
+    baseline_workspaces = c._call("workspace.list") or {}
+    baseline_count = len((baseline_workspaces.get("workspaces") or []))
+
+    # Split with only 1 child — should be rejected
+    try:
+        c._call("workspace.create", {
+            "title": "test_bad",
+            "layout": {
+                "direction": "horizontal",
+                "children": [
+                    {"pane": {"surfaces": [{"type": "terminal"}]}},
+                ],
+            },
+        })
+        raise cmuxError("Expected error for malformed layout, but call succeeded")
+    except cmuxError as e:
+        if "invalid_params" in str(e) or "Invalid layout" in str(e):
+            pass  # expected
+        else:
+            raise
+
+    after_workspaces = c._call("workspace.list") or {}
+    after_count = len((after_workspaces.get("workspaces") or []))
+    _must(after_count == baseline_count, f"malformed layout created a workspace: {baseline_count} -> {after_count}")
+    print("  PASS: malformed layout is rejected without creating a workspace")
+
+
+def test_empty_surfaces_rejected(c: cmux) -> None:
+    """Pane with empty surfaces array is rejected."""
+    try:
+        c._call("workspace.create", {
+            "title": "test_empty",
+            "layout": {
+                "pane": {"surfaces": []},
+            },
+        })
+        raise cmuxError("Expected error for empty surfaces, but call succeeded")
+    except cmuxError as e:
+        if "invalid_params" in str(e) or "Invalid layout" in str(e):
+            pass  # expected
+        else:
+            raise
+    print("  PASS: empty surfaces array is rejected")
+
+
+def main() -> int:
+    with cmux(SOCKET_PATH) as c:
+        print("test_workspace_create_layout:")
+        test_horizontal_split(c)
+        test_nested_splits(c)
+        test_env_vars(c)
+        test_surface_commands(c)
+        test_multi_surface_pane(c)
+        test_malformed_layout_rejected(c)
+        test_empty_surfaces_rejected(c)
+
+    print("PASS: all workspace.create layout tests passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_workspace_create_layout.py
+++ b/tests_v2/test_workspace_create_layout.py
@@ -240,6 +240,9 @@ def test_malformed_layout_rejected(c: cmux) -> None:
 
 def test_empty_surfaces_rejected(c: cmux) -> None:
     """Pane with empty surfaces array is rejected."""
+    baseline_workspaces = c._call("workspace.list") or {}
+    baseline_count = len((baseline_workspaces.get("workspaces") or []))
+
     try:
         c._call("workspace.create", {
             "title": "test_empty",
@@ -253,6 +256,10 @@ def test_empty_surfaces_rejected(c: cmux) -> None:
             pass  # expected
         else:
             raise
+
+    after_workspaces = c._call("workspace.list") or {}
+    after_count = len((after_workspaces.get("workspaces") or []))
+    _must(after_count == baseline_count, f"empty surfaces created a workspace: {baseline_count} -> {after_count}")
     print("  PASS: empty surfaces array is rejected")
 
 


### PR DESCRIPTION
Closes #2915

This adds a `layout` parameter to the `workspace.create` socket API and a `--layout` flag to the `cmux new-workspace` CLI command. It lets you create a workspace with a predefined split layout in a single call, rather than creating a workspace and then issuing a series of split/send commands after the fact.

## What it does

The layout param accepts the same JSON schema that cmux.json custom commands already use for their layout definitions. Internally it calls the existing `Workspace.applyCustomLayout()` — the same code path the command palette uses — so all existing layout features work: splits, nested splits, per-surface commands, per-surface env vars, browser surfaces, multi-surface panes, and focus control.

Example CLI usage:
```
cmux new-workspace --name "Dev" --layout '{"direction":"horizontal","split":0.5,"children":[{"pane":{"surfaces":[{"type":"terminal","command":"vim"}]}},{"pane":{"surfaces":[{"type":"terminal","command":"npm run start"}]}}]}'
```

Example socket call:
```json
{"method": "workspace.create", "params": {"title": "Dev", "layout": {"direction": "horizontal", "split": 0.5, "children": [{"pane": {"surfaces": [{"type": "terminal", "command": "vim"}]}}, {"pane": {"surfaces": [{"type": "terminal"}]}}]}}}
```

## Implementation notes

- The layout JSON is decoded as `CmuxLayoutNode` (which is already `Codable`) via `JSONDecoder`. All existing validation applies — malformed layouts are rejected before the workspace is created.
- When `layout` is provided, `initial_command` and `initial_env` are ignored since the layout's per-surface definitions take precedence. The placeholder terminal created by `addWorkspace` gets reconfigured/replaced by the layout anyway. Worth noting for anyone using the socket API directly — if you pass both, layout wins silently.
- Focus follows the existing socket policy: the workspace is created in the background (not selected). The layout's `focus: true` flag only controls which pane is focused within the workspace when you navigate to it.

## Testing

Added a socket test (`tests_v2/test_workspace_create_layout.py`) covering horizontal splits, nested splits, per-surface env vars, per-surface commands, multi-surface panes, and error rejection for malformed layouts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --layout <json> option to create workspaces with JSON-defined pane and surface layouts at creation.

* **Behavior Changes**
  * When a layout is provided, the usual post-create initial command is skipped so the supplied layout and per-surface settings take effect.

* **Validation / Error Handling**
  * Client and server validate that --layout is a UTF-8 JSON object and return clear errors for malformed or undecodable layouts.

* **Tests**
  * Added end-to-end tests for valid layouts, env/command injection, multi-surface panes, and rejection of malformed or empty layouts.

* **Documentation**
  * Updated help/usage text and examples to document the new --layout flag.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add layout support to workspace creation so you can spin up a workspace with predefined splits in a single call via `workspace.create` and `cmux new-workspace --layout`. Implements #2915 by enabling programmatic split layouts.

- **New Features**
  - Socket: `workspace.create` accepts `layout` (JSON, same schema as `cmux.json` layouts). Validated before creation; invalid or empty-surface layouts return `invalid_params`.
  - CLI: `cmux new-workspace` adds `--layout <json>`; value must be a JSON object (not array/string), parsed and validated. When `--layout` is provided, `--command` is ignored and not sent.
  - Uses existing `Workspace.applyCustomLayout()` so features work as expected: splits, nested splits, per-surface command/env, multi-surface panes, and in-workspace focus.

- **Migration**
  - If `layout` is provided, `initial_command`/`initial_env` (and CLI `--command`) are ignored in favor of per-surface definitions.
  - Workspace creation focus behavior is unchanged; `focus: true` in the layout only affects pane focus within the new workspace.

<sup>Written for commit b555141ae9f829f6de8ce5c591d412f682d98104. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

