### PR TITLE
Fix terminal viewport width reporting in cmux

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4493,7 +4493,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         ghostty_surface_set_content_scale(createdSurface, scaleFactors.x, scaleFactors.y)
-        let backingSize = view.convertToBacking(NSRect(origin: .zero, size: view.bounds.size)).size
+        let surfaceSize = view.resolvedSurfaceSize(preferred: view.bounds.size)
+        let backingSize = view.convertToBacking(NSRect(origin: .zero, size: surfaceSize)).size
         let wpx = pixelDimension(from: backingSize.width)
         let hpx = pixelDimension(from: backingSize.height)
         if wpx > 0, hpx > 0 {
@@ -5212,6 +5213,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     weak var terminalSurface: TerminalSurface?
+    weak var surfaceHostView: GhosttySurfaceScrollView?
     var scrollbar: GhosttyScrollbar?
     /// Pending scrollbar value written from the action callback thread;
     /// read and cleared on the main thread by `flushPendingScrollbar()`.
@@ -5618,7 +5620,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override var isOpaque: Bool { false }
 
-    private func resolvedSurfaceSize(preferred size: CGSize?) -> CGSize {
+    fileprivate func resolvedSurfaceSize(preferred size: CGSize?) -> CGSize {
+        if let hostedViewportSize = surfaceHostView?.renderedSurfaceViewportRect(preferredSize: size).size,
+           hostedViewportSize.width > 0,
+           hostedViewportSize.height > 0 {
+            return hostedViewportSize
+        }
+
         if let size,
            size.width > 0,
            size.height > 0 {
@@ -8993,6 +9001,7 @@ final class GhosttySurfaceScrollView: NSView {
         documentView.addSubview(surfaceView)
 
         super.init(frame: .zero)
+        surfaceView.surfaceHostView = self
         wantsLayer = true
         layer?.masksToBounds = true
 
@@ -9393,17 +9402,6 @@ final class GhosttySurfaceScrollView: NSView {
         let previousSurfaceSize = surfaceView.frame.size
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         _ = setFrameIfNeeded(scrollView, to: bounds)
-        let targetSize = scrollView.bounds.size
-#if DEBUG
-        logLayoutDuringActiveDrag(targetSize: targetSize)
-#endif
-        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
-        _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
-        let targetDocumentFrame = CGRect(
-            origin: documentView.frame.origin,
-            size: CGSize(width: scrollView.bounds.width, height: documentView.frame.height)
-        )
-        _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         _ = setFrameIfNeeded(inactiveOverlayView, to: bounds)
         if let zone = activeDropZone {
             attachDropZoneOverlayIfNeeded()
@@ -9435,6 +9433,18 @@ final class GhosttySurfaceScrollView: NSView {
             scrollView.tile()
         }
         scrollView.layoutSubtreeIfNeeded()
+        let targetViewportRect = renderedSurfaceViewportRect(preferredSize: scrollView.bounds.size)
+        let targetSize = targetViewportRect.size
+#if DEBUG
+        logLayoutDuringActiveDrag(targetSize: targetSize)
+#endif
+        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
+        _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
+        let targetDocumentFrame = CGRect(
+            origin: documentView.frame.origin,
+            size: CGSize(width: targetSize.width, height: documentView.frame.height)
+        )
+        _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         updateNotificationRingPath()
         updateFlashPath(style: lastFlashStyle)
         updateFlashAppearance(style: lastFlashStyle)
@@ -9610,13 +9620,17 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func attachSurface(_ terminalSurface: TerminalSurface) {
+        let hasUsableBounds = bounds.width > 1 && bounds.height > 1
+        if hasUsableBounds {
+            _ = synchronizeGeometryAndContent()
+        }
         surfaceView.attachSurface(terminalSurface)
         let workspace = terminalSurface.owningWorkspace()
         cachedOwningWorkspace = workspace
         updateWorkspaceTerminalScrollBarObserver(workspace)
         // Preserve the bootstrap 800x600 surface until portal reattach churn
         // has produced a real host size instead of a transient 1x1 placeholder.
-        guard bounds.width > 1, bounds.height > 1 else { return }
+        guard hasUsableBounds else { return }
         _ = synchronizeGeometryAndContent()
     }
 
@@ -11356,21 +11370,51 @@ final class GhosttySurfaceScrollView: NSView {
         // Intentionally no-op (no retry loops).
     }
 
-    private func synchronizeSurfaceView() {
+    // The clip view's visible rect is the authoritative terminal viewport. All
+    // Ghostty/PTTY size reporting should flow through this geometry so the
+    // drawn cell grid and the reported cols/rows never diverge.
+    fileprivate func renderedSurfaceViewportRect(preferredSize: CGSize? = nil) -> CGRect {
         let visibleRect = scrollView.contentView.documentVisibleRect
-        guard !pointApproximatelyEqual(surfaceView.frame.origin, visibleRect.origin) else { return }
+        if visibleRect.width > 0, visibleRect.height > 0 {
+            return visibleRect
+        }
+
+        let clipBounds = scrollView.contentView.bounds
+        if clipBounds.width > 0, clipBounds.height > 0 {
+            return CGRect(origin: clipBounds.origin, size: clipBounds.size)
+        }
+
+        if let preferredSize,
+           preferredSize.width > 0,
+           preferredSize.height > 0 {
+            return CGRect(origin: surfaceView.frame.origin, size: preferredSize)
+        }
+
+        if surfaceView.frame.width > 0, surfaceView.frame.height > 0 {
+            return surfaceView.frame
+        }
+
+        return CGRect(origin: .zero, size: scrollView.bounds.size)
+    }
+
+    private func synchronizeSurfaceView() {
+        let visibleRect = renderedSurfaceViewportRect(preferredSize: surfaceView.frame.size)
+        guard !Self.rectApproximatelyEqual(surfaceView.frame, visibleRect) else { return }
 #if DEBUG
-        logDragGeometryChange(event: "surfaceOrigin", old: surfaceView.frame.origin, new: visibleRect.origin)
+        if !pointApproximatelyEqual(surfaceView.frame.origin, visibleRect.origin) {
+            logDragGeometryChange(event: "surfaceOrigin", old: surfaceView.frame.origin, new: visibleRect.origin)
+        }
 #endif
-        surfaceView.frame.origin = visibleRect.origin
+        surfaceView.frame = visibleRect
     }
 
     /// Match upstream Ghostty behavior: use content area width (excluding non-content
     /// regions such as scrollbar space) when telling libghostty the terminal size.
     @discardableResult
     private func synchronizeCoreSurface() -> Bool {
-        let width = max(0, surfaceView.frame.width)
-        let height = surfaceView.frame.height
+        let viewportSize = renderedSurfaceViewportRect(preferredSize: surfaceView.frame.size).size
+        let width = max(0, viewportSize.width)
+        let height = viewportSize.height
         guard width > 0, height > 0 else { return false }
         return surfaceView.pushTargetSurfaceSize(CGSize(width: width, height: height))
     }


### PR DESCRIPTION
## Summary
- make the scroll host's visible terminal viewport the single source of truth for Ghostty surface sizing
- use that viewport for initial surface creation, NSView resize updates, and host geometry sync so PTY cols match the actually drawn grid
- seed host geometry before attaching a surface when real bounds are available to avoid reintroducing the bootstrap width

## Testing
- not run locally (repo policy forbids local test runs)

Fixes #2925

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core terminal sizing/layout paths that affect PTY cols/rows and rendering during resize/scroll; bugs here could cause visual glitches or incorrect terminal dimensions, but no security- or data-sensitive logic is involved.
> 
> **Overview**
> Fixes terminal size/viewport reporting by making the scroll host’s rendered viewport rect the single source of truth for Ghostty surface geometry.
> 
> Surface creation, host layout sync (`synchronizeGeometryAndContent`), and core size pushes (`synchronizeCoreSurface`) now derive width/height from `renderedSurfaceViewportRect`, and surface attachment pre-seeds geometry when bounds are usable to avoid reusing the bootstrap size.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1df203ad7bebd89f5f0d435d7cdf5443b87a69f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes horizontal cutoff by using the scroll view’s visible rect as the terminal viewport for surface sizing and PTY geometry. Reported columns now match the drawn grid across create, resize, and sync; fixes #2925.

- **Bug Fixes**
  - Make the scroll host’s visible viewport the single source of truth for surface size.
  - Apply that viewport to surface creation, NSView resize updates, and host geometry sync to avoid width drift.
  - Seed geometry when real bounds exist and size document/surface to the viewport width (excluding scrollbar).

<sup>Written for commit 1df203ad7bebd89f5f0d435d7cdf5443b87a69f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal surface size calculation to accurately determine viewport geometry, addressing layout issues when the terminal is hosted within scrollable containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->