### PR TITLE
Add GitHub rate-limit cooldown for workspace PR probes

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -754,18 +754,19 @@ class TabManager: ObservableObject {
         let repoSlugs: [String]
     }
 
-    private struct WorkspacePullRequestResolvedItem: Sendable {
+    struct WorkspacePullRequestResolvedItem: Sendable, Equatable {
         let number: Int
         let urlString: String
         let statusRawValue: String
         let branch: String
     }
 
-    private struct WorkspacePullRequestRefreshResult: Sendable {
-        enum Resolution: Sendable {
+    struct WorkspacePullRequestRefreshResult: Sendable {
+        enum Resolution: Sendable, Equatable {
             case unsupportedRepository
             case notFound
             case resolved(WorkspacePullRequestResolvedItem)
+            case rateLimited(retryAt: Date)
             case transientFailure
         }
 
@@ -775,7 +776,7 @@ class TabManager: ObservableObject {
         let usedCachedRepoData: Bool
     }
 
-    private struct WorkspacePullRequestRepoCacheEntry: Sendable {
+    struct WorkspacePullRequestRepoCacheEntry: Sendable, Equatable {
         let fetchedAt: Date
         let pullRequestsByBranch: [String: GitHubPullRequestProbeItem]
         let knownAbsentBranches: Set<String>
@@ -791,29 +792,41 @@ class TabManager: ObservableObject {
         }
     }
 
-    private enum WorkspacePullRequestRepoFetchResult: Sendable {
+    enum WorkspacePullRequestRepoFetchResult: Sendable, Equatable {
         case success(
             WorkspacePullRequestRepoCacheEntry,
             usedCache: Bool,
-            transientBranches: Set<String>
+            transientBranches: Set<String>,
+            rateLimitedBranches: [String: Date]
         )
+        case rateLimited(until: Date)
         case transientFailure
     }
 
-    private enum WorkspacePullRequestBranchFetchResult: Sendable {
+    private enum WorkspacePullRequestBranchFetchResult: Sendable, Equatable {
         case found(GitHubPullRequestProbeItem)
         case notFound
+        case rateLimited(until: Date)
         case transientFailure
     }
 
     private struct WorkspacePullRequestBranchLookupOutcome: Sendable {
         let cacheEntry: WorkspacePullRequestRepoCacheEntry
         let transientBranches: Set<String>
+        let rateLimitedBranches: [String: Date]
     }
 
     private struct WorkspacePullRequestHTTPResponse: Sendable {
         let statusCode: Int
         let data: Data
+        let retryAfter: String?
+        let rateLimitRemaining: String?
+        let rateLimitReset: String?
+    }
+
+    enum WorkspacePullRequestHTTPFailureClassification: Equatable {
+        case rateLimited(retryAt: Date)
+        case transientFailure
     }
 
     private struct WorkspacePullRequestRESTItem: Decodable, Sendable {
@@ -883,6 +896,9 @@ class TabManager: ObservableObject {
     private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
     private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
+    private nonisolated static let workspacePullRequestFailureBackoffMaxInterval: TimeInterval = 5 * 60
+    private nonisolated static let workspacePullRequestRateLimitFallbackCooldown: TimeInterval = 5 * 60
+    private nonisolated static let workspacePullRequestStaleThreshold = 3
     @Published var selectedTabId: UUID? {
         willSet {
 #if DEBUG
@@ -977,6 +993,7 @@ class TabManager: ObservableObject {
     private var workspacePullRequestLastTerminalStateRefreshAtByKey: [WorkspaceGitProbeKey: Date] = [:]
     private var workspacePullRequestTransientFailureCountByKey: [WorkspaceGitProbeKey: Int] = [:]
     private var workspacePullRequestRepoCacheBySlug: [String: WorkspacePullRequestRepoCacheEntry] = [:]
+    private var workspacePullRequestRateLimitedUntilByRepoSlug: [String: Date] = [:]
     private var workspacePullRequestPollTimer: DispatchSourceTimer?
     private var workspacePullRequestRefreshTask: Task<Void, Never>?
     private var workspacePullRequestFollowUpShouldBypassRepoCache = false
@@ -1257,6 +1274,7 @@ class TabManager: ObservableObject {
         }
 
         let cacheBySlug = workspacePullRequestRepoCacheBySlug
+        let rateLimitedUntilByRepoSlug = workspacePullRequestRateLimitedUntilByRepoSlug
         let allowCachedResults = allowCachedResultsOverride
             ?? Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
         workspacePullRequestRefreshTask = Task { [weak self] in
@@ -1264,6 +1282,7 @@ class TabManager: ObservableObject {
                 repoDirectoriesBySlug: repoDirectoriesBySlug,
                 candidateBranchesByRepo: candidateBranchesByRepo,
                 cacheBySlug: cacheBySlug,
+                rateLimitedUntilByRepoSlug: rateLimitedUntilByRepoSlug,
                 now: now,
                 allowCachedResults: allowCachedResults
             )
@@ -1350,11 +1369,22 @@ class TabManager: ObservableObject {
         reason: String
     ) {
         for (repoSlug, repoResult) in repoResults {
-            guard case .success(let cacheEntry, let usedCache, _) = repoResult,
-                  !usedCache else {
+            switch repoResult {
+            case .success(let cacheEntry, let usedCache, _, let rateLimitedBranches):
+                if let rateLimitedUntil = rateLimitedBranches.values.max() {
+                    let existingUntil = workspacePullRequestRateLimitedUntilByRepoSlug[repoSlug] ?? .distantPast
+                    workspacePullRequestRateLimitedUntilByRepoSlug[repoSlug] = max(existingUntil, rateLimitedUntil)
+                } else {
+                    workspacePullRequestRateLimitedUntilByRepoSlug.removeValue(forKey: repoSlug)
+                }
+                guard !usedCache else { continue }
+                workspacePullRequestRepoCacheBySlug[repoSlug] = cacheEntry
+            case .rateLimited(let until):
+                let existingUntil = workspacePullRequestRateLimitedUntilByRepoSlug[repoSlug] ?? .distantPast
+                workspacePullRequestRateLimitedUntilByRepoSlug[repoSlug] = max(existingUntil, until)
+            case .transientFailure:
                 continue
             }
-            workspacePullRequestRepoCacheBySlug[repoSlug] = cacheEntry
         }
 
         let requestedKeySet = Set(requestedKeys)
@@ -1420,22 +1450,16 @@ class TabManager: ObservableObject {
                     branch: resolvedPullRequest.branch,
                     isStale: false
                 )
-            case .notFound:
+            case .notFound, .unsupportedRepository:
                 workspacePullRequestTransientFailureCountByKey[key] = 0
                 workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
                 if workspace.panelPullRequests[result.panelId] != nil {
                     workspace.clearPanelPullRequest(panelId: result.panelId)
                 }
-            case .unsupportedRepository:
-                workspacePullRequestTransientFailureCountByKey[key] = 0
-                workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-                if workspace.panelPullRequests[result.panelId] != nil {
-                    workspace.clearPanelPullRequest(panelId: result.panelId)
-                }
-            case .transientFailure:
+            case .rateLimited, .transientFailure:
                 let nextFailureCount = (workspacePullRequestTransientFailureCountByKey[key] ?? 0) + 1
                 workspacePullRequestTransientFailureCountByKey[key] = nextFailureCount
-                if nextFailureCount >= 3,
+                if nextFailureCount >= Self.workspacePullRequestStaleThreshold,
                    let currentPullRequest = workspace.panelPullRequests[result.panelId] {
                     workspace.updatePanelPullRequest(
                         panelId: result.panelId,
@@ -1468,6 +1492,8 @@ class TabManager: ObservableObject {
                     return "unsupported"
                 case .notFound:
                     return "none"
+                case .rateLimited:
+                    return "rateLimited"
                 case .transientFailure:
                     return "transientFailure"
                 case .resolved(let resolvedPullRequest):
@@ -1494,31 +1520,27 @@ class TabManager: ObservableObject {
             workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
         }
 
-        if case .resolved(let resolvedPullRequest) = resolution,
-           let status = SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue),
-           status != .open {
-            workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
-            return
-        }
-
-        if case .transientFailure = resolution,
-           workspacePullRequestLastTerminalStateRefreshAtByKey[key] != nil {
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
-            return
-        }
-
-        if case .unsupportedRepository = resolution {
+        switch resolution {
+        case .resolved(let resolvedPullRequest):
+            if SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue) != .open {
+                workspacePullRequestLastTerminalStateRefreshAtByKey[key] = now
+            } else {
+                workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
+            }
+        case .notFound, .unsupportedRepository:
             workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
-            return
+        case .rateLimited, .transientFailure:
+            break
         }
 
-        workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-        let baseInterval = isSelectedFocusedPanel(workspace: workspace, panelId: panelId)
-            ? Self.selectedPollInterval
-            : Self.backgroundPollInterval
-        workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
+        let hasTerminalStateSweepContext = workspacePullRequestLastTerminalStateRefreshAtByKey[key] != nil
+        workspacePullRequestNextPollAtByKey[key] = Self.workspacePullRequestNextPollAt(
+            now: now,
+            resolution: resolution,
+            hasTerminalStateSweepContext: hasTerminalStateSweepContext,
+            isSelectedFocusedPanel: isSelectedFocusedPanel(workspace: workspace, panelId: panelId),
+            transientFailureCount: workspacePullRequestTransientFailureCountByKey[key] ?? 0
+        )
     }
 
     private func pruneWorkspacePullRequestTracking(validKeys: Set<WorkspaceGitProbeKey>) {
@@ -1526,9 +1548,13 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { validKeys.contains($0.key) }
-        let repoCacheCutoff = Date().addingTimeInterval(-Self.workspacePullRequestRepoCachePruneLifetime)
+        let pruneNow = Date()
+        let repoCacheCutoff = pruneNow.addingTimeInterval(-Self.workspacePullRequestRepoCachePruneLifetime)
         workspacePullRequestRepoCacheBySlug = workspacePullRequestRepoCacheBySlug.filter {
             $0.value.fetchedAt >= repoCacheCutoff
+        }
+        workspacePullRequestRateLimitedUntilByRepoSlug = workspacePullRequestRateLimitedUntilByRepoSlug.filter {
+            $0.value > pruneNow
         }
     }
 
@@ -1554,6 +1580,7 @@ class TabManager: ObservableObject {
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeAll()
         workspacePullRequestTransientFailureCountByKey.removeAll()
         workspacePullRequestRepoCacheBySlug.removeAll()
+        workspacePullRequestRateLimitedUntilByRepoSlug.removeAll()
         workspacePullRequestFollowUpShouldBypassRepoCache = false
     }
 
@@ -1610,6 +1637,57 @@ class TabManager: ObservableObject {
     private nonisolated static func jitteredPollInterval(base: TimeInterval) -> TimeInterval {
         let jitter = base * Self.workspacePullRequestPollJitterFraction
         return base + Double.random(in: -jitter...jitter)
+    }
+
+    nonisolated static func workspacePullRequestTransientFailureDelay(
+        baseInterval: TimeInterval,
+        failureCount: Int
+    ) -> TimeInterval {
+        let exponent = Double(max(0, max(1, failureCount) - 1))
+        return min(
+            baseInterval * pow(2.0, exponent),
+            Self.workspacePullRequestFailureBackoffMaxInterval
+        )
+    }
+
+    nonisolated static func workspacePullRequestNextPollAt(
+        now: Date,
+        resolution: WorkspacePullRequestRefreshResult.Resolution,
+        hasTerminalStateSweepContext: Bool,
+        isSelectedFocusedPanel: Bool,
+        transientFailureCount: Int
+    ) -> Date {
+        switch resolution {
+        case .rateLimited(let retryAt):
+            return max(retryAt, now)
+        case .resolved(let resolvedPullRequest):
+            if SidebarPullRequestStatus(rawValue: resolvedPullRequest.statusRawValue) != .open {
+                return now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
+            }
+        case .transientFailure:
+            if hasTerminalStateSweepContext {
+                return now.addingTimeInterval(Self.workspacePullRequestTerminalStateSweepInterval)
+            }
+
+            let baseInterval = isSelectedFocusedPanel
+                ? Self.selectedPollInterval
+                : Self.backgroundPollInterval
+            return now.addingTimeInterval(
+                Self.workspacePullRequestTransientFailureDelay(
+                    baseInterval: baseInterval,
+                    failureCount: transientFailureCount
+                )
+            )
+        case .unsupportedRepository:
+            return now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
+        case .notFound:
+            break
+        }
+
+        let baseInterval = isSelectedFocusedPanel
+            ? Self.selectedPollInterval
+            : Self.backgroundPollInterval
+        return now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
     }
 
     nonisolated static func workspacePullRequestRefreshAllowsRepoCache(reason: String) -> Bool {
@@ -2410,6 +2488,7 @@ class TabManager: ObservableObject {
         repoDirectoriesBySlug: [String: String],
         candidateBranchesByRepo: [String: Set<String>],
         cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
+        rateLimitedUntilByRepoSlug: [String: Date],
         now: Date,
         allowCachedResults: Bool
     ) async -> [String: WorkspacePullRequestRepoFetchResult] {
@@ -2436,6 +2515,8 @@ class TabManager: ObservableObject {
                             && (cacheBySlug[repoSlug].map {
                                 now.timeIntervalSince($0.fetchedAt) < Self.workspacePullRequestRepoCacheLifetime
                             } ?? false),
+                        rateLimitedUntil: rateLimitedUntilByRepoSlug[repoSlug],
+                        now: now,
                         session: session,
                         authHeader: authHeader
                     )
@@ -2456,6 +2537,68 @@ class TabManager: ObservableObject {
         return results
     }
 
+    nonisolated static func workspacePullRequestResolution(
+        branch: String,
+        repoSlugs: [String],
+        repoResults: [String: WorkspacePullRequestRepoFetchResult]
+    ) -> (resolution: WorkspacePullRequestRefreshResult.Resolution, usedCachedRepoData: Bool) {
+        var matchedPullRequest: GitHubPullRequestProbeItem?
+        var matchedPullRequestUsedCache = false
+        var latestRateLimitedRetryAt: Date?
+        var sawTransientFailure = false
+        var sawCachedSuccess = false
+
+        for repoSlug in repoSlugs {
+            guard let repoResult = repoResults[repoSlug] else { continue }
+            switch repoResult {
+            case .success(let cacheEntry, let usedCache, let transientBranches, let rateLimitedBranches):
+                if usedCache {
+                    sawCachedSuccess = true
+                }
+                if let candidateMatch = cacheEntry.pullRequestsByBranch[branch] {
+                    matchedPullRequest = candidateMatch
+                    matchedPullRequestUsedCache = usedCache
+                    break
+                }
+                if let retryAt = rateLimitedBranches[branch] {
+                    latestRateLimitedRetryAt = max(latestRateLimitedRetryAt ?? .distantPast, retryAt)
+                }
+                if transientBranches.contains(branch) {
+                    sawTransientFailure = true
+                }
+            case .rateLimited(let until):
+                latestRateLimitedRetryAt = max(latestRateLimitedRetryAt ?? .distantPast, until)
+            case .transientFailure:
+                sawTransientFailure = true
+            }
+        }
+
+        if let matchedPullRequest,
+           let status = pullRequestStatus(from: matchedPullRequest.state) {
+            return (
+                .resolved(
+                    WorkspacePullRequestResolvedItem(
+                        number: matchedPullRequest.number,
+                        urlString: matchedPullRequest.url,
+                        statusRawValue: status.rawValue,
+                        branch: branch
+                    )
+                ),
+                matchedPullRequestUsedCache
+            )
+        }
+
+        if let retryAt = latestRateLimitedRetryAt {
+            return (.rateLimited(retryAt: retryAt), false)
+        }
+
+        if sawTransientFailure {
+            return (.transientFailure, false)
+        }
+
+        return (.notFound, sawCachedSuccess)
+    }
+
     private nonisolated static func resolveWorkspacePullRequestRefreshResults(
         candidates: [WorkspacePullRequestCandidate],
         repoResults: [String: WorkspacePullRequestRepoFetchResult]
@@ -2470,51 +2613,11 @@ class TabManager: ObservableObject {
                 )
             }
 
-            var matchedPullRequest: GitHubPullRequestProbeItem?
-            var matchedPullRequestUsedCache = false
-            var sawTransientFailure = false
-            var sawCachedSuccess = false
-
-            for repoSlug in candidate.repoSlugs {
-                guard let repoResult = repoResults[repoSlug] else { continue }
-                switch repoResult {
-                case .success(let cacheEntry, let usedCache, let transientBranches):
-                    if usedCache {
-                        sawCachedSuccess = true
-                    }
-                    if let candidateMatch = cacheEntry.pullRequestsByBranch[candidate.branch] {
-                        matchedPullRequest = candidateMatch
-                        matchedPullRequestUsedCache = usedCache
-                        break
-                    }
-                    if transientBranches.contains(candidate.branch) {
-                        sawTransientFailure = true
-                    }
-                case .transientFailure:
-                    sawTransientFailure = true
-                }
-            }
-
-            let resolution: WorkspacePullRequestRefreshResult.Resolution
-            let usedCachedRepoData: Bool
-            if let matchedPullRequest,
-               let status = pullRequestStatus(from: matchedPullRequest.state) {
-                resolution = .resolved(
-                    WorkspacePullRequestResolvedItem(
-                        number: matchedPullRequest.number,
-                        urlString: matchedPullRequest.url,
-                        statusRawValue: status.rawValue,
-                        branch: candidate.branch
-                    )
-                )
-                usedCachedRepoData = matchedPullRequestUsedCache
-            } else if sawTransientFailure {
-                resolution = .transientFailure
-                usedCachedRepoData = false
-            } else {
-                resolution = .notFound
-                usedCachedRepoData = sawCachedSuccess
-            }
+            let (resolution, usedCachedRepoData) = workspacePullRequestResolution(
+                branch: candidate.branch,
+                repoSlugs: candidate.repoSlugs,
+                repoResults: repoResults
+            )
 
             return WorkspacePullRequestRefreshResult(
                 workspaceId: candidate.workspaceId,
@@ -2525,15 +2628,21 @@ class TabManager: ObservableObject {
         }
     }
 
-    private nonisolated static func workspacePullRequestRepoFetchResult(
+    nonisolated static func workspacePullRequestRepoFetchResult(
         repoSlug: String,
         candidateBranches: Set<String>,
         cachedEntry: WorkspacePullRequestRepoCacheEntry?,
         useCachedRecentWindow: Bool,
+        rateLimitedUntil: Date? = nil,
+        now: Date = Date(),
         session: URLSession,
         authHeader: String?
     ) async -> WorkspacePullRequestRepoFetchResult {
         let normalizedCandidateBranches = Set(candidateBranches.compactMap(normalizedBranchName))
+        if let rateLimitedUntil,
+           now < rateLimitedUntil {
+            return .rateLimited(until: rateLimitedUntil)
+        }
 
         if useCachedRecentWindow,
            let cachedEntry {
@@ -2548,7 +2657,12 @@ class TabManager: ObservableObject {
                     "branches=\(cachedEntry.pullRequestsByBranch.count)"
                 )
 #endif
-                return .success(cachedEntry, usedCache: true, transientBranches: [])
+                return .success(
+                    cachedEntry,
+                    usedCache: true,
+                    transientBranches: [],
+                    rateLimitedBranches: [:]
+                )
             }
 
             let lookupOutcome = await workspacePullRequestBranchLookupOutcome(
@@ -2568,11 +2682,12 @@ class TabManager: ObservableObject {
             return .success(
                 lookupOutcome.cacheEntry,
                 usedCache: false,
-                transientBranches: lookupOutcome.transientBranches
+                transientBranches: lookupOutcome.transientBranches,
+                rateLimitedBranches: lookupOutcome.rateLimitedBranches
             )
         }
 
-        let fetchTimestamp = Date()
+        let fetchTimestamp = now
         var page = 1
         var fetchedPageCount = 0
         var allPullRequests: [GitHubPullRequestProbeItem] = []
@@ -2590,11 +2705,26 @@ class TabManager: ObservableObject {
                 return .transientFailure
             }
 
-            guard response.statusCode == 200,
-                  let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
+            if response.statusCode != 200 {
 #if DEBUG
                 dlog("workspace.prRefresh.repo.fail repo=\(repoSlug) page=\(page) status=\(response.statusCode)")
 #endif
+                switch classifyWorkspacePullRequestHTTPFailure(
+                    statusCode: response.statusCode,
+                    retryAfter: response.retryAfter,
+                    rateLimitRemaining: response.rateLimitRemaining,
+                    rateLimitReset: response.rateLimitReset,
+                    body: response.data,
+                    now: now
+                ) {
+                case .rateLimited(let retryAt):
+                    return .rateLimited(until: retryAt)
+                case .transientFailure:
+                    return .transientFailure
+                }
+            }
+
+            guard let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
                 return .transientFailure
             }
 
@@ -2618,7 +2748,8 @@ class TabManager: ObservableObject {
         if unresolvedBranches.isEmpty {
             lookupOutcome = WorkspacePullRequestBranchLookupOutcome(
                 cacheEntry: recentWindowEntry,
-                transientBranches: []
+                transientBranches: [],
+                rateLimitedBranches: [:]
             )
         } else {
             lookupOutcome = await workspacePullRequestBranchLookupOutcome(
@@ -2640,7 +2771,8 @@ class TabManager: ObservableObject {
         return .success(
             lookupOutcome.cacheEntry,
             usedCache: false,
-            transientBranches: lookupOutcome.transientBranches
+            transientBranches: lookupOutcome.transientBranches,
+            rateLimitedBranches: lookupOutcome.rateLimitedBranches
         )
     }
 
@@ -2667,7 +2799,8 @@ class TabManager: ObservableObject {
         guard !candidateBranches.isEmpty else {
             return WorkspacePullRequestBranchLookupOutcome(
                 cacheEntry: baseEntry,
-                transientBranches: []
+                transientBranches: [],
+                rateLimitedBranches: [:]
             )
         }
 
@@ -2697,6 +2830,7 @@ class TabManager: ObservableObject {
         var pullRequestsByBranch = baseEntry.pullRequestsByBranch
         var knownAbsentBranches = baseEntry.knownAbsentBranches
         var transientBranches: Set<String> = []
+        var rateLimitedBranches: [String: Date] = [:]
 
         for (branch, result) in branchResults {
             switch result {
@@ -2705,6 +2839,9 @@ class TabManager: ObservableObject {
                 knownAbsentBranches.remove(branch)
             case .notFound:
                 knownAbsentBranches.insert(branch)
+            case .rateLimited(let until):
+                let existingUntil = rateLimitedBranches[branch] ?? .distantPast
+                rateLimitedBranches[branch] = max(existingUntil, until)
             case .transientFailure:
                 transientBranches.insert(branch)
             }
@@ -2716,7 +2853,8 @@ class TabManager: ObservableObject {
                 pullRequestsByBranch: pullRequestsByBranch,
                 knownAbsentBranches: knownAbsentBranches
             ),
-            transientBranches: transientBranches
+            transientBranches: transientBranches,
+            rateLimitedBranches: rateLimitedBranches
         )
     }
 
@@ -2744,14 +2882,29 @@ class TabManager: ObservableObject {
             return .transientFailure
         }
 
-        guard response.statusCode == 200,
-              let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
+        if response.statusCode != 200 {
 #if DEBUG
             dlog(
                 "workspace.prRefresh.branch.fail repo=\(repoSlug) " +
                 "branch=\(branch) status=\(response.statusCode)"
             )
 #endif
+            switch classifyWorkspacePullRequestHTTPFailure(
+                statusCode: response.statusCode,
+                retryAfter: response.retryAfter,
+                rateLimitRemaining: response.rateLimitRemaining,
+                rateLimitReset: response.rateLimitReset,
+                body: response.data,
+                now: Date()
+            ) {
+            case .rateLimited(let retryAt):
+                return .rateLimited(until: retryAt)
+            case .transientFailure:
+                return .transientFailure
+            }
+        }
+
+        guard let pullRequests = decodeJSON([WorkspacePullRequestRESTItem].self, from: response.data) else {
             return .transientFailure
         }
 
@@ -2826,11 +2979,120 @@ class TabManager: ObservableObject {
             }
             return WorkspacePullRequestHTTPResponse(
                 statusCode: httpResponse.statusCode,
-                data: data
+                data: data,
+                retryAfter: httpResponse.value(forHTTPHeaderField: "Retry-After"),
+                rateLimitRemaining: httpResponse.value(forHTTPHeaderField: "X-RateLimit-Remaining"),
+                rateLimitReset: httpResponse.value(forHTTPHeaderField: "X-RateLimit-Reset")
             )
         } catch {
             return nil
         }
+    }
+
+    private nonisolated static let workspacePullRequestRetryAfterHTTPDateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "EEE',' dd MMM yyyy HH':'mm':'ss z"
+        return formatter
+    }()
+
+    nonisolated static func classifyWorkspacePullRequestHTTPFailure(
+        statusCode: Int,
+        retryAfter: String?,
+        rateLimitRemaining: String?,
+        rateLimitReset: String?,
+        body: Data,
+        now: Date
+    ) -> WorkspacePullRequestHTTPFailureClassification {
+        if statusCode == 429 {
+            return .rateLimited(
+                retryAt: workspacePullRequestRateLimitRetryAt(
+                    retryAfter: retryAfter,
+                    rateLimitReset: rateLimitReset,
+                    now: now
+                )
+            )
+        }
+
+        guard statusCode == 403 else {
+            return .transientFailure
+        }
+
+        let hasRetryAfter = retryAfter?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .isEmpty == false
+        let trimmedRemaining = rateLimitRemaining?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let isPrimaryRateLimited = trimmedRemaining == "0"
+
+        let bodyPrefix = body.prefix(2048)
+        let bodyText = String(data: bodyPrefix, encoding: .utf8)?.lowercased() ?? ""
+        let indicatesRateLimit = bodyText.contains("secondary rate limit")
+            || bodyText.contains("rate limit")
+            || bodyText.contains("abuse detection")
+
+        if hasRetryAfter || isPrimaryRateLimited || indicatesRateLimit {
+            return .rateLimited(
+                retryAt: workspacePullRequestRateLimitRetryAt(
+                    retryAfter: retryAfter,
+                    rateLimitReset: rateLimitReset,
+                    now: now
+                )
+            )
+        }
+
+        return .transientFailure
+    }
+
+    nonisolated static func workspacePullRequestRateLimitRetryAt(
+        retryAfter: String?,
+        rateLimitReset: String?,
+        now: Date
+    ) -> Date {
+        if let date = workspacePullRequestRetryAfterDate(retryAfter: retryAfter, now: now) {
+            return date
+        }
+
+        if let resetDate = workspacePullRequestRateLimitResetDate(rateLimitReset: rateLimitReset, now: now) {
+            return resetDate
+        }
+
+        return now.addingTimeInterval(Self.workspacePullRequestRateLimitFallbackCooldown)
+    }
+
+    private nonisolated static func workspacePullRequestRetryAfterDate(
+        retryAfter: String?,
+        now: Date
+    ) -> Date? {
+        guard let rawRetryAfter = retryAfter?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawRetryAfter.isEmpty else {
+            return nil
+        }
+
+        if let seconds = TimeInterval(rawRetryAfter) {
+            return now.addingTimeInterval(max(1, seconds))
+        }
+
+        if let date = workspacePullRequestRetryAfterHTTPDateFormatter.date(from: rawRetryAfter) {
+            return max(date, now)
+        }
+        return nil
+    }
+
+    private nonisolated static func workspacePullRequestRateLimitResetDate(
+        rateLimitReset: String?,
+        now: Date
+    ) -> Date? {
+        guard let rawReset = rateLimitReset?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !rawReset.isEmpty,
+            let resetTimestamp = TimeInterval(rawReset) else {
+            return nil
+        }
+
+        return max(Date(timeIntervalSince1970: resetTimestamp), now)
     }
 
     private nonisolated static func workspacePullRequestAuthHeaderValue() -> String? {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -13,6 +13,33 @@ import UserNotifications
 @testable import cmux
 #endif
 
+private final class WorkspacePullRequestProbeTestURLProtocol: URLProtocol {
+    static var requestCount = 0
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        true
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.requestCount += 1
+        let response = HTTPURLResponse(
+            url: request.url ?? URL(string: "https://example.com")!,
+            statusCode: 500,
+            httpVersion: "HTTP/1.1",
+            headerFields: [:]
+        )!
+        client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+        client?.urlProtocol(self, didLoad: Data("{}".utf8))
+        client?.urlProtocolDidFinishLoading(self)
+    }
+
+    override func stopLoading() {}
+}
+
 let lastSurfaceCloseShortcutDefaultsKey = "closeWorkspaceOnLastSurfaceShortcut"
 
 func drainMainQueue() {
@@ -301,6 +328,22 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
 
 @MainActor
 final class TabManagerPullRequestProbeTests: XCTestCase {
+    private func makePullRequestProbeItem(
+        number: Int = 1888,
+        state: String = "OPEN",
+        branch: String = "feature/work",
+        url: String = "https://github.com/manaflow-ai/cmux/pull/1888",
+        updatedAt: String = "2026-03-20T18:00:00Z"
+    ) -> TabManager.GitHubPullRequestProbeItem {
+        TabManager.GitHubPullRequestProbeItem(
+            number: number,
+            state: state,
+            url: url,
+            updatedAt: updatedAt,
+            headRefName: branch
+        )
+    }
+
     func testGitHubRepositorySlugsPrioritizeUpstreamThenOriginAndDeduplicate() {
         let output = """
         origin https://github.com/austinwang/cmux.git (fetch)
@@ -416,6 +459,220 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange.followUp"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "commandHint:merge"))
+    }
+
+    func testWorkspacePullRequestHTTPFailureClassificationTreatsRetryAfterAsRateLimited() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(
+            TabManager.classifyWorkspacePullRequestHTTPFailure(
+                statusCode: 429,
+                retryAfter: "120",
+                rateLimitRemaining: nil,
+                rateLimitReset: nil,
+                body: Data(),
+                now: now
+            ),
+            .rateLimited(retryAt: now.addingTimeInterval(120))
+        )
+    }
+
+    func testWorkspacePullRequestHTTPFailureClassificationUsesRateLimitResetHeader() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let retryAt = Date(timeIntervalSince1970: 1_234)
+
+        XCTAssertEqual(
+            TabManager.classifyWorkspacePullRequestHTTPFailure(
+                statusCode: 403,
+                retryAfter: nil,
+                rateLimitRemaining: "0",
+                rateLimitReset: "1234",
+                body: Data(),
+                now: now
+            ),
+            .rateLimited(retryAt: retryAt)
+        )
+    }
+
+    func testWorkspacePullRequestHTTPFailureClassificationUsesFallbackCooldownForSecondaryRateLimitBody() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(
+            TabManager.classifyWorkspacePullRequestHTTPFailure(
+                statusCode: 403,
+                retryAfter: nil,
+                rateLimitRemaining: nil,
+                rateLimitReset: nil,
+                body: Data("You have exceeded a secondary rate limit.".utf8),
+                now: now
+            ),
+            .rateLimited(retryAt: now.addingTimeInterval(300))
+        )
+    }
+
+    func testWorkspacePullRequestHTTPFailureClassificationKeeps500AsTransientFailure() {
+        XCTAssertEqual(
+            TabManager.classifyWorkspacePullRequestHTTPFailure(
+                statusCode: 500,
+                retryAfter: nil,
+                rateLimitRemaining: nil,
+                rateLimitReset: nil,
+                body: Data("server error".utf8),
+                now: Date(timeIntervalSince1970: 1_000)
+            ),
+            .transientFailure
+        )
+    }
+
+    func testWorkspacePullRequestTransientFailureDelayUsesExponentialBackoffWithCap() {
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 10, failureCount: 1),
+            10
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 10, failureCount: 2),
+            20
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 10, failureCount: 6),
+            300
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 60, failureCount: 1),
+            60
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 60, failureCount: 3),
+            240
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestTransientFailureDelay(baseInterval: 60, failureCount: 4),
+            300
+        )
+    }
+
+    func testWorkspacePullRequestNextPollAtUsesRetryAtForRateLimit() {
+        let now = Date(timeIntervalSince1970: 1_000)
+        let retryAt = now.addingTimeInterval(180)
+
+        XCTAssertEqual(
+            TabManager.workspacePullRequestNextPollAt(
+                now: now,
+                resolution: .rateLimited(retryAt: retryAt),
+                hasTerminalStateSweepContext: true,
+                isSelectedFocusedPanel: true,
+                transientFailureCount: 4
+            ),
+            retryAt
+        )
+    }
+
+    func testWorkspacePullRequestNextPollAtUsesBackoffForTransientFailures() {
+        let now = Date(timeIntervalSince1970: 1_000)
+
+        XCTAssertEqual(
+            TabManager.workspacePullRequestNextPollAt(
+                now: now,
+                resolution: .transientFailure,
+                hasTerminalStateSweepContext: false,
+                isSelectedFocusedPanel: true,
+                transientFailureCount: 3
+            ),
+            now.addingTimeInterval(40)
+        )
+        XCTAssertEqual(
+            TabManager.workspacePullRequestNextPollAt(
+                now: now,
+                resolution: .transientFailure,
+                hasTerminalStateSweepContext: false,
+                isSelectedFocusedPanel: false,
+                transientFailureCount: 3
+            ),
+            now.addingTimeInterval(240)
+        )
+    }
+
+    func testWorkspacePullRequestResolutionPrefersResolvedOverRateLimitedRepo() {
+        let pullRequest = makePullRequestProbeItem()
+        let cacheEntry = TabManager.WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: Date(timeIntervalSince1970: 1_000),
+            pullRequestsByBranch: ["feature/work": pullRequest]
+        )
+        let retryAt = Date(timeIntervalSince1970: 1_300)
+
+        let (resolution, usedCachedRepoData) = TabManager.workspacePullRequestResolution(
+            branch: "feature/work",
+            repoSlugs: ["upstream", "origin"],
+            repoResults: [
+                "upstream": .rateLimited(until: retryAt),
+                "origin": .success(
+                    cacheEntry,
+                    usedCache: true,
+                    transientBranches: [],
+                    rateLimitedBranches: [:]
+                ),
+            ]
+        )
+
+        XCTAssertEqual(
+            resolution,
+            .resolved(
+                TabManager.WorkspacePullRequestResolvedItem(
+                    number: 1888,
+                    urlString: "https://github.com/manaflow-ai/cmux/pull/1888",
+                    statusRawValue: "open",
+                    branch: "feature/work"
+                )
+            )
+        )
+        XCTAssertTrue(usedCachedRepoData)
+    }
+
+    func testWorkspacePullRequestResolutionReturnsRateLimitedWhenNoRepoMatches() {
+        let cacheEntry = TabManager.WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: Date(timeIntervalSince1970: 1_000),
+            pullRequestsByBranch: [:]
+        )
+        let retryAt = Date(timeIntervalSince1970: 1_420)
+
+        let (resolution, usedCachedRepoData) = TabManager.workspacePullRequestResolution(
+            branch: "feature/work",
+            repoSlugs: ["origin"],
+            repoResults: [
+                "origin": .success(
+                    cacheEntry,
+                    usedCache: false,
+                    transientBranches: [],
+                    rateLimitedBranches: ["feature/work": retryAt]
+                )
+            ]
+        )
+
+        XCTAssertEqual(resolution, .rateLimited(retryAt: retryAt))
+        XCTAssertFalse(usedCachedRepoData)
+    }
+
+    func testWorkspacePullRequestRepoFetchResultReturnsCooldownWithoutRequest() async {
+        WorkspacePullRequestProbeTestURLProtocol.requestCount = 0
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [WorkspacePullRequestProbeTestURLProtocol.self]
+        let session = URLSession(configuration: configuration)
+        let now = Date(timeIntervalSince1970: 1_000)
+        let retryAt = now.addingTimeInterval(300)
+
+        let result = await TabManager.workspacePullRequestRepoFetchResult(
+            repoSlug: "manaflow-ai/cmux",
+            candidateBranches: ["feature/work"],
+            cachedEntry: nil,
+            useCachedRecentWindow: false,
+            rateLimitedUntil: retryAt,
+            now: now,
+            session: session,
+            authHeader: nil
+        )
+
+        XCTAssertEqual(result, .rateLimited(until: retryAt))
+        XCTAssertEqual(WorkspacePullRequestProbeTestURLProtocol.requestCount, 0)
     }
 
     func testWorkspacePullRequestShouldRefreshHonorsForcedRefreshForTerminalStates() {


### PR DESCRIPTION
Classify 429/403 responses as rate-limited (via Retry-After, X-RateLimit-Reset, or body markers) and skip probe requests until cooldown elapses, with exponential backoff on transient failures.

## Summary

- What changed?

Key additions:
  - New classifyWorkspacePullRequestHTTPFailure that inspects 429/403 responses (via
  Retry-After, X-RateLimit-Remaining, X-RateLimit-Reset, and body markers like "secondary
   rate limit" / "abuse detection") and returns either .rateLimited(retryAt:) or
  .transientFailure.
  - New .rateLimited case threaded through WorkspacePullRequestRepoFetchResult,
  WorkspacePullRequestBranchFetchResult, and the Resolution enum.
  - New per-repo cooldown map workspacePullRequestRateLimitedUntilByRepoSlug so
  subsequent repo/branch fetches short-circuit with .rateLimited until retryAt.
  - workspacePullRequestNextPollAt now honors retryAt for rate-limited results and
  applies exponential backoff (capped at 5min) to transient failures via
  workspacePullRequestTransientFailureDelay.
  - Response parsing (WorkspacePullRequestHTTPResponse) now captures Retry-After /
  X-RateLimit-Remaining / X-RateLimit-Reset; fallback cooldown is 5min.
  - Several static helpers made non-private to be unit-testable.

- Why?

 The workspace PR refresh path was hammering GitHub even after being throttled, treating
   429/403 as generic transient failures and retrying on the normal poll cadence. This
  burned rate budget and delayed recovery. The change classifies rate limits explicitly,
  parks the whole repo slug until GitHub's advertised reset time (with a 5-min fallback),
   and backs off exponentially on other transient errors so the app stops self-inflicting
   rate-limit spirals.

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add GitHub rate‑limit handling to workspace PR probes so we pause requests when throttled and back off on transient errors. This reduces wasted API calls and speeds up recovery after hitting limits.

- **New Features**
  - Classify rate limits for 429/403 using Retry-After, X-RateLimit-Reset, X-RateLimit-Remaining=0, and body markers (“secondary rate limit”, “abuse detection”).
  - Add `.rateLimited(retryAt)` to repo/branch and resolution flows; schedule next poll at `retryAt` with a 5‑min fallback when headers are missing.
  - Track per‑repo cooldown (`workspacePullRequestRateLimitedUntilByRepoSlug`) to short‑circuit fetches until the cooldown ends.
  - Apply exponential backoff on transient failures (capped at 5 minutes).
  - Parse and store response headers for retries; expose small helpers for unit testing and add tests for classification, backoff, resolution, and cooldown short‑circuit.

<sup>Written for commit c67e9a0d5c7e8c9be1bfd869eb071cd44d5f3c71. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub API rate limiting is now detected and reported as a distinct refresh outcome.

* **Bug Fixes**
  * Improved polling and retry scheduling to respect GitHub API rate-limit headers and retry-after directives.

* **Tests**
  * Added comprehensive test coverage for rate limit detection and retry scheduling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->