### PR TITLE
Add missing NSAppleEventsUsageDescription to Info.plist

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -43,6 +43,8 @@
 	<string></string>
 	<key>NSMainStoryboardFile</key>
 	<string></string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>A program running within cmux would like to control another application.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>A program running within cmux would like to use your microphone.</string>
 	<key>NSCameraUsageDescription</key>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -2,6 +2,119 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "NSAppleEventsUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within cmux would like to control another application."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 内で実行中のプログラムが別のアプリケーションを制御しようとしています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中运行的程序想要控制另一个应用程序。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 cmux 中執行的程式想要控制另一個應用程式。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 내에서 실행 중인 프로그램이 다른 응용 프로그램을 제어하려고 합니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ein in cmux ausgeführtes Programm möchte eine andere Anwendung steuern."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programa en ejecución dentro de cmux desea controlar otra aplicación."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programme s'exécutant dans cmux souhaite contrôler une autre application."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Un programma in esecuzione in cmux desidera controllare un'altra applicazione."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program, der kører i cmux, vil gerne styre et andet program."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program działający w cmux chciałby sterować inną aplikacją."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Программа, запущенная в cmux, хотела бы управлять другим приложением."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program koji se izvršava unutar cmux želi upravljati drugom aplikacijom."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يرغب برنامج يعمل داخل cmux في التحكم بتطبيق آخر."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Et program som kjører i cmux ønsker å styre et annet program."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Um programa em execução no cmux gostaria de controlar outro aplicativo."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "โปรแกรมที่ทำงานภายใน cmux ต้องการควบคุมแอปพลิเคชันอื่น"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux içinde çalışan bir program başka bir uygulamayı kontrol etmek istiyor."
+          }
+        }
+      }
+    },
     "NSBluetoothAlwaysUsageDescription": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary

- Adds `NSAppleEventsUsageDescription` to `Resources/Info.plist` so macOS TCC can prompt users for Apple Events consent
- Adds localized strings to `Resources/InfoPlist.xcstrings` for all 17 supported locales

## Problem

cmux has the `com.apple.security.automation.apple-events` entitlement, but the corresponding `NSAppleEventsUsageDescription` key is missing from Info.plist. Without it, macOS TCC silently denies Apple Events with error `-1743` and never shows the consent dialog. This means cmux never appears in System Settings > Privacy & Security > Automation, and CLI tools like `bbedit` that send Apple Events to other apps fail.

## Testing

- Verified the built app bundle's Info.plist includes the new key via `plutil -p`
- Confirmed `NSAppleEventsUsageDescription` appears alongside existing usage descriptions
- Validated InfoPlist.xcstrings is well-formed JSON with correct structure matching existing entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `NSAppleEventsUsageDescription` to `Resources/Info.plist` and localize it across all supported locales in `Resources/InfoPlist.xcstrings` so macOS shows the Apple Events consent prompt. Fixes silent -1743 denials and makes cmux appear in System Settings > Privacy & Security > Automation.

<sup>Written for commit 480875869a87901154b02c5c15b207dbfe8c5852. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added application control permissions with multilingual support across 18 languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->