### PR TITLE
feat: horizontal workspace tabs when sidebar is hidden

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -152,6 +152,7 @@
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 		F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */; };
 		F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
+		07B1DAD01CD540A684A61309 /* CollapsedWorkspaceTabsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F3D02AEBFF24368811E0EE5 /* CollapsedWorkspaceTabsTests.swift */; };
 		F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 		F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */; };
 		FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
@@ -377,6 +378,7 @@
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteConnectionTests.swift; sourceTree = "<group>"; };
 		F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
+		7F3D02AEBFF24368811E0EE5 /* CollapsedWorkspaceTabsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CollapsedWorkspaceTabsTests.swift; sourceTree = "<group>"; };
 		F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 		F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyEnsureFocusWindowActivationTests.swift; sourceTree = "<group>"; };
 		FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
@@ -628,6 +630,7 @@
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
+				7F3D02AEBFF24368811E0EE5 /* CollapsedWorkspaceTabsTests.swift */,
 				F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 				F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
 				F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */,
@@ -1026,6 +1029,7 @@
 				F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
 				F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
+				07B1DAD01CD540A684A61309 /* CollapsedWorkspaceTabsTests.swift in Sources */,
 				F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1587,6 +1587,7 @@ private struct CollapsedWorkspaceTabItem: View {
 
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovering = false
+    @State private var didPushCursor = false
 
     private var tabCount: Int { tabManager.tabs.count }
 
@@ -1662,6 +1663,7 @@ private struct CollapsedWorkspaceTabItem: View {
         .onHover { isHovering = $0 }
         .onDrag {
             NSCursor.closedHand.push()
+            didPushCursor = true
             draggedTabId = tab.id
             return SidebarTabDragPayload.provider(for: tab.id)
         } preview: {
@@ -1671,8 +1673,9 @@ private struct CollapsedWorkspaceTabItem: View {
             targetTabId: tab.id, tabManager: tabManager, draggedTabId: $draggedTabId
         ))
         .onChange(of: draggedTabId) { newValue in
-            if newValue == nil {
+            if newValue == nil && didPushCursor {
                 NSCursor.pop()
+                didPushCursor = false
             }
         }
         .contextMenu { collapsedTabContextMenu }
@@ -3002,6 +3005,8 @@ struct ContentView: View {
         }
     }
 
+    @State private var collapsedTabDragMonitor: Any?
+
     private var collapsedWorkspaceTabs: some View {
         let tabs = tabManager.tabs
         let selectedId = tabManager.selectedTabId
@@ -3022,6 +3027,27 @@ struct ContentView: View {
                     onClose: { tabManager.closeWorkspaceWithConfirmation(tab) }
                 )
                 .frame(maxWidth: .infinity)
+            }
+        }
+        .onChange(of: collapsedTabDraggedId) { newValue in
+            if newValue != nil {
+                // Install failsafe monitor for drag cancel (Escape key or mouse-up outside targets).
+                // After a short delay, if draggedTabId is still set, clear it to reset cursor state.
+                let escapeKeyCode: UInt16 = 53
+                collapsedTabDragMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp, .keyDown]) { event in
+                    let shouldClear = event.type == .leftMouseUp || (event.type == .keyDown && event.keyCode == escapeKeyCode)
+                    if shouldClear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                            collapsedTabDraggedId = nil
+                        }
+                    }
+                    return event
+                }
+            } else {
+                if let monitor = collapsedTabDragMonitor {
+                    NSEvent.removeMonitor(monitor)
+                    collapsedTabDragMonitor = nil
+                }
             }
         }
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1588,6 +1588,7 @@ private struct CollapsedWorkspaceTabItem: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var isHovering = false
     @State private var didPushCursor = false
+    @State private var workspaceObservationGeneration: UInt64 = 0
 
     private var tabCount: Int { tabManager.tabs.count }
 
