### PR TITLE
[codex] Restore terminal redraw after notifications and workspace selection

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8821,6 +8821,7 @@ final class GhosttySurfaceScrollView: NSView {
     private var pendingDropZone: DropZone?
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
+    private var pendingVisibleSurfaceDisplayOnWindowAttach = false
     // Intentionally no focus retry loops: rely on AppKit first-responder and bonsplit selection.
 
     /// Tracks whether keyboard focus should go to the search field or the terminal
@@ -9429,6 +9430,30 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
+    /// Nudge AppKit/CoreAnimation to composite the selected surface once the portal sync lands.
+    /// This is only used on structural transitions like new-workspace insertion, not typing paths.
+    func requestVisibleSurfaceDisplayIfNeeded() {
+        if !Thread.isMainThread {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestVisibleSurfaceDisplayIfNeeded()
+            }
+            return
+        }
+
+        guard window != nil else {
+            pendingVisibleSurfaceDisplayOnWindowAttach = true
+            return
+        }
+
+        pendingVisibleSurfaceDisplayOnWindowAttach = false
+        surfaceView.layoutSubtreeIfNeeded()
+        if let metalLayer = surfaceView.layer as? CAMetalLayer {
+            metalLayer.setNeedsDisplay()
+        } else {
+            surfaceView.layer?.setNeedsDisplay()
+        }
+    }
+
     @discardableResult
     private func synchronizeGeometryAndContent() -> Bool {
         CATransaction.begin()
@@ -9617,6 +9642,11 @@ final class GhosttySurfaceScrollView: NSView {
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         windowObservers.removeAll()
         guard let window else { return }
+        if pendingVisibleSurfaceDisplayOnWindowAttach {
+            DispatchQueue.main.async { [weak self] in
+                self?.requestVisibleSurfaceDisplayIfNeeded()
+            }
+        }
         windowObservers.append(NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: window,
@@ -10806,7 +10836,10 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         dlog("focus.surface.refresh surface=\(terminalSurface.id.uuidString.prefix(5)) reason=\(reason)")
 #endif
-        terminalSurface.forceRefresh(reason: "focus.surface.\(reason)")
+        // Focus restoration can happen while AppKit is still settling the hosted subtree after
+        // portal/workspace churn. Route through the same guarded refresh helper used by portal
+        // reveal/frame-change paths so we do not forceRefresh against an unrealized layer tree.
+        refreshSurfaceNow(reason: "focus.surface.\(reason)")
     }
 
     private func applyFirstResponderIfNeeded() {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2041,6 +2041,9 @@ class TabManager: ObservableObject {
                     object: nil,
                     userInfo: [GhosttyNotificationKey.tabId: newWorkspace.id]
                 )
+                newWorkspace.scheduleInitialSelectedTerminalRenderRefresh(
+                    reason: "tabManager.addWorkspace"
+                )
             }
 #if DEBUG
             UITestRecorder.incrementInt("addTabInvocations")

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10958,6 +10958,42 @@ final class Workspace: Identifiable, ObservableObject {
         runRefreshPass(0.03)
     }
 
+    func scheduleInitialSelectedTerminalRenderRefresh(reason: String = "workspace.create.initialSelection") {
+        guard let terminalPanel = focusedTerminalPanel else { return }
+        let panelId = terminalPanel.id
+
+        // New-workspace insertion can saturate the current layout turn before the freshly
+        // selected terminal gets the same portal sync/reveal path that a tab re-present does.
+        terminalPanel.requestViewReattach()
+        scheduleTerminalGeometryReconcile()
+
+        let runRefreshPass: (TimeInterval) -> Void = { [weak self] delay in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+                guard let self,
+                      self.owningTabManager?.selectedTabId == self.id,
+                      self.focusedPanelId == panelId,
+                      let panel = self.terminalPanel(for: panelId) else { return }
+
+                if let window = panel.hostedView.window {
+                    TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
+                } else {
+                    TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronizeForAllWindows()
+                }
+
+                panel.hostedView.reconcileGeometryNow()
+                if panel.surface.surface != nil {
+                    panel.hostedView.refreshSurfaceNow(reason: reason)
+                } else {
+                    panel.surface.requestBackgroundSurfaceStartIfNeeded()
+                }
+                panel.hostedView.requestVisibleSurfaceDisplayIfNeeded()
+            }
+        }
+
+        runRefreshPass(0)
+        runRefreshPass(0.03)
+    }
+
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) {
         for tabId in tabIds {
             if skipPinned,


### PR DESCRIPTION
Fixes a regression where the active terminal can go blank after a background workspace notification, and where a newly selected workspace can still miss its first visible frame until another interaction forces a redraw.

The root problem here is timing. We already have a safer redraw path in `refreshSurfaceNow`, but the focus driven refresh path was still calling `forceRefresh` directly, and the workspace creation path had lost the post selection render nudge that previously kept the selected terminal from sitting blank. In practice those two gaps meet in the same family of failures: the terminal is live, but AppKit and the portal tree have not fully settled yet, so the user sees an empty surface until they switch workspaces or click a notification's Show action.

This patch restores the initial selected terminal refresh after `TabManager.addWorkspace()` selects a new workspace. It also restores the visible surface display nudge with a window attach fallback, and routes focus driven redraws through `refreshSurfaceNow` so the focus path gets the same layout and display flush as the existing portal reveal path.

I verified the code by building a tagged app locally with `PATH="/opt/homebrew/opt/zig@0.15/bin:$PATH" ./scripts/reload.sh --tag notif-blank-refresh`. After that build, the reporter dogfooded the tagged app heavily against the notification triggered blanking flow and reported that the fix held up.

Closes #2887
Closes #2555

This overlaps with #2892 and #2835. I kept this version narrow and grounded in the exact fix that reproduced and held locally.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression that could leave the terminal blank after a notification or when selecting a new workspace. Ensures the first visible frame is drawn reliably. Fixes #2887 and #2555.

- **Bug Fixes**
  - Route focus-driven redraws through `refreshSurfaceNow` to avoid refreshing before the layer tree settles.
  - On new workspace selection, schedule an initial render refresh and geometry sync for the selected terminal.
  - Nudge the visible surface to display and retry on window attach, requesting display on `CAMetalLayer` or fallback layer.

<sup>Written for commit 66e592640b08a12c9eeb57f0757d93a6225f630c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

