### PR TITLE
Fix Ghostty search resize race

### DIFF
--- a/docs/ghostty-fork.md
+++ b/docs/ghostty-fork.md
@@ -14,7 +14,7 @@ When we change the fork, update this document and the parent submodule SHA.
 
 Fork main has advanced beyond the March 30, 2026 rebase onto upstream `main`
 at `3509ccf78` (`v1.3.1-457-g3509ccf78`).
-Current cmux pinned fork head: `3b684a085` (`tip-1717-g3b684a085`).
+Current cmux pinned fork head: `a2f864d61` (`issue-2738-search-resize-race`).
 
 ### 1) macOS display link restart on display changes
 
@@ -123,6 +123,17 @@ tend to conflict together during rebases.
 Fork main now carries the section 8 APC handling fix plus later upstream merges;
 the current cmux pin is the head listed above.
 
+### 9) Search snapshot isolation during page reflow
+
+- Commit: `a2f864d61` (terminal/search: snapshot pages before formatting)
+- Files:
+  - `src/terminal/highlight.zig`
+  - `src/terminal/search/sliding_window.zig`
+- Summary:
+  - Snapshots page contents before `SlidingWindow` runs `PageFormatter`, so background search never formats from live page storage that `PageList.resizeCols` can free or recycle.
+  - Caches page row counts alongside flattened search chunks so later highlight assembly no longer dereferences live page nodes after the source screen has mutated.
+  - Adds a regression test that destroys the source screen after taking search snapshots and verifies the retained search data still produces the expected cross-page match.
+
 ## Upstreamed fork changes
 
 ### cursor-click-to-move respects OSC 133 click-to-move
@@ -183,5 +194,10 @@ These files change frequently upstream; be careful when rebasing the fork:
   - Keep the APC handler wired into `.apc_start`, `.apc_put`, `.apc_end`, and preserve the
     `apcEnd()` response path so kitty graphics still reach `Terminal.kittyGraphics()` and reply via
     `write_pty`.
+
+- `src/terminal/search/sliding_window.zig`, `src/terminal/highlight.zig`
+  - Keep the retained-page search path copying from snapshots rather than live page storage, and
+    preserve the cached `rows` metadata on flattened chunks so reverse-search fixups never have to
+    dereference invalidated page nodes.
 
 If you resolve a conflict, update this doc with what changed.


### PR DESCRIPTION
## Summary
- bump the Ghostty submodule to snapshot page contents before formatting so search/highlight work does not read page storage that `resizeCols` has freed or recycled
- carry cached page row counts in the retained search data so later highlight assembly does not dereference live page nodes after screen mutation
- update `docs/ghostty-fork.md` with the new fork pin and conflict notes for the retained-page search path

## Testing
- not run locally per repo policy

## Notes
- the Ghostty submodule commit includes a regression test covering search data retained after the source screen is torn down

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a search/resize race in `ghostty` that let search/highlight read freed page storage during column resize (Linear 2738). We now snapshot pages before formatting and cache row counts so highlights don’t touch mutated pages.

- **Bug Fixes**
  - Snapshot page contents before running the formatter to avoid reading freed or recycled storage on resize.
  - Cache per-page row counts with flattened search chunks so highlight assembly doesn’t dereference live page nodes after reflow.

- **Dependencies**
  - Bumped `ghostty` submodule to include the snapshot-based search fix and a regression test.
  - Updated `docs/ghostty-fork.md` with the new fork pin and conflict notes for the retained-page search path.

<sup>Written for commit 641d58aed1c28ad284036e240a1f577ffb9f58d2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
* Updated fork documentation reflecting recent optimizations to terminal search functionality, including improvements to snapshot-based processing and search result caching mechanisms.

## Chores
* Updated internal submodule reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->