### PR TITLE
Fix startup hang from repeated file drop overlay install

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1798,20 +1798,30 @@ enum MountedWorkspacePresentationPolicy {
 }
 
 /// Installs a FileDropOverlayView on the window's theme frame for Finder file drag support.
-func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) {
-    guard objc_getAssociatedObject(window, &fileDropOverlayKey) == nil,
-          let contentView = window.contentView,
-          let themeFrame = contentView.superview else { return }
+private func findFileDropOverlayView(in root: NSView?) -> FileDropOverlayView? {
+    guard let root else { return nil }
+    if let overlay = root as? FileDropOverlayView {
+        return overlay
+    }
+    for subview in root.subviews {
+        if let overlay = findFileDropOverlayView(in: subview) {
+            return overlay
+        }
+    }
+    return nil
+}
 
-    let overlay = FileDropOverlayView(frame: contentView.frame)
-    overlay.translatesAutoresizingMaskIntoConstraints = false
+private func configureFileDropOverlay(_ overlay: FileDropOverlayView, tabManager: TabManager) {
     overlay.onDrop = { [weak tabManager] urls in
         MainActor.assumeIsolated {
             guard let tabManager, let terminal = tabManager.selectedWorkspace?.focusedTerminalPanel else { return false }
             return terminal.hostedView.handleDroppedURLs(urls)
         }
     }
+}
 
+private func attachFileDropOverlay(_ overlay: FileDropOverlayView, to contentView: NSView, in themeFrame: NSView) {
+    overlay.translatesAutoresizingMaskIntoConstraints = false
     themeFrame.addSubview(overlay, positioned: .above, relativeTo: contentView)
     NSLayoutConstraint.activate([
         overlay.topAnchor.constraint(equalTo: contentView.topAnchor),
@@ -1819,8 +1829,33 @@ func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) {
         overlay.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
         overlay.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
     ])
+}
 
+@discardableResult
+func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) -> Bool {
+    guard let contentView = window.contentView,
+          let themeFrame = contentView.superview else { return false }
+
+    let existingOverlay =
+        (objc_getAssociatedObject(window, &fileDropOverlayKey) as? FileDropOverlayView)
+        ?? findFileDropOverlayView(in: themeFrame)
+
+    if let existingOverlay {
+        configureFileDropOverlay(existingOverlay, tabManager: tabManager)
+        objc_setAssociatedObject(window, &fileDropOverlayKey, existingOverlay, .OBJC_ASSOCIATION_RETAIN)
+        guard existingOverlay.superview !== themeFrame else { return true }
+        existingOverlay.removeFromSuperview()
+        attachFileDropOverlay(existingOverlay, to: contentView, in: themeFrame)
+        return true
+    }
+
+    let overlay = FileDropOverlayView(frame: contentView.frame)
+    configureFileDropOverlay(overlay, tabManager: tabManager)
+    // Publish the overlay before mutating the view tree so any re-entrant lookup resolves
+    // the in-flight view instead of installing a second overlay during layout.
     objc_setAssociatedObject(window, &fileDropOverlayKey, overlay, .OBJC_ASSOCIATION_RETAIN)
+    attachFileDropOverlay(overlay, to: contentView, in: themeFrame)
+    return true
 }
 
 struct ContentView: View {
@@ -3700,6 +3735,11 @@ struct ContentView: View {
                 sidebarState: sidebarState,
                 sidebarSelectionState: sidebarSelectionState
             )
+        }))
+
+        // Install the file-drop overlay once the window hierarchy is ready, outside the
+        // high-frequency body-level window styling accessor above.
+        view = AnyView(view.background(WindowSetupAccessor { window in
             installFileDropOverlay(on: window, tabManager: tabManager)
         }))
 

--- a/Sources/WindowAccessor.swift
+++ b/Sources/WindowAccessor.swift
@@ -36,6 +36,48 @@ struct WindowAccessor: NSViewRepresentable {
     }
 }
 
