### PR TITLE
reload.sh: always kill same-tag app after build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ After making code changes, always run the reload script with a tag to build the 
 ./scripts/reload.sh --tag fix-zsh-autosuggestions
 ```
 
-By default, `reload.sh` builds but does **not** launch the app. The script prints the `.app` path so the user can cmd-click to open it. Pass `--launch` to kill any existing instance and open the app automatically:
+By default, `reload.sh` builds but does **not** launch the app. The script prints the `.app` path so the user can cmd-click to open it. After a successful build, it always terminates any running app with the same tag (so cmd-clicking launches the freshly-built binary instead of foregrounding the stale instance). Pass `--launch` to open the app automatically after the build:
 
 ```bash
 ./scripts/reload.sh --tag fix-zsh-autosuggestions --launch
@@ -74,7 +74,7 @@ When rebuilding cmuxd for release/bundling, always use ReleaseFast:
 cd cmuxd && zig build -Doptimize=ReleaseFast
 ```
 
-`reload` = build the Debug app (tag required). Pass `--launch` to also kill existing and open:
+`reload` = build the Debug app (tag required) and terminate any running app with the same tag. Pass `--launch` to also open the freshly-built app:
 
 ```bash
 ./scripts/reload.sh --tag <tag>

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -128,6 +128,8 @@ Usage: ./scripts/reload.sh --tag <name> [options]
 Options:
   --tag <name>           Required. Short tag for parallel builds (e.g., feature-xyz-lol).
                          Sets app name, bundle id, and derived data path unless overridden.
+                         After a successful build, terminates any running app with this tag
+                         so macOS launches the freshly-built binary on cmd-click or --launch.
   --launch               Launch the app after building. Without this flag, the script
                          builds and prints the app path but does not open it.
   --name <app name>      Override app display/bundle name.
@@ -487,18 +489,25 @@ if [[ -x "$CLI_PATH" ]]; then
   echo "$CLI_PATH" > /tmp/cmux-last-cli-path || true
 fi
 
-if [[ "$LAUNCH" -eq 1 ]]; then
-  # Ensure any running instance is fully terminated, regardless of DerivedData path.
+# Tag mode: always terminate the existing same-tag instance after a successful build,
+# even without --launch. A stale tagged app pinned to this bundle id would otherwise
+# keep running against freshly-overwritten resources, and macOS would foreground it
+# instead of launching the newly built binary when the user cmd-clicks the .app.
+if [[ -n "$TAG" ]]; then
   /usr/bin/osascript -e "tell application id \"${BUNDLE_ID}\" to quit" >/dev/null 2>&1 || true
   sleep 0.3
+  pkill -f "${APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
+  sleep 0.3
+fi
+
+if [[ "$LAUNCH" -eq 1 ]]; then
   if [[ -z "$TAG" ]]; then
     # Non-tag mode: kill any running instance (across any DerivedData path) to avoid socket conflicts.
+    /usr/bin/osascript -e "tell application id \"${BUNDLE_ID}\" to quit" >/dev/null 2>&1 || true
+    sleep 0.3
     pkill -f "/${BASE_APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
-  else
-    # Tag mode: only kill the tagged instance; allow side-by-side with the main app.
-    pkill -f "${APP_NAME}.app/Contents/MacOS/${BASE_APP_NAME}" || true
+    sleep 0.3
   fi
-  sleep 0.3
 
   # Avoid inheriting cmux/ghostty environment variables from the terminal that
   # runs this script (often inside another cmux instance), which can cause


### PR DESCRIPTION
## Summary
- `reload.sh --tag <foo>` now always terminates the existing `cmux DEV <foo>` instance after a successful build, even when `--launch` is not passed, so cmd-clicking the rebuilt `.app` actually launches the new binary instead of foregrounding the stale one.
- `--launch` behavior is unchanged. Reloading one tag still does not touch other tags (side-by-side isolation preserved).
- Docs + `--help` updated.

## Testing
Manual on worktree `task-reload-kill-same-tag-app`:
- `./scripts/reload.sh --tag killtest --launch` then `pgrep -fl "cmux DEV killtest"` → PID `76832` running.
- `./scripts/reload.sh --tag killtest` (no `--launch`) → `pgrep -fl "cmux DEV killtest"` after ≥1s returns empty. Process `76832` gone.
- `./scripts/reload.sh --tag killtest --launch` again → new PID `1957`, launches cleanly from a dead slate.
- `./scripts/reload.sh --tag othertag --launch` then `./scripts/reload.sh --tag killtest` → `othertag` PID survives, `killtest` dies. Different tags remain isolated.

## Related
- Task: reload script needs to kill same-tag app, let's test it out


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure tagged reloads always launch the new binary by quitting any running app with the same tag after a successful build. `--launch` behavior is unchanged and side-by-side tags stay isolated. Addresses the task to ensure the reload script kills the same-tag app.

- **Bug Fixes**
  - In tag mode, always run quit+pkill after build to terminate only the same-tag instance (fixes stale app being foregrounded on cmd-click).
  - In non-tag mode, `--launch` still kills any running instance to prevent socket conflicts.
  - Updated `--help` and docs to reflect the new default.

<sup>Written for commit 015441875a5c1d21aca7be3736cdca229ee02bdd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed app reload behavior to properly terminate outdated instances after building, ensuring freshly-built versions launch instead of bringing stale instances to the foreground.
  * Improved `--launch` flag to gracefully quit old app instances before opening the newly-built application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->