### PR TITLE
fix: preserve TERM_PROGRAM for claude-teams to prevent crash

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -41,12 +41,13 @@ func runClaudeTeamsRelay(socketPath string, args []string, refreshAddr func() st
 	focused := getFocusedContext(rc)
 
 	configureAgentEnvironment(agentConfig{
-		shimDir:        shimDir,
-		socketPath:     socketPath,
-		focused:        focused,
-		tmuxPathPrefix: "cmux-claude-teams",
-		cmuxBinEnvVar:  "CMUX_CLAUDE_TEAMS_CMUX_BIN",
-		termEnvVar:     "CMUX_CLAUDE_TEAMS_TERM",
+		shimDir:          shimDir,
+		socketPath:       socketPath,
+		focused:          focused,
+		tmuxPathPrefix:   "cmux-claude-teams",
+		cmuxBinEnvVar:    "CMUX_CLAUDE_TEAMS_CMUX_BIN",
+		termEnvVar:       "CMUX_CLAUDE_TEAMS_TERM",
+		unsetTermProgram: false,
 		extraEnv: map[string]string{
 			"CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1",
 		},
@@ -95,13 +96,14 @@ func runOMORelay(socketPath string, args []string, refreshAddr func() string) in
 	focused := getFocusedContext(rc)
 
 	configureAgentEnvironment(agentConfig{
-		shimDir:        shimDir,
-		socketPath:     socketPath,
-		focused:        focused,
-		tmuxPathPrefix: "cmux-omo",
-		cmuxBinEnvVar:  "CMUX_OMO_CMUX_BIN",
-		termEnvVar:     "CMUX_OMO_TERM",
-		extraEnv:       map[string]string{},
+		shimDir:          shimDir,
+		socketPath:       socketPath,
+		focused:          focused,
+		tmuxPathPrefix:   "cmux-omo",
+		cmuxBinEnvVar:    "CMUX_OMO_CMUX_BIN",
+		termEnvVar:       "CMUX_OMO_TERM",
+		unsetTermProgram: true,
+		extraEnv:         map[string]string{},
 	})
 
 	// Set OPENCODE_PORT if not already set
@@ -153,13 +155,14 @@ func runOMXRelay(socketPath string, args []string, refreshAddr func() string) in
 	focused := getFocusedContext(rc)
 
 	configureAgentEnvironment(agentConfig{
-		shimDir:        shimDir,
-		socketPath:     socketPath,
-		focused:        focused,
-		tmuxPathPrefix: "cmux-omx",
-		cmuxBinEnvVar:  "CMUX_OMX_CMUX_BIN",
-		termEnvVar:     "CMUX_OMX_TERM",
-		extraEnv:       map[string]string{},
+		shimDir:          shimDir,
+		socketPath:       socketPath,
+		focused:          focused,
+		tmuxPathPrefix:   "cmux-omx",
+		cmuxBinEnvVar:    "CMUX_OMX_CMUX_BIN",
+		termEnvVar:       "CMUX_OMX_TERM",
+		unsetTermProgram: true,
+		extraEnv:         map[string]string{},
 	})
 
 	launchPath, launchArgv := resolveNodeScriptExec(omxPath, args, originalPath, shimDir)
@@ -189,13 +192,14 @@ func runOMCRelay(socketPath string, args []string, refreshAddr func() string) in
 	focused := getFocusedContext(rc)
 
 	configureAgentEnvironment(agentConfig{
-		shimDir:        shimDir,
-		socketPath:     socketPath,
-		focused:        focused,
-		tmuxPathPrefix: "cmux-omc",
-		cmuxBinEnvVar:  "CMUX_OMC_CMUX_BIN",
-		termEnvVar:     "CMUX_OMC_TERM",
-		extraEnv:       map[string]string{},
+		shimDir:          shimDir,
+		socketPath:       socketPath,
+		focused:          focused,
+		tmuxPathPrefix:   "cmux-omc",
+		cmuxBinEnvVar:    "CMUX_OMC_CMUX_BIN",
+		termEnvVar:       "CMUX_OMC_TERM",
+		unsetTermProgram: true,
+		extraEnv:         map[string]string{},
 	})
 
 	// omc wraps Claude Code, so configure NODE_OPTIONS restore module
@@ -431,13 +435,14 @@ func stringFromAny(values ...any) string {
 // --- Environment configuration ---
 
 type agentConfig struct {
-	shimDir        string
-	socketPath     string
-	focused        *focusedContext
-	tmuxPathPrefix string
-	cmuxBinEnvVar  string
-	termEnvVar     string
-	extraEnv       map[string]string
+	shimDir          string
+	socketPath       string
+	focused          *focusedContext
+	tmuxPathPrefix   string
+	cmuxBinEnvVar    string
+	termEnvVar       string
+	extraEnv         map[string]string
+	unsetTermProgram bool
 }
 
 func configureAgentEnvironment(cfg agentConfig) {
@@ -470,9 +475,12 @@ func configureAgentEnvironment(cfg agentConfig) {
 	// Terminal settings
 	fakeTerm := os.Getenv(cfg.termEnvVar)
 	if fakeTerm == "" {
-		fakeTerm = "screen-256color"
+		fakeTerm = "xterm-ghostty"
 	}
 	os.Setenv("TERM", fakeTerm)
+	if os.Getenv("COLORTERM") == "" {
+		os.Setenv("COLORTERM", "truecolor")
+	}
 
 	// Socket path
 	os.Setenv("CMUX_SOCKET_PATH", cfg.socketPath)
@@ -481,11 +489,10 @@ func configureAgentEnvironment(cfg agentConfig) {
 	// Unset TERM_PROGRAM so apps don't detect the host terminal and
 	// override tmux-compatible behavior (e.g. opencode switches to
 	// light theme when it sees TERM_PROGRAM=ghostty).
-	os.Unsetenv("TERM_PROGRAM")
-
-	// Preserve COLORTERM for truecolor support in subagent panes.
-	if os.Getenv("COLORTERM") == "" {
-		os.Setenv("COLORTERM", "truecolor")
+	// Only unset for OMO/OMX/OMC; claude-teams must preserve it
+	// so Claude Code can detect Ghostty for proper color support.
+	if cfg.unsetTermProgram {
+		os.Unsetenv("TERM_PROGRAM")
 	}
 
 	// Set workspace/surface IDs from focused context


### PR DESCRIPTION
## Summary

Fixes cmux crash when using claude-teams with teamCreate (issue #2947).

## Root Cause

Claude Code v2.1.112 changed how it handles permission escalation based on terminal environment variables. The previous code unconditionally unset  which caused Claude Code's cli.js to crash during  checks.

## Changes

- **Go code** ():
  - Add  flag to  to control  handling per agent type
  - : preserve  (needed for Ghostty detection in Claude Code)
  - //: unset  (opencode switches to light theme when it sees )
  - Change default  from  to 
  - Add  for proper truecolor support

## Testing

The existing test suite covers claude-teams environment configuration. This fix addresses the specific crash that occurs during permission escalation from teammate to team lead.

## Related

- Issue: #2947
- Related PR: #2516 (similar fix for color degradation)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a crash in `claude-teams` during teamCreate by preserving `TERM_PROGRAM`, and added per-agent control of terminal env vars. Also set safer defaults to improve color support. Fixes #2947.

- **Bug Fixes**
  - Added `unsetTermProgram` flag in `agentConfig` to manage `TERM_PROGRAM` per agent.
  - Preserve `TERM_PROGRAM` for `claude-teams`; unset it for `omo`, `omx`, and `omc` to avoid UI issues.
  - Default `TERM` to `xterm-ghostty`; set `COLORTERM=truecolor` when missing.

<sup>Written for commit 4c6f9b290eb7009d2f03f28460151e0845eafd51. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal terminal environment variable configuration handling for improved consistency across different relay types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->