### PR TITLE
Fix scrollback-limit byte handling

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7811,12 +7811,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let tabManager else { return }
         let tab = tabManager.addTab()
         let config = GhosttyConfig.load()
-        let bytesPerLine = "scrollback 000000\n".utf8.count
         let minimumTargetBytes = 2_000_000
         let maximumTargetBytes = 200_000_000
-        let doubledLimit = min(config.scrollbackLimit, maximumTargetBytes / 2) * 2
+        let effectiveLimit = max(config.scrollbackLimit, 0)
+        let doubledLimit = min(effectiveLimit, maximumTargetBytes / 2) * 2
         let targetBytes = min(max(doubledLimit, minimumTargetBytes), maximumTargetBytes)
-        let lineCount = max((targetBytes + bytesPerLine - 1) / bytesPerLine, 2000)
+        let baseBytesPerLine = "scrollback \n".utf8.count
+        var digitCount = 6
+        var lineCount = 2000
+
+        while true {
+            let bytesPerLine = baseBytesPerLine + digitCount
+            let nextLineCount = max((targetBytes + bytesPerLine - 1) / bytesPerLine, 2000)
+            let nextDigitCount = max(6, String(nextLineCount).count)
+            lineCount = nextLineCount
+            if nextDigitCount == digitCount {
+                break
+            }
+            digitCount = nextDigitCount
+        }
+
         let command = #"awk 'BEGIN { for (i = 1; i <= \#(lineCount); ++i) printf "scrollback %06d\n", i }'"# + "\n"
         sendTextWhenReady(command, to: tab)
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7813,23 +7813,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let config = GhosttyConfig.load()
         let minimumTargetBytes = 2_000_000
         let maximumTargetBytes = 200_000_000
+        let minimumLineCount = 2000
         let effectiveLimit = max(config.scrollbackLimit, 0)
         let doubledLimit = min(effectiveLimit, maximumTargetBytes / 2) * 2
         let targetBytes = min(max(doubledLimit, minimumTargetBytes), maximumTargetBytes)
-        let baseBytesPerLine = "scrollback \n".utf8.count
-        var digitCount = 6
-        var lineCount = 2000
-
-        while true {
-            let bytesPerLine = baseBytesPerLine + digitCount
-            let nextLineCount = max((targetBytes + bytesPerLine - 1) / bytesPerLine, 2000)
-            let nextDigitCount = max(6, String(nextLineCount).count)
-            lineCount = nextLineCount
-            if nextDigitCount == digitCount {
-                break
-            }
-            digitCount = nextDigitCount
-        }
+        // `%06d` guarantees at least a 6-digit field width. Any lines beyond
+        // 999,999 only get wider, so this conservative floor always emits at
+        // least `targetBytes` without oscillating at digit-count boundaries.
+        let baseBytesPerLine = "scrollback 000000\n".utf8.count
+        let lineCount = max((targetBytes + baseBytesPerLine - 1) / baseBytesPerLine, minimumLineCount)
 
         let command = #"awk 'BEGIN { for (i = 1; i <= \#(lineCount); ++i) printf "scrollback %06d\n", i }'"# + "\n"
         sendTextWhenReady(command, to: tab)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -7811,8 +7811,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let tabManager else { return }
         let tab = tabManager.addTab()
         let config = GhosttyConfig.load()
