### PR TITLE
Avoid synchronous browser paste preflight on the Cmd+Shift+V hot path

### DIFF
--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -266,7 +266,13 @@ final class CmuxWebView: WKWebView {
         document.addEventListener("focusin", (ev) => {
           publishForElement(ev && ev.target ? ev.target : document.activeElement);
         }, true);
-        document.addEventListener("focusout", () => {
+        document.addEventListener("focusout", (ev) => {
+          const nextTarget = ev && ev.relatedTarget ? ev.relatedTarget : null;
+          if (__cmuxPasteAsPlainTextHelpers.canPasteAsPlainTextInto(nextTarget)) {
+            publish(true);
+            return;
+          }
+          publish(false);
           requestAnimationFrame(() => publishForElement(document.activeElement));
         }, true);
         document.addEventListener("selectionchange", () => {

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -546,10 +546,15 @@ final class CmuxWebView: WKWebView {
     }
 
     @discardableResult
-    private func performPasteAsPlainTextFromPasteboard(_ sender: Any? = nil) -> Bool {
+    private func performPasteAsPlainTextFromPasteboard(
+        _ sender: Any? = nil,
+        requireLiveFocusValidation: Bool = true
+    ) -> Bool {
         guard pasteAsPlainTextTargetAvailable,
-              NSPasteboard.general.string(forType: .string) != nil,
-              pageCanAcceptPlainTextPaste() else {
+              NSPasteboard.general.string(forType: .string) != nil else {
+            return false
+        }
+        if requireLiveFocusValidation && !pageCanAcceptPlainTextPaste() {
             return false
         }
 
@@ -614,7 +619,12 @@ final class CmuxWebView: WKWebView {
             } else {
                 lastPasteAsPlainTextPerformKeyEventTimestamp = nil
             }
-            let result = performPasteAsPlainTextFromPasteboard() || super.performKeyEquivalent(with: event)
+            // This command-equivalent path is latency-sensitive; rely on the
+            // focus-tracker cache here and keep the live JS preflight for the
+            // explicit menu/IBAction path.
+            let result = performPasteAsPlainTextFromPasteboard(
+                requireLiveFocusValidation: false
+            ) || super.performKeyEquivalent(with: event)
             if result {
                 lastPasteAsPlainTextPerformKeyEventTimestamp = nil
             }


### PR DESCRIPTION
Closes #2958

## Summary
- remove the synchronous JS plain-text-paste preflight from the `Cmd+Shift+V` key-equivalent path in `CmuxWebView`
- keep the existing live JS validation for the explicit menu / `IBAction` path so the behavior change stays narrowly scoped to the latency-sensitive command-key route
- tighten the focus-tracker cache on `focusout` so it clears synchronously unless the related target is already another editable element
- preserve the existing `pasteAsPlainTextTargetAvailable` focus-tracker cache as the hot-path gate for browser plain-text paste

## Root Cause
The browser plain-text paste feature already maintains a push-based `canPaste` cache from the injected focus tracker:

- the page script publishes `canPaste` via `postMessage({ canPaste })`
- Swift stores it in `pasteAsPlainTextTargetAvailable`

But `performKeyEquivalent(with:)` still called `performPasteAsPlainTextFromPasteboard()` with a fresh synchronous `pageCanAcceptPlainTextPaste()` check. That helper pumps the main run loop until completion or a 250 ms timeout, so a slow page callback can stall the `Cmd+Shift+V` path even though the cache already says whether the current focus can accept plain-text paste.

The follow-up concern from review was that trusting the cache on the hot path can leave a narrow stale window after `focusout`, because the old tracker only republished via `requestAnimationFrame`.

## Fix
Split the readiness check in two:

- `performPasteAsPlainTextFromPasteboard(..., requireLiveFocusValidation: Bool = true)` keeps the old behavior by default
- the `Cmd+Shift+V` branch in `performKeyEquivalent(with:)` now calls it with `requireLiveFocusValidation: false`
- the explicit `pasteAsPlainText(_:)` action continues to use the live preflight
- the injected focus tracker now handles `focusout` by:
  - immediately publishing `true` when `relatedTarget` is already another editable element, otherwise
  - immediately publishing `false` and then re-syncing on the next animation frame from `document.activeElement`

That keeps the fix narrowly focused on the key-equivalent hot path while addressing the stale-cache concern without restoring the synchronous JS wait.

## Verification
Source-level verification on current `main` before the patch:
- `Sources/Panels/CmuxWebView.swift:231-255` — push-based `canPaste` cache already exists
- `Sources/Panels/CmuxWebView.swift:483-509` — synchronous JS preflight pumps the main run loop
- `Sources/Panels/CmuxWebView.swift:549-553` — hot path required both the cache and the live preflight
- `Sources/Panels/CmuxWebView.swift:581-625` — `Cmd+Shift+V` routed through that synchronous path

Local timing repro for the waiting algorithm showed:
- `callback_delay_ms=20 completed=true elapsed_ms=38`
- `callback_delay_ms=200 completed=true elapsed_ms=237`
- `callback_delay_ms=400 completed=false elapsed_ms=253`

This demonstrates the current wait cost scaling up to the 250 ms timeout budget.

## Testing
- local timing repro used to validate the synchronous wait characteristics
- attempted a local `xcodebuild` compile in the worktree after submodule init; package/dependency resolution completed, but the build produced no further diagnostics before I stopped waiting in this environment
- local test suites were not run per repo policy

## Notes
- this intentionally does **not** touch the explicit menu / `IBAction` path
- this intentionally does **not** try to fold into the broader CEF migration work in `#2945`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved paste-as-plain-text (Cmd+Shift+V) functionality with enhanced focus tracking and validation to ensure reliable behavior across different input contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->