### PR TITLE
Vendor Runestone into cmux

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -43,6 +43,9 @@
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
+		C1A2B3C4D5E6F70900000001 /* VendoredRunestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70900000002 /* VendoredRunestone.swift */; };
+		C1A2B3C4D5E6F70900000003 /* RunestoneVendoringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70900000004 /* RunestoneVendoringTests.swift */; };
+		C1A2B3C4D5E6F70900000007 /* Runestone in Frameworks */ = {isa = PBXBuildFile; productRef = C1A2B3C4D5E6F70900000006 /* Runestone */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
@@ -252,6 +255,7 @@
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		C1A2B3C4D5E6F70900000002 /* VendoredRunestone.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VendoredRunestone.swift; sourceTree = "<group>"; };
 		A5001416 /* Workspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Workspace.swift; sourceTree = "<group>"; };
 		A5001417 /* WorkspaceContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentView.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -344,6 +348,7 @@
 				491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerSocketSecurityTests.swift; sourceTree = "<group>"; };
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerSessionSnapshotTests.swift; sourceTree = "<group>"; };
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
+				C1A2B3C4D5E6F70900000004 /* RunestoneVendoringTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunestoneVendoringTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -356,6 +361,7 @@
 					A5001250 /* Sentry in Frameworks */,
 					A5001270 /* PostHog in Frameworks */,
 					A5001290 /* MarkdownUI in Frameworks */,
+					C1A2B3C4D5E6F70900000007 /* Runestone in Frameworks */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
@@ -509,6 +515,7 @@
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				C1A2B3C4D5E6F70900000002 /* VendoredRunestone.swift */,
 				A5001510 /* CmuxWebView.swift */,
 				A5001415 /* PanelContentView.swift */,
 				A5001211 /* UpdateController.swift */,
@@ -628,6 +635,7 @@
 					491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */,
 					10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 					C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
+					C1A2B3C4D5E6F70900000004 /* RunestoneVendoringTests.swift */,
 					FE002001 /* FileExplorerRootResolverTests.swift */,
 					FE002002 /* FileExplorerStoreTests.swift */,
 				);
@@ -661,6 +669,7 @@
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
 					A5001291 /* MarkdownUI */,
+					C1A2B3C4D5E6F70900000006 /* Runestone */,
 				);
 			name = GhosttyTabs;
 			productName = GhosttyTabs;
@@ -781,6 +790,7 @@
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
+					C1A2B3C4D5E6F70900000005 /* XCLocalSwiftPackageReference "runestone" */,
 				);
 			productRefGroup = A5001042 /* Products */;
 			projectDirPath = "";
@@ -840,6 +850,7 @@
 				A5007422 /* BrowserWebAuthnSupport.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				C1A2B3C4D5E6F70900000001 /* VendoredRunestone.swift in Sources */,
 				A5001500 /* CmuxWebView.swift in Sources */,
 				A5001405 /* PanelContentView.swift in Sources */,
 				A5001201 /* UpdateController.swift in Sources */,
@@ -934,6 +945,7 @@
 					8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */,
 					2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 					C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
+					C1A2B3C4D5E6F70900000003 /* RunestoneVendoringTests.swift in Sources */,
 					FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 					FE002102 /* FileExplorerStoreTests.swift in Sources */,
 				);
@@ -1312,6 +1324,10 @@
 				isa = XCLocalSwiftPackageReference;
 				relativePath = vendor/bonsplit;
 			};
+			C1A2B3C4D5E6F70900000005 /* XCLocalSwiftPackageReference "runestone" */ = {
+				isa = XCLocalSwiftPackageReference;
+				relativePath = vendor/runestone;
+			};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -1339,6 +1355,11 @@
 				isa = XCSwiftPackageProductDependency;
 				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
 				productName = MarkdownUI;
+			};
+			C1A2B3C4D5E6F70900000006 /* Runestone */ = {
+				isa = XCSwiftPackageProductDependency;
+				package = C1A2B3C4D5E6F70900000005 /* XCLocalSwiftPackageReference "runestone" */;
+				productName = Runestone;
 			};
 /* End XCSwiftPackageProductDependency section */
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -42,7 +42,6 @@
 		A5007422 /* BrowserWebAuthnSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007423 /* BrowserWebAuthnSupport.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
-		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		C1A2B3C4D5E6F70900000001 /* VendoredRunestone.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70900000002 /* VendoredRunestone.swift */; };
 		C1A2B3C4D5E6F70900000003 /* RunestoneVendoringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A2B3C4D5E6F70900000004 /* RunestoneVendoringTests.swift */; };
 		C1A2B3C4D5E6F70900000007 /* Runestone in Frameworks */ = {isa = PBXBuildFile; productRef = C1A2B3C4D5E6F70900000006 /* Runestone */; };
@@ -360,7 +359,6 @@
 					A5001230 /* Sparkle in Frameworks */,
 					A5001250 /* Sentry in Frameworks */,
 					A5001270 /* PostHog in Frameworks */,
-					A5001290 /* MarkdownUI in Frameworks */,
 					C1A2B3C4D5E6F70900000007 /* Runestone in Frameworks */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
@@ -668,7 +666,6 @@
 					A5001251 /* Sentry */,
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
-					A5001291 /* MarkdownUI */,
 					C1A2B3C4D5E6F70900000006 /* Runestone */,
 				);
 			name = GhosttyTabs;
@@ -788,7 +785,6 @@
 					A5001232 /* XCRemoteSwiftPackageReference "Sparkle" */,
 					A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
-					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
 					C1A2B3C4D5E6F70900000005 /* XCLocalSwiftPackageReference "runestone" */,
 				);
@@ -1312,14 +1308,6 @@
 					minimumVersion = 3.41.0;
 				};
 			};
-			A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
-				isa = XCRemoteSwiftPackageReference;
-				repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
-				requirement = {
-					kind = upToNextMajorVersion;
-					minimumVersion = 2.4.1;
-				};
-			};
 			A5001260 /* XCLocalSwiftPackageReference "bonsplit" */ = {
 				isa = XCLocalSwiftPackageReference;
 				relativePath = vendor/bonsplit;
@@ -1350,11 +1338,6 @@
 				isa = XCSwiftPackageProductDependency;
 				package = A5001260 /* XCLocalSwiftPackageReference "bonsplit" */;
 				productName = Bonsplit;
-			};
-			A5001291 /* MarkdownUI */ = {
-				isa = XCSwiftPackageProductDependency;
-				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
-				productName = MarkdownUI;
 			};
 			C1A2B3C4D5E6F70900000006 /* Runestone */ = {
 				isa = XCSwiftPackageProductDependency;

--- a/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b66d812c506be67c70b46c63421ab2eb2db013613c74252ad1205f662ada079b",
+  "originHash" : "08a952cf12459f4a18e2a98d4151f55843f4495473336c8c3c47241c1cbb4160",
   "pins" : [
     {
       "identity" : "networkimage",
@@ -53,6 +53,15 @@
       "state" : {
         "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
         "version" : "2.4.1"
+      }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "98be227227af10cc7a269cb3ffb23686c0610b17",
+        "version" : "0.20.9"
       }
     }
   ],

--- a/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,15 +2,6 @@
   "originHash" : "08a952cf12459f4a18e2a98d4151f55843f4495473336c8c3c47241c1cbb4160",
   "pins" : [
     {
-      "identity" : "networkimage",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/NetworkImage",
-      "state" : {
-        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
-        "version" : "6.0.1"
-      }
-    },
-    {
       "identity" : "posthog-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/PostHog/posthog-ios.git",
@@ -35,24 +26,6 @@
       "state" : {
         "revision" : "5581748cef2bae787496fe6d61139aebe0a451f6",
         "version" : "2.8.1"
-      }
-    },
-    {
-      "identity" : "swift-cmark",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark",
-      "state" : {
-        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
-        "version" : "0.7.1"
-      }
-    },
-    {
-      "identity" : "swift-markdown-ui",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
-      "state" : {
-        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
-        "version" : "2.4.1"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -17,6 +17,15 @@
         "revision" : "0b8d99bd19b694df44e1ccaa3891309719d34330",
         "version" : "1.5.1"
       }
+    },
+    {
+      "identity" : "tree-sitter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/tree-sitter/tree-sitter",
+      "state" : {
+        "revision" : "98be227227af10cc7a269cb3ffb23686c0610b17",
+        "version" : "0.20.9"
+      }
     }
   ],
   "version" : 2

--- a/Package.swift
+++ b/Package.swift
@@ -10,12 +10,13 @@ let package = Package(
         .executable(name: "cmux", targets: ["cmux"])
     ],
     dependencies: [
-        .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", from: "1.2.0")
+        .package(url: "https://github.com/migueldeicaza/SwiftTerm.git", from: "1.2.0"),
+        .package(path: "vendor/runestone")
     ],
     targets: [
         .executableTarget(
             name: "cmux",
-            dependencies: ["SwiftTerm"],
+            dependencies: ["SwiftTerm", "Runestone"],
             path: "Sources"
         )
     ]

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -43,35 +43,12 @@ struct MarkdownPanelView: View {
     }
 
     private var markdownContentView: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            filePathHeader
