### PR TITLE
graphql fetch pr all-in-one status

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -71143,6 +71143,601 @@
         }
       }
     },
+    "sidebar.pullRequest.ciFailing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "失敗"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "failing"
+          }
+        }
+      }
+    },
+    "sidebar.pullRequest.ciPassing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "成功"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "passing"
+          }
+        }
+      }
+    },
+    "sidebar.pullRequest.ciPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保留中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "pending"
+          }
+        }
+      }
+    },
+    "sidebar.pullRequest.reviewApproved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "承認済み"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "approved"
+          }
+        }
+      }
+    },
+    "sidebar.pullRequest.reviewChangesRequested": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "変更要求"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "changes requested"
+          }
+        }
+      }
+    },
     "sidebar.workspace.accessibilityHint": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -780,8 +780,8 @@ _cmux_report_pr_for_path() {
         builtin cd "$repo_path" 2>/dev/null \
             && gh pr view "$branch" \
                 "${gh_repo_args[@]}" \
-                --json number,state,url \
-                --jq '[.number, .state, .url] | @tsv' \
+                --json number,state,url,reviewDecision,statusCheckRollup \
+                --jq '[.number, .state, .url, .reviewDecision, .statusCheckRollup] | @tsv' \
                 2>"$err_file"
     )"
     gh_status=$?
@@ -825,7 +825,7 @@ _cmux_report_pr_for_path() {
     fi
 
     local IFS=$'\t'
-    read -r number state url <<< "$gh_output"
+    read -r number state url review_decision ci_status <<< "$gh_output"
     if [[ -z "$number" ]] || [[ -z "$url" ]]; then
         return 1
     fi
@@ -837,18 +837,31 @@ _cmux_report_pr_for_path() {
         *) return 1 ;;
     esac
 
+    local review_opt=""
+    case "$review_decision" in
+        APPROVED) review_opt="--review=approved" ;;
+        CHANGES_REQUESTED) review_opt="--review=changes_requested" ;;
+    esac
+
+    local ci_opt=""
+    case "$ci_status" in
+        SUCCESS) ci_opt="--ci=passing" ;;
+        FAILURE|ERROR) ci_opt="--ci=failing" ;;
+        PENDING|EXPECTED) ci_opt="--ci=pending" ;;
+    esac
+
     if [[ -n "$prefix" ]]; then
         print -r -- "$branch" >| "$branch_file"
         print -r -- "$repo_path" >| "$repo_file"
         print -r -- "$now" >| "$timestamp_file"
-        printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
+        printf '%s\t%s\t%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" "$review_decision" "$ci_status" >| "$result_file"
         /bin/rm -f -- "$no_pr_branch_file" >/dev/null 2>&1 || true
     fi
     _CMUX_PR_LAST_BRANCH="$branch"
     _CMUX_PR_NO_PR_BRANCH=""
 
     local quoted_branch="${branch//\"/\\\"}"
-    _cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+    _cmux_send "report_pr $number $url $status_opt $review_opt $ci_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
 _cmux_child_pids() {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13159,7 +13159,7 @@ private struct TabItemView: View, Equatable {
                                     .underline()
                                     .lineLimit(1)
                                     .truncationMode(.tail)
-                                Text(pullRequestStatusLabel(pullRequest.status))
+                                Text(pullRequestStatusLabel(pullRequest.status, reviewStatus: pullRequest.reviewStatus, ciStatus: pullRequest.ciStatus))
                                     .lineLimit(1)
                                 Spacer(minLength: 0)
                             }
@@ -13982,6 +13982,8 @@ private struct TabItemView: View, Equatable {
         let label: String
         let url: URL
         let status: SidebarPullRequestStatus
+        let reviewStatus: SidebarPullRequestReviewStatus?
+        let ciStatus: SidebarPullRequestCIStatus?
         let isStale: Bool
     }
 
@@ -13993,6 +13995,8 @@ private struct TabItemView: View, Equatable {
                 label: pullRequest.label,
                 url: pullRequest.url,
                 status: pullRequest.status,
+                reviewStatus: pullRequest.reviewStatus,
+                ciStatus: pullRequest.ciStatus,
                 isStale: pullRequest.isStale
             )
         }
@@ -14035,11 +14039,45 @@ private struct TabItemView: View, Equatable {
         NSWorkspace.shared.open(url)
     }
 