+/// Replays the window callback until setup succeeds, then dedupes future updates for that window.
+struct WindowSetupAccessor: NSViewRepresentable {
+    let onWindow: (NSWindow) -> Bool
+
+    init(onWindow: @escaping (NSWindow) -> Bool) {
+        self.onWindow = onWindow
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
+    func makeNSView(context: Context) -> WindowObservingView {
+        let view = WindowObservingView()
+        view.onWindow = { window in
+            guard context.coordinator.completedWindow !== window else { return }
+            if onWindow(window) {
+                context.coordinator.completedWindow = window
+            }
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: WindowObservingView, context: Context) {
+        nsView.onWindow = { window in
+            guard context.coordinator.completedWindow !== window else { return }
+            if onWindow(window) {
+                context.coordinator.completedWindow = window
+            }
+        }
+        if let window = nsView.window {
+            nsView.onWindow?(window)
+        }
+    }
+}
+
+extension WindowSetupAccessor {
+    final class Coordinator {
+        weak var completedWindow: NSWindow?
+    }
+}
+
 extension WindowAccessor {
     final class Coordinator {
         weak var lastWindow: NSWindow?

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1027,6 +1027,40 @@ final class WindowMoveSuppressionHitPathTests: XCTestCase {
 
 @MainActor
 final class FileDropOverlayViewTests: XCTestCase {
+    private func makeContentViewWindow(windowId: UUID = UUID()) -> NSWindow {
+        _ = NSApplication.shared
+
+        let root = ContentView(updateViewModel: UpdateViewModel(), windowId: windowId)
+            .environmentObject(TabManager())
+            .environmentObject(TerminalNotificationStore.shared)
+            .environmentObject(SidebarState())
+            .environmentObject(SidebarSelectionState())
+            .environmentObject(FileExplorerState())
+            .environmentObject(CmuxConfigStore())
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = MainWindowHostingView(rootView: root)
+        return window
+    }
+
+    private func fileDropOverlays(in root: NSView?) -> [FileDropOverlayView] {
+        guard let root else { return [] }
+
+        var overlays: [FileDropOverlayView] = []
+        if let overlay = root as? FileDropOverlayView {
+            overlays.append(overlay)
+        }
+        for subview in root.subviews {
+            overlays.append(contentsOf: fileDropOverlays(in: subview))
+        }
+        return overlays
+    }
+
     private final class DragSpyWebView: WKWebView {
         var dragCalls: [String] = []
 
@@ -1105,6 +1139,34 @@ final class FileDropOverlayViewTests: XCTestCase {
         window.contentView?.layoutSubtreeIfNeeded()
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
         window.contentView?.layoutSubtreeIfNeeded()
+    }
+
+    func testContentViewInstallsSingleFileDropOverlayAcrossRepeatedLayouts() {
+        let window = makeContentViewWindow()
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        realizeWindowLayout(window)
+        realizeWindowLayout(window)
+        realizeWindowLayout(window)
+
+        guard let themeFrame = window.contentView?.superview else {
+            XCTFail("Expected theme frame")
+            return
+        }
+
+        let overlays = fileDropOverlays(in: themeFrame)
+        XCTAssertEqual(
+            overlays.count,
+            1,
+            "ContentView should install exactly one FileDropOverlayView even after repeated layout passes"
+        )
+        XCTAssertTrue(
+            (objc_getAssociatedObject(window, &fileDropOverlayKey) as? FileDropOverlayView) === overlays.first,
+            "The window-associated file-drop overlay should match the single installed view"
+        )
     }
 
     func testOverlayResolvesPortalHostedBrowserWebViewForFileDrops() {


### PR DESCRIPTION
Fixes #2944

## Summary
- add a regression test that hosts `ContentView` in a real window and asserts the file drop overlay appears exactly once after repeated layout passes
- make `installFileDropOverlay` idempotent by reusing an existing overlay from the window association or current view tree
- move the SwiftUI startup installation trigger into a one-shot window setup accessor so it no longer runs from the high-frequency body-level window styling path

## Before
- startup could enter a layout loop on macOS 15.6 because `ContentView` kept trying to install `FileDropOverlayView` while layout was already in progress
- the window opened blank, the app beachballed, and force quit was required

## After
- the file drop overlay is installed once per window after the hierarchy is ready
- re-entrant or repeated calls resolve the existing overlay instead of adding another subview, so startup completes normally

## Testing
- not run locally per repo policy
- required regression coverage added in `cmuxTests/WindowAndDragTests.swift`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window/view setup timing and drag-and-drop overlay attachment, which can impact startup/layout behavior across macOS versions; mitigated by added regression coverage asserting a single overlay after repeated layouts.
> 
> **Overview**
> Prevents a macOS startup/layout hang by making `installFileDropOverlay` **idempotent**: it now reuses or reattaches an existing `FileDropOverlayView` (from the window association or current view tree) and publishes the association before mutating the view hierarchy to avoid re-entrant double-installs.
> 
> Moves overlay installation out of the high-frequency SwiftUI body window accessor into a new `WindowSetupAccessor` that retries until setup succeeds and then dedupes per window.
> 
> Adds a regression test that hosts `ContentView` in a real `NSWindow` and asserts only one overlay exists after repeated layout passes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70618b0faf3285e22701cbde5deb0c6e2d907182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup hang on macOS 15.6 by making the file-drop overlay install idempotent and moving setup to a one-shot window accessor. Startup now completes normally and the overlay is installed exactly once per window (addresses #2944).

- **Bug Fixes**
  - Made `installFileDropOverlay` idempotent: reuses an existing `FileDropOverlayView` or reattaches it instead of adding duplicates; associates early to prevent re-entrant installs.
  - Moved installation to `WindowSetupAccessor` so it runs once after the window hierarchy is ready, not during high-frequency body updates.
  - Added a regression test that hosts `ContentView` in a real window and asserts a single overlay after repeated layout passes.

<sup>Written for commit 70618b0faf3285e22701cbde5deb0c6e2d907182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file drop overlay persistence during window layout changes. The overlay now correctly detects and maintains itself across window resizing and hierarchy reorganizations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->