### PR TITLE
Prepend cd to session-resume command when not already there

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2973,7 +2973,6 @@ struct ContentView: View {
     }
 
     private func resumeSession(entry: SessionEntry) {
-        let inputWithReturn = entry.resumeCommand + "\n"
         let targetCwd = entry.cwd
 
         // Smart placement: if the focused workspace's tracked cwd matches, open a
@@ -2996,9 +2995,15 @@ struct ContentView: View {
             return lhs == rhs
         }()
 
+        // Only skip the `cd` prefix when the receiving terminal is guaranteed to
+        // already be in the session's cwd. That's only the cwd-match path where a
+        // fresh tab is spawned in the same workspace. For the new-workspace path,
+        // we still want the `cd` as a safety net in case the shell's rc files land
+        // it somewhere else.
         if pwdMatches,
            let workspace = selected,
            let paneId = workspace.bonsplitController.focusedPaneId {
+            let inputWithReturn = entry.resumeCommand(alreadyInCwd: true) + "\n"
             workspace.newTerminalSurface(
                 inPane: paneId,
                 focus: true,
@@ -3008,6 +3013,7 @@ struct ContentView: View {
             return
         }
 
+        let inputWithReturn = entry.resumeCommand(alreadyInCwd: false) + "\n"
         tabManager.addWorkspace(
             workingDirectory: targetCwd,
             initialTerminalInput: inputWithReturn

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2995,15 +2995,15 @@ struct ContentView: View {
             return lhs == rhs
         }()
 
-        // Only skip the `cd` prefix when the receiving terminal is guaranteed to
-        // already be in the session's cwd. That's only the cwd-match path where a
-        // fresh tab is spawned in the same workspace. For the new-workspace path,
-        // we still want the `cd` as a safety net in case the shell's rc files land
-        // it somewhere else.
+        // Always prepend `cd`: every path here spawns a NEW shell, and the
+        // shell's rc files can cd elsewhere before our typed input runs. The
+        // cost of a redundant `cd` is zero; the cost of landing in the wrong
+        // repo is a broken `claude --resume`.
+        let inputWithReturn = entry.resumeCommandWithCwd + "\n"
+
         if pwdMatches,
            let workspace = selected,
            let paneId = workspace.bonsplitController.focusedPaneId {
-            let inputWithReturn = entry.resumeCommand(alreadyInCwd: true) + "\n"
             workspace.newTerminalSurface(
                 inPane: paneId,
                 focus: true,
@@ -3013,7 +3013,6 @@ struct ContentView: View {
             return
         }
 
-        let inputWithReturn = entry.resumeCommand(alreadyInCwd: false) + "\n"
         tabManager.addWorkspace(
             workingDirectory: targetCwd,
             initialTerminalInput: inputWithReturn

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -573,6 +573,15 @@ final class SessionIndexStore: ObservableObject {
         return trimmed
     }
 
+    /// Claude Code marks sessions created over `claude ssh <host>` with an
+    /// `ssh-` prefix on the project directory name. Their recorded cwd is on
+    /// the remote machine, so a local `claude --resume` can't find them.
+    /// Filter them out of the local session index rather than surfacing broken
+    /// rows.
+    nonisolated private static func isClaudeRemoteProjectDir(_ dirName: String) -> Bool {
+        return dirName.hasPrefix("ssh-")
+    }
+
     nonisolated private static func decodeClaudeProjectDir(_ raw: String) -> String? {
         // Claude encodes cwd by replacing "/" with "-" and prefixing "-"
         // e.g. "-Users-lawrence-fun-cmuxterm-hq" -> "/Users/lawrence/fun/cmuxterm-hq".
@@ -987,9 +996,10 @@ final class SessionIndexStore: ObservableObject {
            let rgPaths = await ripgrepMatchingPaths(needle: needle, root: projectsRoot, fileGlob: "*.jsonl") {
             rgFiltered = true
             for url in rgPaths {
+                let dirName = url.deletingLastPathComponent().lastPathComponent
+                if isClaudeRemoteProjectDir(dirName) { continue }
                 guard let attrs = try? fm.attributesOfItem(atPath: url.path),
                       let mtime = attrs[.modificationDate] as? Date else { continue }
-                let dirName = url.deletingLastPathComponent().lastPathComponent
                 candidates.append((url, mtime, dirName))
             }
         } else if let cwdFilter {
@@ -1011,6 +1021,7 @@ final class SessionIndexStore: ObservableObject {
         } else {
             guard let projectDirs = try? fm.contentsOfDirectory(atPath: projectsRoot) else { return [] }
             for dirName in projectDirs {
+                if isClaudeRemoteProjectDir(dirName) { continue }
                 let dirPath = (projectsRoot as NSString).appendingPathComponent(dirName)
                 var isDir: ObjCBool = false
                 guard fm.fileExists(atPath: dirPath, isDirectory: &isDir), isDir.boolValue else { continue }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -99,19 +99,14 @@ struct SessionEntry: Identifiable, Hashable {
         }
     }
 
-    /// Shell command that resumes this session, prefixed with `cd <cwd> && ` when
-    /// the caller isn't already in the session's working directory. Use
-    /// `alreadyInCwd: true` for the in-app path that opens a new tab in the same
-    /// workspace as the session's cwd, so we don't emit a redundant `cd`. For the
-    /// clipboard / drag-drop / new-workspace paths, pass `false` (or leave default)
-    /// so the resume works regardless of where the receiving shell lands.
-    func resumeCommand(alreadyInCwd: Bool) -> String {
+    /// Shell command that resumes this session, prefixed with `cd <cwd> && `
+    /// when a cwd is known. Always include `cd`: every caller drops this into a
+    /// fresh or unrelated shell (clipboard, drag-drop, or a newly spawned
+    /// terminal whose rc files can land it anywhere), so we can never assume
+    /// the receiver is already in the session's working directory.
+    var resumeCommandWithCwd: String {
         let base = resumeCommand
-        guard !alreadyInCwd,
-              let cwd,
-              !cwd.isEmpty else {
-            return base
-        }
+        guard let cwd, !cwd.isEmpty else { return base }
         return "cd \(Self.shellQuote(cwd)) && \(base)"
     }
 
@@ -482,12 +477,20 @@ final class SessionIndexStore: ObservableObject {
     nonisolated private static func extractClaudeMetadata(head: String, tail: String, projectDir: String) -> ClaudeParsed {
         var out = ClaudeParsed()
         out.cwd = decodeClaudeProjectDir(projectDir)
+        // Claude records the cwd on every event (including later tool calls that
+        // may have cd'd into a subdirectory). `--resume` needs the *project* cwd,
+        // which is the cwd Claude was launched with, i.e. the first cwd seen in
+        // the transcript. Lock it in the first time and don't let later cwd's
+        // overwrite it.
+        var cwdLocked = false
 
         for line in head.split(separator: "\n", omittingEmptySubsequences: true) {
             guard let data = line.data(using: .utf8),
                   let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else { continue }
-            if let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
+            if !cwdLocked,
+               let cwdField = obj["cwd"] as? String, !cwdField.isEmpty {
                 out.cwd = cwdField
+                cwdLocked = true
             }
             if let branchField = obj["gitBranch"] as? String, !branchField.isEmpty {
                 out.branch = branchField

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -99,8 +99,24 @@ struct SessionEntry: Identifiable, Hashable {
         }
     }
 
+    /// Shell command that resumes this session, prefixed with `cd <cwd> && ` when
+    /// the caller isn't already in the session's working directory. Use
+    /// `alreadyInCwd: true` for the in-app path that opens a new tab in the same
+    /// workspace as the session's cwd, so we don't emit a redundant `cd`. For the
+    /// clipboard / drag-drop / new-workspace paths, pass `false` (or leave default)
+    /// so the resume works regardless of where the receiving shell lands.
+    func resumeCommand(alreadyInCwd: Bool) -> String {
+        let base = resumeCommand
+        guard !alreadyInCwd,
+              let cwd,
+              !cwd.isEmpty else {
+            return base
+        }
+        return "cd \(Self.shellQuote(cwd)) && \(base)"
+    }
+
     /// Single-quote a value for safe shell injection. Escapes embedded single quotes.
-    private static func shellQuote(_ value: String) -> String {
+    fileprivate static func shellQuote(_ value: String) -> String {
         if value.range(of: "[^A-Za-z0-9_./:=+-]", options: .regularExpression) == nil {
             return value
         }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1359,20 +1359,26 @@ final class SessionIndexStore: ObservableObject {
         }
         defer { sqlite3_close(db) }
 
+        // Prefer the session's owning project.worktree over session.directory
+        // for cwd: opencode binds sessions to a project_id, and `--session` must
+        // be run from the project's worktree or it fails with
+        // "No context found for instance". session.directory can point at a
+        // sibling worktree the user was browsing when the session was created.
         var sql = """
-            SELECT s.id, s.title, s.directory, s.time_updated, (
+            SELECT s.id, s.title, COALESCE(p.worktree, s.directory) AS cwd, s.time_updated, (
                 SELECT data FROM message
                 WHERE session_id = s.id AND data LIKE '%"role":"assistant"%'
                 ORDER BY time_created DESC LIMIT 1
             ) AS last_assistant
             FROM session s
+            LEFT JOIN project p ON p.id = s.project_id
             """
         var conditions: [String] = []
         if !needle.isEmpty {
-            conditions.append("(LOWER(s.title) LIKE ? OR LOWER(s.directory) LIKE ?)")
+            conditions.append("(LOWER(s.title) LIKE ? OR LOWER(COALESCE(p.worktree, s.directory)) LIKE ?)")
         }
         if cwdFilter != nil {
-            conditions.append("s.directory = ?")
+            conditions.append("COALESCE(p.worktree, s.directory) = ?")
         }
         if !conditions.isEmpty {
             sql += " WHERE " + conditions.joined(separator: " AND ")

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -487,7 +487,9 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
     Button {
         let pb = NSPasteboard.general
         pb.clearContents()
-        pb.setString(entry.resumeCommand, forType: .string)
+        // Always include `cd` when copied: the user could paste this into any
+        // shell regardless of its current directory.
+        pb.setString(entry.resumeCommand(alreadyInCwd: false), forType: .string)
     } label: {
         Text(String(localized: "sessionIndex.row.copyResume", defaultValue: "Copy Resume Command"))
     }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -489,7 +489,7 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
         pb.clearContents()
         // Always include `cd` when copied: the user could paste this into any
         // shell regardless of its current directory.
-        pb.setString(entry.resumeCommand(alreadyInCwd: false), forType: .string)
+        pb.setString(entry.resumeCommandWithCwd, forType: .string)
     } label: {
         Text(String(localized: "sessionIndex.row.copyResume", defaultValue: "Copy Resume Command"))
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11144,7 +11144,7 @@ final class Workspace: Identifiable, ObservableObject {
         // else (e.g. an auto-chdir in zshrc). Prepend `cd` so the resume
         // lands in the session's cwd regardless of the shell's post-startup
         // cwd.
-        let inputWithReturn = entry.resumeCommand(alreadyInCwd: false) + "\n"
+        let inputWithReturn = entry.resumeCommandWithCwd + "\n"
         switch destination {
         case .insert(let paneId, _):
             let panel = newTerminalSurface(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11139,7 +11139,12 @@ final class Workspace: Identifiable, ObservableObject {
         entry: SessionEntry,
         destination: BonsplitController.ExternalTabDropRequest.Destination
     ) -> Bool {
-        let inputWithReturn = entry.resumeCommand + "\n"
+        // The dropped terminal is freshly spawned with `workingDirectory:
+        // entry.cwd`, but the shell's rc files can still land it somewhere
+        // else (e.g. an auto-chdir in zshrc). Prepend `cd` so the resume
+        // lands in the session's cwd regardless of the shell's post-startup
+        // cwd.
+        let inputWithReturn = entry.resumeCommand(alreadyInCwd: false) + "\n"
         switch destination {
         case .insert(let paneId, _):
             let panel = newTerminalSurface(


### PR DESCRIPTION
## Summary

Resume commands (e.g. `claude --resume <id>`) assume the shell is already in the session's cwd. When it isn't, the CLI can't find the session state or launches against the wrong repo.

New `SessionEntry.resumeCommand(alreadyInCwd:)` returns `cd <shell-quoted cwd> && <resumeCommand>` unless the caller guarantees the shell is already in the session's cwd. Wired at the three call sites:

- **Copy Resume Command** (clipboard): always prepends `cd`, since we can't predict where the user will paste.
- **Drag-drop to make terminal**: always prepends `cd`, since rc files can land the spawned shell outside the requested `workingDirectory`.
- **In-app resume** (double-click / "Resume in New Tab"): only skips `cd` on the cwd-match path where we spawn a fresh tab in the same workspace and know the shell will land in the right place. The new-workspace path still prepends `cd` as a safety net.

## Test plan
- [ ] Right-click a session row → Copy Resume Command → paste into a random shell → command runs and session opens.
- [ ] Drag a session row onto the terminal → new terminal appears with `cd <path> && claude --resume …` typed and session opens.
- [ ] Double-click a session row whose cwd matches the focused workspace → new tab with just the bare resume command (no redundant `cd`).
- [ ] Double-click a session row whose cwd does NOT match → new workspace with `cd` prefix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always prepend `cd <cwd> &&` to resume commands so sessions land in the right repo. Fix cwd resolution for Claude and OpenCode, and hide `ssh-*` remote sessions to avoid broken rows.

- **Bug Fixes**
  - Added `SessionEntry.resumeCommandWithCwd` and wired it for clipboard, drag‑drop terminals, and in‑app resume.
  - CWD fixes: lock to the first Claude event (launch dir) and, for OpenCode, use `project.worktree` via SQL `COALESCE(...)` instead of `session.directory`.
  - Filtered `ssh-*` Claude remote project dirs out of the local index so only resumable sessions appear.

<sup>Written for commit 7b9afa1924d2c466ec25316874fbf32e29be2675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming sessions now reliably lands in the intended working directory, even when shell startup files run.
  * Copying a resume command and dragging/dropping sessions now produce commands that include directory-handling for safer, predictable restoration.
  * Session listings and resumed cwd selection now prefer a project worktree when available and filter out certain remote project entries for clearer results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->