-                .padding(.horizontal, 24)
-                .padding(.top, 16)
-                .padding(.bottom, 8)
-
-            Divider()
-                .padding(.horizontal, 16)
-
-            RunestoneMarkdownTextSurface(
-                markdown: panel.content,
-                colorScheme: colorScheme
-            )
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    private var filePathHeader: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "doc.richtext")
-                .foregroundColor(.secondary)
-                .font(.system(size: 12))
-            Text(panel.filePath)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Spacer()
-        }
+        RunestoneMarkdownTextSurface(
+            markdown: panel.content,
+            ghosttyConfig: ghosttyConfig,
+            isFocused: isFocused
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var fileUnavailableView: some View {
@@ -82,13 +59,6 @@ struct MarkdownPanelView: View {
             Text(String(localized: "markdown.fileUnavailable.title", defaultValue: "File unavailable"))
                 .font(.headline)
                 .foregroundColor(.primary)
-            Text(panel.filePath)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 24)
             Text(String(localized: "markdown.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -97,9 +67,22 @@ struct MarkdownPanelView: View {
     }
 
     private var backgroundColor: Color {
-        colorScheme == .dark
-            ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
-            : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
+        Color(nsColor: ghosttyConfig.backgroundColor)
+    }
+
+    private var ghosttyConfig: GhosttyConfig {
+        GhosttyConfig.load(preferredColorScheme: preferredColorScheme)
+    }
+
+    private var preferredColorScheme: GhosttyConfig.ColorSchemePreference {
+        switch colorScheme {
+        case .dark:
+            return .dark
+        case .light:
+            return .light
+        @unknown default:
+            return .dark
+        }
     }
 
     private func triggerFocusFlashAnimation() {
@@ -129,24 +112,27 @@ struct MarkdownPanelView: View {
 
 struct RunestoneMarkdownTextSurface: NSViewRepresentable {
     let markdown: String
-    let colorScheme: ColorScheme
+    let ghosttyConfig: GhosttyConfig
+    let isFocused: Bool
 
     func makeNSView(context: Context) -> MarkdownPanelRunestoneView {
         let view = MarkdownPanelRunestoneView()
-        view.update(markdown: markdown, colorScheme: colorScheme)
+        view.update(markdown: markdown, ghosttyConfig: ghosttyConfig, isFocused: isFocused)
         return view
     }
 
     func updateNSView(_ nsView: MarkdownPanelRunestoneView, context: Context) {
-        nsView.update(markdown: markdown, colorScheme: colorScheme)
+        nsView.update(markdown: markdown, ghosttyConfig: ghosttyConfig, isFocused: isFocused)
     }
 }
 
-final class MarkdownPanelRunestoneView: NSView {
+final class MarkdownPanelRunestoneView: NSView, TextViewDelegate {
     let editor = TextView(frame: .zero)
 
     private var currentMarkdown = ""
     private var currentThemeKey = ""
+    private var currentFocusState = false
+    private var wantsFirstResponderWhenAttached = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
@@ -168,13 +154,21 @@ final class MarkdownPanelRunestoneView: NSView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func update(markdown: String, colorScheme: ColorScheme) {
-        let theme = MarkdownPanelTheme(colorScheme: colorScheme)
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if wantsFirstResponderWhenAttached {
+            focusEditorIfNeeded()
+        }
+    }
+
+    func update(markdown: String, ghosttyConfig: GhosttyConfig, isFocused: Bool) {
+        let theme = MarkdownPanelTheme(config: ghosttyConfig)
         let themeKey = theme.cacheKey
         let themeChanged = themeKey != currentThemeKey
         let contentChanged = markdown != currentMarkdown
+        let focusChanged = isFocused != currentFocusState
 
-        guard themeChanged || contentChanged else {
+        guard themeChanged || contentChanged || focusChanged else {
             return
         }
 
@@ -191,8 +185,13 @@ final class MarkdownPanelRunestoneView: NSView {
         editor.backgroundColor = theme.editorBackgroundColor
         editor.textView.backgroundColor = theme.editorBackgroundColor
         editor.textView.textColor = theme.textColor
+        editor.textView.selectedTextAttributes = [
+            .backgroundColor: ghosttyConfig.selectionBackground,
+            .foregroundColor: ghosttyConfig.selectionForeground
+        ]
         editor.selectionBarColor = theme.textColor
         editor.selectionHighlightColor = theme.markedTextBackgroundColor
+        editor.insertionPointColor = ghosttyConfig.cursorColor
 
         if contentChanged {
             editor.text = markdown
@@ -216,10 +215,17 @@ final class MarkdownPanelRunestoneView: NSView {
         }
 
         currentThemeKey = themeKey
+        currentFocusState = isFocused
+        if isFocused && focusChanged {
+            focusEditorIfNeeded()
+        } else if !isFocused {
+            wantsFirstResponderWhenAttached = false
+        }
     }
 
     private func configureEditor() {
-        editor.isEditable = false
+        editor.editorDelegate = self
+        editor.isEditable = true
         editor.isSelectable = true
         editor.showLineNumbers = false
         editor.gutterLeadingPadding = 0
@@ -230,7 +236,7 @@ final class MarkdownPanelRunestoneView: NSView {
         editor.hasHorizontalScroller = false
         editor.hasVerticalScroller = true
         editor.borderType = .noBorder
-        editor.textView.textContainerInset = NSSize(width: 24, height: 16)
+        editor.textView.textContainerInset = NSSize(width: 10, height: 8)
         editor.textView.isAutomaticQuoteSubstitutionEnabled = false
         editor.textView.isAutomaticDashSubstitutionEnabled = false
         editor.textView.isAutomaticTextReplacementEnabled = false
@@ -241,6 +247,8 @@ final class MarkdownPanelRunestoneView: NSView {
         editor.textView.isContinuousSpellCheckingEnabled = false
         editor.textView.isGrammarCheckingEnabled = false
         editor.textView.allowsUndo = false
+        editor.textView.isRichText = false
+        editor.textView.usesFindPanel = true
     }
 
     private func markdownScrollRatio(originY: CGFloat, documentHeight: CGFloat, viewportHeight: CGFloat) -> CGFloat {
@@ -257,6 +265,22 @@ final class MarkdownPanelRunestoneView: NSView {
         let restoredY = scrollableHeight * previousRatio
         editor.contentView.scroll(to: NSPoint(x: 0, y: restoredY))
         editor.reflectScrolledClipView(editor.contentView)
+    }
+
+    func textView(_ textView: TextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        false
+    }
+
+    private func focusEditorIfNeeded() {
+        guard let window else {
+            wantsFirstResponderWhenAttached = true
+            return
+        }
+        wantsFirstResponderWhenAttached = false
+        guard !editor.textView.isFirstResponder(in: window) else {
+            return
+        }
+        _ = window.makeFirstResponder(editor.textView)
     }
 }
 
@@ -291,50 +315,58 @@ final class MarkdownPanelTheme: Theme {
     private let codeFontValue: NSFont
     private let headingFonts: [NSFont]
 
-    init(colorScheme: ColorScheme) {
-        let isDark = colorScheme == .dark
-        let baseFont = NSFont.systemFont(ofSize: 14, weight: .regular)
-        cacheKey = isDark ? "dark" : "light"
+    init(config: GhosttyConfig) {
+        let isLightBackground = config.backgroundColor.isLightColor
+        let baseFont = MarkdownPanelTheme.font(
+            family: config.fontFamily,
+            size: config.fontSize,
+            weight: .regular
+        )
+        cacheKey = [
+            config.fontFamily,
+            String(format: "%.2f", config.fontSize),
+            config.backgroundColor.hexString(),
+            config.foregroundColor.hexString(),
+            config.cursorColor.hexString(),
+            config.selectionBackground.hexString(),
+            config.selectionForeground.hexString(),
+            config.palette[2]?.hexString() ?? "nil",
+            config.palette[4]?.hexString() ?? "nil",
+            config.palette[5]?.hexString() ?? "nil"
+        ].joined(separator: "|")
 
         font = baseFont
-        lineNumberFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        lineNumberFont = MarkdownPanelTheme.font(
+            family: config.fontFamily,
+            size: max(config.fontSize - 1, 10),
+            weight: .regular
+        )
         strongFontValue = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
         emphasisFontValue = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
-        codeFontValue = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        codeFontValue = MarkdownPanelTheme.font(
+            family: config.fontFamily,
+            size: config.fontSize,
+            weight: .regular
+        )
 
-        if isDark {
-            editorBackgroundColor = NSColor(white: 0.12, alpha: 1.0)
-            textColor = NSColor(white: 0.92, alpha: 1.0)
-            secondaryTextColor = NSColor(white: 0.72, alpha: 1.0)
-            tertiaryTextColor = NSColor(white: 0.55, alpha: 1.0)
-            headingColor = NSColor.systemPurple.withAlphaComponent(0.95)
-            linkColor = NSColor.systemBlue.withAlphaComponent(0.95)
-            quoteColor = NSColor(white: 0.68, alpha: 1.0)
-            codeColor = NSColor.systemGreen.withAlphaComponent(0.95)
-            codeBackgroundColor = NSColor(white: 0.18, alpha: 1.0)
-            separatorColor = NSColor(white: 0.35, alpha: 1.0)
-            gutterHairlineColor = NSColor(white: 0.22, alpha: 1.0)
-            pageGuideHairlineColor = NSColor(white: 0.22, alpha: 1.0)
-            pageGuideBackgroundColor = NSColor(white: 0.16, alpha: 1.0)
-            markedTextBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.28)
-            selectedLineBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.10)
-        } else {
-            editorBackgroundColor = NSColor(white: 0.98, alpha: 1.0)
-            textColor = NSColor.labelColor
-            secondaryTextColor = NSColor.secondaryLabelColor
-            tertiaryTextColor = NSColor.tertiaryLabelColor
-            headingColor = NSColor.systemPurple
-            linkColor = NSColor.linkColor
-            quoteColor = NSColor.secondaryLabelColor
-            codeColor = NSColor.systemGreen.blended(withFraction: 0.35, of: NSColor.labelColor) ?? NSColor.systemGreen
-            codeBackgroundColor = NSColor(white: 0.93, alpha: 1.0)
-            separatorColor = NSColor.separatorColor
-            gutterHairlineColor = NSColor.separatorColor
-            pageGuideHairlineColor = NSColor.separatorColor
-            pageGuideBackgroundColor = NSColor(white: 0.96, alpha: 1.0)
-            markedTextBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.22)
-            selectedLineBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.08)
-        }
+        editorBackgroundColor = config.backgroundColor
+        textColor = config.foregroundColor
+        secondaryTextColor = config.foregroundColor.blended(withFraction: 0.28, of: config.backgroundColor) ?? config.foregroundColor
+        tertiaryTextColor = config.foregroundColor.blended(withFraction: 0.5, of: config.backgroundColor) ?? config.foregroundColor
+        headingColor = config.palette[5] ?? config.palette[13] ?? config.foregroundColor
+        linkColor = config.palette[4] ?? config.palette[12] ?? config.foregroundColor
+        quoteColor = secondaryTextColor
+        codeColor = config.palette[2] ?? config.palette[10] ?? config.foregroundColor
+        codeBackgroundColor = config.backgroundColor.blended(
+            withFraction: isLightBackground ? 0.18 : 0.28,
+            of: config.selectionBackground
+        ) ?? config.selectionBackground
+        separatorColor = tertiaryTextColor
+        gutterHairlineColor = tertiaryTextColor.withAlphaComponent(isLightBackground ? 0.3 : 0.45)
+        pageGuideHairlineColor = gutterHairlineColor
+        pageGuideBackgroundColor = codeBackgroundColor
+        markedTextBackgroundColor = config.selectionBackground.withAlphaComponent(isLightBackground ? 0.22 : 0.3)
+        selectedLineBackgroundColor = config.selectionBackground.withAlphaComponent(isLightBackground ? 0.08 : 0.12)
 
         gutterBackgroundColor = editorBackgroundColor
         lineNumberColor = tertiaryTextColor
@@ -344,8 +376,27 @@ final class MarkdownPanelTheme: Theme {
 
         headingFonts = (1...6).map { level in
             let size = baseFont.pointSize + CGFloat(7 - level) * 2.6
-            return NSFont.systemFont(ofSize: size, weight: level <= 2 ? .bold : .semibold)
+            return MarkdownPanelTheme.font(
+                family: config.fontFamily,
+                size: size,
+                weight: level <= 2 ? .bold : .semibold
+            )
         }
+    }
+
+    private static func font(family: String, size: CGFloat, weight: NSFont.Weight) -> NSFont {
+        if let font = NSFontManager.shared.font(
+            withFamily: family,
+            traits: weight >= .semibold ? .boldFontMask : [],
+            weight: weight >= .bold ? 9 : (weight >= .semibold ? 7 : 5),
+            size: size
+        ) {
+            return font
+        }
+        if let font = NSFont(name: family, size: size) {
+            return font
+        }
+        return NSFont.monospacedSystemFont(ofSize: size, weight: weight)
     }
 
     func headingFont(for level: Int) -> NSFont {
@@ -362,6 +413,28 @@ final class MarkdownPanelTheme: Theme {
 
     var codeFont: NSFont {
         codeFontValue
+    }
+}
+
+private extension NSResponder {
+    func isDescendant(of ancestor: NSResponder) -> Bool {
+        var current: NSResponder? = self
+        while let responder = current {
+            if responder === ancestor {
+                return true
+            }
+            current = responder.nextResponder
+        }
+        return false
+    }
+}
+
+private extension NSTextView {
+    func isFirstResponder(in window: NSWindow) -> Bool {
+        guard let responder = window.firstResponder else {
+            return false
+        }
+        return responder === self || responder.isDescendant(of: self)
     }
 }
 

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -1,8 +1,9 @@
 import AppKit
 import SwiftUI
-import MarkdownUI
+import Runestone
 
-/// SwiftUI view that renders a MarkdownPanel's content using MarkdownUI.
+/// SwiftUI view that renders a MarkdownPanel's content using a read-only
+/// Runestone surface.
 struct MarkdownPanelView: View {
     @ObservedObject var panel: MarkdownPanel
     let isFocused: Bool
@@ -33,37 +34,29 @@ struct MarkdownPanelView: View {
         }
         .overlay {
             if isVisibleInUI {
-                // Observe left-clicks without intercepting them so markdown text
-                // selection and link activation continue to use the native path.
                 MarkdownPointerObserver(onPointerDown: onRequestPanelFocus)
             }
         }
-        .onChange(of: panel.focusFlashToken) { _ in
+        .onChange(of: panel.focusFlashToken) {
             triggerFocusFlashAnimation()
         }
     }
 
-    // MARK: - Content
-
     private var markdownContentView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                // File path breadcrumb
-                filePathHeader
-                    .padding(.horizontal, 24)
-                    .padding(.top, 16)
-                    .padding(.bottom, 8)
+        VStack(alignment: .leading, spacing: 0) {
+            filePathHeader
+                .padding(.horizontal, 24)
+                .padding(.top, 16)
+                .padding(.bottom, 8)
 
-                Divider()
-                    .padding(.horizontal, 16)
+            Divider()
+                .padding(.horizontal, 16)
 
-                // Rendered markdown
-                Markdown(panel.content)
-                    .markdownTheme(cmuxMarkdownTheme)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 16)
-            }
+            RunestoneMarkdownTextSurface(
+                markdown: panel.content,
+                colorScheme: colorScheme
+            )
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
         }
     }
 
@@ -103,167 +96,11 @@ struct MarkdownPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    // MARK: - Theme
-
     private var backgroundColor: Color {
         colorScheme == .dark
             ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
             : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
     }
-
-    private var cmuxMarkdownTheme: Theme {
-        let isDark = colorScheme == .dark
-
-        return Theme()
-            // Text
-            .text {
-                ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
-                FontSize(14)
-            }
-            // Headings
-            .heading1 { configuration in
-                VStack(alignment: .leading, spacing: 8) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(28)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 24, bottom: 16)
-            }
-            .heading2 { configuration in
-                VStack(alignment: .leading, spacing: 6) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(22)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 20, bottom: 12)
-            }
-            .heading3 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(18)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 16, bottom: 8)
-            }
-            .heading4 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(16)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 12, bottom: 6)
-            }
-            .heading5 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(14)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 10, bottom: 4)
-            }
-            .heading6 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(13)
-                        ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
-                    }
-                    .markdownMargin(top: 8, bottom: 4)
-            }
-            // Code blocks
-            .codeBlock { configuration in
-                ScrollView(.horizontal, showsIndicators: true) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontFamilyVariant(.monospaced)
-                            FontSize(13)
-                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
-                        }
-                        .padding(12)
-                }
-                .background(isDark
-                    ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Inline code
-            .code {
-                FontFamilyVariant(.monospaced)
-                FontSize(13)
-                ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
-                BackgroundColor(isDark
-                    ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.92, alpha: 1.0)))
-            }
-            // Block quotes
-            .blockquote { configuration in
-                HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
-                        .frame(width: 3)
-                    configuration.label
-                        .markdownTextStyle {
-                            ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
-                            FontSize(14)
-                        }
-                        .padding(.leading, 12)
-                }
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Links
-            .link {
-                ForegroundColor(Color.accentColor)
-            }
-            // Strong
-            .strong {
-                FontWeight(.semibold)
-            }
-            // Tables
-            .table { configuration in
-                configuration.label
-                    .markdownTableBorderStyle(.init(color: isDark ? .white.opacity(0.15) : .gray.opacity(0.3)))
-                    .markdownTableBackgroundStyle(
-                        .alternatingRows(
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.14, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
-                        )
-                    )
-                    .markdownMargin(top: 8, bottom: 8)
-            }
-            // Thematic break (horizontal rule)
-            .thematicBreak {
-                Divider()
-                    .markdownMargin(top: 16, bottom: 16)
-            }
-            // List items
-            .listItem { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 4)
-            }
-            // Paragraphs
-            .paragraph { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 8)
-            }
-    }
-
-    // MARK: - Focus Flash
 
     private func triggerFocusFlashAnimation() {
         focusFlashAnimationGeneration &+= 1
@@ -287,6 +124,574 @@ struct MarkdownPanelView: View {
         case .easeOut:
             return .easeOut(duration: duration)
         }
+    }
+}
+
+struct RunestoneMarkdownTextSurface: NSViewRepresentable {
+    let markdown: String
+    let colorScheme: ColorScheme
+
+    func makeNSView(context: Context) -> MarkdownPanelRunestoneView {
+        let view = MarkdownPanelRunestoneView()
+        view.update(markdown: markdown, colorScheme: colorScheme)
+        return view
+    }
+
+    func updateNSView(_ nsView: MarkdownPanelRunestoneView, context: Context) {
+        nsView.update(markdown: markdown, colorScheme: colorScheme)
+    }
+}
+
+final class MarkdownPanelRunestoneView: NSView {
+    let editor = TextView(frame: .zero)
+
+    private var currentMarkdown = ""
+    private var currentThemeKey = ""
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+
+        editor.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(editor)
+        NSLayoutConstraint.activate([
+            editor.leadingAnchor.constraint(equalTo: leadingAnchor),
+            editor.trailingAnchor.constraint(equalTo: trailingAnchor),
+            editor.topAnchor.constraint(equalTo: topAnchor),
+            editor.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        configureEditor()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func update(markdown: String, colorScheme: ColorScheme) {
+        let theme = MarkdownPanelTheme(colorScheme: colorScheme)
+        let themeKey = theme.cacheKey
+        let themeChanged = themeKey != currentThemeKey
+        let contentChanged = markdown != currentMarkdown
+
+        guard themeChanged || contentChanged else {
+            return
+        }
+
+        let previousOrigin = editor.contentView.bounds.origin
+        let previousViewportHeight = editor.contentView.bounds.height
+        let previousDocumentHeight = editor.documentView?.frame.height ?? 0
+        let previousScrollRatio = markdownScrollRatio(
+            originY: previousOrigin.y,
+            documentHeight: previousDocumentHeight,
+            viewportHeight: previousViewportHeight
+        )
+
+        editor.theme = theme
+        editor.backgroundColor = theme.editorBackgroundColor
+        editor.textView.backgroundColor = theme.editorBackgroundColor
+        editor.textView.textColor = theme.textColor
+        editor.selectionBarColor = theme.textColor
+        editor.selectionHighlightColor = theme.markedTextBackgroundColor
+
+        if contentChanged {
+            editor.text = markdown
+            currentMarkdown = markdown
+        }
+
+        MarkdownPanelAttributedRenderer.render(
+            markdown: editor.text,
+            in: editor.textView.textStorage,
+            theme: theme
+        )
+
+        if contentChanged {
+            restoreScrollPosition(
+                previousRatio: previousScrollRatio,
+                viewportHeight: editor.contentView.bounds.height
+            )
+        } else if themeChanged {
+            editor.contentView.scroll(to: previousOrigin)
+            editor.reflectScrolledClipView(editor.contentView)
+        }
+
+        currentThemeKey = themeKey
+    }
+
+    private func configureEditor() {
+        editor.isEditable = false
+        editor.isSelectable = true
+        editor.showLineNumbers = false
+        editor.gutterLeadingPadding = 0
+        editor.gutterTrailingPadding = 0
+        editor.isLineWrappingEnabled = true
+        editor.lineBreakMode = .byWordWrapping
+        editor.showPageGuide = false
+        editor.hasHorizontalScroller = false
+        editor.hasVerticalScroller = true
+        editor.borderType = .noBorder
+        editor.textView.textContainerInset = NSSize(width: 24, height: 16)
+        editor.textView.isAutomaticQuoteSubstitutionEnabled = false
+        editor.textView.isAutomaticDashSubstitutionEnabled = false
+        editor.textView.isAutomaticTextReplacementEnabled = false
+        editor.textView.isAutomaticSpellingCorrectionEnabled = false
+        editor.textView.isAutomaticTextCompletionEnabled = false
+        editor.textView.isAutomaticDataDetectionEnabled = false
+        editor.textView.isAutomaticLinkDetectionEnabled = false
+        editor.textView.isContinuousSpellCheckingEnabled = false
+        editor.textView.isGrammarCheckingEnabled = false
+        editor.textView.allowsUndo = false
+    }
+
+    private func markdownScrollRatio(originY: CGFloat, documentHeight: CGFloat, viewportHeight: CGFloat) -> CGFloat {
+        let scrollableHeight = max(documentHeight - viewportHeight, 0)
+        guard scrollableHeight > 0 else {
+            return 0
+        }
+        return min(max(originY / scrollableHeight, 0), 1)
+    }
+
+    private func restoreScrollPosition(previousRatio: CGFloat, viewportHeight: CGFloat) {
+        let documentHeight = editor.documentView?.frame.height ?? 0
+        let scrollableHeight = max(documentHeight - viewportHeight, 0)
+        let restoredY = scrollableHeight * previousRatio
+        editor.contentView.scroll(to: NSPoint(x: 0, y: restoredY))
+        editor.reflectScrolledClipView(editor.contentView)
+    }
+}
+
+final class MarkdownPanelTheme: Theme {
+    let cacheKey: String
+    let font: NSFont
+    let textColor: NSColor
+    let gutterBackgroundColor: NSColor
+    let gutterHairlineColor: NSColor
+    let lineNumberColor: NSColor
+    let lineNumberFont: NSFont
+    let selectedLineBackgroundColor: NSColor
+    let selectedLinesLineNumberColor: NSColor
+    let selectedLinesGutterBackgroundColor: NSColor
+    let invisibleCharactersColor: NSColor
+    let pageGuideHairlineColor: NSColor
+    let pageGuideBackgroundColor: NSColor
+    let markedTextBackgroundColor: NSColor
+
+    let editorBackgroundColor: NSColor
+    let secondaryTextColor: NSColor
+    let tertiaryTextColor: NSColor
+    let headingColor: NSColor
+    let linkColor: NSColor
+    let quoteColor: NSColor
+    let codeColor: NSColor
+    let codeBackgroundColor: NSColor
+    let separatorColor: NSColor
+
+    private let strongFontValue: NSFont
+    private let emphasisFontValue: NSFont
+    private let codeFontValue: NSFont
+    private let headingFonts: [NSFont]
+
+    init(colorScheme: ColorScheme) {
+        let isDark = colorScheme == .dark
+        let baseFont = NSFont.systemFont(ofSize: 14, weight: .regular)
+        cacheKey = isDark ? "dark" : "light"
+
+        font = baseFont
+        lineNumberFont = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        strongFontValue = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
+        emphasisFontValue = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
+        codeFontValue = .monospacedSystemFont(ofSize: 13, weight: .regular)
+
+        if isDark {
+            editorBackgroundColor = NSColor(white: 0.12, alpha: 1.0)
+            textColor = NSColor(white: 0.92, alpha: 1.0)
+            secondaryTextColor = NSColor(white: 0.72, alpha: 1.0)
+            tertiaryTextColor = NSColor(white: 0.55, alpha: 1.0)
+            headingColor = NSColor.systemPurple.withAlphaComponent(0.95)
+            linkColor = NSColor.systemBlue.withAlphaComponent(0.95)
+            quoteColor = NSColor(white: 0.68, alpha: 1.0)
+            codeColor = NSColor.systemGreen.withAlphaComponent(0.95)
+            codeBackgroundColor = NSColor(white: 0.18, alpha: 1.0)
+            separatorColor = NSColor(white: 0.35, alpha: 1.0)
+            gutterHairlineColor = NSColor(white: 0.22, alpha: 1.0)
+            pageGuideHairlineColor = NSColor(white: 0.22, alpha: 1.0)
+            pageGuideBackgroundColor = NSColor(white: 0.16, alpha: 1.0)
+            markedTextBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.28)
+            selectedLineBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.10)
+        } else {
+            editorBackgroundColor = NSColor(white: 0.98, alpha: 1.0)
+            textColor = NSColor.labelColor
+            secondaryTextColor = NSColor.secondaryLabelColor
+            tertiaryTextColor = NSColor.tertiaryLabelColor
+            headingColor = NSColor.systemPurple
+            linkColor = NSColor.linkColor
+            quoteColor = NSColor.secondaryLabelColor
+            codeColor = NSColor.systemGreen.blended(withFraction: 0.35, of: NSColor.labelColor) ?? NSColor.systemGreen
+            codeBackgroundColor = NSColor(white: 0.93, alpha: 1.0)
+            separatorColor = NSColor.separatorColor
+            gutterHairlineColor = NSColor.separatorColor
+            pageGuideHairlineColor = NSColor.separatorColor
+            pageGuideBackgroundColor = NSColor(white: 0.96, alpha: 1.0)
+            markedTextBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.22)
+            selectedLineBackgroundColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.08)
+        }
+
+        gutterBackgroundColor = editorBackgroundColor
+        lineNumberColor = tertiaryTextColor
+        selectedLinesLineNumberColor = textColor
+        selectedLinesGutterBackgroundColor = editorBackgroundColor
+        invisibleCharactersColor = tertiaryTextColor
+
+        headingFonts = (1...6).map { level in
+            let size = baseFont.pointSize + CGFloat(7 - level) * 2.6
+            return NSFont.systemFont(ofSize: size, weight: level <= 2 ? .bold : .semibold)
+        }
+    }
+
+    func headingFont(for level: Int) -> NSFont {
+        headingFonts[max(0, min(headingFonts.count - 1, level - 1))]
+    }
+
+    var strongFont: NSFont {
+        strongFontValue
+    }
+
+    var emphasisFont: NSFont {
+        emphasisFontValue
+    }
+
+    var codeFont: NSFont {
+        codeFontValue
+    }
+}
+
+enum MarkdownPanelAttributedRenderer {
+    private static let markdownLinkRegex = makeRegex(#"\[([^\]]+)\]\(([^)\s]+)\)"#)
+    private static let autolinkRegex = makeRegex(#"<((?:https?|mailto):[^>\s]+)>"#)
+    private static let strongRegex = makeRegex(#"(\*\*[^*\n]+\*\*|__[^_\n]+__)"#)
+    private static let emphasisRegex = makeRegex(#"(?<!\*)\*[^*\n]+\*(?!\*)|(?<!_)_[^_\n]+_(?!_)"#)
+    private static let inlineCodeRegex = makeRegex(#"`[^`\n]+`"#)
+    private static let unorderedListRegex = makeRegex(#"^\s*(?:[-*+]\s+)"#)
+    private static let orderedListRegex = makeRegex(#"^\s*\d+\.\s+"#)
+    private static let taskListRegex = makeRegex(#"^\s*[-*+]\s+\[[ xX]\]\s+"#)
+    private static let blockQuoteRegex = makeRegex(#"^\s*>\s?.*$"#)
+    private static let thematicBreakRegex = makeRegex(#"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$"#)
+    private static let fenceRegex = makeRegex(#"^\s*```"#)
+
+    static func render(markdown: String, in textStorage: NSTextStorage?, theme: MarkdownPanelTheme) {
+        guard let textStorage else {
+            return
+        }
+
+        let source = markdown as NSString
+        let fullRange = NSRange(location: 0, length: source.length)
+        let excludedInlineRanges = NSMutableArray()
+
+        textStorage.beginEditing()
+        defer { textStorage.endEditing() }
+
+        let baseParagraphStyle = paragraphStyle(
+            lineSpacing: 3,
+            paragraphSpacing: 8,
+            paragraphSpacingBefore: 0
+        )
+        textStorage.setAttributes(
+            [
+                .font: theme.font,
+                .foregroundColor: theme.textColor,
+                .paragraphStyle: baseParagraphStyle
+            ],
+            range: fullRange
+        )
+
+        var isInsideFencedCodeBlock = false
+        var location = 0
+        while location < source.length {
+            let lineRange = source.lineRange(for: NSRange(location: location, length: 0))
+            let lineContentRange = trimmedLineContentRange(for: lineRange, in: source)
+            let lineText = source.substring(with: lineContentRange)
+
+            if matches(Self.fenceRegex, lineText) {
+                excludedInlineRanges.add(NSValue(range: lineContentRange))
+                textStorage.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.tertiaryTextColor,
+                        .backgroundColor: theme.codeBackgroundColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 6, paragraphSpacingBefore: 6)
+                    ],
+                    range: lineRange
+                )
+                isInsideFencedCodeBlock.toggle()
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if isInsideFencedCodeBlock {
+                excludedInlineRanges.add(NSValue(range: lineContentRange))
+                textStorage.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.codeColor,
+                        .backgroundColor: theme.codeBackgroundColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 4, paragraphSpacingBefore: 0)
+                    ],
+                    range: lineRange
+                )
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if let heading = headingMetadata(in: lineText) {
+                let hashRange = NSRange(
+                    location: lineContentRange.location + heading.hashRange.location,
+                    length: heading.hashRange.length
+                )
+                let titleRange = NSRange(
+                    location: lineContentRange.location + heading.titleRange.location,
+                    length: heading.titleRange.length
+                )
+                textStorage.addAttributes(
+                    [
+                        .foregroundColor: theme.tertiaryTextColor
+                    ],
+                    range: hashRange
+                )
+                textStorage.addAttributes(
+                    [
+                        .font: theme.headingFont(for: heading.level),
+                        .foregroundColor: theme.headingColor
+                    ],
+                    range: titleRange
+                )
+                textStorage.addAttribute(
+                    .paragraphStyle,
+                    value: paragraphStyle(
+                        lineSpacing: 4,
+                        paragraphSpacing: heading.level <= 2 ? 16 : 10,
+                        paragraphSpacingBefore: heading.level == 1 ? 8 : 4
+                    ),
+                    range: lineRange
+                )
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if matches(Self.blockQuoteRegex, lineText) {
+                textStorage.addAttributes(
+                    [
+                        .foregroundColor: theme.quoteColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 3, paragraphSpacing: 8, paragraphSpacingBefore: 0)
+                    ],
+                    range: lineRange
+                )
+            } else if matches(Self.thematicBreakRegex, lineText) {
+                textStorage.addAttributes(
+                    [
+                        .foregroundColor: theme.separatorColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 12, paragraphSpacingBefore: 6)
+                    ],
+                    range: lineRange
+                )
+            } else if lineText.contains("|") {
+                textStorage.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.textColor
+                    ],
+                    range: lineContentRange
+                )
+            }
+
+            if let markerRange = listMarkerRange(in: lineText) {
+                let absoluteMarkerRange = NSRange(
+                    location: lineContentRange.location + markerRange.location,
+                    length: markerRange.length
+                )
+                textStorage.addAttribute(
+                    .foregroundColor,
+                    value: theme.tertiaryTextColor,
+                    range: absoluteMarkerRange
+                )
+            }
+
+            location = NSMaxRange(lineRange)
+        }
+
+        applyStrongAttributes(to: textStorage, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyEmphasisAttributes(to: textStorage, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyInlineCodeAttributes(to: textStorage, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyLinkAttributes(to: textStorage, markdown: source, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+    }
+
+    private static func applyStrongAttributes(
+        to textStorage: NSTextStorage,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        Self.strongRegex.enumerateMatches(in: textStorage.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            textStorage.addAttribute(.font, value: theme.strongFont, range: range)
+        }
+    }
+
+    private static func applyEmphasisAttributes(
+        to textStorage: NSTextStorage,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        Self.emphasisRegex.enumerateMatches(in: textStorage.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            textStorage.addAttribute(.font, value: theme.emphasisFont, range: range)
+        }
+    }
+
+    private static func applyInlineCodeAttributes(
+        to textStorage: NSTextStorage,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        Self.inlineCodeRegex.enumerateMatches(in: textStorage.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            textStorage.addAttributes(
+                [
+                    .font: theme.codeFont,
+                    .foregroundColor: theme.codeColor,
+                    .backgroundColor: theme.codeBackgroundColor
+                ],
+                range: range
+            )
+        }
+    }
+
+    private static func applyLinkAttributes(
+        to textStorage: NSTextStorage,
+        markdown: NSString,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        Self.markdownLinkRegex.enumerateMatches(in: markdown as String, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !intersectsExcludedRanges(match.range, excludedRanges: excludedRanges) else { return }
+            let urlString = markdown.substring(with: match.range(at: 2))
+            guard let url = URL(string: urlString) else { return }
+            textStorage.addAttributes(
+                [
+                    .foregroundColor: theme.linkColor,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                    .link: url
+                ],
+                range: match.range
+            )
+        }
+
+        Self.autolinkRegex.enumerateMatches(in: markdown as String, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !intersectsExcludedRanges(match.range, excludedRanges: excludedRanges) else { return }
+            let urlString = markdown.substring(with: match.range(at: 1))
+            guard let url = URL(string: urlString) else { return }
+            textStorage.addAttributes(
+                [
+                    .foregroundColor: theme.linkColor,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                    .link: url
+                ],
+                range: match.range
+            )
+        }
+    }
+
+    private static func headingMetadata(in lineText: String) -> (level: Int, hashRange: NSRange, titleRange: NSRange)? {
+        let source = lineText as NSString
+        var level = 0
+        while level < min(6, source.length), source.character(at: level) == unichar(35) {
+            level += 1
+        }
+        guard level > 0,
+              source.length > level,
+              CharacterSet.whitespaces.contains(UnicodeScalar(source.character(at: level))!) else {
+            return nil
+        }
+
+        let titleLocation = level + 1
+        guard titleLocation <= source.length else {
+            return nil
+        }
+
+        let titleLength = source.length - titleLocation
+        guard titleLength > 0 else {
+            return nil
+        }
+
+        return (
+            level,
+            NSRange(location: 0, length: level),
+            NSRange(location: titleLocation, length: titleLength)
+        )
+    }
+
+    private static func listMarkerRange(in lineText: String) -> NSRange? {
+        let fullRange = NSRange(location: 0, length: (lineText as NSString).length)
+        if let match = Self.taskListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        if let match = Self.unorderedListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        if let match = Self.orderedListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        return nil
+    }
+
+    private static func paragraphStyle(
+        lineSpacing: CGFloat,
+        paragraphSpacing: CGFloat,
+        paragraphSpacingBefore: CGFloat
+    ) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = lineSpacing
+        style.paragraphSpacing = paragraphSpacing
+        style.paragraphSpacingBefore = paragraphSpacingBefore
+        style.lineBreakMode = .byWordWrapping
+        return style
+    }
+
+    private static func trimmedLineContentRange(for lineRange: NSRange, in source: NSString) -> NSRange {
+        var length = lineRange.length
+        while length > 0 {
+            let character = source.character(at: lineRange.location + length - 1)
+            if character == 10 || character == 13 {
+                length -= 1
+            } else {
+                break
+            }
+        }
+        return NSRange(location: lineRange.location, length: length)
+    }
+
+    private static func matches(_ regex: NSRegularExpression, _ text: String) -> Bool {
+        regex.firstMatch(in: text, range: NSRange(location: 0, length: (text as NSString).length)) != nil
+    }
+
+    private static func intersectsExcludedRanges(_ range: NSRange, excludedRanges: NSMutableArray) -> Bool {
+        for case let value as NSValue in excludedRanges {
+            if NSIntersectionRange(range, value.rangeValue).length > 0 {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        try! NSRegularExpression(pattern: pattern)
     }
 }
 
@@ -381,15 +786,9 @@ final class MarkdownPanelPointerObserverView: NSView {
 
     private func forwardedTarget(for event: NSEvent) -> NSView? {
         guard let window else {
-#if DEBUG
-            NSLog("MarkdownPanelPointerObserverView.forwardedTarget skipped, window=0 contentView=0")
-#endif
             return nil
         }
         guard let contentView = window.contentView else {
-#if DEBUG
-            NSLog("MarkdownPanelPointerObserverView.forwardedTarget skipped, window=1 contentView=0")
-#endif
             return nil
         }
         isHidden = true

--- a/Sources/VendoredRunestone.swift
+++ b/Sources/VendoredRunestone.swift
@@ -1,0 +1,26 @@
+import AppKit
+import Runestone
+
+struct VendoredRunestoneSmokeSnapshot {
+    let text: String
+    let isEditable: Bool
+    let isSelectable: Bool
+    let themeTypeName: String
+}
+
+enum VendoredRunestoneSupport {
+    static func makeSmokeSnapshot() -> VendoredRunestoneSmokeSnapshot {
+        let editor = TextView(frame: NSRect(x: 0, y: 0, width: 320, height: 240))
+        editor.theme = DefaultTheme()
+        editor.isEditable = true
+        editor.isSelectable = true
+        editor.text = "# cmux\nVendored Runestone\n"
+
+        return VendoredRunestoneSmokeSnapshot(
+            text: editor.text,
+            isEditable: editor.isEditable,
+            isSelectable: editor.isSelectable,
+            themeTypeName: String(describing: type(of: editor.theme))
+        )
+    }
+}

--- a/THIRD_PARTY_LICENSES.md
+++ b/THIRD_PARTY_LICENSES.md
@@ -56,6 +56,58 @@ SOFTWARE.
 
 ---
 
+## Runestone
+
+- **License:** MIT License
+- **Copyright:** Copyright (c) 2021 Simon Støvring
+- **Source:** https://github.com/simonbs/Runestone
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+## tree-sitter
+
+- **License:** MIT License
+- **Copyright:** Copyright (c) 2018-2023 Max Brunsfeld
+- **Source:** https://github.com/tree-sitter/tree-sitter
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
 ## SwiftTerm
 
 - **License:** MIT License

--- a/cmuxTests/RunestoneVendoringTests.swift
+++ b/cmuxTests/RunestoneVendoringTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class RunestoneVendoringTests: XCTestCase {
+    func testVendoredRunestoneSmokeSnapshot() {
+        let snapshot = VendoredRunestoneSupport.makeSmokeSnapshot()
+
+        XCTAssertEqual(snapshot.text, "# cmux\nVendored Runestone\n")
+        XCTAssertTrue(snapshot.isEditable)
+        XCTAssertTrue(snapshot.isSelectable)
+        XCTAssertEqual(snapshot.themeTypeName, "DefaultTheme")
+    }
+}

--- a/cmuxTests/RunestoneVendoringTests.swift
+++ b/cmuxTests/RunestoneVendoringTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -6,6 +7,7 @@ import XCTest
 @testable import cmux
 #endif
 
+@MainActor
 final class RunestoneVendoringTests: XCTestCase {
     func testVendoredRunestoneSmokeSnapshot() {
         let snapshot = VendoredRunestoneSupport.makeSmokeSnapshot()
@@ -14,5 +16,25 @@ final class RunestoneVendoringTests: XCTestCase {
         XCTAssertTrue(snapshot.isEditable)
         XCTAssertTrue(snapshot.isSelectable)
         XCTAssertEqual(snapshot.themeTypeName, "DefaultTheme")
+    }
+
+    func testMarkdownRendererAppliesHeadingAndLinkAttributes() {
+        let storage = NSTextStorage(string: "# Title\n\nA [link](https://example.com)\n")
+        let theme = MarkdownPanelTheme(colorScheme: .light)
+
+        MarkdownPanelAttributedRenderer.render(
+            markdown: storage.string,
+            in: storage,
+            theme: theme
+        )
+
+        let titleRange = (storage.string as NSString).range(of: "Title")
+        let headingFont = storage.attribute(.font, at: titleRange.location, effectiveRange: nil) as? NSFont
+        XCTAssertNotNil(headingFont)
+        XCTAssertGreaterThan(headingFont?.pointSize ?? 0, theme.font.pointSize)
+
+        let linkRange = (storage.string as NSString).range(of: "[link](https://example.com)")
+        let linkValue = storage.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
+        XCTAssertEqual(linkValue?.absoluteString, "https://example.com")
     }
 }

--- a/cmuxTests/RunestoneVendoringTests.swift
+++ b/cmuxTests/RunestoneVendoringTests.swift
@@ -20,7 +20,7 @@ final class RunestoneVendoringTests: XCTestCase {
 
     func testMarkdownRendererAppliesHeadingAndLinkAttributes() {
         let storage = NSTextStorage(string: "# Title\n\nA [link](https://example.com)\n")
-        let theme = MarkdownPanelTheme(colorScheme: .light)
+        let theme = MarkdownPanelTheme(config: GhosttyConfig())
 
         MarkdownPanelAttributedRenderer.render(
             markdown: storage.string,
@@ -36,5 +36,29 @@ final class RunestoneVendoringTests: XCTestCase {
         let linkRange = (storage.string as NSString).range(of: "[link](https://example.com)")
         let linkValue = storage.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
         XCTAssertEqual(linkValue?.absoluteString, "https://example.com")
+    }
+
+    func testMarkdownThemeUsesGhosttyFontAndPalette() {
+        var config = GhosttyConfig()
+        config.fontFamily = "Menlo"
+        config.fontSize = 17
+        config.backgroundColor = NSColor(hex: "#101214")!
+        config.foregroundColor = NSColor(hex: "#f5f6f7")!
+        config.selectionBackground = NSColor(hex: "#303846")!
+        config.selectionForeground = NSColor(hex: "#ffffff")!
+        config.cursorColor = NSColor(hex: "#87d7ff")!
+        config.palette[2] = NSColor(hex: "#7ec16e")!
+        config.palette[4] = NSColor(hex: "#6aa9ff")!
+        config.palette[5] = NSColor(hex: "#c792ea")!
+
+        let theme = MarkdownPanelTheme(config: config)
+
+        XCTAssertEqual(theme.font.pointSize, 17)
+        XCTAssertEqual(theme.font.familyName, "Menlo")
+        XCTAssertEqual(theme.editorBackgroundColor.hexString(), "#101214")
+        XCTAssertEqual(theme.textColor.hexString(), "#F5F6F7")
+        XCTAssertEqual(theme.headingColor.hexString(), "#C792EA")
+        XCTAssertEqual(theme.linkColor.hexString(), "#6AA9FF")
+        XCTAssertEqual(theme.codeColor.hexString(), "#7EC16E")
     }
 }

--- a/vendor/runestone/LICENSE
+++ b/vendor/runestone/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2021 Simon Støvring
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/runestone/Package.swift
+++ b/vendor/runestone/Package.swift
@@ -1,0 +1,47 @@
+// swift-tools-version:5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "Runestone",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "Runestone", targets: ["Runestone"]),
+        .library(name: "RunestoneCore", targets: ["RunestoneCore"]),
+        .library(name: "RunestonePlatform", targets: ["RunestonePlatform"]),
+        .library(name: "RunestoneUIMac", targets: ["RunestoneUIMac"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/tree-sitter/tree-sitter", .upToNextMinor(from: "0.20.9"))
+    ],
+    targets: [
+        .target(
+            name: "Runestone",
+            dependencies: [
+                "RunestoneUIMac"
+            ],
+            path: "Sources/RunestoneFacade"
+        ),
+        .target(
+            name: "RunestonePlatform",
+            path: "Sources/RunestonePlatform"
+        ),
+        .target(
+            name: "RunestoneCore",
+            dependencies: [
+                .product(name: "TreeSitter", package: "tree-sitter")
+            ],
+            path: "Sources/RunestoneCore"
+        ),
+        .target(
+            name: "RunestoneUIMac",
+            dependencies: [
+                "RunestonePlatform",
+                "RunestoneCore"
+            ],
+            path: "Sources/RunestoneMac"
+        ),
+    ]
+)

--- a/vendor/runestone/Sources/RunestoneCore/Library/ByteCount.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/ByteCount.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+struct ByteCount: Hashable {
+    private(set) var value: Int
+    var utf16Length: Int {
+        value / 2
+    }
+
+    init(_ value: Int) {
+        self.value = value
+    }
+
+    init(_ value: UInt32) {
+        self.value = Int(value)
+    }
+
+    init(utf16Length: Int) {
+        self.value = utf16Length * 2
+    }
+}
+
+extension ByteCount: Comparable {
+    static func < (lhs: ByteCount, rhs: ByteCount) -> Bool {
+        lhs.value < rhs.value
+    }
+
+    static func <= (lhs: ByteCount, rhs: ByteCount) -> Bool {
+        lhs.value <= rhs.value
+    }
+
+    static func >= (lhs: ByteCount, rhs: ByteCount) -> Bool {
+        lhs.value >= rhs.value
+    }
+
+    static func > (lhs: ByteCount, rhs: ByteCount) -> Bool {
+        lhs.value > rhs.value
+    }
+}
+
+extension ByteCount: Numeric {
+    typealias Magnitude = Int
+    typealias IntegerLiteralType = Int
+
+    static var zero: ByteCount {
+        ByteCount(0)
+    }
+
+    var magnitude: Int {
+        value
+    }
+
+    init?<T>(exactly source: T) where T: BinaryInteger {
+        self.value = Int(source)
+    }
+
+    init(integerLiteral value: Int) {
+        self.value = value
+    }
+
+    static func - (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
+        ByteCount(lhs.value - rhs.value)
+    }
+
+    static func -= (lhs: inout ByteCount, rhs: ByteCount) {
+        lhs.value -= rhs.value
+    }
+
+    static func + (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
+        ByteCount(lhs.value + rhs.value)
+    }
+
+    static func += (lhs: inout ByteCount, rhs: ByteCount) {
+        lhs.value += rhs.value
+    }
+
+    static func * (lhs: ByteCount, rhs: ByteCount) -> ByteCount {
+        ByteCount(lhs.value * rhs.value)
+    }
+
+    static func *= (lhs: inout ByteCount, rhs: ByteCount) {
+        lhs.value *= rhs.value
+    }
+}
+
+extension ByteCount: CustomStringConvertible {
+    var description: String {
+        "\(value)"
+    }
+}
+
+extension ByteCount: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "\(value)"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/ByteRange.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/ByteRange.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct ByteRange: Hashable {
+    let location: ByteCount
+    let length: ByteCount
+    var lowerBound: ByteCount {
+        location
+    }
+    var upperBound: ByteCount {
+        location + length
+    }
+    var isEmpty: Bool {
+        length == 0
+    }
+
+    init(location: ByteCount, length: ByteCount) {
+        self.location = location
+        self.length = length
+    }
+
+    init(from startByte: ByteCount, to endByte: ByteCount) {
+        self.location = startByte
+        self.length = endByte - startByte
+    }
+
+    init(utf16Range: NSRange) {
+        self.location = ByteCount(utf16Range.location * 2)
+        self.length = ByteCount(utf16Range.length * 2)
+    }
+
+    func overlaps(_ otherRange: Self) -> Bool {
+        let r1 = location ... location + length
+        let r2 = otherRange.location ... otherRange.location + otherRange.length
+        return r1.overlaps(r2)
+    }
+}
+
+extension ByteRange: CustomStringConvertible {
+    var description: String {
+        "{\(location), \(length)}"
+    }
+}
+
+extension ByteRange: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "{\(location), \(length)}"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/CharacterSet+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/CharacterSet+Helpers.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+extension CharacterSet {
+    func containsAllCharacters(of string: String) -> Bool {
+        var containsAllCharacters = true
+        for char in string.unicodeScalars where !contains(char) {
+            containsAllCharacters = false
+            break
+        }
+        return containsAllCharacters
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/LineEndingDetector.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/LineEndingDetector.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+final class LineEndingDetector {
+    private let lineManager: LineManager
+    private let stringView: StringView
+
+    init(lineManager: LineManager, stringView: StringView) {
+        self.lineManager = lineManager
+        self.stringView = stringView
+    }
+
+    func detect() -> LineEnding? {
+        var shouldScan = true
+        let iterator = lineManager.createLineIterator()
+        let lineCount = lineManager.lineCount
+        var scannedLineCount = 0
+        var lineEndingCountMap: [LineEnding: Int] = [:]
+        while let line = iterator.next(), shouldScan {
+            let lineLocation = line.location
+            let lineLength = line.data.totalLength
+            let delimiterLength = line.data.delimiterLength
+            let delimiterRange = NSRange(location: lineLocation + lineLength - delimiterLength, length: delimiterLength)
+            if let character = stringView.substring(in: delimiterRange), let lineEnding = LineEnding(symbol: character) {
+                scannedLineCount += 1
+                let count = lineEndingCountMap[lineEnding] ?? 0
+                lineEndingCountMap[lineEnding] = count + 1
+            }
+            let hasScannedEnoughLines = scannedLineCount >= min(lineCount, 20)
+            if hasScannedEnoughLines {
+                shouldScan = false
+            }
+        }
+        let fallbackOrder = LineEnding.allCases
+        let maxCountLineEnding = lineEndingCountMap.max { lhsPair, rhsPair in
+            if lhsPair.value < rhsPair.value {
+                return true
+            } else if lhsPair.value > rhsPair.value {
+                return false
+            } else {
+                let lhsIndex = fallbackOrder.firstIndex(of: lhsPair.key)!
+                let rhsIndex = fallbackOrder.firstIndex(of: rhsPair.key)!
+                return lhsIndex > rhsIndex
+            }
+        }
+        return maxCountLineEnding?.key
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/NSAttributedString+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/NSAttributedString+Helpers.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+extension NSAttributedString {
+    func isWhitespaceCharacter(at location: Int) -> Bool {
+        guard location < length else {
+            return false
+        }
+        let range = NSRange(location: location, length: 1)
+        let characterSet: CharacterSet = .whitespaces
+        let attributingSubstring = attributedSubstring(from: range)
+        return characterSet.containsAllCharacters(of: attributingSubstring.string)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/NSRange+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/NSRange+Helpers.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension NSRange {
+    /// Creates an NSRange from a `ByteRange`.
+    /// - Parameter byteRange: `ByteRange` to convert to NSRange.
+    init(_ byteRange: ByteRange) {
+        let location = byteRange.location.value / 2
+        let length = byteRange.length.value / 2
+        self.init(location: location, length: length)
+    }
+
+    /// Checks if range overlaps another range.
+    /// - Parameter range: Range to check against.
+    /// - Returns: True if the ranges overlap otherwise false.
+    func overlaps(_ range: NSRange) -> Bool {
+        let r1 = location ..< location + length
+        let r2 = range.location ..< range.location + range.length
+        return r1.overlaps(r2)
+    }
+
+    /// Returns a range that is guaranteed not to have a negative length. As an example the range (20, -4) will be converted to (16, 4) and the range (20, -25) will be converted to (0, 20).
+    var nonNegativeLength: NSRange {
+        if length < 0 {
+            let absoluteLength = abs(length)
+            let safeAbsoluteLength = min(absoluteLength, location)
+            return NSRange(location: location - safeAbsoluteLength, length: safeAbsoluteLength)
+        } else {
+            return self
+        }
+    }
+
+    /// Ensures the range fits within the specified range.
+    /// - Parameter cappingRange: The target range.
+    /// - Returns: A range that fits within the target range.
+    func capped(to cappingRange: NSRange) -> NSRange {
+        let newLowerBound = min(max(lowerBound, cappingRange.lowerBound), cappingRange.upperBound)
+        let tmpNewUpperBound = newLowerBound + length - (newLowerBound - lowerBound)
+        let newUpperBound = min(max(tmpNewUpperBound, cappingRange.lowerBound), cappingRange.upperBound)
+        let newLength = min(newUpperBound - newLowerBound, cappingRange.length)
+        return NSRange(location: newLowerBound, length: newLength)
+    }
+
+    /// Crates a range that is local to the specified range.
+    /// - Parameter parentRange: The parent range.
+    /// - Returns: A range that is local to the parent range.
+    func local(to parentRange: NSRange) -> NSRange {
+        let localLowerBound = lowerBound - parentRange.lowerBound
+        let localUpperBound = upperBound - parentRange.lowerBound
+        let length = localUpperBound - localLowerBound
+        return NSRange(location: localLowerBound, length: length)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/NSString+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/NSString+Helpers.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+extension NSString {
+    var byteCount: ByteCount {
+        ByteCount(length * 2)
+    }
+
+    func getAllBytes(withEncoding encoding: String.Encoding, usedLength: inout Int) -> UnsafePointer<Int8>? {
+        let range = NSRange(location: 0, length: length)
+        return getBytes(in: range, encoding: encoding, usedLength: &usedLength)
+    }
+
+    func getBytes(in range: NSRange, encoding: String.Encoding, usedLength: inout Int) -> UnsafePointer<Int8>? {
+        let byteRange = ByteRange(utf16Range: range)
+        let buffer = UnsafeMutablePointer<Int8>.allocate(capacity: byteRange.length.value)
+        let didGetBytes = getBytes(
+            buffer,
+            maxLength: byteRange.length.value,
+            usedLength: &usedLength,
+            encoding: encoding.rawValue,
+            options: [],
+            range: range,
+            remaining: nil)
+        if didGetBytes {
+            return UnsafePointer<Int8>(buffer)
+        } else {
+            return nil
+        }
+    }
+
+    /// A wrapper around `rangeOfComposedCharacterSequences(for:)` that considers CRLF line endings as composed character sequences.
+    func customRangeOfComposedCharacterSequence(at location: Int) -> NSRange {
+        let range = NSRange(location: location, length: 0)
+        return customRangeOfComposedCharacterSequences(for: range)
+    }
+
+    /// A wrapper around `rangeOfComposedCharacterSequences(for:)` that considers CRLF line endings as composed character sequences.
+    func customRangeOfComposedCharacterSequences(for range: NSRange) -> NSRange {
+        let defaultRange = rangeOfComposedCharacterSequences(for: range)
+        let candidateCRLFRange = NSRange(location: defaultRange.location - 1, length: 2)
+        if candidateCRLFRange.location >= 0 && candidateCRLFRange.upperBound <= length && isCRLFLineEnding(in: candidateCRLFRange) {
+            return NSRange(location: defaultRange.location - 1, length: defaultRange.length + 1)
+        } else {
+            return defaultRange
+        }
+    }
+}
+
+private extension NSString {
+    private func isCRLFLineEnding(in range: NSRange) -> Bool {
+        substring(with: range) == Symbol.carriageReturnLineFeed
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/String+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/String+Helpers.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension String {
+    static var preferredUTF16Encoding: String.Encoding {
+        // Implementation from https://github.com/ChimeHQ/SwiftTreeSitter/blob/main/Sources/SwiftTreeSitter/String%2BData.swift
+        let dataA = "abc".data(using: .utf16LittleEndian)
+        let dataB = "abc".data(using: .utf16)?.suffix(from: 2)
+        return dataA == dataB ? .utf16LittleEndian : .utf16BigEndian
+    }
+
+    var byteCount: ByteCount {
+        ByteCount(utf16.count * 2)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/Symbol.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/Symbol.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum Symbol {
+    enum Character {
+        static let lineFeed: Swift.Character = "\n"
+        static let carriageReturn: Swift.Character = "\r"
+        static let carriageReturnLineFeed: Swift.Character = "\r\n"
+        static let lineSeparator: Swift.Character = "\u{2028}"
+        static let tab: Swift.Character = "\t"
+        static let space: Swift.Character = " "
+        static let nonBreakingSpace: Swift.Character = "\u{A0}"
+    }
+
+    static let lineFeed = String(Self.Character.lineFeed)
+    static let carriageReturn = String(Self.Character.carriageReturn)
+    static let carriageReturnLineFeed = String(Self.Character.carriageReturnLineFeed)
+    static let tab = String(Self.Character.tab)
+    static let space = String(Self.Character.space)
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/TextChange.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/TextChange.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+struct TextChange {
+    let byteRange: ByteRange
+    let bytesAdded: ByteCount
+    let oldEndLinePosition: LinePosition
+    let startLinePosition: LinePosition
+    let newEndLinePosition: LinePosition
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/TextEditHelper.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/TextEditHelper.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+struct TextEditResult {
+    let textChange: TextChange
+    let lineChangeSet: LineChangeSet
+    var didAddOrRemoveLines: Bool {
+        let didAddLines = !lineChangeSet.insertedLines.isEmpty
+        let didRemoveLines = !lineChangeSet.removedLines.isEmpty
+        return didAddLines || didRemoveLines
+    }
+}
+
+final class TextEditHelper {
+    private let stringView: StringView
+    private let lineManager: LineManager
+    private let lineEndings: LineEnding
+
+    init(stringView: StringView, lineManager: LineManager, lineEndings: LineEnding) {
+        self.stringView = stringView
+        self.lineManager = lineManager
+        self.lineEndings = lineEndings
+    }
+
+    func replaceText(in range: NSRange, with newString: String) -> TextEditResult {
+        let nsNewString = newString as NSString
+        let byteRange = ByteRange(utf16Range: range)
+        let oldEndLinePosition = lineManager.linePosition(at: range.location + range.length)!
+        stringView.replaceText(in: range, with: newString)
+        let lineChangeSet = LineChangeSet()
+        let lineChangeSetFromRemovingCharacters = lineManager.removeCharacters(in: range)
+        lineChangeSet.union(with: lineChangeSetFromRemovingCharacters)
+        let lineChangeSetFromInsertingCharacters = lineManager.insert(nsNewString, at: range.location)
+        lineChangeSet.union(with: lineChangeSetFromInsertingCharacters)
+        let startLinePosition = lineManager.linePosition(at: range.location)!
+        let newEndLinePosition = lineManager.linePosition(at: range.location + nsNewString.length)!
+        let textChange = TextChange(byteRange: byteRange,
+                                    bytesAdded: newString.byteCount,
+                                    oldEndLinePosition: oldEndLinePosition,
+                                    startLinePosition: startLinePosition,
+                                    newEndLinePosition: newEndLinePosition)
+        return TextEditResult(textChange: textChange, lineChangeSet: lineChangeSet)
+    }
+
+    func string(byApplying batchReplaceSet: BatchReplaceSet) -> NSString {
+        let sortedReplacements = batchReplaceSet.replacements.sorted { $0.range.lowerBound < $1.range.lowerBound }
+        // swiftlint:disable:next force_cast
+        let mutableSubstring = stringView.string.mutableCopy() as! NSMutableString
+        var totalChangeInLength = 0
+        var replacedRanges: [NSRange] = []
+        for replacement in sortedReplacements where !replacedRanges.contains(where: { $0.overlaps(replacement.range) }) {
+            let range = replacement.range
+            let adjustedRange = NSRange(location: range.location + totalChangeInLength, length: range.length)
+            mutableSubstring.replaceCharacters(in: adjustedRange, with: replacement.text)
+            replacedRanges.append(replacement.range)
+            totalChangeInLength += replacement.text.utf16.count - adjustedRange.length
+        }
+        return mutableSubstring
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/Library/TreeSitterTextPoint+Helpers.swift
+++ b/vendor/runestone/Sources/RunestoneCore/Library/TreeSitterTextPoint+Helpers.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension TreeSitterTextPoint {
+    convenience init(_ linePosition: LinePosition) {
+        let row = UInt32(linePosition.row)
+        let column = UInt32(linePosition.column * 2)
+        self.init(row: row, column: column)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/DocumentLineChildrenUpdater.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/DocumentLineChildrenUpdater.swift
@@ -1,0 +1,24 @@
+import CoreGraphics
+import Foundation
+
+final class DocumentLineChildrenUpdater: RedBlackTreeChildrenUpdater<DocumentLineNodeID, Int, DocumentLineNodeData> {
+    override func updateAfterChangingChildren(of node: Node) -> Bool {
+        var totalLineHeight = node.data.lineHeight
+        var totalByteCount = node.data.byteCount
+        if let leftNode = node.left {
+            totalLineHeight += leftNode.data.totalLineHeight
+            totalByteCount += leftNode.data.nodeTotalByteCount
+        }
+        if let rightNode = node.right {
+            totalLineHeight += rightNode.data.totalLineHeight
+            totalByteCount += rightNode.data.nodeTotalByteCount
+        }
+        if totalLineHeight != node.data.totalLineHeight || totalByteCount != node.data.nodeTotalByteCount {
+            node.data.totalLineHeight = totalLineHeight
+            node.data.nodeTotalByteCount = totalByteCount
+            return true
+        } else {
+            return false
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/DocumentLineNodeData.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/DocumentLineNodeData.swift
@@ -1,0 +1,45 @@
+import CoreGraphics
+import Foundation
+
+final class DocumentLineNodeData {
+    var delimiterLength = 0 {
+        didSet {
+            assert(delimiterLength >= 0 && delimiterLength <= 2)
+        }
+    }
+    var totalLength = 0
+    var length: Int {
+        totalLength - delimiterLength
+    }
+    var lineHeight: CGFloat
+    var totalLineHeight: CGFloat = 0
+    var nodeTotalByteCount = ByteCount(0)
+    var startByte: ByteCount {
+        node!.tree.startByte(of: node!)
+    }
+    var byteCount = ByteCount(0)
+    var byteRange: ByteRange {
+        ByteRange(location: startByte, length: byteCount - ByteCount(delimiterLength))
+    }
+    var totalByteRange: ByteRange {
+        ByteRange(location: startByte, length: byteCount)
+    }
+
+    weak var node: DocumentLineNode?
+
+    init(lineHeight: CGFloat) {
+        self.lineHeight = lineHeight
+    }
+}
+
+private extension DocumentLineTree {
+    func startByte(of node: Node) -> ByteCount {
+        offset(of: node, valueKeyPath: \.data.byteCount, totalValueKeyPath: \.data.nodeTotalByteCount, minimumValue: ByteCount(0))
+    }
+}
+
+extension DocumentLineNodeData: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[DocumentLineNodeData length=\(length) delimiterLength=\(delimiterLength) totalLength=\(totalLength)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/LineChangeSet.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/LineChangeSet.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+final class LineChangeSet {
+    private(set) var insertedLines: Set<DocumentLineNode> = []
+    private(set) var removedLines: Set<DocumentLineNode> = []
+    private(set) var editedLines: Set<DocumentLineNode> = []
+
+    func markLineInserted(_ line: DocumentLineNode) {
+        removedLines.remove(line)
+        editedLines.remove(line)
+        insertedLines.insert(line)
+    }
+
+    func markLineRemoved(_ line: DocumentLineNode) {
+        insertedLines.remove(line)
+        editedLines.remove(line)
+        removedLines.insert(line)
+    }
+
+    func markLineEdited(_ line: DocumentLineNode) {
+        if !insertedLines.contains(line) && !removedLines.contains(line) {
+            editedLines.insert(line)
+        }
+    }
+
+    func union(with otherChangeSet: LineChangeSet) {
+        insertedLines.formUnion(otherChangeSet.insertedLines)
+        removedLines.formUnion(otherChangeSet.removedLines)
+        editedLines.formUnion(otherChangeSet.editedLines)
+    }
+}
+
+extension LineChangeSet: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[LineChangeSet insertedLines=\(insertedLines) removedLines=\(removedLines) editedLines=\(editedLines)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/LineManager.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/LineManager.swift
@@ -1,0 +1,378 @@
+import CoreGraphics
+import Foundation
+
+struct DocumentLineNodeID: RedBlackTreeNodeID, Hashable {
+    let id = UUID()
+    var rawValue: String {
+        id.uuidString
+    }
+}
+
+extension DocumentLineNodeID: CustomDebugStringConvertible {
+    var debugDescription: String {
+        rawValue
+    }
+}
+
+typealias DocumentLineTree = RedBlackTree<DocumentLineNodeID, Int, DocumentLineNodeData>
+typealias DocumentLineNode = RedBlackTreeNode<DocumentLineNodeID, Int, DocumentLineNodeData>
+
+final class LineManager {
+    var stringView: StringView
+    var lineCount: Int {
+        documentLineTree.nodeTotalCount
+    }
+    var contentHeight: CGFloat {
+        let rightMost = documentLineTree.root.rightMost
+        return rightMost.yPosition + rightMost.data.lineHeight
+    }
+    var estimatedLineHeight: CGFloat = 12
+    var firstLine: DocumentLineNode {
+        documentLineTree.root.leftMost
+    }
+    var lastLine: DocumentLineNode {
+        documentLineTree.root.rightMost
+    }
+    // When rebuilding, and only when rebuilding, the tree we keep track of the longest line.
+    // This helps the text editor to determine the width of the content. The "initial" in the name implies
+    // that the reference does not necessarily point to the longest line as the document is edited.
+    private(set) weak var initialLongestLine: DocumentLineNode?
+
+    private let documentLineTree: DocumentLineTree
+
+    init(stringView: StringView) {
+        self.stringView = stringView
+        let rootData = DocumentLineNodeData(lineHeight: estimatedLineHeight)
+        documentLineTree = DocumentLineTree(minimumValue: 0, rootValue: 0, rootData: rootData)
+        documentLineTree.childrenUpdater = DocumentLineChildrenUpdater()
+        rootData.node = documentLineTree.root
+    }
+
+    func rebuild() {
+        // Reset the tree so we only have a single line.
+        let rootData = DocumentLineNodeData(lineHeight: estimatedLineHeight)
+        documentLineTree.reset(rootValue: 0, rootData: rootData)
+        rootData.node = documentLineTree.root
+        initialLongestLine = nil
+        // Iterate over lines in the string.
+        var line = documentLineTree.node(atIndex: 0)
+        var workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: stringView.string, startingAt: 0)
+        var lines: [DocumentLineNode] = []
+        var lastDelimiterEnd = 0
+        var totalLineHeight: CGFloat = 0
+        var longestLineLength: Int = 0
+        while let newLineRange = workingNewLineRange {
+            let totalLength = newLineRange.location + newLineRange.length - lastDelimiterEnd
+            let substringRange = NSRange(location: lastDelimiterEnd, length: totalLength)
+            let substring = stringView.string.substring(with: substringRange)
+            line.value = totalLength
+            line.data.totalLength = totalLength
+            line.data.delimiterLength = newLineRange.length
+            line.data.lineHeight = estimatedLineHeight
+            line.data.totalLineHeight = totalLineHeight
+            line.data.byteCount = substring.byteCount
+            lastDelimiterEnd = newLineRange.location + newLineRange.length
+            lines.append(line)
+            if totalLength > longestLineLength {
+                longestLineLength = totalLength
+                initialLongestLine = line
+            }
+            let data = DocumentLineNodeData(lineHeight: estimatedLineHeight)
+            line = DocumentLineNode(tree: documentLineTree, value: 0, data: data)
+            data.node = line
+            workingNewLineRange = NewLineFinder.rangeOfNextNewLine(in: stringView.string, startingAt: lastDelimiterEnd)
+            totalLineHeight += estimatedLineHeight
+        }
+        let totalLength = stringView.string.length - lastDelimiterEnd
+        let substringRange = NSRange(location: lastDelimiterEnd, length: totalLength)
+        let substring = stringView.string.substring(with: substringRange)
+        line.value = totalLength
+        line.data.totalLength = totalLength
+        line.data.byteCount = substring.byteCount
+        lines.append(line)
+        if totalLength > longestLineLength {
+            longestLineLength = totalLength
+            initialLongestLine = line
+        }
+        documentLineTree.rebuild(from: lines)
+    }
+
+    @discardableResult
+    func removeCharacters(in range: NSRange) -> LineChangeSet {
+        guard range.length > 0 else {
+            return LineChangeSet()
+        }
+        guard let startLine = documentLineTree.node(containingLocation: range.location) else {
+            return LineChangeSet()
+        }
+        if range.location > Int(startLine.location) + startLine.data.length {
+            // Deleting starting in the middle of a delimiter.
+            let changeSet = LineChangeSet()
+            let otherChangeSetA = setLength(of: startLine, to: startLine.value - 1)
+            changeSet.union(with: otherChangeSetA)
+            let otherChangeSetB = removeCharacters(in: NSRange(location: range.location, length: range.length - 1))
+            changeSet.union(with: otherChangeSetB)
+            return changeSet
+        } else if range.location + range.length < Int(startLine.location) + startLine.value {
+            // Removing a part of the start line.
+            return setLength(of: startLine, to: startLine.value - range.length)
+        } else {
+            // Merge startLine with another line because the startLine's delimeter was deleted,
+            // possibly removing lines in between if multiple delimeters were deleted.
+            let charactersRemovedInStartLine = Int(startLine.location) + startLine.value - range.location
+            assert(charactersRemovedInStartLine > 0)
+            guard let endLine = documentLineTree.node(containingLocation: range.location + range.length) else {
+                return LineChangeSet()
+            }
+            if endLine === startLine {
+                // Removing characters in the last line.
+                return setLength(of: startLine, to: startLine.value - range.length)
+            } else {
+                let changeSet = LineChangeSet()
+                let charactersLeftInEndLine = Int(endLine.location) + endLine.value - (range.location + range.length)
+                // Remove all lines between startLine and endLine, excluding startLine but including endLine.
+                var tmp = startLine.next
+                var lineToRemove = tmp
+                repeat {
+                    lineToRemove = tmp
+                    tmp = tmp.next
+                    changeSet.markLineRemoved(lineToRemove)
+                    documentLineTree.remove(lineToRemove)
+                } while lineToRemove !== endLine
+                let newLength = startLine.value - charactersRemovedInStartLine + charactersLeftInEndLine
+                let otherChangeSet = setLength(of: startLine, to: newLength)
+                changeSet.union(with: otherChangeSet)
+                return changeSet
+            }
+        }
+    }
+
+    @discardableResult
+    func insert(_ string: NSString, at location: Int) -> LineChangeSet {
+        let changeSet = LineChangeSet()
+        guard var line = documentLineTree.node(containingLocation: location) else {
+            return LineChangeSet()
+        }
+        var lineLocation = Int(line.location)
+        assert(location <= lineLocation + line.value)
+        if location > lineLocation + line.data.length {
+            // Inserting in the middle of a delimiter.
+            let otherChangeSetA = setLength(of: line, to: line.value - 1)
+            changeSet.union(with: otherChangeSetA)
+            // Add new line.
+            line = insertLine(ofLength: 1, after: line)
+            changeSet.markLineInserted(line)
+            let otherChangeSetB = setLength(of: line, to: 1, newLine: &line)
+            changeSet.union(with: otherChangeSetB)
+        }
+        if let rangeOfFirstNewLine = NewLineFinder.rangeOfNextNewLine(in: string, startingAt: 0) {
+            var lastDelimiterEnd = 0
+            var rangeOfNewLine = rangeOfFirstNewLine
+            var hasReachedEnd = false
+            while !hasReachedEnd {
+                let lineBreakLocation = location + rangeOfNewLine.location + rangeOfNewLine.length
+                lineLocation = Int(line.location)
+                let lengthAfterInsertionPos = lineLocation + line.value - (location + lastDelimiterEnd)
+                let otherChangeSetA = setLength(of: line, to: lineBreakLocation - lineLocation, newLine: &line)
+                changeSet.union(with: otherChangeSetA)
+                var newLine = insertLine(ofLength: lengthAfterInsertionPos, after: line)
+                changeSet.markLineInserted(newLine)
+                let otherChangeSetB = setLength(of: newLine, to: lengthAfterInsertionPos, newLine: &newLine)
+                changeSet.union(with: otherChangeSetB)
+                line = newLine
+                lastDelimiterEnd = rangeOfNewLine.location + rangeOfNewLine.length
+                if let rangeOfNextNewLine = NewLineFinder.rangeOfNextNewLine(in: string, startingAt: lastDelimiterEnd) {
+                    rangeOfNewLine = rangeOfNextNewLine
+                } else {
+                    hasReachedEnd = true
+                }
+            }
+            // Insert rest of last delimiter.
+            if lastDelimiterEnd != string.length {
+                let otherChangeSet = setLength(of: line, to: line.value + string.length - lastDelimiterEnd)
+                changeSet.union(with: otherChangeSet)
+            }
+        } else {
+            // No newline is being inserted. All the text is in a single line.
+            let otherChangeSet = setLength(of: line, to: line.value + string.length)
+            changeSet.union(with: otherChangeSet)
+        }
+        return changeSet
+    }
+
+    func linePosition(at location: Int) -> LinePosition? {
+        if let line = line(containingCharacterAt: location) {
+            let column = location - line.location
+            return LinePosition(row: line.index, column: column)
+        } else {
+            return nil
+        }
+    }
+
+    func line(containingCharacterAt location: Int) -> DocumentLineNode? {
+        if location >= 0 && location <= Int(documentLineTree.nodeTotalValue) {
+            return documentLineTree.node(containingLocation: location)
+        } else {
+            return nil
+        }
+    }
+
+    func line(containingYOffset yOffset: CGFloat) -> DocumentLineNode? {
+        documentLineTree.node(containingLocation: yOffset,
+                              minimumValue: 0,
+                              valueKeyPath: \.data.lineHeight,
+                              totalValueKeyPath: \.data.totalLineHeight)
+    }
+
+    func line(containingByteAt byteIndex: ByteCount) -> DocumentLineNode? {
+        documentLineTree.node(containingLocation: byteIndex,
+                              minimumValue: ByteCount(0),
+                              valueKeyPath: \.data.byteCount,
+                              totalValueKeyPath: \.data.nodeTotalByteCount)
+    }
+
+    func line(atRow row: Int) -> DocumentLineNode {
+        documentLineTree.node(atIndex: row)
+    }
+
+    @discardableResult
+    func setHeight(of line: DocumentLineNode, to newHeight: CGFloat) -> Bool {
+        if abs(newHeight - line.data.lineHeight) < CGFloat.ulpOfOne {
+            return false
+        } else {
+            line.data.lineHeight = newHeight
+            documentLineTree.updateAfterChangingChildren(of: line)
+            return true
+        }
+    }
+
+    func lines(in range: NSRange) -> [DocumentLineNode] {
+        guard let firstLine = line(containingCharacterAt: range.location) else {
+            return []
+        }
+        var lines: [DocumentLineNode] = [firstLine]
+        if range.length > 0, let lastLine = line(containingCharacterAt: range.location + range.length), lastLine != firstLine {
+            let startLineIndex = firstLine.index + 1 // Skip the first line since we already have it
+            let endLineIndex = lastLine.index - 1 // Skip the last line since we already have it
+            if startLineIndex <= endLineIndex {
+                lines += (startLineIndex ... endLineIndex).map(line(atRow:))
+            }
+            lines.append(lastLine)
+        }
+        return lines
+    }
+
+    func startAndEndLine(in range: NSRange) -> (startLine: DocumentLineNode, endLine: DocumentLineNode)? {
+        if range.length == 0 {
+            if let line = line(containingCharacterAt: range.lowerBound) {
+                return (line, line)
+            } else {
+                return nil
+            }
+        } else if let startLine = line(containingCharacterAt: range.lowerBound), let endLine = line(containingCharacterAt: range.upperBound) {
+            return (startLine, endLine)
+        } else {
+            return nil
+        }
+    }
+
+    func createLineIterator() -> RedBlackTreeIterator<DocumentLineNodeID, Int, DocumentLineNodeData> {
+        RedBlackTreeIterator(tree: documentLineTree)
+    }
+}
+
+private extension LineManager {
+    private func setLength(of line: DocumentLineNode, to newTotalLength: Int) -> LineChangeSet {
+        var newLine: DocumentLineNode = line
+        return setLength(of: line, to: newTotalLength, newLine: &newLine)
+    }
+
+    private func setLength(of line: DocumentLineNode, to newTotalLength: Int, newLine: inout DocumentLineNode) -> LineChangeSet {
+        let changeSet = LineChangeSet()
+        changeSet.markLineEdited(line)
+        let range = NSRange(location: line.location, length: newTotalLength)
+        let substring = stringView.substring(in: range)
+        let newByteCount = substring?.byteCount ?? 0
+        if newTotalLength != line.value || newTotalLength != line.data.totalLength || newByteCount != line.data.byteCount {
+            line.value = newTotalLength
+            line.data.totalLength = newTotalLength
+            line.data.byteCount = newByteCount
+            documentLineTree.updateAfterChangingChildren(of: line)
+        }
+        // Determine new delimiter length.
+        if newTotalLength == 0 {
+            line.data.delimiterLength = 0
+        } else {
+            let lastChar = getCharacter(at: Int(line.location) + newTotalLength - 1)
+            if lastChar == Symbol.carriageReturn {
+                line.data.delimiterLength = 1
+            } else if lastChar == Symbol.lineFeed {
+                if newTotalLength >= 2 && getCharacter(at: Int(line.location) + newTotalLength - 2) == Symbol.carriageReturn {
+                    line.data.delimiterLength = 2
+                } else if newTotalLength == 1 && line.location > 0 && getCharacter(at: Int(line.location) - 1) == Symbol.carriageReturn {
+                    // We need to join this line with the previous line.
+                    let previousLine = line.previous
+                    changeSet.markLineRemoved(line)
+                    documentLineTree.remove(line)
+                    let otherChangeSet = setLength(of: previousLine, to: previousLine.value + 1, newLine: &newLine)
+                    changeSet.union(with: otherChangeSet)
+                } else {
+                    line.data.delimiterLength = 1
+                }
+            } else {
+                line.data.delimiterLength = 0
+            }
+        }
+        newLine = line
+        return changeSet
+    }
+
+    @discardableResult
+    private func insertLine(ofLength length: Int, after otherLine: DocumentLineNode) -> DocumentLineNode {
+        let data = DocumentLineNodeData(lineHeight: estimatedLineHeight)
+        let insertedLine = documentLineTree.insertNode(value: length, data: data, after: otherLine)
+        let range = NSRange(location: insertedLine.location, length: length)
+        let substring = stringView.substring(in: range)
+        let byteCount = substring?.byteCount ?? 0
+        insertedLine.data.totalLength = length
+        insertedLine.data.byteCount = byteCount
+        insertedLine.data.nodeTotalByteCount = byteCount
+        insertedLine.data.node = insertedLine
+        // Call updateAfterChangingChildren(of:) to update the values of nodeTotalByteCount.
+        documentLineTree.updateAfterChangingChildren(of: insertedLine)
+        return insertedLine
+    }
+
+    private func getCharacter(at location: Int) -> String? {
+        let range = NSRange(location: location, length: 1)
+        return stringView.substring(in: range)
+    }
+}
+
+extension DocumentLineTree {
+    func yPosition(of node: DocumentLineNode) -> CGFloat {
+        var yPosition = node.left?.data.totalLineHeight ?? 0
+        var workingNode = node
+        while let parentNode = workingNode.parent {
+            if workingNode === workingNode.parent?.right {
+                if let leftNode = workingNode.parent?.left {
+                    yPosition += leftNode.data.totalLineHeight
+                }
+                yPosition += parentNode.data.lineHeight
+            }
+            workingNode = parentNode
+        }
+        return yPosition
+    }
+}
+
+extension DocumentLineNode {
+    var yPosition: CGFloat {
+        tree.yPosition(of: self)
+    }
+
+    var range: ClosedRange<Int> {
+        let _location = location
+        return _location ... _location + data.totalLength
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/LinePosition.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/LinePosition.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class LinePosition: Hashable, Equatable {
+    let row: Int
+    let column: Int
+
+    init(row: Int, column: Int) {
+        self.row = row
+        self.column = column
+    }
+
+    convenience init(_ point: TreeSitterTextPoint) {
+        let row = Int(point.row)
+        let column = Int(point.column / 2)
+        self.init(row: row, column: column)
+    }
+
+    static func == (lhs: LinePosition, rhs: LinePosition) -> Bool {
+        lhs.row == rhs.row && lhs.column == rhs.column
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(row)
+        hasher.combine(column)
+    }
+}
+
+extension LinePosition: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[LinePosition row=\(row) column=\(column)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/LineManager/NewLineFinder.swift
+++ b/vendor/runestone/Sources/RunestoneCore/LineManager/NewLineFinder.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum NewLineFinder {
+    static func rangeOfNextNewLine(in text: NSString, startingAt location: Int) -> NSRange? {
+        let range = NSRange(location: location, length: 0)
+        var end: Int = NSNotFound
+        var contentsEnd: Int = NSNotFound
+        text.getLineStart(nil, end: &end, contentsEnd: &contentsEnd, for: range)
+        if end != NSNotFound && contentsEnd != NSNotFound && end != contentsEnd {
+            return NSRange(location: contentsEnd, length: end - contentsEnd)
+        } else {
+            return nil
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/MarkdownDocumentModel.swift
+++ b/vendor/runestone/Sources/RunestoneCore/MarkdownDocumentModel.swift
@@ -1,0 +1,389 @@
+import Foundation
+
+public struct MarkdownHeading: Equatable {
+    public let level: Int
+    public let hashRange: NSRange
+    public let titleRange: NSRange
+
+    public init(level: Int, hashRange: NSRange, titleRange: NSRange) {
+        self.level = level
+        self.hashRange = hashRange
+        self.titleRange = titleRange
+    }
+}
+
+public enum MarkdownBlockSemantic: Equatable {
+    case plain
+    case heading(MarkdownHeading)
+    case fencedCode
+    case fencedCodeDelimiter
+    case blockQuote
+    case listItem
+    case horizontalRule
+    case tableRow
+}
+
+public struct MarkdownDocumentLine: Equatable {
+    public let lineRange: NSRange
+    public let contentRange: NSRange
+    public let semantic: MarkdownBlockSemantic
+    public let entersFence: Bool
+    public let exitsFence: Bool
+    public let requiresMarkdownProcessing: Bool
+
+    public init(
+        lineRange: NSRange,
+        contentRange: NSRange,
+        semantic: MarkdownBlockSemantic,
+        entersFence: Bool,
+        exitsFence: Bool,
+        requiresMarkdownProcessing: Bool
+    ) {
+        self.lineRange = lineRange
+        self.contentRange = contentRange
+        self.semantic = semantic
+        self.entersFence = entersFence
+        self.exitsFence = exitsFence
+        self.requiresMarkdownProcessing = requiresMarkdownProcessing
+    }
+
+    public var isInFencedCode: Bool {
+        entersFence
+    }
+
+    public var isFenceDelimiter: Bool {
+        entersFence != exitsFence
+    }
+}
+
+public final class MarkdownDocumentModel {
+    private static let inlineMarkdownSignalCharacterSet = CharacterSet(charactersIn: "*_`[]()!<>|")
+    private static let structuralMarkdownSignalCharacterSet = CharacterSet(charactersIn: "#>-+|<")
+    private static let decimalDigitsCharacterSet = CharacterSet.decimalDigits
+
+    private var lines: [MarkdownDocumentLine] = []
+    private var lineIndexNeedsRebuild = true
+    private var invalidationLocation = Int.max
+
+    public init() {}
+
+    public var lineCount: Int {
+        lines.count
+    }
+
+    public func line(at index: Int) -> MarkdownDocumentLine {
+        lines[index]
+    }
+
+    public func invalidate(
+        forEditedRange editedRange: NSRange,
+        changeInLength: Int,
+        text: NSString
+    ) {
+        guard editedRange.location != NSNotFound else {
+            return
+        }
+        let clampedLocation = min(max(0, editedRange.location), max(0, text.length - 1))
+        let lineStart = text.lineRange(for: NSRange(location: clampedLocation, length: 0)).location
+        if changeInLength != 0 {
+            invalidationLocation = min(invalidationLocation, lineStart)
+            lineIndexNeedsRebuild = true
+        } else if lines.isEmpty {
+            lineIndexNeedsRebuild = true
+            invalidationLocation = min(invalidationLocation, lineStart)
+        } else {
+            invalidationLocation = min(invalidationLocation, lineStart)
+        }
+    }
+
+    @discardableResult
+    public func prepare(text: NSString) -> Double {
+        guard lineIndexNeedsRebuild || invalidationLocation != Int.max else {
+            return 0
+        }
+        let started = CFAbsoluteTimeGetCurrent()
+        let previousLines = lines
+        let effectiveInvalidationLocation = invalidationLocation == Int.max ? 0 : invalidationLocation
+        let clampedInvalidationLocation = min(max(0, effectiveInvalidationLocation), max(0, text.length))
+
+        var preservedCount = 0
+        if clampedInvalidationLocation > 0, !previousLines.isEmpty {
+            while preservedCount < previousLines.count {
+                let line = previousLines[preservedCount]
+                if NSMaxRange(line.lineRange) <= clampedInvalidationLocation {
+                    preservedCount += 1
+                } else {
+                    break
+                }
+            }
+        }
+
+        var rebuiltLines: [MarkdownDocumentLine] = []
+        rebuiltLines.reserveCapacity(max(32, previousLines.count))
+        if preservedCount > 0 {
+            rebuiltLines.append(contentsOf: previousLines.prefix(preservedCount))
+        }
+
+        var location = 0
+        var entryFenceState = false
+        if let lastPreservedLine = rebuiltLines.last {
+            location = NSMaxRange(lastPreservedLine.lineRange)
+            entryFenceState = lastPreservedLine.exitsFence
+        }
+        location = min(max(0, location), text.length)
+
+        if text.length > 0 {
+            while location < text.length {
+                let lineRange = text.lineRange(for: NSRange(location: location, length: 0))
+                guard lineRange.length > 0 else {
+                    break
+                }
+                let line = Self.makeLine(lineRange: lineRange, text: text, entryFenceState: entryFenceState)
+                rebuiltLines.append(line)
+                entryFenceState = line.exitsFence
+                location = NSMaxRange(lineRange)
+            }
+        }
+
+        lines = rebuiltLines
+        lineIndexNeedsRebuild = false
+        invalidationLocation = Int.max
+        return (CFAbsoluteTimeGetCurrent() - started) * 1_000
+    }
+
+    public func lineIndexRange(for characterRange: NSRange, in text: NSString) -> Range<Int>? {
+        guard !lines.isEmpty else {
+            return nil
+        }
+        let safeRange = NSIntersectionRange(characterRange, NSRange(location: 0, length: text.length))
+        guard safeRange.length > 0 else {
+            return nil
+        }
+
+        let firstLineIndex = lineIndex(for: safeRange.location)
+        let endLocation = max(safeRange.location, NSMaxRange(safeRange) - 1)
+        let lastLineIndex = lineIndex(for: endLocation)
+        return firstLineIndex..<(lastLineIndex + 1)
+    }
+
+    public func lineIndex(for location: Int) -> Int {
+        guard !lines.isEmpty else {
+            return 0
+        }
+        var low = 0
+        var high = lines.count - 1
+        while low <= high {
+            let mid = (low + high) / 2
+            let range = lines[mid].lineRange
+            if location < range.location {
+                high = mid - 1
+            } else if location >= NSMaxRange(range) {
+                low = mid + 1
+            } else {
+                return mid
+            }
+        }
+        return min(max(0, low), lines.count - 1)
+    }
+}
+
+private extension MarkdownDocumentModel {
+    static func makeLine(
+        lineRange: NSRange,
+        text: NSString,
+        entryFenceState: Bool
+    ) -> MarkdownDocumentLine {
+        let contentRange = trimmedContentRange(for: lineRange, text: text)
+        guard contentRange.length > 0 else {
+            return MarkdownDocumentLine(
+                lineRange: lineRange,
+                contentRange: contentRange,
+                semantic: .plain,
+                entersFence: entryFenceState,
+                exitsFence: entryFenceState,
+                requiresMarkdownProcessing: false
+            )
+        }
+
+        let lineText = text.substring(with: contentRange) as NSString
+        let hasFenceDelimiter = isFenceDelimiter(lineText)
+        let exitsFenceState: Bool
+        let semantic: MarkdownBlockSemantic
+
+        if hasFenceDelimiter {
+            semantic = .fencedCodeDelimiter
+            exitsFenceState = !entryFenceState
+        } else if entryFenceState {
+            semantic = .fencedCode
+            exitsFenceState = entryFenceState
+        } else if let heading = headingMetadata(in: lineText) {
+            semantic = .heading(heading)
+            exitsFenceState = false
+        } else if isHorizontalRule(lineText) {
+            semantic = .horizontalRule
+            exitsFenceState = false
+        } else if isBlockQuote(lineText) {
+            semantic = .blockQuote
+            exitsFenceState = false
+        } else if isListItem(lineText) {
+            semantic = .listItem
+            exitsFenceState = false
+        } else if isTableRow(lineText) {
+            semantic = .tableRow
+            exitsFenceState = false
+        } else {
+            semantic = .plain
+            exitsFenceState = false
+        }
+
+        let requiresMarkdownProcessing = semantic != .plain || lineNeedsMarkdownProcessing(lineText)
+        return MarkdownDocumentLine(
+            lineRange: lineRange,
+            contentRange: contentRange,
+            semantic: semantic,
+            entersFence: entryFenceState,
+            exitsFence: exitsFenceState,
+            requiresMarkdownProcessing: requiresMarkdownProcessing
+        )
+    }
+
+    static func trimmedContentRange(for lineRange: NSRange, text: NSString) -> NSRange {
+        var contentLength = lineRange.length
+        while contentLength > 0 {
+            let character = text.character(at: lineRange.location + contentLength - 1)
+            if character == 10 || character == 13 {
+                contentLength -= 1
+            } else {
+                break
+            }
+        }
+        return NSRange(location: lineRange.location, length: contentLength)
+    }
+
+    static func isFenceDelimiter(_ lineText: NSString) -> Bool {
+        let length = lineText.length
+        guard length >= 3 else {
+            return false
+        }
+        var index = 0
+        while index < length, CharacterSet.whitespaces.contains(UnicodeScalar(lineText.character(at: index)) ?? " ") {
+            index += 1
+        }
+        guard index + 2 < length else {
+            return false
+        }
+        return lineText.character(at: index) == 96 &&
+            lineText.character(at: index + 1) == 96 &&
+            lineText.character(at: index + 2) == 96
+    }
+
+    static func headingMetadata(in lineText: NSString) -> MarkdownHeading? {
+        let length = lineText.length
+        guard length >= 3, lineText.character(at: 0) == 35 else {
+            return nil
+        }
+
+        var hashCount = 0
+        while hashCount < min(6, length), lineText.character(at: hashCount) == 35 {
+            hashCount += 1
+        }
+
+        guard hashCount > 0,
+              hashCount < length,
+              lineText.character(at: hashCount) == 32 else {
+            return nil
+        }
+
+        let titleLocation = hashCount + 1
+        guard titleLocation < length else {
+            return nil
+        }
+
+        return MarkdownHeading(
+            level: hashCount,
+            hashRange: NSRange(location: 0, length: hashCount),
+            titleRange: NSRange(location: titleLocation, length: length - titleLocation)
+        )
+    }
+
+    static func isHorizontalRule(_ lineText: NSString) -> Bool {
+        let trimmed = lineText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.count >= 3 && trimmed.allSatisfy { $0 == "-" }
+    }
+
+    static func isBlockQuote(_ lineText: NSString) -> Bool {
+        let first = firstNonWhitespaceIndex(in: lineText)
+        guard first != NSNotFound else {
+            return false
+        }
+        return lineText.character(at: first) == 62
+    }
+
+    static func isListItem(_ lineText: NSString) -> Bool {
+        let first = firstNonWhitespaceIndex(in: lineText)
+        guard first != NSNotFound else {
+            return false
+        }
+        let character = lineText.character(at: first)
+        if character == 45 || character == 42 || character == 43 {
+            return first + 1 < lineText.length && lineText.character(at: first + 1) == 32
+        }
+        var index = first
+        var foundDigit = false
+        while index < lineText.length,
+              let scalar = UnicodeScalar(lineText.character(at: index)),
+              decimalDigitsCharacterSet.contains(scalar) {
+            foundDigit = true
+            index += 1
+        }
+        return foundDigit &&
+            index + 1 < lineText.length &&
+            lineText.character(at: index) == 46 &&
+            lineText.character(at: index + 1) == 32
+    }
+
+    static func isTableRow(_ lineText: NSString) -> Bool {
+        let string = lineText as String
+        let pipeCount = string.reduce(into: 0) { partialResult, character in
+            if character == "|" {
+                partialResult += 1
+            }
+        }
+        return pipeCount >= 2
+    }
+
+    static func lineNeedsMarkdownProcessing(_ lineText: NSString) -> Bool {
+        let searchRange = NSRange(location: 0, length: lineText.length)
+        if lineText.rangeOfCharacter(from: inlineMarkdownSignalCharacterSet, options: [], range: searchRange).location != NSNotFound {
+            return true
+        }
+
+        let firstNonWhitespace = firstNonWhitespaceIndex(in: lineText)
+        guard firstNonWhitespace != NSNotFound else {
+            return false
+        }
+        let firstCharacterRange = NSRange(location: firstNonWhitespace, length: 1)
+        if lineText.rangeOfCharacter(
+            from: structuralMarkdownSignalCharacterSet,
+            options: [],
+            range: firstCharacterRange
+        ).location != NSNotFound {
+            return true
+        }
+        return lineText.rangeOfCharacter(
+            from: decimalDigitsCharacterSet,
+            options: [],
+            range: firstCharacterRange
+        ).location != NSNotFound
+    }
+
+    static func firstNonWhitespaceIndex(in lineText: NSString) -> Int {
+        let searchRange = NSRange(location: 0, length: lineText.length)
+        let range = lineText.rangeOfCharacter(
+            from: CharacterSet.whitespacesAndNewlines.inverted,
+            options: [],
+            range: searchRange
+        )
+        return range.location
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/ClosedRangeValueDescriptor.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/ClosedRangeValueDescriptor.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+final class ClosedRangeValueSearchQuery<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, NodeData>: RedBlackTreeSearchQuery {
+    private let range: ClosedRange<NodeValue>
+    private var cachedNodeLocations: [NodeID: NodeValue] = [:]
+
+    init(range: ClosedRange<NodeValue>) {
+        self.range = range
+    }
+
+    func shouldTraverseLeftChildren(of node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool {
+        location(of: node) > range.upperBound
+    }
+
+    func shouldTraverseRightChildren(of node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool {
+        location(of: node) + node.value < range.upperBound
+    }
+
+    func shouldInclude(_ node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool {
+        let nodeLowerBound = location(of: node)
+        let nodeUpperBound = nodeLowerBound + node.value
+        return nodeLowerBound <= range.upperBound && range.lowerBound <= nodeUpperBound
+    }
+}
+
+private extension ClosedRangeValueSearchQuery {
+    private func location(of node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> NodeValue {
+        if let cachedLocation = cachedNodeLocations[node.id] {
+            return cachedLocation
+        } else {
+            let location = node.location
+            cachedNodeLocations[node.id] = location
+            return location
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTree.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTree.swift
@@ -1,0 +1,557 @@
+// swiftlint:disable file_length
+import Foundation
+
+final class RedBlackTree<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, NodeData> {
+    typealias Node = RedBlackTreeNode<NodeID, NodeValue, NodeData>
+
+    // swiftlint:disable:next implicitly_unwrapped_optional
+    private(set) var root: Node!
+    var nodeTotalCount: Int {
+        root.nodeTotalCount
+    }
+    var nodeTotalValue: NodeValue {
+        root.nodeTotalValue
+    }
+    var childrenUpdater: RedBlackTreeChildrenUpdater<NodeID, NodeValue, NodeData>?
+
+    private let minimumValue: NodeValue
+
+    init(minimumValue: NodeValue, rootValue: NodeValue, rootData: NodeData) {
+        self.minimumValue = minimumValue
+        self.root = Node(tree: self, value: rootValue, data: rootData)
+        self.root.color = .black
+    }
+
+    func reset(rootValue: NodeValue, rootData: NodeData) {
+        root = Node(tree: self, value: rootValue, data: rootData)
+    }
+
+    func rebuild(from nodes: [Node]) {
+        assert(!nodes.isEmpty, "Cannot rebuild tree from empty set of nodes")
+        let height = getTreeHeight(nodeCount: nodes.count)
+        root = buildTree(from: nodes, start: 0, end: nodes.count, subtreeHeight: height)
+        root.color = .black
+    }
+
+    func node(containingLocation location: NodeValue) -> Node? {
+        guard location >= minimumValue && location <= root.nodeTotalValue else {
+            #if DEBUG
+            fatalError("\(location) is out of bounds. Valid range is \(minimumValue) - \(root.nodeTotalValue)."
+                       + " This issue is under investigation. Please open an issue at https://github.com/simonbs/Runestone/issues"
+                       + " and include this stack trace and a sample text file if possible. This fatal error is only thrown in debug builds.")
+            #else
+            return nil
+            #endif
+        }
+        return node(containingLocation: location, minimumValue: minimumValue, valueKeyPath: \.value, totalValueKeyPath: \.nodeTotalValue)
+    }
+
+    func node<T: Comparable & AdditiveArithmetic>(containingLocation location: T,
+                                                  minimumValue: T,
+                                                  valueKeyPath: KeyPath<Node, T>,
+                                                  totalValueKeyPath: KeyPath<Node, T>) -> Node? {
+        if location == root[keyPath: totalValueKeyPath] {
+            return root.rightMost
+        } else {
+            var remainingLocation = location
+            var node = root!
+            while true {
+                if let leftNode = node.left, remainingLocation < leftNode[keyPath: totalValueKeyPath] {
+                    node = leftNode
+                } else {
+                    if let leftNode = node.left {
+                        remainingLocation -= leftNode[keyPath: totalValueKeyPath]
+                    }
+                    remainingLocation -= node[keyPath: valueKeyPath]
+                    if remainingLocation < minimumValue {
+                        return node
+                    } else if let rightNode = node.right {
+                        node = rightNode
+                    } else {
+                        return nil
+                    }
+                }
+            }
+        }
+    }
+
+    func nodePosition(at location: NodeValue) -> RedBlackTreeNodePosition<NodeValue>? {
+        guard location >= minimumValue && location <= root.nodeTotalValue else {
+            return nil
+        }
+        if location == root.nodeTotalValue {
+            let node = root.rightMost
+            let nodeStartLocation = root.nodeTotalValue - node.nodeTotalValue
+            let offset = location - nodeStartLocation
+            return RedBlackTreeNodePosition(
+                nodeStartLocation: nodeStartLocation,
+                index: node.index,
+                offset: offset,
+                value: node.value)
+        } else {
+            var nodeStartLocation = minimumValue
+            var remainingLocation = location
+            var node = root!
+            while true {
+                if let leftNode = node.left, remainingLocation < leftNode.nodeTotalValue {
+                    node = leftNode
+                } else {
+                    if let leftNode = node.left {
+                        nodeStartLocation += leftNode.nodeTotalValue
+                        remainingLocation -= leftNode.nodeTotalValue
+                    }
+                    nodeStartLocation += node.value
+                    remainingLocation -= node.value
+                    if remainingLocation < minimumValue {
+                        nodeStartLocation -= node.value
+                        let offset = location - nodeStartLocation
+                        return RedBlackTreeNodePosition(
+                            nodeStartLocation: nodeStartLocation,
+                            index: node.index,
+                            offset: offset,
+                            value: node.value)
+                    } else {
+                        node = node.right!
+                    }
+                }
+            }
+        }
+    }
+
+    func location(of node: Node) -> NodeValue {
+        offset(of: node, valueKeyPath: \.value, totalValueKeyPath: \.nodeTotalValue, minimumValue: minimumValue)
+    }
+
+    func offset<T: AdditiveArithmetic>(of node: Node, valueKeyPath: KeyPath<Node, T>, totalValueKeyPath: KeyPath<Node, T>, minimumValue: T) -> T {
+        var location = node.left?[keyPath: totalValueKeyPath] ?? minimumValue
+        var workingNode = node
+        while let parentNode = workingNode.parent {
+            if workingNode === workingNode.parent?.right {
+                if let leftNode = workingNode.parent?.left {
+                    location += leftNode[keyPath: totalValueKeyPath]
+                }
+                location += parentNode[keyPath: valueKeyPath]
+            }
+            workingNode = parentNode
+        }
+        return location
+    }
+
+    func index(of node: Node) -> Int {
+        var index = node.left?.nodeTotalCount ?? 0
+        var workingNode = node
+        while let parentNode = workingNode.parent {
+            if workingNode === parentNode.right {
+                if let leftNode = parentNode.left {
+                    index += leftNode.nodeTotalCount
+                }
+                index += 1
+            }
+            workingNode = parentNode
+        }
+        return index
+    }
+
+    func node(atIndex index: Int) -> Node {
+        assert(index >= 0)
+        assert(index < root.nodeTotalCount)
+        var remainingIndex = index
+        var node = root!
+        while true {
+            if let leftNode = node.left, remainingIndex < leftNode.nodeTotalCount {
+                node = leftNode
+            } else {
+                if let leftNode = node.left {
+                    remainingIndex -= leftNode.nodeTotalCount
+                }
+                if remainingIndex == 0 {
+                    return node
+                }
+                remainingIndex -= 1
+                node = node.right!
+            }
+        }
+    }
+
+    @discardableResult
+    func insertNode(value: NodeValue, data: NodeData, after existingNode: Node) -> Node {
+        let newNode = Node(tree: self, value: value, data: data)
+        insert(newNode, after: existingNode)
+        return newNode
+    }
+
+    func remove(_ removedNode: Node) {
+        if let removedNodeRight = removedNode.right, removedNode.left != nil {
+            let leftMost = removedNodeRight.leftMost
+            // Remove leftMost node from its current location
+            remove(leftMost)
+            // ...and overwrite removedNode with it.
+            replace(removedNode, with: leftMost)
+            leftMost.left = removedNode.left
+            leftMost.left?.parent = leftMost
+            leftMost.right = removedNode.right
+            leftMost.right?.parent = leftMost
+            leftMost.color = removedNode.color
+            updateAfterChangingChildren(of: leftMost)
+            if let leftMostParent = leftMost.parent {
+                updateAfterChangingChildren(of: leftMostParent)
+            }
+        } else {
+            // Either removedNode.left or removedNode.right is null.
+            let parentNode = removedNode.parent
+            let childNode = removedNode.left ?? removedNode.right
+            replace(removedNode, with: childNode)
+            if let parentNode = parentNode {
+                updateAfterChangingChildren(of: parentNode)
+            }
+            if removedNode.color == .black {
+                if childNode != nil && childNode?.color == .red {
+                    childNode?.color = .black
+                } else if let parentNode = parentNode {
+                    fixTree(afterDeleting: childNode, parentNode: parentNode)
+                }
+            }
+        }
+    }
+
+    func updateAfterChangingChildren(of node: Node) {
+        var totalCount = 1
+        var totalValue = node.value
+        if let leftNode = node.left {
+            totalCount += leftNode.nodeTotalCount
+            totalValue += leftNode.nodeTotalValue
+        }
+        if let rightNode = node.right {
+            totalCount += rightNode.nodeTotalCount
+            totalValue += rightNode.nodeTotalValue
+        }
+        let hasNewTotalValues = totalCount != node.nodeTotalCount || totalValue != node.nodeTotalValue
+        if hasNewTotalValues {
+            node.nodeTotalCount = totalCount
+            node.nodeTotalValue = totalValue
+        }
+        let didUpdateExternally = childrenUpdater?.updateAfterChangingChildren(of: node) ?? false
+        let didUpdate = hasNewTotalValues || didUpdateExternally
+        if let parent = node.parent, didUpdate {
+            updateAfterChangingChildren(of: parent)
+        }
+    }
+
+    func searchRange(_ range: ClosedRange<NodeValue>) -> [RedBlackTreeSearchMatch<NodeID, NodeValue, NodeData>] {
+        let query = ClosedRangeValueSearchQuery<NodeID, NodeValue, NodeData>(range: range)
+        return search(using: query)
+    }
+
+    func search<T: RedBlackTreeSearchQuery>(using query: T)
+    -> [RedBlackTreeSearchMatch<NodeID, NodeValue, NodeData>]
+    where T.NodeID == NodeID, T.NodeValue == NodeValue, T.NodeData == NodeData {
+        var matches: [RedBlackTreeSearchMatch<NodeID, NodeValue, NodeData>] = []
+        func search(from node: Node) {
+            let nodeLowerBound = node.location
+            let nodeUpperBound = nodeLowerBound + node.value
+            if query.shouldTraverseLeftChildren(of: node) {
+                if let leftNode = node.left {
+                    search(from: leftNode)
+                }
+            }
+            if query.shouldInclude(node) {
+                let match = RedBlackTreeSearchMatch(location: nodeLowerBound, value: nodeUpperBound, node: node)
+                matches.append(match)
+            }
+            if query.shouldTraverseRightChildren(of: node) {
+                if let rightNode = node.right {
+                    search(from: rightNode)
+                }
+            }
+        }
+        search(from: root)
+        return matches
+    }
+}
+
+private extension RedBlackTree {
+    private func insert(_ newNode: Node, after node: Node) {
+        if node.right == nil {
+            insert(newNode, asRightChildOf: node)
+        } else {
+            insert(newNode, asLeftChildOf: node.right!.leftMost)
+        }
+    }
+
+    private func insert(_ newNode: Node, asLeftChildOf parentNode: Node) {
+        assert(parentNode.left == nil)
+        parentNode.left = newNode
+        newNode.parent = parentNode
+        newNode.color = .red
+        updateAfterChangingChildren(of: parentNode)
+        fixTree(afterInserting: newNode)
+    }
+
+    private func insert(_ newNode: Node, asRightChildOf parentNode: Node) {
+        assert(parentNode.right == nil)
+        parentNode.right = newNode
+        newNode.parent = parentNode
+        newNode.color = .red
+        updateAfterChangingChildren(of: parentNode)
+        fixTree(afterInserting: newNode)
+    }
+
+    private func replace(_ replacedNode: Node, with newNode: Node?) {
+        if replacedNode.parent == nil {
+            assert(replacedNode === root)
+            root = newNode!
+        } else if replacedNode.parent?.left === replacedNode {
+            replacedNode.parent?.left = newNode
+        } else {
+            replacedNode.parent?.right = newNode
+        }
+        newNode?.parent = replacedNode.parent
+        replacedNode.parent = nil
+    }
+
+    private func fixTree(afterInserting newNode: Node) {
+        var node = newNode
+        assert(node.color == .red)
+        assert(node.left == nil || node.left?.color == .black)
+        assert(node.right == nil || node.right?.color == .black)
+        if var parentNode = node.parent {
+            switch parentNode.color {
+            case .black:
+                // The parent is black so our red node, as ensured by the assert, is placed correctly,
+                // since the number of black nodes on the path haven't changed.
+                break
+            case .red:
+                // The parent is red so we have a conflict which we need to resolve.
+                // Since the root is always black and the parent to this node is red,
+                // we must have a grandparent node.
+                var grandparentNode = parentNode.parent!
+                if let uncleNode = sibling(to: parentNode), uncleNode.color == .red {
+                    parentNode.color = .black
+                    uncleNode.color = .black
+                    grandparentNode.color = .red
+                    fixTree(afterInserting: grandparentNode)
+                } else {
+                    // We now know that the parent is red and the uncle is black.
+                    if node === parentNode.right && parentNode === grandparentNode.left {
+                        rotateLeft(parentNode)
+                        node = node.left!
+                    } else if node === parentNode.left && parentNode === grandparentNode.right {
+                        rotateRight(parentNode)
+                        node = node.right!
+                    }
+                    // Nodes might have changed after rotation.
+                    parentNode = node.parent!
+                    grandparentNode = parentNode.parent!
+                    // Recolor nodes.
+                    parentNode.color = .black
+                    grandparentNode.color = .red
+                    // Rotate again.
+                    if node === parentNode.left && parentNode === grandparentNode.left {
+                        rotateRight(grandparentNode)
+                    } else {
+                        assert(node === parentNode.right && parentNode === grandparentNode.right)
+                        rotateLeft(grandparentNode)
+                    }
+                }
+            }
+        } else {
+            // We inserted the root node which must be black. Making the root node black increments the number
+            // of black nodes on all paths by 1, so all paths still have the same number of black nodes.
+            node.color = .black
+        }
+    }
+
+    // swiftlint:disable:next cyclomatic_complexity function_body_length
+    private func fixTree(afterDeleting node: Node?, parentNode: Node) {
+        assert(node == nil || node?.parent === parentNode)
+        var sibling = self.sibling(to: node, through: parentNode)
+        if sibling?.color == .red {
+            parentNode.color = .red
+            sibling?.color = .black
+            if node === parentNode.left {
+                rotateLeft(parentNode)
+            } else {
+                rotateRight(parentNode)
+            }
+            // Update sibling after rotation.
+            sibling = self.sibling(to: node, through: parentNode)
+        }
+        if parentNode.color == .black
+            && sibling?.color == .black
+            && getColor(of: sibling?.left) == .black
+            && getColor(of: sibling?.right) == .black {
+            sibling?.color = .red
+            if let parentNodesParentNode = parentNode.parent {
+                fixTree(afterDeleting: parentNode, parentNode: parentNodesParentNode)
+            }
+        } else if parentNode.color == .red
+                    && sibling?.color == .black
+                    && getColor(of: sibling?.left) == .black
+                    && getColor(of: sibling?.right) == .black {
+            sibling?.color = .red
+            parentNode.color = .black
+        } else {
+            if node === parentNode.left
+                && sibling?.color == .black
+                && getColor(of: sibling?.left) == .red
+                && getColor(of: sibling?.right) == .black {
+                sibling?.color = .red
+                sibling?.left?.color = .black
+                if let sibling = sibling {
+                    rotateRight(sibling)
+                }
+            } else if node === parentNode.right
+                        && sibling?.color == .black
+                        && getColor(of: sibling?.right) == .red
+                        && getColor(of: sibling?.left) == .black {
+                sibling?.color = .red
+                sibling?.right?.color = .black
+                if let sibling = sibling {
+                    rotateLeft(sibling)
+                }
+            }
+            // Update sibling after rotation.
+            sibling = self.sibling(to: node, through: parentNode)
+            sibling?.color = parentNode.color
+            parentNode.color = .black
+            if node === parentNode.left {
+                if let rightSibling = sibling?.right {
+                    assert(rightSibling.color == .red)
+                    rightSibling.color = .black
+                }
+                rotateLeft(parentNode)
+            } else {
+                if let leftSibling = sibling?.left {
+                    assert(leftSibling.color == .red)
+                    leftSibling.color = .black
+                }
+                rotateRight(parentNode)
+            }
+        }
+    }
+
+    private func rotateLeft(_ p: Node) {
+        // Let q be p's right child.
+        guard let q = p.right else {
+            fatalError("Can't rotate left when p's right-hand side child is nil.")
+        }
+        assert(q.parent === p)
+        // Set q to be the new root.
+        replace(p, with: q)
+        // Set p's right child to be q's left child.
+        p.right = q.left
+        p.right?.parent = p
+        // Set q's left child to be p.
+        q.left = p
+        p.parent = q
+        updateAfterChangingChildren(of: p)
+    }
+
+    private func rotateRight(_ p: Node) {
+        // Let q be p's left child.
+        guard let q = p.left else {
+            fatalError("Can't rotate right when p's left-hand side child is nil.")
+        }
+        assert(q.parent === p)
+        // Set q to be the new root.
+        replace(p, with: q)
+        // Set p's left child to be q's right child.
+        p.left = q.right
+        p.left?.parent = p
+        // Set q's right child to be p.
+        q.right = p
+        p.parent = q
+        updateAfterChangingChildren(of: p)
+    }
+
+    private func sibling(to node: Node) -> Node? {
+        if node === node.parent?.left {
+            return node.parent?.right
+        } else {
+            return node.parent?.left
+        }
+    }
+
+    private func sibling(to node: Node?, through parentNode: Node) -> Node? {
+        assert(node == nil || node?.parent === parentNode)
+        if node === parentNode.left {
+            return parentNode.right
+        } else {
+            return parentNode.left
+        }
+    }
+
+    private func getColor(of node: Node?) -> RedBlackTreeNodeColor {
+        node?.color ?? .black
+    }
+
+    private func buildTree(from nodes: [Node], start: Int, end: Int, subtreeHeight: Int) -> Node? {
+        assert(start <= end)
+        if start == end {
+            return nil
+        }
+        let middle = (start + end) / 2
+        let node = nodes[middle]
+        node.left = buildTree(from: nodes, start: start, end: middle, subtreeHeight: subtreeHeight - 1)
+        node.right = buildTree(from: nodes, start: middle + 1, end: end, subtreeHeight: subtreeHeight - 1)
+        node.left?.parent = node
+        node.right?.parent = node
+        if subtreeHeight == 1 {
+            node.color = .red
+        }
+        updateAfterChangingChildren(of: node)
+        return node
+    }
+
+    private func getTreeHeight(nodeCount: Int) -> Int {
+        if nodeCount == 0 {
+            return 0
+        } else {
+            return getTreeHeight(nodeCount: nodeCount / 2) + 1
+        }
+    }
+}
+
+extension RedBlackTree: CustomDebugStringConvertible {
+    var debugDescription: String {
+        append(root, to: "", indent: 0)
+    }
+
+    private func append(_ node: Node, to string: String, indent: Int) -> String {
+        var result = string
+        switch node.color {
+        case .red:
+            result += "🔴  "
+        case .black:
+            result += "⚫️ "
+        }
+        result += node.debugDescription
+        result += "\n"
+        if let leftNode = node.left {
+            result += String(repeating: " ", count: indent)
+            result += "L: "
+            result = append(leftNode, to: result, indent: indent + 2)
+        }
+        if let rightNode = node.right {
+            result += String(repeating: " ", count: indent)
+            result += "R: "
+            result = append(rightNode, to: result, indent: indent + 2)
+        }
+        return result
+    }
+}
+
+extension RedBlackTree where NodeData == Void {
+    convenience init(minimumValue: NodeValue, rootValue: NodeValue) {
+        self.init(minimumValue: minimumValue, rootValue: rootValue, rootData: ())
+    }
+
+    func reset(rootValue: NodeValue) {
+        reset(rootValue: rootValue, rootData: ())
+    }
+
+    @discardableResult
+    func insertNode(value: NodeValue, after existingNode: Node) -> Node {
+        insertNode(value: value, data: (), after: existingNode)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeChildrenUpdater.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeChildrenUpdater.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+class RedBlackTreeChildrenUpdater<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, NodeData> {
+    typealias Node = RedBlackTreeNode<NodeID, NodeValue, NodeData>
+
+    func updateAfterChangingChildren(of node: Node) -> Bool {
+        false
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeIterator.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeIterator.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+final class RedBlackTreeIterator<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, NodeData>: IteratorProtocol, LazySequenceProtocol {
+    private let tree: RedBlackTree<NodeID, NodeValue, NodeData>
+    private var node: RedBlackTreeNode<NodeID, NodeValue, NodeData>?
+
+    init(tree: RedBlackTree<NodeID, NodeValue, NodeData>) {
+        self.tree = tree
+        self.node = tree.root.leftMost
+    }
+
+    func next() -> RedBlackTreeNode<NodeID, NodeValue, NodeData>? {
+        let currentNode = node
+        if let rightNode = node?.right {
+            node = rightNode.leftMost
+        } else {
+            while node?.parent != nil, node == node?.parent?.right {
+                node = node?.parent
+            }
+            node = node?.parent
+        }
+        return currentNode
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNode.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNode.swift
@@ -1,0 +1,109 @@
+import Foundation
+
+protocol RedBlackTreeNodeID: Identifiable, Hashable {
+    init()
+}
+
+typealias RedBlackTreeNodeValue = Comparable & AdditiveArithmetic
+
+final class RedBlackTreeNode<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, NodeData> {
+    typealias Tree = RedBlackTree<NodeID, NodeValue, NodeData>
+
+    let id = NodeID()
+    var nodeTotalValue: NodeValue
+    var nodeTotalCount: Int
+    var location: NodeValue {
+        tree.location(of: self)
+    }
+    var value: NodeValue
+    var index: Int {
+        tree.index(of: self)
+    }
+    var left: RedBlackTreeNode?
+    var right: RedBlackTreeNode?
+    weak var parent: RedBlackTreeNode?
+    var color: RedBlackTreeNodeColor = .black
+    let data: NodeData
+    var tree: Tree {
+        if let tree = _tree {
+            return tree
+        } else {
+            fatalError("Accessing tree after it has been deallocated.")
+        }
+    }
+
+    private weak var _tree: Tree?
+
+    init(tree: Tree, value: NodeValue, data: NodeData) {
+        self._tree = tree
+        self.nodeTotalCount = 1
+        self.nodeTotalValue = value
+        self.value = value
+        self.data = data
+    }
+}
+
+extension RedBlackTreeNode {
+    var leftMost: RedBlackTreeNode {
+        var node = self
+        while let newNode = node.left {
+            node = newNode
+        }
+        return node
+    }
+    var rightMost: RedBlackTreeNode {
+        var node = self
+        while let newNode = node.right {
+            node = newNode
+        }
+        return node
+    }
+    var previous: RedBlackTreeNode {
+        if let left = left {
+            return left.rightMost
+        } else {
+            var oldNode = self
+            var node = parent ?? self
+            while let parent = node.parent, node.left === oldNode {
+                oldNode = node
+                node = parent
+            }
+            return node
+        }
+    }
+    var next: RedBlackTreeNode {
+        if let right = right {
+            return right.leftMost
+        } else {
+            var oldNode = self
+            var node = parent ?? self
+            while let parent = node.parent, node.right === oldNode {
+                oldNode = node
+                node = parent
+            }
+            return node
+        }
+    }
+}
+
+extension RedBlackTreeNode: Hashable {
+    static func == (lhs: RedBlackTreeNode<NodeID, NodeValue, NodeData>, rhs: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool {
+        lhs.id == rhs.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+}
+
+extension RedBlackTreeNode where NodeData == Void {
+    convenience init(tree: Tree, value: NodeValue) {
+        self.init(tree: tree, value: value, data: ())
+    }
+}
+
+extension RedBlackTreeNode: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[RedBlackTreeNode index=\(index) location=\(location) nodeTotalCount=\(nodeTotalCount)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNodeColor.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNodeColor.swift
@@ -1,0 +1,6 @@
+import Foundation
+
+enum RedBlackTreeNodeColor {
+    case black
+    case red
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNodePosition.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeNodePosition.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class RedBlackTreeNodePosition<NodeValue> {
+    let nodeStartLocation: NodeValue
+    let index: Int
+    let offset: NodeValue
+    let value: NodeValue
+
+    init(nodeStartLocation: NodeValue, index: Int, offset: NodeValue, value: NodeValue) {
+        self.nodeStartLocation = nodeStartLocation
+        self.index = index
+        self.offset = offset
+        self.value = value
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeSearchMatch.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeSearchMatch.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+final class RedBlackTreeSearchMatch<NodeID: RedBlackTreeNodeID, NodeValue: RedBlackTreeNodeValue, Data> {
+    typealias Node = RedBlackTreeNode<NodeID, NodeValue, Data>
+
+    let location: NodeValue
+    let value: NodeValue
+    let node: Node
+
+    init(location: NodeValue, value: NodeValue, node: Node) {
+        self.location = location
+        self.value = value
+        self.node = node
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeSearchQuery.swift
+++ b/vendor/runestone/Sources/RunestoneCore/RedBlackTree/RedBlackTreeSearchQuery.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+protocol RedBlackTreeSearchQuery {
+    associatedtype NodeID: RedBlackTreeNodeID
+    associatedtype NodeValue: RedBlackTreeNodeValue
+    associatedtype NodeData
+    func shouldTraverseLeftChildren(of node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool
+    func shouldTraverseRightChildren(of node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool
+    func shouldInclude(_ node: RedBlackTreeNode<NodeID, NodeValue, NodeData>) -> Bool
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/FontTraits.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/FontTraits.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Traits to be applied to a font.
+///
+/// The font traits can be used with a ``Theme`` to change the appearance of the font when syntax highlighting text.
+public struct FontTraits: OptionSet {
+    /// Attribute creating a bold font.
+    public static let bold = Self(rawValue: 1 << 0)
+    /// Attribute creating an italic font.
+    public static let italic = Self(rawValue: 1 << 1)
+
+    /// The corresponding value of the raw type.
+    public let rawValue: Int
+
+    /// Creates a set of font traits.
+    /// - Parameter rawValue: The raw vlaue to create the font traits from.
+    public init(rawValue: Int) {
+        self.rawValue = rawValue
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/HighlightName.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/HighlightName.swift
@@ -1,0 +1,41 @@
+#if DEBUG
+private var previousUnrecognizedHighlightNames: [String] = []
+#endif
+
+enum HighlightName: String {
+    case comment
+    case constantBuiltin = "constant.builtin"
+    case constantCharacter = "constant.character"
+    case constructor
+    case function
+    case keyword
+    case number
+    case `operator`
+    case property
+    case punctuation
+    case string
+    case type
+    case variable
+    case variableBuiltin = "variable.builtin"
+
+    init?(_ rawHighlightName: String) {
+        var comps = rawHighlightName.split(separator: ".")
+        while !comps.isEmpty {
+            let candidateRawHighlightName = comps.joined(separator: ".")
+            if let highlightName = Self(rawValue: candidateRawHighlightName) {
+                self = highlightName
+                return
+            }
+            comps.removeLast()
+        }
+#if DEBUG
+        if !previousUnrecognizedHighlightNames.contains(rawHighlightName) {
+            previousUnrecognizedHighlightNames.append(rawHighlightName)
+            print("Unrecognized highlight name: '\(rawHighlightName)'."
+                  + " Add the highlight name to HighlightName.swift if you want to add support for syntax highlighting it."
+                  + " This message will only be shown once per highlight name.")
+        }
+#endif
+        return nil
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/LineBreakMode.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/LineBreakMode.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+ /// Line break mode for text view.
+ public enum LineBreakMode: Int, CaseIterable {
+     /// Wrap at word boundaries.
+     case byWordWrapping = 0
+     /// Wrap at character boundaries.
+     case byCharWrapping = 1
+ }

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/LineSelectionDisplayType.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Appearance/LineSelectionDisplayType.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// Approach for highlighting the selected line.
+public enum LineSelectionDisplayType {
+    /// Do not highlight the selected line.
+    case disabled
+    /// Highlight the entire selected line.
+    case line
+    /// Only highlight the selected line fragment. A line may span multiple line fragments if line wrapping is enabled.
+    case lineFragment
+}
+
+extension LineSelectionDisplayType {
+    var shouldShowLineSelection: Bool {
+        switch self {
+        case .disabled:
+            return false
+        case .line, .lineFragment:
+            return true
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/CharacterPairs/CharacterPair.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/CharacterPairs/CharacterPair.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Character pair to be registered with a text view.
+public protocol CharacterPair {
+    /// Leading component of the character pair. For example an opening bracket.
+    var leading: String { get }
+    /// Trailing component of the character pair. For example a closing bracket.
+    var trailing: String { get }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/CharacterPairs/CharacterPairTrailingComponentDeletionMode.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/CharacterPairs/CharacterPairTrailingComponentDeletionMode.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+/// Determines what should happen to the trailing component of a character pair when deleting the leading component.
+public enum CharacterPairTrailingComponentDeletionMode {
+    /// Do not delete the trailing component of the character pair when deleting the leading component.
+    case disabled
+    /// Delete the trailing component when it is immediately following the leading component which is deleted.
+    case immediatelyFollowingLeadingComponent
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Core/LineEnding.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Core/LineEnding.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Line ending character to use when inserting a line break in the text view.
+public enum LineEnding: String, CaseIterable {
+    /// Unix (LF) line endings.
+    ///
+    /// Uses the `\n` character.
+    case lf
+    /// Windows (CRLF) line endings.
+    ///
+    /// Uses the `\r\n` character.
+    case crlf
+    /// Mac (CR) line endings.
+    ///
+    /// Uses the `\r` character.
+    case cr
+
+    public var symbol: String {
+        switch self {
+        case .cr:
+            return Symbol.carriageReturn
+        case .lf:
+            return Symbol.lineFeed
+        case .crlf:
+            return Symbol.carriageReturnLineFeed
+        }
+    }
+
+    init?(symbol: String) {
+        if symbol == Self.cr.symbol {
+            self = .cr
+        } else if symbol == Self.lf.symbol {
+            self = .lf
+        } else if symbol == Self.crlf.symbol {
+            self = .crlf
+        } else {
+            return nil
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Core/MoveLinesService.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Core/MoveLinesService.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+struct MoveLinesOperation {
+    let removeRange: NSRange
+    let replacementRange: NSRange
+    let replacementString: String
+    let selectedRange: NSRange
+}
+
+final class MoveLinesService {
+    private let stringView: StringView
+    private let lineManager: LineManager
+    private let lineEndingSymbol: String
+
+    init(stringView: StringView, lineManager: LineManager, lineEndingSymbol: String) {
+        self.stringView = stringView
+        self.lineManager = lineManager
+        self.lineEndingSymbol = lineEndingSymbol
+    }
+
+    func operationForMovingLines(in selectedRange: NSRange, byOffset lineOffset: Int) -> MoveLinesOperation? {
+        // This implementation of moving lines is naive, as it first removes the selected lines and then inserts the text at the target line.
+        // That requires two parses of the syntax tree and two operations on our line manager. Ideally we would do this in one operation.
+        let isMovingDown = lineOffset > 0
+        let selectedLines = lineManager.lines(in: selectedRange)
+        guard !selectedLines.isEmpty else {
+            return nil
+        }
+        let firstLine = selectedLines[0]
+        let lastLine = selectedLines[selectedLines.count - 1]
+        let firstLineIndex = firstLine.index
+        var targetLineIndex = firstLineIndex + lineOffset
+        if isMovingDown {
+            targetLineIndex += selectedLines.count - 1
+        }
+        guard targetLineIndex >= 0 && targetLineIndex < lineManager.lineCount else {
+            return nil
+        }
+        // Find the line to move the selected text to.
+        let targetLine = lineManager.line(atRow: targetLineIndex)
+        // Find the range of text to remove. That's the range encapsulating selected lines.
+        let removeLocation = firstLine.location
+        let removeLength = lastLine.location + lastLine.data.totalLength - removeLocation
+        // Find the location to insert the text at.
+        var insertLocation = targetLine.location
+        if isMovingDown {
+            insertLocation += targetLine.data.totalLength - removeLength
+        }
+        // Update the selected range to match the old one but at the new lines.
+        var locationOffset = insertLocation - removeLocation
+        // Perform the remove and insert operations.
+        var removeRange = NSRange(location: removeLocation, length: removeLength)
+        let insertRange = NSRange(location: insertLocation, length: 0)
+        var text = stringView.substring(in: removeRange) ?? ""
+        if isMovingDown && targetLine.data.delimiterLength == 0 {
+            if lastLine.data.delimiterLength > 0 {
+                // We're moving to a line with no line break so we'll remove the last line break from the text we're moving.
+                // This behavior matches the one of Nova.
+                text.removeLast(lastLine.data.delimiterLength)
+            }
+            // Since the line we're moving to has no line break, we should add one in the beginning of the text.
+            text = lineEndingSymbol + text
+            locationOffset += lineEndingSymbol.count
+        } else if !isMovingDown && lastLine.data.delimiterLength == 0 {
+            // The last line we're moving has no line break, so we'll add one.
+            text += lineEndingSymbol
+            // Adjust the removal range to remove the line break of the line we're moving to.
+            if targetLine.data.delimiterLength > 0 {
+                removeRange.location -= targetLine.data.delimiterLength
+                removeRange.length += targetLine.data.delimiterLength
+            }
+        }
+        let newSelectedRange = NSRange(location: selectedRange.location + locationOffset, length: selectedRange.length)
+        return MoveLinesOperation(removeRange: removeRange, replacementRange: insertRange, replacementString: text, selectedRange: newSelectedRange)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Core/StringView.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Core/StringView.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+final class StringViewBytesResult {
+    // The bytes are not deallocated by this type.
+    let bytes: UnsafePointer<Int8>
+    let length: ByteCount
+
+    init(bytes: UnsafePointer<Int8>, length: ByteCount) {
+        self.bytes = bytes
+        self.length = length
+    }
+}
+
+final class StringView {
+    var string: NSString {
+        get {
+            internalString
+        }
+        set {
+            internalString = NSMutableString(string: newValue)
+        }
+    }
+    private var internalString: NSMutableString {
+        didSet {
+            if internalString != oldValue {
+                invalidate()
+            }
+        }
+    }
+    private var swiftString: String {
+        if let swiftString = _swiftString {
+            return swiftString
+        } else {
+            let swiftString = internalString as String
+            _swiftString = swiftString
+            return swiftString
+        }
+    }
+
+    private var _swiftString: String?
+
+    init(string: NSMutableString = NSMutableString()) {
+        self.internalString = string
+    }
+
+    convenience init(string: String) {
+        self.init(string: NSMutableString(string: string))
+    }
+
+    func substring(in range: NSRange) -> String? {
+        if range.location >= 0 && range.upperBound <= internalString.length && range.length > 0 {
+            return internalString.substring(with: range)
+        } else {
+            return nil
+        }
+    }
+
+    func character(at location: Int) -> Character? {
+        if location >= 0 && location < string.length, let scalar = Unicode.Scalar(internalString.character(at: location)) {
+            return Character(scalar)
+        } else {
+            return nil
+        }
+    }
+
+    func replaceText(in range: NSRange, with string: String) {
+        internalString.replaceCharacters(in: range, with: string)
+        invalidate()
+    }
+
+    func bytes(in range: ByteRange) -> StringViewBytesResult? {
+        guard range.lowerBound.value >= 0 && range.upperBound <= string.byteCount else {
+            return nil
+        }
+        let stringRange = NSRange(range)
+        var usedLength = 0
+        if let buffer = string.getBytes(in: stringRange, encoding: String.preferredUTF16Encoding, usedLength: &usedLength) {
+            return StringViewBytesResult(bytes: buffer, length: ByteCount(usedLength))
+        } else {
+            return nil
+        }
+    }
+}
+
+private extension StringView {
+    private func invalidate() {
+        _swiftString = nil
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Core/TimedUndoManager.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Core/TimedUndoManager.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+final class TimedUndoManager: UndoManager {
+    private let endGroupingInterval: TimeInterval = 1
+    private var endGroupingTimer: Timer?
+    private var hasOpenGroup: Bool {
+        groupingLevel > 0
+    }
+
+    override init() {
+        super.init()
+        groupsByEvent = false
+    }
+
+    override func removeAllActions() {
+        cancelTimer()
+        super.removeAllActions()
+    }
+
+    override func beginUndoGrouping() {
+        if !hasOpenGroup {
+            super.beginUndoGrouping()
+            if endGroupingTimer == nil {
+                scheduleTimer()
+            }
+        }
+    }
+
+    override func endUndoGrouping() {
+        cancelTimer()
+        if hasOpenGroup {
+            super.endUndoGrouping()
+        }
+    }
+
+    override func undo() {
+        endUndoGrouping()
+        super.undo()
+    }
+}
+
+private extension TimedUndoManager {
+    private func scheduleTimer() {
+        let timer = Timer(timeInterval: endGroupingInterval, target: self, selector: #selector(timerDidTrigger), userInfo: nil, repeats: false)
+        endGroupingTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
+    }
+
+    private func cancelTimer() {
+        endGroupingTimer?.invalidate()
+        endGroupingTimer = nil
+    }
+
+    @objc private func timerDidTrigger() {
+        cancelTimer()
+        endUndoGrouping()
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Indent/DetectedIndentStrategy.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Indent/DetectedIndentStrategy.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Indentation strategy detected in text.
+///
+/// the indentation strategy is detected when creating an instance of ``TextViewState``.
+public enum DetectedIndentStrategy {
+    /// Indent using tab.
+    case tab
+    /// Indent using a numer of spaces.
+    case space(length: Int)
+    /// The indentation strategy could not be determined.
+    case unknown
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Indent/IndentLevelMeasurer.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Indent/IndentLevelMeasurer.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+final class IndentLevelMeasurer {
+    private let stringView: StringView
+
+    init(stringView: StringView) {
+        self.stringView = stringView
+    }
+
+    func indentLevel(lineStartLocation: Int, lineTotalLength: Int, tabLength: Int) -> Int {
+        var indentLength = 0
+        for i in 0 ..< lineTotalLength {
+            let range = NSRange(location: lineStartLocation + i, length: 1)
+            if let str = stringView.substring(in: range)?.first {
+                if str == Symbol.Character.tab {
+                    indentLength += tabLength - (indentLength % tabLength)
+                } else if str == Symbol.Character.space {
+                    indentLength += 1
+                } else {
+                    break
+                }
+            }
+        }
+        return indentLength / tabLength
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Indent/IndentStrategy.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Indent/IndentStrategy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+/// Strategy to use when indenting text.
+public enum IndentStrategy: Equatable {
+    /// Indent using tabs. The specified length is used to determine the width of the tab measured in space characers.
+    case tab(length: Int)
+    /// Indent using a number of spaces.
+    case space(length: Int)
+}
+
+extension IndentStrategy {
+    var tabLength: Int {
+        switch self {
+        case .tab(let length):
+            return length
+        case .space(let length):
+            return length
+        }
+    }
+
+    func string(indentLevel: Int) -> String {
+        switch self {
+        case .tab:
+            return String(repeating: Symbol.Character.tab, count: indentLevel)
+        case .space(let length):
+            return String(repeating: Symbol.Character.space, count: length * indentLevel)
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Navigation/GoToLineSelection.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Navigation/GoToLineSelection.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Amount of text to select when navigating to a line.
+public enum GoToLineSelection {
+    /// Position the crat at the beginning of the line.
+    case beginning
+    /// Position the caret at the end of the line.
+    case end
+    /// Select the entire line.
+    case line
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/Navigation/TextLocation.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/Navigation/TextLocation.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// A location in the text.
+public struct TextLocation: Hashable, Equatable {
+    /// Zero-based line number.
+    public let lineNumber: Int
+    /// Column in the line.
+    public let column: Int
+
+    /// Initializes TextLocation from the given line and column
+    public init (lineNumber: Int, column: Int) {
+        self.lineNumber = lineNumber
+        self.column = column
+    }
+
+    init(_ linePosition: LinePosition) {
+        self.lineNumber = linePosition.row
+        self.column = linePosition.column
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/BatchReplaceSet.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/BatchReplaceSet.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Multiple ranges of the text in a text view to be replaced with a string.
+///
+/// When replacing text in batches, Runestone can do some optimizations to make the operation faster than when replacing the ranges one by one.
+///
+/// Replacing a batch of matches will only register a single undo operation.
+///
+/// All ranges should be provided relative to the current text in the text view.
+public struct BatchReplaceSet: Hashable {
+    /// A range of text to replace and the text to replace that range with.
+    public struct Replacement: Hashable {
+        /// The range of text in the text view to replace.
+        public let range: NSRange
+        /// The text to replace the text in the specified range with.
+        public let text: String
+
+        /// Creates a match to be replaced with the specified replacement text.
+        /// - Parameters:
+        ///   - range: The range of text in the text view to replace.
+        ///   - text: The text to replace the text in the specified range with.
+        public init(range: NSRange, text: String) {
+            self.range = range
+            self.text = text
+        }
+    }
+
+    /// All text matches to replace.
+    public let replacements: [Replacement]
+
+    /// Creates a set of ranges to replace with specified strings.
+    /// - Parameter replacements: All ranges to replace in the text view and their corresponding replacement texts.
+    public init(replacements: [Replacement]) {
+        self.replacements = replacements
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/ParsedReplacementString.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/ParsedReplacementString.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+struct ParsedReplacementString: Equatable {
+    enum Component: Equatable {
+        struct TextParameters: Equatable {
+            let text: String
+        }
+
+        struct PlaceholderParameters: Equatable {
+            let modifiers: [StringModifier]
+            let index: Int
+        }
+
+        case text(TextParameters)
+        case placeholder(PlaceholderParameters)
+
+        static func text(_ text: String) -> Self {
+            let parameters = TextParameters(text: text)
+            return .text(parameters)
+        }
+
+        static func placeholder(_ index: Int) -> Self {
+            let parameters = PlaceholderParameters(modifiers: [], index: index)
+            return .placeholder(parameters)
+        }
+
+        static func placeholder(modifiers: [StringModifier], index: Int) -> Self {
+            let parameters = PlaceholderParameters(modifiers: modifiers, index: index)
+            return .placeholder(parameters)
+        }
+    }
+
+    let components: [Component]
+
+    var containsPlaceholder: Bool {
+        components.contains { component in
+            switch component {
+            case .text:
+                return false
+            case .placeholder:
+                return true
+            }
+        }
+    }
+
+    func string(byMatching textCheckingResult: NSTextCheckingResult, in string: NSString) -> String {
+        var result = ""
+        for component in components {
+            switch component {
+            case .text(let parameters):
+                result += parameters.text
+            case .placeholder(let parameters):
+                if parameters.index < textCheckingResult.numberOfRanges {
+                    let range = textCheckingResult.range(at: parameters.index)
+                    let substring = string.substring(with: range)
+                    if parameters.index == 0 {
+                        // Visual Studio Code doesn't apply modifiers to capture groups with index 0 (i.e. the entire match).
+                        // We copy Visual Studio Code's behavior as it's likely familiar to our users.
+                        result += substring
+                    } else {
+                        result += StringModifier.string(byApplying: parameters.modifiers, to: substring)
+                    }
+                } else {
+                    // Placeholder is out of bounds so we just insert the raw placeholder.
+                    result += "$\(parameters.index)"
+                }
+            }
+        }
+        return result
+    }
+}
+
+extension ParsedReplacementString: CustomDebugStringConvertible {
+    var debugDescription: String {
+        var stringComponents: [String] = []
+        for component in components {
+            switch component {
+            case .text(let textParameters):
+                stringComponents.append(".text(\"\(textParameters.text)\")")
+            case .placeholder(let placeholderParameters):
+                var string = ".placeholder("
+                if !placeholderParameters.modifiers.isEmpty {
+                    string += String(placeholderParameters.modifiers.map(\.character))
+                }
+                string += "\"\(placeholderParameters.index)\")"
+                stringComponents.append(string)
+            }
+        }
+        return stringComponents.joined(separator: ", ")
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/ReplacementStringParser.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/ReplacementStringParser.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+final class ReplacementStringParser {
+    private enum State {
+        case `default`
+        case placeholder
+        case escapeSequence
+    }
+
+    private let string: String
+    private var state: State = .default
+    private var collectedString = ""
+    private var collectedModifiers: [StringModifier] = []
+    private var components: [ParsedReplacementString.Component] = []
+    private let numberCharacterSet = CharacterSet(charactersIn: "1234567890")
+
+    init(string: String) {
+        self.string = string
+    }
+
+    func parse() -> ParsedReplacementString {
+        var index = string.startIndex
+        while index < string.endIndex {
+            let character = string[index]
+            take(character, at: index)
+            index = string.index(after: index)
+        }
+        if let component = makeComponent() {
+            components.append(component)
+        }
+        return ParsedReplacementString(components: components)
+    }
+}
+
+private extension ReplacementStringParser {
+    private func take(_ character: Character, at index: String.Index) {
+        if state == .placeholder {
+            takeCharacterInPlaceholder(character, at: index)
+        } else if state == .escapeSequence {
+            takeCharacterInEscapeSequence(character)
+        } else if character == "\\" {
+            collectedString += String(character)
+            state = .escapeSequence
+        } else if character == "$" {
+            takeDollarSign(at: index)
+        } else {
+            appendCollectedModifiersToCollectedString()
+            collectedString += String(character)
+            state = .default
+        }
+    }
+
+    private func takeCharacterInPlaceholder(_ character: Character, at index: String.Index) {
+        if isCharacterValidInPlaceholderIndex(character) {
+            collectedString += String(character)
+        } else if let component = makeComponent() {
+            components.append(component)
+            state = .default
+            take(character, at: index)
+        } else {
+            // swiftlint:disable:next line_length
+            fatalError("We thought we were collecting a placeholder but the current character isn't valid in a placeholder and the collected string isn't a valid placeholder value either. Since we're peeking at the next character when starting a placeholder we should never be able to end up in this case.")
+        }
+    }
+
+    private func takeCharacterInEscapeSequence(_ character: Character) {
+        switch character {
+        case "\\":
+            collectedString.removeLast()
+            collectedString += String(character)
+            state = .default
+        case "n":
+            collectedString.removeLast()
+            collectedString += "\n"
+            state = .default
+        case "r":
+            collectedString.removeLast()
+            collectedString += "\r"
+            state = .default
+        case "t":
+            collectedString.removeLast()
+            collectedString += "\t"
+            state = .default
+        case "u":
+            collectedString.removeLast()
+            collectedModifiers.append(.uppercaseLetter)
+            state = .default
+        case "U":
+            collectedString.removeLast()
+            collectedModifiers.append(.uppercaseAllLetters)
+            state = .default
+        case "l":
+            collectedString.removeLast()
+            collectedModifiers.append(.lowercaseLetter)
+            state = .default
+        case "L":
+            collectedString.removeLast()
+            collectedModifiers.append(.lowercaseAllLetters)
+            state = .default
+        case "$":
+            collectedString.removeLast()
+            appendCollectedModifiersToCollectedString()
+            collectedString += String(character)
+            state = .default
+        default:
+            // We remove the backslash and insert it later to ensure our collected modifiers are inserted infront of the character.
+            collectedString.removeLast()
+            appendCollectedModifiersToCollectedString()
+            collectedString += "\\"
+            collectedString += String(character)
+            state = .default
+        }
+    }
+
+    private func takeDollarSign(at index: String.Index) {
+        if canStartPlaceholder(at: index) {
+            if let component = makeComponent() {
+                components.append(component)
+            }
+            state = .placeholder
+        } else {
+            appendCollectedModifiersToCollectedString()
+            collectedString += "$"
+            state = .default
+        }
+    }
+
+    private func canStartPlaceholder(at index: String.Index) -> Bool {
+        guard index < string.index(before: string.endIndex) else {
+            return false
+        }
+        let peekCharacterIndex = string.index(after: index)
+        let peekCharacter = string[peekCharacterIndex]
+        return isCharacterValidInPlaceholderIndex(peekCharacter)
+    }
+
+    private func isCharacterValidInPlaceholderIndex(_ character: Character) -> Bool {
+        let unicodeScalars = character.unicodeScalars
+        return unicodeScalars.count == 1 && numberCharacterSet.contains(unicodeScalars[unicodeScalars.startIndex])
+    }
+
+    private func appendCollectedModifiersToCollectedString() {
+        if !collectedModifiers.isEmpty {
+            collectedString += collectedModifiers.map(\.string).joined()
+            collectedModifiers = []
+        }
+    }
+
+    private func makeComponent() -> ParsedReplacementString.Component? {
+        switch state {
+        case .default, .escapeSequence:
+            let component = makeTextComponent()
+            collectedString = ""
+            return component
+        case .placeholder:
+            let component = makePlaceholderComponent()
+            collectedString = ""
+            collectedModifiers = []
+            return component
+        }
+    }
+
+    private func makeTextComponent() -> ParsedReplacementString.Component? {
+        if !collectedString.isEmpty {
+            let parameters = ParsedReplacementString.Component.TextParameters(text: collectedString)
+            return .text(parameters)
+        } else {
+            return nil
+        }
+    }
+
+    private func makePlaceholderComponent() -> ParsedReplacementString.Component? {
+        if !collectedString.isEmpty, let index = Int(collectedString) {
+            let parameters = ParsedReplacementString.Component.PlaceholderParameters(modifiers: collectedModifiers, index: index)
+            return .placeholder(parameters)
+        } else {
+            return nil
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchController.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchController.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+protocol SearchControllerDelegate: AnyObject {
+    func searchController(_ searchController: SearchController, linePositionAt location: Int) -> LinePosition?
+}
+
+final class SearchController {
+    weak var delegate: SearchControllerDelegate?
+
+    private let stringView: StringView
+
+    init(stringView: StringView) {
+        self.stringView = stringView
+    }
+
+    func search(for query: SearchQuery) -> [SearchResult] {
+        search(for: query) { textCheckingResult in
+            searchResult(in: textCheckingResult.range)
+        }
+    }
+
+    func search(for query: SearchQuery, replacingMatchesWith replacementText: String) -> [SearchReplaceResult] {
+        guard query.matchMethod == .regularExpression else {
+            return search(for: query, replacingWithPlainText: replacementText)
+        }
+        let replacementStringParser = ReplacementStringParser(string: replacementText)
+        let parsedReplacementString = replacementStringParser.parse()
+        return search(for: query) { textCheckingResult in
+            let replacementText = parsedReplacementString.string(byMatching: textCheckingResult, in: stringView.string)
+            return searchReplaceResult(in: textCheckingResult.range, replacementText: replacementText)
+        }
+    }
+}
+
+private extension SearchController {
+    private func search(for query: SearchQuery, replacingWithPlainText replacementText: String) -> [SearchReplaceResult] {
+        search(for: query) { textCheckingResult in
+            searchReplaceResult(in: textCheckingResult.range, replacementText: replacementText)
+        }
+    }
+
+    private func search<T>(for query: SearchQuery, mappingResultsWith mapper: (NSTextCheckingResult) -> T?) -> [T] {
+        guard !query.text.isEmpty else {
+            return []
+        }
+        let matches = query.matches(in: stringView.string)
+        return matches.compactMap { textCheckingResult in
+            if textCheckingResult.range.length > 0, let mappedValue = mapper(textCheckingResult) {
+                return mappedValue
+            } else {
+                return nil
+            }
+        }
+    }
+
+    private func searchResult(in range: NSRange) -> SearchResult? {
+        guard let startLinePosition = delegate?.searchController(self, linePositionAt: range.lowerBound) else {
+            return nil
+        }
+        guard let endLinePosition = delegate?.searchController(self, linePositionAt: range.upperBound) else {
+            return nil
+        }
+        return SearchResult(range: range, startLocation: TextLocation(startLinePosition), endLocation: TextLocation(endLinePosition))
+    }
+
+    private func searchReplaceResult(in range: NSRange, replacementText: String) -> SearchReplaceResult? {
+        guard let startLinePosition = delegate?.searchController(self, linePositionAt: range.lowerBound) else {
+            return nil
+        }
+        guard let endLinePosition = delegate?.searchController(self, linePositionAt: range.upperBound) else {
+            return nil
+        }
+        let startLocation = TextLocation(startLinePosition)
+        let endLocation = TextLocation(endLinePosition)
+        return SearchReplaceResult(range: range, startLocation: startLocation, endLocation: endLocation, replacementText: replacementText)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchQuery.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchQuery.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+/// Query to search for in the text view.
+///
+/// Use the options on the query to specify if the text is a regular expression and if the query should be case sensitive or not.
+///
+/// When the query contains a regular expression the capture groups can be referred in a replacement text using $0, $1, $2 etc.
+public struct SearchQuery: Hashable, Equatable {
+    /// Strategy to use when matching the search text against the text in the text view.
+    public enum MatchMethod {
+        /// Word contains the search text.
+        case contains
+        /// Word matches the search text.
+        case fullWord
+        /// Word starts with the search text.
+        case startsWith
+        /// Word ends with the search text.
+        case endsWith
+        /// Treat the search text as a regular expression.
+        case regularExpression
+    }
+
+    /// The text to search for.
+    public let text: String
+    /// Whether the text is a regular expression.
+    public let matchMethod: MatchMethod
+    /// Whether to perform a case-sensitive search.
+    public let isCaseSensitive: Bool
+    /// A range in the text view that the search should run against.
+    ///
+    /// When set to `nil` the search will run against the full text view. Defaults to `nil`.
+    public let range: NSRange?
+
+    private var annotatedText: String {
+        switch matchMethod {
+        case .fullWord:
+            return "\\b\(escapedText)\\b"
+        case .startsWith:
+            return "\\b\(escapedText)"
+        case .endsWith:
+            return "\(escapedText)\\b"
+        case .contains:
+            return escapedText
+        case .regularExpression:
+            return text
+        }
+    }
+    private var escapedText: String {
+        NSRegularExpression.escapedPattern(for: text)
+    }
+    private var regularExpressionOptions: NSRegularExpression.Options {
+        var options: NSRegularExpression.Options = [.anchorsMatchLines]
+        if !isCaseSensitive {
+            options.insert(.caseInsensitive)
+        }
+        return options
+    }
+
+    /// Creates a query to search for in the text view.
+    /// - Parameters:
+    ///   - text: The text to search for. May be a regular expression if `isRegularExpression` is `true`.
+    ///   - matchMethod: Strategy to use when matching the search text against the text in the text view. Defaults to `contains`.
+    ///   - isCaseSensitive: Whether to perform a case-sensitive search.
+    ///   - range: A range in the text view that the search should run against. Defaults to `nil` meaning full text view.
+    public init(text: String, matchMethod: MatchMethod = .contains, isCaseSensitive: Bool = false, range: NSRange? = nil) {
+        self.text = text
+        self.matchMethod = matchMethod
+        self.isCaseSensitive = isCaseSensitive
+        self.range = range
+    }
+
+    func matches(in string: NSString) -> [NSTextCheckingResult] {
+        do {
+            let regex = try NSRegularExpression(pattern: annotatedText, options: regularExpressionOptions)
+            return regex.matches(in: string as String, range: range ?? NSRange(location: 0, length: string.length))
+        } catch {
+            #if DEBUG
+            print(error)
+            #endif
+            return []
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchReplaceResult.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchReplaceResult.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// Contains information necessary to replace a range in the text view with a replacement text.
+///
+/// When the text view returns this result the text has not been replaced yet. It is up to the developer to use the range and replacement text in this result to replace the text in the text view, for example by calling ``TextView/replaceText(in:)``.
+public struct SearchReplaceResult: Hashable, Equatable {
+    /// Unique identifier of the result.
+    public let id: String = UUID().uuidString
+    /// Range of the matched text.
+    public let range: NSRange
+    /// Position at which the matched text starts.
+    public let startLocation: TextLocation
+    /// Position at which the matched text ends.
+    public let endLocation: TextLocation
+    /// Text to replace the match with.
+    ///
+    /// The replacement text is expanded to account for any capture groups referenced by the replacement text passed to ``TextView/search(for:replacingMatchesWith:)`` using $0, $1, $2 etc.
+    public let replacementText: String
+
+    /// Creates a search replacement result.
+    /// - Parameters:
+    ///   - range: Range of the matched text.
+    ///   - startLocation: Location where the match starts.
+    ///   - endLocation: Location where the match ends.
+    ///   - replacementText: Text that should replace the match.
+    public init(range: NSRange, startLocation: TextLocation, endLocation: TextLocation, replacementText: String) {
+        self.range = range
+        self.startLocation = startLocation
+        self.endLocation = endLocation
+        self.replacementText = replacementText
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchResult.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/SearchResult.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// A match returned by performing a search query.
+public struct SearchResult: Hashable, Equatable {
+    /// Unique identifier of the result.
+    public let id: String = UUID().uuidString
+    /// Range of the matched text.
+    public let range: NSRange
+    /// Location of line on which the matched text starts.
+    public let startLocation: TextLocation
+    /// Location of line on which the matched text ends.
+    public let endLocation: TextLocation
+
+    /// Creates a search result.
+    /// - Parameters:
+    ///   - range: Range of the matched text.
+    ///   - startLocation: Location where the match starts.
+    ///   - endLocation: Location where the match ends.
+    public init(range: NSRange, startLocation: TextLocation, endLocation: TextLocation) {
+        self.range = range
+        self.startLocation = startLocation
+        self.endLocation = endLocation
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/StringModifier.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SearchAndReplace/StringModifier.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+enum StringModifier {
+    case uppercaseLetter
+    case uppercaseAllLetters
+    case lowercaseLetter
+    case lowercaseAllLetters
+
+    var character: Character {
+        switch self {
+        case .uppercaseLetter:
+            return "u"
+        case .uppercaseAllLetters:
+            return "U"
+        case .lowercaseLetter:
+            return "l"
+        case .lowercaseAllLetters:
+            return "L"
+        }
+    }
+    var string: String {
+        "\\" + String(character)
+    }
+
+    private var terminatesStringModification: Bool {
+        switch self {
+        case .uppercaseAllLetters, .lowercaseAllLetters:
+            return true
+        case .uppercaseLetter, .lowercaseLetter:
+            return false
+        }
+    }
+
+    static func string(byApplying modifiers: [Self], to string: String) -> String {
+        guard !modifiers.isEmpty else {
+            return string
+        }
+        var stringIndex = string.startIndex
+        var modifierIndex = modifiers.startIndex
+        var result = ""
+        while stringIndex < string.endIndex && modifierIndex < modifiers.endIndex {
+            let modifier = modifiers[modifierIndex]
+            switch modifier {
+            case .uppercaseLetter:
+                result += string[stringIndex].uppercased()
+            case .lowercaseLetter:
+                result += string[stringIndex].lowercased()
+            case .uppercaseAllLetters:
+                result += string[stringIndex ..< string.endIndex].uppercased()
+            case .lowercaseAllLetters:
+                result += string[stringIndex ..< string.endIndex].lowercased()
+            }
+            if modifier.terminatesStringModification {
+                stringIndex = string.endIndex
+            } else {
+                stringIndex = string.index(after: stringIndex)
+            }
+            modifierIndex = modifiers.index(after: modifierIndex)
+        }
+        if stringIndex < string.endIndex {
+            result += string[stringIndex ..< string.endIndex]
+        }
+        return result
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TextView/SyntaxHighlighting/Internal/TreeSitter/TreeSitterTextPredicatesEvaluator.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+final class TreeSitterTextPredicatesEvaluator {
+    private let match: TreeSitterQueryMatch
+    private let stringView: StringView
+#if DEBUG
+    static var previousUnsupportedPredicateNames: [String] = []
+#endif
+
+    init(match: TreeSitterQueryMatch, stringView: StringView) {
+        self.match = match
+        self.stringView = stringView
+    }
+
+    func evaluatePredicates(in capture: TreeSitterCapture) -> Bool {
+        guard !capture.textPredicates.isEmpty else {
+            return true
+        }
+        for textPredicate in capture.textPredicates {
+            switch textPredicate {
+            case .captureEqualsString(let parameters):
+                if !evaluate(using: parameters) {
+                    return false
+                }
+            case .captureEqualsCapture(let parameters):
+                if !evaluate(using: parameters) {
+                    return false
+                }
+            case .captureMatchesPattern(let parameters):
+                if !evaluate(using: parameters) {
+                    return false
+                }
+            case .unsupported(let parameters):
+                #if DEBUG
+                if !Self.previousUnsupportedPredicateNames.contains(parameters.name) {
+                    Self.previousUnsupportedPredicateNames.append(parameters.name)
+                    print("Unsupported predicate '\(parameters.name)'."
+                          + " This message is only printed once and only when running in the debug configuration.")
+                }
+                #endif
+                return false
+            }
+        }
+        return true
+    }
+}
+
+private extension TreeSitterTextPredicatesEvaluator {
+    func evaluate(using parameters: TreeSitterTextPredicate.CaptureEqualsStringParameters) -> Bool {
+        guard let capture = match.capture(forIndex: parameters.captureIndex) else {
+            return false
+        }
+        let byteRange = capture.byteRange
+        let range = NSRange(byteRange)
+        let contentText = stringView.substring(in: range)
+        let comparisonResult = contentText == parameters.string
+        return comparisonResult == parameters.isPositive
+    }
+
+    func evaluate(using parameters: TreeSitterTextPredicate.CaptureEqualsCaptureParameters) -> Bool {
+        guard let lhsCapture = match.capture(forIndex: parameters.lhsCaptureIndex) else {
+            return false
+        }
+        guard let rhsCapture = match.capture(forIndex: parameters.lhsCaptureIndex) else {
+            return false
+        }
+        let lhsByteRange = lhsCapture.byteRange
+        let rhsByteRange = rhsCapture.byteRange
+        let lhsRange = NSRange(lhsByteRange)
+        let rhsRange = NSRange(rhsByteRange)
+        let lhsContentText = stringView.substring(in: lhsRange)
+        let rhsContentText = stringView.substring(in: rhsRange)
+        let comparisonResult = lhsContentText == rhsContentText
+        return comparisonResult == parameters.isPositive
+    }
+
+    func evaluate(using parameters: TreeSitterTextPredicate.CaptureMatchesPatternParameters) -> Bool {
+        guard let capture = match.capture(forIndex: parameters.captureIndex) else {
+            return false
+        }
+        let byteRange = capture.byteRange
+        let range = NSRange(location: byteRange.location.value / 2, length: byteRange.length.value / 2)
+        guard let contentText = stringView.substring(in: range) else {
+            return false
+        }
+        let matchingRange = contentText.range(of: parameters.pattern, options: .regularExpression)
+        let isMatch = matchingRange != nil
+        return isMatch == parameters.isPositive
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterCapture.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterCapture.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+final class TreeSitterCapture {
+    let node: TreeSitterNode
+    let index: UInt32
+    let name: String
+    let byteRange: ByteRange
+    let properties: [String: String]
+    let textPredicates: [TreeSitterTextPredicate]
+    let nameComponentCount: Int
+
+    convenience init(node: TreeSitterNode, index: UInt32, name: String, predicates: [TreeSitterPredicate]) {
+        self.init(node: node, index: index, name: name, byteRange: node.byteRange, predicates: predicates)
+    }
+
+    private init(node: TreeSitterNode, index: UInt32, name: String, byteRange: ByteRange, predicates: [TreeSitterPredicate]) {
+        let predicateMapResult = TreeSitterPredicateMapper.map(predicates)
+        self.node = node
+        self.index = index
+        self.name = name
+        self.byteRange = byteRange
+        self.properties = predicateMapResult.properties
+        self.textPredicates = predicateMapResult.textPredicates
+        self.nameComponentCount = name.split(separator: ".").count
+    }
+}
+
+extension TreeSitterCapture: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterCapture byteRange=\(byteRange) name=\(name) properties=\(properties) textPredicates=\(textPredicates)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterInputEdit.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterInputEdit.swift
@@ -1,0 +1,42 @@
+import TreeSitter
+
+final class TreeSitterInputEdit {
+    let startByte: ByteCount
+    let oldEndByte: ByteCount
+    let newEndByte: ByteCount
+    let startPoint: TreeSitterTextPoint
+    let oldEndPoint: TreeSitterTextPoint
+    let newEndPoint: TreeSitterTextPoint
+
+    init(startByte: ByteCount,
+         oldEndByte: ByteCount,
+         newEndByte: ByteCount,
+         startPoint: TreeSitterTextPoint,
+         oldEndPoint: TreeSitterTextPoint,
+         newEndPoint: TreeSitterTextPoint) {
+        self.startByte = startByte
+        self.oldEndByte = oldEndByte
+        self.newEndByte = newEndByte
+        self.startPoint = startPoint
+        self.oldEndPoint = oldEndPoint
+        self.newEndPoint = newEndPoint
+    }
+}
+
+extension TreeSitterInputEdit: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterInputEdit startByte=\(startByte) oldEndByte=\(oldEndByte) newEndByte=\(newEndByte)"
+            + " startPoint=\(startPoint) oldEndPoint=\(oldEndPoint) newEndPoint=\(newEndPoint)]"
+    }
+}
+
+extension TSInputEdit {
+    init(_ inputEdit: TreeSitterInputEdit) {
+        self.init(start_byte: UInt32(inputEdit.startByte.value),
+                  old_end_byte: UInt32(inputEdit.oldEndByte.value),
+                  new_end_byte: UInt32(inputEdit.newEndByte.value),
+                  start_point: inputEdit.startPoint.rawValue,
+                  old_end_point: inputEdit.oldEndPoint.rawValue,
+                  new_end_point: inputEdit.newEndPoint.rawValue)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterNode.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterNode.swift
@@ -1,0 +1,96 @@
+import TreeSitter
+
+final class TreeSitterNode {
+    let rawValue: TSNode
+    var expressionString: String? {
+        if let str = ts_node_string(rawValue) {
+            let result = String(cString: str)
+            str.deallocate()
+            return result
+        } else {
+            return nil
+        }
+    }
+    var type: String? {
+        if let str = ts_node_type(rawValue) {
+            return String(cString: str)
+        } else {
+            return nil
+        }
+    }
+    var startByte: ByteCount {
+        ByteCount(ts_node_start_byte(rawValue))
+    }
+    var endByte: ByteCount {
+        ByteCount(ts_node_end_byte(rawValue))
+    }
+    var startPoint: TreeSitterTextPoint {
+        TreeSitterTextPoint(ts_node_start_point(rawValue))
+    }
+    var endPoint: TreeSitterTextPoint {
+        TreeSitterTextPoint(ts_node_end_point(rawValue))
+    }
+    var byteRange: ByteRange {
+        ByteRange(from: startByte, to: endByte)
+    }
+    var parent: TreeSitterNode? {
+        getRelationship(using: ts_node_parent)
+    }
+    var previousSibling: TreeSitterNode? {
+        getRelationship(using: ts_node_prev_sibling)
+    }
+    var nextSibling: TreeSitterNode? {
+        getRelationship(using: ts_node_next_sibling)
+    }
+    var textRange: TreeSitterTextRange {
+        TreeSitterTextRange(startPoint: startPoint, endPoint: endPoint, startByte: startByte, endByte: endByte)
+    }
+    var childCount: Int {
+        Int(ts_node_child_count(rawValue))
+    }
+
+    init(node: TSNode) {
+        self.rawValue = node
+    }
+
+    func descendantForRange(from startPoint: TreeSitterTextPoint, to endPoint: TreeSitterTextPoint) -> TreeSitterNode {
+        let node = ts_node_descendant_for_point_range(rawValue, startPoint.rawValue, endPoint.rawValue)
+        return Self(node: node)
+    }
+
+    func child(at index: Int) -> Self? {
+        if index < childCount {
+            let node = ts_node_child(rawValue, UInt32(index))
+            return Self(node: node)
+        } else {
+            return nil
+        }
+    }
+}
+
+private extension TreeSitterNode {
+    private func getRelationship(using f: (TSNode) -> TSNode) -> TreeSitterNode? {
+        let node = f(rawValue)
+        if ts_node_is_null(node) {
+            return nil
+        } else {
+            return TreeSitterNode(node: node)
+        }
+    }
+}
+
+extension TreeSitterNode: Hashable {
+    static func == (lhs: TreeSitterNode, rhs: TreeSitterNode) -> Bool {
+        lhs.rawValue.id == rhs.rawValue.id
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(rawValue.id)
+    }
+}
+
+extension TreeSitterNode: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterNode startByte=\(startByte) endByte=\(endByte) startPoint=\(startPoint) endPoint=\(endPoint)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterParser.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterParser.swift
@@ -1,0 +1,90 @@
+import Foundation
+import TreeSitter
+
+protocol TreeSitterParserDelegate: AnyObject {
+    func parser(_ parser: TreeSitterParser, bytesAt byteIndex: ByteCount) -> TreeSitterTextProviderResult?
+}
+
+final class TreeSitterParser {
+    weak var delegate: TreeSitterParserDelegate?
+    let encoding: TSInputEncoding
+    var language: UnsafePointer<TSLanguage>? {
+        didSet {
+            ts_parser_set_language(pointer, language)
+        }
+    }
+    var canParse: Bool {
+        language != nil
+    }
+
+    private var pointer: OpaquePointer
+
+    init(encoding: TSInputEncoding) {
+        self.encoding = encoding
+        self.pointer = ts_parser_new()
+    }
+
+    deinit {
+        ts_parser_delete(pointer)
+    }
+
+    func parse(_ string: NSString, oldTree: TreeSitterTree? = nil) -> TreeSitterTree? {
+        guard string.length > 0 else {
+            return nil
+        }
+        guard let stringEncoding = encoding.stringEncoding else {
+            return nil
+        }
+        var usedLength = 0
+        let buffer = string.getAllBytes(withEncoding: stringEncoding, usedLength: &usedLength)
+        let newTreePointer = ts_parser_parse_string_encoding(pointer, oldTree?.pointer, buffer, UInt32(usedLength), encoding)
+        buffer?.deallocate()
+        if let newTreePointer = newTreePointer {
+            return TreeSitterTree(newTreePointer)
+        } else {
+            return nil
+        }
+    }
+
+    func parse(oldTree: TreeSitterTree? = nil) -> TreeSitterTree? {
+        let input = TreeSitterTextInput(encoding: encoding) { [weak self] byteIndex, _ in
+            if let self = self {
+                return self.delegate?.parser(self, bytesAt: byteIndex)
+            } else {
+                return nil
+            }
+        }
+        let newTreePointer = ts_parser_parse(pointer, oldTree?.pointer, input.makeTSInput())
+        input.deallocate()
+        if let newTreePointer = newTreePointer {
+            return TreeSitterTree(newTreePointer)
+        } else {
+            return nil
+        }
+    }
+
+    @discardableResult
+    func setIncludedRanges(_ ranges: [TreeSitterTextRange]) -> Bool {
+        let rawRanges = ranges.map { $0.rawValue }
+        return rawRanges.withUnsafeBufferPointer { rangesPointer in
+            ts_parser_set_included_ranges(pointer, rangesPointer.baseAddress, UInt32(rawRanges.count))
+        }
+    }
+
+    func removeAllIncludedRanges() {
+        ts_parser_set_included_ranges(pointer, nil, 0)
+    }
+}
+
+private extension TSInputEncoding {
+    var stringEncoding: String.Encoding? {
+        switch self {
+        case TSInputEncodingUTF8:
+            return .utf8
+        case TSInputEncodingUTF16:
+            return String.preferredUTF16Encoding
+        default:
+            return nil
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterPredicate.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterPredicate.swift
@@ -1,0 +1,33 @@
+import Foundation
+
+final class TreeSitterPredicate {
+    enum Step {
+        case capture(UInt32)
+        case string(String)
+    }
+
+    let name: String
+    let steps: [Step]
+
+    init(name: String, steps: [Step]) {
+        self.name = name
+        self.steps = steps
+    }
+}
+
+extension TreeSitterPredicate: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterPredicate name=\(name) steps=\(steps)]"
+    }
+}
+
+extension TreeSitterPredicate.Step: CustomDebugStringConvertible {
+    var debugDescription: String {
+        switch self {
+        case .capture(let id):
+            return "[TreeSitterPredicate.Step capture=\(id)]"
+        case .string(let string):
+            return "[TreeSitterPredicate.Step string=\(string)]"
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterPredicateMapper.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterPredicateMapper.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum TreeSitterPredicateMapper {
+    struct MapResult {
+        let properties: [String: String]
+        let textPredicates: [TreeSitterTextPredicate]
+    }
+
+    static func map(_ predicates: [TreeSitterPredicate]) -> MapResult {
+        var properties: [String: String] = [:]
+        var textPredicates: [TreeSitterTextPredicate] = []
+        for predicate in predicates {
+            switch predicate.name {
+            case "set!":
+                let setProperties = self.properties(fromSetSteps: predicate.steps)
+                properties[setProperties.name] = setProperties.value
+            case "eq?":
+                textPredicates.append(self.textPredicate(fromEqSteps: predicate.steps, isPositive: true))
+            case "not-eq?":
+                textPredicates.append(self.textPredicate(fromEqSteps: predicate.steps, isPositive: false))
+            case "match?":
+                textPredicates.append(self.textPredicate(fromMatchSteps: predicate.steps, isPositive: true))
+            case "not-match?":
+                textPredicates.append(textPredicate(fromMatchSteps: predicate.steps, isPositive: false))
+            default:
+                let parameters = TreeSitterTextPredicate.UnsupportedParameters(name: predicate.name)
+                textPredicates.append(.unsupported(parameters))
+            }
+        }
+        return MapResult(properties: properties, textPredicates: textPredicates)
+    }
+}
+
+private extension TreeSitterPredicateMapper {
+    private static func properties(fromSetSteps steps: [TreeSitterPredicate.Step]) -> (name: String, value: String) {
+        guard steps.count == 2 else {
+            fatalError("Set predicate must contain exactly two steps.")
+        }
+        switch (steps[0], steps[1]) {
+        case let (.string(name), .string(value)):
+            return (name, value)
+        default:
+            fatalError("Set predicate must contain exactly two string steps.")
+        }
+    }
+
+    private static func textPredicate(fromEqSteps steps: [TreeSitterPredicate.Step], isPositive: Bool) -> TreeSitterTextPredicate {
+        guard steps.count == 2 else {
+            fatalError("eq? and not-eq? predicates must contain exactly two teps.")
+        }
+        switch (steps[0], steps[1]) {
+        case let (.capture(captureIndex), .string(value)):
+            return .captureEqualsString(.init(captureIndex: captureIndex, string: value, isPositive: isPositive))
+        case let (.capture(lhsCaptureIndex), .capture(rhsCaptureIndex)):
+            return .captureEqualsCapture(.init(lhsCaptureIndex: lhsCaptureIndex, rhsCaptureIndex: rhsCaptureIndex, isPositive: isPositive))
+        default:
+            fatalError("Predicate contains invalid combination of steps.")
+        }
+    }
+
+    private static func textPredicate(fromMatchSteps steps: [TreeSitterPredicate.Step], isPositive: Bool) -> TreeSitterTextPredicate {
+        guard steps.count == 2 else {
+            fatalError("match? and not-match? predicates must contain exactly stwo teps.")
+        }
+        switch (steps[0], steps[1]) {
+        case let (.capture(captureIndex), .string(value)):
+            return .captureMatchesPattern(.init(captureIndex: captureIndex, pattern: value, isPositive: isPositive))
+        default:
+            fatalError("Predicate contains invalid combination of steps.")
+        }
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQuery.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQuery.swift
@@ -1,0 +1,103 @@
+import TreeSitter
+
+enum TreeSitterQueryError: Error {
+    case syntax(offset: UInt32)
+    case nodeType(offset: UInt32)
+    case field(offset: UInt32)
+    case capture(offset: UInt32)
+    case structure(offset: UInt32)
+    case unknown
+}
+
+final class TreeSitterQuery {
+    let pointer: OpaquePointer
+
+    private let language: UnsafePointer<TSLanguage>
+    private var patternCount: UInt32 {
+        ts_query_pattern_count(pointer)
+    }
+
+    init(source: String, language: UnsafePointer<TSLanguage>) throws {
+        let errorOffset = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
+        let errorType = UnsafeMutablePointer<TSQueryError>.allocate(capacity: 1)
+        let pointer = source.withCString { cstr in
+            ts_query_new(language, cstr, UInt32(source.count), errorOffset, errorType)
+        }
+        defer {
+            errorOffset.deallocate()
+            errorType.deallocate()
+        }
+        switch errorType.pointee.rawValue {
+        case 1:
+            throw TreeSitterQueryError.syntax(offset: errorOffset.pointee)
+        case 2:
+            throw TreeSitterQueryError.nodeType(offset: errorOffset.pointee)
+        case 3:
+            throw TreeSitterQueryError.field(offset: errorOffset.pointee)
+        case 4:
+            throw TreeSitterQueryError.capture(offset: errorOffset.pointee)
+        case 5:
+            throw TreeSitterQueryError.structure(offset: errorOffset.pointee)
+        default:
+            if let pointer = pointer {
+                self.language = language
+                self.pointer = pointer
+            } else {
+                throw TreeSitterQueryError.unknown
+            }
+        }
+    }
+
+    deinit {
+        ts_query_delete(pointer)
+    }
+
+    func captureName(forId id: UInt32) -> String {
+        let lengthPointer = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
+        let cString = ts_query_capture_name_for_id(pointer, id, lengthPointer)
+        lengthPointer.deallocate()
+        return String(cString: cString!)
+    }
+
+    func predicates(forPatternIndex index: UInt32) -> [TreeSitterPredicate] {
+        let lengthPointer = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
+        defer {
+            lengthPointer.deallocate()
+        }
+        guard let rawSteps = ts_query_predicates_for_pattern(pointer, index, lengthPointer) else {
+            return []
+        }
+        var predicates: [TreeSitterPredicate] = []
+        var l = 0
+        while l < lengthPointer.pointee {
+            var steps: [TreeSitterPredicate.Step] = []
+            let name = stringValue(forId: rawSteps.pointee.value_id)
+            l += 1
+            for i in 1 ..< .max {
+                let step = (rawSteps + UnsafePointer<TSQueryPredicateStep>.Stride(i)).pointee
+                l += 1
+                if step.type == TSQueryPredicateStepTypeCapture {
+                    steps.append(.capture(step.value_id))
+                } else if step.type == TSQueryPredicateStepTypeString {
+                    steps.append(.string(stringValue(forId: step.value_id)))
+                } else if step.type == TSQueryPredicateStepTypeDone {
+                    break
+                }
+            }
+            let predicate = TreeSitterPredicate(name: name, steps: steps)
+            predicates.append(predicate)
+        }
+        return predicates
+    }
+}
+
+private extension TreeSitterQuery {
+    private func stringValue(forId id: uint) -> String {
+        let lengthPointer = UnsafeMutablePointer<UInt32>.allocate(capacity: 1)
+        defer {
+            lengthPointer.deallocate()
+        }
+        let cString = ts_query_string_value_for_id(pointer, id, lengthPointer)
+        return String(cString: cString!)
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQueryCursor.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQueryCursor.swift
@@ -1,0 +1,55 @@
+import TreeSitter
+
+final class TreeSitterQueryCursor {
+    private let pointer: OpaquePointer
+    private let query: TreeSitterQuery
+    private let node: TreeSitterNode
+    private var haveExecuted = false
+
+    init(query: TreeSitterQuery, node: TreeSitterNode) {
+        self.pointer = ts_query_cursor_new()
+        self.query = query
+        self.node = node
+    }
+
+    deinit {
+        ts_query_cursor_delete(pointer)
+    }
+
+    func setQueryRange(_ range: ByteRange) {
+        let start = UInt32(range.location.value)
+        let end = UInt32((range.location + range.length).value)
+        ts_query_cursor_set_byte_range(pointer, start, end)
+    }
+
+    func execute() {
+        if !haveExecuted {
+            haveExecuted = true
+            ts_query_cursor_exec(pointer, query.pointer, node.rawValue)
+        }
+    }
+
+    func validCaptures(in stringView: StringView) -> [TreeSitterCapture] {
+        guard haveExecuted else {
+            fatalError("Cannot get captures of a query that has not been executed.")
+        }
+        var match = TSQueryMatch(id: 0, pattern_index: 0, capture_count: 0, captures: nil)
+        var result: [TreeSitterCapture] = []
+        while ts_query_cursor_next_match(pointer, &match) {
+            let captureCount = Int(match.capture_count)
+            let captureBuffer = UnsafeBufferPointer<TSQueryCapture>(start: match.captures, count: captureCount)
+            let captures: [TreeSitterCapture] = captureBuffer.compactMap { capture in
+                let node = TreeSitterNode(node: capture.node)
+                let captureName = query.captureName(forId: capture.index)
+                let predicates = query.predicates(forPatternIndex: UInt32(match.pattern_index))
+                return TreeSitterCapture(node: node, index: capture.index, name: captureName, predicates: predicates)
+            }
+            let match = TreeSitterQueryMatch(captures: captures)
+            let evaluator = TreeSitterTextPredicatesEvaluator(match: match, stringView: stringView)
+            result += captures.filter { capture in
+                capture.byteRange.length > 0 && evaluator.evaluatePredicates(in: capture)
+            }
+        }
+        return result
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQueryMatch.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterQueryMatch.swift
@@ -1,0 +1,19 @@
+import TreeSitter
+
+final class TreeSitterQueryMatch {
+    let captures: [TreeSitterCapture]
+
+    init(captures: [TreeSitterCapture]) {
+        self.captures = captures
+    }
+
+    func capture(forIndex index: UInt32) -> TreeSitterCapture? {
+        captures.first { $0.index == index }
+    }
+}
+
+extension TreeSitterQueryMatch: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterQueryMatch captures=\(captures.count)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextInput.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextInput.swift
@@ -1,0 +1,48 @@
+import TreeSitter
+
+struct TreeSitterTextProviderResult {
+    let bytes: UnsafePointer<Int8>
+    let length: UInt32
+}
+
+typealias TreeSitterReadCallback = (_ byteIndex: ByteCount, _ position: TreeSitterTextPoint) -> TreeSitterTextProviderResult?
+
+/// The implementation is inspired by SwiftTreeSitter.
+/// https://github.com/ChimeHQ/SwiftTreeSitter/blob/main/Sources/SwiftTreeSitter/Input.swift
+final class TreeSitterTextInput {
+    fileprivate let encoding: TSInputEncoding
+    fileprivate let callback: TreeSitterReadCallback
+    fileprivate var bytePointers: [UnsafePointer<Int8>] = []
+
+    init(encoding: TSInputEncoding, callback: @escaping TreeSitterReadCallback) {
+        self.encoding = encoding
+        self.callback = callback
+    }
+
+    func makeTSInput() -> TSInput {
+        let payload = Unmanaged.passUnretained(self).toOpaque()
+        return TSInput(payload: payload, read: read, encoding: encoding)
+    }
+
+    func deallocate() {
+        for bytePointer in bytePointers {
+            bytePointer.deallocate()
+        }
+        bytePointers = []
+    }
+}
+
+private func read(payload: UnsafeMutableRawPointer?,
+                  byteIndex: UInt32,
+                  position: TSPoint,
+                  bytesRead: UnsafeMutablePointer<UInt32>?) -> UnsafePointer<Int8>? {
+    let input: TreeSitterTextInput = Unmanaged.fromOpaque(payload!).takeUnretainedValue()
+    if let result = input.callback(ByteCount(byteIndex), TreeSitterTextPoint(position)) {
+        bytesRead?.pointee = result.length
+        input.bytePointers.append(result.bytes)
+        return result.bytes
+    } else {
+        bytesRead?.pointee = 0
+        return nil
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextPoint.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextPoint.swift
@@ -1,0 +1,26 @@
+import TreeSitter
+
+final class TreeSitterTextPoint {
+    var row: UInt32 {
+        rawValue.row
+    }
+    var column: UInt32 {
+        rawValue.column
+    }
+
+    let rawValue: TSPoint
+
+    init(_ point: TSPoint) {
+        self.rawValue = point
+    }
+
+    init(row: UInt32, column: UInt32) {
+        self.rawValue = TSPoint(row: row, column: column)
+    }
+}
+
+extension TreeSitterTextPoint: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTextPoint row=\(row) column=\(column)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextPredicate.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextPredicate.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+enum TreeSitterTextPredicate {
+    final class CaptureEqualsStringParameters {
+        let captureIndex: UInt32
+        let string: String
+        let isPositive: Bool
+
+        init(captureIndex: UInt32, string: String, isPositive: Bool) {
+            self.captureIndex = captureIndex
+            self.string = string
+            self.isPositive = isPositive
+        }
+    }
+
+    struct CaptureEqualsCaptureParameters {
+        let lhsCaptureIndex: UInt32
+        let rhsCaptureIndex: UInt32
+        let isPositive: Bool
+
+        init(lhsCaptureIndex: UInt32, rhsCaptureIndex: UInt32, isPositive: Bool) {
+            self.lhsCaptureIndex = lhsCaptureIndex
+            self.rhsCaptureIndex = rhsCaptureIndex
+            self.isPositive = isPositive
+        }
+    }
+
+    struct CaptureMatchesPatternParameters {
+        let captureIndex: UInt32
+        let pattern: String
+        let isPositive: Bool
+
+        init(captureIndex: UInt32, pattern: String, isPositive: Bool) {
+            self.captureIndex = captureIndex
+            self.pattern = pattern
+            self.isPositive = isPositive
+        }
+    }
+
+    struct UnsupportedParameters {
+        let name: String
+
+        init(name: String) {
+            self.name = name
+        }
+    }
+
+    case captureEqualsString(CaptureEqualsStringParameters)
+    case captureEqualsCapture(CaptureEqualsCaptureParameters)
+    case captureMatchesPattern(CaptureMatchesPatternParameters)
+    case unsupported(UnsupportedParameters)
+}
+
+extension TreeSitterTextPredicate.CaptureEqualsStringParameters: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTextPredicate.CaptureEqualsStringParameters captureIndex=\(captureIndex) string=\(string) isPositive=\(isPositive)]"
+    }
+}
+
+extension TreeSitterTextPredicate.CaptureEqualsCaptureParameters: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTextPredicate.CaptureEqualsCaptureParameters lhsCaptureIndex=\(lhsCaptureIndex)"
+        + " rhsCaptureIndex=\(rhsCaptureIndex)"
+        + " isPositive=\(isPositive)]"
+    }
+}
+
+extension TreeSitterTextPredicate.CaptureMatchesPatternParameters: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTextPredicate.CaptureMatchesPatternParameters captureIndex=\(captureIndex) pattern=\(pattern) isPositive=\(isPositive)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextRange.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTextRange.swift
@@ -1,0 +1,31 @@
+import TreeSitter
+
+final class TreeSitterTextRange {
+    let rawValue: TSRange
+    var startPoint: TreeSitterTextPoint {
+        TreeSitterTextPoint(row: rawValue.start_point.row, column: rawValue.start_point.column)
+    }
+    var endPoint: TreeSitterTextPoint {
+        TreeSitterTextPoint(row: rawValue.end_point.row, column: rawValue.end_point.column)
+    }
+    var startByte: ByteCount {
+        ByteCount(rawValue.start_byte)
+    }
+    var endByte: ByteCount {
+        ByteCount(rawValue.end_byte)
+    }
+
+    init(startPoint: TreeSitterTextPoint, endPoint: TreeSitterTextPoint, startByte: ByteCount, endByte: ByteCount) {
+        self.rawValue = TSRange(
+            start_point: startPoint.rawValue,
+            end_point: endPoint.rawValue,
+            start_byte: UInt32(startByte.value),
+            end_byte: UInt32(endByte.value))
+    }
+}
+
+extension TreeSitterTextRange: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTextRange startByte=\(startByte) endByte=\(endByte) startPoint=\(startPoint) endPoint=\(endPoint)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTree.swift
+++ b/vendor/runestone/Sources/RunestoneCore/TreeSitter/TreeSitterTree.swift
@@ -1,0 +1,40 @@
+import TreeSitter
+
+final class TreeSitterTree {
+    let pointer: OpaquePointer
+    var rootNode: TreeSitterNode {
+        TreeSitterNode(node: ts_tree_root_node(pointer))
+    }
+
+    init(_ tree: OpaquePointer) {
+        self.pointer = tree
+    }
+
+    deinit {
+        ts_tree_delete(pointer)
+    }
+
+    func apply(_ inputEdit: TreeSitterInputEdit) {
+        withUnsafePointer(to: TSInputEdit(inputEdit)) { inputEditPointer in
+            ts_tree_edit(pointer, inputEditPointer)
+        }
+    }
+
+    func rangesChanged(comparingTo otherTree: TreeSitterTree) -> [TreeSitterTextRange] {
+        var count = CUnsignedInt(0)
+        let ptr = ts_tree_get_changed_ranges(pointer, otherTree.pointer, &count)
+        return UnsafeBufferPointer(start: ptr, count: Int(count)).map { range in
+            let startPoint = TreeSitterTextPoint(range.start_point)
+            let endPoint = TreeSitterTextPoint(range.end_point)
+            let startByte = ByteCount(range.start_byte)
+            let endByte = ByteCount(range.end_byte)
+            return TreeSitterTextRange(startPoint: startPoint, endPoint: endPoint, startByte: startByte, endByte: endByte)
+        }
+    }
+}
+
+extension TreeSitterTree: CustomDebugStringConvertible {
+    var debugDescription: String {
+        "[TreeSitterTree rootNode=\(rootNode)]"
+    }
+}

--- a/vendor/runestone/Sources/RunestoneFacade/Exports.swift
+++ b/vendor/runestone/Sources/RunestoneFacade/Exports.swift
@@ -1,0 +1,5 @@
+#if canImport(RunestoneUIiOS)
+@_exported import RunestoneUIiOS
+#elseif canImport(RunestoneUIMac)
+@_exported import RunestoneUIMac
+#endif

--- a/vendor/runestone/Sources/RunestoneMac/DefaultTheme.swift
+++ b/vendor/runestone/Sources/RunestoneMac/DefaultTheme.swift
@@ -1,0 +1,58 @@
+#if canImport(AppKit)
+import AppKit
+import Foundation
+import RunestoneCore
+
+/// Default theme used by Runestone on macOS when no other theme has been set.
+public final class DefaultTheme: Theme {
+    public let font: NSFont = .monospacedSystemFont(ofSize: 14, weight: .regular)
+    public let textColor: NSColor = .labelColor
+    public let gutterBackgroundColor: NSColor = NSColor.windowBackgroundColor
+    public let gutterHairlineColor: NSColor = NSColor.separatorColor
+    public let lineNumberColor: NSColor = NSColor.secondaryLabelColor
+    public let lineNumberFont: NSFont = .monospacedSystemFont(ofSize: 14, weight: .regular)
+    public let selectedLineBackgroundColor: NSColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.12)
+    public let selectedLinesLineNumberColor: NSColor = NSColor.labelColor
+    public let selectedLinesGutterBackgroundColor: NSColor = NSColor.windowBackgroundColor
+    public let invisibleCharactersColor: NSColor = NSColor.tertiaryLabelColor
+    public let pageGuideHairlineColor: NSColor = NSColor.separatorColor
+    public let pageGuideBackgroundColor: NSColor = NSColor.controlBackgroundColor
+    public let markedTextBackgroundColor: NSColor = NSColor.selectedTextBackgroundColor.withAlphaComponent(0.25)
+
+    public init() {}
+
+    public func textColor(for highlightName: String) -> NSColor? {
+        if highlightName.hasPrefix("comment") {
+            return NSColor.systemGreen
+        } else if highlightName.hasPrefix("constant.builtin") || highlightName.hasPrefix("constant.character") {
+            return NSColor.systemPink
+        } else if highlightName.hasPrefix("constructor") || highlightName.hasPrefix("type") {
+            return NSColor.systemOrange
+        } else if highlightName.hasPrefix("function") {
+            return NSColor.systemBlue
+        } else if highlightName.hasPrefix("keyword") {
+            return NSColor.systemPurple
+        } else if highlightName.hasPrefix("number") {
+            return NSColor.systemRed
+        } else if highlightName.hasPrefix("property") {
+            return NSColor.systemTeal
+        } else if highlightName.hasPrefix("string") {
+            return NSColor.systemMint
+        } else if highlightName.hasPrefix("variable.builtin") {
+            return NSColor.systemIndigo
+        } else if highlightName.hasPrefix("operator") || highlightName.hasPrefix("punctuation") {
+            return NSColor.secondaryLabelColor
+        } else {
+            return nil
+        }
+    }
+
+    public func fontTraits(for highlightName: String) -> FontTraits {
+        if highlightName.hasPrefix("keyword") {
+            return .bold
+        } else {
+            return []
+        }
+    }
+}
+#endif

--- a/vendor/runestone/Sources/RunestoneMac/Exports.swift
+++ b/vendor/runestone/Sources/RunestoneMac/Exports.swift
@@ -1,0 +1,2 @@
+@_exported import RunestoneCore
+@_exported import RunestonePlatform

--- a/vendor/runestone/Sources/RunestoneMac/RunestoneDebugLog.swift
+++ b/vendor/runestone/Sources/RunestoneMac/RunestoneDebugLog.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+public enum RunestoneDebugLog {
+    private static let logFileEnvironmentKey = "RUNESTONE_DEMO_DEBUG_LOG_FILE"
+    private static let fileQueue = DispatchQueue(label: "RunestoneDebugLog.file", qos: .utility)
+    private static let configuredLogFilePath: String? = {
+        guard let path = ProcessInfo.processInfo.environment[logFileEnvironmentKey],
+              !path.isEmpty else {
+            return nil
+        }
+        return path
+    }()
+    private static var fileHandle: FileHandle?
+
+    public static func write(_ message: @autoclosure () -> String) {
+        let line = message() + "\n"
+        guard let data = line.data(using: .utf8) else {
+            return
+        }
+        fileQueue.async {
+            FileHandle.standardError.write(data)
+            guard let handle = openFileHandleIfNeeded() else {
+                return
+            }
+            handle.seekToEndOfFile()
+            handle.write(data)
+        }
+    }
+
+    public static func flush() {
+        fileQueue.sync {
+            fileHandle?.synchronizeFile()
+        }
+    }
+
+    private static func openFileHandleIfNeeded() -> FileHandle? {
+        if let fileHandle {
+            return fileHandle
+        }
+        guard let configuredLogFilePath else {
+            return nil
+        }
+        let fileManager = FileManager.default
+        if !fileManager.fileExists(atPath: configuredLogFilePath) {
+            fileManager.createFile(atPath: configuredLogFilePath, contents: nil)
+        }
+        guard let handle = FileHandle(forWritingAtPath: configuredLogFilePath) else {
+            return nil
+        }
+        fileHandle = handle
+        return handle
+    }
+}

--- a/vendor/runestone/Sources/RunestoneMac/TextView.swift
+++ b/vendor/runestone/Sources/RunestoneMac/TextView.swift
@@ -1,0 +1,1877 @@
+#if canImport(AppKit)
+import AppKit
+import Foundation
+import RunestoneCore
+
+private final class NativeTextView: NSTextView {
+    weak var hostingTextView: TextView?
+
+    override func scrollRangeToVisible(_ range: NSRange) {
+        guard let hostingTextView else {
+            super.scrollRangeToVisible(range)
+            return
+        }
+        if hostingTextView.scrollRangeToVisibleMinimallyFromNative(range) {
+            return
+        }
+        super.scrollRangeToVisible(range)
+    }
+
+    override func insertNewline(_ sender: Any?) {
+        let previousOrigin = enclosingScrollView?.contentView.bounds.origin ?? .zero
+        hostingTextView?.beginEnterShiftTrace(previousOrigin: previousOrigin)
+        super.insertNewline(sender)
+        hostingTextView?.constrainPostEnterScroll(previousOrigin: previousOrigin)
+        hostingTextView?.finishEnterShiftTrace()
+    }
+}
+
+/// A macOS text editor view with Runestone-compatible APIs.
+open class TextView: NSScrollView {
+    private static let debugUndoLagEnabled = ProcessInfo.processInfo.environment["RUNESTONE_DEMO_DEBUG_UNDO_LAG"] == "1"
+    private static let debugLagTraceEnabled = ProcessInfo.processInfo.environment["RUNESTONE_DEMO_DEBUG_LAG_TRACE"] == "1"
+    private static let debugEnterShiftEnabled = ProcessInfo.processInfo.environment["RUNESTONE_DEMO_DEBUG_ENTER_SHIFT"] == "1"
+    private static let lagTraceNotificationName = Notification.Name("RunestoneLagTraceEvent")
+
+    /// Delegate to receive callbacks for events triggered by the editor.
+    public weak var editorDelegate: TextViewDelegate?
+
+    /// The text that the text view displays.
+    public var text: String {
+        get {
+            textView.string
+        }
+        set {
+            isPerformingProgrammaticEdit = true
+            textStorage.setString(newValue)
+            textView.string = textStorage as String
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+            isPerformingProgrammaticEdit = false
+            needsTextStorageResync = false
+            pendingNonWrappingLineBreakDelta = 0
+            pendingNonWrappingLayoutReconciliation = nil
+            stabilizeDocumentLayout()
+            editorDelegate?.textViewDidChange(self)
+            editorDelegate?.textViewDidChangeSelection(self)
+        }
+    }
+
+    /// A Boolean value that indicates whether the text view is editable.
+    public var isEditable: Bool {
+        get {
+            textView.isEditable
+        }
+        set {
+            textView.isEditable = newValue
+        }
+    }
+
+    /// A Boolean value that indicates whether the text view is selectable.
+    public var isSelectable: Bool {
+        get {
+            textView.isSelectable
+        }
+        set {
+            textView.isSelectable = newValue
+        }
+    }
+
+    /// Colors and fonts to be used by the editor.
+    public var theme: Theme {
+        didSet {
+            apply(theme: theme)
+        }
+    }
+
+    /// The color of the insertion point.
+    public var insertionPointColor: NSColor {
+        get {
+            textView.insertionPointColor
+        }
+        set {
+            textView.insertionPointColor = newValue
+        }
+    }
+
+    /// The color of the selection bar.
+    public var selectionBarColor: NSColor {
+        get {
+            _selectionBarColor
+        }
+        set {
+            _selectionBarColor = newValue
+            textView.insertionPointColor = newValue
+        }
+    }
+
+    /// The color of the selection highlight.
+    public var selectionHighlightColor: NSColor {
+        get {
+            _selectionHighlightColor
+        }
+        set {
+            _selectionHighlightColor = newValue
+            applySelectionHighlightColorIfPossible()
+        }
+    }
+
+    /// The current selection range of the text view.
+    public var selectedRange: NSRange {
+        get {
+            textView.selectedRange()
+        }
+        set {
+            let safeRange = clamped(range: newValue)
+            textView.setSelectedRange(safeRange)
+            editorDelegate?.textViewDidChangeSelection(self)
+        }
+    }
+
+    /// Handles URLs activated through link interaction in the text view.
+    public var openURLHandler: (URL) -> Bool = { url in
+        NSWorkspace.shared.open(url)
+    }
+
+    /// Provides the modifier flags for the current event when handling link activation.
+    public var currentEventModifierFlagsProvider: () -> NSEvent.ModifierFlags = {
+        NSApp.currentEvent?.modifierFlags ?? []
+    }
+
+    /// Returns the undo manager used by the text view.
+    override public var undoManager: UndoManager? {
+        super.undoManager
+    }
+
+    /// Whether line numbers should be shown.
+    public var showLineNumbers = false {
+        didSet {
+            updateGutterMetrics()
+        }
+    }
+
+    /// Leading padding in the gutter area.
+    public var gutterLeadingPadding: CGFloat = 0 {
+        didSet {
+            updateGutterMetrics()
+        }
+    }
+
+    /// Trailing padding in the gutter area.
+    public var gutterTrailingPadding: CGFloat = 0 {
+        didSet {
+            updateGutterMetrics()
+        }
+    }
+
+    /// Computed gutter width.
+    public private(set) var gutterWidth: CGFloat = 0
+
+    /// Whether line wrapping is enabled.
+    public var isLineWrappingEnabled = false {
+        didSet {
+            updateLineWrapping()
+        }
+    }
+
+    /// Wrapping mode used when line wrapping is enabled.
+    public var lineBreakMode: LineBreakMode = .byWordWrapping {
+        didSet {
+            updateLineWrapping()
+        }
+    }
+
+    /// Whether page guide should be shown.
+    public var showPageGuide = false
+
+    /// Page guide column when page guide is visible.
+    public var pageGuideColumn = 80
+
+    /// Line endings to insert on line break operations.
+    public var lineEndings: LineEnding = .lf
+    /// Strategy to use when indenting text.
+    public var indentStrategy: IndentStrategy = .space(length: 4)
+
+    /// Underlying native text view.
+    public let textView: NSTextView
+
+    private struct PendingNonWrappingLayoutReconciliation {
+        let beforeLocalHeight: CGFloat
+        let beforeLineBreakCount: Int
+        let afterLocationHint: Int
+        let extraContextLines: Int
+        var appliedEstimatedHeightDelta: CGFloat
+    }
+
+    private let textStorage = NSMutableString()
+    private var isPerformingProgrammaticEdit = false
+    private var needsTextStorageResync = false
+    private var needsDocumentLayoutStabilizationAfterEdit = false
+    private var pendingNonWrappingLineBreakDelta = 0
+    private var pendingNonWrappingLayoutReconciliation: PendingNonWrappingLayoutReconciliation?
+    private var lastNativeEditDate = Date.distantPast
+    private var liveResizeAnchorOrigin: NSPoint?
+    private var observedUndoManager: UndoManager?
+    private var willUndoObserver: NSObjectProtocol?
+    private var willRedoObserver: NSObjectProtocol?
+    private var undoObserver: NSObjectProtocol?
+    private var redoObserver: NSObjectProtocol?
+    private var undoRedoSequence = 0
+    private var enterTraceSequence = 0
+    private var activeEnterTraceSequence: Int?
+    private var lastEnterTraceDate = Date.distantPast
+    private var _selectionBarColor: NSColor
+    private var _selectionHighlightColor: NSColor
+
+    public override init(frame frameRect: NSRect) {
+        let defaultTheme = DefaultTheme()
+        self.theme = defaultTheme
+        self._selectionBarColor = defaultTheme.textColor
+        self._selectionHighlightColor = defaultTheme.markedTextBackgroundColor.withAlphaComponent(0.45)
+
+        let contentSize = frameRect.size
+        let textView = NativeTextView(frame: NSRect(origin: .zero, size: contentSize))
+        textView.minSize = NSSize(width: 0, height: max(contentSize.height, 1))
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.usesFindBar = true
+        textView.isAutomaticLinkDetectionEnabled = false
+        textView.layoutManager?.allowsNonContiguousLayout = false
+        if let textContainer = textView.textContainer {
+            textContainer.heightTracksTextView = false
+            textContainer.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        }
+
+        self.textView = textView
+        super.init(frame: frameRect)
+        textView.hostingTextView = self
+
+        borderType = .noBorder
+        hasVerticalScroller = true
+        hasHorizontalScroller = true
+        drawsBackground = true
+        documentView = textView
+
+        self.textView.delegate = self
+        apply(theme: defaultTheme)
+        updateGutterMetrics()
+        updateLineWrapping()
+        text = ""
+        attachUndoObserversIfNeeded()
+    }
+
+    required public init?(coder: NSCoder) {
+        let defaultTheme = DefaultTheme()
+        self.theme = defaultTheme
+        self._selectionBarColor = defaultTheme.textColor
+        self._selectionHighlightColor = defaultTheme.markedTextBackgroundColor.withAlphaComponent(0.45)
+        let textView = NativeTextView(frame: .zero)
+        textView.minSize = NSSize(width: 0, height: 1)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        self.textView = textView
+        super.init(coder: coder)
+        textView.hostingTextView = self
+
+        documentView = textView
+        borderType = .noBorder
+        hasVerticalScroller = true
+        hasHorizontalScroller = true
+        drawsBackground = true
+
+        textView.isRichText = false
+        textView.allowsUndo = true
+        textView.usesFindBar = true
+        textView.isAutomaticLinkDetectionEnabled = false
+        textView.isHorizontallyResizable = true
+        textView.isVerticallyResizable = true
+        textView.layoutManager?.allowsNonContiguousLayout = false
+        if let textContainer = textView.textContainer {
+            textContainer.heightTracksTextView = false
+            textContainer.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        }
+        textView.delegate = self
+        apply(theme: defaultTheme)
+        updateGutterMetrics()
+        updateLineWrapping()
+        text = ""
+        attachUndoObserversIfNeeded()
+    }
+
+    open override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        attachUndoObserversIfNeeded()
+        applySelectionHighlightColorIfPossible()
+    }
+
+    open override func viewWillStartLiveResize() {
+        super.viewWillStartLiveResize()
+        liveResizeAnchorOrigin = contentView.bounds.origin
+    }
+
+    open override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+        maintainLiveResizeAnchorIfNeeded(force: true)
+        liveResizeAnchorOrigin = nil
+    }
+
+    open override func resizeSubviews(withOldSize oldSize: NSSize) {
+        super.resizeSubviews(withOldSize: oldSize)
+        maintainLiveResizeAnchorIfNeeded(force: false)
+    }
+
+    deinit {
+        detachUndoObservers()
+    }
+
+    /// Returns the text location for the specified character location.
+    public func textLocation(at location: Int) -> TextLocation? {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard location >= 0, location <= textStorage.length else {
+            return nil
+        }
+        return textLocationUnchecked(at: location)
+    }
+
+    /// Returns the character location for the specified text location.
+    public func location(at textLocation: TextLocation) -> Int? {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard textLocation.lineNumber >= 0, textLocation.column >= 0 else {
+            return nil
+        }
+        let lineRanges = allLineRanges()
+        guard textLocation.lineNumber < lineRanges.count else {
+            return nil
+        }
+        let lineRange = lineRanges[textLocation.lineNumber]
+        let lineLength = trimmedLineLength(for: lineRange)
+        guard textLocation.column <= lineLength else {
+            return nil
+        }
+        return lineRange.location + textLocation.column
+    }
+
+    /// Inserts text at the current selection.
+    open func insertText(_ text: String) {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        replace(selectedRange, withText: text)
+    }
+
+    /// Replaces text in the specified range.
+    public func replace(_ range: NSRange, withText replacementText: String) {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        _ = applyReplacement(in: range, withText: replacementText, respectDelegate: true)
+    }
+
+    /// Replaces text for all ranges in the replacement set.
+    public func replaceText(in batchReplaceSet: BatchReplaceSet) {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let orderedReplacements = batchReplaceSet.replacements.sorted { lhs, rhs in
+            lhs.range.location > rhs.range.location
+        }
+        for replacement in orderedReplacements {
+            replace(replacement.range, withText: replacement.text)
+        }
+    }
+
+    /// Deletes backwards from the insertion point.
+    public func deleteBackward() {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let selection = selectedRange
+        if selection.length > 0 {
+            replace(selection, withText: "")
+        } else if selection.location > 0 {
+            replace(NSRange(location: selection.location - 1, length: 1), withText: "")
+        }
+    }
+
+    /// Returns text in the specified range.
+    public func text(in range: NSRange) -> String? {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard isValid(range: range) else {
+            return nil
+        }
+        return textStorage.substring(with: range)
+    }
+
+    /// Decreases the indentation level of the selected lines.
+    public func shiftLeft() {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let originalSelection = selectedRange
+        let lineRanges = selectedLineRanges(for: originalSelection)
+        guard !lineRanges.isEmpty else {
+            return
+        }
+
+        var totalRemoved = 0
+        var firstLineRemoved = 0
+        var locationOffset = 0
+        for (index, lineRange) in lineRanges.enumerated() {
+            let location = lineRange.location - locationOffset
+            let currentLineRange = lineRangeContainingLocation(location)
+            let lineText = textStorage.substring(with: currentLineRange)
+            let removalLength = leadingIndentRemovalLength(in: lineText)
+            guard removalLength > 0 else {
+                continue
+            }
+            let removalRange = NSRange(location: location, length: removalLength)
+            if applyReplacement(in: removalRange, withText: "", respectDelegate: true) {
+                totalRemoved += removalLength
+                locationOffset += removalLength
+                if index == 0 {
+                    firstLineRemoved = removalLength
+                }
+            }
+        }
+
+        let newLocation = max(0, originalSelection.location - firstLineRemoved)
+        let newLength: Int
+        if originalSelection.length == 0 {
+            newLength = 0
+        } else {
+            newLength = max(0, originalSelection.length - totalRemoved)
+        }
+        selectedRange = NSRange(location: newLocation, length: newLength)
+    }
+
+    /// Increases the indentation level of the selected lines.
+    public func shiftRight() {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let originalSelection = selectedRange
+        let lineRanges = selectedLineRanges(for: originalSelection)
+        guard !lineRanges.isEmpty else {
+            return
+        }
+
+        let indentString = indentationString()
+        let indentLength = (indentString as NSString).length
+        var offset = 0
+        for lineRange in lineRanges {
+            let insertionRange = NSRange(location: lineRange.location + offset, length: 0)
+            if applyReplacement(in: insertionRange, withText: indentString, respectDelegate: true) {
+                offset += indentLength
+            }
+        }
+
+        let newLocation = originalSelection.location + indentLength
+        let newLength: Int
+        if originalSelection.length == 0 {
+            newLength = 0
+        } else {
+            newLength = originalSelection.length + lineRanges.count * indentLength
+        }
+        selectedRange = NSRange(location: newLocation, length: newLength)
+    }
+
+    /// Moves the selected lines up by one line.
+    public func moveSelectedLinesUp() {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        moveSelectedLines(by: -1)
+    }
+
+    /// Moves the selected lines down by one line.
+    public func moveSelectedLinesDown() {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        moveSelectedLines(by: 1)
+    }
+
+    /// Attempts to detect the indentation strategy used in the current text.
+    public func detectIndentStrategy() -> DetectedIndentStrategy {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let lines = (textStorage as String).components(separatedBy: .newlines).prefix(200)
+        var tabIndentedLines = 0
+        var spaceIndentCount: [Int: Int] = [:]
+
+        for line in lines {
+            if line.hasPrefix("\t") {
+                tabIndentedLines += 1
+                continue
+            }
+            let leadingSpaces = line.prefix { $0 == " " }.count
+            if leadingSpaces > 0 {
+                spaceIndentCount[leadingSpaces, default: 0] += 1
+            }
+        }
+
+        if tabIndentedLines == 0 && spaceIndentCount.isEmpty {
+            return .unknown
+        }
+
+        let spaceLineCount = spaceIndentCount.values.reduce(0, +)
+        if tabIndentedLines >= spaceLineCount {
+            return .tab
+        } else if let mostCommonSpaceLength = spaceIndentCount.max(by: { lhs, rhs in lhs.value < rhs.value })?.key {
+            return .space(length: mostCommonSpaceLength)
+        } else {
+            return .unknown
+        }
+    }
+
+    /// Performs text search.
+    public func search(for query: SearchQuery) -> [SearchResult] {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard !query.text.isEmpty else {
+            return []
+        }
+        guard let regex = regularExpression(for: query) else {
+            return []
+        }
+        let searchRange = query.range ?? NSRange(location: 0, length: textStorage.length)
+        let matches = regex.matches(in: textStorage as String, range: searchRange)
+        return matches.compactMap { match in
+            guard match.range.length > 0 else {
+                return nil
+            }
+            guard let start = textLocation(at: match.range.location),
+                  let end = textLocation(at: match.range.location + match.range.length) else {
+                return nil
+            }
+            return SearchResult(range: match.range, startLocation: start, endLocation: end)
+        }
+    }
+
+    /// Performs text search and expands replacement text for each result.
+    public func search(for query: SearchQuery, replacingMatchesWith replacementString: String) -> [SearchReplaceResult] {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard !query.text.isEmpty else {
+            return []
+        }
+        guard let regex = regularExpression(for: query) else {
+            return []
+        }
+        let searchRange = query.range ?? NSRange(location: 0, length: textStorage.length)
+        let matches = regex.matches(in: textStorage as String, range: searchRange)
+        return matches.compactMap { match in
+            guard match.range.length > 0 else {
+                return nil
+            }
+            let replacementText = regex.replacementString(for: match, in: textStorage as String, offset: 0, template: replacementString)
+            guard let start = textLocation(at: match.range.location),
+                  let end = textLocation(at: match.range.location + match.range.length) else {
+                return nil
+            }
+            return SearchReplaceResult(
+                range: match.range,
+                startLocation: start,
+                endLocation: end,
+                replacementText: replacementText
+            )
+        }
+    }
+
+    /// Go to the beginning of the line at the specified index.
+    ///
+    /// - Parameter lineIndex: Zero-based index of line to navigate to.
+    /// - Parameter selection: The placement of the caret on the line.
+    /// - Returns: True if the text view could navigate to the specified line index, otherwise false.
+    @discardableResult
+    public func goToLine(_ lineIndex: Int, select selection: GoToLineSelection = .beginning) -> Bool {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        guard lineIndex >= 0 else {
+            return false
+        }
+        let lineRanges = allLineRanges()
+        guard lineIndex < lineRanges.count else {
+            return false
+        }
+        let lineRange = lineRanges[lineIndex]
+        switch selection {
+        case .beginning:
+            selectedRange = NSRange(location: lineRange.location, length: 0)
+        case .line:
+            selectedRange = NSRange(location: lineRange.location, length: trimmedLineLength(for: lineRange))
+        case .end:
+            selectedRange = NSRange(location: lineRange.location + trimmedLineLength(for: lineRange), length: 0)
+        }
+        scrollRangeToVisible(selectedRange)
+        return true
+    }
+
+    /// Scrolls so the given range is visible.
+    public func scrollRangeToVisible(_ range: NSRange) {
+        ensureSynchronizedShadowTextStorageIfNeeded()
+        let safeRange = clamped(range: range)
+        if !scrollRangeToVisibleMinimally(safeRange, from: contentView.bounds.origin) {
+            textView.scrollRangeToVisible(safeRange)
+        }
+    }
+
+    fileprivate func scrollRangeToVisibleMinimallyFromNative(_ range: NSRange) -> Bool {
+        let nativeLength = (textView.string as NSString).length
+        let safeRange = clamped(range: range, upperBound: nativeLength)
+        return scrollRangeToVisibleMinimally(safeRange, from: contentView.bounds.origin)
+    }
+
+    fileprivate func constrainPostEnterScroll(previousOrigin: NSPoint) {
+        let selection = textView.selectedRange()
+        let currentOrigin = contentView.bounds.origin
+        guard let targetOrigin = minimalScrollOriginToReveal(selection, from: previousOrigin) else {
+            debugEnterShiftLog(
+                "postEnter.noTarget seq=\(currentEnterTraceSequence) " +
+                "selection=\(selection.location):\(selection.length) " +
+                "prevY=\(formatDebug(previousOrigin.y)) curY=\(formatDebug(currentOrigin.y))"
+            )
+            return
+        }
+        debugEnterShiftLog(
+            "postEnter.begin seq=\(currentEnterTraceSequence) " +
+            "selection=\(selection.location):\(selection.length) " +
+            "prevY=\(formatDebug(previousOrigin.y)) curY=\(formatDebug(currentOrigin.y)) " +
+            "targetY=\(formatDebug(targetOrigin.y))"
+        )
+        guard abs(currentOrigin.x - targetOrigin.x) >= 0.5 ||
+                abs(currentOrigin.y - targetOrigin.y) >= 0.5 else {
+            debugEnterShiftLog(
+                "postEnter.skip seq=\(currentEnterTraceSequence) " +
+                "curY=\(formatDebug(currentOrigin.y)) targetY=\(formatDebug(targetOrigin.y))"
+            )
+            return
+        }
+        contentView.scroll(to: targetOrigin)
+        reflectScrolledClipView(contentView)
+        debugEnterShiftLog(
+            "postEnter.end seq=\(currentEnterTraceSequence) endY=\(formatDebug(contentView.bounds.origin.y))"
+        )
+    }
+
+    /// Ensures the document view frame matches the fully laid out text geometry.
+    public func stabilizeDocumentLayout(preserveScrollOrigin: Bool = false, anchorOrigin: NSPoint? = nil) {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return
+        }
+
+        let started = CFAbsoluteTimeGetCurrent()
+        let preservedOrigin = anchorOrigin ?? (preserveScrollOrigin ? contentView.bounds.origin : nil)
+        let previousSize = textView.frame.size
+        let previousOrigin = contentView.bounds.origin
+        layoutManager.ensureLayout(for: textContainer)
+        let usedRect = layoutManager.usedRect(for: textContainer)
+        let inset = textView.textContainerInset
+        let targetHeight = max(contentView.bounds.height, ceil(usedRect.height + (inset.height * 2)))
+        let targetWidth: CGFloat
+        if textContainer.widthTracksTextView {
+            targetWidth = max(contentView.bounds.width, textView.frame.width)
+        } else {
+            targetWidth = max(contentView.bounds.width, ceil(usedRect.width + (inset.width * 2)))
+        }
+
+        let targetSize = NSSize(width: targetWidth, height: targetHeight)
+        debugEnterShiftLog(
+            "stabilize.begin seq=\(currentEnterTraceSequence) " +
+            "preserve=\(preserveScrollOrigin) anchorY=\(formatDebug(preservedOrigin?.y ?? -1)) " +
+            "prevDocH=\(formatDebug(previousSize.height)) usedH=\(formatDebug(usedRect.height)) " +
+            "targetDocH=\(formatDebug(targetHeight)) prevY=\(formatDebug(previousOrigin.y))"
+        )
+        if textView.frame.size != targetSize {
+            textView.setFrameSize(targetSize)
+        }
+        if let preservedOrigin {
+            restoreScrollOriginIfNeeded(preservedOrigin)
+        }
+        let elapsedMS = (CFAbsoluteTimeGetCurrent() - started) * 1_000
+        debugEnterShiftLog(
+            "stabilize.end seq=\(currentEnterTraceSequence) " +
+            "elapsedMS=\(formatDebug(elapsedMS)) docH=\(formatDebug(textView.frame.height)) " +
+            "y=\(formatDebug(contentView.bounds.origin.y))"
+        )
+        let sizeChanged = abs(previousSize.height - targetSize.height) >= 0.5 || abs(previousSize.width - targetSize.width) >= 0.5
+        if Self.debugLagTraceEnabled && (elapsedMS >= 4 || sizeChanged) {
+            lagTrace(
+                event: "stabilizeLayout",
+                elapsedMS: elapsedMS,
+                details:
+                    "sizeChanged=\(sizeChanged) " +
+                    "from=\(formatDebug(previousSize.width))x\(formatDebug(previousSize.height)) " +
+                    "to=\(formatDebug(targetSize.width))x\(formatDebug(targetSize.height)) " +
+                    "y=\(formatDebug(contentView.bounds.origin.y))"
+            )
+        }
+    }
+
+    /// Refreshes layout for the visible region without recomputing full document height.
+    public func refreshVisibleLayout(preserveScrollOrigin: Bool = false) {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return
+        }
+
+        let preservedOrigin = preserveScrollOrigin ? contentView.bounds.origin : nil
+        let inset = textView.textContainerInset
+        var visibleRect = contentView.bounds
+        visibleRect.origin.x = 0
+        visibleRect.origin.y = max(0, visibleRect.origin.y - (inset.height * 2))
+        visibleRect.size.height += inset.height * 4
+
+        let glyphRange = layoutManager.glyphRange(forBoundingRect: visibleRect, in: textContainer)
+        let characterRange: NSRange
+        if glyphRange.length > 0 {
+            characterRange = layoutManager.characterRange(forGlyphRange: glyphRange, actualGlyphRange: nil)
+        } else {
+            let selection = textView.selectedRange()
+            characterRange = NSRange(location: selection.location, length: max(1, selection.length))
+        }
+        layoutManager.ensureLayout(forCharacterRange: characterRange)
+
+        if let preservedOrigin {
+            restoreScrollOriginIfNeeded(preservedOrigin)
+        }
+    }
+
+    @discardableResult
+    public func finalizePendingNonWrappingLayoutReconciliation(preserveScrollOrigin: Bool = false) -> Bool {
+        consumePendingNonWrappingLayoutReconciliation(preserveScrollOrigin: preserveScrollOrigin)
+    }
+}
+
+private extension TextView {
+    func applySelectionHighlightColorIfPossible() {
+        guard textView.window != nil else {
+            return
+        }
+        var selectedTextAttributes = textView.selectedTextAttributes
+        if let existingColor = selectedTextAttributes[.backgroundColor] as? NSColor,
+           existingColor.isEqual(_selectionHighlightColor) {
+            return
+        }
+        selectedTextAttributes[.backgroundColor] = _selectionHighlightColor
+        textView.selectedTextAttributes = selectedTextAttributes
+    }
+
+    private func apply(theme: Theme) {
+        textView.font = theme.font
+        textView.textColor = theme.textColor
+        textView.backgroundColor = theme.gutterBackgroundColor
+        var typingAttributes = textView.typingAttributes
+        typingAttributes[.font] = theme.font
+        typingAttributes[.foregroundColor] = theme.textColor
+        textView.typingAttributes = typingAttributes
+        insertionPointColor = theme.textColor
+        selectionBarColor = theme.textColor
+        selectionHighlightColor = theme.markedTextBackgroundColor.withAlphaComponent(0.45)
+    }
+
+    @discardableResult
+    private func applyReplacement(in range: NSRange, withText replacementText: String, respectDelegate: Bool) -> Bool {
+        guard isValid(range: range) else {
+            return false
+        }
+        let normalizedText = normalizeLineEndings(in: replacementText)
+        let editAffectsDocumentLayout = editAffectsDocumentLayout(in: range, replacementText: normalizedText)
+        let nonWrappingLineBreakDelta = lineBreakDelta(
+            in: range,
+            replacementText: normalizedText,
+            currentText: textStorage
+        )
+        if editAffectsDocumentLayout {
+            debugUndoLagLog(
+                "edit.shouldChange range=\(range.location):\(range.length) " +
+                "replacementLen=\((normalizedText as NSString).length) " +
+                "selection=\(selectedRange.location):\(selectedRange.length) " +
+                "nativeLen=\((textView.string as NSString).length)"
+            )
+        }
+        if respectDelegate {
+            let shouldChangeText = editorDelegate?.textView(self, shouldChangeTextIn: range, replacementText: normalizedText) ?? true
+            guard shouldChangeText else {
+                return false
+            }
+        }
+
+        isPerformingProgrammaticEdit = true
+        textStorage.replaceCharacters(in: range, with: normalizedText)
+        textView.string = textStorage as String
+        let selectedLocation = range.location + (normalizedText as NSString).length
+        textView.setSelectedRange(NSRange(location: selectedLocation, length: 0))
+        isPerformingProgrammaticEdit = false
+        needsTextStorageResync = false
+        pendingNonWrappingLayoutReconciliation = nil
+        if editAffectsDocumentLayout {
+            if isLineWrappingEnabled || !applyEstimatedNonWrappingDocumentHeightDelta(lineBreakDelta: nonWrappingLineBreakDelta) {
+                stabilizeDocumentLayout(preserveScrollOrigin: true)
+            }
+            debugUndoLagLog(
+                "edit.applied range=\(range.location):\(range.length) " +
+                "replacementLen=\((normalizedText as NSString).length) " +
+                "nativeLen=\((textView.string as NSString).length) " +
+                "docH=\(formatDebug(textView.frame.height)) y=\(formatDebug(contentView.bounds.origin.y))"
+            )
+        }
+
+        editorDelegate?.textViewDidChange(self)
+        editorDelegate?.textViewDidChangeSelection(self)
+        return true
+    }
+
+    private func isValid(range: NSRange) -> Bool {
+        let upperBound = range.location + range.length
+        return range.location >= 0 && range.length >= 0 && range.location <= textStorage.length && upperBound <= textStorage.length
+    }
+
+    private func clamped(range: NSRange) -> NSRange {
+        let location = min(max(0, range.location), textStorage.length)
+        let length = max(0, min(range.length, textStorage.length - location))
+        return NSRange(location: location, length: length)
+    }
+
+    private func normalizeLineEndings(in text: String) -> String {
+        guard text.contains("\n") || text.contains("\r") else {
+            return text
+        }
+        let unifiedLineFeeds = text.replacingOccurrences(of: "\r\n", with: "\n").replacingOccurrences(of: "\r", with: "\n")
+        return unifiedLineFeeds.replacingOccurrences(of: "\n", with: lineEndings.symbol)
+    }
+
+    private func attachUndoObserversIfNeeded() {
+        let currentUndoManager = textView.undoManager ?? super.undoManager
+        guard observedUndoManager !== currentUndoManager else {
+            return
+        }
+        detachUndoObservers()
+        observedUndoManager = currentUndoManager
+        guard let currentUndoManager else {
+            return
+        }
+        undoObserver = NotificationCenter.default.addObserver(
+            forName: .NSUndoManagerDidUndoChange,
+            object: currentUndoManager,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleUndoRedoChange(kind: "undo")
+        }
+        willUndoObserver = NotificationCenter.default.addObserver(
+            forName: .NSUndoManagerWillUndoChange,
+            object: currentUndoManager,
+            queue: nil
+        ) { [weak self] _ in
+            self?.prepareUndoRedoLayoutReconciliation()
+        }
+        redoObserver = NotificationCenter.default.addObserver(
+            forName: .NSUndoManagerDidRedoChange,
+            object: currentUndoManager,
+            queue: nil
+        ) { [weak self] _ in
+            self?.handleUndoRedoChange(kind: "redo")
+        }
+        willRedoObserver = NotificationCenter.default.addObserver(
+            forName: .NSUndoManagerWillRedoChange,
+            object: currentUndoManager,
+            queue: nil
+        ) { [weak self] _ in
+            self?.prepareUndoRedoLayoutReconciliation()
+        }
+    }
+
+    private func ensureSynchronizedShadowTextStorageIfNeeded() {
+        guard needsTextStorageResync else {
+            return
+        }
+        _ = synchronizeShadowTextStorageIfNeeded(forceComparison: true)
+    }
+
+    private func detachUndoObservers() {
+        if let willUndoObserver {
+            NotificationCenter.default.removeObserver(willUndoObserver)
+        }
+        if let willRedoObserver {
+            NotificationCenter.default.removeObserver(willRedoObserver)
+        }
+        if let undoObserver {
+            NotificationCenter.default.removeObserver(undoObserver)
+        }
+        if let redoObserver {
+            NotificationCenter.default.removeObserver(redoObserver)
+        }
+        willUndoObserver = nil
+        willRedoObserver = nil
+        undoObserver = nil
+        redoObserver = nil
+        observedUndoManager = nil
+    }
+
+    private func handleUndoRedoChange(kind: String) {
+        undoRedoSequence += 1
+        let currentSequence = undoRedoSequence
+        let started = CFAbsoluteTimeGetCurrent()
+        let beforeHeight = textView.frame.height
+        let beforeOffset = contentView.bounds.origin.y
+        let beforeSelection = textView.selectedRange()
+        debugUndoLagLog(
+            "\(kind).begin seq=\(currentSequence) " +
+            "selection=\(beforeSelection.location):\(beforeSelection.length) " +
+            "nativeLen=\((textView.string as NSString).length) " +
+            "shadowLen=\(textStorage.length) " +
+            "docH=\(formatDebug(beforeHeight)) y=\(formatDebug(beforeOffset))"
+        )
+        let didResync = synchronizeShadowTextStorageIfNeeded(forceComparison: true)
+        let selectedRange = textView.selectedRange()
+        if isLineWrappingEnabled {
+            stabilizeDocumentLayout(preserveScrollOrigin: true)
+        } else if didResync {
+            let appliedEstimatedHeightDelta = applyEstimatedNonWrappingUndoRedoHeightDelta()
+            pendingNonWrappingLayoutReconciliation?.appliedEstimatedHeightDelta = appliedEstimatedHeightDelta
+            if !consumePendingNonWrappingLayoutReconciliation(preserveScrollOrigin: true) {
+                stabilizeDocumentLayout(preserveScrollOrigin: true)
+            }
+        } else {
+            pendingNonWrappingLayoutReconciliation = nil
+        }
+        _ = scrollRangeToVisibleMinimallyFromNative(selectedRange)
+        let elapsedMS = (CFAbsoluteTimeGetCurrent() - started) * 1_000
+        let afterSelection = selectedRange
+        debugUndoLagLog(
+            "\(kind).end seq=\(currentSequence) elapsedMS=\(formatDebug(elapsedMS)) " +
+            "didResync=\(didResync) selection=\(afterSelection.location):\(afterSelection.length) " +
+            "nativeLen=\((textView.string as NSString).length) shadowLen=\(textStorage.length) " +
+            "docH=\(formatDebug(textView.frame.height)) y=\(formatDebug(contentView.bounds.origin.y))"
+        )
+        if didResync {
+            editorDelegate?.textViewDidChange(self)
+        }
+        editorDelegate?.textViewDidChangeSelection(self)
+    }
+
+    @discardableResult
+    private func synchronizeShadowTextStorageIfNeeded(forceComparison: Bool = false) -> Bool {
+        let nativeText = textView.string
+        if !forceComparison {
+            let nativeLength = (nativeText as NSString).length
+            guard nativeLength != textStorage.length else {
+                return false
+            }
+        }
+        guard forceComparison || nativeText != textStorage as String else {
+            return false
+        }
+        textStorage.setString(nativeText)
+        needsTextStorageResync = false
+        return true
+    }
+
+    private func prepareUndoRedoLayoutReconciliation() {
+        let selection = textView.selectedRange()
+        preparePendingNonWrappingLayoutReconciliation(
+            beforeLocation: selection.location,
+            afterLocationHint: selection.location
+        )
+    }
+
+    private func debugUndoLagLog(_ message: @autoclosure () -> String) {
+        guard Self.debugUndoLagEnabled else {
+            return
+        }
+        RunestoneDebugLog.write("[RunestoneUndo] \(message())")
+    }
+
+    private var currentEnterTraceSequence: Int {
+        if let activeEnterTraceSequence,
+           Date().timeIntervalSince(lastEnterTraceDate) <= 1.5 {
+            return activeEnterTraceSequence
+        }
+        return -1
+    }
+
+    func beginEnterShiftTrace(previousOrigin: NSPoint) {
+        guard Self.debugEnterShiftEnabled else {
+            return
+        }
+        enterTraceSequence += 1
+        activeEnterTraceSequence = enterTraceSequence
+        lastEnterTraceDate = Date()
+        let selection = textView.selectedRange()
+        let caret = rectForSelectionRange(selection)
+        debugEnterShiftLog(
+            "enter.begin seq=\(enterTraceSequence) " +
+            "selection=\(selection.location):\(selection.length) " +
+            "prevY=\(formatDebug(previousOrigin.y)) docH=\(formatDebug(textView.frame.height)) " +
+            "caretMinY=\(formatDebug(caret?.minY ?? -1)) caretMaxY=\(formatDebug(caret?.maxY ?? -1))"
+        )
+    }
+
+    func finishEnterShiftTrace() {
+        guard Self.debugEnterShiftEnabled else {
+            return
+        }
+        let selection = textView.selectedRange()
+        let caret = rectForSelectionRange(selection)
+        debugEnterShiftLog(
+            "enter.end seq=\(currentEnterTraceSequence) " +
+            "selection=\(selection.location):\(selection.length) y=\(formatDebug(contentView.bounds.origin.y)) " +
+            "docH=\(formatDebug(textView.frame.height)) " +
+            "caretMinY=\(formatDebug(caret?.minY ?? -1)) caretMaxY=\(formatDebug(caret?.maxY ?? -1))"
+        )
+    }
+
+    private func debugEnterShiftLog(_ message: @autoclosure () -> String) {
+        guard Self.debugEnterShiftEnabled else {
+            return
+        }
+        if let activeEnterTraceSequence,
+           Date().timeIntervalSince(lastEnterTraceDate) > 1.5 {
+            RunestoneDebugLog.write("[RunestoneEnter] traceExpired seq=\(activeEnterTraceSequence)")
+            self.activeEnterTraceSequence = nil
+        }
+        RunestoneDebugLog.write("[RunestoneEnter] \(message())")
+    }
+
+    private func maintainLiveResizeAnchorIfNeeded(force: Bool) {
+        guard force || inLiveResize,
+              let documentView,
+              let liveResizeAnchorOrigin else {
+            return
+        }
+
+        let documentFrame = documentView.frame
+        let clipBounds = contentView.bounds
+        let maxX = max(0, documentFrame.width - clipBounds.width)
+        let maxY = max(0, documentFrame.height - clipBounds.height)
+        let anchoredOrigin = NSPoint(
+            x: min(max(0, liveResizeAnchorOrigin.x), maxX),
+            y: min(max(0, liveResizeAnchorOrigin.y), maxY)
+        )
+        let currentOrigin = clipBounds.origin
+        guard abs(currentOrigin.x - anchoredOrigin.x) >= 0.5 ||
+                abs(currentOrigin.y - anchoredOrigin.y) >= 0.5 else {
+            return
+        }
+
+        contentView.scroll(to: anchoredOrigin)
+        reflectScrolledClipView(contentView)
+    }
+
+    private func restoreScrollOriginIfNeeded(_ origin: NSPoint) {
+        guard let documentView else {
+            return
+        }
+
+        let documentFrame = documentView.frame
+        let clipBounds = contentView.bounds
+        let maxX = max(0, documentFrame.width - clipBounds.width)
+        let maxY = max(0, documentFrame.height - clipBounds.height)
+        let currentOrigin = clipBounds.origin
+        let isActivelyEditingInTextView =
+            (window?.firstResponder as AnyObject?) === textView &&
+            Date().timeIntervalSince(lastNativeEditDate) < 0.4
+        let targetY: CGFloat
+        if isActivelyEditingInTextView {
+            // Preserve current vertical position while typing to avoid fighting NSTextView's own minimal caret scrolling.
+            targetY = min(max(0, currentOrigin.y), maxY)
+        } else {
+            targetY = min(max(0, origin.y), maxY)
+        }
+        let anchoredOrigin = NSPoint(
+            x: min(max(0, origin.x), maxX),
+            y: targetY
+        )
+        let xNeedsScrollRestore = abs(currentOrigin.x - anchoredOrigin.x) >= 0.5
+        let yNeedsScrollRestore = abs(currentOrigin.y - anchoredOrigin.y) >= 2.0
+        debugEnterShiftLog(
+            "restore.evaluate seq=\(currentEnterTraceSequence) " +
+            "activeEdit=\(isActivelyEditingInTextView) originY=\(formatDebug(origin.y)) " +
+            "curY=\(formatDebug(currentOrigin.y)) targetY=\(formatDebug(anchoredOrigin.y)) " +
+            "maxY=\(formatDebug(maxY)) yNeeds=\(yNeedsScrollRestore)"
+        )
+        guard xNeedsScrollRestore || yNeedsScrollRestore else {
+            return
+        }
+
+        contentView.scroll(to: anchoredOrigin)
+        reflectScrolledClipView(contentView)
+        debugEnterShiftLog(
+            "restore.end seq=\(currentEnterTraceSequence) endY=\(formatDebug(contentView.bounds.origin.y))"
+        )
+    }
+
+    private func scrollRangeToVisibleMinimally(_ range: NSRange, from origin: NSPoint) -> Bool {
+        guard let targetOrigin = minimalScrollOriginToReveal(range, from: origin) else {
+            return false
+        }
+        let currentOrigin = contentView.bounds.origin
+        guard abs(currentOrigin.x - targetOrigin.x) >= 0.5 ||
+                abs(currentOrigin.y - targetOrigin.y) >= 0.5 else {
+            return true
+        }
+        contentView.scroll(to: targetOrigin)
+        reflectScrolledClipView(contentView)
+        return true
+    }
+
+    private func minimalScrollOriginToReveal(_ range: NSRange, from origin: NSPoint) -> NSPoint? {
+        guard let selectionRect = rectForSelectionRange(range) else {
+            return nil
+        }
+        let normalizedOrigin = normalizedScrollOrigin(origin)
+        let visibleRect = NSRect(origin: normalizedOrigin, size: contentView.bounds.size)
+        let fontSize = textView.font?.pointSize ?? 14
+        let horizontalPadding = max(6, floor(fontSize * 0.45))
+        let verticalPadding = max(2, floor(fontSize * 0.35))
+
+        var targetX = normalizedOrigin.x
+        var targetY = normalizedOrigin.y
+
+        if selectionRect.minX < visibleRect.minX + horizontalPadding {
+            targetX = selectionRect.minX - horizontalPadding
+        } else if selectionRect.maxX > visibleRect.maxX - horizontalPadding {
+            targetX = selectionRect.maxX + horizontalPadding - visibleRect.width
+        }
+
+        if selectionRect.minY < visibleRect.minY + verticalPadding {
+            targetY = selectionRect.minY - verticalPadding
+        } else if selectionRect.maxY > visibleRect.maxY - verticalPadding {
+            targetY = selectionRect.maxY + verticalPadding - visibleRect.height
+        }
+
+        return normalizedScrollOrigin(NSPoint(x: targetX, y: targetY))
+    }
+
+    private func normalizedScrollOrigin(_ origin: NSPoint) -> NSPoint {
+        guard let documentView else {
+            return origin
+        }
+        let documentFrame = documentView.frame
+        let clipBounds = contentView.bounds
+        let maxX = max(0, documentFrame.width - clipBounds.width)
+        let maxY = max(0, documentFrame.height - clipBounds.height)
+        return NSPoint(
+            x: min(max(0, origin.x), maxX),
+            y: min(max(0, origin.y), maxY)
+        )
+    }
+
+    private func rectForSelectionRange(_ range: NSRange) -> NSRect? {
+        guard let layoutManager = textView.layoutManager,
+              let textContainer = textView.textContainer else {
+            return nil
+        }
+
+        let nativeTextLength = (textView.string as NSString).length
+        let clampedRange = clamped(range: range, upperBound: nativeTextLength)
+        if clampedRange.length == 0 {
+            return caretRectForInsertionLocation(
+                clampedRange.location,
+                textLength: nativeTextLength,
+                layoutManager: layoutManager,
+                textContainer: textContainer
+            )
+        }
+
+        if nativeTextLength == 0 {
+            return nil
+        }
+
+        let characterRange: NSRange
+        characterRange = clampedRange
+
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: characterRange,
+            actualCharacterRange: nil
+        )
+        guard glyphRange.location != NSNotFound else {
+            return nil
+        }
+
+        var selectionRect = layoutManager.boundingRect(
+            forGlyphRange: glyphRange,
+            in: textContainer
+        )
+        selectionRect.origin.x += textView.textContainerOrigin.x
+        selectionRect.origin.y += textView.textContainerOrigin.y
+        if selectionRect.height < 1 {
+            selectionRect.size.height = max(1, textView.font?.pointSize ?? 1)
+        }
+        if selectionRect.width < 1 {
+            selectionRect.size.width = 1
+        }
+        return selectionRect
+    }
+
+    private func caretRectForInsertionLocation(
+        _ location: Int,
+        textLength: Int,
+        layoutManager: NSLayoutManager,
+        textContainer: NSTextContainer
+    ) -> NSRect? {
+        let clampedLocation = min(max(0, location), textLength)
+
+        if clampedLocation == textLength,
+           layoutManager.extraLineFragmentTextContainer === textContainer {
+            let extraLineRect = layoutManager.extraLineFragmentRect
+            if !extraLineRect.isEmpty {
+                var caretRect = extraLineRect
+                caretRect.origin.x += textView.textContainerOrigin.x
+                caretRect.origin.y += textView.textContainerOrigin.y
+                caretRect.size.width = max(1, caretRect.width)
+                caretRect.size.height = max(1, caretRect.height)
+                return caretRect
+            }
+        }
+
+        guard textLength > 0 else {
+            let fontSize = textView.font?.pointSize ?? 1
+            return NSRect(
+                x: textView.textContainerOrigin.x,
+                y: textView.textContainerOrigin.y,
+                width: 1,
+                height: max(1, fontSize)
+            )
+        }
+
+        let referenceLocation = min(clampedLocation, textLength - 1)
+        let characterRange = NSRange(location: referenceLocation, length: 1)
+        let glyphRange = layoutManager.glyphRange(forCharacterRange: characterRange, actualCharacterRange: nil)
+        guard glyphRange.location != NSNotFound else {
+            return nil
+        }
+
+        var caretRect = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+        caretRect.origin.x += textView.textContainerOrigin.x
+        caretRect.origin.y += textView.textContainerOrigin.y
+        if clampedLocation > referenceLocation {
+            caretRect.origin.x = caretRect.maxX
+        }
+        caretRect.size.width = 1
+        if caretRect.height < 1 {
+            caretRect.size.height = max(1, textView.font?.pointSize ?? 1)
+        }
+        return caretRect
+    }
+
+    private func formatDebug(_ value: CGFloat) -> String {
+        String(format: "%.2f", value)
+    }
+
+    private func formatDebug(_ value: Double) -> String {
+        String(format: "%.2f", value)
+    }
+
+    private func clamped(range: NSRange, upperBound: Int) -> NSRange {
+        let location = min(max(0, range.location), upperBound)
+        let length = max(0, min(range.length, upperBound - location))
+        return NSRange(location: location, length: length)
+    }
+
+    private func lineBreakDelta(
+        in range: NSRange,
+        replacementText: String,
+        currentText: NSString
+    ) -> Int {
+        let insertedLineBreaks = lineBreakCount(in: replacementText)
+        let removedLineBreaks: Int
+        if range.length > 0, isValid(range: range) {
+            removedLineBreaks = lineBreakCount(in: currentText.substring(with: range))
+        } else {
+            removedLineBreaks = 0
+        }
+        return insertedLineBreaks - removedLineBreaks
+    }
+
+    private func lineBreakCount(in string: String) -> Int {
+        lineBreakCount(in: string as NSString)
+    }
+
+    private func lineBreakCount(in string: NSString) -> Int {
+        let nsString = string
+        var count = 0
+        var index = 0
+        while index < nsString.length {
+            let character = nsString.character(at: index)
+            if character == 10 { // \n
+                count += 1
+            } else if character == 13 { // \r or \r\n
+                count += 1
+                if index + 1 < nsString.length, nsString.character(at: index + 1) == 10 {
+                    index += 1
+                }
+            }
+            index += 1
+        }
+        return count
+    }
+
+    @discardableResult
+    private func applyEstimatedNonWrappingDocumentHeightDelta(lineBreakDelta: Int) -> Bool {
+        applyEstimatedNonWrappingDocumentHeightDeltaValue(lineBreakDelta: lineBreakDelta) != 0
+    }
+
+    @discardableResult
+    private func applyEstimatedNonWrappingDocumentHeightDeltaValue(lineBreakDelta: Int) -> CGFloat {
+        guard !isLineWrappingEnabled,
+              lineBreakDelta != 0 else {
+            return 0
+        }
+        let estimatedLineHeight = max(
+            1,
+            rectForSelectionRange(textView.selectedRange())?.height ??
+                textView.font.flatMap { textView.layoutManager?.defaultLineHeight(for: $0) } ??
+                0
+        )
+        let currentHeight = textView.frame.height
+        let targetHeight = max(
+            contentView.bounds.height,
+            currentHeight + (CGFloat(lineBreakDelta) * estimatedLineHeight)
+        )
+        let appliedDelta = targetHeight - currentHeight
+        guard abs(appliedDelta) >= 0.5 else {
+            return 0
+        }
+        textView.setFrameSize(NSSize(width: textView.frame.width, height: targetHeight))
+        debugEnterShiftLog(
+            "nonWrapHeightDelta seq=\(currentEnterTraceSequence) " +
+            "lineBreakDelta=\(lineBreakDelta) lineHeight=\(formatDebug(estimatedLineHeight)) " +
+            "from=\(formatDebug(currentHeight)) to=\(formatDebug(targetHeight))"
+        )
+        return appliedDelta
+    }
+
+    private func preparePendingNonWrappingLayoutReconciliation(
+        beforeLocation: Int,
+        afterLocationHint: Int,
+        extraContextLines: Int = 6
+    ) {
+        guard !isLineWrappingEnabled,
+              let beforeLocalHeight = captureLocalLayoutHeight(
+                around: beforeLocation,
+                extraLines: extraContextLines
+              ) else {
+            pendingNonWrappingLayoutReconciliation = nil
+            return
+        }
+        pendingNonWrappingLayoutReconciliation = PendingNonWrappingLayoutReconciliation(
+            beforeLocalHeight: beforeLocalHeight,
+            beforeLineBreakCount: lineBreakCount(in: textView.string as NSString),
+            afterLocationHint: afterLocationHint,
+            extraContextLines: extraContextLines,
+            appliedEstimatedHeightDelta: 0
+        )
+    }
+
+    private func applyEstimatedNonWrappingUndoRedoHeightDelta() -> CGFloat {
+        guard let pendingNonWrappingLayoutReconciliation else {
+            return 0
+        }
+        let currentLineBreakCount = lineBreakCount(in: textView.string as NSString)
+        return applyEstimatedNonWrappingDocumentHeightDeltaValue(
+            lineBreakDelta: currentLineBreakCount - pendingNonWrappingLayoutReconciliation.beforeLineBreakCount
+        )
+    }
+
+    @discardableResult
+    func consumePendingNonWrappingLayoutReconciliation(preserveScrollOrigin: Bool) -> Bool {
+        guard let pendingNonWrappingLayoutReconciliation else {
+            return false
+        }
+        defer { self.pendingNonWrappingLayoutReconciliation = nil }
+
+        let nativeLength = (textView.string as NSString).length
+        let selectedLocation = textView.selectedRange().location
+        let afterLocation = min(
+            max(
+                0,
+                selectedLocation == NSNotFound ? pendingNonWrappingLayoutReconciliation.afterLocationHint : selectedLocation
+            ),
+            nativeLength
+        )
+        guard let afterLocalHeight = captureLocalLayoutHeight(
+            around: afterLocation,
+            extraLines: pendingNonWrappingLayoutReconciliation.extraContextLines
+        ) else {
+            return false
+        }
+
+        let correction =
+            (afterLocalHeight - pendingNonWrappingLayoutReconciliation.beforeLocalHeight) -
+            pendingNonWrappingLayoutReconciliation.appliedEstimatedHeightDelta
+        guard abs(correction) >= 0.5 else {
+            return true
+        }
+
+        let preservedOrigin = preserveScrollOrigin ? contentView.bounds.origin : nil
+        let currentHeight = textView.frame.height
+        let targetHeight = max(contentView.bounds.height, currentHeight + correction)
+        guard abs(targetHeight - currentHeight) >= 0.5 else {
+            return true
+        }
+
+        textView.setFrameSize(NSSize(width: textView.frame.width, height: targetHeight))
+        if let preservedOrigin {
+            restoreScrollOriginIfNeeded(preservedOrigin)
+        }
+        if Self.debugLagTraceEnabled {
+            lagTrace(
+                event: "localHeightReconcile",
+                details:
+                    "before=\(formatDebug(pendingNonWrappingLayoutReconciliation.beforeLocalHeight)) " +
+                    "after=\(formatDebug(afterLocalHeight)) " +
+                    "estimated=\(formatDebug(pendingNonWrappingLayoutReconciliation.appliedEstimatedHeightDelta)) " +
+                    "correction=\(formatDebug(correction)) " +
+                    "target=\(formatDebug(targetHeight))"
+            )
+        }
+        return true
+    }
+
+    private func captureLocalLayoutHeight(around location: Int, extraLines: Int) -> CGFloat? {
+        guard let layoutManager = textView.layoutManager,
+              textView.textContainer != nil else {
+            return nil
+        }
+
+        let nativeText = textView.string as NSString
+        guard nativeText.length > 0 else {
+            return 0
+        }
+
+        let characterRange = expandedNativeLineRange(
+            around: location,
+            extraLines: extraLines,
+            text: nativeText
+        )
+        guard characterRange.length > 0 else {
+            return 0
+        }
+
+        layoutManager.ensureLayout(forCharacterRange: characterRange)
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: characterRange,
+            actualCharacterRange: nil
+        )
+        guard glyphRange.location != NSNotFound else {
+            return nil
+        }
+
+        var unionRect = NSRect.null
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) { lineFragmentRect, _, _, _, _ in
+            unionRect = unionRect.isNull ? lineFragmentRect : unionRect.union(lineFragmentRect)
+        }
+        if unionRect.isNull {
+            return rectForSelectionRange(NSRange(location: min(characterRange.location, nativeText.length), length: 0))?.height
+        }
+        return unionRect.height
+    }
+
+    private func expandedNativeLineRange(
+        around location: Int,
+        extraLines: Int,
+        text: NSString
+    ) -> NSRange {
+        guard text.length > 0 else {
+            return NSRange(location: 0, length: 0)
+        }
+
+        let anchorLocation = min(max(0, location), max(0, text.length - 1))
+        var startLocation = text.lineRange(for: NSRange(location: anchorLocation, length: 0)).location
+        for _ in 0..<extraLines {
+            guard startLocation > 0 else {
+                break
+            }
+            startLocation = text.lineRange(for: NSRange(location: startLocation - 1, length: 0)).location
+        }
+
+        var endRange = text.lineRange(for: NSRange(location: anchorLocation, length: 0))
+        var endLocation = endRange.location + endRange.length
+        for _ in 0..<extraLines {
+            guard endLocation < text.length else {
+                break
+            }
+            endRange = text.lineRange(for: NSRange(location: endLocation, length: 0))
+            endLocation = endRange.location + endRange.length
+        }
+
+        return NSRange(location: startLocation, length: endLocation - startLocation)
+    }
+
+    private func editAffectsDocumentLayout(in range: NSRange, replacementText: String) -> Bool {
+        if isLineWrappingEnabled {
+            return true
+        }
+        if replacementText.contains("\n") || replacementText.contains("\r") {
+            return true
+        }
+        guard range.length > 0, isValid(range: range) else {
+            return false
+        }
+        let removedText = textStorage.substring(with: range)
+        return removedText.contains("\n") || removedText.contains("\r")
+    }
+
+    private func regularExpression(for query: SearchQuery) -> NSRegularExpression? {
+        let pattern: String
+        switch query.matchMethod {
+        case .contains:
+            pattern = NSRegularExpression.escapedPattern(for: query.text)
+        case .fullWord:
+            pattern = "\\b" + NSRegularExpression.escapedPattern(for: query.text) + "\\b"
+        case .startsWith:
+            pattern = "\\b" + NSRegularExpression.escapedPattern(for: query.text)
+        case .endsWith:
+            pattern = NSRegularExpression.escapedPattern(for: query.text) + "\\b"
+        case .regularExpression:
+            pattern = query.text
+        }
+        var options: NSRegularExpression.Options = [.anchorsMatchLines]
+        if !query.isCaseSensitive {
+            options.insert(.caseInsensitive)
+        }
+        return try? NSRegularExpression(pattern: pattern, options: options)
+    }
+
+    private func textLocationUnchecked(at location: Int) -> TextLocation {
+        let safeLocation = min(max(0, location), textStorage.length)
+        var row = 0
+        var column = 0
+        var index = 0
+        while index < safeLocation {
+            let character = textStorage.character(at: index)
+            if character == 10 { // \n
+                row += 1
+                column = 0
+            } else if character == 13 { // \r
+                if index + 1 < safeLocation && textStorage.character(at: index + 1) == 10 {
+                    index += 1
+                }
+                row += 1
+                column = 0
+            } else {
+                column += 1
+            }
+            index += 1
+        }
+        return TextLocation(lineNumber: row, column: column)
+    }
+
+    private func allLineRanges() -> [NSRange] {
+        let nsString = textStorage as NSString
+        guard nsString.length > 0 else {
+            return [NSRange(location: 0, length: 0)]
+        }
+
+        var ranges: [NSRange] = []
+        var currentLocation = 0
+        while currentLocation < nsString.length {
+            let lineRange = nsString.lineRange(for: NSRange(location: currentLocation, length: 0))
+            ranges.append(lineRange)
+            currentLocation = lineRange.location + lineRange.length
+        }
+        return ranges
+    }
+
+    private func selectedLineRanges(for selectedRange: NSRange) -> [NSRange] {
+        let lineRanges = allLineRanges()
+        guard !lineRanges.isEmpty else {
+            return []
+        }
+
+        let nsString = textStorage as NSString
+        let maxLocation = max(0, nsString.length - 1)
+        let safeStart = min(max(0, selectedRange.location), nsString.length)
+        let safeEnd: Int
+        if selectedRange.length > 0 {
+            safeEnd = min(max(safeStart, selectedRange.location + selectedRange.length - 1), maxLocation)
+        } else {
+            safeEnd = min(safeStart, maxLocation)
+        }
+
+        let startRange = nsString.lineRange(for: NSRange(location: safeStart, length: 0))
+        let endRange = nsString.lineRange(for: NSRange(location: safeEnd, length: 0))
+        guard let startIndex = lineRanges.firstIndex(of: startRange),
+              let endIndex = lineRanges.firstIndex(of: endRange),
+              startIndex <= endIndex else {
+            return [lineRanges[0]]
+        }
+        return Array(lineRanges[startIndex ... endIndex])
+    }
+
+    private func lineRangeContainingLocation(_ location: Int) -> NSRange {
+        let safeLocation = min(max(0, location), textStorage.length)
+        let nsString = textStorage as NSString
+        return nsString.lineRange(for: NSRange(location: safeLocation, length: 0))
+    }
+
+    private func leadingIndentRemovalLength(in lineText: String) -> Int {
+        switch indentStrategy {
+        case .tab:
+            return lineText.hasPrefix("\t") ? 1 : 0
+        case .space(let length):
+            let desiredLength = max(1, length)
+            let leadingSpaces = lineText.prefix { $0 == " " }.count
+            return min(desiredLength, leadingSpaces)
+        }
+    }
+
+    private func indentationString() -> String {
+        switch indentStrategy {
+        case .tab:
+            return "\t"
+        case .space(let length):
+            return String(repeating: " ", count: max(1, length))
+        }
+    }
+
+    private func moveSelectedLines(by lineOffset: Int) {
+        let originalSelection = selectedRange
+        let selectedLines = selectedLineRanges(for: originalSelection)
+        guard let firstLine = selectedLines.first, let lastLine = selectedLines.last else {
+            return
+        }
+
+        let lineRanges = allLineRanges()
+        guard let firstLineIndex = lineRanges.firstIndex(of: firstLine),
+              let lastLineIndex = lineRanges.firstIndex(of: lastLine) else {
+            return
+        }
+
+        let blockLocation = firstLine.location
+        let blockLength = (lastLine.location + lastLine.length) - firstLine.location
+        let blockRange = NSRange(location: blockLocation, length: blockLength)
+        guard let blockText = text(in: blockRange) else {
+            return
+        }
+
+        if lineOffset < 0 {
+            guard firstLineIndex > 0 else {
+                return
+            }
+            let previousLineRange = lineRanges[firstLineIndex - 1]
+            guard let previousLineText = text(in: previousLineRange) else {
+                return
+            }
+            let replacementRange = NSRange(location: previousLineRange.location, length: previousLineRange.length + blockRange.length)
+            let replacementText = blockText + previousLineText
+            let newSelection = NSRange(location: max(0, originalSelection.location - previousLineRange.length), length: originalSelection.length)
+            if applyReplacement(in: replacementRange, withText: replacementText, respectDelegate: true) {
+                selectedRange = newSelection
+            }
+        } else if lineOffset > 0 {
+            guard lastLineIndex + 1 < lineRanges.count else {
+                return
+            }
+            let nextLineRange = lineRanges[lastLineIndex + 1]
+            guard let nextLineText = text(in: nextLineRange) else {
+                return
+            }
+            let replacementRange = NSRange(location: blockRange.location, length: blockRange.length + nextLineRange.length)
+            let replacementText = nextLineText + blockText
+            let newSelection = NSRange(location: originalSelection.location + nextLineRange.length, length: originalSelection.length)
+            if applyReplacement(in: replacementRange, withText: replacementText, respectDelegate: true) {
+                selectedRange = newSelection
+            }
+        }
+    }
+
+    private func trimmedLineLength(for lineRange: NSRange) -> Int {
+        guard lineRange.length > 0 else {
+            return 0
+        }
+        let lineText = textStorage.substring(with: lineRange)
+        if lineText.hasSuffix("\r\n") {
+            return lineRange.length - 2
+        } else if lineText.hasSuffix("\n") || lineText.hasSuffix("\r") {
+            return lineRange.length - 1
+        } else {
+            return lineRange.length
+        }
+    }
+
+    private func updateGutterMetrics() {
+        if showLineNumbers {
+            gutterWidth = max(0, gutterLeadingPadding + gutterTrailingPadding + 28)
+        } else {
+            gutterWidth = 0
+        }
+    }
+
+    private func updateLineWrapping() {
+        guard let textContainer = textView.textContainer else {
+            return
+        }
+
+        textContainer.lineBreakMode = nsLineBreakMode(for: lineBreakMode)
+        textView.isVerticallyResizable = true
+        textContainer.heightTracksTextView = false
+        if isLineWrappingEnabled {
+            textView.isHorizontallyResizable = false
+            textContainer.widthTracksTextView = true
+            textContainer.containerSize = NSSize(width: contentSize.width, height: CGFloat.greatestFiniteMagnitude)
+            hasHorizontalScroller = false
+        } else {
+            textView.isHorizontallyResizable = true
+            textContainer.widthTracksTextView = false
+            textContainer.containerSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+            hasHorizontalScroller = true
+        }
+        stabilizeDocumentLayout()
+    }
+
+    private func nsLineBreakMode(for mode: LineBreakMode) -> NSLineBreakMode {
+        switch mode {
+        case .byWordWrapping:
+            return .byWordWrapping
+        case .byCharWrapping:
+            return .byCharWrapping
+        }
+    }
+}
+
+extension TextView: NSTextViewDelegate {
+    public func textDidChange(_ notification: Notification) {
+        if !isPerformingProgrammaticEdit {
+            let started = CFAbsoluteTimeGetCurrent()
+            lastNativeEditDate = Date()
+            let didExpectNativeMutation = needsTextStorageResync
+            needsTextStorageResync = true
+            let nativeTextLength = (textView.string as NSString).length
+            let shadowTextLength = textStorage.length
+            let nativeEditAffectsLayout =
+                needsDocumentLayoutStabilizationAfterEdit ||
+                (
+                    isLineWrappingEnabled &&
+                    (
+                        !didExpectNativeMutation ||
+                            nativeTextLength != shadowTextLength
+                    )
+                )
+            let didResyncDirectMutation: Bool
+            if didExpectNativeMutation {
+                didResyncDirectMutation = false
+            } else {
+                didResyncDirectMutation = synchronizeShadowTextStorageIfNeeded(forceComparison: true)
+            }
+            if nativeEditAffectsLayout {
+                let selection = textView.selectedRange()
+                debugEnterShiftLog(
+                    "textDidChange.begin seq=\(currentEnterTraceSequence) " +
+                    "selection=\(selection.location):\(selection.length) " +
+                    "nativeLen=\(nativeTextLength) shadowLenBefore=\(shadowTextLength) " +
+                    "didExpect=\(didExpectNativeMutation) docH=\(formatDebug(textView.frame.height)) " +
+                    "y=\(formatDebug(contentView.bounds.origin.y))"
+                )
+                debugUndoLagLog(
+                    "textDidChange selection=\(selection.location):\(selection.length) " +
+                    "nativeLen=\(nativeTextLength) shadowLenBefore=\(shadowTextLength) " +
+                    "didResyncDirectMutation=\(didResyncDirectMutation) " +
+                    "docHBefore=\(formatDebug(textView.frame.height)) " +
+                    "yBefore=\(formatDebug(contentView.bounds.origin.y))"
+                )
+            }
+            if needsDocumentLayoutStabilizationAfterEdit {
+                needsDocumentLayoutStabilizationAfterEdit = false
+                if isLineWrappingEnabled {
+                    stabilizeDocumentLayout(preserveScrollOrigin: true)
+                } else {
+                    let appliedEstimatedHeightDelta = applyEstimatedNonWrappingDocumentHeightDeltaValue(
+                        lineBreakDelta: pendingNonWrappingLineBreakDelta
+                    )
+                    pendingNonWrappingLayoutReconciliation?.appliedEstimatedHeightDelta = appliedEstimatedHeightDelta
+                }
+                pendingNonWrappingLineBreakDelta = 0
+            } else if nativeEditAffectsLayout {
+                stabilizeDocumentLayout(preserveScrollOrigin: true)
+            }
+            if nativeEditAffectsLayout {
+                debugEnterShiftLog(
+                    "textDidChange.end seq=\(currentEnterTraceSequence) " +
+                    "nativeLen=\((textView.string as NSString).length) shadowLen=\(textStorage.length) " +
+                    "docH=\(formatDebug(textView.frame.height)) y=\(formatDebug(contentView.bounds.origin.y))"
+                )
+                debugUndoLagLog(
+                    "textDidChange.stabilized nativeLen=\((textView.string as NSString).length) " +
+                    "shadowLen=\(textStorage.length) docH=\(formatDebug(textView.frame.height)) " +
+                    "y=\(formatDebug(contentView.bounds.origin.y))"
+                )
+            }
+            let elapsedMS = (CFAbsoluteTimeGetCurrent() - started) * 1_000
+            if Self.debugLagTraceEnabled && (elapsedMS >= 6 || nativeEditAffectsLayout) {
+                let selection = textView.selectedRange()
+                lagTrace(
+                    event: "textDidChange",
+                    elapsedMS: elapsedMS,
+                    details:
+                        "layout=\(nativeEditAffectsLayout) didResync=\(didResyncDirectMutation) " +
+                        "selection=\(selection.location):\(selection.length) " +
+                        "nativeLen=\(nativeTextLength) shadowLenBefore=\(shadowTextLength) " +
+                        "docH=\(formatDebug(textView.frame.height)) y=\(formatDebug(contentView.bounds.origin.y))"
+                )
+            }
+            editorDelegate?.textViewDidChange(self)
+        }
+    }
+
+    public func textViewDidChangeSelection(_ notification: Notification) {
+        editorDelegate?.textViewDidChangeSelection(self)
+    }
+
+    public func textView(
+        _ textView: NSTextView,
+        shouldChangeTextIn affectedCharRange: NSRange,
+        replacementString: String?
+    ) -> Bool {
+        let replacementText = replacementString ?? ""
+        let normalizedText = normalizeLineEndings(in: replacementText)
+        if normalizedText != replacementText {
+            _ = applyReplacement(in: affectedCharRange, withText: normalizedText, respectDelegate: true)
+            return false
+        }
+        let shouldChange = editorDelegate?.textView(self, shouldChangeTextIn: affectedCharRange, replacementText: normalizedText) ?? true
+        if shouldChange && !isPerformingProgrammaticEdit {
+            needsDocumentLayoutStabilizationAfterEdit = editAffectsDocumentLayout(
+                in: affectedCharRange,
+                replacementText: normalizedText
+            )
+            pendingNonWrappingLineBreakDelta = lineBreakDelta(
+                in: affectedCharRange,
+                replacementText: normalizedText,
+                currentText: textStorage
+            )
+            if needsDocumentLayoutStabilizationAfterEdit && !isLineWrappingEnabled {
+                preparePendingNonWrappingLayoutReconciliation(
+                    beforeLocation: affectedCharRange.location,
+                    afterLocationHint: affectedCharRange.location + (normalizedText as NSString).length
+                )
+            } else {
+                pendingNonWrappingLayoutReconciliation = nil
+            }
+            needsTextStorageResync = true
+        } else if !shouldChange {
+            pendingNonWrappingLineBreakDelta = 0
+            pendingNonWrappingLayoutReconciliation = nil
+        }
+        return shouldChange
+    }
+
+    public func textView(_ textView: NSTextView, clickedOnLink link: Any, at charIndex: Int) -> Bool {
+        let modifierFlags = currentEventModifierFlagsProvider()
+        guard modifierFlags.contains(.command) else {
+            // Do not open links on plain click.
+            return false
+        }
+
+        if let url = link as? URL {
+            return openURLHandler(url)
+        }
+        if let urlString = link as? String, let url = URL(string: urlString) {
+            return openURLHandler(url)
+        }
+        return false
+    }
+
+    private func lagTrace(event: String, elapsedMS: Double? = nil, details: String = "") {
+        guard Self.debugLagTraceEnabled else {
+            return
+        }
+        var userInfo: [String: Any] = [
+            "component": "textView",
+            "event": event,
+            "details": details
+        ]
+        if let elapsedMS {
+            userInfo["elapsedMS"] = NSNumber(value: elapsedMS)
+        }
+        NotificationCenter.default.post(
+            name: Self.lagTraceNotificationName,
+            object: nil,
+            userInfo: userInfo
+        )
+    }
+}
+#endif

--- a/vendor/runestone/Sources/RunestoneMac/TextViewDelegate.swift
+++ b/vendor/runestone/Sources/RunestoneMac/TextViewDelegate.swift
@@ -1,0 +1,21 @@
+#if canImport(AppKit)
+import Foundation
+
+/// Delegate callbacks for editing and selection updates in macOS `TextView`.
+public protocol TextViewDelegate: AnyObject {
+    /// Called when text changes.
+    func textViewDidChange(_ textView: TextView)
+    /// Called when selection changes.
+    func textViewDidChangeSelection(_ textView: TextView)
+    /// Called before replacing text in a range.
+    func textView(_ textView: TextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool
+}
+
+public extension TextViewDelegate {
+    func textViewDidChange(_ textView: TextView) {}
+    func textViewDidChangeSelection(_ textView: TextView) {}
+    func textView(_ textView: TextView, shouldChangeTextIn range: NSRange, replacementText text: String) -> Bool {
+        true
+    }
+}
+#endif

--- a/vendor/runestone/Sources/RunestoneMac/Theme.swift
+++ b/vendor/runestone/Sources/RunestoneMac/Theme.swift
@@ -1,0 +1,48 @@
+#if canImport(AppKit)
+import AppKit
+import Foundation
+import RunestoneCore
+import RunestonePlatform
+
+/// Fonts and colors to be used by a macOS `TextView`.
+public protocol Theme: RunestoneTheme, AnyObject {
+    /// Color of text matching the capture sequence.
+    func textColor(for highlightName: String) -> NSColor?
+    /// Font of text matching the capture sequence.
+    func font(for highlightName: String) -> NSFont?
+    /// Traits of text matching the capture sequence.
+    func fontTraits(for highlightName: String) -> FontTraits
+    /// Shadow of text matching the capture sequence.
+    func shadow(for highlightName: String) -> NSShadow?
+}
+
+public extension Theme {
+    var gutterHairlineWidth: CGFloat {
+        1
+    }
+
+    var pageGuideHairlineWidth: CGFloat {
+        1
+    }
+
+    var markedTextBackgroundCornerRadius: CGFloat {
+        0
+    }
+
+    func textColor(for highlightName: String) -> NSColor? {
+        nil
+    }
+
+    func font(for highlightName: String) -> NSFont? {
+        nil
+    }
+
+    func fontTraits(for highlightName: String) -> FontTraits {
+        []
+    }
+
+    func shadow(for highlightName: String) -> NSShadow? {
+        nil
+    }
+}
+#endif

--- a/vendor/runestone/Sources/RunestonePlatform/PlatformTypes.swift
+++ b/vendor/runestone/Sources/RunestonePlatform/PlatformTypes.swift
@@ -1,0 +1,49 @@
+import Foundation
+import CoreGraphics
+
+#if canImport(UIKit)
+import UIKit
+public typealias RunestoneNativeColor = UIColor
+public typealias RunestoneNativeFont = UIFont
+public typealias RunestoneNativeEdgeInsets = UIEdgeInsets
+#elseif canImport(AppKit)
+import AppKit
+public typealias RunestoneNativeColor = NSColor
+public typealias RunestoneNativeFont = NSFont
+public typealias RunestoneNativeEdgeInsets = NSEdgeInsets
+#endif
+
+/// Platform-neutral edge insets for portable editor layout contracts.
+public struct RunestoneEdgeInsets: Sendable, Equatable {
+    public var top: Double
+    public var left: Double
+    public var bottom: Double
+    public var right: Double
+
+    public init(top: Double, left: Double, bottom: Double, right: Double) {
+        self.top = top
+        self.left = left
+        self.bottom = bottom
+        self.right = right
+    }
+}
+
+/// Portable theme contract shared by Runestone UI adapters.
+public protocol RunestoneTheme: AnyObject {
+    var font: RunestoneNativeFont { get }
+    var textColor: RunestoneNativeColor { get }
+    var gutterBackgroundColor: RunestoneNativeColor { get }
+    var gutterHairlineColor: RunestoneNativeColor { get }
+    var gutterHairlineWidth: CGFloat { get }
+    var lineNumberColor: RunestoneNativeColor { get }
+    var lineNumberFont: RunestoneNativeFont { get }
+    var selectedLineBackgroundColor: RunestoneNativeColor { get }
+    var selectedLinesLineNumberColor: RunestoneNativeColor { get }
+    var selectedLinesGutterBackgroundColor: RunestoneNativeColor { get }
+    var invisibleCharactersColor: RunestoneNativeColor { get }
+    var pageGuideHairlineColor: RunestoneNativeColor { get }
+    var pageGuideHairlineWidth: CGFloat { get }
+    var pageGuideBackgroundColor: RunestoneNativeColor { get }
+    var markedTextBackgroundColor: RunestoneNativeColor { get }
+    var markedTextBackgroundCornerRadius: CGFloat { get }
+}


### PR DESCRIPTION
## Summary
- vendor the Runestone editor package into `vendor/runestone` and wire it into cmux via a local Swift package dependency
- add a small cmux smoke seam plus a unit test that instantiates `Runestone.TextView` and verifies the vendored package is usable from the app target
- record Runestone and tree-sitter in `THIRD_PARTY_LICENSES.md`

## Testing
- `./scripts/reload.sh --tag task-vendor-runestone-into-cmux` ✅
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-vendor-runestone-into-cmux-unit test -only-testing:cmuxTests/RunestoneVendoringTests` ✅

## Task
- Task reference: Vendor Runestone into cmux

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Vendors the `Runestone` editor as a local Swift package, replaces the Markdown viewer with a read‑only `Runestone` surface themed to Ghostty, and updates dependencies/licenses (implements the “Vendor Runestone into cmux” task).

- **New Features**
  - Replaced `MarkdownPanelView`’s `MarkdownUI` renderer with a read‑only `Runestone.TextView` and applied Ghostty theme colors.
  - Added `VendoredRunestoneSupport.makeSmokeSnapshot()` and `RunestoneVendoringTests` covering editor instantiation and Markdown heading/link attributes.

- **Dependencies**
  - Added local `vendor/runestone` and linked `Runestone`; added `tree-sitter` v0.20.9.
  - Removed `MarkdownUI`, `swift-cmark`, and `NetworkImage` SPM pins.
  - Recorded licenses for `Runestone` and `tree-sitter` in `THIRD_PARTY_LICENSES.md`.

<sup>Written for commit 597fb3d330bde3c2844e0fc74f1aa1888354def0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Embedded Runestone editor: rich macOS text editing with syntax highlighting, search & replace, indentation detection, line movement, and navigation.
  * Markdown rendering switched to Runestone-based renderer with theme driven by app config.
  * Tree-sitter integration for improved parsing and syntax-aware behavior.

* **Chores**
  * Updated package/dependency wiring and license list to include Runestone and tree-sitter.

* **Tests**
  * Added vendoring and markdown-related unit tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->