### PR TITLE
Fix OpenCode bracketed paste fallback in terminal

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1938,6 +1938,26 @@ func shouldRouteCommandEquivalentDirectlyToMainMenu(_ event: NSEvent) -> Bool {
     return true
 }
 
+private enum TerminalPasteCommandEquivalent {
+    case paste
+    case pasteAsPlainText
+}
+
+private func terminalPasteCommandEquivalent(for event: NSEvent) -> TerminalPasteCommandEquivalent? {
+    guard event.keyCode == 9 else { return nil } // V key (hardware position, layout-independent)
+
+    let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
+    switch normalizedFlags {
+    case [.command]:
+        return .paste
+    case [.command, .shift]:
+        return .pasteAsPlainText
+    default:
+        return nil
+    }
+}
+
 private enum BrowserFindCommandEquivalent {
     case find
     case findNext
@@ -14504,6 +14524,24 @@ private extension NSWindow {
 #endif
                 return true
             }
+        }
+
+        if let ghosttyView = firstResponderGhosttyView,
+           let pasteCommand = terminalPasteCommandEquivalent(for: event),
+           GhosttyPasteboardHelper.hasString(for: GHOSTTY_CLIPBOARD_STANDARD) {
+            // If the window-level direct-to-menu path misses Cmd+V, do not let the
+            // event fall through to generic keyDown routing. Bracketed-paste TUIs
+            // such as OpenCode need the dedicated terminal paste action.
+            switch pasteCommand {
+            case .paste:
+                ghosttyView.paste(nil)
+            case .pasteAsPlainText:
+                ghosttyView.pasteAsPlainText(nil)
+            }
+#if DEBUG
+            dlog("  → consumed by direct terminal paste fallback")
+#endif
+            return true
         }
 
         let result = cmux_performKeyEquivalent(with: event)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14532,16 +14532,29 @@ private extension NSWindow {
             // If the window-level direct-to-menu path misses Cmd+V, do not let the
             // event fall through to generic keyDown routing. Bracketed-paste TUIs
             // such as OpenCode need the dedicated terminal paste action.
+            let handledDirectPaste: Bool
             switch pasteCommand {
             case .paste:
-                ghosttyView.paste(nil)
+                handledDirectPaste = ghosttyView.prepareSurfaceForPaste(
+                    reason: "window.performKeyEquivalent.paste.missingSurface"
+                )
+                if handledDirectPaste {
+                    ghosttyView.paste(nil)
+                }
             case .pasteAsPlainText:
-                ghosttyView.pasteAsPlainText(nil)
+                handledDirectPaste = ghosttyView.prepareSurfaceForPaste(
+                    reason: "window.performKeyEquivalent.pasteAsPlainText.missingSurface"
+                )
+                if handledDirectPaste {
+                    ghosttyView.pasteAsPlainText(nil)
+                }
             }
+            if handledDirectPaste {
 #if DEBUG
-            dlog("  → consumed by direct terminal paste fallback")
+                dlog("  → consumed by direct terminal paste fallback")
 #endif
-            return true
+                return true
+            }
         }
 
         let result = cmux_performKeyEquivalent(with: event)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1938,26 +1938,6 @@ func shouldRouteCommandEquivalentDirectlyToMainMenu(_ event: NSEvent) -> Bool {
     return true
 }
 
