### PR TITLE
Replace markdown pane with STTextView

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -45,7 +45,7 @@
 		A5007422 /* BrowserWebAuthnSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007423 /* BrowserWebAuthnSupport.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
-		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
+		A5001295 /* STTextView in Frameworks */ = {isa = PBXBuildFile; productRef = A5001294 /* STTextView */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		A5001406 /* Workspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001416 /* Workspace.swift */; };
 		A5001407 /* WorkspaceContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001417 /* WorkspaceContentView.swift */; };
@@ -121,6 +121,7 @@
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 					F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */; };
 					F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
+					FA200000A1B2C3D4E5F60718 /* MarkdownPanelTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA200001A1B2C3D4E5F60718 /* MarkdownPanelTextViewTests.swift */; };
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
@@ -328,6 +329,7 @@
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 					F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyEnsureFocusWindowActivationTests.swift; sourceTree = "<group>"; };
 					F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
+					FA200001A1B2C3D4E5F60718 /* MarkdownPanelTextViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTextViewTests.swift; sourceTree = "<group>"; };
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 					A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 				A5008382 /* CommandPaletteSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchEngineTests.swift; sourceTree = "<group>"; };
@@ -361,7 +363,7 @@
 					A5001230 /* Sparkle in Frameworks */,
 					A5001250 /* Sentry in Frameworks */,
 					A5001270 /* PostHog in Frameworks */,
-					A5001290 /* MarkdownUI in Frameworks */,
+					A5001295 /* STTextView in Frameworks */,
 				);
 				runOnlyForDeploymentPostprocessing = 0;
 			};
@@ -618,6 +620,7 @@
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 					F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
 					F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */,
+					FA200001A1B2C3D4E5F60718 /* MarkdownPanelTextViewTests.swift */,
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 					A5008382 /* CommandPaletteSearchEngineTests.swift */,
@@ -669,7 +672,7 @@
 					A5001251 /* Sentry */,
 					A5001271 /* PostHog */,
 					A5001261 /* Bonsplit */,
-					A5001291 /* MarkdownUI */,
+					A5001294 /* STTextView */,
 				);
 			name = GhosttyTabs;
 			productName = GhosttyTabs;
@@ -788,7 +791,7 @@
 					A5001232 /* XCRemoteSwiftPackageReference "Sparkle" */,
 					A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 					A5001272 /* XCRemoteSwiftPackageReference "posthog-ios" */,
-					A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */,
+					A5001293 /* XCRemoteSwiftPackageReference "STTextView" */,
 					A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
 				);
 			productRefGroup = A5001042 /* Products */;
@@ -927,6 +930,7 @@
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 					F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
 					F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,
+					FA200000A1B2C3D4E5F60718 /* MarkdownPanelTextViewTests.swift in Sources */,
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
@@ -1312,12 +1316,12 @@
 					minimumVersion = 3.41.0;
 				};
 			};
