### PR TITLE
fix(i18n): unify Korean workspace terminology with correct particles

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -70359,7 +70359,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "tab colors palette accent badge selected highlight 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 • %@"
+                    "value": "tab colors palette accent badge selected highlight 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 • %@"
                 }
             },
             "nb": {
@@ -71192,7 +71192,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 새 작업 공간 • %@ 위치 끝 맨 위"
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 새 워크스페이스 • %@ 위치 끝 맨 위"
                 }
             },
             "nb": {
@@ -71430,7 +71430,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 편집기 파일 코드 열기 경로 닫기 작업 공간 • %@ 탭을 닫으시겠습니까? 공간을 열림"
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 편집기 파일 코드 열기 경로 닫기 워크스페이스 • %@ 탭을 닫으시겠습니까? 공간을 열림"
                 }
             },
             "nb": {
@@ -72025,7 +72025,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 작업 공간 • %@ 이동 않은 1개 맨 위"
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 워크스페이스 • %@ 이동 않은 1개 맨 위"
                 }
             },
             "nb": {
@@ -72144,7 +72144,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 아이콘"
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 아이콘"
                 }
             },
             "nb": {
@@ -72620,7 +72620,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "notifications.paneFlash flash blink highlight pane notification pulse 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 패인 플래시"
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 패인 플래시"
                 }
             },
             "nb": {
@@ -73334,7 +73334,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 작업 공간 이름 변경 변경… • %@ 명령어 팔레트… 시 기존 선택 워크스페이스 1…9"
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 워크스페이스 이름 변경 변경… • %@ 명령어 팔레트… 시 기존 선택 워크스페이스 1…9"
                 }
             },
             "nb": {
@@ -73453,7 +73453,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 검색 제안 자동완성 제공자 엔진 브라우저: %@ 마크다운 • 명령어 팔레트…"
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 워크스페이스 색상 팔레트 배지 선택됨 강조 표시기 활성 점 검색 제안 자동완성 제공자 엔진 브라우저: %@ 마크다운 • 명령어 팔레트…"
                 }
             },
             "nb": {
@@ -76666,7 +76666,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "browser.enabled enable disable webview embedded browser tabs links 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음 브라우저: %@ •"
+                    "value": "browser.enabled enable disable webview embedded browser tabs links 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 워크스페이스 색상 팔레트 배지 선택됨 강조 표시기 활성 점 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음 브라우저: %@ •"
                 }
             },
             "nb": {
@@ -77856,7 +77856,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 브라우저: %@ 가져오기… •"
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 워크스페이스 색상 팔레트 배지 선택됨 강조 표시기 활성 점 브라우저: %@ 가져오기… •"
                 }
             },
             "nb": {
@@ -78808,7 +78808,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 작업 공간 • %@"
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 워크스페이스 • %@"
                 }
             },
             "nb": {
@@ -78927,7 +78927,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 작업 공간 • %@"
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 워크스페이스 • %@"
                 }
             },
             "nb": {
@@ -79046,7 +79046,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 않은 1개"
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 않은 1개"
                 }
             },
             "nb": {
@@ -79165,7 +79165,7 @@
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 재설정 초기화 기본값 복원 지우기 외관 테마 색 구성표 라이트 다크 시스템 모드 사용자 지정 작업 공간 정의: %@ •"
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in 워크스페이스 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 재설정 초기화 기본값 복원 지우기 외관 테마 색 구성표 라이트 다크 시스템 모드 사용자 지정 워크스페이스 정의: %@ •"
                 }
             },
             "nb": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -4564,7 +4564,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "%1$@, 작업 공간 %2$lld / %3$lld"
