### PR TITLE
Guard Ghostty callbacks against stale runtime surfaces

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1750,7 +1750,13 @@ fileprivate static func runtimeReadClipboardCallback(
             guard let callbackContext = GhosttyApp.callbackContext(from: userdata) else { return }
             let callbackSurfaceId = callbackContext.surfaceId
             let callbackTabId = callbackContext.tabId
-            callbackContext.terminalSurface?.suppressRuntimeSurfaceRestart(reason: "ghostty.close_surface_cb")
+            if !needsConfirmClose {
+                // Confirmed-close flows suppress restart when the host actually begins closing.
+                // Suppressing here would strand the panel if the user cancels the dialog.
+                callbackContext.terminalSurface?.suppressRuntimeSurfaceRestart(
+                    reason: "ghostty.close_surface_cb"
+                )
+            }
 
 #if DEBUG
             cmuxWriteChildExitProbe(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1338,7 +1338,25 @@ private final class GhosttySurfaceCallbackContext {
     }
 
     var runtimeSurface: ghostty_surface_t? {
-        terminalSurface?.surface ?? surfaceView?.terminalSurface?.surface
+        liveRuntimeSurface(reason: "callbackContext.runtimeSurface")
+    }
+
+    func liveRuntimeSurface(reason: String) -> ghostty_surface_t? {
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated {
+                terminalSurface?.liveSurfaceForGhosttyAccess(reason: reason)
+                    ?? surfaceView?.terminalSurface?.liveSurfaceForGhosttyAccess(reason: reason)
+            }
+        }
+
+        var liveSurface: ghostty_surface_t?
+        DispatchQueue.main.sync {
+            liveSurface = MainActor.assumeIsolated {
+                terminalSurface?.liveSurfaceForGhosttyAccess(reason: reason)
+                    ?? surfaceView?.terminalSurface?.liveSurfaceForGhosttyAccess(reason: reason)
+            }
+        }
+        return liveSurface
     }
 }
 
@@ -1392,18 +1410,18 @@ class GhosttyApp {
         return URL(fileURLWithPath: "/tmp/cmux-bg.log")
     }
 