-			A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */ = {
+			A5001293 /* XCRemoteSwiftPackageReference "STTextView" */ = {
 				isa = XCRemoteSwiftPackageReference;
-				repositoryURL = "https://github.com/gonzalezreal/swift-markdown-ui";
+				repositoryURL = "https://github.com/krzyzanowskim/STTextView";
 				requirement = {
 					kind = upToNextMajorVersion;
-					minimumVersion = 2.4.1;
+					minimumVersion = 2.3.9;
 				};
 			};
 			A5001260 /* XCLocalSwiftPackageReference "bonsplit" */ = {
@@ -1347,10 +1351,10 @@
 				package = A5001260 /* XCLocalSwiftPackageReference "bonsplit" */;
 				productName = Bonsplit;
 			};
-			A5001291 /* MarkdownUI */ = {
+			A5001294 /* STTextView */ = {
 				isa = XCSwiftPackageProductDependency;
-				package = A5001292 /* XCRemoteSwiftPackageReference "swift-markdown-ui" */;
-				productName = MarkdownUI;
+				package = A5001293 /* XCRemoteSwiftPackageReference "STTextView" */;
+				productName = STTextView;
 			};
 /* End XCSwiftPackageProductDependency section */
 

--- a/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/GhosttyTabs.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,13 +1,13 @@
 {
-  "originHash" : "b66d812c506be67c70b46c63421ab2eb2db013613c74252ad1205f662ada079b",
+  "originHash" : "d6e697ed61148b5ed6f7c38d488b1cba990cb1cdbc72aa1498ab6cb2f08d01d5",
   "pins" : [
     {
-      "identity" : "networkimage",
+      "identity" : "coretextswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/NetworkImage",
+      "location" : "https://github.com/krzyzanowskim/CoreTextSwift",
       "state" : {
-        "revision" : "2849f5323265386e200484b0d0f896e73c3411b9",
-        "version" : "6.0.1"
+        "revision" : "833177201d6421e6322296f39fce6ff6ae52618a",
+        "version" : "0.2.0"
       }
     },
     {
@@ -38,21 +38,21 @@
       }
     },
     {
-      "identity" : "swift-cmark",
+      "identity" : "sttextkitplus",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-cmark",
+      "location" : "https://github.com/krzyzanowskim/STTextKitPlus",
       "state" : {
-        "revision" : "5d9bdaa4228b381639fff09403e39a04926e2dbe",
-        "version" : "0.7.1"
+        "revision" : "2ee74906f4d753458eeaa9a2f6d4538aacb86a1d",
+        "version" : "0.3.0"
       }
     },
     {
-      "identity" : "swift-markdown-ui",
+      "identity" : "sttextview",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gonzalezreal/swift-markdown-ui",
+      "location" : "https://github.com/krzyzanowskim/STTextView",
       "state" : {
-        "revision" : "5f613358148239d0292c0cef674a3c2314737f9e",
-        "version" : "2.4.1"
+        "revision" : "c36bf60f098f05d82d16dd4a7fe5135ef0678706",
+        "version" : "2.3.9"
       }
     }
   ],

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -1,8 +1,7 @@
 import AppKit
 import SwiftUI
-import MarkdownUI
+import STTextView
 
-/// SwiftUI view that renders a MarkdownPanel's content using MarkdownUI.
 struct MarkdownPanelView: View {
     @ObservedObject var panel: MarkdownPanel
     let isFocused: Bool
@@ -33,52 +32,21 @@ struct MarkdownPanelView: View {
         }
         .overlay {
             if isVisibleInUI {
-                // Observe left-clicks without intercepting them so markdown text
-                // selection and link activation continue to use the native path.
                 MarkdownPointerObserver(onPointerDown: onRequestPanelFocus)
             }
         }
-        .onChange(of: panel.focusFlashToken) { _ in
+        .onChange(of: panel.focusFlashToken) {
             triggerFocusFlashAnimation()
         }
     }
 
-    // MARK: - Content
-
     private var markdownContentView: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 0) {
-                // File path breadcrumb
-                filePathHeader
-                    .padding(.horizontal, 24)
-                    .padding(.top, 16)
-                    .padding(.bottom, 8)
-
-                Divider()
-                    .padding(.horizontal, 16)
-
-                // Rendered markdown
-                Markdown(panel.content)
-                    .markdownTheme(cmuxMarkdownTheme)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 24)
-                    .padding(.vertical, 16)
-            }
-        }
-    }
-
-    private var filePathHeader: some View {
-        HStack(spacing: 6) {
-            Image(systemName: "doc.richtext")
-                .foregroundColor(.secondary)
-                .font(.system(size: 12))
-            Text(panel.filePath)
-                .font(.system(size: 11, design: .monospaced))
-                .foregroundColor(.secondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-            Spacer()
-        }
+        MarkdownPanelTextSurface(
+            markdown: panel.content,
+            ghosttyConfig: ghosttyConfig,
+            isFocused: isFocused
+        )
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private var fileUnavailableView: some View {
@@ -89,13 +57,6 @@ struct MarkdownPanelView: View {
             Text(String(localized: "markdown.fileUnavailable.title", defaultValue: "File unavailable"))
                 .font(.headline)
                 .foregroundColor(.primary)
-            Text(panel.filePath)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 24)
             Text(String(localized: "markdown.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
                 .font(.caption)
                 .foregroundColor(.secondary)
@@ -103,167 +64,24 @@ struct MarkdownPanelView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    // MARK: - Theme
-
     private var backgroundColor: Color {
-        colorScheme == .dark
-            ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
-            : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
+        Color(nsColor: ghosttyConfig.backgroundColor)
     }
 
-    private var cmuxMarkdownTheme: Theme {
-        let isDark = colorScheme == .dark
-
-        return Theme()
-            // Text
-            .text {
-                ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
-                FontSize(14)
-            }
-            // Headings
-            .heading1 { configuration in
-                VStack(alignment: .leading, spacing: 8) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(28)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 24, bottom: 16)
-            }
-            .heading2 { configuration in
-                VStack(alignment: .leading, spacing: 6) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(22)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 20, bottom: 12)
-            }
-            .heading3 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(18)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 16, bottom: 8)
-            }
-            .heading4 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(16)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 12, bottom: 6)
-            }
-            .heading5 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(14)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 10, bottom: 4)
-            }
-            .heading6 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(13)
-                        ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
-                    }
-                    .markdownMargin(top: 8, bottom: 4)
-            }
-            // Code blocks
-            .codeBlock { configuration in
-                ScrollView(.horizontal, showsIndicators: true) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontFamilyVariant(.monospaced)
-                            FontSize(13)
-                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
-                        }
-                        .padding(12)
-                }
-                .background(isDark
-                    ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Inline code
-            .code {
-                FontFamilyVariant(.monospaced)
-                FontSize(13)
-                ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
-                BackgroundColor(isDark
-                    ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.92, alpha: 1.0)))
-            }
-            // Block quotes
-            .blockquote { configuration in
-                HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
-                        .frame(width: 3)
-                    configuration.label
-                        .markdownTextStyle {
-                            ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
-                            FontSize(14)
-                        }
-                        .padding(.leading, 12)
-                }
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Links
-            .link {
-                ForegroundColor(Color.accentColor)
-            }
-            // Strong
-            .strong {
-                FontWeight(.semibold)
-            }
-            // Tables
-            .table { configuration in
-                configuration.label
-                    .markdownTableBorderStyle(.init(color: isDark ? .white.opacity(0.15) : .gray.opacity(0.3)))
-                    .markdownTableBackgroundStyle(
-                        .alternatingRows(
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.14, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
-                        )
-                    )
-                    .markdownMargin(top: 8, bottom: 8)
-            }
-            // Thematic break (horizontal rule)
-            .thematicBreak {
-                Divider()
-                    .markdownMargin(top: 16, bottom: 16)
-            }
-            // List items
-            .listItem { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 4)
-            }
-            // Paragraphs
-            .paragraph { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 8)
-            }
+    private var ghosttyConfig: GhosttyConfig {
+        GhosttyConfig.load(preferredColorScheme: preferredColorScheme)
     }
 