-        let lineCount = min(max(config.scrollbackLimit * 2, 2000), 60000)
-        let command = "for i in {1..\(lineCount)}; do printf \"scrollback %06d\\n\" $i; done\n"
+        let bytesPerLine = "scrollback 000000\n".utf8.count
+        let minimumTargetBytes = 2_000_000
+        let maximumTargetBytes = 200_000_000
+        let doubledLimit = min(config.scrollbackLimit, maximumTargetBytes / 2) * 2
+        let targetBytes = min(max(doubledLimit, minimumTargetBytes), maximumTargetBytes)
+        let lineCount = max((targetBytes + bytesPerLine - 1) / bytesPerLine, 2000)
+        let command = #"awk 'BEGIN { for (i = 1; i <= \#(lineCount); ++i) printf "scrollback %06d\n", i }'"# + "\n"
         sendTextWhenReady(command, to: tab)
     }
 

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -318,8 +318,13 @@ struct GhosttyConfig {
     }
 
     private static func parseIntegerLiteral(_ value: String) -> Int? {
+        // Strip digit-group separators (for example 10_000_000).
+        // Hex and float literals are intentionally unsupported here.
         let normalized = value.replacingOccurrences(of: "_", with: "")
-        return Int(normalized)
+        guard let parsed = Int(normalized), parsed > 0 else {
+            return nil
+        }
+        return parsed
     }
 
     mutating func loadTheme(_ name: String) {

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -321,7 +321,7 @@ struct GhosttyConfig {
         // Strip digit-group separators (for example 10_000_000).
         // Hex and float literals are intentionally unsupported here.
         let normalized = value.replacingOccurrences(of: "_", with: "")
-        guard let parsed = Int(normalized), parsed > 0 else {
+        guard let parsed = Int(normalized), parsed >= 0 else {
             return nil
         }
         return parsed

--- a/Sources/GhosttyConfig.swift
+++ b/Sources/GhosttyConfig.swift
@@ -16,7 +16,8 @@ struct GhosttyConfig {
     var surfaceTabBarFontSize: CGFloat = 11
     var theme: String?
     var workingDirectory: String?
-    var scrollbackLimit: Int = 10000
+    // Ghostty measures scrollback-limit in bytes, not lines.
+    var scrollbackLimit: Int = 10_000_000
     var unfocusedSplitOpacity: Double = 0.7
     var unfocusedSplitFill: NSColor?
     var splitDividerColor: NSColor?
@@ -252,7 +253,7 @@ struct GhosttyConfig {
                 case "working-directory":
                     workingDirectory = value
                 case "scrollback-limit":
-                    if let limit = Int(value) {
+                    if let limit = Self.parseIntegerLiteral(value) {
                         scrollbackLimit = limit
                     }
                 case "background":
@@ -314,6 +315,11 @@ struct GhosttyConfig {
                 }
             }
         }
+    }
+
+    private static func parseIntegerLiteral(_ value: String) -> Int? {
+        let normalized = value.replacingOccurrences(of: "_", with: "")
+        return Int(normalized)
     }
 
     mutating func loadTheme(_ name: String) {

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -247,7 +247,7 @@ touch ~/.config/ghostty/config`}</CodeBlock>
       <CodeBlock title="~/.config/ghostty/config" lang="ini">{`font-family = SF Mono
 font-size = 13
 theme = One Dark
-scrollback-limit = 50000
+scrollback-limit = 50000000
 split-divider-color = #3e4451
 working-directory = ~/code`}</CodeBlock>
 


### PR DESCRIPTION
Fixes #2879.

## Summary
- treat `scrollback-limit` as bytes in the local Ghostty config model
- size the DEBUG large-scrollback generator by bytes and stream it with `awk` instead of brace expansion
- update the docs example to use a byte-based `scrollback-limit` value

## Testing
- attempted `./scripts/reload.sh --tag issue-2879-scrollback-limit-ignored --launch`
- local tagged reload was blocked by repeated Xcode build-service hangs/crashes before the app launched in this environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the semantics and default of `scrollback-limit`, which can affect runtime memory usage and user expectations if existing configs assumed lines. Also adjusts the debug scrollback generator command generation, so regressions would surface mainly in debug tooling and config parsing.
> 
> **Overview**
> Fixes `scrollback-limit` handling to match Ghostty’s **byte-based** semantics by updating the local config model default to `10_000_000` bytes and allowing underscore-separated integer literals via a new `parseIntegerLiteral` parser.
> 
> Updates the DEBUG large-scrollback tab generator to size output by target bytes (with 2MB–200MB bounds) and emit lines via a streamed `awk` loop instead of shell brace expansion. Documentation is updated to show a byte-scale `scrollback-limit` example value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3856ffaa66b6c817ffc180fd20506cf5de9a7118. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `scrollback-limit` as bytes (not lines) and update the debug scrollback generator to size and stream by bytes. Fixes #2879 and aligns code and docs with Ghostty’s byte-based setting.

- **Bug Fixes**
  - Config: parse `scrollback-limit` as bytes, default to `10_000_000`, allow underscores, ignore invalid/negative values.
  - Debug generator: size by bytes (double limit with 2MB–200MB caps), compute lines by bytes-per-line with 6-digit width and a 2k line floor, stream via `awk`.
  - Docs: switch example to a byte value (`scrollback-limit = 50000000`).

<sup>Written for commit 3856ffaa66b6c817ffc180fd20506cf5de9a7118. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Scrollback capacity is now measured in bytes instead of lines, enabling much larger terminal history; default increased to 10,000,000.
  * Generating scrollback output now produces consistent, correctly numbered lines and always includes a trailing newline.
  * Configuration parsing accepts digit-group separators (e.g., underscores) and ignores invalid or non‑positive values.

* **Documentation**
  * Updated configuration examples to reflect the new scrollback-limit units and default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->