+            "value": "%1$@, 워크스페이스 %2$lld / %3$lld"
           }
         },
         "de": {
@@ -5040,7 +5040,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용자 지정 작업 공간 색상"
+            "value": "사용자 지정 워크스페이스 색상"
           }
         },
         "de": {
@@ -5754,7 +5754,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이 작업 공간의 사용자 지정 이름을 입력하세요."
+            "value": "이 워크스페이스의 사용자 지정 이름을 입력하세요."
           }
         },
         "de": {
@@ -5873,7 +5873,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름"
+            "value": "워크스페이스 이름"
           }
         },
         "de": {
@@ -6111,7 +6111,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경"
+            "value": "워크스페이스 이름 변경"
           }
         },
         "de": {
@@ -17464,7 +17464,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 지우기"
+            "value": "워크스페이스 이름 지우기"
           }
         },
         "de": {
@@ -18128,7 +18128,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -18247,7 +18247,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -21586,7 +21586,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -21705,7 +21705,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간"
+            "value": "새 워크스페이스"
           }
         },
         "de": {
@@ -22062,7 +22062,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 탐색"
+            "value": "워크스페이스 탐색"
           }
         },
         "de": {
@@ -22181,7 +22181,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다음 작업 공간"
+            "value": "다음 워크스페이스"
           }
         },
         "de": {
@@ -22300,7 +22300,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -22822,7 +22822,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 PR 링크 모두 열기"
+            "value": "워크스페이스 PR 링크 모두 열기"
           }
         },
         "de": {
@@ -23060,7 +23060,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정"
+            "value": "워크스페이스 고정"
           }
         },
         "de": {
@@ -23417,7 +23417,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 탐색"
+            "value": "워크스페이스 탐색"
           }
         },
         "de": {
@@ -23536,7 +23536,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이전 작업 공간"
+            "value": "이전 워크스페이스"
           }
         },
         "de": {
@@ -23774,7 +23774,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경…"
+            "value": "워크스페이스 이름 변경…"
           }
         },
         "de": {
@@ -27497,7 +27497,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정 해제"
+            "value": "워크스페이스 고정 해제"
           }
         },
         "de": {
@@ -27941,7 +27941,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -28774,7 +28774,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Enter를 눌러 작업 공간 이름을 적용하거나, Escape를 눌러 취소하세요."
+            "value": "Enter를 눌러 워크스페이스 이름을 적용하거나, Escape를 눌러 취소하세요."
           }
         },
         "de": {
@@ -28893,7 +28893,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용자 지정 작업 공간 이름을 선택하세요."
+            "value": "사용자 지정 워크스페이스 이름을 선택하세요."
           }
         },
         "de": {
@@ -29012,7 +29012,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름을 입력하세요. Enter로 이름 변경, Escape로 취소."
+            "value": "워크스페이스 이름을 입력하세요. Enter로 이름 변경, Escape로 취소."
           }
         },
         "de": {
@@ -29131,7 +29131,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름"
+            "value": "워크스페이스 이름"
           }
         },
         "de": {
@@ -29250,7 +29250,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경"
+            "value": "워크스페이스 이름 변경"
           }
         },
         "de": {
@@ -29607,7 +29607,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "검색과 일치하는 작업 공간이 없습니다."
+            "value": "검색과 일치하는 워크스페이스가 없습니다."
           }
         },
         "de": {
@@ -29755,7 +29755,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 검색"
+            "value": "워크스페이스 검색"
           }
         },
         "de": {
@@ -30379,7 +30379,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -30498,7 +30498,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 • %@"
+            "value": "워크스페이스 • %@"
           }
         },
         "de": {
@@ -30736,7 +30736,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -32834,7 +32834,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다른 작업 공간 닫기"
+            "value": "다른 워크스페이스 닫기"
           }
         },
         "de": {
@@ -32953,7 +32953,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -33072,7 +33072,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -33191,7 +33191,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "위쪽 작업 공간 닫기"
+            "value": "위쪽 워크스페이스 닫기"
           }
         },
         "de": {
@@ -33310,7 +33310,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "아래쪽 작업 공간 닫기"
+            "value": "아래쪽 워크스페이스 닫기"
           }
         },
         "de": {
@@ -33429,7 +33429,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 읽음으로 표시"
+            "value": "워크스페이스를 읽음으로 표시"
           }
         },
         "de": {
@@ -33548,7 +33548,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 읽지 않음으로 표시"
+            "value": "워크스페이스를 읽지 않음으로 표시"
           }
         },
         "de": {
@@ -33667,7 +33667,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 읽음으로 표시"
+            "value": "워크스페이스를 읽음으로 표시"
           }
         },
         "de": {
@@ -33786,7 +33786,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 읽지 않음으로 표시"
+            "value": "워크스페이스를 읽지 않음으로 표시"
           }
         },
         "de": {
@@ -34453,7 +34453,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 윈도우로 이동"
+            "value": "워크스페이스를 윈도우로 이동"
           }
         },
         "de": {
@@ -34572,7 +34572,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 윈도우로 이동"
+            "value": "워크스페이스를 윈도우로 이동"
           }
         },
         "de": {
@@ -34810,7 +34810,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정"
+            "value": "워크스페이스 고정"
           }
         },
         "de": {
@@ -34929,7 +34929,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정"
+            "value": "워크스페이스 고정"
           }
         },
         "de": {
@@ -35048,7 +35048,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용자 지정 작업 공간 이름 제거"
+            "value": "사용자 지정 워크스페이스 이름 제거"
           }
         },
         "de": {
@@ -35167,7 +35167,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경…"
+            "value": "워크스페이스 이름 변경…"
           }
         },
         "de": {
@@ -35286,7 +35286,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정 해제"
+            "value": "워크스페이스 고정 해제"
           }
         },
         "de": {
@@ -35405,7 +35405,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 고정 해제"
+            "value": "워크스페이스 고정 해제"
           }
         },
         "de": {
@@ -35524,7 +35524,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 색상"
+            "value": "워크스페이스 색상"
           }
         },
         "de": {
@@ -35762,7 +35762,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "마지막 탭이 닫히면 해당 작업 공간도 닫힙니다."
+            "value": "마지막 탭이 닫히면 해당 워크스페이스도 닫힙니다."
           }
         },
         "de": {
@@ -36856,7 +36856,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간과 모든 패널을 닫습니다."
+            "value": "워크스페이스와 모든 패널을 닫습니다."
           }
         },
         "de": {
@@ -36975,7 +36975,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간을 닫으시겠습니까?"
+            "value": "워크스페이스를 닫으시겠습니까?"
           }
         },
         "de": {
@@ -38165,7 +38165,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "현재 윈도우의 새 작업 공간"
+            "value": "현재 윈도우의 새 워크스페이스"
           }
         },
         "de": {
@@ -38284,7 +38284,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "선택한 작업 공간을 새 윈도우로"
+            "value": "선택한 워크스페이스를 새 윈도우로"
           }
         },
         "de": {
@@ -38522,7 +38522,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "모든 윈도우와 작업 공간을 닫습니다."
+            "value": "모든 윈도우와 워크스페이스를 닫습니다."
           }
         },
         "de": {
@@ -39236,7 +39236,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이 작업 공간의 사용자 지정 이름을 입력하세요."
+            "value": "이 워크스페이스의 사용자 지정 이름을 입력하세요."
           }
         },
         "de": {
@@ -39355,7 +39355,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름"
+            "value": "워크스페이스 이름"
           }
         },
         "de": {
@@ -39474,7 +39474,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경"
+            "value": "워크스페이스 이름 변경"
           }
         },
         "de": {
@@ -40925,7 +40925,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -41163,7 +41163,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간으로 이동…"
+            "value": "워크스페이스로 이동…"
           }
         },
         "de": {
@@ -41401,7 +41401,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간"
+            "value": "새 워크스페이스"
           }
         },
         "de": {
@@ -46305,7 +46305,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다음 작업 공간"
+            "value": "다음 워크스페이스"
           }
         },
         "de": {
@@ -46543,7 +46543,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이전 작업 공간"
+            "value": "이전 워크스페이스"
           }
         },
         "de": {
@@ -46781,7 +46781,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경…"
+            "value": "워크스페이스 이름 변경…"
           }
         },
         "de": {
@@ -47887,7 +47887,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 %lld"
+            "value": "워크스페이스 %lld"
           }
         },
         "de": {
@@ -51323,7 +51323,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간 위치"
+            "value": "새 워크스페이스 위치"
           }
         },
         "de": {
@@ -53504,7 +53504,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "알림을 받은 작업 공간을 맨 위로 이동합니다. 단축키 위치를 고정하려면 비활성화하세요."
+            "value": "알림을 받은 워크스페이스를 맨 위로 이동합니다. 단축키 위치를 고정하려면 비활성화하세요."
           }
         },
         "de": {
@@ -54572,7 +54572,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "활성 작업 공간에서 감지된 수신 대기 포트를 표시합니다."
+            "value": "활성 워크스페이스에서 감지된 수신 대기 포트를 표시합니다."
           }
         },
         "de": {
@@ -58770,7 +58770,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "각 작업 공간에 전용 포트 범위가 있는 CMUX_PORT 및 CMUX_PORT_END 환경 변수가 할당됩니다. 새 터미널은 이 값을 상속합니다."
+            "value": "각 워크스페이스에 전용 포트 범위가 있는 CMUX_PORT 및 CMUX_PORT_END 환경 변수가 할당됩니다. 새 터미널은 이 값을 상속합니다."
           }
         },
         "de": {
@@ -59246,7 +59246,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간당 포트 수."
+            "value": "워크스페이스당 포트 수."
           }
         },
         "de": {
@@ -67980,7 +67980,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 색상"
+            "value": "워크스페이스 색상"
           }
         },
         "de": {
@@ -79952,7 +79952,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 색상 표시기"
+            "value": "워크스페이스 색상 표시기"
           }
         },
         "de": {
@@ -80071,7 +80071,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사용자 지정 색상: 아직 없습니다. 작업 공간 컨텍스트 메뉴에서 \"사용자 지정 색상 선택...\"을 사용하세요."
+            "value": "사용자 지정 색상: 아직 없습니다. 워크스페이스 컨텍스트 메뉴에서 \"사용자 지정 색상 선택...\"을 사용하세요."
           }
         },
         "de": {
@@ -80190,7 +80190,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사이드바 > 작업 공간 색상에서 사용하는 작업 공간 색상 팔레트를 사용자 지정합니다. \"사용자 지정 색상 선택...\" 항목은 아래에 저장됩니다."
+            "value": "사이드바 > 워크스페이스 색상에서 사용하는 워크스페이스 색상 팔레트를 사용자 지정합니다. \"사용자 지정 색상 선택...\" 항목은 아래에 저장됩니다."
           }
         },
         "de": {
@@ -80927,7 +80927,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -81998,7 +81998,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간"
+            "value": "새 워크스페이스"
           }
         },
         "de": {
@@ -82236,7 +82236,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "다음 작업 공간"
+            "value": "다음 워크스페이스"
           }
         },
         "de": {
@@ -83149,7 +83149,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이전 작업 공간"
+            "value": "이전 워크스페이스"
           }
         },
         "de": {
@@ -83387,7 +83387,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 이름 변경"
+            "value": "워크스페이스 이름 변경"
           }
         },
         "de": {
@@ -85074,7 +85074,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간 닫기"
+            "value": "워크스페이스 닫기"
           }
         },
         "de": {
@@ -86708,7 +86708,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이 작업 공간에 포커스하려면 활성화하세요. 드래그하여 순서를 변경하거나 위로 이동 및 아래로 이동 동작을 사용하세요."
+            "value": "이 워크스페이스에 포커스하려면 활성화하세요. 드래그하여 순서를 변경하거나 위로 이동 및 아래로 이동 동작을 사용하세요."
           }
         },
         "de": {
@@ -90475,7 +90475,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간"
+            "value": "새 워크스페이스"
           }
         },
         "de": {
@@ -90594,7 +90594,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 작업 공간"
+            "value": "새 워크스페이스"
           }
         },
         "de": {
@@ -98329,7 +98329,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "작업 공간"
+            "value": "워크스페이스"
           }
         },
         "de": {
@@ -98596,7 +98596,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "활성 작업 공간 바로 다음에 새 작업 공간을 삽입합니다."
+            "value": "활성 워크스페이스 바로 다음에 새 워크스페이스를 삽입합니다."
           }
         },
         "de": {
@@ -98834,7 +98834,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "목록 하단에 새 작업 공간을 추가합니다."
+            "value": "목록 하단에 새 워크스페이스를 추가합니다."
           }
         },
         "de": {
@@ -99072,7 +99072,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "목록 맨 위에 새 작업 공간을 삽입합니다."
+            "value": "목록 맨 위에 새 워크스페이스를 삽입합니다."
           }
         },
         "de": {
@@ -102442,7 +102442,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "현재 창에 새 작업 공간"
+            "value": "현재 창에 새 워크스페이스"
           }
         },
         "de": {
@@ -102555,7 +102555,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새 창에서 선택한 작업 공간"
+            "value": "새 창에서 선택한 워크스페이스"
           }
         },
         "de": {


### PR DESCRIPTION
## Summary

Standardize "작업 공간" → "워크스페이스" (102 strings) with proper Korean particle (조사) adjustments.

### Why "워크스페이스" not "작업 공간" / "작업공간"?

Researched 34 developer/collaboration tools using primary sources (official Korean help pages, official blogs, product UI). All five lines of evidence point the same way.

#### 1. Internal consistency (decisive)

- After this PR, ko strings using "워크스페이스" = **144**
- ko strings using "작업공간" / "작업 공간" = **0**
- `README.ko.md` already uses "워크스페이스" consistently (새 워크스페이스, 워크스페이스 닫기, 워크스페이스 이름 변경, 워크스페이스 1–8로 이동)
- Reverting would mean re-touching 246 strings against the established direction

#### 2. Korean developer/collaboration-tool standard

Surveyed 34 tools, primary sources only. Of the 21 tools that ship Korean UI:

| Term | Count | Tools |
|------|-------|-------|
| **"워크스페이스"** | 7 | Slack, Notion, Monday.com, Miro, GitLab (본문), 카카오워크, Google Workspace (구어) |
| **"작업 영역"** | 5 | VS Code, Microsoft Teams, Jira/Confluence, Azure DevOps, Microsoft Fabric |
| **"작업 공간"** | 2 | Asana, Figma (일부) |
| English kept | 3 | AWS WorkSpaces, Google Workspace (brand), GitLab (page title) |
| Different concept | 4 | 잔디 ("팀"), 네이버웍스 ("스페이스"), 플로우 ("조직/팀"), Discord ("서버") |

Sources: [Slack 워크스페이스 생성](https://slack.com/help/articles/206845317-Create-a-Slack-workspace), [Notion 워크스페이스 소개](https://www.notion.com/help/intro-to-workspaces), [Miro 비주얼 워크스페이스](https://miro.com/ko/login/), [Monday.com 한국어](https://monday.com/lang/ko/), [Kakao Work 워크스페이스 개설](https://kakaowork.gitbook.io/kakao-work/basic/admin/get-started), [GitLab 한글 작업 공간 (본문은 워크스페이스)](https://gitlab-docs.infograb.net/ee/user/workspace/), [VS Code Korean Pack](https://github.com/microsoft/vscode-loc/blob/main/i18n/vscode-language-pack-ko/translations/main.i18n.json), [MS Teams 작업 영역](https://www.microsoft.com/ko-kr/microsoft-365/blog/2016/11/02/introducing-microsoft-teams-the-chat-based-workspace-in-office-365/), [Confluence 작업 영역](https://www.atlassian.com/ko/software/confluence), [Azure DevOps 작업 영역](https://learn.microsoft.com/ko-kr/azure/devops/repos/tfvc/create-work-workspaces), [Asana 작업 공간](https://help.asana.com/s/article/navigating-asana?language=ko), [Figma 작업공간](https://help.figma.com/hc/ko/articles/360039485514).

**Three observations from the data:**

- **"워크스페이스" is the most common single choice (7).** Even within Microsoft's "작업 영역" bloc (5), the term is locked to MS-internal data/code-bundle semantics, not the team/context-container semantics cmux uses.
- **No two tools share both meaning AND wording with cmux.** Among the seven "워크스페이스" adopters, Slack/Notion/카카오워크/Monday.com/Miro all treat workspace as an isolated context container — exactly cmux's model (a tab/pane container scoped to one project or task).
- **The "작업 영역" bloc is product-family-driven, not language-driven.** Every "작업 영역" hit is a Microsoft product. That is a corporate translation glossary decision, not a Korean-language consensus.

#### 3. No Apple precedent

Apple's Korean localization does **not** expose "Workspace" as a UI term. Spaces stays as "Spaces", Stage Manager uses "윈도우 그룹". Unlike "윈도우" (which has an explicit Apple Korean precedent — see below), "Workspace" cannot piggyback on Apple's choice. Reliance on developer-tool convention is the right fallback.

- Source: [macOS 사용 설명서 - Spaces](https://support.apple.com/ko-kr/guide/mac-help/mh14112/mac)

#### 4. National Institute of Korean Language (국립국어원)

"워크스페이스" is **not registered** in the standard Korean dictionary, and no official 순화어 (purified-Korean replacement) is recommended. There is no normative pressure to convert it to "작업공간".

- Source: [표준국어대사전](https://stdict.korean.go.kr/search/searchView.do?searchKeyword=워크스페이스)

#### 5. Semantic precision

cmux's workspace = a tab/pane container scoped to one project or task. Closest semantic neighbors in the survey:
- ✅ Slack workspace (team context container)
- ✅ Notion workspace (account-scoped content container)
- ✅ Miro workspace (visual canvas environment)
- ✅ 카카오워크 워크스페이스 (organization workspace)
- ❌ VS Code "작업 영역" (multi-folder file bundle — different mental model)
- ❌ Microsoft Fabric / Azure "작업 영역" (data/repository workspace)

Importing VS Code's "작업 영역" terminology into cmux would attach the wrong mental model to a different concept.

### Why keep "윈도우" unchanged?

Apple's Korean localization for "Window" is explicit and consistent:
- **Apple Support (ko-kr/102650)**: "윈도우 닫기", "새로운 Finder 윈도우"
- **macOS Window menu**: labeled "윈도우" in Korean
- **Japanese parallel**: Apple uses ウィンドウ (loanword), same CJK loanword pattern

So "윈도우" follows an established Apple precedent; "워크스페이스" follows the developer/collaboration-tool convention. Both are loanword choices, both are intentional.

### Counter-argument considered

Microsoft's "작업 영역" bloc is large (VS Code, Teams, Azure DevOps, Microsoft Fabric, Confluence/Jira). For a developer audience, VS Code in particular is influential. We rejected this for two reasons:

1. The "작업 영역" semantics in MS products refers to **file/data bundles**, not **session/tab containers**. cmux's concept maps cleanly onto Slack/Notion/Miro semantics, not VS Code semantics.
2. Korean developer communities (velog, tistory, clien) overwhelmingly use "워크스페이스" when discussing Slack/Notion/Eclipse-style workspaces. Outside the MS docs corpus, "작업 영역" is rare.

### Korean particle rules applied

"작업 공간" ends in consonant ㄴ, "워크스페이스" ends in vowel — particles must change:

| Particle | Before (consonant) | After (vowel) |
|----------|-------------------|---------------|
| Object | 작업 공간**을** | 워크스페이스**를** |
| Subject | 작업 공간**이** | 워크스페이스**가** |
| Conjunction | 작업 공간**과** | 워크스페이스**와** |
| Direction | 작업 공간**으로** | 워크스페이스**로** |
| Topic | 작업 공간**은** | 워크스페이스**는** |

### Changes

- **`Resources/Localizable.xcstrings`**: 102 Korean string replacements (102 ins / 102 del)
  - 88 user-facing UI strings (labels, dialogs, menus, prompts)
  - 14 `settings.search.alias.*` keyword bundles — keeps Settings search consistent so "워크스페이스" matches all relevant entries
- No code changes, no other languages affected
- Zero particle errors verified programmatically

### Quality checks

- [x] JSON validity verified
- [x] No remaining "작업 공간" / "작업공간" in Korean values
- [x] Zero bad particle combinations (을/이/과/으로/은 after 워크스페이스)
- [x] Format specifiers preserved
- [x] Only `ko` values modified

## Test plan

- [ ] Verify `Resources/Localizable.xcstrings` loads in Xcode
- [ ] Switch to Korean and verify "워크스페이스" used consistently in settings, dialogs, menus
- [ ] Open Settings search, type "워크스페이스" and confirm all relevant rows match

## Review Trigger

\`\`\`text
@coderabbitai review
@cubic-dev-ai review
\`\`\`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Standardized Korean localization across the app by replacing the term "작업 공간" with "워크스페이스" in UI labels, commands, help text, prompts, formatted strings, and Settings search keyword aliases. Adjusted surrounding grammar and casing for natural Korean phrasing, improving consistency and clarity across status messages, labels, instructions, command descriptions, and search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->