### PR TITLE
Allow repo cache for shellPrompt PR refreshes

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1617,6 +1617,7 @@ class TabManager: ObservableObject {
             "periodicPoll",
             "selectedPeriodicPoll",
             "timer",
+            "shellPrompt",
         ]
         return periodicPrefixes.contains { prefix in
             reason == prefix || reason.hasPrefix("\(prefix).")

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -411,10 +411,11 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "selectedPeriodicPoll.followUp"))
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer"))
         XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "timer.followUp"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt"))
+        XCTAssertTrue(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt.followUp"))
 
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange.followUp"))
-        XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "commandHint:merge"))
     }
 


### PR DESCRIPTION
Treat shellPrompt-triggered PR status refreshes as periodic so they can reuse the 15s repo cache instead of bypassing it. Prompt-idle transitions fire frequently and don't carry new state beyond what the action-specific bypass reasons (branchChange, commandHint:*) already cover, so caching them reduces GitHub API pressure without adding staleness risk.

## Summary

- What changed?
Added "shellPrompt" to the list of refresh reasons that are allowed to
  use the repo cache in TabManager.workspacePullRequestRefreshAllowsRepoCache
  (Sources/TabManager.swift:1620), and flipped the corresponding unit test assertions in
  cmuxTests/TabManagerUnitTests.swift so shellPrompt / shellPrompt.followUp now assert
  true.

- Why?
Shell-prompt-triggered PR refreshes fire frequently (every time a prompt
  redraws) and were bypassing the repo cache, which consumed GitHub API budget
  unnecessarily. Treating them like the other periodic/background reasons (periodicPoll,
  selectedPeriodicPoll, timer) lets them reuse cached repo data, cutting GitHub API usage
   without affecting user-initiated refreshes like branchChange or commandHint:* which
  still bypass the cache.

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat `shellPrompt`-triggered PR refreshes as periodic so they reuse the 15s repo cache, reducing GitHub API calls without adding staleness. Updated `TabManager.workspacePullRequestRefreshAllowsRepoCache` and tests to allow `shellPrompt` and `shellPrompt.followUp`; `branchChange` and `commandHint:*` still bypass the cache.

<sup>Written for commit 1e5500afd08399eba97ba486e9137892948f156d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized repository cache handling for workspace pull request updates when refreshing from terminal shell prompts. This change improves performance and responsiveness when checking pull request status through command-line initiated triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->