@@ -1612,6 +1613,7 @@ private struct CollapsedWorkspaceTabItem: View {
     }
 
     var body: some View {
+        let _ = workspaceObservationGeneration
         HStack(spacing: 0) {
             if let shortcutLabel {
                 Text(shortcutLabel)
@@ -1679,6 +1681,12 @@ private struct CollapsedWorkspaceTabItem: View {
             }
         }
         .contextMenu { collapsedTabContextMenu }
+        .onReceive(
+            tab.sidebarImmediateObservationPublisher
+                .receive(on: RunLoop.main)
+        ) { _ in
+            workspaceObservationGeneration &+= 1
+        }
     }
 
     // MARK: - Context Menu

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1655,6 +1655,7 @@ private struct CollapsedWorkspaceTabItem: View {
             }
             .buttonStyle(.plain)
             .opacity(isHovering && canClose ? 1 : 0)
+            .allowsHitTesting(isHovering && canClose)
             .frame(width: 20, alignment: .center)
             .padding(.trailing, 4)
         }
@@ -3013,7 +3014,7 @@ struct ContentView: View {
         }
     }
 
-    @State private var collapsedTabDragMonitor: Any?
+    @StateObject private var collapsedTabDragFailsafe = SidebarDragFailsafeMonitor()
 
     private var collapsedWorkspaceTabs: some View {
         let tabs = tabManager.tabs
@@ -3037,26 +3038,18 @@ struct ContentView: View {
                 .frame(maxWidth: .infinity)
             }
         }
+        .onDisappear {
+            collapsedTabDragFailsafe.stop()
+            collapsedTabDraggedId = nil
+        }
         .onChange(of: collapsedTabDraggedId) { newValue in
             if newValue != nil {
-                // Install failsafe monitor for drag cancel (Escape key or mouse-up outside targets).
-                // After a short delay, if draggedTabId is still set, clear it to reset cursor state.
-                let escapeKeyCode: UInt16 = 53
-                collapsedTabDragMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseUp, .keyDown]) { event in
-                    let shouldClear = event.type == .leftMouseUp || (event.type == .keyDown && event.keyCode == escapeKeyCode)
-                    if shouldClear {
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-                            collapsedTabDraggedId = nil
-                        }
-                    }
-                    return event
+                collapsedTabDragFailsafe.start { _ in
+                    collapsedTabDraggedId = nil
                 }
-            } else {
-                if let monitor = collapsedTabDragMonitor {
-                    NSEvent.removeMonitor(monitor)
-                    collapsedTabDragMonitor = nil
-                }
+                return
             }
+            collapsedTabDragFailsafe.stop()
         }
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1517,6 +1517,332 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
     }
 }
 