-    // MARK: - Focus Flash
+    private var preferredColorScheme: GhosttyConfig.ColorSchemePreference {
+        switch colorScheme {
+        case .dark:
+            return .dark
+        case .light:
+            return .light
+        @unknown default:
+            return .dark
+        }
+    }
 
     private func triggerFocusFlashAnimation() {
         focusFlashAnimationGeneration &+= 1
@@ -286,6 +104,631 @@ struct MarkdownPanelView: View {
             return .easeIn(duration: duration)
         case .easeOut:
             return .easeOut(duration: duration)
+        }
+    }
+}
+
+struct MarkdownPanelTextSurface: NSViewRepresentable {
+    let markdown: String
+    let ghosttyConfig: GhosttyConfig
+    let isFocused: Bool
+
+    func makeNSView(context: Context) -> MarkdownPanelSTTextContainerView {
+        let view = MarkdownPanelSTTextContainerView()
+        view.update(markdown: markdown, ghosttyConfig: ghosttyConfig, isFocused: isFocused)
+        return view
+    }
+
+    func updateNSView(_ nsView: MarkdownPanelSTTextContainerView, context: Context) {
+        nsView.update(markdown: markdown, ghosttyConfig: ghosttyConfig, isFocused: isFocused)
+    }
+}
+
+@MainActor
+final class MarkdownPanelSTTextContainerView: NSView, STTextViewDelegate {
+    let scrollView = MarkdownPanelSTTextView.scrollableTextView()
+    let textView: MarkdownPanelSTTextView
+
+    private var currentMarkdown = ""
+    private var currentThemeKey = ""
+    private var currentFocusState = false
+    private var wantsFirstResponderWhenAttached = false
+
+    override init(frame frameRect: NSRect) {
+        guard let textView = scrollView.documentView as? MarkdownPanelSTTextView else {
+            fatalError("Expected MarkdownPanelSTTextView document view")
+        }
+        self.textView = textView
+        super.init(frame: frameRect)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor)
+        ])
+
+        MarkdownPanelEditorConfiguration.configure(textView: textView, scrollView: scrollView)
+        textView.textDelegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if wantsFirstResponderWhenAttached {
+            focusTextViewIfNeeded()
+        }
+    }
+
+    func update(markdown: String, ghosttyConfig: GhosttyConfig, isFocused: Bool) {
+        let theme = MarkdownPanelTheme(config: ghosttyConfig)
+        let themeChanged = theme.cacheKey != currentThemeKey
+        let contentChanged = markdown != currentMarkdown
+        let focusChanged = isFocused != currentFocusState
+
+        guard themeChanged || contentChanged || focusChanged else {
+            return
+        }
+
+        let previousOrigin = scrollView.contentView.bounds.origin
+        let previousViewportHeight = scrollView.contentView.bounds.height
+        let previousDocumentHeight = textView.frame.height
+        let previousScrollRatio = markdownScrollRatio(
+            originY: previousOrigin.y,
+            documentHeight: previousDocumentHeight,
+            viewportHeight: previousViewportHeight
+        )
+
+        MarkdownPanelEditorConfiguration.apply(theme: theme, to: textView, scrollView: scrollView)
+
+        if themeChanged || contentChanged {
+            textView.attributedText = MarkdownPanelAttributedRenderer.attributedString(markdown: markdown, theme: theme)
+        }
+
+        if contentChanged {
+            restoreScrollPosition(previousRatio: previousScrollRatio)
+            currentMarkdown = markdown
+        } else if themeChanged {
+            scrollView.contentView.scroll(to: previousOrigin)
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+        }
+
+        currentThemeKey = theme.cacheKey
+        currentFocusState = isFocused
+        if isFocused && focusChanged {
+            focusTextViewIfNeeded()
+        } else if !isFocused {
+            wantsFirstResponderWhenAttached = false
+        }
+    }
+
+    func textView(_ textView: STTextView, shouldChangeTextIn affectedCharRange: NSTextRange, replacementString: String?) -> Bool {
+        false
+    }
+
+    func textView(_ textView: STTextView, clickedOnLink link: Any, at location: any NSTextLocation) -> Bool {
+        guard let url = MarkdownPanelLinkActivationPolicy.url(for: link) else {
+            return true
+        }
+        guard MarkdownPanelLinkActivationPolicy.shouldOpenLink(
+            modifierFlags: (textView as? MarkdownPanelSTTextView)?.lastMouseDownModifierFlags ?? []
+        ) else {
+            return true
+        }
+        NSWorkspace.shared.open(url)
+        return true
+    }
+
+    private func markdownScrollRatio(originY: CGFloat, documentHeight: CGFloat, viewportHeight: CGFloat) -> CGFloat {
+        let scrollableHeight = max(documentHeight - viewportHeight, 0)
+        guard scrollableHeight > 0 else {
+            return 0
+        }
+        return min(max(originY / scrollableHeight, 0), 1)
+    }
+
+    private func restoreScrollPosition(previousRatio: CGFloat) {
+        let viewportHeight = scrollView.contentView.bounds.height
+        let scrollableHeight = max(textView.frame.height - viewportHeight, 0)
+        let restoredY = scrollableHeight * previousRatio
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: restoredY))
+        scrollView.reflectScrolledClipView(scrollView.contentView)
+    }
+
+    private func focusTextViewIfNeeded() {
+        guard let window else {
+            wantsFirstResponderWhenAttached = true
+            return
+        }
+        wantsFirstResponderWhenAttached = false
+        guard window.firstResponder !== textView else {
+            return
+        }
+        _ = window.makeFirstResponder(textView)
+    }
+}
+
+final class MarkdownPanelSTTextView: STTextView {
+    var lastMouseDownModifierFlags: NSEvent.ModifierFlags = []
+
+    override func mouseDown(with event: NSEvent) {
+        lastMouseDownModifierFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        super.mouseDown(with: event)
+        lastMouseDownModifierFlags = []
+    }
+}
+
+@MainActor
+enum MarkdownPanelEditorConfiguration {
+    static func configure(textView: STTextView, scrollView: NSScrollView) {
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.highlightSelectedLine = false
+        textView.showsLineNumbers = true
+        textView.isHorizontallyResizable = false
+        textView.isVerticallyResizable = true
+        textView.isIncrementalSearchingEnabled = true
+        textView.textFinder.incrementalSearchingShouldDimContentView = true
+
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+    }
+
+    static func apply(theme: MarkdownPanelTheme, to textView: STTextView, scrollView: NSScrollView) {
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.lineBreakMode = .byWordWrapping
+        paragraphStyle.lineSpacing = 3
+        paragraphStyle.paragraphSpacing = 8
+
+        textView.defaultParagraphStyle = paragraphStyle
+        textView.font = theme.font
+        textView.textColor = theme.textColor
+        textView.backgroundColor = theme.editorBackgroundColor
+        textView.insertionPointColor = theme.linkColor
+
+        scrollView.backgroundColor = theme.editorBackgroundColor
+
+        if let gutterView = textView.gutterView {
+            gutterView.font = theme.lineNumberFont
+            gutterView.textColor = theme.lineNumberColor
+            gutterView.selectedLineTextColor = theme.lineNumberColor
+            gutterView.selectedLineHighlightColor = theme.editorBackgroundColor
+            gutterView.separatorColor = theme.gutterBackgroundColor
+            gutterView.drawSeparator = false
+            gutterView.highlightSelectedLine = false
+            gutterView.minimumThickness = 44
+        }
+    }
+}
+
+struct MarkdownPanelTheme {
+    let cacheKey: String
+    let font: NSFont
+    let lineNumberFont: NSFont
+    let textColor: NSColor
+    let secondaryTextColor: NSColor
+    let tertiaryTextColor: NSColor
+    let headingColor: NSColor
+    let linkColor: NSColor
+    let quoteColor: NSColor
+    let codeColor: NSColor
+    let codeBackgroundColor: NSColor
+    let separatorColor: NSColor
+    let editorBackgroundColor: NSColor
+    let gutterBackgroundColor: NSColor
+    let lineNumberColor: NSColor
+    let strongFont: NSFont
+    let emphasisFont: NSFont
+    let codeFont: NSFont
+
+    private let headingFonts: [NSFont]
+
+    init(config: GhosttyConfig) {
+        let isLightBackground = config.backgroundColor.isLightColor
+        let baseFont = Self.font(family: config.fontFamily, size: config.fontSize, weight: .regular)
+        let baseLineNumberFont = Self.font(
+            family: config.fontFamily,
+            size: max(config.fontSize - 1, 10),
+            weight: .regular
+        )
+
+        cacheKey = [
+            config.fontFamily,
+            String(format: "%.2f", config.fontSize),
+            config.backgroundColor.hexString(),
+            config.foregroundColor.hexString(),
+            config.cursorColor.hexString(),
+            config.selectionBackground.hexString(),
+            config.selectionForeground.hexString(),
+            config.palette[2]?.hexString() ?? "nil",
+            config.palette[4]?.hexString() ?? "nil",
+            config.palette[5]?.hexString() ?? "nil"
+        ].joined(separator: "|")
+
+        font = baseFont
+        lineNumberFont = baseLineNumberFont
+        strongFont = NSFontManager.shared.convert(baseFont, toHaveTrait: .boldFontMask)
+        emphasisFont = NSFontManager.shared.convert(baseFont, toHaveTrait: .italicFontMask)
+        codeFont = Self.font(family: config.fontFamily, size: config.fontSize, weight: .regular)
+
+        editorBackgroundColor = config.backgroundColor
+        gutterBackgroundColor = config.backgroundColor
+        textColor = config.foregroundColor
+        secondaryTextColor = config.foregroundColor.blended(withFraction: 0.28, of: config.backgroundColor) ?? config.foregroundColor
+        tertiaryTextColor = config.foregroundColor.blended(withFraction: 0.5, of: config.backgroundColor) ?? config.foregroundColor
+        lineNumberColor = tertiaryTextColor
+        headingColor = config.palette[5] ?? config.palette[13] ?? config.foregroundColor
+        linkColor = config.palette[4] ?? config.palette[12] ?? config.foregroundColor
+        quoteColor = secondaryTextColor
+        codeColor = config.palette[2] ?? config.palette[10] ?? config.foregroundColor
+        codeBackgroundColor = config.backgroundColor.blended(
+            withFraction: isLightBackground ? 0.18 : 0.28,
+            of: config.selectionBackground
+        ) ?? config.selectionBackground
+        separatorColor = tertiaryTextColor
+
+        headingFonts = (1...6).map { level in
+            let size = baseFont.pointSize + CGFloat(7 - level) * 2.6
+            return Self.font(
+                family: config.fontFamily,
+                size: size,
+                weight: level <= 2 ? .bold : .semibold
+            )
+        }
+    }
+
+    func headingFont(for level: Int) -> NSFont {
+        headingFonts[max(0, min(headingFonts.count - 1, level - 1))]
+    }
+
+    private static func font(family: String, size: CGFloat, weight: NSFont.Weight) -> NSFont {
+        if let font = NSFontManager.shared.font(
+            withFamily: family,
+            traits: weight >= .semibold ? .boldFontMask : [],
+            weight: weight >= .bold ? 9 : (weight >= .semibold ? 7 : 5),
+            size: size
+        ) {
+            return font
+        }
+        if let font = NSFont(name: family, size: size) {
+            return font
+        }
+        return NSFont.monospacedSystemFont(ofSize: size, weight: weight)
+    }
+}
+
+enum MarkdownPanelAttributedRenderer {
+    private static let markdownLinkRegex = makeRegex(#"\[([^\]]+)\]\(([^)\s]+)\)"#)
+    private static let autolinkRegex = makeRegex(#"<((?:https?|mailto):[^>\s]+)>"#)
+    private static let strongRegex = makeRegex(#"(\*\*[^*\n]+\*\*|__[^_\n]+__)"#)
+    private static let emphasisRegex = makeRegex(#"(?<!\*)\*[^*\n]+\*(?!\*)|(?<!_)_[^_\n]+_(?!_)"#)
+    private static let inlineCodeRegex = makeRegex(#"`[^`\n]+`"#)
+    private static let unorderedListRegex = makeRegex(#"^\s*(?:[-*+]\s+)"#)
+    private static let orderedListRegex = makeRegex(#"^\s*\d+\.\s+"#)
+    private static let taskListRegex = makeRegex(#"^\s*[-*+]\s+\[[ xX]\]\s+"#)
+    private static let blockQuoteRegex = makeRegex(#"^\s*>\s?.*$"#)
+    private static let thematicBreakRegex = makeRegex(#"^\s*(?:-{3,}|\*{3,}|_{3,})\s*$"#)
+    private static let fenceRegex = makeRegex(#"^\s*```"#)
+
+    static func attributedString(markdown: String, theme: MarkdownPanelTheme) -> NSAttributedString {
+        let source = markdown as NSString
+        let fullRange = NSRange(location: 0, length: source.length)
+        let attributed = NSMutableAttributedString(
+            string: markdown,
+            attributes: [
+                .font: theme.font,
+                .foregroundColor: theme.textColor,
+                .paragraphStyle: paragraphStyle(
+                    lineSpacing: 3,
+                    paragraphSpacing: 8,
+                    paragraphSpacingBefore: 0
+                )
+            ]
+        )
+        let excludedInlineRanges = NSMutableArray()
+
+        var isInsideFencedCodeBlock = false
+        var location = 0
+        while location < source.length {
+            let lineRange = source.lineRange(for: NSRange(location: location, length: 0))
+            let lineContentRange = trimmedLineContentRange(for: lineRange, in: source)
+            let lineText = source.substring(with: lineContentRange)
+
+            if matches(fenceRegex, lineText) {
+                excludedInlineRanges.add(NSValue(range: lineContentRange))
+                attributed.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.tertiaryTextColor,
+                        .backgroundColor: theme.codeBackgroundColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 6, paragraphSpacingBefore: 6)
+                    ],
+                    range: lineRange
+                )
+                isInsideFencedCodeBlock.toggle()
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if isInsideFencedCodeBlock {
+                excludedInlineRanges.add(NSValue(range: lineContentRange))
+                attributed.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.codeColor,
+                        .backgroundColor: theme.codeBackgroundColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 4, paragraphSpacingBefore: 0)
+                    ],
+                    range: lineRange
+                )
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if let heading = headingMetadata(in: lineText) {
+                let hashRange = NSRange(
+                    location: lineContentRange.location + heading.hashRange.location,
+                    length: heading.hashRange.length
+                )
+                let titleRange = NSRange(
+                    location: lineContentRange.location + heading.titleRange.location,
+                    length: heading.titleRange.length
+                )
+                attributed.addAttribute(.foregroundColor, value: theme.tertiaryTextColor, range: hashRange)
+                attributed.addAttributes(
+                    [
+                        .font: theme.headingFont(for: heading.level),
+                        .foregroundColor: theme.headingColor
+                    ],
+                    range: titleRange
+                )
+                attributed.addAttribute(
+                    .paragraphStyle,
+                    value: paragraphStyle(
+                        lineSpacing: 4,
+                        paragraphSpacing: heading.level <= 2 ? 16 : 10,
+                        paragraphSpacingBefore: heading.level == 1 ? 8 : 4
+                    ),
+                    range: lineRange
+                )
+                location = NSMaxRange(lineRange)
+                continue
+            }
+
+            if matches(blockQuoteRegex, lineText) {
+                attributed.addAttributes(
+                    [
+                        .foregroundColor: theme.quoteColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 3, paragraphSpacing: 8, paragraphSpacingBefore: 0)
+                    ],
+                    range: lineRange
+                )
+            } else if matches(thematicBreakRegex, lineText) {
+                attributed.addAttributes(
+                    [
+                        .foregroundColor: theme.separatorColor,
+                        .paragraphStyle: paragraphStyle(lineSpacing: 2, paragraphSpacing: 12, paragraphSpacingBefore: 6)
+                    ],
+                    range: lineRange
+                )
+            } else if lineText.contains("|") {
+                attributed.addAttributes(
+                    [
+                        .font: theme.codeFont,
+                        .foregroundColor: theme.textColor
+                    ],
+                    range: lineContentRange
+                )
+            }
+
+            if let markerRange = listMarkerRange(in: lineText) {
+                let absoluteMarkerRange = NSRange(
+                    location: lineContentRange.location + markerRange.location,
+                    length: markerRange.length
+                )
+                attributed.addAttribute(.foregroundColor, value: theme.tertiaryTextColor, range: absoluteMarkerRange)
+            }
+
+            location = NSMaxRange(lineRange)
+        }
+
+        applyStrongAttributes(to: attributed, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyEmphasisAttributes(to: attributed, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyInlineCodeAttributes(to: attributed, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+        applyLinkAttributes(to: attributed, markdown: source, in: fullRange, theme: theme, excludedRanges: excludedInlineRanges)
+
+        return attributed
+    }
+
+    private static func applyStrongAttributes(
+        to attributed: NSMutableAttributedString,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        strongRegex.enumerateMatches(in: attributed.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            attributed.addAttribute(.font, value: theme.strongFont, range: range)
+        }
+    }
+
+    private static func applyEmphasisAttributes(
+        to attributed: NSMutableAttributedString,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        emphasisRegex.enumerateMatches(in: attributed.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            attributed.addAttribute(.font, value: theme.emphasisFont, range: range)
+        }
+    }
+
+    private static func applyInlineCodeAttributes(
+        to attributed: NSMutableAttributedString,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        inlineCodeRegex.enumerateMatches(in: attributed.string, range: fullRange) { match, _, _ in
+            guard let range = match?.range, range.length > 0 else { return }
+            guard !intersectsExcludedRanges(range, excludedRanges: excludedRanges) else { return }
+            attributed.addAttributes(
+                [
+                    .font: theme.codeFont,
+                    .foregroundColor: theme.codeColor,
+                    .backgroundColor: theme.codeBackgroundColor
+                ],
+                range: range
+            )
+        }
+    }
+
+    private static func applyLinkAttributes(
+        to attributed: NSMutableAttributedString,
+        markdown: NSString,
+        in fullRange: NSRange,
+        theme: MarkdownPanelTheme,
+        excludedRanges: NSMutableArray
+    ) {
+        markdownLinkRegex.enumerateMatches(in: markdown as String, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !intersectsExcludedRanges(match.range, excludedRanges: excludedRanges) else { return }
+            let urlString = markdown.substring(with: match.range(at: 2))
+            guard let url = URL(string: urlString) else { return }
+            attributed.addAttributes(
+                [
+                    .foregroundColor: theme.linkColor,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                    .link: url
+                ],
+                range: match.range
+            )
+        }
+
+        autolinkRegex.enumerateMatches(in: markdown as String, range: fullRange) { match, _, _ in
+            guard let match else { return }
+            guard !intersectsExcludedRanges(match.range, excludedRanges: excludedRanges) else { return }
+            let urlString = markdown.substring(with: match.range(at: 1))
+            guard let url = URL(string: urlString) else { return }
+            attributed.addAttributes(
+                [
+                    .foregroundColor: theme.linkColor,
+                    .underlineStyle: NSUnderlineStyle.single.rawValue,
+                    .link: url
+                ],
+                range: match.range
+            )
+        }
+    }
+
+    private static func headingMetadata(in lineText: String) -> (level: Int, hashRange: NSRange, titleRange: NSRange)? {
+        let source = lineText as NSString
+        var level = 0
+        while level < min(6, source.length), source.character(at: level) == unichar(35) {
+            level += 1
+        }
+        guard level > 0,
+              source.length > level,
+              CharacterSet.whitespaces.contains(UnicodeScalar(source.character(at: level))!) else {
+            return nil
+        }
+
+        let titleLocation = level + 1
+        let titleLength = source.length - titleLocation
+        guard titleLength > 0 else {
+            return nil
+        }
+
+        return (
+            level,
+            NSRange(location: 0, length: level),
+            NSRange(location: titleLocation, length: titleLength)
+        )
+    }
+
+    private static func listMarkerRange(in lineText: String) -> NSRange? {
+        let fullRange = NSRange(location: 0, length: (lineText as NSString).length)
+        if let match = taskListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        if let match = unorderedListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        if let match = orderedListRegex.firstMatch(in: lineText, range: fullRange) {
+            return match.range
+        }
+        return nil
+    }
+
+    private static func paragraphStyle(
+        lineSpacing: CGFloat,
+        paragraphSpacing: CGFloat,
+        paragraphSpacingBefore: CGFloat
+    ) -> NSParagraphStyle {
+        let style = NSMutableParagraphStyle()
+        style.lineSpacing = lineSpacing
+        style.paragraphSpacing = paragraphSpacing
+        style.paragraphSpacingBefore = paragraphSpacingBefore
+        style.lineBreakMode = .byWordWrapping
+        return style
+    }
+
+    private static func trimmedLineContentRange(for lineRange: NSRange, in source: NSString) -> NSRange {
+        var length = lineRange.length
+        while length > 0 {
+            let character = source.character(at: lineRange.location + length - 1)
+            if character == 10 || character == 13 {
+                length -= 1
+            } else {
+                break
+            }
+        }
+        return NSRange(location: lineRange.location, length: length)
+    }
+
+    private static func matches(_ regex: NSRegularExpression, _ text: String) -> Bool {
+        regex.firstMatch(in: text, range: NSRange(location: 0, length: (text as NSString).length)) != nil
+    }
+
+    private static func intersectsExcludedRanges(_ range: NSRange, excludedRanges: NSMutableArray) -> Bool {
+        for case let value as NSValue in excludedRanges {
+            if NSIntersectionRange(range, value.rangeValue).length > 0 {
+                return true
+            }
+        }
+        return false
+    }
+
+    private static func makeRegex(_ pattern: String) -> NSRegularExpression {
+        try! NSRegularExpression(pattern: pattern, options: [.anchorsMatchLines])
+    }
+}
+
+enum MarkdownPanelLinkActivationPolicy {
+    static func shouldOpenLink(modifierFlags: NSEvent.ModifierFlags) -> Bool {
+        modifierFlags.contains(.command)
+    }
+
+    static func url(for value: Any) -> URL? {
+        switch value {
+        case let url as URL:
+            return url
+        case let string as String:
+            return URL(string: string)
+        default:
+            return nil
         }
     }
 }
@@ -380,16 +823,7 @@ final class MarkdownPanelPointerObserverView: NSView {
     }
 
     private func forwardedTarget(for event: NSEvent) -> NSView? {
-        guard let window else {
-#if DEBUG
-            NSLog("MarkdownPanelPointerObserverView.forwardedTarget skipped, window=0 contentView=0")
-#endif
-            return nil
-        }
-        guard let contentView = window.contentView else {
-#if DEBUG
-            NSLog("MarkdownPanelPointerObserverView.forwardedTarget skipped, window=1 contentView=0")
-#endif
+        guard let window, let contentView = window.contentView else {
             return nil
         }
         isHidden = true

--- a/cmuxTests/MarkdownPanelTextViewTests.swift
+++ b/cmuxTests/MarkdownPanelTextViewTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+import AppKit
+import STTextView
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class MarkdownPanelTextViewTests: XCTestCase {
+    func testRendererStylesHeadingsAndLinks() {
+        let theme = MarkdownPanelTheme(config: makeGhosttyConfig())
+        let markdown = """
+        ## Heading
+        Visit [repo](https://example.com/repo)
+        """
+
+        let attributed = MarkdownPanelAttributedRenderer.attributedString(markdown: markdown, theme: theme)
+        let source = markdown as NSString
+
+        let headingRange = source.range(of: "Heading")
+        let headingFont = attributed.attribute(.font, at: headingRange.location, effectiveRange: nil) as? NSFont
+        XCTAssertNotNil(headingFont)
+        XCTAssertGreaterThan(headingFont?.pointSize ?? 0, theme.font.pointSize)
+
+        let linkRange = source.range(of: "[repo](https://example.com/repo)")
+        let linkURL = attributed.attribute(.link, at: linkRange.location, effectiveRange: nil) as? URL
+        XCTAssertEqual(linkURL?.absoluteString, "https://example.com/repo")
+    }
+
+    func testEditorConfigurationEnablesLineNumbersAndGhosttyTheme() {
+        let scrollView = MarkdownPanelSTTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? MarkdownPanelSTTextView else {
+            XCTFail("Expected MarkdownPanelSTTextView document view")
+            return
+        }
+
+        let config = makeGhosttyConfig()
+        let theme = MarkdownPanelTheme(config: config)
+
+        MarkdownPanelEditorConfiguration.configure(textView: textView, scrollView: scrollView)
+        MarkdownPanelEditorConfiguration.apply(theme: theme, to: textView, scrollView: scrollView)
+
+        guard let gutterView = textView.gutterView else {
+            XCTFail("Expected STTextView gutter view")
+            return
+        }
+
+        XCTAssertTrue(textView.showsLineNumbers)
+        XCTAssertFalse(textView.isEditable)
+        XCTAssertFalse(scrollView.hasHorizontalScroller)
+        XCTAssertEqual(textView.font.pointSize, config.fontSize, accuracy: 0.01)
+        XCTAssertEqual(textView.textColor.hexString(), config.foregroundColor.hexString())
+        XCTAssertEqual(textView.backgroundColor?.hexString(), config.backgroundColor.hexString())
+        XCTAssertEqual(scrollView.backgroundColor.hexString(), config.backgroundColor.hexString())
+        XCTAssertEqual(gutterView.font.pointSize, max(config.fontSize - 1, 10), accuracy: 0.01)
+        XCTAssertEqual(gutterView.textColor.hexString(), theme.lineNumberColor.hexString())
+        XCTAssertFalse(gutterView.drawSeparator)
+    }
+
+    func testLinkActivationRequiresCommandModifier() {
+        XCTAssertFalse(MarkdownPanelLinkActivationPolicy.shouldOpenLink(modifierFlags: []))
+        XCTAssertTrue(MarkdownPanelLinkActivationPolicy.shouldOpenLink(modifierFlags: [.command]))
+    }
+
+    private func makeGhosttyConfig() -> GhosttyConfig {
+        var config = GhosttyConfig()
+        config.fontFamily = "Menlo"
+        config.fontSize = 14
+        config.backgroundColor = NSColor(hex: "#1f2330")!
+        config.foregroundColor = NSColor(hex: "#d5d8da")!
+        config.cursorColor = NSColor(hex: "#88c0d0")!
+        config.selectionBackground = NSColor(hex: "#39404f")!
+        config.selectionForeground = NSColor(hex: "#f6f7f8")!
+        config.palette[2] = NSColor(hex: "#a3be8c")!
+        config.palette[4] = NSColor(hex: "#81a1c1")!
+        config.palette[5] = NSColor(hex: "#b48ead")!
+        return config
+    }
+}


### PR DESCRIPTION
Replaces the markdown pane implementation with STTextView.

What changed:
- swaps the package dependency from MarkdownUI to STTextView
- renders markdown into a read-only STTextView surface
- keeps Ghostty font family, font size, and background/foreground colors
- enables line numbers in the markdown pane
- keeps link attributes and opens links on cmd-click
- adds focused unit coverage for renderer styling, theme application, and cmd-click link policy

Verification:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sttext-unit test -only-testing:cmuxTests/MarkdownPanelTextViewTests`
- `./scripts/reload.sh --tag sttext`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the markdown pane with `STTextView` for native text rendering while keeping the Ghostty look and feel. Adds line numbers and cmd-click to open links, and removes `MarkdownUI`.

- **New Features**
  - Read-only `STTextView` markdown surface with Ghostty font, size, and colors.
  - Line numbers enabled; links keep attributes and open on cmd-click.
  - Preserves scroll position on content/theme changes; adds focused tests for styling, theming, and link policy.

- **Dependencies**
  - Swap `MarkdownUI` → `STTextView` (adds `CoreTextSwift` and `STTextKitPlus`).
  - Update Xcode project and `Package.resolved`.

<sup>Written for commit 48cc4119136690281bbe759e3c1b25e0651d51dd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated markdown panel rendering with improved text display component.
  * Links in markdown panels now require Command modifier to open.

* **Tests**
  * Added comprehensive test coverage for markdown panel functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->