-    fileprivate static func runtimeReadClipboardCallback(
+fileprivate static func runtimeReadClipboardCallback(
         _ userdata: UnsafeMutableRawPointer?,
         _ location: ghostty_clipboard_e,
         _ state: UnsafeMutableRawPointer?
     ) -> Bool {
         guard let callbackContext = Self.callbackContext(from: userdata),
-              let requestSurface = callbackContext.runtimeSurface else { return false }
+              let requestSurface = callbackContext.liveRuntimeSurface(reason: "ghostty.clipboard.read.begin") else { return false }
 
         DispatchQueue.main.async {
             func completeClipboardRequest(with text: String) {
                 let finish = {
-                    guard callbackContext.runtimeSurface == requestSurface else { return }
+                    guard callbackContext.liveRuntimeSurface(reason: "ghostty.clipboard.read.finish") == requestSurface else { return }
                     text.withCString { ptr in
                         ghostty_surface_complete_clipboard_request(requestSurface, ptr, state, false)
                     }
@@ -1697,7 +1715,7 @@ class GhosttyApp {
         runtimeConfig.confirm_read_clipboard_cb = { userdata, content, state, _ in
             guard let content else { return }
             guard let callbackContext = GhosttyApp.callbackContext(from: userdata),
-                  let surface = callbackContext.runtimeSurface else { return }
+                  let surface = callbackContext.liveRuntimeSurface(reason: "ghostty.clipboard.confirm") else { return }
 
             ghostty_surface_complete_clipboard_request(surface, content, state, true)
         }
@@ -1732,6 +1750,7 @@ class GhosttyApp {
             guard let callbackContext = GhosttyApp.callbackContext(from: userdata) else { return }
             let callbackSurfaceId = callbackContext.surfaceId
             let callbackTabId = callbackContext.tabId
+            callbackContext.terminalSurface?.suppressRuntimeSurfaceRestart(reason: "ghostty.close_surface_cb")
 
 #if DEBUG
             cmuxWriteChildExitProbe(
@@ -2970,6 +2989,9 @@ class GhosttyApp {
             // "Process exited. Press any key..." into the terminal unless the host
             // handles this action. For cmux, the correct behavior is to close
             // the panel immediately (no prompt).
+            callbackContext?.terminalSurface?.suppressRuntimeSurfaceRestart(
+                reason: "ghostty.show_child_exited"
+            )
 #if DEBUG
             dlog(
                 "surface.action.showChildExited tab=\(callbackTabId?.uuidString.prefix(5) ?? "nil") " +
@@ -3622,10 +3644,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var lastXScale: CGFloat = 0
     private var lastYScale: CGFloat = 0
     private let debugMetadataLock = NSLock()
+    private let runtimeRestartSuppressionLock = NSLock()
     private let createdAt: Date = Date()
     private var runtimeSurfaceCreatedAt: Date?
     private var teardownRequestedAt: Date?
     private var teardownRequestReason: String?
+    private var runtimeSurfaceRestartSuppressed = false
     private var pendingSocketInputQueue: [PendingSocketInput] = []
     private var pendingSocketInputBytes: Int = 0
     private let maxPendingSocketInputBytes = 1_048_576
@@ -4027,13 +4051,56 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    private func withRuntimeRestartSuppressionLock<T>(_ body: () -> T) -> T {
+        runtimeRestartSuppressionLock.lock()
+        defer { runtimeRestartSuppressionLock.unlock() }
+        return body()
+    }
+
+    private func isRuntimeSurfaceRestartSuppressed() -> Bool {
+        withRuntimeRestartSuppressionLock { runtimeSurfaceRestartSuppressed }
+    }
+
+    func suppressRuntimeSurfaceRestart(reason: String) {
+        let shouldLog = withRuntimeRestartSuppressionLock {
+            let didChange = !runtimeSurfaceRestartSuppressed
+            runtimeSurfaceRestartSuppressed = true
+            return didChange
+        }
+#if DEBUG
+        if shouldLog {
+            dlog(
+                "surface.lifecycle.restartSuppressed surface=\(id.uuidString.prefix(5)) " +
+                "workspace=\(tabId.uuidString.prefix(5)) reason=\(reason)"
+            )
+        }
+#endif
+    }
+
     private func allowsRuntimeSurfaceCreation() -> Bool {
-        portalLifecycleState == .live
+        portalLifecycleState == .live && !isRuntimeSurfaceRestartSuppressed()
+    }
+
+    private func liveSurface(reason: String) -> ghostty_surface_t? {
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated {
+                liveSurfaceForGhosttyAccess(reason: reason)
+            }
+        }
+
+        var liveSurface: ghostty_surface_t?
+        DispatchQueue.main.sync {
+            liveSurface = MainActor.assumeIsolated {
+                liveSurfaceForGhosttyAccess(reason: reason)
+            }
+        }
+        return liveSurface
     }
 
     func beginPortalCloseLifecycle(reason: String) {
         guard portalLifecycleState != .closed else { return }
         guard portalLifecycleState != .closing else { return }
+        suppressRuntimeSurfaceRestart(reason: reason)
         recordTeardownRequest(reason: reason)
         portalLifecycleState = .closing
         portalLifecycleGeneration &+= 1
@@ -4048,6 +4115,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private func markPortalLifecycleClosed(reason: String) {
         guard portalLifecycleState != .closed else { return }
+        suppressRuntimeSurfaceRestart(reason: reason)
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
 #if DEBUG
@@ -4106,6 +4174,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func debugDesiredFocusState() -> Bool {
         desiredFocusState
+    }
+
+    func debugRuntimeSurfaceRestartSuppressed() -> Bool {
+        isRuntimeSurfaceRestartSuppressed()
     }
 
     private static func surfaceLog(_ message: String) {
@@ -4177,15 +4249,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
         // SwiftUI also re-enters this path for ordinary state propagation (drag hover, active
         // markers, visibility flags), so avoid forcing a geometry refresh when the attachment
         // itself is unchanged.
-        if attachedView === view && surface != nil {
+        if attachedView === view, let liveSurface = liveSurface(reason: "surface.attach.reuse") {
 #if DEBUG
             dlog("surface.attach.reuse surface=\(id.uuidString.prefix(5)) view=\(Unmanaged.passUnretained(view).toOpaque())")
 #endif
             if let screen = view.window?.screen ?? NSScreen.main,
                let displayID = screen.displayID,
-               displayID != 0,
-               let s = surface {
-                ghostty_surface_set_display_id(s, displayID)
+               displayID != 0 {
+                ghostty_surface_set_display_id(liveSurface, displayID)
             }
             return
         }
@@ -4204,7 +4275,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
         // If surface doesn't exist yet, create it once the view is in a real window so
         // content scale and pixel geometry are derived from the actual backing context.
-        if surface == nil {
+        if liveSurface(reason: "surface.attach.needsCreate") == nil {
             guard allowsRuntimeSurfaceCreation() else {
 #if DEBUG
                 dlog(
@@ -4233,7 +4304,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         } else if let screen = view.window?.screen ?? NSScreen.main,
                   let displayID = screen.displayID,
                   displayID != 0,
-                  let s = surface {
+                  let s = liveSurface(reason: "surface.attach.displayId") {
             // Surface exists but we're (re)attaching after a view hierarchy move; ensure display id.
             ghostty_surface_set_display_id(s, displayID)
 #if DEBUG
@@ -4606,7 +4677,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         layerScale: CGFloat,
         backingSize: CGSize? = nil
     ) -> Bool {
-        guard let surface = surface else { return false }
+        guard let surface = liveSurface(reason: "terminalSurface.updateSize") else { return false }
         _ = layerScale
 
         let resolvedBackingWidth = backingSize?.width ?? (width * xScale)
@@ -4649,7 +4720,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     /// Force a full size recalculation and surface redraw.
     func forceRefresh(reason: String = "unspecified") {
-        let hasSurface = surface != nil
+        let hasSurface = liveSurface(reason: "terminalSurface.forceRefresh.preflight") != nil
         let viewState: String
         if let view = attachedView {
             let inWindow = view.window != nil
@@ -4663,13 +4734,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
         dlog("forceRefresh: \(id) reason=\(reason) \(viewState)")
         #endif
         guard let view = attachedView,
-              let surface,
               view.window != nil,
               view.bounds.width > 0,
               view.bounds.height > 0 else {
             return
         }
-        guard let currentSurface = self.surface else { return }
+        guard let currentSurface = liveSurface(reason: "terminalSurface.forceRefresh") else { return }
 
         // Re-read self.surface before each ghostty call to guard against the surface
         // being freed during wake-from-sleep geometry reconciliation (issue #432).
@@ -4685,7 +4755,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
 
         view.forceRefreshSurface()
-        guard let surface = self.surface else { return }
+        guard let surface = liveSurface(reason: "terminalSurface.forceRefresh.final") else { return }
         ghostty_surface_refresh(surface)
     }
 
@@ -4707,7 +4777,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         desiredFocusState = focused
         // Track desired state even before the C surface exists (e.g. during
         // layout restoration). createSurface syncs the state once created.
-        guard let surface = surface else { return }
+        guard let surface = liveSurface(reason: "terminalSurface.setFocus") else { return }
         ghostty_surface_set_focus(surface, focused)
 
         // If we focus a surface while it is being rapidly reparented (closing splits, etc),
@@ -4724,7 +4794,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     func setOcclusion(_ visible: Bool) {
-        guard let surface = surface else { return }
+        guard let surface = liveSurface(reason: "terminalSurface.setOcclusion") else { return }
         ghostty_surface_set_occlusion(surface, visible)
     }
 
@@ -4734,13 +4804,13 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return needsConfirmCloseOverrideForTesting
         }
 #endif
-        guard let surface = surface else { return false }
+        guard let surface = liveSurface(reason: "terminalSurface.needsConfirmClose") else { return false }
         return ghostty_surface_needs_confirm_quit(surface)
     }
 
     func sendText(_ text: String) {
         guard let data = text.data(using: .utf8), !data.isEmpty else { return }
-        guard let surface = surface else {
+        guard let surface = liveSurface(reason: "terminalSurface.sendText") else {
             enqueuePendingSocketInput(.text(data))
             requestBackgroundSurfaceStartIfNeeded()
             return
@@ -4751,7 +4821,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     @discardableResult
     func sendNamedKey(_ keyName: String) -> Bool {
         guard let event = pendingKeyEvent(for: keyName) else { return false }
-        if let surface = surface {
+        if let surface = liveSurface(reason: "terminalSurface.sendNamedKey") {
             sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
         } else {
             enqueuePendingSocketInput(.key(event))
@@ -4764,7 +4834,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// events so the shell processes them, while regular text is sent via the
     /// normal key-text path.  Mirrors `TerminalController.sendSocketText`.
     func sendInput(_ text: String) {
-        guard let surface = surface else { return }
+        guard let surface = liveSurface(reason: "terminalSurface.sendInput") else { return }
         var bufferedText = ""
         var previousWasCR = false
         for scalar in text.unicodeScalars {
@@ -5025,7 +5095,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     private func flushPendingSocketInputIfNeeded() {
-        guard let surface = surface, !pendingSocketInputQueue.isEmpty else { return }
+        guard let surface = liveSurface(reason: "terminalSurface.flushPendingSocketInput"),
+              !pendingSocketInputQueue.isEmpty else { return }
         let queued = pendingSocketInputQueue
         let queuedBytes = pendingSocketInputBytes
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
@@ -5050,7 +5121,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     func performBindingAction(_ action: String) -> Bool {
-        guard let surface = surface else { return false }
+        guard let surface = liveSurface(reason: "terminalSurface.performBindingAction") else { return false }
         return action.withCString { cString in
             ghostty_surface_binding_action(surface, cString, UInt(strlen(cString)))
         }
@@ -5080,7 +5151,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     func hasSelection() -> Bool {
-        guard let surface = surface else { return false }
+        guard let surface = liveSurface(reason: "terminalSurface.hasSelection") else { return false }
         return ghostty_surface_has_selection(surface)
     }
 
@@ -5600,7 +5671,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             self?.windowDidChangeScreen(notification)
         }
 
-        if let surface = terminalSurface?.surface,
+        if let surface = surface,
            let displayID = window.screen?.displayID,
            displayID != 0 {
             ghostty_surface_set_display_id(surface, displayID)
@@ -5877,7 +5948,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     // Convenience accessor for the ghostty surface
     private var surface: ghostty_surface_t? {
-        terminalSurface?.surface
+        if Thread.isMainThread {
+            return MainActor.assumeIsolated {
+                terminalSurface?.liveSurfaceForGhosttyAccess(reason: "ghosttyNSView.surface")
+            }
+        }
+
+        var liveSurface: ghostty_surface_t?
+        DispatchQueue.main.sync {
+            liveSurface = MainActor.assumeIsolated {
+                terminalSurface?.liveSurfaceForGhosttyAccess(
+                    reason: "ghosttyNSView.surface.background"
+                )
+            }
+        }
+        return liveSurface
     }
 
     private func applySurfaceColorScheme(force: Bool = false) {
@@ -8377,7 +8462,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let window else { return }
         guard let object = notification.object as? NSWindow, window == object else { return }
         guard let screen = window.screen else { return }
-        guard let surface = terminalSurface?.surface else { return }
+        guard let surface = surface else { return }
 
         if let displayID = screen.displayID,
            displayID != 0 {
@@ -10802,7 +10887,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func reassertTerminalSurfaceFocus(reason: String) {
         guard let terminalSurface = surfaceView.terminalSurface else { return }
-        if terminalSurface.surface == nil {
+        let liveSurface = MainActor.assumeIsolated {
+            terminalSurface.liveSurfaceForGhosttyAccess(reason: "focus.surface.reassert")
+        }
+        if liveSurface == nil {
             terminalSurface.requestBackgroundSurfaceStartIfNeeded()
         }
 #if DEBUG

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5694,7 +5694,9 @@ class TerminalController {
             let sendStart = ProcessInfo.processInfo.systemUptime
             #endif
             let queued: Bool
-            if let surface = terminalPanel.surface.surface {
+            if let surface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+                reason: "terminalController.v2SurfaceSendText"
+            ) {
                 sendSocketText(text, surface: surface)
                 // Ensure we present a new frame after injecting input so snapshot-based tests (and
                 // socket-driven agents) can observe the updated terminal without requiring a focus
@@ -5750,7 +5752,9 @@ class TerminalController {
                 result = .err(code: "invalid_params", message: "Surface is not a terminal", data: ["surface_id": surfaceId.uuidString])
                 return
             }
-            let surfaceWasReady = terminalPanel.surface.surface != nil
+            let surfaceWasReady = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+                reason: "terminalController.v2SurfaceSendKey.preflight"
+            ) != nil
             guard terminalPanel.surface.sendNamedKey(key) else {
                 result = .err(code: "invalid_params", message: "Unknown key", data: ["key": key])
                 return
@@ -5885,7 +5889,9 @@ class TerminalController {
     }
 
     private func readTerminalTextBase64(terminalPanel: TerminalPanel, includeScrollback: Bool = false, lineLimit: Int? = nil) -> String {
-        guard let surface = terminalPanel.surface.surface else { return "ERROR: Terminal surface not found" }
+        guard let surface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+            reason: "terminalController.readTerminalTextBase64"
+        ) else { return "ERROR: Terminal surface not found" }
 
         func readSelectionText(pointTag: ghostty_point_tag_e) -> String? {
             let topLeft = ghostty_point_s(
@@ -6183,7 +6189,9 @@ class TerminalController {
                 if let panelUUID = selectedSurfaceUUID,
                    let panel = ws.panels[panelUUID] as? TerminalPanel,
                    panel.surface.hasLiveSurface,
-                   let ghosttySurface = panel.surface.surface {
+                   let ghosttySurface = panel.surface.liveSurfaceForGhosttyAccess(
+                    reason: "terminalController.workspaceList"
+                   ) {
                     let size = ghostty_surface_size(ghosttySurface)
                     if size.columns > 0 && size.rows > 0 {
                         dict["columns"] = Int(size.columns)
@@ -13421,7 +13429,9 @@ class TerminalController {
     }
 
     private func waitForTerminalSurface(_ terminalPanel: TerminalPanel, waitUpTo timeout: TimeInterval = 0.6) -> ghostty_surface_t? {
-        if let surface = terminalPanel.surface.surface { return surface }
+        if let surface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+            reason: "terminalController.waitForTerminalSurface.initial"
+        ) { return surface }
 
         let terminalSurface = terminalPanel.surface
         terminalSurface.requestBackgroundSurfaceStartIfNeeded()
@@ -13451,18 +13461,24 @@ class TerminalController {
                 queue: .main
             ) { _ in
                 Task { @MainActor in
-                    if terminalSurface.surface != nil {
+                    if terminalSurface.liveSurfaceForGhosttyAccess(
+                        reason: "terminalController.waitForTerminalSurface.hostedObserver"
+                    ) != nil {
                         finishOnce()
                     }
                 }
             }
 
-            if terminalSurface.surface != nil {
+            if terminalSurface.liveSurfaceForGhosttyAccess(
+                reason: "terminalController.waitForTerminalSurface.immediate"
+            ) != nil {
                 finishOnce()
             }
         }
 
-        return terminalPanel.surface.surface
+        return terminalPanel.surface.liveSurfaceForGhosttyAccess(
+            reason: "terminalController.waitForTerminalSurface.final"
+        )
     }
 
     private func resolveSurface(from arg: String, tabManager: TabManager) -> ghostty_surface_t? {
@@ -13740,7 +13756,9 @@ class TerminalController {
             // payload does not hold the control-socket response open in CI.
             DispatchQueue.main.async { [weak self] in
                 guard let self else { return }
-                if let surface = terminalPanel.surface.surface {
+                if let surface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+                    reason: "terminalController.sendInputToWorkspace"
+                ) {
                     self.sendSocketText(unescaped, surface: surface)
                 } else {
                     terminalPanel.sendText(unescaped)


### PR DESCRIPTION
## Summary
- gate Ghostty callback access through live-surface validation instead of reusing stale runtime pointers
- seal terminal surface lifecycle state when stale runtime surfaces are detected so background restart paths do not recreate freed Ghostty surfaces
- update terminal controller send/read/wait paths to use the validated surface accessor

Closes #2963.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guards all Ghostty callbacks and terminal operations behind a main-thread live-surface check to prevent use-after-free of stale surfaces. Defers background restart suppression until close is confirmed; still suppresses after close/child-exit, addressing #2963 freezes/crashes.

- **Bug Fixes**
  - Added a validated live-surface accessor and routed Ghostty callbacks and `TerminalController` send/read/wait through it.
  - Suppress runtime restart only after confirmed close; still suppress on close lifecycle and child-exit; lock-protected flag on `TerminalSurface`.
  - Guarded geometry updates, display ID, focus/occlusion, selection checks, input (text/keys/flush), refresh, and NSView helpers with live-surface checks; only start background when no live surface exists.

<sup>Written for commit 4bde67f5f31d3818cfd31ff9f343d9de963653ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved terminal surface validation and access throughout the app to use live-validated surface handles, reducing use of stale pointers and improving stability during lifecycle transitions.
* **Bug Fixes**
  * Made clipboard, close/show, child-exit, and background-start flows safer by suppressing unwanted surface restarts and ensuring callbacks use validated live surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->