### PR TITLE
Remove dead per-shell PR poll code from shell integrations

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -419,7 +419,6 @@ _cmux_clear_pr_for_panel() {
     [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
     [[ -n "$CMUX_TAB_ID" ]] || return 0
     [[ -n "$CMUX_PANEL_ID" ]] || return 0
-    # Synchronous: must arrive before the next report_pr from the poll loop.
     _cmux_send "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -182,13 +182,6 @@ _CMUX_GIT_JOB_STARTED_AT="${_CMUX_GIT_JOB_STARTED_AT:-0}"
 _CMUX_GIT_HEAD_LAST_PWD="${_CMUX_GIT_HEAD_LAST_PWD:-}"
 _CMUX_GIT_HEAD_PATH="${_CMUX_GIT_HEAD_PATH:-}"
 _CMUX_GIT_HEAD_SIGNATURE="${_CMUX_GIT_HEAD_SIGNATURE:-}"
-_CMUX_PR_POLL_PID="${_CMUX_PR_POLL_PID:-}"
-_CMUX_PR_POLL_PWD="${_CMUX_PR_POLL_PWD:-}"
-_CMUX_PR_LAST_BRANCH="${_CMUX_PR_LAST_BRANCH:-}"
-_CMUX_PR_NO_PR_BRANCH="${_CMUX_PR_NO_PR_BRANCH:-}"
-_CMUX_PR_POLL_INTERVAL="${_CMUX_PR_POLL_INTERVAL:-45}"
-_CMUX_PR_FORCE="${_CMUX_PR_FORCE:-0}"
-_CMUX_PR_DEBUG="${_CMUX_PR_DEBUG:-0}"
 _CMUX_ASYNC_JOB_TIMEOUT="${_CMUX_ASYNC_JOB_TIMEOUT:-20}"
 _CMUX_LAST_PR_ACTION="${_CMUX_LAST_PR_ACTION:-}"
 _CMUX_LAST_PR_TARGET="${_CMUX_LAST_PR_TARGET:-}"
@@ -308,8 +301,6 @@ _cmux_tmux_refresh_cmux_environment() {
         _CMUX_GIT_HEAD_LAST_PWD=""
         _CMUX_GIT_HEAD_PATH=""
         _CMUX_GIT_HEAD_SIGNATURE=""
-        _CMUX_PR_FORCE=1
-        _cmux_stop_pr_poll_loop
     fi
 }
 
@@ -521,350 +512,6 @@ _cmux_emit_pr_command_hint() {
     _CMUX_LAST_PR_TARGET=""
 }
 
-_cmux_pr_output_indicates_no_pull_request() {
-    local output="$1"
-    output="$(printf '%s' "$output" | tr '[:upper:]' '[:lower:]')"
-    [[ "$output" == *"no pull requests found"* \
-        || "$output" == *"no pull request found"* \
-        || "$output" == *"no pull requests associated"* \
-        || "$output" == *"no pull request associated"* ]]
-}
-
-_cmux_github_repo_slug_for_path() {
-    local repo_path="$1"
-    local remote_url="" path_part=""
-    [[ -n "$repo_path" ]] || return 0
-
-    remote_url="$(git -C "$repo_path" remote get-url origin 2>/dev/null)"
-    [[ -n "$remote_url" ]] || return 0
-
-    case "$remote_url" in
-        git@github.com:*)
-            path_part="${remote_url#git@github.com:}"
-            ;;
-        ssh://git@github.com/*)
-            path_part="${remote_url#ssh://git@github.com/}"
-            ;;
-        https://github.com/*)
-            path_part="${remote_url#https://github.com/}"
-            ;;
-        http://github.com/*)
-            path_part="${remote_url#http://github.com/}"
-            ;;
-        git://github.com/*)
-            path_part="${remote_url#git://github.com/}"
-            ;;
-        *)
-            return 0
-            ;;
-    esac
-
-    path_part="${path_part%.git}"
-    [[ "$path_part" == */* ]] || return 0
-    printf '%s\n' "$path_part"
-}
-
-_cmux_pr_cache_prefix() {
-    [[ -n "$CMUX_PANEL_ID" ]] || return 1
-    printf '%s\n' "/tmp/cmux-pr-cache-${CMUX_PANEL_ID}"
-}
-
-_cmux_pr_force_signal_path() {
-    [[ -n "$CMUX_PANEL_ID" ]] || return 1
-    printf '%s\n' "/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
-}
-
-_cmux_pr_debug_log() {
-    (( _CMUX_PR_DEBUG )) || return 0
-
-    local branch="$1"
-    local event="$2"
-    local now
-    now="$(_cmux_now)"
-    printf '%s\tbranch=%s\tevent=%s\n' "$now" "$branch" "$event" >> /tmp/cmux-pr-debug.log
-}
-
-_cmux_pr_cache_clear() {
-    local prefix=""
-    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
-    if [[ -n "$prefix" ]]; then
-        /bin/rm -f -- \
-            "${prefix}.branch" \
-            "${prefix}.repo" \
-            "${prefix}.result" \
-            "${prefix}.timestamp" \
-            "${prefix}.no-pr-branch" \
-            >/dev/null 2>&1 || true
-    fi
-
-    _CMUX_PR_LAST_BRANCH=""
-    _CMUX_PR_NO_PR_BRANCH=""
-}
-
-_cmux_pr_request_probe() {
-    local signal_path=""
-    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-    [[ -n "$signal_path" ]] || return 0
-    : >| "$signal_path"
-}
-
-_cmux_report_pr_for_path() {
-    local repo_path="$1"
-    local force_probe="${2:-0}"
-    [[ -n "$repo_path" ]] || {
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    }
-    [[ -d "$repo_path" ]] || {
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    }
-    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
-    [[ -n "$CMUX_TAB_ID" ]] || return 0
-    [[ -n "$CMUX_PANEL_ID" ]] || return 0
-
-    local branch repo_slug="" gh_output="" gh_error="" err_file="" gh_status number state url status_opt=""
-    local now prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
-    local cache_branch="" cache_result="" cache_no_pr_branch=""
-    local -a gh_repo_args=()
-    now="$(_cmux_now)"
-    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
-    if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
-        _cmux_pr_debug_log "$branch" "cache-miss:clear"
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    fi
-
-    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
-    if [[ -n "$prefix" ]]; then
-        branch_file="${prefix}.branch"
-        repo_file="${prefix}.repo"
-        result_file="${prefix}.result"
-        timestamp_file="${prefix}.timestamp"
-        no_pr_branch_file="${prefix}.no-pr-branch"
-        [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
-        [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
-        [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
-    fi
-
-    _CMUX_PR_LAST_BRANCH="$cache_branch"
-    _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
-    if [[ "$cache_branch" == "$branch" && -n "$cache_result" ]]; then
-        _cmux_pr_debug_log "$branch" "cache-refresh"
-    else
-        _cmux_pr_debug_log "$branch" "cache-miss"
-    fi
-
-    repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
-    if [[ -n "$repo_slug" ]]; then
-        gh_repo_args=(--repo "$repo_slug")
-    fi
-
-    err_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/cmux-gh-pr-view.XXXXXX" 2>/dev/null || true)"
-    [[ -n "$err_file" ]] || return 1
-    gh_output="$(
-        builtin cd "$repo_path" 2>/dev/null \
-            && gh pr view "$branch" \
-                "${gh_repo_args[@]}" \
-                --json number,state,url \
-                --jq '[.number, .state, .url] | @tsv' \
-                2>"$err_file"
-    )"
-    gh_status=$?
-    if [[ -f "$err_file" ]]; then
-        gh_error="$("/bin/cat" -- "$err_file" 2>/dev/null || true)"
-        /bin/rm -f -- "$err_file" >/dev/null 2>&1 || true
-    fi
-
-    if (( gh_status != 0 )) || [[ -z "$gh_output" ]]; then
-        if (( gh_status == 0 )) && [[ -z "$gh_output" ]]; then
-            if [[ -n "$prefix" ]]; then
-                printf '%s\n' "$branch" >| "$branch_file"
-                printf '%s\n' "$repo_path" >| "$repo_file"
-                printf '%s\n' "$now" >| "$timestamp_file"
-                printf '%s\n' "none" >| "$result_file"
-                printf '%s\n' "$branch" >| "$no_pr_branch_file"
-            fi
-            _CMUX_PR_LAST_BRANCH="$branch"
-            _CMUX_PR_NO_PR_BRANCH="$branch"
-            _cmux_clear_pr_for_panel
-            return 0
-        fi
-        if _cmux_pr_output_indicates_no_pull_request "$gh_error"; then
-            if [[ -n "$prefix" ]]; then
-                printf '%s\n' "$branch" >| "$branch_file"
-                printf '%s\n' "$repo_path" >| "$repo_file"
-                printf '%s\n' "$now" >| "$timestamp_file"
-                printf '%s\n' "none" >| "$result_file"
-                printf '%s\n' "$branch" >| "$no_pr_branch_file"
-            fi
-            _CMUX_PR_LAST_BRANCH="$branch"
-            _CMUX_PR_NO_PR_BRANCH="$branch"
-            _cmux_clear_pr_for_panel
-            return 0
-        fi
-
-        # Always scope PR detection to the exact current branch. Preserve the
-        # last-known PR badge when gh fails transiently, then retry on the next
-        # background poll instead of showing a mismatched PR.
-        return 1
-    fi
-
-    IFS=$'\t' read -r number state url <<< "$gh_output"
-    if [[ -z "$number" || -z "$url" ]]; then
-        return 1
-    fi
-
-    case "$state" in
-        MERGED) status_opt="--state=merged" ;;
-        OPEN) status_opt="--state=open" ;;
-        CLOSED) status_opt="--state=closed" ;;
-        *) return 1 ;;
-    esac
-
-    if [[ -n "$prefix" ]]; then
-        printf '%s\n' "$branch" >| "$branch_file"
-        printf '%s\n' "$repo_path" >| "$repo_file"
-        printf '%s\n' "$now" >| "$timestamp_file"
-        printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
-        /bin/rm -f -- "$no_pr_branch_file" >/dev/null 2>&1 || true
-    fi
-    _CMUX_PR_LAST_BRANCH="$branch"
-    _CMUX_PR_NO_PR_BRANCH=""
-
-    local quoted_branch="${branch//\"/\\\"}"
-    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-}
-
-_cmux_child_pids() {
-    local parent_pid="$1"
-    [[ -n "$parent_pid" ]] || return 0
-    /bin/ps -ax -o pid= -o ppid= 2>/dev/null | /usr/bin/awk -v parent="$parent_pid" '$2 == parent { print $1 }'
-}
-
-_cmux_kill_process_tree() {
-    local pid="$1"
-    local signal="${2:-TERM}"
-    local child_pid=""
-    [[ -n "$pid" ]] || return 0
-
-    while IFS= read -r child_pid; do
-        [[ -n "$child_pid" ]] || continue
-        [[ "$child_pid" == "$pid" ]] && continue
-        _cmux_kill_process_tree "$child_pid" "$signal"
-    done < <(_cmux_child_pids "$pid")
-
-    kill "-$signal" "$pid" >/dev/null 2>&1 || true
-}
-
-_cmux_run_pr_probe_with_timeout() {
-    local repo_path="$1"
-    local force_probe="${2:-0}"
-    local probe_pid=""
-    local started_at=""
-    local now=""
-    started_at="$(_cmux_now)"
-    now=$started_at
-
-    (
-        _cmux_report_pr_for_path "$repo_path" "$force_probe"
-    ) &
-    probe_pid=$!
-
-    while kill -0 "$probe_pid" >/dev/null 2>&1; do
-        sleep 1
-        now="$(_cmux_now)"
-        if (( _CMUX_ASYNC_JOB_TIMEOUT > 0 )) && (( now - started_at >= _CMUX_ASYNC_JOB_TIMEOUT )); then
-            _cmux_kill_process_tree "$probe_pid" TERM
-            sleep 0.2
-            if kill -0 "$probe_pid" >/dev/null 2>&1; then
-                _cmux_kill_process_tree "$probe_pid" KILL
-                sleep 0.2
-            fi
-            if ! kill -0 "$probe_pid" >/dev/null 2>&1; then
-                wait "$probe_pid" >/dev/null 2>&1 || true
-            fi
-            return 1
-        fi
-    done
-
-    wait "$probe_pid"
-}
-
-_cmux_halt_pr_poll_loop() {
-    if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        # Process-group kill: background jobs are process-group leaders, so
-        # negative PID kills the loop + all descendants (gh, sleep) without
-        # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-        kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
-    fi
-    local signal_path=""
-    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-    [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-    _CMUX_PR_POLL_PID=""
-    _CMUX_PR_POLL_PWD=""
-}
-
-_cmux_stop_pr_poll_loop() {
-    _cmux_halt_pr_poll_loop
-    _cmux_pr_cache_clear
-}
-
-_cmux_start_pr_poll_loop() {
-    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
-    [[ -n "$CMUX_TAB_ID" ]] || return 0
-    [[ -n "$CMUX_PANEL_ID" ]] || return 0
-
-    local watch_pwd="${1:-$PWD}"
-    local force_restart="${2:-0}"
-    local watch_shell_pid="$$"
-    local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
-
-    if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
-        && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        return 0
-    fi
-
-    if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        _cmux_halt_pr_poll_loop
-    else
-        _CMUX_PR_POLL_PID=""
-    fi
-    _CMUX_PR_POLL_PWD="$watch_pwd"
-
-    {
-        local signal_path=""
-        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-        while :; do
-            kill -0 "$watch_shell_pid" 2>/dev/null || break
-            local force_probe=0
-            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                force_probe=1
-                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-            fi
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
-
-            local slept=0
-            while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" 2>/dev/null || exit 0
-                if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                    break
-                fi
-                sleep 1
-                slept=$(( slept + 1 ))
-            done
-        done
-    } >/dev/null 2>&1 &
-    _CMUX_PR_POLL_PID=$!
-    disown "$_CMUX_PR_POLL_PID" 2>/dev/null || disown
-}
-
-_cmux_bash_cleanup() {
-    _cmux_stop_pr_poll_loop
-}
 
 _cmux_command_starts_nested_shell() {
     local cmd="$1"
@@ -936,7 +583,6 @@ _cmux_preexec_command() {
     _cmux_report_shell_activity_state running
     _cmux_report_tty_once
     _cmux_ports_kick command
-    _cmux_halt_pr_poll_loop
     if _cmux_command_starts_nested_shell "$cmd"; then
         return 0
     fi
@@ -1030,8 +676,6 @@ _cmux_prompt_command() {
             elif [[ "$head_signature" != "$_CMUX_GIT_HEAD_SIGNATURE" ]]; then
                 _CMUX_GIT_HEAD_SIGNATURE="$head_signature"
                 git_head_changed=1
-                # Also invalidate the PR poller so it refreshes with the new branch.
-                _CMUX_PR_FORCE=1
             fi
         fi
     fi
@@ -1071,7 +715,6 @@ _cmux_prompt_command() {
     fi
 
     if [[ "$git_head_changed" == "1" ]]; then
-        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
     fi
     if (( last_status == 0 )); then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -185,13 +185,6 @@ typeset -g _CMUX_GIT_HEAD_LAST_PWD=""
 typeset -g _CMUX_GIT_HEAD_PATH=""
 typeset -g _CMUX_GIT_HEAD_SIGNATURE=""
 typeset -g _CMUX_GIT_HEAD_WATCH_PID=""
-typeset -g _CMUX_PR_POLL_PID=""
-typeset -g _CMUX_PR_POLL_PWD=""
-typeset -g _CMUX_PR_LAST_BRANCH=""
-typeset -g _CMUX_PR_NO_PR_BRANCH=""
-typeset -g _CMUX_PR_POLL_INTERVAL=45
-typeset -g _CMUX_PR_FORCE=0
-typeset -g _CMUX_PR_DEBUG=${_CMUX_PR_DEBUG:-0}
 typeset -g _CMUX_ASYNC_JOB_TIMEOUT=20
 typeset -g _CMUX_LAST_PR_ACTION=""
 typeset -g _CMUX_LAST_PR_TARGET=""
@@ -314,8 +307,6 @@ _cmux_tmux_refresh_cmux_environment() {
         _CMUX_GIT_HEAD_PATH=""
         _CMUX_GIT_HEAD_SIGNATURE=""
         _CMUX_GIT_FORCE=1
-        _CMUX_PR_FORCE=1
-        _cmux_stop_pr_poll_loop
         _cmux_stop_git_head_watch
     fi
 }
@@ -633,344 +624,6 @@ _cmux_clear_pr_for_panel() {
     _cmux_send_bg "clear_pr --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
-_cmux_pr_output_indicates_no_pull_request() {
-    local output="${1:l}"
-    [[ "$output" == *"no pull requests found"* \
-        || "$output" == *"no pull request found"* \
-        || "$output" == *"no pull requests associated"* \
-        || "$output" == *"no pull request associated"* ]]
-}
-
-_cmux_github_repo_slug_for_path() {
-    local repo_path="$1"
-    local remote_url="" path_part=""
-    [[ -n "$repo_path" ]] || return 0
-
-    remote_url="$(git -C "$repo_path" remote get-url origin 2>/dev/null)"
-    [[ -n "$remote_url" ]] || return 0
-
-    case "$remote_url" in
-        git@github.com:*)
-            path_part="${remote_url#git@github.com:}"
-            ;;
-        ssh://git@github.com/*)
-            path_part="${remote_url#ssh://git@github.com/}"
-            ;;
-        https://github.com/*)
-            path_part="${remote_url#https://github.com/}"
-            ;;
-        http://github.com/*)
-            path_part="${remote_url#http://github.com/}"
-            ;;
-        git://github.com/*)
-            path_part="${remote_url#git://github.com/}"
-            ;;
-        *)
-            return 0
-            ;;
-    esac
-
-    path_part="${path_part%.git}"
-    [[ "$path_part" == */* ]] || return 0
-    print -r -- "$path_part"
-}
-
-_cmux_pr_cache_prefix() {
-    [[ -n "$CMUX_PANEL_ID" ]] || return 1
-    print -r -- "/tmp/cmux-pr-cache-${CMUX_PANEL_ID}"
-}
-
-_cmux_pr_force_signal_path() {
-    [[ -n "$CMUX_PANEL_ID" ]] || return 1
-    print -r -- "/tmp/cmux-pr-force-${CMUX_PANEL_ID}"
-}
-
-_cmux_pr_debug_log() {
-    (( _CMUX_PR_DEBUG )) || return 0
-
-    local branch="$1"
-    local event="$2"
-    local now="${EPOCHSECONDS:-$SECONDS}"
-    printf '%s\tbranch=%s\tevent=%s\n' "$now" "$branch" "$event" >> /tmp/cmux-pr-debug.log
-}
-
-_cmux_pr_cache_clear() {
-    local prefix=""
-    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
-    if [[ -n "$prefix" ]]; then
-        /bin/rm -f -- \
-            "${prefix}.branch" \
-            "${prefix}.repo" \
-            "${prefix}.result" \
-            "${prefix}.timestamp" \
-            "${prefix}.no-pr-branch" \
-            >/dev/null 2>&1 || true
-    fi
-
-    _CMUX_PR_LAST_BRANCH=""
-    _CMUX_PR_NO_PR_BRANCH=""
-}
-
-_cmux_pr_request_probe() {
-    local signal_path=""
-    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-    [[ -n "$signal_path" ]] || return 0
-    : >| "$signal_path"
-}
-
-_cmux_report_pr_for_path() {
-    local repo_path="$1"
-    local force_probe="${2:-0}"
-    [[ -n "$repo_path" ]] || {
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    }
-    [[ -d "$repo_path" ]] || {
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    }
-    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
-    [[ -n "$CMUX_TAB_ID" ]] || return 0
-    [[ -n "$CMUX_PANEL_ID" ]] || return 0
-
-    local branch repo_slug="" gh_output="" gh_error="" err_file="" number state url status_opt="" gh_status
-    local now="${EPOCHSECONDS:-$SECONDS}"
-    local prefix="" branch_file="" repo_file="" result_file="" timestamp_file="" no_pr_branch_file=""
-    local cache_branch="" cache_result="" cache_no_pr_branch=""
-    local -a gh_repo_args
-    gh_repo_args=()
-    branch="$(git -C "$repo_path" branch --show-current 2>/dev/null)"
-    if [[ -z "$branch" ]] || ! command -v gh >/dev/null 2>&1; then
-        _cmux_pr_debug_log "$branch" "cache-miss:clear"
-        _cmux_pr_cache_clear
-        _cmux_clear_pr_for_panel
-        return 0
-    fi
-
-    prefix="$(_cmux_pr_cache_prefix 2>/dev/null || true)"
-    if [[ -n "$prefix" ]]; then
-        branch_file="${prefix}.branch"
-        repo_file="${prefix}.repo"
-        result_file="${prefix}.result"
-        timestamp_file="${prefix}.timestamp"
-        no_pr_branch_file="${prefix}.no-pr-branch"
-        [[ -r "$branch_file" ]] && cache_branch="$(<"$branch_file")"
-        [[ -r "$result_file" ]] && cache_result="$(<"$result_file")"
-        [[ -r "$no_pr_branch_file" ]] && cache_no_pr_branch="$(<"$no_pr_branch_file")"
-    fi
-
-    _CMUX_PR_LAST_BRANCH="$cache_branch"
-    _CMUX_PR_NO_PR_BRANCH="$cache_no_pr_branch"
-    if [[ "$cache_branch" == "$branch" && -n "$cache_result" ]]; then
-        _cmux_pr_debug_log "$branch" "cache-refresh"
-    else
-        _cmux_pr_debug_log "$branch" "cache-miss"
-    fi
-
-    repo_slug="$(_cmux_github_repo_slug_for_path "$repo_path")"
-    if [[ -n "$repo_slug" ]]; then
-        gh_repo_args=(--repo "$repo_slug")
-    fi
-
-    err_file="$(/usr/bin/mktemp "${TMPDIR:-/tmp}/cmux-gh-pr-view.XXXXXX" 2>/dev/null || true)"
-    [[ -n "$err_file" ]] || return 1
-    gh_output="$(
-        builtin cd "$repo_path" 2>/dev/null \
-            && gh pr view "$branch" \
-                "${gh_repo_args[@]}" \
-                --json number,state,url \
-                --jq '[.number, .state, .url] | @tsv' \
-                2>"$err_file"
-    )"
-    gh_status=$?
-    if [[ -f "$err_file" ]]; then
-        gh_error="$("/bin/cat" -- "$err_file" 2>/dev/null || true)"
-        /bin/rm -f -- "$err_file" >/dev/null 2>&1 || true
-    fi
-
-    if (( gh_status != 0 )) || [[ -z "$gh_output" ]]; then
-        if (( gh_status == 0 )) && [[ -z "$gh_output" ]]; then
-            if [[ -n "$prefix" ]]; then
-                print -r -- "$branch" >| "$branch_file"
-                print -r -- "$repo_path" >| "$repo_file"
-                print -r -- "$now" >| "$timestamp_file"
-                print -r -- "none" >| "$result_file"
-                print -r -- "$branch" >| "$no_pr_branch_file"
-            fi
-            _CMUX_PR_LAST_BRANCH="$branch"
-            _CMUX_PR_NO_PR_BRANCH="$branch"
-            _cmux_clear_pr_for_panel
-            return 0
-        fi
-        if _cmux_pr_output_indicates_no_pull_request "$gh_error"; then
-            if [[ -n "$prefix" ]]; then
-                print -r -- "$branch" >| "$branch_file"
-                print -r -- "$repo_path" >| "$repo_file"
-                print -r -- "$now" >| "$timestamp_file"
-                print -r -- "none" >| "$result_file"
-                print -r -- "$branch" >| "$no_pr_branch_file"
-            fi
-            _CMUX_PR_LAST_BRANCH="$branch"
-            _CMUX_PR_NO_PR_BRANCH="$branch"
-            _cmux_clear_pr_for_panel
-            return 0
-        fi
-
-        # Always scope PR detection to the exact current branch. When gh fails
-        # transiently (auth hiccups, API lag, rate limiting), keep the last-known
-        # badge and retry on the next poll instead of showing a mismatched PR.
-        return 1
-    fi
-
-    local IFS=$'\t'
-    read -r number state url <<< "$gh_output"
-    if [[ -z "$number" ]] || [[ -z "$url" ]]; then
-        return 1
-    fi
-
-    case "$state" in
-        MERGED) status_opt="--state=merged" ;;
-        OPEN) status_opt="--state=open" ;;
-        CLOSED) status_opt="--state=closed" ;;
-        *) return 1 ;;
-    esac
-
-    if [[ -n "$prefix" ]]; then
-        print -r -- "$branch" >| "$branch_file"
-        print -r -- "$repo_path" >| "$repo_file"
-        print -r -- "$now" >| "$timestamp_file"
-        printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
-        /bin/rm -f -- "$no_pr_branch_file" >/dev/null 2>&1 || true
-    fi
-    _CMUX_PR_LAST_BRANCH="$branch"
-    _CMUX_PR_NO_PR_BRANCH=""
-
-    local quoted_branch="${branch//\"/\\\"}"
-    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
-}
-
-_cmux_child_pids() {
-    local parent_pid="$1"
-    [[ -n "$parent_pid" ]] || return 0
-    /bin/ps -ax -o pid= -o ppid= 2>/dev/null | /usr/bin/awk -v parent="$parent_pid" '$2 == parent { print $1 }'
-}
-
-_cmux_kill_process_tree() {
-    local pid="$1"
-    local signal="${2:-TERM}"
-    local child_pid=""
-    [[ -n "$pid" ]] || return 0
-
-    while IFS= read -r child_pid; do
-        [[ -n "$child_pid" ]] || continue
-        [[ "$child_pid" == "$pid" ]] && continue
-        _cmux_kill_process_tree "$child_pid" "$signal"
-    done < <(_cmux_child_pids "$pid")
-
-    kill "-$signal" "$pid" >/dev/null 2>&1 || true
-}
-
-_cmux_run_pr_probe_with_timeout() {
-    local repo_path="$1"
-    local force_probe="${2:-0}"
-    local probe_pid=""
-    local started_at="${EPOCHSECONDS:-$SECONDS}"
-    local now=$started_at
-
-    (
-        _cmux_report_pr_for_path "$repo_path" "$force_probe"
-    ) &
-    probe_pid=$!
-
-    while kill -0 "$probe_pid" >/dev/null 2>&1; do
-        sleep 1
-        now="${EPOCHSECONDS:-$SECONDS}"
-        if (( _CMUX_ASYNC_JOB_TIMEOUT > 0 )) && (( now - started_at >= _CMUX_ASYNC_JOB_TIMEOUT )); then
-            _cmux_kill_process_tree "$probe_pid" TERM
-            sleep 0.2
-            if kill -0 "$probe_pid" >/dev/null 2>&1; then
-                _cmux_kill_process_tree "$probe_pid" KILL
-                sleep 0.2
-            fi
-            if ! kill -0 "$probe_pid" >/dev/null 2>&1; then
-                wait "$probe_pid" >/dev/null 2>&1 || true
-            fi
-            return 1
-        fi
-    done
-
-    wait "$probe_pid"
-}
-
-_cmux_halt_pr_poll_loop() {
-    if [[ -n "$_CMUX_PR_POLL_PID" ]]; then
-        # Process-group kill: background jobs are process-group leaders, so
-        # negative PID kills the loop + all descendants (gh, sleep) without
-        # the synchronous /bin/ps + awk of tree-kill (~5-13ms).
-        kill -KILL -- -"$_CMUX_PR_POLL_PID" 2>/dev/null || true
-    fi
-    local signal_path=""
-    signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-    [[ -n "$signal_path" ]] && /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-    _CMUX_PR_POLL_PID=""
-    _CMUX_PR_POLL_PWD=""
-}
-
-_cmux_stop_pr_poll_loop() {
-    _cmux_halt_pr_poll_loop
-    _cmux_pr_cache_clear
-}
-
-_cmux_start_pr_poll_loop() {
-    [[ -S "$CMUX_SOCKET_PATH" ]] || return 0
-    [[ -n "$CMUX_TAB_ID" ]] || return 0
-    [[ -n "$CMUX_PANEL_ID" ]] || return 0
-
-    local watch_pwd="${1:-$PWD}"
-    local force_restart="${2:-0}"
-    local watch_shell_pid="$$"
-    local interval="${_CMUX_PR_POLL_INTERVAL:-45}"
-
-    if [[ "$force_restart" != "1" && "$watch_pwd" == "$_CMUX_PR_POLL_PWD" && -n "$_CMUX_PR_POLL_PID" ]] \
-        && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        return 0
-    fi
-
-    if [[ -n "$_CMUX_PR_POLL_PID" ]] && kill -0 "$_CMUX_PR_POLL_PID" 2>/dev/null; then
-        _cmux_halt_pr_poll_loop
-    else
-        _CMUX_PR_POLL_PID=""
-    fi
-    _CMUX_PR_POLL_PWD="$watch_pwd"
-
-    {
-        local signal_path=""
-        signal_path="$(_cmux_pr_force_signal_path 2>/dev/null || true)"
-        while true; do
-            kill -0 "$watch_shell_pid" >/dev/null 2>&1 || break
-            local force_probe=0
-            if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                force_probe=1
-                /bin/rm -f -- "$signal_path" >/dev/null 2>&1 || true
-            fi
-            _cmux_run_pr_probe_with_timeout "$watch_pwd" "$force_probe" || true
-
-            local slept=0
-            while (( slept < interval )); do
-                kill -0 "$watch_shell_pid" >/dev/null 2>&1 || exit 0
-                if [[ -n "$signal_path" && -f "$signal_path" ]]; then
-                    break
-                fi
-                sleep 1
-                slept=$(( slept + 1 ))
-            done
-        done
-    } >/dev/null 2>&1 &!
-    _CMUX_PR_POLL_PID=$!
-}
-
 _cmux_stop_git_head_watch() {
     if [[ -n "$_CMUX_GIT_HEAD_WATCH_PID" ]]; then
         kill "$_CMUX_GIT_HEAD_WATCH_PID" >/dev/null 2>&1 || true
@@ -1005,7 +658,6 @@ _cmux_start_git_head_watch() {
             signature="$(_cmux_git_head_signature "$watch_head_path" 2>/dev/null || true)"
             if [[ -n "$signature" && "$signature" != "$last_signature" ]]; then
                 last_signature="$signature"
-                _cmux_pr_cache_clear
                 _cmux_report_git_branch_for_path "$watch_pwd"
                 _cmux_clear_pr_for_panel
             fi
@@ -1085,14 +737,12 @@ _cmux_preexec() {
     # Heuristic: commands that may change git branch/dirty state without changing $PWD.
     case "$cmd" in
         git\ *|git|gh\ *|lazygit|lazygit\ *|tig|tig\ *|gitui|gitui\ *|stg\ *|jj\ *)
-            _CMUX_GIT_FORCE=1
-            _CMUX_PR_FORCE=1 ;;
+            _CMUX_GIT_FORCE=1 ;;
     esac
 
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
     _cmux_ports_kick command
-    _cmux_halt_pr_poll_loop
     _cmux_stop_git_head_watch
     if _cmux_command_starts_nested_shell "$cmd"; then
         return 0
@@ -1197,7 +847,6 @@ _cmux_precmd() {
                 # Treat HEAD file change like a git command — force-replace any
                 # running probe so the sidebar picks up the new branch immediately.
                 _CMUX_GIT_FORCE=1
-                _CMUX_PR_FORCE=1
                 should_git=1
             fi
         fi
@@ -1241,7 +890,6 @@ _cmux_precmd() {
         fi
     fi
     if (( git_head_changed )); then
-        _cmux_pr_cache_clear
         _cmux_clear_pr_for_panel
     fi
     if (( last_status == 0 )); then
@@ -1288,7 +936,6 @@ _cmux_restore_terminal_identity_after_startup() {
 
 _cmux_zshexit() {
     _cmux_stop_git_head_watch
-    _cmux_stop_pr_poll_loop
 }
 
 autoload -Uz add-zsh-hook


### PR DESCRIPTION
## Summary

Removes ~700 lines of orphaned shell-integration code that PR #2585 left behind when it moved sidebar PR polling from per-shell `gh pr view` loops to the shared in-app REST poller in `TabManager`.

PR #2585 deleted the call sites that started `_cmux_start_pr_poll_loop` (so per-shell polling no longer happens), but left:

- `_cmux_start_pr_poll_loop` and its helpers (`_cmux_run_pr_probe_with_timeout`, `_cmux_report_pr_for_path`, `_cmux_pr_request_probe`, `_cmux_pr_force_signal_path`, `_cmux_pr_debug_log`, `_cmux_pr_cache_clear`, `_cmux_pr_cache_prefix`, `_cmux_github_repo_slug_for_path`, `_cmux_pr_output_indicates_no_pull_request`, `_cmux_kill_process_tree`, `_cmux_child_pids`)
- `_cmux_halt_pr_poll_loop` / `_cmux_stop_pr_poll_loop` no-op wrappers, plus their callers in `_cmux_preexec`, `_cmux_zshexit`, `_cmux_bash_cleanup`, and the tmux env handler
- State variables: `_CMUX_PR_POLL_PID`, `_CMUX_PR_POLL_PWD`, `_CMUX_PR_LAST_BRANCH`, `_CMUX_PR_NO_PR_BRANCH`, `_CMUX_PR_POLL_INTERVAL`, `_CMUX_PR_FORCE`, `_CMUX_PR_DEBUG`

All of those are now gone from both `cmux-zsh-integration.zsh` and `cmux-bash-integration.bash`. `_cmux_clear_pr_for_panel` is preserved — it still sends `clear_pr` over the socket on HEAD changes so the in-app poller can drop a stale PR badge promptly.

Verified there are no remaining references in `Sources/`, `tests/`, or `cmuxTests/`. Both files pass `bash -n` / `zsh -n`. No behavior change — purely dead-code removal.

Refs #2746 (the issue stems from older installed builds that predate #2585 — this PR doesn't change runtime behavior on top of #2585, just deletes scaffolding it left behind).

## Test plan

- [x] `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- [x] `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- [x] grep confirms no remaining references to removed symbols anywhere in tracked code
- [ ] CI shell-integration regression tests (`tests/test_issue_1138_sidebar_pr_polling.py`) still pass — they assert the prompt path no longer makes direct GitHub calls, which is exactly what we're preserving

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed orphaned per-shell PR polling from the bash/zsh integrations after moving to the in-app REST poller. No behavior change; PR badges still clear on HEAD changes, addressing leftovers from #2746.

- **Refactors**
  - Deleted per-shell PR poll functions, helpers, and state vars in `cmux-zsh-integration.zsh` and `cmux-bash-integration.bash`.
  - Removed no-op callers in preexec/zshexit and tmux env refresh; dropped halt/stop wrappers.
  - Kept `_cmux_clear_pr_for_panel`; removed a stale poll-loop reference in its comment.
  - Verified no remaining references; scripts pass `bash -n` and `zsh -n`.

<sup>Written for commit f54329fb605bc981643316b2dac26e0f429c21d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed background pull-request polling from Bash and Zsh shell integrations.
  * Automatic PR status updates and sidebar refreshes are no longer performed in the background.
  * PR cache is no longer invalidated on HEAD changes or shell/terminal lifecycle events.
  * Polling will no longer start, stop, or restart in response to git commands, environment refreshes, or shell exit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->