-private enum TerminalPasteCommandEquivalent {
-    case paste
-    case pasteAsPlainText
-}
-
-private func terminalPasteCommandEquivalent(for event: NSEvent) -> TerminalPasteCommandEquivalent? {
-    guard event.keyCode == 9 else { return nil } // V key (hardware position, layout-independent)
-
-    let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-    let normalizedFlags = flags.subtracting([.numericPad, .function, .capsLock])
-    switch normalizedFlags {
-    case [.command]:
-        return .paste
-    case [.command, .shift]:
-        return .pasteAsPlainText
-    default:
-        return nil
-    }
-}
-
 private enum BrowserFindCommandEquivalent {
     case find
     case findNext
@@ -14517,41 +14497,18 @@ private extension NSWindow {
             }
 #endif
             if !consumedByMenu {
-                // Fall through to the original performKeyEquivalent path below.
+                // After a direct-to-menu miss, let Ghostty resolve the command key
+                // through its normal binding path so user key overrides still win.
+                let consumedByGhostty = firstResponderGhosttyView?.performKeyEquivalentAfterMenuMiss(with: event) == true
+#if DEBUG
+                dlog("  → mainMenu miss; ghostty command path: \(consumedByGhostty)")
+#endif
+                if consumedByGhostty {
+                    return true
+                }
             } else {
 #if DEBUG
                 dlog("  → consumed by mainMenu (bypassed SwiftUI)")
-#endif
-                return true
-            }
-        }
-
-        if let ghosttyView = firstResponderGhosttyView,
-           let pasteCommand = terminalPasteCommandEquivalent(for: event),
-           GhosttyPasteboardHelper.hasString(for: GHOSTTY_CLIPBOARD_STANDARD) {
-            // If the window-level direct-to-menu path misses Cmd+V, do not let the
-            // event fall through to generic keyDown routing. Bracketed-paste TUIs
-            // such as OpenCode need the dedicated terminal paste action.
-            let handledDirectPaste: Bool
-            switch pasteCommand {
-            case .paste:
-                handledDirectPaste = ghosttyView.prepareSurfaceForPaste(
-                    reason: "window.performKeyEquivalent.paste.missingSurface"
-                )
-                if handledDirectPaste {
-                    ghosttyView.paste(nil)
-                }
-            case .pasteAsPlainText:
-                handledDirectPaste = ghosttyView.prepareSurfaceForPaste(
-                    reason: "window.performKeyEquivalent.pasteAsPlainText.missingSurface"
-                )
-                if handledDirectPaste {
-                    ghosttyView.pasteAsPlainText(nil)
-                }
-            }
-            if handledDirectPaste {
-#if DEBUG
-                dlog("  → consumed by direct terminal paste fallback")
 #endif
                 return true
             }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5927,6 +5927,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
     }
 