+// MARK: - Collapsed Workspace Tabs Policy
+
+enum CollapsedWorkspaceTabsPolicy {
+    /// Whether horizontal collapsed tabs should be shown in the titlebar.
+    static func shouldShowCollapsedTabs(sidebarVisible: Bool, workspaceCount: Int) -> Bool {
+        !sidebarVisible && workspaceCount > 1
+    }
+
+    /// Whether the titlebar bottom separator should be visible.
+    static func shouldShowTitlebarSeparator(sidebarVisible: Bool, workspaceCount: Int) -> Bool {
+        sidebarVisible || workspaceCount <= 1
+    }
+
+    /// Resolve the foreground color for a collapsed tab element.
+    static func foregroundNSColor(isActive: Bool, opacity: CGFloat, colorScheme: ColorScheme) -> NSColor {
+        isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(opacity: opacity)
+            : NSColor.secondaryLabelColor.withAlphaComponent(opacity)
+    }
+
+    /// Resolve the background color for a collapsed tab.
+    static func backgroundNSColor(isActive: Bool, colorScheme: ColorScheme) -> NSColor {
+        isActive
+            ? sidebarSelectedWorkspaceBackgroundNSColor(for: colorScheme)
+            : .clear
+    }
+}
+
+// MARK: - Collapsed Workspace Tab Item
+
+private struct CollapsedTabDropDelegate: DropDelegate {
+    let targetTabId: UUID
+    let tabManager: TabManager
+    @Binding var draggedTabId: UUID?
+
+    func validateDrop(info: DropInfo) -> Bool {
+        info.hasItemsConforming(to: [SidebarTabDragPayload.typeIdentifier])
+    }
+
+    func performDrop(info: DropInfo) -> Bool {
+        draggedTabId = nil
+        return true
+    }
+
+    func dropEntered(info: DropInfo) {
+        guard let draggedId = draggedTabId, draggedId != targetTabId else { return }
+        withAnimation(.easeInOut(duration: 0.2)) {
+            _ = tabManager.reorderWorkspace(tabId: draggedId, toIndex: tabManager.tabs.firstIndex(where: { $0.id == targetTabId }) ?? 0)
+        }
+    }
+
+    func dropUpdated(info: DropInfo) -> DropProposal? {
+        DropProposal(operation: .move)
+    }
+}
+
+private struct CollapsedWorkspaceTabItem: View {
+    let tab: Workspace
+    let isActive: Bool
+    let unreadCount: Int
+    let canClose: Bool
+    let shortcutLabel: String?
+    let index: Int
+    let tabManager: TabManager
+    @Binding var draggedTabId: UUID?
+    let onSelect: () -> Void
+    let onClose: () -> Void
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isHovering = false
+
+    private var tabCount: Int { tabManager.tabs.count }
+
+    // MARK: - Colors (derived from CollapsedWorkspaceTabsPolicy / sidebar palette)
+
+    private var activeBackgroundColor: Color {
+        Color(nsColor: CollapsedWorkspaceTabsPolicy.backgroundNSColor(isActive: true, colorScheme: colorScheme))
+    }
+
+    private var primaryTextColor: Color {
+        Color(nsColor: CollapsedWorkspaceTabsPolicy.foregroundNSColor(isActive: isActive, opacity: 1.0, colorScheme: colorScheme))
+    }
+
+    private var secondaryColor: Color {
+        Color(nsColor: CollapsedWorkspaceTabsPolicy.foregroundNSColor(isActive: isActive, opacity: 0.7, colorScheme: colorScheme))
+    }
+
+    private var unreadBadgeFillColor: Color {
+        isActive
+            ? Color(nsColor: CollapsedWorkspaceTabsPolicy.foregroundNSColor(isActive: true, opacity: 0.25, colorScheme: colorScheme))
+            : cmuxAccentColor()
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if let shortcutLabel {
+                Text(shortcutLabel)
+                    .font(.system(size: 10, weight: .regular))
+                    .foregroundColor(secondaryColor.opacity(isActive ? 1 : 0.85))
+                    .padding(.leading, 8)
+            }
+
+            Spacer(minLength: 4)
+
+            HStack(spacing: 4) {
+                if unreadCount > 0 {
+                    ZStack {
+                        Circle().fill(unreadBadgeFillColor)
+                        Text("\(unreadCount)")
+                            .font(.system(size: 8, weight: .bold))
+                            .foregroundColor(.white)
+                    }
+                    .frame(width: 14, height: 14)
+                }
+                if tab.isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9, weight: .semibold))
+                        .foregroundColor(secondaryColor)
+                }
+                Text(tab.title)
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundColor(primaryTextColor)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+            }
+
+            Spacer(minLength: 4)
+
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .medium))
+                    .foregroundColor(secondaryColor)
+            }
+            .buttonStyle(.plain)
+            .opacity(isHovering && canClose ? 1 : 0)
+            .frame(width: 20, alignment: .center)
+            .padding(.trailing, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(isActive ? activeBackgroundColor : Color.clear)
+        .contentShape(Rectangle())
+        .onTapGesture { onSelect() }
+        .onHover { isHovering = $0 }
+        .onDrag {
+            NSCursor.closedHand.push()
+            draggedTabId = tab.id
+            return SidebarTabDragPayload.provider(for: tab.id)
+        } preview: {
+            Color.clear.frame(width: 1, height: 1)
+        }
+        .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: CollapsedTabDropDelegate(
+            targetTabId: tab.id, tabManager: tabManager, draggedTabId: $draggedTabId
+        ))
+        .onChange(of: draggedTabId) { newValue in
+            if newValue == nil {
+                NSCursor.pop()
+            }
+        }
+        .contextMenu { collapsedTabContextMenu }
+    }
+
+    // MARK: - Context Menu
+
+    @ViewBuilder
+    private var collapsedTabContextMenu: some View {
+        let shouldPin = !tab.isPinned
+
+        Button(shouldPin
+            ? String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace")
+            : String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
+        ) {
+            tabManager.setPinned(tab, pinned: shouldPin)
+        }
+
+        renameButton
+        if tab.hasCustomTitle {
+            Button(String(localized: "contextMenu.removeCustomWorkspaceName", defaultValue: "Remove Custom Workspace Name")) {
+                tabManager.clearCustomTitle(tabId: tab.id)
+            }
+        }
+
+        workspaceColorMenu
+
+        Divider()
+
+        Button(String(localized: "contextMenu.moveUp", defaultValue: "Move Up")) {
+            _ = tabManager.reorderWorkspace(tabId: tab.id, toIndex: index - 1)
+        }.disabled(index == 0)
+
+        Button(String(localized: "contextMenu.moveDown", defaultValue: "Move Down")) {
+            _ = tabManager.reorderWorkspace(tabId: tab.id, toIndex: index + 1)
+        }.disabled(index >= tabCount - 1)
+
+        Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
+            tabManager.moveTabsToTop(Set([tab.id]))
+        }.disabled(index == 0)
+
+        moveToWindowMenu
+
+        Divider()
+
+        closeButton
+
+        Button(String(localized: "contextMenu.closeOtherWorkspaces", defaultValue: "Close Other Workspaces")) {
+            tabManager.closeWorkspacesWithConfirmation(
+                tabManager.tabs.filter { $0.id != tab.id }.map(\.id), allowPinned: false
+            )
+        }.disabled(tabCount <= 1)
+
+        Button(String(localized: "contextMenu.closeWorkspacesBelow", defaultValue: "Close Workspaces Below")) {
+            let below = tabManager.tabs.suffix(from: index + 1).map(\.id)
+            tabManager.closeWorkspacesWithConfirmation(Array(below), allowPinned: false)
+        }.disabled(index >= tabCount - 1)
+
+        Button(String(localized: "contextMenu.closeWorkspacesAbove", defaultValue: "Close Workspaces Above")) {
+            let above = tabManager.tabs.prefix(index).map(\.id)
+            tabManager.closeWorkspacesWithConfirmation(Array(above), allowPinned: false)
+        }.disabled(index == 0)
+
+        Divider()
+
+        Button(String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read")) {
+            TerminalNotificationStore.shared.markRead(forTabId: tab.id)
+        }
+        Button(String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread")) {
+            TerminalNotificationStore.shared.markUnread(forTabId: tab.id)
+        }
+        Button(String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification")) {
+            TerminalNotificationStore.shared.clearLatestNotification(forTabId: tab.id)
+        }
+    }
+
+    @ViewBuilder
+    private var renameButton: some View {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
+        let button = Button(String(localized: "contextMenu.renameWorkspace", defaultValue: "Rename Workspace…")) { promptRename() }
+        if let key = shortcut.keyEquivalent {
+            button.keyboardShortcut(key, modifiers: shortcut.eventModifiers)
+        } else {
+            button
+        }
+    }
+
+    @ViewBuilder
+    private var closeButton: some View {
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
+        let button = Button(String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace")) {
+            tabManager.closeWorkspaceWithConfirmation(tab)
+        }.disabled(!canClose)
+        if let key = shortcut.keyEquivalent {
+            button.keyboardShortcut(key, modifiers: shortcut.eventModifiers)
+        } else {
+            button
+        }
+    }
+
+    private var workspaceColorMenu: some View {
+        Menu(String(localized: "contextMenu.workspaceColor", defaultValue: "Workspace Color")) {
+            if tab.customColor != nil {
+                Button { tab.setCustomColor(nil) } label: {
+                    Label(String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"), systemImage: "xmark.circle")
+                }
+            }
+            Button { promptCustomColor() } label: {
+                Label(String(localized: "contextMenu.chooseCustomColor", defaultValue: "Choose Custom Color…"), systemImage: "paintpalette")
+            }
+            if !WorkspaceTabColorSettings.palette().isEmpty { Divider() }
+            ForEach(WorkspaceTabColorSettings.palette(), id: \.id) { entry in
+                Button { tab.setCustomColor(entry.hex) } label: { Text(entry.name) }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var moveToWindowMenu: some View {
+        let targets = AppDelegate.shared?.windowMoveTargets(
+            referenceWindowId: AppDelegate.shared?.windowId(for: tabManager)
+        ) ?? []
+        Menu(String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")) {
+            Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {
+                _ = AppDelegate.shared?.moveWorkspaceToNewWindow(workspaceId: tab.id)
+            }
+            if !targets.isEmpty { Divider() }
+            ForEach(targets) { target in
+                Button(target.label) {
+                    _ = AppDelegate.shared?.moveWorkspaceToWindow(workspaceId: tab.id, windowId: target.windowId)
+                }.disabled(target.isCurrentWindow)
+            }
+        }
+    }
+
+    private func promptRename() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "alert.renameWorkspace.title", defaultValue: "Rename Workspace")
+        alert.informativeText = String(localized: "alert.renameWorkspace.message", defaultValue: "Enter a custom name for this workspace.")
+        let input = NSTextField(string: tab.customTitle ?? tab.title)
+        input.placeholderString = String(localized: "alert.renameWorkspace.placeholder", defaultValue: "Workspace name")
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "alert.renameWorkspace.rename", defaultValue: "Rename"))
+        alert.addButton(withTitle: String(localized: "alert.renameWorkspace.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        DispatchQueue.main.async { alert.window.makeFirstResponder(input); input.selectText(nil) }
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        tabManager.setCustomTitle(tabId: tab.id, title: input.stringValue)
+    }
+
+    private func promptCustomColor() {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "alert.customColor.title", defaultValue: "Custom Workspace Color")
+        alert.informativeText = String(localized: "alert.customColor.message", defaultValue: "Enter a hex color in the format #RRGGBB.")
+        let input = NSTextField(string: tab.customColor ?? "")
+        input.placeholderString = "#1565C0"
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply"))
+        alert.addButton(withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        DispatchQueue.main.async { alert.window.makeFirstResponder(input); input.selectText(nil) }
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        if let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) {
+            tab.setCustomColor(normalized)
+        }
+    }
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -1549,6 +1875,7 @@ struct ContentView: View {
     @State private var didApplyUITestSidebarSelection = false
     @State private var titlebarThemeGeneration: UInt64 = 0
     @State private var sidebarDraggedTabId: UUID?
+    @State private var collapsedTabDraggedId: UUID?
     @State private var titlebarTextUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
     @State private var sidebarResizerCursorReleaseWorkItem: DispatchWorkItem?
     @State private var sidebarResizerPointerMonitor: Any?
@@ -2614,34 +2941,46 @@ struct ContentView: View {
             TitlebarLeadingInsetReader(inset: $titlebarLeadingInset)
                 .allowsHitTesting(false)
 
-            HStack(spacing: 8) {
-                if isFullScreen && !sidebarState.isVisible {
-                    fullscreenControls
+            if CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: sidebarState.isVisible, workspaceCount: tabManager.tabs.count) {
+                HStack(spacing: 0) {
+                    if isFullScreen {
+                        fullscreenControls.padding(.leading, 8)
+                    }
+                    collapsedWorkspaceTabs
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.leading, isFullScreen ? 0 : titlebarLeadingInset + CGFloat(debugTitlebarLeadingExtra))
+                .transition(.opacity)
+            } else {
+                HStack(spacing: 8) {
+                    if isFullScreen && !sidebarState.isVisible {
+                        fullscreenControls
+                    }
 
-                // Draggable folder icon + focused command name
-                if let directory = focusedDirectory {
-                    DraggableFolderIcon(directory: directory)
-                        .padding(.leading, -6)
+                    if let directory = focusedDirectory {
+                        DraggableFolderIcon(directory: directory)
+                            .padding(.leading, -6)
+                    }
+
+                    Text(titlebarText)
+                        .font(.system(size: 13, weight: .bold))
+                        .foregroundColor(fakeTitlebarTextColor)
+                        .lineLimit(1)
+                        .allowsHitTesting(false)
+
+                    Spacer()
                 }
-
-                Text(titlebarText)
-                    .font(.system(size: 13, weight: .bold))
-                    .foregroundColor(fakeTitlebarTextColor)
-                    .lineLimit(1)
-                    .allowsHitTesting(false)
-
-                Spacer()
-
+                .frame(height: 28)
+                .padding(.top, 2)
+                .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? 8 : (sidebarState.isVisible ? 12 : titlebarLeadingInset + CGFloat(debugTitlebarLeadingExtra)))
+                .padding(.trailing, 8)
+                .transition(.opacity)
             }
-            .frame(height: 28)
-            .padding(.top, 2)
-            .padding(.leading, (isFullScreen && !sidebarState.isVisible) ? 8 : (sidebarState.isVisible ? 12 : titlebarLeadingInset + CGFloat(debugTitlebarLeadingExtra)))
-            .padding(.trailing, 8)
         }
         .frame(height: titlebarPadding)
         .frame(maxWidth: .infinity)
         .contentShape(Rectangle())
+        .animation(.easeInOut(duration: 0.2), value: sidebarState.isVisible)
         .background(TitlebarDoubleClickMonitorView())
         .background({
             // The terminal background is provided by a single CALayer
@@ -2654,9 +2993,36 @@ struct ContentView: View {
             )
         }())
         .overlay(alignment: .bottom) {
-            Rectangle()
-                .fill(Color(nsColor: .separatorColor))
-                .frame(height: 1)
+            if CollapsedWorkspaceTabsPolicy.shouldShowTitlebarSeparator(sidebarVisible: sidebarState.isVisible, workspaceCount: tabManager.tabs.count) {
+                Rectangle()
+                    .fill(Color(nsColor: .separatorColor))
+                    .frame(height: 1)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    private var collapsedWorkspaceTabs: some View {
+        let tabs = tabManager.tabs
+        let selectedId = tabManager.selectedTabId
+        let shortcutPrefix = KeyboardShortcutSettings.shortcut(for: .selectWorkspaceByNumber).numberedDigitHintPrefix
+        return HStack(spacing: 0) {
+            ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
+                let isActive = tab.id == selectedId
+
+                CollapsedWorkspaceTabItem(
+                    tab: tab, isActive: isActive,
+                    unreadCount: TerminalNotificationStore.shared.unreadCount(forTabId: tab.id),
+                    canClose: tabs.count > 1,
+                    shortcutLabel: WorkspaceShortcutMapper.digitForWorkspace(at: index, workspaceCount: tabs.count)
+                        .map { "\(shortcutPrefix)\($0)" },
+                    index: index, tabManager: tabManager,
+                    draggedTabId: $collapsedTabDraggedId,
+                    onSelect: { tabManager.selectTab(tab) },
+                    onClose: { tabManager.closeWorkspaceWithConfirmation(tab) }
+                )
+                .frame(maxWidth: .infinity)
+            }
         }
     }
 

--- a/cmuxTests/CollapsedWorkspaceTabsTests.swift
+++ b/cmuxTests/CollapsedWorkspaceTabsTests.swift
@@ -118,6 +118,8 @@ final class CollapsedWorkspaceTabsColorTests: XCTestCase {
             return
         }
         XCTAssertEqual(srgb.redComponent, expectedSrgb.redComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.greenComponent, expectedSrgb.greenComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.blueComponent, expectedSrgb.blueComponent, accuracy: 0.001)
         XCTAssertEqual(srgb.alphaComponent, expectedSrgb.alphaComponent, accuracy: 0.001)
     }
 
@@ -132,6 +134,7 @@ final class CollapsedWorkspaceTabsColorTests: XCTestCase {
         XCTAssertEqual(srgb.redComponent, expectedSrgb.redComponent, accuracy: 0.001)
         XCTAssertEqual(srgb.greenComponent, expectedSrgb.greenComponent, accuracy: 0.001)
         XCTAssertEqual(srgb.blueComponent, expectedSrgb.blueComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, expectedSrgb.alphaComponent, accuracy: 0.001)
     }
 
     func testInactiveBackgroundIsClear() {

--- a/cmuxTests/CollapsedWorkspaceTabsTests.swift
+++ b/cmuxTests/CollapsedWorkspaceTabsTests.swift
@@ -1,0 +1,145 @@
+import XCTest
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+import WebKit
+import ObjectiveC.runtime
+import Bonsplit
+import UserNotifications
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class CollapsedWorkspaceTabsVisibilityTests: XCTestCase {
+    func testHiddenWhenSidebarVisible() {
+        XCTAssertFalse(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: true, workspaceCount: 3)
+        )
+    }
+
+    func testHiddenWithSingleWorkspace() {
+        XCTAssertFalse(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: false, workspaceCount: 1)
+        )
+    }
+
+    func testHiddenWithZeroWorkspaces() {
+        XCTAssertFalse(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: false, workspaceCount: 0)
+        )
+    }
+
+    func testVisibleWhenSidebarHiddenAndMultipleWorkspaces() {
+        XCTAssertTrue(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: false, workspaceCount: 2)
+        )
+    }
+
+    func testVisibleWithManyWorkspaces() {
+        XCTAssertTrue(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: false, workspaceCount: 10)
+        )
+    }
+
+    func testHiddenWhenSidebarVisibleEvenWithManyWorkspaces() {
+        XCTAssertFalse(
+            CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(sidebarVisible: true, workspaceCount: 10)
+        )
+    }
+}
+
+
+final class CollapsedWorkspaceTabsSeparatorTests: XCTestCase {
+    func testSeparatorShownWhenSidebarVisible() {
+        XCTAssertTrue(
+            CollapsedWorkspaceTabsPolicy.shouldShowTitlebarSeparator(sidebarVisible: true, workspaceCount: 3)
+        )
+    }
+
+    func testSeparatorShownWithSingleWorkspace() {
+        XCTAssertTrue(
+            CollapsedWorkspaceTabsPolicy.shouldShowTitlebarSeparator(sidebarVisible: false, workspaceCount: 1)
+        )
+    }
+
+    func testSeparatorHiddenWhenCollapsedTabsVisible() {
+        XCTAssertFalse(
+            CollapsedWorkspaceTabsPolicy.shouldShowTitlebarSeparator(sidebarVisible: false, workspaceCount: 2)
+        )
+    }
+
+    func testSeparatorAndCollapsedTabsAreMutuallyExclusive() {
+        for sidebarVisible in [true, false] {
+            for count in 0...5 {
+                let showTabs = CollapsedWorkspaceTabsPolicy.shouldShowCollapsedTabs(
+                    sidebarVisible: sidebarVisible, workspaceCount: count
+                )
+                let showSeparator = CollapsedWorkspaceTabsPolicy.shouldShowTitlebarSeparator(
+                    sidebarVisible: sidebarVisible, workspaceCount: count
+                )
+                XCTAssertNotEqual(
+                    showTabs, showSeparator,
+                    "Tabs and separator must be mutually exclusive (sidebar=\(sidebarVisible), count=\(count))"
+                )
+            }
+        }
+    }
+}
+
+
+final class CollapsedWorkspaceTabsColorTests: XCTestCase {
+    func testActiveTabUsesSidebarSelectedForeground() {
+        let color = CollapsedWorkspaceTabsPolicy.foregroundNSColor(
+            isActive: true, opacity: 1.0, colorScheme: .dark
+        )
+        let expected = sidebarSelectedWorkspaceForegroundNSColor(opacity: 1.0)
+        guard let srgb = color.usingColorSpace(.sRGB),
+              let expectedSrgb = expected.usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+        XCTAssertEqual(srgb.redComponent, expectedSrgb.redComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.greenComponent, expectedSrgb.greenComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.blueComponent, expectedSrgb.blueComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, expectedSrgb.alphaComponent, accuracy: 0.001)
+    }
+
+    func testInactiveTabUsesSecondaryLabelColor() {
+        let color = CollapsedWorkspaceTabsPolicy.foregroundNSColor(
+            isActive: false, opacity: 0.7, colorScheme: .dark
+        )
+        let expected = NSColor.secondaryLabelColor.withAlphaComponent(0.7)
+        guard let srgb = color.usingColorSpace(.sRGB),
+              let expectedSrgb = expected.usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+        XCTAssertEqual(srgb.redComponent, expectedSrgb.redComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.alphaComponent, expectedSrgb.alphaComponent, accuracy: 0.001)
+    }
+
+    func testActiveBackgroundUsesSidebarSelectedBackground() {
+        let color = CollapsedWorkspaceTabsPolicy.backgroundNSColor(isActive: true, colorScheme: .dark)
+        let expected = sidebarSelectedWorkspaceBackgroundNSColor(for: .dark)
+        guard let srgb = color.usingColorSpace(.sRGB),
+              let expectedSrgb = expected.usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+        XCTAssertEqual(srgb.redComponent, expectedSrgb.redComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.greenComponent, expectedSrgb.greenComponent, accuracy: 0.001)
+        XCTAssertEqual(srgb.blueComponent, expectedSrgb.blueComponent, accuracy: 0.001)
+    }
+
+    func testInactiveBackgroundIsClear() {
+        let color = CollapsedWorkspaceTabsPolicy.backgroundNSColor(isActive: false, colorScheme: .dark)
+        guard let srgb = color.usingColorSpace(.sRGB) else {
+            XCTFail("Expected sRGB-convertible color")
+            return
+        }
+        XCTAssertEqual(srgb.alphaComponent, 0, accuracy: 0.001)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds iTerm2-style horizontal workspace tabs in the titlebar when the sidebar is hidden and 2+ workspaces exist
- Reclaims sidebar space without losing any workspace management features — all sidebar capabilities (pin, rename, custom color, drag-to-reorder, notifications, close) are available via the collapsed tab bar
- When sidebar is visible or only one workspace exists, behavior is unchanged

### Features

- **Full-width proportional tabs** — tabs divide equally and shrink as workspaces are added
- **Active tab highlight** — uses `cmuxAccentColor` background with white text, matching the sidebar selection style
- **Keyboard shortcut hints** — displays ⌘1, ⌘2, etc. on the left side of each tab
- **Close button** — appears on hover (right side), no layout shift
- **Drag-to-reorder** — live reorder with grab cursor, invisible drag ghost
- **Full context menu** — Pin/Unpin, Rename, Custom Color, Move Up/Down/To Top, Move to Window, Close/Close Others/Close Above/Below, Mark Read/Unread, Clear Notification
- **Notification badges** — unread count badges matching sidebar behavior
- **Pin icon** — visual indicator for pinned workspaces
- **Smooth animation** — crossfade transition when toggling sidebar visibility
- **Theme-aware** — colors derived from the same sidebar palette functions (`sidebarSelectedWorkspaceBackgroundNSColor`, `sidebarSelectedWorkspaceForegroundNSColor`), adapts to accent color and custom selection color changes
- **Fullscreen support** — fullscreen controls included in collapsed tab mode

### Why

Many users prefer a minimal UI without the sidebar, but currently lose workspace navigation when it's hidden. This feature provides efficient workspace switching in the titlebar row — similar to iTerm2's tab bar — without consuming any additional screen real estate.

## Testing

- Built and tested locally with `./scripts/reload.sh --tag horizontal-tabs --launch`
- Verified: tab switching (click + keyboard), drag-to-reorder, context menu actions (pin, rename, color, close, move), notification badges, sidebar toggle animation, fullscreen mode, theme adaptation
- Verified all existing features continue to work identically with sidebar visible

## Demo Video

- Video URL or attachment:


https://github.com/user-attachments/assets/723af632-ecd2-4337-9ffe-9031bbdc23a8



## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Collapsed workspace tabs in the titlebar when the sidebar is hidden and multiple workspaces exist; tap to switch, pin/unpin, unread badges, hover-close, drag-to-reorder, and rich per-tab context menu (rename, color, move, close).
* **Bug Fixes**
  * Improved drag-state cleanup and refined animated opacity/transitions and titlebar separator visibility when toggling the sidebar.
* **Tests**
  * Added tests for collapsed-tab visibility rules, separator behavior, and tab color/foreground rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->