-    private func pullRequestStatusLabel(_ status: SidebarPullRequestStatus) -> String {
+    private func pullRequestReviewStatusLabel(_ reviewStatus: SidebarPullRequestReviewStatus) -> String {
+        switch reviewStatus {
+        case .approved:
+            return String(localized: "sidebar.pullRequest.reviewApproved", defaultValue: "approved")
+        case .changesRequested:
+            return String(localized: "sidebar.pullRequest.reviewChangesRequested", defaultValue: "changes requested")
+        }
+    }
+
+    private func pullRequestCIStatusLabel(_ ciStatus: SidebarPullRequestCIStatus) -> String {
+        switch ciStatus {
+        case .passing:
+            return String(localized: "sidebar.pullRequest.ciPassing", defaultValue: "passing")
+        case .failing:
+            return String(localized: "sidebar.pullRequest.ciFailing", defaultValue: "failing")
+        case .pending:
+            return String(localized: "sidebar.pullRequest.ciPending", defaultValue: "pending")
+        }
+    }
+
+    private func pullRequestStatusLabel(
+        _ status: SidebarPullRequestStatus,
+        reviewStatus: SidebarPullRequestReviewStatus?,
+        ciStatus: SidebarPullRequestCIStatus?
+    ) -> String {
         switch status {
-        case .open: return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
-        case .merged: return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
-        case .closed: return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+        case .open:
+            var parts = [String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")]
+            if let reviewStatus {
+                parts.append(pullRequestReviewStatusLabel(reviewStatus))
+            }
+            if let ciStatus {
+                parts.append(pullRequestCIStatusLabel(ciStatus))
+            }
+            return parts.joined(separator: " \u{00B7} ")
+        case .merged:
+            return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+        case .closed:
+            return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -759,6 +759,8 @@ class TabManager: ObservableObject {
         let urlString: String
         let statusRawValue: String
         let branch: String
+        let reviewStatusRawValue: String?
+        let ciStatusRawValue: String?
     }
 
     private struct WorkspacePullRequestRefreshResult: Sendable {
@@ -836,6 +838,60 @@ class TabManager: ObservableObject {
             case mergedAt = "merged_at"
             case head
         }
+    }
+
+    private struct GraphQLEnrichmentResponse: Decodable, Sendable {
+        let data: GraphQLEnrichmentData?
+    }
+
+    private struct GraphQLEnrichmentData: Decodable, Sendable {
+        let repository: [String: GraphQLPullRequestNode]?
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+            guard let repoContainer = try? container.nestedContainer(
+                keyedBy: DynamicCodingKey.self,
+                forKey: DynamicCodingKey(stringValue: "repository")!
+            ) else {
+                repository = nil
+                return
+            }
+            var result: [String: GraphQLPullRequestNode] = [:]
+            for key in repoContainer.allKeys {
+                if let node = try? repoContainer.decode(GraphQLPullRequestNode.self, forKey: key) {
+                    result[key.stringValue] = node
+                }
+            }
+            repository = result
+        }
+    }
+
+    private struct GraphQLPullRequestNode: Decodable, Sendable {
+        let reviewDecision: String?
+        let commits: GraphQLCommitConnection?
+    }
+
+    private struct GraphQLCommitConnection: Decodable, Sendable {
+        let nodes: [GraphQLCommitNode]?
+    }
+
+    private struct GraphQLCommitNode: Decodable, Sendable {
+        let commit: GraphQLCommit?
+    }
+
+    private struct GraphQLCommit: Decodable, Sendable {
+        let statusCheckRollup: GraphQLStatusCheckRollup?
+    }
+
+    private struct GraphQLStatusCheckRollup: Decodable, Sendable {
+        let state: String?
+    }
+
+    private struct DynamicCodingKey: CodingKey {
+        var stringValue: String
+        var intValue: Int?
+        init?(stringValue: String) { self.stringValue = stringValue }
+        init?(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
     }
 
     struct GitHubPullRequestProbeItem: Decodable, Equatable, Sendable {
@@ -1267,11 +1323,27 @@ class TabManager: ObservableObject {
                 now: now,
                 allowCachedResults: allowCachedResults
             )
-            let results = Self.resolveWorkspacePullRequestRefreshResults(
+            var results = Self.resolveWorkspacePullRequestRefreshResults(
                 candidates: candidates,
                 repoResults: repoResults
             )
             guard !Task.isCancelled else { return }
+
+            // Fetch review status for open PRs
+            let reviewConfiguration = URLSessionConfiguration.ephemeral
+            reviewConfiguration.timeoutIntervalForRequest = max(Self.workspacePullRequestProbeTimeout, 8)
+            reviewConfiguration.timeoutIntervalForResource = max(Self.workspacePullRequestProbeTimeout, 8)
+            let reviewSession = URLSession(configuration: reviewConfiguration)
+            let reviewAuthHeader = Self.workspacePullRequestAuthHeaderValue()
+
+            results = await Self.enrichResultsWithGraphQL(
+                results: results,
+                candidates: candidates,
+                session: reviewSession,
+                authHeader: reviewAuthHeader
+            )
+            guard !Task.isCancelled else { return }
+
             await MainActor.run { [weak self] in
                 guard let self else { return }
                 guard !Task.isCancelled else { return }
@@ -1411,6 +1483,10 @@ class TabManager: ObservableObject {
                       let url = URL(string: resolvedPullRequest.urlString) else {
                     continue
                 }
+                let reviewStatus = resolvedPullRequest.reviewStatusRawValue
+                    .flatMap(SidebarPullRequestReviewStatus.init(rawValue:))
+                let ciStatus = resolvedPullRequest.ciStatusRawValue
+                    .flatMap(SidebarPullRequestCIStatus.init(rawValue:))
                 workspace.updatePanelPullRequest(
                     panelId: result.panelId,
                     number: resolvedPullRequest.number,
@@ -1418,7 +1494,9 @@ class TabManager: ObservableObject {
                     url: url,
                     status: status,
                     branch: resolvedPullRequest.branch,
-                    isStale: false
+                    isStale: false,
+                    reviewStatus: reviewStatus,
+                    ciStatus: ciStatus
                 )
             case .notFound:
                 workspacePullRequestTransientFailureCountByKey[key] = 0
@@ -2504,7 +2582,9 @@ class TabManager: ObservableObject {
                         number: matchedPullRequest.number,
                         urlString: matchedPullRequest.url,
                         statusRawValue: status.rawValue,
-                        branch: candidate.branch
+                        branch: candidate.branch,
+                        reviewStatusRawValue: nil,
+                        ciStatusRawValue: nil
                     )
                 )
                 usedCachedRepoData = matchedPullRequestUsedCache
@@ -2831,6 +2911,168 @@ class TabManager: ObservableObject {
         } catch {
             return nil
         }
+    }
+
+    private nonisolated static func enrichResultsWithGraphQL(
+        results: [WorkspacePullRequestRefreshResult],
+        candidates: [WorkspacePullRequestCandidate],
+        session: URLSession,
+        authHeader: String?
+    ) async -> [WorkspacePullRequestRefreshResult] {
+        // Group open PRs by repo slug
+        var prNumbersByRepo: [String: [(index: Int, item: WorkspacePullRequestResolvedItem)]] = [:]
+        for (index, result) in results.enumerated() {
+            guard case .resolved(let item) = result.resolution,
+                  item.statusRawValue == SidebarPullRequestStatus.open.rawValue else {
+                continue
+            }
+            let candidate = candidates[index]
+            guard let repoSlug = candidate.repoSlugs.first else { continue }
+            prNumbersByRepo[repoSlug, default: []].append((index: index, item: item))
+        }
+
+        guard !prNumbersByRepo.isEmpty else { return results }
+
+        let enrichments = await withTaskGroup(
+            of: (String, [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]).self,
+            returning: [String: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]].self
+        ) { group in
+            for (repoSlug, entries) in prNumbersByRepo {
+                let prNumbers = entries.map(\.item.number)
+                group.addTask {
+                    let result = await fetchPullRequestEnrichmentViaGraphQL(
+                        repoSlug: repoSlug,
+                        prNumbers: prNumbers,
+                        session: session,
+                        authHeader: authHeader
+                    )
+                    return (repoSlug, result)
+                }
+            }
+            var collected: [String: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]] = [:]
+            for await (repoSlug, result) in group {
+                collected[repoSlug] = result
+            }
+            return collected
+        }
+
+        var updatedResults = results
+        for (repoSlug, entries) in prNumbersByRepo {
+            guard let repoEnrichments = enrichments[repoSlug] else { continue }
+            for (index, item) in entries {
+                let enrichment = repoEnrichments[item.number]
+                let enrichedItem = WorkspacePullRequestResolvedItem(
+                    number: item.number,
+                    urlString: item.urlString,
+                    statusRawValue: item.statusRawValue,
+                    branch: item.branch,
+                    reviewStatusRawValue: enrichment?.reviewStatus?.rawValue ?? item.reviewStatusRawValue,
+                    ciStatusRawValue: enrichment?.ciStatus?.rawValue
+                )
+                updatedResults[index] = WorkspacePullRequestRefreshResult(
+                    workspaceId: results[index].workspaceId,
+                    panelId: results[index].panelId,
+                    resolution: .resolved(enrichedItem),
+                    usedCachedRepoData: results[index].usedCachedRepoData
+                )
+            }
+        }
+        return updatedResults
+    }
+
+    private nonisolated static func buildPullRequestEnrichmentQuery(
+        owner: String,
+        repo: String,
+        prNumbers: [Int]
+    ) -> String {
+        let fragment = """
+        reviewDecision
+        commits(last: 1) {
+          nodes {
+            commit {
+              statusCheckRollup {
+                state
+              }
+            }
+          }
+        }
+        """
+        let fields = prNumbers.map { number in
+            "pr_\(number): pullRequest(number: \(number)) { \(fragment) }"
+        }.joined(separator: "\n    ")
+        return """
+        query {
+          repository(owner: "\(owner)", name: "\(repo)") {
+            \(fields)
+          }
+        }
+        """
+    }
+
+    private nonisolated static func fetchPullRequestEnrichmentViaGraphQL(
+        repoSlug: String,
+        prNumbers: [Int],
+        session: URLSession,
+        authHeader: String?
+    ) async -> [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)] {
+        guard !prNumbers.isEmpty else { return [:] }
+        let components = repoSlug.split(separator: "/")
+        guard components.count == 2 else { return [:] }
+        let owner = String(components[0])
+        let repo = String(components[1])
+
+        let query = buildPullRequestEnrichmentQuery(owner: owner, repo: repo, prNumbers: prNumbers)
+        let body: [String: Any] = ["query": query]
+        guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return [:] }
+
+        guard let url = URL(string: "https://api.github.com/graphql") else { return [:] }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+        if let authHeader, !authHeader.isEmpty {
+            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = bodyData
+
+        guard let (data, response) = try? await session.data(for: request),
+              let httpResponse = response as? HTTPURLResponse,
+              httpResponse.statusCode == 200 else {
+            return [:]
+        }
+
+        guard let graphQLResponse = decodeJSON(GraphQLEnrichmentResponse.self, from: data),
+              let repository = graphQLResponse.data?.repository else {
+            return [:]
+        }
+
+        var results: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)] = [:]
+        for prNumber in prNumbers {
+            let key = "pr_\(prNumber)"
+            guard let node = repository[key] else { continue }
+
+            let reviewStatus: SidebarPullRequestReviewStatus? = {
+                switch node.reviewDecision?.uppercased() {
+                case "APPROVED": return .approved
+                case "CHANGES_REQUESTED": return .changesRequested
+                default: return nil
+                }
+            }()
+
+            let ciStatus: SidebarPullRequestCIStatus? = {
+                let state = node.commits?.nodes?.first?.commit?.statusCheckRollup?.state?.uppercased()
+                switch state {
+                case "SUCCESS": return .passing
+                case "FAILURE", "ERROR": return .failing
+                case "PENDING", "EXPECTED": return .pending
+                default: return nil
+                }
+            }()
+
+            results[prNumber] = (reviewStatus: reviewStatus, ciStatus: ciStatus)
+        }
+        return results
     }
 
     private nonisolated static func workspacePullRequestAuthHeaderValue() -> String? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -389,7 +389,9 @@ class TerminalController {
         label: String,
         url: URL,
         status: SidebarPullRequestStatus,
-        branch: String?
+        branch: String?,
+        reviewStatus: SidebarPullRequestReviewStatus? = nil,
+        ciStatus: SidebarPullRequestCIStatus? = nil
     ) -> Bool {
         guard let current else { return true }
         let normalizedBranch = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -411,6 +413,8 @@ class TerminalController {
             || current.status != status
             || current.branch != effectiveBranch
             || current.isStale
+            || current.reviewStatus != reviewStatus
+            || current.ciStatus != ciStatus
     }
 
     nonisolated static func shouldReplacePorts(current: [Int]?, next: [Int]) -> Bool {
@@ -11419,8 +11423,8 @@ class TerminalController {
           clear_progress [--tab=X] - Clear progress bar
           report_git_branch <branch> [--status=dirty] [--tab=X] [--panel=Y] - Report git branch
           clear_git_branch [--tab=X] [--panel=Y] - Clear git branch
-          report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y] - Report pull request / review item
-          report_review <number> <url> [--label=MR] [--state=open|merged|closed] [--tab=X] [--panel=Y] - Alias for provider-specific review item
+          report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y] - Report pull request / review item
+          report_review <number> <url> [--label=MR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y] - Alias for provider-specific review item
           clear_pr [--tab=X] [--panel=Y] - Clear pull request
           report_ports <port1> [port2...] [--tab=X] [--panel=Y] - Report listening ports
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
@@ -15114,7 +15118,7 @@ class TerminalController {
     private func reportPullRequest(_ args: String) -> String {
         let parsed = parseOptions(args)
         guard parsed.positional.count >= 2 else {
-            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
+            return "ERROR: Missing pull request number or URL — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y]"
         }
 
         let rawNumber = parsed.positional[0].trimmingCharacters(in: .whitespacesAndNewlines)
@@ -15135,13 +15139,33 @@ class TerminalController {
             return "ERROR: Invalid pull request state '\(statusRaw)' — use: open, merged, closed"
         }
         let branch = normalizedOptionValue(parsed.options["branch"])
+        let reviewStatusRaw = normalizedOptionValue(parsed.options["review"])
+        let reviewStatus: SidebarPullRequestReviewStatus?
+        if let reviewStatusRaw {
+            guard let parsedReview = SidebarPullRequestReviewStatus(rawValue: reviewStatusRaw.lowercased()) else {
+                return "ERROR: Invalid review status '\(reviewStatusRaw)' — use: approved, changes_requested"
+            }
+            reviewStatus = status == .open ? parsedReview : nil
+        } else {
+            reviewStatus = nil
+        }
+        let ciStatusRaw = normalizedOptionValue(parsed.options["ci"])
+        let ciStatus: SidebarPullRequestCIStatus?
+        if let ciStatusRaw {
+            guard let parsedCI = SidebarPullRequestCIStatus(rawValue: ciStatusRaw.lowercased()) else {
+                return "ERROR: Invalid CI status '\(ciStatusRaw)' — use: passing, failing, pending"
+            }
+            ciStatus = status == .open ? parsedCI : nil
+        } else {
+            ciStatus = nil
+        }
         if normalizedOptionValue(parsed.options["checks"]) != nil {
             return "ERROR: Unsupported option '--checks' — pull request checks are no longer tracked"
         }
 
         let labelRaw = normalizedOptionValue(parsed.options["label"]) ?? "PR"
         guard !labelRaw.isEmpty else {
-            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
+            return "ERROR: Invalid review label — usage: report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y]"
         }
         let label = String(labelRaw.prefix(16))
 
@@ -15150,7 +15174,7 @@ class TerminalController {
         return schedulePanelMetadataMutation(
             args: args,
             options: parsed.options,
-            missingPanelUsage: "report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]"
+            missingPanelUsage: "report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y]"
         ) { tab, surfaceId in
             guard Self.shouldReplacePullRequest(
                 current: tab.panelPullRequests[surfaceId],
@@ -15158,7 +15182,9 @@ class TerminalController {
                 label: label,
                 url: url,
                 status: status,
-                branch: branch
+                branch: branch,
+                reviewStatus: reviewStatus,
+                ciStatus: ciStatus
             ) else {
                 return
             }
@@ -15169,7 +15195,9 @@ class TerminalController {
                 label: label,
                 url: url,
                 status: status,
-                branch: branch
+                branch: branch,
+                reviewStatus: reviewStatus,
+                ciStatus: ciStatus
             )
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6041,6 +6041,17 @@ enum SidebarPullRequestStatus: String {
     case closed
 }
 
+enum SidebarPullRequestReviewStatus: String {
+    case approved
+    case changesRequested = "changes_requested"
+}
+
+enum SidebarPullRequestCIStatus: String {
+    case passing
+    case failing
+    case pending
+}
+
 private func normalizedSidebarBranchName(_ branch: String?) -> String? {
     guard let branch else { return nil }
     let trimmed = branch.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -6054,6 +6065,8 @@ struct SidebarPullRequestState: Equatable {
     let status: SidebarPullRequestStatus
     let branch: String?
     let isStale: Bool
+    let reviewStatus: SidebarPullRequestReviewStatus?
+    let ciStatus: SidebarPullRequestCIStatus?
 
     init(
         number: Int,
@@ -6061,7 +6074,9 @@ struct SidebarPullRequestState: Equatable {
         url: URL,
         status: SidebarPullRequestStatus,
         branch: String? = nil,
-        isStale: Bool = false
+        isStale: Bool = false,
+        reviewStatus: SidebarPullRequestReviewStatus? = nil,
+        ciStatus: SidebarPullRequestCIStatus? = nil
     ) {
         self.number = number
         self.label = label
@@ -6069,6 +6084,8 @@ struct SidebarPullRequestState: Equatable {
         self.status = status
         self.branch = normalizedSidebarBranchName(branch)
         self.isStale = isStale
+        self.reviewStatus = reviewStatus
+        self.ciStatus = ciStatus
     }
 }
 
@@ -7659,7 +7676,9 @@ final class Workspace: Identifiable, ObservableObject {
         url: URL,
         status: SidebarPullRequestStatus,
         branch: String? = nil,
-        isStale: Bool = false
+        isStale: Bool = false,
+        reviewStatus: SidebarPullRequestReviewStatus? = nil,
+        ciStatus: SidebarPullRequestCIStatus? = nil
     ) {
         let existing = panelPullRequests[panelId]
         let normalizedBranch = normalizedSidebarBranchName(branch)
@@ -7686,7 +7705,9 @@ final class Workspace: Identifiable, ObservableObject {
             url: url,
             status: status,
             branch: resolvedBranch,
-            isStale: isStale
+            isStale: isStale,
+            reviewStatus: reviewStatus,
+            ciStatus: ciStatus
         )
         if existing != state {
             panelPullRequests[panelId] = state

--- a/docs/superpowers/plans/2026-04-15-sidebar-pr-review-status.md
+++ b/docs/superpowers/plans/2026-04-15-sidebar-pr-review-status.md
@@ -1,0 +1,788 @@
+# Sidebar PR Review Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Display GitHub PR review status (approved, changes requested) alongside the PR lifecycle state in the sidebar.
+
+**Architecture:** Add `SidebarPullRequestReviewStatus` enum and thread it through the existing data pipeline: shell integration emits `--review` on the `report_pr` socket command, `TerminalController` parses it, `Workspace` stores it, background poller fetches `/pulls/{number}/reviews` for open PRs, and `ContentView` renders the suffix text.
+
+**Tech Stack:** Swift, SwiftUI, zsh, GitHub REST API
+
+---
+
+### Task 1: Add Data Model (`Workspace.swift`)
+
+**Files:**
+- Modify: `Sources/Workspace.swift:6038-6072` (enum + struct area)
+- Modify: `Sources/Workspace.swift:7655-7697` (`updatePanelPullRequest`)
+
+- [ ] **Step 1: Add `SidebarPullRequestReviewStatus` enum**
+
+Insert immediately after the `SidebarPullRequestStatus` enum (after line 6042):
+
+```swift
+enum SidebarPullRequestReviewStatus: String {
+    case approved
+    case changesRequested = "changes_requested"
+}
+```
+
+- [ ] **Step 2: Add `reviewStatus` field to `SidebarPullRequestState`**
+
+Update the struct at line 6050 to include `reviewStatus`:
+
+```swift
+struct SidebarPullRequestState: Equatable {
+    let number: Int
+    let label: String
+    let url: URL
+    let status: SidebarPullRequestStatus
+    let branch: String?
+    let isStale: Bool
+    let reviewStatus: SidebarPullRequestReviewStatus?
+
+    init(
+        number: Int,
+        label: String,
+        url: URL,
+        status: SidebarPullRequestStatus,
+        branch: String? = nil,
+        isStale: Bool = false,
+        reviewStatus: SidebarPullRequestReviewStatus? = nil
+    ) {
+        self.number = number
+        self.label = label
+        self.url = url
+        self.status = status
+        self.branch = normalizedSidebarBranchName(branch)
+        self.isStale = isStale
+        self.reviewStatus = reviewStatus
+    }
+}
+```
+
+- [ ] **Step 3: Update `updatePanelPullRequest` to accept `reviewStatus`**
+
+At `Workspace.swift:7655`, add the parameter and thread it through:
+
+```swift
+func updatePanelPullRequest(
+    panelId: UUID,
+    number: Int,
+    label: String,
+    url: URL,
+    status: SidebarPullRequestStatus,
+    branch: String? = nil,
+    isStale: Bool = false,
+    reviewStatus: SidebarPullRequestReviewStatus? = nil
+) {
+    let existing = panelPullRequests[panelId]
+    let normalizedBranch = normalizedSidebarBranchName(branch)
+    let currentPanelBranch = normalizedSidebarBranchName(panelGitBranches[panelId]?.branch)
+    let resolvedBranch: String? = {
+        if let normalizedBranch {
+            return normalizedBranch
+        }
+        if let currentPanelBranch {
+            return currentPanelBranch
+        }
+        guard let existing,
+              existing.number == number,
+              existing.label == label,
+              existing.url == url,
+              existing.status == status else {
+            return nil
+        }
+        return existing.branch
+    }()
+    let state = SidebarPullRequestState(
+        number: number,
+        label: label,
+        url: url,
+        status: status,
+        branch: resolvedBranch,
+        isStale: isStale,
+        reviewStatus: reviewStatus
+    )
+    if existing != state {
+        panelPullRequests[panelId] = state
+    }
+    if panelId == focusedPanelId, pullRequest != state {
+        pullRequest = state
+    }
+}
+```
+
+- [ ] **Step 4: Build to verify compilation**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pr-review build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED (the new field has a default value, so all existing call sites compile unchanged).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/Workspace.swift
+git commit -m "feat: add SidebarPullRequestReviewStatus model and reviewStatus field"
+```
+
+---
+
+### Task 2: Parse `--review` in Socket Command (`TerminalController.swift`)
+
+**Files:**
+- Modify: `Sources/TerminalController.swift:15114-15175` (`reportPullRequest`)
+- Modify: `Sources/TerminalController.swift:386-411` (`shouldReplacePullRequest`)
+
+- [ ] **Step 1: Parse `--review` option in `reportPullRequest`**
+
+In `reportPullRequest` at line 15137 (after the `branch` line, before the `checks` guard), add review parsing:
+
+```swift
+let reviewStatusRaw = normalizedOptionValue(parsed.options["review"])
+let reviewStatus: SidebarPullRequestReviewStatus?
+if let reviewStatusRaw {
+    guard let parsed = SidebarPullRequestReviewStatus(rawValue: reviewStatusRaw.lowercased()) else {
+        return "ERROR: Invalid review status '\(reviewStatusRaw)' — use: approved, changes_requested"
+    }
+    reviewStatus = status == .open ? parsed : nil
+} else {
+    reviewStatus = nil
+}
+```
+
+- [ ] **Step 2: Update usage strings**
+
+Update the three usage strings in `reportPullRequest` (lines 15117, 15144, 15153) from:
+
+```
+report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--branch=<name>] [--tab=X] [--panel=Y]
+```
+
+to:
+
+```
+report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--branch=<name>] [--tab=X] [--panel=Y]
+```
+
+- [ ] **Step 3: Thread `reviewStatus` into `shouldReplacePullRequest` and `updatePanelPullRequest`**
+
+Update the `shouldReplacePullRequest` call at line 15155 to include `reviewStatus`:
+
+```swift
+guard Self.shouldReplacePullRequest(
+    current: tab.panelPullRequests[surfaceId],
+    number: number,
+    label: label,
+    url: url,
+    status: status,
+    branch: branch,
+    reviewStatus: reviewStatus
+) else {
+    return
+}
+
+tab.updatePanelPullRequest(
+    panelId: surfaceId,
+    number: number,
+    label: label,
+    url: url,
+    status: status,
+    branch: branch,
+    reviewStatus: reviewStatus
+)
+```
+
+- [ ] **Step 4: Update `shouldReplacePullRequest` to include `reviewStatus`**
+
+At `TerminalController.swift:386`, add the parameter and comparison:
+
+```swift
+nonisolated static func shouldReplacePullRequest(
+    current: SidebarPullRequestState?,
+    number: Int,
+    label: String,
+    url: URL,
+    status: SidebarPullRequestStatus,
+    branch: String?,
+    reviewStatus: SidebarPullRequestReviewStatus? = nil
+) -> Bool {
+    guard let current else { return true }
+    let normalizedBranch = branch?.trimmingCharacters(in: .whitespacesAndNewlines)
+    let effectiveBranch: String? = {
+        if let normalizedBranch, !normalizedBranch.isEmpty {
+            return normalizedBranch
+        }
+        guard current.number == number,
+              current.label == label,
+              current.url == url,
+              current.status == status else {
+            return nil
+        }
+        return current.branch
+    }()
+    return current.number != number
+        || current.label != label
+        || current.url != url
+        || current.status != status
+        || current.branch != effectiveBranch
+        || current.reviewStatus != reviewStatus
+}
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pr-review build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/TerminalController.swift
+git commit -m "feat: parse --review option in report_pr socket command"
+```
+
+---
+
+### Task 3: Add Review Fetch to Background Poller (`TabManager.swift`)
+
+**Files:**
+- Modify: `Sources/TabManager.swift:757-762` (`WorkspacePullRequestResolvedItem`)
+- Modify: `Sources/TabManager.swift:2459-2526` (`resolveWorkspacePullRequestRefreshResults`)
+- Modify: `Sources/TabManager.swift:1262-1287` (refresh task)
+- Modify: `Sources/TabManager.swift:1345-1482` (`applyWorkspacePullRequestRefreshResults`)
+
+- [ ] **Step 1: Add `reviewStatusRawValue` to `WorkspacePullRequestResolvedItem`**
+
+At `TabManager.swift:757`:
+
+```swift
+private struct WorkspacePullRequestResolvedItem: Sendable {
+    let number: Int
+    let urlString: String
+    let statusRawValue: String
+    let branch: String
+    let reviewStatusRawValue: String?
+}
+```
+
+- [ ] **Step 2: Add REST review item struct**
+
+Add a new decodable struct near the other REST structs (after `WorkspacePullRequestRESTItem` around line 839):
+
+```swift
+private struct WorkspacePullRequestReviewRESTItem: Decodable, Sendable {
+    let state: String
+    let user: ReviewUser?
+
+    struct ReviewUser: Decodable, Sendable {
+        let login: String
+    }
+}
+```
+
+- [ ] **Step 3: Add review fetch function**
+
+Add a new static function near `performWorkspacePullRequestRequest` (around line 2805):
+
+```swift
+private nonisolated static func fetchPullRequestReviewStatus(
+    repoSlug: String,
+    prNumber: Int,
+    session: URLSession,
+    authHeader: String?
+) async -> SidebarPullRequestReviewStatus? {
+    let endpoint = "repos/\(repoSlug)/pulls/\(prNumber)/reviews"
+    guard let response = await performWorkspacePullRequestRequest(
+        session: session,
+        endpoint: endpoint,
+        authHeader: authHeader
+    ) else {
+        return nil
+    }
+    guard response.statusCode == 200,
+          let reviews = decodeJSON([WorkspacePullRequestReviewRESTItem].self, from: response.data) else {
+        return nil
+    }
+    return aggregateReviewStatus(from: reviews)
+}
+
+private nonisolated static func aggregateReviewStatus(
+    from reviews: [WorkspacePullRequestReviewRESTItem]
+) -> SidebarPullRequestReviewStatus? {
+    var latestByUser: [String: String] = [:]
+    for review in reviews {
+        guard let login = review.user?.login else { continue }
+        let state = review.state.uppercased()
+        if state == "APPROVED" || state == "CHANGES_REQUESTED" {
+            latestByUser[login] = state
+        } else if state == "DISMISSED" {
+            latestByUser.removeValue(forKey: login)
+        }
+    }
+    guard !latestByUser.isEmpty else { return nil }
+    if latestByUser.values.contains("CHANGES_REQUESTED") {
+        return .changesRequested
+    }
+    if latestByUser.values.allSatisfy({ $0 == "APPROVED" }) {
+        return .approved
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Fetch reviews for open resolved PRs in the refresh task**
+
+In the refresh task at line 1262, after `resolveWorkspacePullRequestRefreshResults` produces `results`, add a review-fetch pass before dispatching to main. Replace the block from line 1262-1287:
+
+```swift
+workspacePullRequestRefreshTask = Task { [weak self] in
+    let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
+        repoDirectoriesBySlug: repoDirectoriesBySlug,
+        candidateBranchesByRepo: candidateBranchesByRepo,
+        cacheBySlug: cacheBySlug,
+        now: now,
+        allowCachedResults: allowCachedResults
+    )
+    var results = Self.resolveWorkspacePullRequestRefreshResults(
+        candidates: candidates,
+        repoResults: repoResults
+    )
+    guard !Task.isCancelled else { return }
+
+    // Fetch review status for open PRs
+    let configuration = URLSessionConfiguration.ephemeral
+    configuration.timeoutIntervalForRequest = max(Self.workspacePullRequestProbeTimeout, 8)
+    configuration.timeoutIntervalForResource = max(Self.workspacePullRequestProbeTimeout, 8)
+    let reviewSession = URLSession(configuration: configuration)
+    let reviewAuthHeader = workspacePullRequestAuthHeaderValue()
+
+    results = await Self.enrichResultsWithReviewStatus(
+        results: results,
+        candidates: candidates,
+        repoDirectoriesBySlug: repoDirectoriesBySlug,
+        session: reviewSession,
+        authHeader: reviewAuthHeader
+    )
+    guard !Task.isCancelled else { return }
+
+    await MainActor.run { [weak self] in
+        guard let self else { return }
+        guard !Task.isCancelled else { return }
+        self.workspacePullRequestRefreshTask = nil
+        self.applyWorkspacePullRequestRefreshResults(
+            results,
+            repoResults: repoResults,
+            requestedKeys: requestedKeys,
+            now: Date(),
+            reason: reason
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Add `enrichResultsWithReviewStatus` function**
+
+```swift
+private nonisolated static func enrichResultsWithReviewStatus(
+    results: [WorkspacePullRequestRefreshResult],
+    candidates: [WorkspacePullRequestCandidate],
+    repoDirectoriesBySlug: [String: String],
+    session: URLSession,
+    authHeader: String?
+) async -> [WorkspacePullRequestRefreshResult] {
+    let enriched = await withTaskGroup(
+        of: (Int, WorkspacePullRequestRefreshResult).self,
+        returning: [WorkspacePullRequestRefreshResult].self
+    ) { group in
+        for (index, result) in results.enumerated() {
+            guard case .resolved(let item) = result.resolution,
+                  item.statusRawValue == SidebarPullRequestStatus.open.rawValue,
+                  item.reviewStatusRawValue == nil else {
+                continue
+            }
+
+            let candidate = candidates[index]
+            guard let repoSlug = candidate.repoSlugs.first else { continue }
+
+            group.addTask {
+                let reviewStatus = await fetchPullRequestReviewStatus(
+                    repoSlug: repoSlug,
+                    prNumber: item.number,
+                    session: session,
+                    authHeader: authHeader
+                )
+                let enrichedItem = WorkspacePullRequestResolvedItem(
+                    number: item.number,
+                    urlString: item.urlString,
+                    statusRawValue: item.statusRawValue,
+                    branch: item.branch,
+                    reviewStatusRawValue: reviewStatus?.rawValue
+                )
+                return (index, WorkspacePullRequestRefreshResult(
+                    workspaceId: result.workspaceId,
+                    panelId: result.panelId,
+                    resolution: .resolved(enrichedItem),
+                    usedCachedRepoData: result.usedCachedRepoData
+                ))
+            }
+        }
+
+        var updatedResults = results
+        for await (index, enrichedResult) in group {
+            updatedResults[index] = enrichedResult
+        }
+        return updatedResults
+    }
+    return enriched
+}
+```
+
+- [ ] **Step 6: Update `resolveWorkspacePullRequestRefreshResults` to pass `nil` review status**
+
+At line 2503, update the `WorkspacePullRequestResolvedItem` construction:
+
+```swift
+resolution = .resolved(
+    WorkspacePullRequestResolvedItem(
+        number: matchedPullRequest.number,
+        urlString: matchedPullRequest.url,
+        statusRawValue: status.rawValue,
+        branch: candidate.branch,
+        reviewStatusRawValue: nil
+    )
+)
+```
+
+- [ ] **Step 7: Update `applyWorkspacePullRequestRefreshResults` to pass `reviewStatus`**
+
+At line 1414, in the `.resolved` case, parse and pass review status:
+
+```swift
+case .resolved(let resolvedPullRequest):
+    workspacePullRequestTransientFailureCountByKey[key] = 0
+    guard let status = SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
+          let url = URL(string: resolvedPullRequest.urlString) else {
+        continue
+    }
+    let reviewStatus = resolvedPullRequest.reviewStatusRawValue
+        .flatMap(SidebarPullRequestReviewStatus.init(rawValue:))
+    workspace.updatePanelPullRequest(
+        panelId: result.panelId,
+        number: resolvedPullRequest.number,
+        label: "PR",
+        url: url,
+        status: status,
+        branch: resolvedPullRequest.branch,
+        isStale: false,
+        reviewStatus: reviewStatus
+    )
+```
+
+- [ ] **Step 8: Build to verify compilation**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pr-review build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add Sources/TabManager.swift
+git commit -m "feat: fetch PR review status from GitHub REST API for open PRs"
+```
+
+---
+
+### Task 4: Update UI to Display Review Status (`ContentView.swift`)
+
+**Files:**
+- Modify: `Sources/ContentView.swift:13979-13998` (`PullRequestDisplay`, `pullRequestDisplays`)
+- Modify: `Sources/ContentView.swift:13146-13174` (sidebar PR rendering)
+- Modify: `Sources/ContentView.swift:14038-14044` (`pullRequestStatusLabel`)
+
+- [ ] **Step 1: Add `reviewStatus` to `PullRequestDisplay`**
+
+At line 13979:
+
+```swift
+private struct PullRequestDisplay: Identifiable {
+    let id: String
+    let number: Int
+    let label: String
+    let url: URL
+    let status: SidebarPullRequestStatus
+    let isStale: Bool
+    let reviewStatus: SidebarPullRequestReviewStatus?
+}
+```
+
+- [ ] **Step 2: Update `pullRequestDisplays` to pass `reviewStatus`**
+
+At line 13988:
+
+```swift
+private func pullRequestDisplays(orderedPanelIds: [UUID]) -> [PullRequestDisplay] {
+    tab.sidebarPullRequestsInDisplayOrder(orderedPanelIds: orderedPanelIds).map { pullRequest in
+        PullRequestDisplay(
+            id: "\(pullRequest.label.lowercased())#\(pullRequest.number)|\(pullRequest.url.absoluteString)",
+            number: pullRequest.number,
+            label: pullRequest.label,
+            url: pullRequest.url,
+            status: pullRequest.status,
+            isStale: pullRequest.isStale,
+            reviewStatus: pullRequest.reviewStatus
+        )
+    }
+}
+```
+
+- [ ] **Step 3: Update `pullRequestStatusLabel` to include review suffix**
+
+Replace the function at line 14038:
+
+```swift
+private func pullRequestStatusLabel(
+    _ status: SidebarPullRequestStatus,
+    reviewStatus: SidebarPullRequestReviewStatus?
+) -> String {
+    switch status {
+    case .open:
+        switch reviewStatus {
+        case .approved:
+            return String(localized: "sidebar.pullRequest.statusOpenApproved", defaultValue: "open \u{00B7} approved")
+        case .changesRequested:
+            return String(localized: "sidebar.pullRequest.statusOpenChangesRequested", defaultValue: "open \u{00B7} changes requested")
+        case nil:
+            return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
+        }
+    case .merged:
+        return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+    case .closed:
+        return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+    }
+}
+```
+
+- [ ] **Step 4: Update the call site in sidebar rendering**
+
+At line 13162, update the `Text` call to pass `reviewStatus`:
+
+```swift
+Text(pullRequestStatusLabel(pullRequest.status, reviewStatus: pullRequest.reviewStatus))
+```
+
+- [ ] **Step 5: Build to verify compilation**
+
+```bash
+xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-pr-review build 2>&1 | tail -5
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/ContentView.swift
+git commit -m "feat: display PR review status suffix in sidebar"
+```
+
+---
+
+### Task 5: Update Shell Integration (`cmux-zsh-integration.zsh`)
+
+**Files:**
+- Modify: `Resources/shell-integration/cmux-zsh-integration.zsh:779-851`
+
+- [ ] **Step 1: Add `reviewDecision` to `gh pr view` JSON fields**
+
+At line 783, change the `--json` and `--jq` arguments:
+
+From:
+```bash
+&& gh pr view "$branch" \
+    "${gh_repo_args[@]}" \
+    --json number,state,url \
+    --jq '[.number, .state, .url] | @tsv' \
+```
+
+To:
+```bash
+&& gh pr view "$branch" \
+    "${gh_repo_args[@]}" \
+    --json number,state,url,reviewDecision \
+    --jq '[.number, .state, .url, .reviewDecision] | @tsv' \
+```
+
+- [ ] **Step 2: Parse the `reviewDecision` field from output**
+
+At line 828, update the read to capture the fourth field:
+
+From:
+```bash
+local IFS=$'\t'
+read -r number state url <<< "$gh_output"
+if [[ -z "$number" ]] || [[ -z "$url" ]]; then
+    return 1
+fi
+```
+
+To:
+```bash
+local IFS=$'\t'
+read -r number state url review_decision <<< "$gh_output"
+if [[ -z "$number" ]] || [[ -z "$url" ]]; then
+    return 1
+fi
+```
+
+- [ ] **Step 3: Build the `--review` option**
+
+After the existing `case "$state"` block (after line 838), add review mapping:
+
+```bash
+local review_opt=""
+case "$review_decision" in
+    APPROVED) review_opt="--review=approved" ;;
+    CHANGES_REQUESTED) review_opt="--review=changes_requested" ;;
+esac
+```
+
+- [ ] **Step 4: Include `--review` in the `report_pr` socket command**
+
+At line 851, update the `_cmux_send` call to include `$review_opt`:
+
+From:
+```bash
+_cmux_send "report_pr $number $url $status_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+```
+
+To:
+```bash
+_cmux_send "report_pr $number $url $status_opt $review_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+```
+
+- [ ] **Step 5: Update the cache format to include review decision**
+
+At line 844, update the cache write to store the review decision:
+
+From:
+```bash
+printf '%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" >| "$result_file"
+```
+
+To:
+```bash
+printf '%s\t%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" "$review_decision" >| "$result_file"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/shell-integration/cmux-zsh-integration.zsh
+git commit -m "feat: emit --review flag from shell integration PR detection"
+```
+
+---
+
+### Task 6: Add Localization Keys (`Localizable.xcstrings`)
+
+**Files:**
+- Modify: `Resources/Localizable.xcstrings`
+
+- [ ] **Step 1: Add `sidebar.pullRequest.statusOpenApproved` key**
+
+In the `strings` object of `Localizable.xcstrings`, add the following entry (alphabetically near the other `sidebar.pullRequest.status*` keys):
+
+```json
+"sidebar.pullRequest.statusOpenApproved": {
+  "extractionState": "manual",
+  "localizations": {
+    "en": {
+      "stringUnit": {
+        "state": "translated",
+        "value": "open \u00B7 approved"
+      }
+    },
+    "ja": {
+      "stringUnit": {
+        "state": "translated",
+        "value": "\u30AA\u30FC\u30D7\u30F3 \u00B7 \u627F\u8A8D\u6E08\u307F"
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Add `sidebar.pullRequest.statusOpenChangesRequested` key**
+
+```json
+"sidebar.pullRequest.statusOpenChangesRequested": {
+  "extractionState": "manual",
+  "localizations": {
+    "en": {
+      "stringUnit": {
+        "state": "translated",
+        "value": "open \u00B7 changes requested"
+      }
+    },
+    "ja": {
+      "stringUnit": {
+        "state": "translated",
+        "value": "\u30AA\u30FC\u30D7\u30F3 \u00B7 \u5909\u66F4\u8981\u6C42"
+      }
+    }
+  }
+}
+```
+
+Note: Add translations for all other languages present in the existing `sidebar.pullRequest.statusOpen` entry (zh-Hans, zh-Hant, ko, de, es, fr, it, da, tr, uk, etc.) following the same pattern. The English value serves as the `defaultValue` fallback for untranslated locales.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Resources/Localizable.xcstrings
+git commit -m "feat: add localization keys for PR review status labels"
+```
+
+---
+
+### Task 7: Final Build and Smoke Test
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full build**
+
+```bash
+./scripts/reload.sh --tag pr-review-status
+```
+
+Expected: Build succeeds, app path printed.
+
+- [ ] **Step 2: Verify with debug log**
+
+Open the tagged app, navigate to a repo with an open PR that has reviews. Tail the debug log:
+
+```bash
+tail -f /tmp/cmux-debug-pr-review-status.log
+```
+
+Verify:
+- Shell integration sends `report_pr` with `--review=approved` or `--review=changes_requested`
+- Sidebar shows "open · approved" or "open · changes requested"
+- Merged/closed PRs still show only "merged" / "closed"
+- A PR with no reviews shows just "open"
+
+- [ ] **Step 3: Commit all remaining changes (if any)**
+
+```bash
+git add -A
+git commit -m "feat: sidebar PR review status display"
+```

--- a/docs/superpowers/plans/2026-04-16-sidebar-ci-status-graphql-migration.md
+++ b/docs/superpowers/plans/2026-04-16-sidebar-ci-status-graphql-migration.md
@@ -1,0 +1,611 @@
+# Sidebar CI Status + GraphQL Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add CI status to sidebar PR display and migrate enrichment from N REST calls to 1 GraphQL call per repo.
+
+**Architecture:** Extend the existing review status pipeline with CI status. Replace the REST-based `enrichResultsWithReviewStatus` with a GraphQL enrichment that fetches both `reviewDecision` and `statusCheckRollup` in a single batched query per repo. Refactor localization from combo keys to composable parts.
+
+**Tech Stack:** Swift, SwiftUI, zsh, GitHub GraphQL API
+
+---
+
+### Task 1: Add CI Status Data Model (`Workspace.swift`)
+
+**Files:**
+- Modify: `Sources/Workspace.swift` (near existing `SidebarPullRequestReviewStatus` enum ~line 6044, `SidebarPullRequestState` struct ~line 6055, `updatePanelPullRequest` ~line 7663)
+
+- [ ] **Step 1: Add `SidebarPullRequestCIStatus` enum**
+
+Insert after `SidebarPullRequestReviewStatus` enum:
+
+```swift
+enum SidebarPullRequestCIStatus: String {
+    case passing
+    case failing
+    case pending
+}
+```
+
+- [ ] **Step 2: Add `ciStatus` field to `SidebarPullRequestState`**
+
+Add `let ciStatus: SidebarPullRequestCIStatus?` after `reviewStatus`, and add `ciStatus: SidebarPullRequestCIStatus? = nil` to the init.
+
+- [ ] **Step 3: Update `updatePanelPullRequest` to accept `ciStatus`**
+
+Add `ciStatus: SidebarPullRequestCIStatus? = nil` parameter, pass through to `SidebarPullRequestState` init.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Sources/Workspace.swift
+git commit -m "feat: add SidebarPullRequestCIStatus model"
+```
+
+---
+
+### Task 2: Parse `--ci` in Socket Command (`TerminalController.swift`)
+
+**Files:**
+- Modify: `Sources/TerminalController.swift` (~line 15140 in `reportPullRequest`, ~line 386 in `shouldReplacePullRequest`)
+
+- [ ] **Step 1: Parse `--ci` option in `reportPullRequest`**
+
+After the existing `reviewStatus` parsing block, add:
+
+```swift
+let ciStatusRaw = normalizedOptionValue(parsed.options["ci"])
+let ciStatus: SidebarPullRequestCIStatus?
+if let ciStatusRaw {
+    guard let parsedCI = SidebarPullRequestCIStatus(rawValue: ciStatusRaw.lowercased()) else {
+        return "ERROR: Invalid CI status '\(ciStatusRaw)' — use: passing, failing, pending"
+    }
+    ciStatus = status == .open ? parsedCI : nil
+} else {
+    ciStatus = nil
+}
+```
+
+- [ ] **Step 2: Update usage strings**
+
+Update all usage strings to include `[--ci=passing|failing|pending]` after `[--review=...]`.
+
+- [ ] **Step 3: Thread `ciStatus` into `shouldReplacePullRequest` and `updatePanelPullRequest`**
+
+Add `ciStatus` parameter to both calls. Add `|| current.ciStatus != ciStatus` to the return expression in `shouldReplacePullRequest`.
+
+- [ ] **Step 4: Update `report_review` help string**
+
+Add `[--ci=passing|failing|pending]` to the help text at ~line 11425.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Sources/TerminalController.swift
+git commit -m "feat: parse --ci option in report_pr socket command"
+```
+
+---
+
+### Task 3: Migrate Enrichment to GraphQL (`TabManager.swift`)
+
+**Files:**
+- Modify: `Sources/TabManager.swift`
+
+This is the core migration task. Replace REST review fetching with batched GraphQL queries that return both review and CI status.
+
+- [ ] **Step 1: Add `ciStatusRawValue` to `WorkspacePullRequestResolvedItem`**
+
+At ~line 757, add `let ciStatusRawValue: String?` field.
+
+- [ ] **Step 2: Add GraphQL response structs**
+
+Replace `WorkspacePullRequestReviewRESTItem` with GraphQL response types:
+
+```swift
+private struct GraphQLResponse<T: Decodable>: Decodable, Sendable where T: Sendable {
+    let data: T?
+    let errors: [GraphQLError]?
+}
+
+private struct GraphQLError: Decodable, Sendable {
+    let message: String
+}
+
+private struct GraphQLRepositoryResponse: Decodable, Sendable {
+    let repository: [String: GraphQLPullRequestNode]?
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DynamicCodingKey.self)
+        guard let repoContainer = try? container.nestedContainer(
+            keyedBy: DynamicCodingKey.self,
+            forKey: DynamicCodingKey(stringValue: "repository")!
+        ) else {
+            repository = nil
+            return
+        }
+        var result: [String: GraphQLPullRequestNode] = [:]
+        for key in repoContainer.allKeys {
+            if let node = try? repoContainer.decode(GraphQLPullRequestNode.self, forKey: key) {
+                result[key.stringValue] = node
+            }
+        }
+        repository = result
+    }
+}
+
+private struct GraphQLPullRequestNode: Decodable, Sendable {
+    let reviewDecision: String?
+    let commits: GraphQLCommitConnection?
+}
+
+private struct GraphQLCommitConnection: Decodable, Sendable {
+    let nodes: [GraphQLCommitNode]?
+}
+
+private struct GraphQLCommitNode: Decodable, Sendable {
+    let commit: GraphQLCommit?
+}
+
+private struct GraphQLCommit: Decodable, Sendable {
+    let statusCheckRollup: GraphQLStatusCheckRollup?
+}
+
+private struct GraphQLStatusCheckRollup: Decodable, Sendable {
+    let state: String?
+}
+
+private struct DynamicCodingKey: CodingKey {
+    var stringValue: String
+    var intValue: Int?
+    init?(stringValue: String) { self.stringValue = stringValue }
+    init?(intValue: Int) { self.stringValue = "\(intValue)"; self.intValue = intValue }
+}
+```
+
+- [ ] **Step 3: Add GraphQL query builder**
+
+```swift
+private nonisolated static func buildPullRequestEnrichmentQuery(
+    owner: String,
+    repo: String,
+    prNumbers: [Int]
+) -> String {
+    let fragment = """
+    reviewDecision
+    commits(last: 1) {
+      nodes {
+        commit {
+          statusCheckRollup {
+            state
+          }
+        }
+      }
+    }
+    """
+    let fields = prNumbers.map { number in
+        "pr_\(number): pullRequest(number: \(number)) { \(fragment) }"
+    }.joined(separator: "\n    ")
+    return """
+    query {
+      repository(owner: "\(owner)", name: "\(repo)") {
+        \(fields)
+      }
+    }
+    """
+}
+```
+
+- [ ] **Step 4: Add GraphQL fetch function**
+
+```swift
+private nonisolated static func fetchPullRequestEnrichmentViaGraphQL(
+    repoSlug: String,
+    prNumbers: [Int],
+    session: URLSession,
+    authHeader: String?
+) async -> [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)] {
+    guard !prNumbers.isEmpty else { return [:] }
+    let components = repoSlug.split(separator: "/")
+    guard components.count == 2 else { return [:] }
+    let owner = String(components[0])
+    let repo = String(components[1])
+
+    let query = buildPullRequestEnrichmentQuery(owner: owner, repo: repo, prNumbers: prNumbers)
+    let body: [String: Any] = ["query": query]
+    guard let bodyData = try? JSONSerialization.data(withJSONObject: body) else { return [:] }
+
+    guard let url = URL(string: "https://api.github.com/graphql") else { return [:] }
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+    request.setValue("application/json", forHTTPHeaderField: "Accept")
+    request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+    if let authHeader, !authHeader.isEmpty {
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+    }
+    request.httpBody = bodyData
+
+    guard let (data, response) = try? await session.data(for: request),
+          let httpResponse = response as? HTTPURLResponse,
+          httpResponse.statusCode == 200 else {
+        return [:]
+    }
+
+    guard let graphQLResponse = decodeJSON(GraphQLResponse<GraphQLRepositoryResponse>.self, from: data),
+          let repository = graphQLResponse.data?.repository else {
+        return [:]
+    }
+
+    var results: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)] = [:]
+    for prNumber in prNumbers {
+        let key = "pr_\(prNumber)"
+        guard let node = repository[key] else { continue }
+
+        let reviewStatus: SidebarPullRequestReviewStatus? = {
+            switch node.reviewDecision?.uppercased() {
+            case "APPROVED": return .approved
+            case "CHANGES_REQUESTED": return .changesRequested
+            default: return nil
+            }
+        }()
+
+        let ciStatus: SidebarPullRequestCIStatus? = {
+            let state = node.commits?.nodes?.first?.commit?.statusCheckRollup?.state?.uppercased()
+            switch state {
+            case "SUCCESS": return .passing
+            case "FAILURE", "ERROR": return .failing
+            case "PENDING", "EXPECTED": return .pending
+            default: return nil
+            }
+        }()
+
+        results[prNumber] = (reviewStatus: reviewStatus, ciStatus: ciStatus)
+    }
+    return results
+}
+```
+
+- [ ] **Step 5: Replace `enrichResultsWithReviewStatus` with GraphQL-based enrichment**
+
+Replace the function at ~line 2910:
+
+```swift
+private nonisolated static func enrichResultsWithGraphQL(
+    results: [WorkspacePullRequestRefreshResult],
+    candidates: [WorkspacePullRequestCandidate],
+    session: URLSession,
+    authHeader: String?
+) async -> [WorkspacePullRequestRefreshResult] {
+    // Group open PRs by repo slug
+    var prNumbersByRepo: [String: [(index: Int, item: WorkspacePullRequestResolvedItem)]] = [:]
+    for (index, result) in results.enumerated() {
+        guard case .resolved(let item) = result.resolution,
+              item.statusRawValue == SidebarPullRequestStatus.open.rawValue else {
+            continue
+        }
+        let candidate = candidates[index]
+        guard let repoSlug = candidate.repoSlugs.first else { continue }
+        prNumbersByRepo[repoSlug, default: []].append((index: index, item: item))
+    }
+
+    guard !prNumbersByRepo.isEmpty else { return results }
+
+    // One GraphQL call per repo (concurrent across repos)
+    let enrichments = await withTaskGroup(
+        of: (String, [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]).self,
+        returning: [String: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]].self
+    ) { group in
+        for (repoSlug, _) in prNumbersByRepo {
+            let prNumbers = prNumbersByRepo[repoSlug]!.map(\.item.number)
+            group.addTask {
+                let result = await fetchPullRequestEnrichmentViaGraphQL(
+                    repoSlug: repoSlug,
+                    prNumbers: prNumbers,
+                    session: session,
+                    authHeader: authHeader
+                )
+                return (repoSlug, result)
+            }
+        }
+        var collected: [String: [Int: (reviewStatus: SidebarPullRequestReviewStatus?, ciStatus: SidebarPullRequestCIStatus?)]] = [:]
+        for await (repoSlug, result) in group {
+            collected[repoSlug] = result
+        }
+        return collected
+    }
+
+    // Apply enrichments to results
+    var updatedResults = results
+    for (repoSlug, entries) in prNumbersByRepo {
+        guard let repoEnrichments = enrichments[repoSlug] else { continue }
+        for (index, item) in entries {
+            let enrichment = repoEnrichments[item.number]
+            let enrichedItem = WorkspacePullRequestResolvedItem(
+                number: item.number,
+                urlString: item.urlString,
+                statusRawValue: item.statusRawValue,
+                branch: item.branch,
+                reviewStatusRawValue: enrichment?.reviewStatus?.rawValue ?? item.reviewStatusRawValue,
+                ciStatusRawValue: enrichment?.ciStatus?.rawValue
+            )
+            updatedResults[index] = WorkspacePullRequestRefreshResult(
+                workspaceId: results[index].workspaceId,
+                panelId: results[index].panelId,
+                resolution: .resolved(enrichedItem),
+                usedCachedRepoData: results[index].usedCachedRepoData
+            )
+        }
+    }
+    return updatedResults
+}
+```
+
+- [ ] **Step 6: Remove old REST review functions**
+
+Delete:
+- `WorkspacePullRequestReviewRESTItem` struct (~line 842)
+- `fetchPullRequestReviewStatus` function (~line 2866)
+- `aggregateReviewStatus` function (~line 2887)
+
+- [ ] **Step 7: Update refresh task to call `enrichResultsWithGraphQL`**
+
+At ~line 1294, change:
+```swift
+results = await Self.enrichResultsWithReviewStatus(
+    results: results,
+    candidates: candidates,
+    session: reviewSession,
+    authHeader: reviewAuthHeader
+)
+```
+To:
+```swift
+results = await Self.enrichResultsWithGraphQL(
+    results: results,
+    candidates: candidates,
+    session: reviewSession,
+    authHeader: reviewAuthHeader
+)
+```
+
+- [ ] **Step 8: Update `resolveWorkspacePullRequestRefreshResults`**
+
+At the `WorkspacePullRequestResolvedItem` construction (~line 2537), add `ciStatusRawValue: nil`.
+
+- [ ] **Step 9: Update `applyWorkspacePullRequestRefreshResults`**
+
+In the `.resolved` case (~line 1440), parse and pass CI status:
+
+```swift
+let reviewStatus = resolvedPullRequest.reviewStatusRawValue
+    .flatMap(SidebarPullRequestReviewStatus.init(rawValue:))
+let ciStatus = resolvedPullRequest.ciStatusRawValue
+    .flatMap(SidebarPullRequestCIStatus.init(rawValue:))
+workspace.updatePanelPullRequest(
+    panelId: result.panelId,
+    number: resolvedPullRequest.number,
+    label: "PR",
+    url: url,
+    status: status,
+    branch: resolvedPullRequest.branch,
+    isStale: false,
+    reviewStatus: reviewStatus,
+    ciStatus: ciStatus
+)
+```
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Sources/TabManager.swift
+git commit -m "feat: migrate PR enrichment from REST to GraphQL, add CI status"
+```
+
+---
+
+### Task 4: Update UI to Display CI Status (`ContentView.swift`)
+
+**Files:**
+- Modify: `Sources/ContentView.swift`
+
+- [ ] **Step 1: Add `ciStatus` to `PullRequestDisplay`**
+
+Add `let ciStatus: SidebarPullRequestCIStatus?` to the struct.
+
+- [ ] **Step 2: Update `pullRequestDisplays` to pass `ciStatus`**
+
+Add `ciStatus: pullRequest.ciStatus` to the `PullRequestDisplay` construction.
+
+- [ ] **Step 3: Add helper functions for review and CI labels**
+
+```swift
+private func pullRequestReviewStatusLabel(_ reviewStatus: SidebarPullRequestReviewStatus) -> String {
+    switch reviewStatus {
+    case .approved:
+        return String(localized: "sidebar.pullRequest.reviewApproved", defaultValue: "approved")
+    case .changesRequested:
+        return String(localized: "sidebar.pullRequest.reviewChangesRequested", defaultValue: "changes requested")
+    }
+}
+
+private func pullRequestCIStatusLabel(_ ciStatus: SidebarPullRequestCIStatus) -> String {
+    switch ciStatus {
+    case .passing:
+        return String(localized: "sidebar.pullRequest.ciPassing", defaultValue: "passing")
+    case .failing:
+        return String(localized: "sidebar.pullRequest.ciFailing", defaultValue: "failing")
+    case .pending:
+        return String(localized: "sidebar.pullRequest.ciPending", defaultValue: "pending")
+    }
+}
+```
+
+- [ ] **Step 4: Rewrite `pullRequestStatusLabel` to build from parts**
+
+```swift
+private func pullRequestStatusLabel(
+    _ status: SidebarPullRequestStatus,
+    reviewStatus: SidebarPullRequestReviewStatus?,
+    ciStatus: SidebarPullRequestCIStatus?
+) -> String {
+    switch status {
+    case .open:
+        var parts = [String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")]
+        if let reviewStatus {
+            parts.append(pullRequestReviewStatusLabel(reviewStatus))
+        }
+        if let ciStatus {
+            parts.append(pullRequestCIStatusLabel(ciStatus))
+        }
+        return parts.joined(separator: " \u{00B7} ")
+    case .merged:
+        return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+    case .closed:
+        return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+    }
+}
+```
+
+- [ ] **Step 5: Update call site**
+
+```swift
+Text(pullRequestStatusLabel(pullRequest.status, reviewStatus: pullRequest.reviewStatus, ciStatus: pullRequest.ciStatus))
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Sources/ContentView.swift
+git commit -m "feat: display CI status suffix in sidebar PR label"
+```
+
+---
+
+### Task 5: Update Shell Integration (`cmux-zsh-integration.zsh`)
+
+**Files:**
+- Modify: `Resources/shell-integration/cmux-zsh-integration.zsh`
+
+- [ ] **Step 1: Add `statusCheckRollup` to `gh pr view` JSON fields**
+
+Change:
+```bash
+--json number,state,url,reviewDecision \
+--jq '[.number, .state, .url, .reviewDecision] | @tsv' \
+```
+To:
+```bash
+--json number,state,url,reviewDecision,statusCheckRollup \
+--jq '[.number, .state, .url, .reviewDecision, .statusCheckRollup] | @tsv' \
+```
+
+- [ ] **Step 2: Parse the fifth field**
+
+Change:
+```bash
+read -r number state url review_decision <<< "$gh_output"
+```
+To:
+```bash
+read -r number state url review_decision ci_status <<< "$gh_output"
+```
+
+- [ ] **Step 3: Build `--ci` option**
+
+After the `review_opt` case block, add:
+
+```bash
+local ci_opt=""
+case "$ci_status" in
+    SUCCESS) ci_opt="--ci=passing" ;;
+    FAILURE|ERROR) ci_opt="--ci=failing" ;;
+    PENDING|EXPECTED) ci_opt="--ci=pending" ;;
+esac
+```
+
+- [ ] **Step 4: Include `$ci_opt` in `_cmux_send`**
+
+Change:
+```bash
+_cmux_send "report_pr $number $url $status_opt $review_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+```
+To:
+```bash
+_cmux_send "report_pr $number $url $status_opt $review_opt $ci_opt --branch=\"$quoted_branch\" --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
+```
+
+- [ ] **Step 5: Update cache format**
+
+Change:
+```bash
+printf '%s\t%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" "$review_decision" >| "$result_file"
+```
+To:
+```bash
+printf '%s\t%s\t%s\t%s\t%s\t%s\n' "pr" "$number" "$state" "$url" "$review_decision" "$ci_status" >| "$result_file"
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Resources/shell-integration/cmux-zsh-integration.zsh
+git commit -m "feat: emit --ci flag from shell integration PR detection"
+```
+
+---
+
+### Task 6: Update Localization (`Localizable.xcstrings`)
+
+**Files:**
+- Modify: `Resources/Localizable.xcstrings`
+
+- [ ] **Step 1: Remove old combo keys**
+
+Delete `sidebar.pullRequest.statusOpenApproved` and `sidebar.pullRequest.statusOpenChangesRequested` entries.
+
+- [ ] **Step 2: Add individual review part keys**
+
+Add:
+- `sidebar.pullRequest.reviewApproved` — en: `"approved"`, ja: `"承認済み"`
+- `sidebar.pullRequest.reviewChangesRequested` — en: `"changes requested"`, ja: `"変更要求"`
+
+Include all languages present in the existing `sidebar.pullRequest.statusOpen` entry.
+
+- [ ] **Step 3: Add CI status keys**
+
+Add:
+- `sidebar.pullRequest.ciPassing` — en: `"passing"`, ja: `"成功"`
+- `sidebar.pullRequest.ciFailing` — en: `"failing"`, ja: `"失敗"`
+- `sidebar.pullRequest.ciPending` — en: `"pending"`, ja: `"保留中"`
+
+Include all languages present in the existing `sidebar.pullRequest.statusOpen` entry.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Resources/Localizable.xcstrings
+git commit -m "feat: add localization keys for review and CI status parts"
+```
+
+---
+
+### Task 7: Build and Verify
+
+- [ ] **Step 1: Full build**
+
+```bash
+./scripts/reload.sh --tag pr-ci-status
+```
+
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 2: Verify**
+
+Open the tagged app, navigate to a repo with an open PR that has reviews and CI checks. Verify:
+- "open · approved · passing" for approved PR with green CI
+- "open · changes requested · failing" for requested changes with red CI
+- "open · approved" for approved PR with no CI
+- "open · passing" for PR with CI but no reviews
+- "open" for PR with neither
+- Merged/closed PRs show only "merged" / "closed"

--- a/docs/superpowers/specs/2026-04-15-sidebar-pr-review-status-design.md
+++ b/docs/superpowers/specs/2026-04-15-sidebar-pr-review-status-design.md
@@ -1,0 +1,145 @@
+# Sidebar PR Review Status
+
+Display GitHub pull request review status alongside the PR lifecycle state in the sidebar.
+
+## Goal
+
+Open PRs in the sidebar currently show only their lifecycle state (`open`, `merged`, `closed`). This change adds review status so users can see at a glance whether a PR has been approved or has changes requested, without leaving the terminal.
+
+## Display Format
+
+The status text for open PRs gains an optional suffix:
+
+| Review Decision | Sidebar Text |
+|---|---|
+| Approved | `open · approved` |
+| Changes requested | `open · changes requested` |
+| No decision / pending / commented / dismissed / fetch failure | `open` |
+
+Merged and closed PRs never show a review suffix. If the review status fetch fails or returns no actionable decision, the display falls back to `open`.
+
+## Data Model
+
+### New enum (`Workspace.swift`)
+
+```swift
+enum SidebarPullRequestReviewStatus: String {
+    case approved
+    case changesRequested = "changes_requested"
+}
+```
+
+### Updated struct (`Workspace.swift`)
+
+Add one optional field to `SidebarPullRequestState`:
+
+```swift
+struct SidebarPullRequestState {
+    let number: Int
+    let label: String
+    let url: URL
+    let status: SidebarPullRequestStatus
+    let branch: String?
+    let isStale: Bool
+    let reviewStatus: SidebarPullRequestReviewStatus?  // nil = no actionable decision
+}
+```
+
+## Data Sources
+
+### 1. Shell integration (`cmux-zsh-integration.zsh`)
+
+The existing `_cmux_report_pr_for_path` function calls `gh pr view --json number,state,url`.
+
+Changes:
+- Add `reviewDecision` to the `--json` fields and `--jq` template.
+- Map the GitHub GraphQL `reviewDecision` value:
+  - `APPROVED` -> `--review=approved`
+  - `CHANGES_REQUESTED` -> `--review=changes_requested`
+  - Any other value or empty -> omit `--review` flag
+- This runs on directory change, providing immediate data.
+
+### 2. Background poller (`TabManager.swift`)
+
+The existing poller fetches `GET /repos/{owner}/{repo}/pulls?state=all` in bulk. The REST list endpoint does not include review decisions.
+
+Changes:
+- After the bulk fetch resolves which PRs are open and visible in the sidebar, make one additional REST call per open PR: `GET /repos/{owner}/{repo}/pulls/{number}/reviews`.
+- Only fetch reviews for open PRs (not merged/closed).
+- Compute the aggregate review status:
+  1. Parse the reviews array from the response.
+  2. For each reviewer, take their most recent review.
+  3. If any reviewer's latest review is `CHANGES_REQUESTED`, the aggregate is `changesRequested`.
+  4. If all reviewers' latest reviews are `APPROVED` (and at least one exists), the aggregate is `approved`.
+  5. Otherwise, the aggregate is `nil` (no actionable decision).
+- Reuse existing auth header, timeout, error handling, and cache infrastructure.
+- On transient failure, preserve the last known review status (same pattern as existing stale handling).
+- Respect the existing polling intervals: `selectedPollInterval` for focused panels, `backgroundPollInterval` for others. Reviews are fetched as part of the same poll cycle, not on a separate timer.
+
+### 3. Socket command (`TerminalController.swift`)
+
+Update the `report_pr` command to accept an optional `--review` flag:
+
+```
+report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--branch=<name>] [--tab=X] [--panel=Y]
+```
+
+- `--review` is optional. When omitted, `reviewStatus` is `nil`.
+- Invalid `--review` values produce an error response.
+- `--review` is ignored when `--state` is `merged` or `closed`.
+
+## UI Changes (`ContentView.swift`)
+
+### Status label
+
+Update `pullRequestStatusLabel()`:
+
+```swift
+private func pullRequestStatusLabel(_ status: SidebarPullRequestStatus, reviewStatus: SidebarPullRequestReviewStatus?) -> String {
+    switch status {
+    case .open:
+        switch reviewStatus {
+        case .approved:
+            return String(localized: "sidebar.pullRequest.statusOpenApproved", defaultValue: "open \u{00B7} approved")
+        case .changesRequested:
+            return String(localized: "sidebar.pullRequest.statusOpenChangesRequested", defaultValue: "open \u{00B7} changes requested")
+        case nil:
+            return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
+        }
+    case .merged:
+        return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+    case .closed:
+        return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+    }
+}
+```
+
+### No icon or color changes
+
+The existing `PullRequestStatusIcon` and `pullRequestForegroundColor` remain unchanged. The review status is conveyed through the text suffix only.
+
+## Localization
+
+New localization keys in `Resources/Localizable.xcstrings`:
+
+- `sidebar.pullRequest.statusOpenApproved` (en: `"open \u{00B7} approved"`, ja: TBD)
+- `sidebar.pullRequest.statusOpenChangesRequested` (en: `"open \u{00B7} changes requested"`, ja: TBD)
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `Sources/Workspace.swift` | Add `SidebarPullRequestReviewStatus` enum, add `reviewStatus` field to `SidebarPullRequestState` |
+| `Sources/TerminalController.swift` | Parse `--review` option in `reportPullRequest()` |
+| `Sources/TabManager.swift` | Fetch `/pulls/{number}/reviews` for open PRs, compute aggregate, pass to workspace |
+| `Sources/ContentView.swift` | Update `pullRequestStatusLabel()` to include review suffix |
+| `Resources/shell-integration/cmux-zsh-integration.zsh` | Add `reviewDecision` to `gh pr view` JSON fields, emit `--review` flag |
+| `Resources/Localizable.xcstrings` | Add two new localization keys |
+
+## Non-Goals
+
+- CI/check status display (explicitly excluded).
+- Draft PR state display.
+- Review status for merged/closed PRs.
+- Icon or color changes based on review status.
+- Separate polling timer for reviews (piggybacks on existing PR poll cycle).

--- a/docs/superpowers/specs/2026-04-16-sidebar-ci-status-graphql-migration-design.md
+++ b/docs/superpowers/specs/2026-04-16-sidebar-ci-status-graphql-migration-design.md
@@ -1,0 +1,207 @@
+# Sidebar CI Status + GraphQL Enrichment Migration
+
+Add CI status to the sidebar PR display and migrate the per-open-PR enrichment from REST to GraphQL.
+
+## Goal
+
+Open PRs in the sidebar show review status ("open · approved"). This change adds CI/check status and migrates the background poller's enrichment pass from N REST calls to 1 GraphQL call per repo, fetching both review and CI status together.
+
+## Display Format
+
+The status text for open PRs gains an optional CI suffix:
+
+| Review | CI | Sidebar Text |
+|---|---|---|
+| none | none | `open` |
+| approved | none | `open · approved` |
+| changes requested | none | `open · changes requested` |
+| none | passing | `open · passing` |
+| none | failing | `open · failing` |
+| none | pending | `open · pending` |
+| approved | passing | `open · approved · passing` |
+| approved | failing | `open · approved · failing` |
+| changes requested | failing | `open · changes requested · failing` |
+| any | any | `open [· review] [· ci]` |
+
+Merged and closed PRs never show review or CI suffix. Fallback is always `open`.
+
+## Data Model
+
+### New enum (`Workspace.swift`)
+
+```swift
+enum SidebarPullRequestCIStatus: String {
+    case passing
+    case failing
+    case pending
+}
+```
+
+### Updated struct (`Workspace.swift`)
+
+Add `ciStatus` to `SidebarPullRequestState`:
+
+```swift
+struct SidebarPullRequestState {
+    // ... existing fields ...
+    let reviewStatus: SidebarPullRequestReviewStatus?
+    let ciStatus: SidebarPullRequestCIStatus?      // new
+}
+```
+
+## Data Sources
+
+### 1. Shell integration (`cmux-zsh-integration.zsh`)
+
+The existing `gh pr view --json` call already fetches `reviewDecision`. Add `statusCheckRollup`:
+
+```bash
+gh pr view "$branch" --json number,state,url,reviewDecision,statusCheckRollup \
+    --jq '[.number, .state, .url, .reviewDecision, .statusCheckRollup] | @tsv'
+```
+
+Map `statusCheckRollup`:
+- `SUCCESS` → `--ci=passing`
+- `FAILURE` / `ERROR` → `--ci=failing`
+- `PENDING` / `EXPECTED` → `--ci=pending`
+- Empty/null → omit `--ci` flag
+
+This is zero additional cost — same single `gh pr view` call.
+
+### 2. Background poller — GraphQL migration (`TabManager.swift`)
+
+**Replace** the current REST-based `enrichResultsWithReviewStatus` (which makes one `GET /pulls/{number}/reviews` per open PR) with a single GraphQL query per repo.
+
+#### GraphQL query structure
+
+For each repo that has open PRs visible in the sidebar, issue one `POST https://api.github.com/graphql` call:
+
+```graphql
+query {
+  repository(owner: "owner", name: "repo") {
+    pr_42: pullRequest(number: 42) {
+      reviewDecision
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+            }
+          }
+        }
+      }
+    }
+    pr_55: pullRequest(number: 55) {
+      reviewDecision
+      commits(last: 1) {
+        nodes {
+          commit {
+            statusCheckRollup {
+              state
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Each PR is aliased as `pr_{number}` to batch them in one query.
+
+#### GraphQL response mapping
+
+- `reviewDecision`: `APPROVED` → `.approved`, `CHANGES_REQUESTED` → `.changesRequested`, null/other → `nil`
+- `statusCheckRollup.state`: `SUCCESS` → `.passing`, `FAILURE`/`ERROR` → `.failing`, `PENDING`/`EXPECTED` → `.pending`, null → `nil`
+
+#### Migration scope
+
+| Component | Before | After |
+|---|---|---|
+| `enrichResultsWithReviewStatus` | N REST calls (1 per open PR) | 1 GraphQL call per repo |
+| `fetchPullRequestReviewStatus` | REST `/pulls/{n}/reviews` | Removed |
+| `aggregateReviewStatus` | Manual per-reviewer aggregation | Removed (GraphQL gives `reviewDecision` directly) |
+| `WorkspacePullRequestReviewRESTItem` | REST review struct | Removed |
+| New: GraphQL request function | — | `POST /graphql` with query + JSON response parsing |
+| New: GraphQL response structs | — | Decodable structs for the response shape |
+
+#### Auth and infrastructure
+
+- Same auth header (`Bearer` token from `GH_TOKEN`/`GITHUB_TOKEN`/`gh auth token`)
+- Same timeout and URLSession configuration
+- Same ephemeral session pattern
+- GraphQL endpoint: `https://api.github.com/graphql` (POST, not GET)
+- On failure: preserve last known review/CI status (existing stale pattern)
+
+### 3. Socket command (`TerminalController.swift`)
+
+Update `report_pr` to accept `--ci=passing|failing|pending`:
+
+```
+report_pr <number> <url> [--label=PR] [--state=open|merged|closed] [--review=approved|changes_requested] [--ci=passing|failing|pending] [--branch=<name>] [--tab=X] [--panel=Y]
+```
+
+- `--ci` is optional. When omitted, `ciStatus` is `nil`.
+- Invalid values produce an error.
+- Ignored for merged/closed PRs.
+
+## UI Changes (`ContentView.swift`)
+
+### Status label
+
+Build the label programmatically from parts rather than one localization key per combination:
+
+```swift
+private func pullRequestStatusLabel(
+    _ status: SidebarPullRequestStatus,
+    reviewStatus: SidebarPullRequestReviewStatus?,
+    ciStatus: SidebarPullRequestCIStatus?
+) -> String {
+    switch status {
+    case .open:
+        var parts = [String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")]
+        if let reviewStatus {
+            parts.append(pullRequestReviewStatusLabel(reviewStatus))
+        }
+        if let ciStatus {
+            parts.append(pullRequestCIStatusLabel(ciStatus))
+        }
+        return parts.joined(separator: " \u{00B7} ")
+    case .merged:
+        return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+    case .closed:
+        return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+    }
+}
+```
+
+This avoids combinatorial localization keys. Individual review and CI labels are localized separately.
+
+## Localization
+
+Replace the two combo keys (`statusOpenApproved`, `statusOpenChangesRequested`) with individual part keys:
+
+- `sidebar.pullRequest.reviewApproved` (en: `"approved"`)
+- `sidebar.pullRequest.reviewChangesRequested` (en: `"changes requested"`)
+- `sidebar.pullRequest.ciPassing` (en: `"passing"`)
+- `sidebar.pullRequest.ciFailing` (en: `"failing"`)
+- `sidebar.pullRequest.ciPending` (en: `"pending"`)
+
+Remove old combo keys: `statusOpenApproved`, `statusOpenChangesRequested`.
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `Sources/Workspace.swift` | Add `SidebarPullRequestCIStatus` enum, add `ciStatus` field |
+| `Sources/TerminalController.swift` | Parse `--ci` option, thread through |
+| `Sources/TabManager.swift` | Replace REST enrichment with GraphQL; add query builder, response parsing; remove REST review structs/functions |
+| `Sources/ContentView.swift` | Update `pullRequestStatusLabel` to build from parts with CI suffix |
+| `Resources/shell-integration/cmux-zsh-integration.zsh` | Add `statusCheckRollup` to `gh pr view`, emit `--ci` flag |
+| `Resources/Localizable.xcstrings` | Add 5 new part keys, remove 2 old combo keys |
+
+## Non-Goals
+
+- Showing individual check run names or details
+- CI status for merged/closed PRs
+- Changing the bulk `/pulls` REST fetch to GraphQL (only the enrichment pass migrates)


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show review and CI status for open PRs in the sidebar and fetch both in one GraphQL call per repo for faster, lighter polling.

- **New Features**
  - Sidebar now shows “open · approved · passing” (or “changes requested”, “failing”, “pending”) for open PRs.
  - GraphQL enrichment batches `reviewDecision` and `statusCheckRollup` per repo; fewer requests than REST per-PR calls.
  - `report_pr` accepts `--review=approved|changes_requested` and `--ci=passing|failing|pending`.
  - Zsh integration adds these flags via `gh pr view --json number,state,url,reviewDecision,statusCheckRollup`.
  - New localized strings for review and CI parts: `sidebar.pullRequest.reviewApproved`, `reviewChangesRequested`, `ciPassing`, `ciFailing`, `ciPending`.

- **Migration**
  - No breaking changes; fields are optional and only shown for open PRs.
  - Ensure GitHub auth is available for GraphQL (`GH_TOKEN`/`GITHUB_TOKEN` or `gh auth login`).
  - Reload shell to pick up updated `cmux` zsh integration so `--review`/`--ci` flags are sent.

<sup>Written for commit 9b40321d0ea138d1e99761f91eb421086f0edd18. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Sidebar now displays pull request review status (approved/changes requested) and CI status (passing/failing/pending) alongside PR state for open pull requests.
  * Added multi-language support for new status indicators.

* **Documentation**
  * Added implementation and design specifications for sidebar PR review and CI status display features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->