+    @discardableResult
+    func prepareSurfaceForPaste(reason: String) -> Bool {
+        guard ensureSurfaceReadyForInput() != nil else {
+            requestInputRecoveryAfterSurfaceMiss(reason: reason)
+            return false
+        }
+        return true
+    }
+
     func performBindingAction(_ action: String) -> Bool {
         guard let surface = surface else { return false }
         return action.withCString { cString in
@@ -6149,11 +6158,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // MARK: - Clipboard paste
 
     @IBAction func paste(_ sender: Any?) {
+        guard prepareSurfaceForPaste(reason: "paste.missingSurface") else { return }
         _ = performBindingAction("paste_from_clipboard")
     }
 
     /// Pastes clipboard text as plain text, stripping any rich formatting.
     @IBAction func pasteAsPlainText(_ sender: Any?) {
+        guard prepareSurfaceForPaste(reason: "pasteAsPlainText.missingSurface") else { return }
         _ = performBindingAction("paste_from_clipboard")
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6444,6 +6444,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        performKeyEquivalent(with: event, shouldRetryMainMenu: true)
+    }
+
+    func performKeyEquivalentAfterMenuMiss(with event: NSEvent) -> Bool {
+        performKeyEquivalent(with: event, shouldRetryMainMenu: false)
+    }
+
+    private func performKeyEquivalent(with event: NSEvent, shouldRetryMainMenu: Bool) -> Bool {
 #if DEBUG
         let typingTimingStart = CmuxTypingTiming.start()
         defer {
@@ -6515,14 +6523,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if let bindingFlags {
             let isConsumed = (bindingFlags.rawValue & GHOSTTY_BINDING_FLAGS_CONSUMED.rawValue) != 0
             let isAll = (bindingFlags.rawValue & GHOSTTY_BINDING_FLAGS_ALL.rawValue) != 0
-            let isPerformable = (bindingFlags.rawValue & GHOSTTY_BINDING_FLAGS_PERFORMABLE.rawValue) != 0
 
             // If the binding is consumed and not meant for the menu, allow menu first.
             // Performable bindings (e.g. paste_from_clipboard) also need the menu
             // path so that Edit > Paste handles Cmd+V instead of keyDown double-
             // firing the clipboard request through both interpretKeyEvents and
             // ghostty_surface_key.
-            if isConsumed && !isAll && keySequence.isEmpty && keyTables.isEmpty {
+            if shouldRetryMainMenu && isConsumed && !isAll && keySequence.isEmpty && keyTables.isEmpty {
                 if let menu = NSApp.mainMenu, menu.performKeyEquivalent(with: event) {
                     return true
                 }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -11,6 +11,25 @@ private final class FakeWKInspectorContainerView: NSView {}
 private final class FocusableTestView: NSView {
     override var acceptsFirstResponder: Bool { true }
 }
+private final class GhosttyCommandEquivalentProbeView: GhosttyNSView {
+    var afterMenuMissCallCount = 0
+    var pasteCallCount = 0
+    var pasteAsPlainTextCallCount = 0
+    var performAfterMenuMissResult = true
+
+    override func performKeyEquivalentAfterMenuMiss(with event: NSEvent) -> Bool {
+        afterMenuMissCallCount += 1
+        return performAfterMenuMissResult
+    }
+
+    override func paste(_ sender: Any?) {
+        pasteCallCount += 1
+    }
+
+    override func pasteAsPlainText(_ sender: Any?) {
+        pasteAsPlainTextCallCount += 1
+    }
+}
 
 @MainActor
 final class AppDelegateShortcutRoutingTests: XCTestCase {
@@ -4252,6 +4271,55 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         // responder assertions above act as the Release-build proxy.
         XCTAssertGreaterThan(forwardedKeyDownCount, 0, "Typing repair should forward the keyDown into Ghostty")
 #endif
+    }
+
+    func testWindowPerformKeyEquivalentDefersTerminalPasteMenuMissToGhosttyBindingResolution() {
+        let previousMainMenu = NSApp.mainMenu
+        let probeWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = NSView(frame: probeWindow.contentRect(forFrameRect: probeWindow.frame))
+        let probeView = GhosttyCommandEquivalentProbeView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
+
+        defer {
+            NSApp.mainMenu = previousMainMenu
+            probeWindow.orderOut(nil)
+        }
+
+        let emptyMenu = NSMenu(title: "Test")
+        emptyMenu.addItem(withTitle: "Placeholder", action: nil, keyEquivalent: "")
+        NSApp.mainMenu = emptyMenu
+
+        probeWindow.contentView = contentView
+        contentView.addSubview(probeView)
+        probeWindow.makeKeyAndOrderFront(nil)
+        probeWindow.displayIfNeeded()
+        XCTAssertTrue(probeWindow.makeFirstResponder(probeView), "Expected probe Ghostty view to own first responder")
+
+        guard let event = makeKeyDownEvent(
+            key: "v",
+            modifiers: [.command],
+            keyCode: 9,
+            windowNumber: probeWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+V event")
+            return
+        }
+
+        XCTAssertTrue(
+            probeWindow.performKeyEquivalent(with: event),
+            "Cmd+V menu miss should still route through Ghostty binding resolution"
+        )
+        XCTAssertEqual(probeView.afterMenuMissCallCount, 1, "Ghostty binding resolution should run after the menu miss")
+        XCTAssertEqual(probeView.pasteCallCount, 0, "Window routing must not force paste before Ghostty inspects bindings")
+        XCTAssertEqual(
+            probeView.pasteAsPlainTextCallCount,
+            0,
+            "Window routing must not force plain-text paste before Ghostty inspects bindings"
+        )
     }
 
     func testWindowSendEventRepairsVisibleSameWindowResponderDriftForFocusedTerminalTyping() {

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1545,7 +1545,7 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
 }
 
 @MainActor
-final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
+final class GhosttyKeyEquivalentRegressionTests: XCTestCase {
     private struct PasteboardItemSnapshot {
         let representations: [(type: NSPasteboard.PasteboardType, data: Data)]
     }
@@ -1703,6 +1703,8 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             )
         }
     }
+
+    // MARK: - Terminal Paste Fallback
 
     func testCommandVPasteStillInvokesTerminalPasteWhenMainMenuMisses() throws {
         installGhosttyPasteActionSwizzle()

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -10,6 +10,8 @@ import ObjectiveC.runtime
 
 private var cjkIMEInterpretKeyEventsSwizzled = false
 private var cjkIMEInterpretKeyEventsHook: ((GhosttyNSView, [NSEvent]) -> Bool)?
+private var ghosttyPasteActionSwizzled = false
+private var ghosttyPasteActionHook: ((GhosttyNSView, Any?) -> Void)?
 
 private extension GhosttyNSView {
     @objc func cmuxUnitTest_interpretKeyEvents(_ eventArray: [NSEvent]) {
@@ -17,6 +19,11 @@ private extension GhosttyNSView {
             return
         }
         cmuxUnitTest_interpretKeyEvents(eventArray)
+    }
+
+    @objc func cmuxUnitTest_paste(_ sender: Any?) {
+        ghosttyPasteActionHook?(self, sender)
+        cmuxUnitTest_paste(sender)
     }
 }
 
@@ -50,6 +57,38 @@ private func installCJKIMEInterpretKeyEventsSwizzle() {
     }
 
     cjkIMEInterpretKeyEventsSwizzled = true
+}
+
+private func installGhosttyPasteActionSwizzle() {
+    guard !ghosttyPasteActionSwizzled else { return }
+
+    let originalSelector = #selector(GhosttyNSView.paste(_:))
+    let swizzledSelector = #selector(GhosttyNSView.cmuxUnitTest_paste(_:))
+
+    guard let originalMethod = class_getInstanceMethod(GhosttyNSView.self, originalSelector),
+          let swizzledMethod = class_getInstanceMethod(GhosttyNSView.self, swizzledSelector) else {
+        fatalError("Unable to locate GhosttyNSView paste methods for swizzling")
+    }
+
+    let didAddMethod = class_addMethod(
+        GhosttyNSView.self,
+        originalSelector,
+        method_getImplementation(swizzledMethod),
+        method_getTypeEncoding(swizzledMethod)
+    )
+
+    if didAddMethod {
+        class_replaceMethod(
+            GhosttyNSView.self,
+            swizzledSelector,
+            method_getImplementation(originalMethod),
+            method_getTypeEncoding(originalMethod)
+        )
+    } else {
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+
+    ghosttyPasteActionSwizzled = true
 }
 
 private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
@@ -1470,6 +1509,10 @@ final class GhosttyBackquoteRegressionTests: XCTestCase {
 
 @MainActor
 final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
+    private struct PasteboardItemSnapshot {
+        let representations: [(type: NSPasteboard.PasteboardType, data: Data)]
+    }
+
     private struct HostedTerminalWindow {
         let surface: TerminalSurface
         let window: NSWindow
@@ -1514,6 +1557,48 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             hostedView: hostedView,
             surfaceView: surfaceView
         )
+    }
+
+    private func snapshotPasteboardItems(_ pasteboard: NSPasteboard) -> [PasteboardItemSnapshot] {
+        guard let items = pasteboard.pasteboardItems else { return [] }
+        return items.map { item in
+            let representations = item.types.compactMap { type -> (NSPasteboard.PasteboardType, Data)? in
+                guard let data = item.data(forType: type) else { return nil }
+                return (type, data)
+            }
+            return PasteboardItemSnapshot(representations: representations)
+        }
+    }
+
+    private func restorePasteboardItems(
+        _ snapshots: [PasteboardItemSnapshot],
+        to pasteboard: NSPasteboard
+    ) {
+        pasteboard.clearContents()
+        guard !snapshots.isEmpty else { return }
+        let items = snapshots.compactMap { snapshot -> NSPasteboardItem? in
+            let item = NSPasteboardItem()
+            guard !snapshot.representations.isEmpty else { return nil }
+            for representation in snapshot.representations {
+                item.setData(representation.data, forType: representation.type)
+            }
+            return item
+        }
+        if !items.isEmpty {
+            _ = pasteboard.writeObjects(items)
+        }
+    }
+
+    private func installUnrelatedMainMenu() -> NSMenu {
+        let mainMenu = NSMenu()
+        let fileItem = NSMenuItem(title: "File", action: nil, keyEquivalent: "")
+        let fileMenu = NSMenu(title: "File")
+        let item = NSMenuItem(title: "New", action: nil, keyEquivalent: "n")
+        item.keyEquivalentModifierMask = [.command]
+        fileMenu.addItem(item)
+        mainMenu.addItem(fileItem)
+        mainMenu.setSubmenu(fileMenu, for: fileItem)
+        return mainMenu
     }
 
     func testShiftSlashPrintableKeyEquivalentBypassesShortcutPath() throws {
@@ -1580,6 +1665,74 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
                 "Printable Shift+? should continue through keyDown instead of being consumed as a key equivalent"
             )
         }
+    }
+
+    func testCommandVPasteStillInvokesTerminalPasteWhenMainMenuMisses() throws {
+        installGhosttyPasteActionSwizzle()
+
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        defer { window.orderOut(nil) }
+
+        window.makeFirstResponder(surfaceView)
+        XCTAssertNotNil(surfaceView.terminalSurface)
+
+        let previousMainMenu = NSApp.mainMenu
+        NSApp.mainMenu = installUnrelatedMainMenu()
+        defer { NSApp.mainMenu = previousMainMenu }
+
+        let pasteboard = NSPasteboard.general
+        let pasteboardSnapshot = snapshotPasteboardItems(pasteboard)
+        defer { restorePasteboardItems(pasteboardSnapshot, to: pasteboard) }
+        pasteboard.clearContents()
+        pasteboard.setString("opencode paste", forType: .string)
+
+        var pasteInvocationCount = 0
+        let previousPasteHook = ghosttyPasteActionHook
+        ghosttyPasteActionHook = { _, _ in
+            pasteInvocationCount += 1
+        }
+        defer { ghosttyPasteActionHook = previousPasteHook }
+
+        var forwardedCommandVCount = 0
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 9 else { return }
+            forwardedCommandVCount += 1
+        }
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "v",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ) else {
+            XCTFail("Failed to construct Cmd+V event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: event))
+        XCTAssertEqual(
+            pasteInvocationCount,
+            1,
+            "Cmd+V should still invoke the terminal paste action even if the window main-menu fast path misses"
+        )
+        XCTAssertEqual(
+            forwardedCommandVCount,
+            0,
+            "Cmd+V should not fall back to Ghostty keyDown when the terminal paste action is available"
+        )
     }
 }
 

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -12,6 +12,8 @@ private var cjkIMEInterpretKeyEventsSwizzled = false
 private var cjkIMEInterpretKeyEventsHook: ((GhosttyNSView, [NSEvent]) -> Bool)?
 private var ghosttyPasteActionSwizzled = false
 private var ghosttyPasteActionHook: ((GhosttyNSView, Any?) -> Void)?
+private var ghosttyPasteAsPlainTextActionSwizzled = false
+private var ghosttyPasteAsPlainTextActionHook: ((GhosttyNSView, Any?) -> Void)?
 
 private extension GhosttyNSView {
     @objc func cmuxUnitTest_interpretKeyEvents(_ eventArray: [NSEvent]) {
@@ -24,6 +26,11 @@ private extension GhosttyNSView {
     @objc func cmuxUnitTest_paste(_ sender: Any?) {
         ghosttyPasteActionHook?(self, sender)
         cmuxUnitTest_paste(sender)
+    }
+
+    @objc func cmuxUnitTest_pasteAsPlainText(_ sender: Any?) {
+        ghosttyPasteAsPlainTextActionHook?(self, sender)
+        cmuxUnitTest_pasteAsPlainText(sender)
     }
 }
 
@@ -89,6 +96,36 @@ private func installGhosttyPasteActionSwizzle() {
     }
 
     ghosttyPasteActionSwizzled = true
+
+    guard !ghosttyPasteAsPlainTextActionSwizzled else { return }
+
+    let plainTextOriginalSelector = #selector(GhosttyNSView.pasteAsPlainText(_:))
+    let plainTextSwizzledSelector = #selector(GhosttyNSView.cmuxUnitTest_pasteAsPlainText(_:))
+
+    guard let plainTextOriginalMethod = class_getInstanceMethod(GhosttyNSView.self, plainTextOriginalSelector),
+          let plainTextSwizzledMethod = class_getInstanceMethod(GhosttyNSView.self, plainTextSwizzledSelector) else {
+        fatalError("Unable to locate GhosttyNSView pasteAsPlainText methods for swizzling")
+    }
+
+    let didAddPlainTextMethod = class_addMethod(
+        GhosttyNSView.self,
+        plainTextOriginalSelector,
+        method_getImplementation(plainTextSwizzledMethod),
+        method_getTypeEncoding(plainTextSwizzledMethod)
+    )
+
+    if didAddPlainTextMethod {
+        class_replaceMethod(
+            GhosttyNSView.self,
+            plainTextSwizzledSelector,
+            method_getImplementation(plainTextOriginalMethod),
+            method_getTypeEncoding(plainTextOriginalMethod)
+        )
+    } else {
+        method_exchangeImplementations(plainTextOriginalMethod, plainTextSwizzledMethod)
+    }
+
+    ghosttyPasteAsPlainTextActionSwizzled = true
 }
 
 private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
@@ -1671,6 +1708,7 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
         installGhosttyPasteActionSwizzle()
 
         let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
         let window = hostedTerminal.window
         let surfaceView = hostedTerminal.surfaceView
         defer { window.orderOut(nil) }
@@ -1690,7 +1728,9 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
 
         var pasteInvocationCount = 0
         let previousPasteHook = ghosttyPasteActionHook
-        ghosttyPasteActionHook = { _, _ in
+        ghosttyPasteActionHook = { candidateView, sender in
+            previousPasteHook?(candidateView, sender)
+            guard candidateView === surfaceView else { return }
             pasteInvocationCount += 1
         }
         defer { ghosttyPasteActionHook = previousPasteHook }
@@ -1722,30 +1762,120 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertEqual(
-            pasteInvocationCount,
-            1,
-            "Cmd+V should still invoke the terminal paste action even if the window main-menu fast path misses"
-        )
-        XCTAssertEqual(
-            forwardedCommandVCount,
-            0,
-            "Cmd+V should not fall back to Ghostty keyDown when the terminal paste action is available"
-        )
+        withExtendedLifetime(terminalSurface) {
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(
+                pasteInvocationCount,
+                1,
+                "Cmd+V should still invoke the terminal paste action even if the window main-menu fast path misses"
+            )
+            XCTAssertEqual(
+                forwardedCommandVCount,
+                0,
+                "Cmd+V should not fall back to Ghostty keyDown when the terminal paste action is available"
+            )
+        }
     }
 
-    func testCommandVPasteRecreatesReleasedSurfaceBeforeConsumption() throws {
+    func testCommandShiftVPasteAsPlainTextStillInvokesTerminalFallbackWhenMainMenuMisses() throws {
         installGhosttyPasteActionSwizzle()
 
         let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
         let window = hostedTerminal.window
         let surfaceView = hostedTerminal.surfaceView
         defer { window.orderOut(nil) }
 
         window.makeFirstResponder(surfaceView)
         XCTAssertNotNil(surfaceView.terminalSurface)
-        XCTAssertNotNil(hostedTerminal.surface.surface)
+
+        let previousMainMenu = NSApp.mainMenu
+        NSApp.mainMenu = installUnrelatedMainMenu()
+        defer { NSApp.mainMenu = previousMainMenu }
+
+        let pasteboard = NSPasteboard.general
+        let pasteboardSnapshot = snapshotPasteboardItems(pasteboard)
+        defer { restorePasteboardItems(pasteboardSnapshot, to: pasteboard) }
+        pasteboard.clearContents()
+        pasteboard.setString("opencode paste plain text", forType: .string)
+
+        var pasteInvocationCount = 0
+        let previousPasteHook = ghosttyPasteActionHook
+        ghosttyPasteActionHook = { candidateView, sender in
+            previousPasteHook?(candidateView, sender)
+            guard candidateView === surfaceView else { return }
+            pasteInvocationCount += 1
+        }
+        defer { ghosttyPasteActionHook = previousPasteHook }
+
+        var pasteAsPlainTextInvocationCount = 0
+        let previousPasteAsPlainTextHook = ghosttyPasteAsPlainTextActionHook
+        ghosttyPasteAsPlainTextActionHook = { candidateView, sender in
+            previousPasteAsPlainTextHook?(candidateView, sender)
+            guard candidateView === surfaceView else { return }
+            pasteAsPlainTextInvocationCount += 1
+        }
+        defer { ghosttyPasteAsPlainTextActionHook = previousPasteAsPlainTextHook }
+
+        var forwardedCommandVCount = 0
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 9 else { return }
+            forwardedCommandVCount += 1
+        }
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+        }
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "V",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ) else {
+            XCTFail("Failed to construct Cmd+Shift+V event")
+            return
+        }
+
+        withExtendedLifetime(terminalSurface) {
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(
+                pasteInvocationCount,
+                0,
+                "Cmd+Shift+V should route through pasteAsPlainText instead of the regular terminal paste action"
+            )
+            XCTAssertEqual(
+                pasteAsPlainTextInvocationCount,
+                1,
+                "Cmd+Shift+V should still invoke the terminal pasteAsPlainText action even if the window main-menu fast path misses"
+            )
+            XCTAssertEqual(
+                forwardedCommandVCount,
+                0,
+                "Cmd+Shift+V should not fall back to Ghostty keyDown when the terminal plain-text paste action is available"
+            )
+        }
+    }
+
+    func testCommandVPasteRecreatesReleasedSurfaceBeforeConsumption() throws {
+        installGhosttyPasteActionSwizzle()
+
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        defer { window.orderOut(nil) }
+
+        window.makeFirstResponder(surfaceView)
+        XCTAssertNotNil(surfaceView.terminalSurface)
+        XCTAssertNotNil(terminalSurface.surface)
 
         let previousMainMenu = NSApp.mainMenu
         NSApp.mainMenu = installUnrelatedMainMenu()
@@ -1759,14 +1889,27 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
 
         var pasteInvocationCount = 0
         let previousPasteHook = ghosttyPasteActionHook
-        ghosttyPasteActionHook = { _, _ in
+        ghosttyPasteActionHook = { candidateView, sender in
+            previousPasteHook?(candidateView, sender)
+            guard candidateView === surfaceView else { return }
             pasteInvocationCount += 1
         }
         defer { ghosttyPasteActionHook = previousPasteHook }
 
-        hostedTerminal.surface.releaseSurfaceForTesting()
+        var forwardedCommandVCount = 0
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 9 else { return }
+            forwardedCommandVCount += 1
+        }
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+        }
+
+        terminalSurface.releaseSurfaceForTesting()
         XCTAssertNil(
-            hostedTerminal.surface.surface,
+            terminalSurface.surface,
             "Expected the runtime Ghostty surface to be released before simulating Cmd+V"
         )
 
@@ -1786,16 +1929,23 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             return
         }
 
-        XCTAssertTrue(window.performKeyEquivalent(with: event))
-        XCTAssertEqual(
-            pasteInvocationCount,
-            1,
-            "Cmd+V should still invoke the terminal paste action after a transient surface release"
-        )
-        XCTAssertNotNil(
-            hostedTerminal.surface.surface,
-            "Cmd+V should recreate the Ghostty surface before the direct terminal paste fallback consumes the shortcut"
-        )
+        withExtendedLifetime(terminalSurface) {
+            XCTAssertTrue(window.performKeyEquivalent(with: event))
+            XCTAssertEqual(
+                pasteInvocationCount,
+                1,
+                "Cmd+V should still invoke the terminal paste action after a transient surface release"
+            )
+            XCTAssertEqual(
+                forwardedCommandVCount,
+                0,
+                "Cmd+V should recover the Ghostty surface without falling back to keyDown"
+            )
+            XCTAssertNotNil(
+                terminalSurface.surface,
+                "Cmd+V should recreate the Ghostty surface before the direct terminal paste fallback consumes the shortcut"
+            )
+        }
     }
 }
 

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -1734,6 +1734,69 @@ final class GhosttyPrintableShiftKeyEquivalentRegressionTests: XCTestCase {
             "Cmd+V should not fall back to Ghostty keyDown when the terminal paste action is available"
         )
     }
