### PR TITLE
Debounce shell-triggered sidebar PR refreshes

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -55871,6 +55871,108 @@
         }
       }
     },
+    "settings.automation.pullRequestShellDebounce": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delay Shell PR Refreshes"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェル PR 更新を遅延"
+          }
+        }
+      }
+    },
+    "settings.automation.pullRequestShellDebounce.delay": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR Refresh Delay"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "PR 更新遅延"
+          }
+        }
+      }
+    },
+    "settings.automation.pullRequestShellDebounce.delay.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delay shell-triggered pull request refreshes by this many seconds before checking GitHub."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェル起点の PR 更新を GitHub 確認前にこの秒数だけ遅延します。"
+          }
+        }
+      }
+    },
+    "settings.automation.pullRequestShellDebounce.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Applies to shell prompt and command-hint pull request refreshes. Matching repo and branch targets share one queued refresh window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "shell prompt と command hint の PR 更新に適用されます。同じ repo と branch の更新は 1 つの待機ウィンドウを共有します。"
+          }
+        }
+      }
+    },
+    "settings.automation.pullRequestShellDebounce.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell-triggered sidebar pull request refreshes check GitHub immediately."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェル起点のサイドバー PR 更新はすぐに GitHub を確認します。"
+          }
+        }
+      }
+    },
+    "settings.automation.pullRequestShellDebounce.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shell-triggered sidebar pull request refreshes are delayed and coalesced before checking GitHub."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェル起点のサイドバー PR 更新は GitHub 確認前に遅延・集約されます。"
+          }
+        }
+      }
+    },
     "settings.automation.portBase": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -76,6 +76,8 @@ final class CmuxSettingsFileStore {
         "automation.claudeBinaryPath",
         "automation.cursorIntegration",
         "automation.geminiIntegration",
+        "automation.sidebarPullRequestShellDebounceEnabled",
+        "automation.sidebarPullRequestShellDebounceSeconds",
         "automation.portBase",
         "automation.portRange",
         "customCommands.trustedDirectories",
@@ -723,6 +725,22 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonBool(section["geminiIntegration"]) {
             snapshot.managedUserDefaults[GeminiIntegrationSettings.hooksEnabledKey] = .bool(value)
+        }
+        if let value = jsonBool(section["sidebarPullRequestShellDebounceEnabled"]) {
+            snapshot.managedUserDefaults[SidebarPullRequestShellDebounceSettings.enabledKey] = .bool(value)
+        } else if section.keys.contains("sidebarPullRequestShellDebounceEnabled") {
+            logInvalid("automation.sidebarPullRequestShellDebounceEnabled", sourcePath: sourcePath)
+            return
+        }
+        if let value = jsonInt(section["sidebarPullRequestShellDebounceSeconds"]) {
+            guard value > 0 else {
+                logInvalid("automation.sidebarPullRequestShellDebounceSeconds", sourcePath: sourcePath)
+                return
+            }
+            snapshot.managedUserDefaults[SidebarPullRequestShellDebounceSettings.delaySecondsKey] = .int(value)
+        } else if section.keys.contains("sidebarPullRequestShellDebounceSeconds") {
+            logInvalid("automation.sidebarPullRequestShellDebounceSeconds", sourcePath: sourcePath)
+            return
         }
         if let value = jsonInt(section["portBase"]) {
             guard value > 0 else {
@@ -1428,6 +1446,8 @@ final class CmuxSettingsFileStore {
                     "claudeBinaryPath": "",
                     "cursorIntegration": CursorIntegrationSettings.defaultHooksEnabled,
                     "geminiIntegration": GeminiIntegrationSettings.defaultHooksEnabled,
+                    "sidebarPullRequestShellDebounceEnabled": SidebarPullRequestShellDebounceSettings.defaultEnabled,
+                    "sidebarPullRequestShellDebounceSeconds": SidebarPullRequestShellDebounceSettings.defaultDelaySeconds,
                     "portBase": 9100,
                     "portRange": 10,
                 ],

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -730,17 +730,15 @@ final class CmuxSettingsFileStore {
             snapshot.managedUserDefaults[SidebarPullRequestShellDebounceSettings.enabledKey] = .bool(value)
         } else if section.keys.contains("sidebarPullRequestShellDebounceEnabled") {
             logInvalid("automation.sidebarPullRequestShellDebounceEnabled", sourcePath: sourcePath)
-            return
         }
         if let value = jsonInt(section["sidebarPullRequestShellDebounceSeconds"]) {
-            guard value > 0 else {
+            if value > 0 {
+                snapshot.managedUserDefaults[SidebarPullRequestShellDebounceSettings.delaySecondsKey] = .int(value)
+            } else {
                 logInvalid("automation.sidebarPullRequestShellDebounceSeconds", sourcePath: sourcePath)
-                return
             }
-            snapshot.managedUserDefaults[SidebarPullRequestShellDebounceSettings.delaySecondsKey] = .int(value)
         } else if section.keys.contains("sidebarPullRequestShellDebounceSeconds") {
             logInvalid("automation.sidebarPullRequestShellDebounceSeconds", sourcePath: sourcePath)
-            return
         }
         if let value = jsonInt(section["portBase"]) {
             guard value > 0 else {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -754,6 +754,17 @@ class TabManager: ObservableObject {
         let repoSlugs: [String]
     }
 
+    struct WorkspacePullRequestShellRefreshTarget: Hashable, Sendable {
+        let branch: String
+        let repoSlugs: [String]
+    }
+
+    private struct WorkspacePullRequestShellRefreshEntry: Sendable {
+        var probeKeys: Set<WorkspaceGitProbeKey>
+        var fireAt: Date
+        var bypassRepoCache: Bool
+    }
+
     private struct WorkspacePullRequestResolvedItem: Sendable {
         let number: Int
         let urlString: String
@@ -883,6 +894,7 @@ class TabManager: ObservableObject {
     private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
     private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
+    private nonisolated static let workspacePullRequestQueuedShellTriggerReason = "queuedShellTrigger"
     @Published var selectedTabId: UUID? {
         willSet {
 #if DEBUG
@@ -977,6 +989,7 @@ class TabManager: ObservableObject {
     private var workspacePullRequestLastTerminalStateRefreshAtByKey: [WorkspaceGitProbeKey: Date] = [:]
     private var workspacePullRequestTransientFailureCountByKey: [WorkspaceGitProbeKey: Int] = [:]
     private var workspacePullRequestRepoCacheBySlug: [String: WorkspacePullRequestRepoCacheEntry] = [:]
+    private var workspacePullRequestShellRefreshEntriesByTarget: [WorkspacePullRequestShellRefreshTarget: WorkspacePullRequestShellRefreshEntry] = [:]
     private var workspacePullRequestPollTimer: DispatchSourceTimer?
     private var workspacePullRequestRefreshTask: Task<Void, Never>?
     private var workspacePullRequestFollowUpShouldBypassRepoCache = false
@@ -1141,7 +1154,10 @@ class TabManager: ObservableObject {
         timer.setEventHandler { [weak self] in
             guard let self else { return }
             DispatchQueue.main.async { [weak self] in
-                self?.refreshTrackedWorkspacePullRequestsIfNeeded(reason: "timer")
+                guard let self else { return }
+                if !self.flushQueuedWorkspacePullRequestShellRefreshesIfNeeded(now: Date()) {
+                    self.refreshTrackedWorkspacePullRequestsIfNeeded(reason: "timer")
+                }
             }
         }
         timer.resume()
@@ -1315,31 +1331,159 @@ class TabManager: ObservableObject {
         )
     }
 
-    private func scheduleWorkspacePullRequestRefresh(
+    nonisolated static func workspacePullRequestShellRefreshTarget(
+        branch: String,
+        repoSlugs: [String]
+    ) -> WorkspacePullRequestShellRefreshTarget? {
+        guard let normalizedBranch = normalizedBranchName(branch) else {
+            return nil
+        }
+        return WorkspacePullRequestShellRefreshTarget(
+            branch: normalizedBranch,
+            repoSlugs: repoSlugs
+        )
+    }
+
+    private func workspacePullRequestShellRefreshTarget(
+        workspace: Workspace,
+        panelId: UUID
+    ) -> WorkspacePullRequestShellRefreshTarget? {
+        let branch = workspace.panelGitBranches[panelId]?.branch
+            ?? workspace.panelPullRequests[panelId]?.branch
+        let repoSlugs = gitProbeDirectory(for: workspace, panelId: panelId)
+            .map(Self.githubRepositorySlugs(directory:)) ?? []
+        guard let branch else { return nil }
+        return Self.workspacePullRequestShellRefreshTarget(
+            branch: branch,
+            repoSlugs: repoSlugs
+        )
+    }
+
+    private func workspacePullRequestShellRefreshTarget(
+        for key: WorkspaceGitProbeKey
+    ) -> WorkspacePullRequestShellRefreshTarget? {
+        guard let workspace = tabs.first(where: { $0.id == key.workspaceId }),
+              workspace.panels[key.panelId] != nil else {
+            return nil
+        }
+        return workspacePullRequestShellRefreshTarget(
+            workspace: workspace,
+            panelId: key.panelId
+        )
+    }
+
+    private func removeWorkspacePullRequestShellRefreshProbeKey(_ key: WorkspaceGitProbeKey) {
+        guard !workspacePullRequestShellRefreshEntriesByTarget.isEmpty else { return }
+        for target in Array(workspacePullRequestShellRefreshEntriesByTarget.keys) {
+            guard var entry = workspacePullRequestShellRefreshEntriesByTarget[target] else { continue }
+            entry.probeKeys.remove(key)
+            if entry.probeKeys.isEmpty {
+                workspacePullRequestShellRefreshEntriesByTarget.removeValue(forKey: target)
+            } else {
+                workspacePullRequestShellRefreshEntriesByTarget[target] = entry
+            }
+        }
+    }
+
+    @discardableResult
+    private func queueWorkspacePullRequestShellRefreshIfNeeded(
         workspaceId: UUID,
         panelId: UUID,
-        reason: String
-    ) {
+        reason: String,
+        now: Date = Date()
+    ) -> Bool {
+        guard SidebarPullRequestShellDebounceSettings.isEnabled(),
+              reason == "shellPrompt" || reason.hasPrefix("commandHint:"),
+              let workspace = tabs.first(where: { $0.id == workspaceId }),
+              let target = workspacePullRequestShellRefreshTarget(
+                workspace: workspace,
+                panelId: panelId
+              ) else {
+            return false
+        }
+
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
-        let shouldBypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
-        if shouldBypassRepoCache, workspacePullRequestRefreshTask != nil {
+        let bypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
+        removeWorkspacePullRequestShellRefreshProbeKey(key)
+
+        if var existingEntry = workspacePullRequestShellRefreshEntriesByTarget[target] {
+            existingEntry.probeKeys.insert(key)
+            existingEntry.bypassRepoCache = existingEntry.bypassRepoCache || bypassRepoCache
+            workspacePullRequestShellRefreshEntriesByTarget[target] = existingEntry
+        } else {
+            workspacePullRequestShellRefreshEntriesByTarget[target] = WorkspacePullRequestShellRefreshEntry(
+                probeKeys: [key],
+                fireAt: now.addingTimeInterval(
+                    TimeInterval(SidebarPullRequestShellDebounceSettings.delaySeconds())
+                ),
+                bypassRepoCache: bypassRepoCache
+            )
+        }
+
+#if DEBUG
+        if let entry = workspacePullRequestShellRefreshEntriesByTarget[target] {
+            let fireDelay = entry.fireAt.timeIntervalSince(now)
+            dlog(
+                "workspace.prRefresh.queue workspace=\(workspaceId.uuidString.prefix(5)) " +
+                "panel=\(panelId.uuidString.prefix(5)) reason=\(reason) " +
+                "branch=\(target.branch) repos=\(target.repoSlugs.count) " +
+                "keys=\(entry.probeKeys.count) delay=\(String(format: "%.2f", fireDelay))"
+            )
+        }
+#endif
+        return true
+    }
+
+    private func requestWorkspacePullRequestRefresh(
+        key: WorkspaceGitProbeKey,
+        reason: String,
+        bypassRepoCache: Bool,
+        triggerImmediateRefresh: Bool = true
+    ) {
+        if bypassRepoCache, workspacePullRequestRefreshTask != nil {
             workspacePullRequestFollowUpShouldBypassRepoCache = true
         }
         if case .inFlight = workspacePullRequestProbeStateByKey[key] {
             markWorkspacePullRequestProbeRerunPending(
                 for: key,
-                bypassRepoCache: shouldBypassRepoCache
+                bypassRepoCache: bypassRepoCache
             )
         } else {
             workspacePullRequestNextPollAtByKey[key] = .distantPast
         }
 #if DEBUG
         dlog(
-            "workspace.prRefresh.schedule workspace=\(workspaceId.uuidString.prefix(5)) " +
-            "panel=\(panelId.uuidString.prefix(5)) reason=\(reason)"
+            "workspace.prRefresh.schedule workspace=\(key.workspaceId.uuidString.prefix(5)) " +
+            "panel=\(key.panelId.uuidString.prefix(5)) reason=\(reason)"
         )
 #endif
-        refreshTrackedWorkspacePullRequestsIfNeeded(reason: reason)
+        guard triggerImmediateRefresh else { return }
+        let allowCachedResultsOverride = bypassRepoCache ? false : nil
+        refreshTrackedWorkspacePullRequestsIfNeeded(
+            reason: reason,
+            allowCachedResultsOverride: allowCachedResultsOverride
+        )
+    }
+
+    private func scheduleWorkspacePullRequestRefresh(
+        workspaceId: UUID,
+        panelId: UUID,
+        reason: String
+    ) {
+        if queueWorkspacePullRequestShellRefreshIfNeeded(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            reason: reason
+        ) {
+            return
+        }
+
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        requestWorkspacePullRequestRefresh(
+            key: key,
+            reason: reason,
+            bypassRepoCache: !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
+        )
     }
 
     private func applyWorkspacePullRequestRefreshResults(
@@ -1521,6 +1665,88 @@ class TabManager: ObservableObject {
         workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
     }
 
+    @discardableResult
+    private func flushQueuedWorkspacePullRequestShellRefreshesIfNeeded(
+        now: Date = Date()
+    ) -> Bool {
+        if workspacePullRequestShellRefreshEntriesByTarget.isEmpty {
+            return false
+        }
+        guard SidebarPullRequestShellDebounceSettings.isEnabled() else {
+            workspacePullRequestShellRefreshEntriesByTarget.removeAll()
+            return false
+        }
+
+        var validKeys = Set(workspacePullRequestNextPollAtByKey.keys)
+        validKeys.formUnion(workspacePullRequestProbeStateByKey.keys)
+        for workspace in tabs {
+            for panelId in Set(workspace.panelGitBranches.keys).union(workspace.panelPullRequests.keys) {
+                validKeys.insert(WorkspaceGitProbeKey(workspaceId: workspace.id, panelId: panelId))
+            }
+        }
+        pruneWorkspacePullRequestShellRefreshQueue(validKeys: validKeys)
+
+        let dueTargets = workspacePullRequestShellRefreshEntriesByTarget
+            .filter { $0.value.fireAt <= now }
+            .map(\.key)
+        guard !dueTargets.isEmpty else { return false }
+
+        var scheduledAnyRefresh = false
+        for target in dueTargets {
+            guard let entry = workspacePullRequestShellRefreshEntriesByTarget.removeValue(forKey: target) else {
+                continue
+            }
+
+            var scheduledKeys: Set<WorkspaceGitProbeKey> = []
+            for key in entry.probeKeys {
+                guard workspacePullRequestShellRefreshTarget(for: key) == target else {
+                    continue
+                }
+                scheduledKeys.insert(key)
+                requestWorkspacePullRequestRefresh(
+                    key: key,
+                    reason: Self.workspacePullRequestQueuedShellTriggerReason,
+                    bypassRepoCache: entry.bypassRepoCache,
+                    triggerImmediateRefresh: false
+                )
+            }
+
+            scheduledAnyRefresh = scheduledAnyRefresh || !scheduledKeys.isEmpty
+
+#if DEBUG
+            dlog(
+                "workspace.prRefresh.queue.flush branch=\(target.branch) " +
+                "repos=\(target.repoSlugs.count) scheduled=\(scheduledKeys.count)"
+            )
+#endif
+        }
+
+        guard scheduledAnyRefresh else { return false }
+        refreshTrackedWorkspacePullRequestsIfNeeded(
+            reason: Self.workspacePullRequestQueuedShellTriggerReason,
+            allowCachedResultsOverride: false
+        )
+        return true
+    }
+
+    private func pruneWorkspacePullRequestShellRefreshQueue(validKeys: Set<WorkspaceGitProbeKey>) {
+        var prunedEntries: [WorkspacePullRequestShellRefreshTarget: WorkspacePullRequestShellRefreshEntry] = [:]
+
+        for (target, entry) in workspacePullRequestShellRefreshEntriesByTarget {
+            let matchingProbeKeys = entry.probeKeys.filter { key in
+                guard validKeys.contains(key) else { return false }
+                return workspacePullRequestShellRefreshTarget(for: key) == target
+            }
+            guard !matchingProbeKeys.isEmpty else { continue }
+
+            var nextEntry = entry
+            nextEntry.probeKeys = Set(matchingProbeKeys)
+            prunedEntries[target] = nextEntry
+        }
+
+        workspacePullRequestShellRefreshEntriesByTarget = prunedEntries
+    }
+
     private func pruneWorkspacePullRequestTracking(validKeys: Set<WorkspaceGitProbeKey>) {
         workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.filter { validKeys.contains($0.key) }
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { validKeys.contains($0.key) }
@@ -1530,6 +1756,7 @@ class TabManager: ObservableObject {
         workspacePullRequestRepoCacheBySlug = workspacePullRequestRepoCacheBySlug.filter {
             $0.value.fetchedAt >= repoCacheCutoff
         }
+        pruneWorkspacePullRequestShellRefreshQueue(validKeys: validKeys)
     }
 
     private func clearWorkspacePullRequestTracking(for key: WorkspaceGitProbeKey) {
@@ -1537,6 +1764,7 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey.removeValue(forKey: key)
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
         workspacePullRequestTransientFailureCountByKey.removeValue(forKey: key)
+        removeWorkspacePullRequestShellRefreshProbeKey(key)
     }
 
     private func clearWorkspacePullRequestTracking(workspaceId: UUID) {
@@ -1544,6 +1772,11 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { $0.key.workspaceId != workspaceId }
+        workspacePullRequestShellRefreshEntriesByTarget = workspacePullRequestShellRefreshEntriesByTarget.compactMapValues { entry in
+            var nextEntry = entry
+            nextEntry.probeKeys = Set(nextEntry.probeKeys.filter { $0.workspaceId != workspaceId })
+            return nextEntry.probeKeys.isEmpty ? nil : nextEntry
+        }
     }
 
     private func resetWorkspacePullRequestRefreshState() {
@@ -1554,6 +1787,7 @@ class TabManager: ObservableObject {
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeAll()
         workspacePullRequestTransientFailureCountByKey.removeAll()
         workspacePullRequestRepoCacheBySlug.removeAll()
+        workspacePullRequestShellRefreshEntriesByTarget.removeAll()
         workspacePullRequestFollowUpShouldBypassRepoCache = false
     }
 
@@ -1662,6 +1896,71 @@ class TabManager: ObservableObject {
         let probeKeys = Set(workspaceGitProbeStateByKey.keys.filter { $0.workspaceId == workspaceId })
             .union(workspaceGitProbeTimersByKey.keys.filter { $0.workspaceId == workspaceId })
         return Set(probeKeys.map(\.panelId))
+    }
+
+    @discardableResult
+    func queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+        workspaceId: UUID,
+        panelId: UUID,
+        reason: String,
+        now: Date
+    ) -> Bool {
+        queueWorkspacePullRequestShellRefreshIfNeeded(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            reason: reason,
+            now: now
+        )
+    }
+
+    @discardableResult
+    func flushQueuedWorkspacePullRequestShellRefreshesIfNeededForTesting(now: Date) -> Bool {
+        flushQueuedWorkspacePullRequestShellRefreshesIfNeeded(now: now)
+    }
+
+    func scheduleWorkspacePullRequestRefreshForTesting(
+        workspaceId: UUID,
+        panelId: UUID,
+        reason: String
+    ) {
+        scheduleWorkspacePullRequestRefresh(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            reason: reason
+        )
+    }
+
+    func workspacePullRequestShellRefreshQueueTargetsForTesting() -> [WorkspacePullRequestShellRefreshTarget] {
+        workspacePullRequestShellRefreshEntriesByTarget.keys.sorted {
+            let lhs = "\($0.branch)|\($0.repoSlugs.joined(separator: ","))"
+            let rhs = "\($1.branch)|\($1.repoSlugs.joined(separator: ","))"
+            return lhs < rhs
+        }
+    }
+
+    func workspacePullRequestShellRefreshQueueSnapshotForTesting() -> [(target: WorkspacePullRequestShellRefreshTarget, fireAt: Date, probeKeyCount: Int)] {
+        workspacePullRequestShellRefreshEntriesByTarget
+            .map { target, entry in
+                (
+                    target: target,
+                    fireAt: entry.fireAt,
+                    probeKeyCount: entry.probeKeys.count
+                )
+            }
+            .sorted {
+                let lhs = "\($0.target.branch)|\($0.target.repoSlugs.joined(separator: ","))"
+                let rhs = "\($1.target.branch)|\($1.target.repoSlugs.joined(separator: ","))"
+                return lhs < rhs
+            }
+    }
+
+    func workspacePullRequestNextPollAtForTesting(
+        workspaceId: UUID,
+        panelId: UUID
+    ) -> Date? {
+        workspacePullRequestNextPollAtByKey[
+            WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        ]
     }
 
     private func trackedWorkspaceGitMetadataPollCandidatePanelIds(
@@ -3622,6 +3921,9 @@ class TabManager: ObservableObject {
         tab.updatePanelDirectory(panelId: surfaceId, directory: normalized)
         let nextDirectory = normalizedWorkingDirectory(normalized)
         if previousDirectory != nextDirectory {
+            removeWorkspacePullRequestShellRefreshProbeKey(
+                WorkspaceGitProbeKey(workspaceId: tabId, panelId: surfaceId)
+            )
             scheduleWorkspacePullRequestRefresh(
                 workspaceId: tabId,
                 panelId: surfaceId,
@@ -3646,8 +3948,9 @@ class TabManager: ObservableObject {
         let normalizedBranch = Self.normalizedBranchName(branch) ?? branch
         guard current?.branch != normalizedBranch || current?.isDirty != isDirty else { return }
         tab.updatePanelGitBranch(panelId: surfaceId, branch: normalizedBranch, isDirty: isDirty)
+        let probeKey = WorkspaceGitProbeKey(workspaceId: tabId, panelId: surfaceId)
+        removeWorkspacePullRequestShellRefreshProbeKey(probeKey)
         if let directory = gitProbeDirectory(for: tab, panelId: surfaceId) {
-            let probeKey = WorkspaceGitProbeKey(workspaceId: tabId, panelId: surfaceId)
             workspaceGitTrackedDirectoryByKey[probeKey] = directory
         }
         scheduleWorkspacePullRequestRefresh(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -992,7 +992,7 @@ class TabManager: ObservableObject {
     private var workspacePullRequestShellRefreshEntriesByTarget: [WorkspacePullRequestShellRefreshTarget: WorkspacePullRequestShellRefreshEntry] = [:]
     private var workspacePullRequestPollTimer: DispatchSourceTimer?
     private var workspacePullRequestRefreshTask: Task<Void, Never>?
-    private var workspacePullRequestFollowUpShouldBypassRepoCache = false
+    private var workspacePullRequestFollowUpBypassRepoCacheSlugs: Set<String> = []
 
     // Recent tab history for back/forward navigation (like browser history)
     private var tabHistory: [UUID] = []
@@ -1204,7 +1204,7 @@ class TabManager: ObservableObject {
 
     private func refreshTrackedWorkspacePullRequestsIfNeeded(
         reason: String,
-        allowCachedResultsOverride: Bool? = nil
+        bypassRepoCacheForSlugs: Set<String> = []
     ) {
         let now = Date()
         var candidates: [WorkspacePullRequestCandidate] = []
@@ -1273,15 +1273,15 @@ class TabManager: ObservableObject {
         }
 
         let cacheBySlug = workspacePullRequestRepoCacheBySlug
-        let allowCachedResults = allowCachedResultsOverride
-            ?? Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
+        let reasonAllowsCachedResults = Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
         workspacePullRequestRefreshTask = Task { [weak self] in
             let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
                 repoDirectoriesBySlug: repoDirectoriesBySlug,
                 candidateBranchesByRepo: candidateBranchesByRepo,
                 cacheBySlug: cacheBySlug,
                 now: now,
-                allowCachedResults: allowCachedResults
+                reasonAllowsCachedResults: reasonAllowsCachedResults,
+                bypassRepoCacheForSlugs: bypassRepoCacheForSlugs
             )
             let results = Self.resolveWorkspacePullRequestRefreshResults(
                 candidates: candidates,
@@ -1406,16 +1406,18 @@ class TabManager: ObservableObject {
         let bypassRepoCache = !Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
         removeWorkspacePullRequestShellRefreshProbeKey(key)
 
+        let fireAt = now.addingTimeInterval(
+            TimeInterval(SidebarPullRequestShellDebounceSettings.delaySeconds())
+        )
         if var existingEntry = workspacePullRequestShellRefreshEntriesByTarget[target] {
             existingEntry.probeKeys.insert(key)
+            existingEntry.fireAt = fireAt
             existingEntry.bypassRepoCache = existingEntry.bypassRepoCache || bypassRepoCache
             workspacePullRequestShellRefreshEntriesByTarget[target] = existingEntry
         } else {
             workspacePullRequestShellRefreshEntriesByTarget[target] = WorkspacePullRequestShellRefreshEntry(
                 probeKeys: [key],
-                fireAt: now.addingTimeInterval(
-                    TimeInterval(SidebarPullRequestShellDebounceSettings.delaySeconds())
-                ),
+                fireAt: fireAt,
                 bypassRepoCache: bypassRepoCache
             )
         }
@@ -1440,8 +1442,11 @@ class TabManager: ObservableObject {
         bypassRepoCache: Bool,
         triggerImmediateRefresh: Bool = true
     ) {
+        let bypassSlugs: Set<String> = bypassRepoCache
+            ? Set(workspacePullRequestShellRefreshTarget(for: key)?.repoSlugs ?? [])
+            : []
         if bypassRepoCache, workspacePullRequestRefreshTask != nil {
-            workspacePullRequestFollowUpShouldBypassRepoCache = true
+            workspacePullRequestFollowUpBypassRepoCacheSlugs.formUnion(bypassSlugs)
         }
         if case .inFlight = workspacePullRequestProbeStateByKey[key] {
             markWorkspacePullRequestProbeRerunPending(
@@ -1458,10 +1463,9 @@ class TabManager: ObservableObject {
         )
 #endif
         guard triggerImmediateRefresh else { return }
-        let allowCachedResultsOverride = bypassRepoCache ? false : nil
         refreshTrackedWorkspacePullRequestsIfNeeded(
             reason: reason,
-            allowCachedResultsOverride: allowCachedResultsOverride
+            bypassRepoCacheForSlugs: bypassSlugs
         )
     }
 
@@ -1511,11 +1515,11 @@ class TabManager: ObservableObject {
 
         defer {
             if needsFollowUpPass {
-                let shouldBypassRepoCache = workspacePullRequestFollowUpShouldBypassRepoCache
-                workspacePullRequestFollowUpShouldBypassRepoCache = false
+                let bypassSlugs = workspacePullRequestFollowUpBypassRepoCacheSlugs
+                workspacePullRequestFollowUpBypassRepoCacheSlugs.removeAll()
                 refreshTrackedWorkspacePullRequestsIfNeeded(
                     reason: "\(reason).followUp",
-                    allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
+                    bypassRepoCacheForSlugs: bypassSlugs
                 )
             }
         }
@@ -1534,8 +1538,10 @@ class TabManager: ObservableObject {
             }
 
             if rerunPending,
-               workspacePullRequestFollowUpShouldBypassRepoCache,
-               result.usedCachedRepoData {
+               !workspacePullRequestFollowUpBypassRepoCacheSlugs.isEmpty,
+               result.usedCachedRepoData,
+               let target = workspacePullRequestShellRefreshTarget(for: key),
+               target.repoSlugs.contains(where: workspacePullRequestFollowUpBypassRepoCacheSlugs.contains) {
                 continue
             }
 
@@ -1677,21 +1683,13 @@ class TabManager: ObservableObject {
             return false
         }
 
-        var validKeys = Set(workspacePullRequestNextPollAtByKey.keys)
-        validKeys.formUnion(workspacePullRequestProbeStateByKey.keys)
-        for workspace in tabs {
-            for panelId in Set(workspace.panelGitBranches.keys).union(workspace.panelPullRequests.keys) {
-                validKeys.insert(WorkspaceGitProbeKey(workspaceId: workspace.id, panelId: panelId))
-            }
-        }
-        pruneWorkspacePullRequestShellRefreshQueue(validKeys: validKeys)
-
         let dueTargets = workspacePullRequestShellRefreshEntriesByTarget
             .filter { $0.value.fireAt <= now }
             .map(\.key)
         guard !dueTargets.isEmpty else { return false }
 
         var scheduledAnyRefresh = false
+        var bypassRepoCacheForSlugs: Set<String> = []
         for target in dueTargets {
             guard let entry = workspacePullRequestShellRefreshEntriesByTarget.removeValue(forKey: target) else {
                 continue
@@ -1711,7 +1709,12 @@ class TabManager: ObservableObject {
                 )
             }
 
-            scheduledAnyRefresh = scheduledAnyRefresh || !scheduledKeys.isEmpty
+            if !scheduledKeys.isEmpty {
+                scheduledAnyRefresh = true
+                if entry.bypassRepoCache {
+                    bypassRepoCacheForSlugs.formUnion(target.repoSlugs)
+                }
+            }
 
 #if DEBUG
             dlog(
@@ -1724,7 +1727,7 @@ class TabManager: ObservableObject {
         guard scheduledAnyRefresh else { return false }
         refreshTrackedWorkspacePullRequestsIfNeeded(
             reason: Self.workspacePullRequestQueuedShellTriggerReason,
-            allowCachedResultsOverride: false
+            bypassRepoCacheForSlugs: bypassRepoCacheForSlugs
         )
         return true
     }
@@ -1733,10 +1736,7 @@ class TabManager: ObservableObject {
         var prunedEntries: [WorkspacePullRequestShellRefreshTarget: WorkspacePullRequestShellRefreshEntry] = [:]
 
         for (target, entry) in workspacePullRequestShellRefreshEntriesByTarget {
-            let matchingProbeKeys = entry.probeKeys.filter { key in
-                guard validKeys.contains(key) else { return false }
-                return workspacePullRequestShellRefreshTarget(for: key) == target
-            }
+            let matchingProbeKeys = entry.probeKeys.filter(validKeys.contains)
             guard !matchingProbeKeys.isEmpty else { continue }
 
             var nextEntry = entry
@@ -1788,7 +1788,7 @@ class TabManager: ObservableObject {
         workspacePullRequestTransientFailureCountByKey.removeAll()
         workspacePullRequestRepoCacheBySlug.removeAll()
         workspacePullRequestShellRefreshEntriesByTarget.removeAll()
-        workspacePullRequestFollowUpShouldBypassRepoCache = false
+        workspacePullRequestFollowUpBypassRepoCacheSlugs.removeAll()
     }
 
     private var activeWorkspaceGitProbeKeys: Set<WorkspaceGitProbeKey> {
@@ -1817,17 +1817,16 @@ class TabManager: ObservableObject {
         for key: WorkspaceGitProbeKey,
         bypassRepoCache: Bool
     ) {
+        let bypassSlugs: Set<String> = bypassRepoCache
+            ? Set(workspacePullRequestShellRefreshTarget(for: key)?.repoSlugs ?? [])
+            : []
         guard case .inFlight(let rerunPending) = workspacePullRequestProbeStateByKey[key],
               !rerunPending else {
-            if bypassRepoCache {
-                workspacePullRequestFollowUpShouldBypassRepoCache = true
-            }
+            workspacePullRequestFollowUpBypassRepoCacheSlugs.formUnion(bypassSlugs)
             return
         }
         workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: true)
-        if bypassRepoCache {
-            workspacePullRequestFollowUpShouldBypassRepoCache = true
-        }
+        workspacePullRequestFollowUpBypassRepoCacheSlugs.formUnion(bypassSlugs)
     }
 
     private func workspacePullRequestProbeRerunPending(for key: WorkspaceGitProbeKey) -> Bool {
@@ -2710,7 +2709,8 @@ class TabManager: ObservableObject {
         candidateBranchesByRepo: [String: Set<String>],
         cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
         now: Date,
-        allowCachedResults: Bool
+        reasonAllowsCachedResults: Bool,
+        bypassRepoCacheForSlugs: Set<String>
     ) async -> [String: WorkspacePullRequestRepoFetchResult] {
         guard !repoDirectoriesBySlug.isEmpty else { return [:] }
 
@@ -2727,6 +2727,8 @@ class TabManager: ObservableObject {
         ) { group in
             for repoSlug in repoDirectoriesBySlug.keys {
                 group.addTask {
+                    let allowCachedResults = reasonAllowsCachedResults
+                        && !bypassRepoCacheForSlugs.contains(repoSlug)
                     let result = await Self.workspacePullRequestRepoFetchResult(
                         repoSlug: repoSlug,
                         candidateBranches: candidateBranchesByRepo[repoSlug] ?? [],

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4109,6 +4109,25 @@ enum GeminiIntegrationSettings {
     }
 }
 
+enum SidebarPullRequestShellDebounceSettings {
+    static let enabledKey = "sidebarPullRequestShellDebounceEnabled"
+    static let delaySecondsKey = "sidebarPullRequestShellDebounceSeconds"
+    static let defaultEnabled = false
+    static let defaultDelaySeconds = 5
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+
+    static func delaySeconds(defaults: UserDefaults = .standard) -> Int {
+        guard let value = defaults.object(forKey: delaySecondsKey) as? Int,
+              value > 0 else {
+            return defaultDelaySeconds
+        }
+        return value
+    }
+}
+
 enum WelcomeSettings {
     static let shownKey = "cmuxWelcomeShown"
 }
@@ -4390,6 +4409,10 @@ struct SettingsView: View {
     private var cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
     @AppStorage(GeminiIntegrationSettings.hooksEnabledKey)
     private var geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
+    @AppStorage(SidebarPullRequestShellDebounceSettings.enabledKey)
+    private var sidebarPullRequestShellDebounceEnabled = SidebarPullRequestShellDebounceSettings.defaultEnabled
+    @AppStorage(SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+    private var sidebarPullRequestShellDebounceDelaySeconds = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
@@ -5913,6 +5936,38 @@ struct SettingsView: View {
                     }
 
                     SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("automation.sidebarPullRequestShellDebounceEnabled"),
+                            String(localized: "settings.automation.pullRequestShellDebounce", defaultValue: "Delay Shell PR Refreshes"),
+                            subtitle: sidebarPullRequestShellDebounceEnabled
+                                ? String(localized: "settings.automation.pullRequestShellDebounce.subtitleOn", defaultValue: "Shell-triggered sidebar pull request refreshes are delayed and coalesced before checking GitHub.")
+                                : String(localized: "settings.automation.pullRequestShellDebounce.subtitleOff", defaultValue: "Shell-triggered sidebar pull request refreshes check GitHub immediately.")
+                        ) {
+                            Toggle("", isOn: $sidebarPullRequestShellDebounceEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("automation.sidebarPullRequestShellDebounceSeconds"),
+                            String(localized: "settings.automation.pullRequestShellDebounce.delay", defaultValue: "PR Refresh Delay"),
+                            subtitle: String(localized: "settings.automation.pullRequestShellDebounce.delay.subtitle", defaultValue: "Delay shell-triggered pull request refreshes by this many seconds before checking GitHub."),
+                            controlWidth: pickerColumnWidth
+                        ) {
+                            TextField("", value: $sidebarPullRequestShellDebounceDelaySeconds, format: .number)
+                                .textFieldStyle(.roundedBorder)
+                                .multilineTextAlignment(.trailing)
+                                .disabled(!sidebarPullRequestShellDebounceEnabled)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardNote(String(localized: "settings.automation.pullRequestShellDebounce.note", defaultValue: "Applies to shell prompt and command-hint pull request refreshes. Matching repo and branch targets share one queued refresh window."))
+                    }
+
+                    SettingsCard {
                         SettingsCardRow(configurationReview: .json("automation.portBase"), String(localized: "settings.automation.portBase", defaultValue: "Port Base"), subtitle: String(localized: "settings.automation.portBase.subtitle", defaultValue: "Starting port for CMUX_PORT env var."), controlWidth: pickerColumnWidth) {
                             TextField("", value: $cmuxPortBase, format: .number)
                                 .textFieldStyle(.roundedBorder)
@@ -6419,6 +6474,10 @@ struct SettingsView: View {
         .onChange(of: notificationSoundCustomFilePath) { _, _ in
             refreshNotificationCustomSoundStatus()
         }
+        .onChange(of: sidebarPullRequestShellDebounceDelaySeconds) { _, newValue in
+            guard newValue <= 0 else { return }
+            sidebarPullRequestShellDebounceDelaySeconds = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
+        }
         .onChange(of: browserInsecureHTTPAllowlist) { oldValue, newValue in
             // Keep draft in sync with external changes unless the user has local unsaved edits.
             if browserInsecureHTTPAllowlistDraft == oldValue {
@@ -6524,6 +6583,8 @@ struct SettingsView: View {
         customClaudePath = ""
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
+        sidebarPullRequestShellDebounceEnabled = SidebarPullRequestShellDebounceSettings.defaultEnabled
+        sidebarPullRequestShellDebounceDelaySeconds = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         preferredEditorCommand = ""
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4880,6 +4880,11 @@ struct SettingsView: View {
         )
     }
 
+    private func normalizeSidebarPullRequestShellDebounceDelayIfNeeded() {
+        guard sidebarPullRequestShellDebounceDelaySeconds <= 0 else { return }
+        sidebarPullRequestShellDebounceDelaySeconds = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
+    }
+
     private func refreshNotificationCustomSoundStatus(showAlertOnFailure: Bool = false) {
         guard notificationSound == NotificationSoundSettings.customFileValue else {
             notificationCustomSoundStatusMessage = nil
@@ -6467,6 +6472,7 @@ struct SettingsView: View {
             refreshDetectedImportBrowsers()
             reloadWorkspaceTabColorSettings()
             refreshNotificationCustomSoundStatus()
+            normalizeSidebarPullRequestShellDebounceDelayIfNeeded()
         }
         .onChange(of: notificationSound) { _, _ in
             refreshNotificationCustomSoundStatus()
@@ -6474,9 +6480,8 @@ struct SettingsView: View {
         .onChange(of: notificationSoundCustomFilePath) { _, _ in
             refreshNotificationCustomSoundStatus()
         }
-        .onChange(of: sidebarPullRequestShellDebounceDelaySeconds) { _, newValue in
-            guard newValue <= 0 else { return }
-            sidebarPullRequestShellDebounceDelaySeconds = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
+        .onChange(of: sidebarPullRequestShellDebounceDelaySeconds) { _, _ in
+            normalizeSidebarPullRequestShellDebounceDelayIfNeeded()
         }
         .onChange(of: browserInsecureHTTPAllowlist) { oldValue, newValue in
             // Keep draft in sync with external changes unless the user has local unsaved edits.

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -301,6 +301,32 @@ final class TabManagerWorkspaceOwnershipTests: XCTestCase {
 
 @MainActor
 final class TabManagerPullRequestProbeTests: XCTestCase {
+    private func withSidebarPullRequestShellDebounceSettings(
+        enabled: Bool,
+        delaySeconds: Int = SidebarPullRequestShellDebounceSettings.defaultDelaySeconds,
+        _ body: () -> Void
+    ) {
+        let defaults = UserDefaults.standard
+        let previousEnabled = defaults.object(forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+        let previousDelay = defaults.object(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        defer {
+            if let previousEnabled {
+                defaults.set(previousEnabled, forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+            } else {
+                defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+            }
+            if let previousDelay {
+                defaults.set(previousDelay, forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            } else {
+                defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            }
+        }
+
+        defaults.set(enabled, forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+        defaults.set(delaySeconds, forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        body()
+    }
+
     func testGitHubRepositorySlugsPrioritizeUpstreamThenOriginAndDeduplicate() {
         let output = """
         origin https://github.com/austinwang/cmux.git (fetch)
@@ -416,6 +442,238 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "branchChange.followUp"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "shellPrompt"))
         XCTAssertFalse(TabManager.workspacePullRequestRefreshAllowsRepoCache(reason: "commandHint:merge"))
+    }
+
+    func testScheduleWorkspacePullRequestRefreshRunsImmediatelyWhenShellDebounceDisabled() {
+        withSidebarPullRequestShellDebounceSettings(enabled: false) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let panelId = workspace.focusedPanelId else {
+                XCTFail("Expected selected workspace with focused panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: panelId, branch: "feature/work", isDirty: false)
+
+            manager.scheduleWorkspacePullRequestRefreshForTesting(
+                workspaceId: workspace.id,
+                panelId: panelId,
+                reason: "shellPrompt"
+            )
+
+            XCTAssertTrue(manager.workspacePullRequestShellRefreshQueueSnapshotForTesting().isEmpty)
+            XCTAssertEqual(
+                manager.workspacePullRequestNextPollAtForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId
+                ),
+                .distantPast
+            )
+        }
+    }
+
+    func testShellDebounceQueuesSameTargetWithinFixedWindow() {
+        withSidebarPullRequestShellDebounceSettings(enabled: true, delaySeconds: 5) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let panelId = workspace.focusedPanelId else {
+                XCTFail("Expected selected workspace with focused panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: panelId, branch: "feature/work", isDirty: false)
+            let now = Date(timeIntervalSince1970: 1_000)
+
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    reason: "commandHint:merge",
+                    now: now
+                )
+            )
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    reason: "shellPrompt",
+                    now: now.addingTimeInterval(2)
+                )
+            )
+
+            let snapshot = manager.workspacePullRequestShellRefreshQueueSnapshotForTesting()
+            XCTAssertEqual(snapshot.count, 1)
+            XCTAssertEqual(
+                snapshot.first?.target,
+                TabManager.workspacePullRequestShellRefreshTarget(
+                    branch: "feature/work",
+                    repoSlugs: []
+                )
+            )
+            XCTAssertEqual(snapshot.first?.probeKeyCount, 1)
+            XCTAssertEqual(snapshot.first?.fireAt, now.addingTimeInterval(5))
+            XCTAssertNil(
+                manager.workspacePullRequestNextPollAtForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId
+                )
+            )
+        }
+    }
+
+    func testShellDebounceCoalescesAcrossPanelsForSameProbeTarget() {
+        withSidebarPullRequestShellDebounceSettings(enabled: true, delaySeconds: 5) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let firstPanelId = workspace.focusedPanelId,
+                  let secondPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal) else {
+                XCTFail("Expected selected workspace with split panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: firstPanelId, branch: "feature/shared", isDirty: false)
+            workspace.updatePanelGitBranch(panelId: secondPanel.id, branch: "feature/shared", isDirty: false)
+            let now = Date(timeIntervalSince1970: 1_000)
+
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: firstPanelId,
+                    reason: "shellPrompt",
+                    now: now
+                )
+            )
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: secondPanel.id,
+                    reason: "commandHint:merge",
+                    now: now.addingTimeInterval(1)
+                )
+            )
+
+            let snapshot = manager.workspacePullRequestShellRefreshQueueSnapshotForTesting()
+            XCTAssertEqual(snapshot.count, 1)
+            XCTAssertEqual(snapshot.first?.probeKeyCount, 2)
+        }
+    }
+
+    func testShellDebounceKeepsDifferentProbeTargetsSeparate() {
+        withSidebarPullRequestShellDebounceSettings(enabled: true, delaySeconds: 5) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let firstPanelId = workspace.focusedPanelId,
+                  let secondPanel = workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal) else {
+                XCTFail("Expected selected workspace with split panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: firstPanelId, branch: "feature/one", isDirty: false)
+            workspace.updatePanelGitBranch(panelId: secondPanel.id, branch: "feature/two", isDirty: false)
+            let now = Date(timeIntervalSince1970: 1_000)
+
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: firstPanelId,
+                    reason: "shellPrompt",
+                    now: now
+                )
+            )
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: secondPanel.id,
+                    reason: "commandHint:view",
+                    now: now
+                )
+            )
+
+            let targets = manager.workspacePullRequestShellRefreshQueueTargetsForTesting()
+            XCTAssertEqual(targets.count, 2)
+            XCTAssertEqual(Set(targets.map(\.branch)), Set(["feature/one", "feature/two"]))
+        }
+    }
+
+    func testShellDebounceFlushesDueEntriesOnceAndClearsQueue() {
+        withSidebarPullRequestShellDebounceSettings(enabled: true, delaySeconds: 5) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let panelId = workspace.focusedPanelId else {
+                XCTFail("Expected selected workspace with focused panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: panelId, branch: "feature/work", isDirty: false)
+            let now = Date(timeIntervalSince1970: 1_000)
+
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    reason: "shellPrompt",
+                    now: now
+                )
+            )
+            XCTAssertFalse(
+                manager.flushQueuedWorkspacePullRequestShellRefreshesIfNeededForTesting(
+                    now: now.addingTimeInterval(4)
+                )
+            )
+            XCTAssertEqual(manager.workspacePullRequestShellRefreshQueueSnapshotForTesting().count, 1)
+
+            XCTAssertTrue(
+                manager.flushQueuedWorkspacePullRequestShellRefreshesIfNeededForTesting(
+                    now: now.addingTimeInterval(5)
+                )
+            )
+            XCTAssertTrue(manager.workspacePullRequestShellRefreshQueueSnapshotForTesting().isEmpty)
+            XCTAssertEqual(
+                manager.workspacePullRequestNextPollAtForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId
+                ),
+                .distantPast
+            )
+        }
+    }
+
+    func testShellDebounceSkipsStaleQueuedEntryAfterBranchChanges() {
+        withSidebarPullRequestShellDebounceSettings(enabled: true, delaySeconds: 5) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let panelId = workspace.focusedPanelId else {
+                XCTFail("Expected selected workspace with focused panel")
+                return
+            }
+
+            workspace.updatePanelGitBranch(panelId: panelId, branch: "feature/old", isDirty: false)
+            let now = Date(timeIntervalSince1970: 1_000)
+
+            XCTAssertTrue(
+                manager.queueWorkspacePullRequestShellRefreshIfNeededForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    reason: "commandHint:merge",
+                    now: now
+                )
+            )
+
+            workspace.updatePanelGitBranch(panelId: panelId, branch: "feature/new", isDirty: false)
+
+            XCTAssertFalse(
+                manager.flushQueuedWorkspacePullRequestShellRefreshesIfNeededForTesting(
+                    now: now.addingTimeInterval(5)
+                )
+            )
+            XCTAssertTrue(manager.workspacePullRequestShellRefreshQueueSnapshotForTesting().isEmpty)
+            XCTAssertNil(
+                manager.workspacePullRequestNextPollAtForTesting(
+                    workspaceId: workspace.id,
+                    panelId: panelId
+                )
+            )
+        }
     }
 
     func testWorkspacePullRequestShouldRefreshHonorsForcedRefreshForTerminalStates() {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -827,6 +827,8 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertTrue(contents.contains(#"//   "app" : {"#))
         XCTAssertTrue(contents.contains(#"//     "colors" : {"#))
         XCTAssertTrue(contents.contains(##"//       "Red" : "#C0392B""##))
+        XCTAssertTrue(contents.contains(#""sidebarPullRequestShellDebounceEnabled""#))
+        XCTAssertTrue(contents.contains(#""sidebarPullRequestShellDebounceSeconds""#))
         XCTAssertTrue(contents.contains(#"//   "shortcuts" : {"#))
     }
 
@@ -990,6 +992,107 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(
             store.override(for: .showNotifications),
             StoredShortcut(key: "i", command: true, shift: false, option: false, control: false)
+        )
+    }
+
+    func testSettingsFileStoreAppliesSidebarPullRequestShellDebounceSettings() throws {
+        let defaults = UserDefaults.standard
+        let previousEnabled = defaults.object(forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+        let previousDelay = defaults.object(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousEnabled {
+                defaults.set(previousEnabled, forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+            } else {
+                defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+            }
+            if let previousDelay {
+                defaults.set(previousDelay, forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            } else {
+                defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.enabledKey)
+        defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "automation": {
+                "sidebarPullRequestShellDebounceEnabled": true,
+                "sidebarPullRequestShellDebounceSeconds": 9
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(defaults.object(forKey: SidebarPullRequestShellDebounceSettings.enabledKey) as? Bool, true)
+        XCTAssertEqual(defaults.object(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey) as? Int, 9)
+    }
+
+    func testSidebarPullRequestShellDebounceDelayFallsBackToDefaultForInvalidManagedValue() throws {
+        let defaults = UserDefaults.standard
+        let previousDelay = defaults.object(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousDelay {
+                defaults.set(previousDelay, forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            } else {
+                defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "automation": {
+                "sidebarPullRequestShellDebounceSeconds": 0
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertNil(defaults.object(forKey: SidebarPullRequestShellDebounceSettings.delaySecondsKey))
+        XCTAssertEqual(
+            SidebarPullRequestShellDebounceSettings.delaySeconds(defaults: defaults),
+            SidebarPullRequestShellDebounceSettings.defaultDelaySeconds
         )
     }
 

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -402,6 +402,17 @@
           "default": "",
           "description": "Custom path to the claude binary."
         },
+        "sidebarPullRequestShellDebounceEnabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Delay and coalesce shell-triggered sidebar pull request refreshes before checking GitHub."
+        },
+        "sidebarPullRequestShellDebounceSeconds": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 5,
+          "description": "Delay window in seconds for shell-triggered sidebar pull request refreshes."
+        },
         "portBase": {
           "type": "integer",
           "minimum": 1,


### PR DESCRIPTION
Add an optional automation setting that queues shell-prompt and command-hint PR refreshes for a configurable delay, coalescing matching branch+repo targets into a single GitHub round-trip. Default is off; when enabled, the poll timer flushes due entries before falling back to the regular refresh path.

## Summary

- What changed?
Adds an automation setting Delay Shell PR Refreshes
  (automation.sidebarPullRequestShellDebounce{Enabled,Seconds}, default off, 5 s when
  on).

  When enabled, sidebar PR refreshes triggered by shell prompt or command-hint events are
   queued instead of fired immediately. Matching (branch, repoSlugs) targets across
  panels/tabs are coalesced into one queued window, then flushed by the existing PR poll
  timer into a single GitHub round-trip with allowCachedResults=false.

- Why?
Shell prompt and command-hint hooks fire often (every prompt, every git-adjacent
  command). Each one was scheduling an immediate gh round-trip even when several panels
  share the same branch. The debounce window collapses the burst into a single network
  call per branch+repo group, cutting GitHub API usage on heavy shell activity.
  Off-by-default keeps existing latency for users who want immediate refresh.


## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an optional debounce for shell‑triggered sidebar PR refreshes to cut redundant GitHub calls. Matching branch+repo targets queue for a short window (default 5s) and flush before the normal poll; cache bypass is scoped to the affected repos only.

- **New Features**
  - Added “Delay Shell PR Refreshes” in Settings > Automation with a numeric “PR Refresh Delay.” Keys: `automation.sidebarPullRequestShellDebounceEnabled` and `automation.sidebarPullRequestShellDebounceSeconds` (min 1, default 5). Localized strings, schema, and settings UI updated.
  - Tab manager queues shell prompt and `command-hint` PR refreshes by (branch, repo slugs), coalesces across panels/tabs, and flushes due entries before the normal poll. Flush bypasses the repo cache only for the queued repos. Queue is pruned on branch/directory changes. No behavior change unless enabled.

- **Bug Fixes**
  - Scoped cache-bypass handling per repo slug so a bypass for one repo doesn’t force fresh fetches for all repos.
  - Settings parsing no longer stops after one invalid automation field, and the debounce delay value is normalized on initial load.

<sup>Written for commit 4aab2d525e3d8ad13c5cf51780a14ba767fb55b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pull request refresh debouncing setting in Automation preferences (toggle + configurable delay, default 5s) to coalesce sidebar refreshes triggered by shell prompts/command hints.
* **Behavior**
  * Shell-triggered PR refreshes now queue and coalesce per target, flushing after the configured delay to reduce redundant checks.
* **Localization**
  * Added English and Japanese strings for the new automation settings and explanatory notes.
* **Tests**
  * Added unit tests covering debouncing, coalescing, flushing, and settings parsing.
* **Documentation**
  * Updated settings schema to include the new automation fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->