+
+    func testCommandVPasteRecreatesReleasedSurfaceBeforeConsumption() throws {
+        installGhosttyPasteActionSwizzle()
+
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        defer { window.orderOut(nil) }
+
+        window.makeFirstResponder(surfaceView)
+        XCTAssertNotNil(surfaceView.terminalSurface)
+        XCTAssertNotNil(hostedTerminal.surface.surface)
+
+        let previousMainMenu = NSApp.mainMenu
+        NSApp.mainMenu = installUnrelatedMainMenu()
+        defer { NSApp.mainMenu = previousMainMenu }
+
+        let pasteboard = NSPasteboard.general
+        let pasteboardSnapshot = snapshotPasteboardItems(pasteboard)
+        defer { restorePasteboardItems(pasteboardSnapshot, to: pasteboard) }
+        pasteboard.clearContents()
+        pasteboard.setString("surface recovery paste", forType: .string)
+
+        var pasteInvocationCount = 0
+        let previousPasteHook = ghosttyPasteActionHook
+        ghosttyPasteActionHook = { _, _ in
+            pasteInvocationCount += 1
+        }
+        defer { ghosttyPasteActionHook = previousPasteHook }
+
+        hostedTerminal.surface.releaseSurfaceForTesting()
+        XCTAssertNil(
+            hostedTerminal.surface.surface,
+            "Expected the runtime Ghostty surface to be released before simulating Cmd+V"
+        )
+
+        guard let event = NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: "v",
+            charactersIgnoringModifiers: "v",
+            isARepeat: false,
+            keyCode: 9
+        ) else {
+            XCTFail("Failed to construct Cmd+V event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: event))
+        XCTAssertEqual(
+            pasteInvocationCount,
+            1,
+            "Cmd+V should still invoke the terminal paste action after a transient surface release"
+        )
+        XCTAssertNotNil(
+            hostedTerminal.surface.surface,
+            "Cmd+V should recreate the Ghostty surface before the direct terminal paste fallback consumes the shortcut"
+        )
+    }
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- add a regression test covering `Cmd+V` when the window-level main-menu bypass misses
- fall back to the terminal paste action instead of letting `Cmd+V` fall through to generic keyDown routing
- preserve bracketed paste behavior for TUIs like OpenCode when paste is available

Closes #2966

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+V/Cmd+Shift+V so a missed main‑menu path first runs Ghostty’s keybinding resolution, then falls back to terminal paste, preserving bracketed paste for TUIs like OpenCode. Also recreates the terminal surface before consuming the shortcut so paste works after a transient surface release.

- **Bug Fixes**
  - After a menu miss, the window now defers to the focused Ghostty view’s binding path; if consumed there, no forced paste is triggered, honoring user overrides.
  - When paste actions run, the view calls a new prepareSurfaceForPaste helper to ensure the surface exists before invoking paste or pasteAsPlainText, avoiding keyDown fallback.
  - Adds regression tests for menu-miss deferral, Cmd+V and Cmd+Shift+V fallbacks, surface recovery before paste, and pasteboard state preservation.
  - Closes #2966.

<sup>Written for commit a90bc5480ccc9f22e3efb7e50dbcab9e5e6a5c1e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Cmd+V and Cmd+Shift+V now consistently invoke the terminal's paste behavior when the terminal is focused, avoiding duplicate handling or fallback when the app menu path misses; pastes are blocked until the terminal is ready to accept input.
* **Tests**
  * Added regression tests to verify single paste invocation, menu-path miss handling, and clipboard preservation across surface recreation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts macOS key-equivalent routing for terminal-focused windows, which can affect global/menu shortcuts and paste behavior across layouts; covered by new regression tests but still touches input handling paths.
> 
> **Overview**
> Fixes a terminal paste regression where **Cmd+V / Cmd+Shift+V could bypass the terminal paste actions** after the window’s direct-to-menu key-equivalent fast path misses, causing the event to fall through to generic `keyDown` and break bracketed paste in TUIs.
> 
> The window now retries Ghostty’s command-binding resolution after a main-menu miss via `performKeyEquivalentAfterMenuMiss`, and the terminal view splits `performKeyEquivalent` into a main-menu-retry vs post-miss path. Paste actions (`paste`, `pasteAsPlainText`) now ensure/recover the underlying surface before executing.
> 
> Adds targeted regression tests that simulate main-menu misses, swizzle paste actions to assert single invocation, snapshot/restore the pasteboard, and verify surface recreation works when the runtime surface was released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a90bc5480ccc9f22e3efb7e50dbcab9e5e6a5c1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->