### PR TITLE
Restore previous sessions and resume agents

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1752,6 +1752,16 @@ struct CMUXCLI {
             return
         }
 
+        if command == "restore-session" {
+            try runRestoreSession(
+                commandArgs: commandArgs,
+                socketPath: resolvedSocketPath,
+                explicitPassword: socketPasswordArg,
+                jsonOutput: jsonOutput
+            )
+            return
+        }
+
         if command == "feedback" {
             try runFeedback(
                 commandArgs: commandArgs,
@@ -3137,6 +3147,45 @@ struct CMUXCLI {
             "target": "keyboardShortcuts",
             "activate": true,
         ])
+        if jsonOutput {
+            print(jsonString(response))
+        } else {
+            print("OK")
+        }
+    }
+
+    private func runRestoreSession(
+        commandArgs: [String],
+        socketPath: String,
+        explicitPassword: String?,
+        jsonOutput: Bool
+    ) throws {
+        let remaining = commandArgs.filter { $0 != "--" }
+        if let unknown = remaining.first {
+            throw CLIError(message: "restore-session: unknown flag '\(unknown)'")
+        }
+
+        let client = SocketClient(path: socketPath)
+        if (try? client.connect()) == nil {
+            client.close()
+            try launchApp()
+            try activateApp()
+            if jsonOutput {
+                print(jsonString(["restored": true, "launched": true]))
+            } else {
+                print("OK")
+            }
+            return
+        }
+
+        defer { client.close() }
+        try authenticateClientIfNeeded(
+            client,
+            explicitPassword: explicitPassword,
+            socketPath: socketPath
+        )
+
+        let response = try client.sendV2(method: "session.restore_previous")
         if jsonOutput {
             print(jsonString(response))
         } else {
@@ -6837,6 +6886,15 @@ struct CMUXCLI {
             Usage: cmux shortcuts
 
             Open the Settings window to Keyboard Shortcuts.
+            """
+        case "restore-session":
+            return """
+            Usage: cmux restore-session
+
+            Reopen the previous saved cmux session.
+
+            If the app is already running, this restores the last saved session into the current app.
+            If the app is not running, this launches cmux and lets startup restore reopen the saved session.
             """
         case "feedback":
             return """
@@ -14351,6 +14409,7 @@ struct CMUXCLI {
         Commands:
           welcome
           shortcuts
+          restore-session
           feedback [--email <email> --body <text> [--image <path> ...]]
           themes [list|set|clear]
           claude-teams [claude-args...]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -76,6 +76,7 @@
 		A5001209 /* WindowToolbarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001219 /* WindowToolbarController.swift */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
 		A5001610 /* SessionPersistence.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001611 /* SessionPersistence.swift */; };
+		A5001660 /* RestorableAgentSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001661 /* RestorableAgentSession.swift */; };
 		A5001640 /* RemoteRelayZshBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001641 /* RemoteRelayZshBootstrap.swift */; };
 		A5001650 /* CmuxConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001651 /* CmuxConfig.swift */; };
 		A5001652 /* CmuxConfigExecutor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001653 /* CmuxConfigExecutor.swift */; };
@@ -280,6 +281,7 @@
 		A5001223 /* UpdateLogStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateLogStore.swift; sourceTree = "<group>"; };
 		A5001241 /* WindowDecorationsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDecorationsController.swift; sourceTree = "<group>"; };
 		A5001611 /* SessionPersistence.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistence.swift; sourceTree = "<group>"; };
+		A5001661 /* RestorableAgentSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentSession.swift; sourceTree = "<group>"; };
 		A5001651 /* CmuxConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfig.swift; sourceTree = "<group>"; };
 		A5001653 /* CmuxConfigExecutor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigExecutor.swift; sourceTree = "<group>"; };
 		A5001655 /* CmuxDirectoryTrust.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxDirectoryTrust.swift; sourceTree = "<group>"; };
@@ -527,6 +529,7 @@
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				A5001611 /* SessionPersistence.swift */,
+				A5001661 /* RestorableAgentSession.swift */,
 				A5001641 /* RemoteRelayZshBootstrap.swift */,
 				A5001651 /* CmuxConfig.swift */,
 				A5001653 /* CmuxConfigExecutor.swift */,
@@ -858,6 +861,7 @@
 				A5001240 /* WindowDecorationsController.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
 				A5001610 /* SessionPersistence.swift in Sources */,
+				A5001660 /* RestorableAgentSession.swift in Sources */,
 				A5001640 /* RemoteRelayZshBootstrap.swift in Sources */,
 				A5001650 /* CmuxConfig.swift in Sources */,
 				A5001652 /* CmuxConfigExecutor.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Browser developer-tool shortcuts follow Safari defaults and are customizable in 
 | Shortcut | Action |
 |----------|--------|
 | ⌘ ⇧ N | New window |
+| ⌘ ⇧ O | Reopen previous session |
 | ⌘ , | Settings |
 | ⌘ ⇧ , | Reload configuration |
 | ⌘ Q | Quit |
@@ -236,15 +237,21 @@ cmux NIGHTLY is a separate app with its own bundle ID, so it runs alongside the 
 
 Report nightly bugs on [GitHub Issues](https://github.com/manaflow-ai/cmux/issues) or in [#nightly-bugs on Discord](https://discord.gg/xsgFEVrWCZ).
 
-## Session restore (current behavior)
+## Session restore
 
-On relaunch, cmux currently restores app layout and metadata only:
+Quitting cmux saves the current session. On relaunch, cmux restores:
 - Window/workspace/pane layout
 - Working directories
 - Terminal scrollback (best effort)
 - Browser URL and navigation history
+- Saved Claude Code and Codex sessions, when cmux has a resume token for the panel
 
-cmux does **not** restore live process state inside terminal apps. For example, active Claude Code/tmux/vim sessions are not resumed after restart yet.
+If you need to reapply the last saved snapshot manually, use:
+- `File > Reopen Previous Session`
+- `⌘ ⇧ O`
+- `cmux restore-session`
+
+cmux does **not** restore arbitrary live terminal process state. tmux, vim, shells, and other tools without a cmux resume flow still reopen as normal terminals rather than resuming in-process state.
 
 ## Star History
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -21128,6 +21128,40 @@
         }
       }
     },
+    "command.reopenPreviousSession.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション"
+          }
+        }
+      }
+    },
+    "command.reopenPreviousSession.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reopen Previous Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回のセッションを再度開く"
+          }
+        }
+      }
+    },
     "command.restartSocketListener.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -38822,6 +38856,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Відновити закриту панель браузера"
+          }
+        }
+      }
+    },
+    "menu.file.reopenPreviousSession": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reopen Previous Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回のセッションを再度開く"
           }
         }
       }
@@ -68167,6 +68218,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "Перейменувати робочу область"
+          }
+        }
+      }
+    },
+    "shortcut.reopenPreviousSession.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reopen Previous Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "前回のセッションを再度開く"
           }
         }
       }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2428,7 +2428,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var startupSessionSnapshot: AppSessionSnapshot?
     private var didPrepareStartupSessionSnapshot = false
     private var didAttemptStartupSessionRestore = false
-    private var isApplyingStartupSessionRestore = false
+    private var isApplyingSessionRestore = false
     private var sessionAutosaveTimer: DispatchSourceTimer?
     private var sessionAutosaveTickInFlight = false
     private var sessionAutosaveDeferredRetryPending = false
@@ -3777,8 +3777,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func prepareStartupSessionSnapshotIfNeeded() {
         guard !didPrepareStartupSessionSnapshot else { return }
         didPrepareStartupSessionSnapshot = true
-        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
         Self.removeLegacyPersistedWindowGeometry()
+        SessionPersistenceStore.syncManualRestoreSnapshotCache()
+        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
         startupSessionSnapshot = SessionPersistenceStore.load()
     }
 
@@ -3873,7 +3874,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let startupSnapshot = startupSessionSnapshot
         let primaryWindowSnapshot = startupSnapshot?.windows.first
         if let primaryWindowSnapshot {
-            isApplyingStartupSessionRestore = true
+            isApplyingSessionRestore = true
 #if DEBUG
             dlog(
                 "session.restore.start windows=\(startupSnapshot?.windows.count ?? 0) " +
@@ -3920,18 +3921,67 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     for windowSnapshot in additionalWindows {
                         _ = self.createMainWindow(sessionWindowSnapshot: windowSnapshot)
                     }
-                    self.completeStartupSessionRestore()
+                    self.completeSessionRestoreOperation()
                 }
             } else {
-                completeStartupSessionRestore()
+                completeSessionRestoreOperation()
             }
         }
     }
 
-    private func completeStartupSessionRestore() {
+    private func completeSessionRestoreOperation() {
         startupSessionSnapshot = nil
-        isApplyingStartupSessionRestore = false
+        isApplyingSessionRestore = false
         _ = saveSessionSnapshot(includeScrollback: false)
+    }
+
+    @discardableResult
+    func reopenPreviousSession() -> Bool {
+        guard let snapshot = SessionPersistenceStore.loadReopenSessionSnapshot() else {
+            return false
+        }
+
+        let snapshotWindows = Array(
+            snapshot.windows.prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)
+        )
+        guard !snapshotWindows.isEmpty else { return false }
+
+        let existingContexts = sortedMainWindowContextsForSessionSnapshot()
+        isApplyingSessionRestore = true
+
+        if existingContexts.isEmpty {
+            for windowSnapshot in snapshotWindows {
+                _ = createMainWindow(sessionWindowSnapshot: windowSnapshot)
+            }
+        } else {
+            for (context, windowSnapshot) in zip(existingContexts, snapshotWindows) {
+                applySessionWindowSnapshot(
+                    windowSnapshot,
+                    to: context,
+                    window: context.window ?? windowForMainWindowId(context.windowId)
+                )
+            }
+
+            if snapshotWindows.count > existingContexts.count {
+                for windowSnapshot in snapshotWindows.dropFirst(existingContexts.count) {
+                    _ = createMainWindow(sessionWindowSnapshot: windowSnapshot)
+                }
+            }
+        }
+
+        completeSessionRestoreOperation()
+
+        if let primaryWindow = sortedMainWindowContextsForSessionSnapshot()
+            .compactMap({ $0.window ?? windowForMainWindowId($0.windowId) })
+            .first {
+            primaryWindow.makeKeyAndOrderFront(nil)
+            setActiveMainWindow(primaryWindow)
+            NSRunningApplication.current.activate(
+                options: [.activateAllWindows, .activateIgnoringOtherApps]
+            )
+        }
+
+        return true
     }
 
     private func applySessionWindowSnapshot(
@@ -4455,12 +4505,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     private func saveSessionSnapshot(includeScrollback: Bool, removeWhenEmpty: Bool = false) -> Bool {
-        if Self.shouldSkipSessionSaveDuringStartupRestore(
-            isApplyingStartupSessionRestore: isApplyingStartupSessionRestore,
+        if Self.shouldSkipSessionSaveDuringRestore(
+            isApplyingSessionRestore: isApplyingSessionRestore,
             includeScrollback: includeScrollback
         ) {
 #if DEBUG
-            dlog("session.save.skipped reason=startup_restore_in_progress includeScrollback=0")
+            dlog("session.save.skipped reason=session_restore_in_progress includeScrollback=0")
 #endif
             return false
         }
@@ -4519,11 +4569,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         !isTerminatingApp
     }
 
-    nonisolated static func shouldSkipSessionSaveDuringStartupRestore(
-        isApplyingStartupSessionRestore: Bool,
+    nonisolated static func shouldSkipSessionSaveDuringRestore(
+        isApplyingSessionRestore: Bool,
         includeScrollback: Bool
     ) -> Bool {
-        isApplyingStartupSessionRestore && !includeScrollback
+        isApplyingSessionRestore && !includeScrollback
     }
 
     nonisolated static func shouldRunSessionAutosaveTick(isTerminatingApp: Bool) -> Bool {
@@ -4715,8 +4765,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func buildSessionSnapshot(includeScrollback: Bool) -> AppSessionSnapshot? {
-        let contexts = mainWindowContexts.values.sorted { lhs, rhs in
+    private func sortedMainWindowContextsForSessionSnapshot() -> [MainWindowContext] {
+        mainWindowContexts.values.sorted { lhs, rhs in
             let lhsWindow = lhs.window ?? windowForMainWindowId(lhs.windowId)
             let rhsWindow = rhs.window ?? windowForMainWindowId(rhs.windowId)
             let lhsIsKey = lhsWindow?.isKeyWindow ?? false
@@ -4726,8 +4776,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return lhs.windowId.uuidString < rhs.windowId.uuidString
         }
+    }
+
+    private func buildSessionSnapshot(includeScrollback: Bool) -> AppSessionSnapshot? {
+        let contexts = sortedMainWindowContextsForSessionSnapshot()
 
         guard !contexts.isEmpty else { return nil }
+        let restorableAgentIndex = RestorableAgentSessionIndex.load()
 
         let windows: [SessionWindowSnapshot] = contexts
             .prefix(SessionPersistencePolicy.maxWindowsPerSnapshot)
@@ -4736,7 +4791,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return SessionWindowSnapshot(
                     frame: window.map { SessionRectSnapshot($0.frame) },
                     display: displaySnapshot(for: window),
-                    tabManager: context.tabManager.sessionSnapshot(includeScrollback: includeScrollback),
+                    tabManager: context.tabManager.sessionSnapshot(
+                        includeScrollback: includeScrollback,
+                        restorableAgentIndex: restorableAgentIndex
+                    ),
                     sidebar: SessionSidebarSnapshot(
                         isVisible: context.sidebarState.isVisible,
                         selection: SessionSidebarSelection(selection: context.sidebarSelectionState.selection),
@@ -11527,6 +11585,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         if matchConfiguredShortcut(event: event, action: .useSelectionForFind) {
             tabManager?.searchSelection()
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .reopenPreviousSession) {
+            if !reopenPreviousSession() {
+                NSSound.beep()
+            }
             return true
         }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6331,6 +6331,8 @@ struct ContentView: View {
             return .newWindow
         case "palette.openFolder":
             return .openFolder
+        case "palette.reopenPreviousSession":
+            return .reopenPreviousSession
         case "palette.newTerminalTab":
             return .newSurface
         case "palette.newBrowserTab":
@@ -6587,6 +6589,14 @@ struct ContentView: View {
                 ),
                 keywords: ["open", "folder", "directory", "project", "vs", "code", "inline", "editor", "browser"],
                 when: { _ in TerminalDirectoryOpenTarget.vscodeInline.isAvailable() }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.reopenPreviousSession",
+                title: constant(String(localized: "command.reopenPreviousSession.title", defaultValue: "Reopen Previous Session")),
+                subtitle: constant(String(localized: "command.reopenPreviousSession.subtitle", defaultValue: "Session")),
+                keywords: ["reopen", "restore", "previous", "session", "resume"]
             )
         )
         contributions.append(
@@ -7308,6 +7318,11 @@ struct ContentView: View {
         registry.register(commandId: "palette.openFolderInVSCodeInline") {
             DispatchQueue.main.async {
                 AppDelegate.shared?.showOpenFolderInInlineVSCodePanel(tabManager: tabManager)
+            }
+        }
+        registry.register(commandId: "palette.reopenPreviousSession") {
+            if AppDelegate.shared?.reopenPreviousSession() != true {
+                NSSound.beep()
             }
         }
         registry.register(commandId: "palette.newWindow") {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -28,6 +28,7 @@ enum KeyboardShortcutSettings {
         case toggleSidebar
         case newTab
         case openFolder
+        case reopenPreviousSession
         case goToWorkspace
         case commandPalette
         case sendFeedback
@@ -98,6 +99,7 @@ enum KeyboardShortcutSettings {
             case .toggleSidebar: return String(localized: "shortcut.toggleSidebar.label", defaultValue: "Toggle Sidebar")
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
             case .openFolder: return String(localized: "shortcut.openFolder.label", defaultValue: "Open Folder")
+            case .reopenPreviousSession: return String(localized: "shortcut.reopenPreviousSession.label", defaultValue: "Reopen Previous Session")
             case .goToWorkspace: return String(localized: "menu.file.goToWorkspace", defaultValue: "Go to Workspace…")
             case .commandPalette: return String(localized: "menu.file.commandPalette", defaultValue: "Command Palette…")
             case .sendFeedback: return String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback")
@@ -176,6 +178,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "n", command: true, shift: false, option: false, control: false)
             case .openFolder:
                 return StoredShortcut(key: "o", command: true, shift: false, option: false, control: false)
+            case .reopenPreviousSession:
+                return StoredShortcut(key: "o", command: true, shift: true, option: false, control: false)
             case .goToWorkspace:
                 return StoredShortcut(key: "p", command: true, shift: false, option: false, control: false)
             case .commandPalette:

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+enum RestorableAgentKind: String, Codable, CaseIterable, Sendable {
+    case claude
+    case codex
+
+    private var hookStoreFilename: String {
+        "\(rawValue)-hook-sessions.json"
+    }
+
+    func resumeCommand(sessionId: String) -> String {
+        let quotedSessionId = Self.shellSingleQuoted(sessionId)
+        switch self {
+        case .claude:
+            return "claude --resume \(quotedSessionId)"
+        case .codex:
+            return "codex resume \(quotedSessionId)"
+        }
+    }
+
+    func hookStoreFileURL(homeDirectory: String = NSHomeDirectory()) -> URL {
+        URL(fileURLWithPath: homeDirectory, isDirectory: true)
+            .appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent(hookStoreFilename, isDirectory: false)
+    }
+
+    private static func shellSingleQuoted(_ value: String) -> String {
+        "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+struct SessionRestorableAgentSnapshot: Codable, Sendable {
+    var kind: RestorableAgentKind
+    var sessionId: String
+    var workingDirectory: String?
+
+    var resumeCommand: String {
+        kind.resumeCommand(sessionId: sessionId)
+    }
+}
+
+private struct RestorableAgentHookSessionRecord: Codable, Sendable {
+    var sessionId: String
+    var workspaceId: String
+    var surfaceId: String
+    var cwd: String?
+    var updatedAt: TimeInterval
+}
+
+private struct RestorableAgentHookSessionStoreFile: Codable, Sendable {
+    var version: Int = 1
+    var sessions: [String: RestorableAgentHookSessionRecord] = [:]
+}
+
+struct RestorableAgentSessionIndex: Sendable {
+    private struct PanelKey: Hashable, Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+    }
+
+    private let snapshotsByPanel: [PanelKey: SessionRestorableAgentSnapshot]
+
+    func snapshot(workspaceId: UUID, panelId: UUID) -> SessionRestorableAgentSnapshot? {
+        snapshotsByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)]
+    }
+
+    static func load(
+        homeDirectory: String = NSHomeDirectory(),
+        fileManager: FileManager = .default
+    ) -> RestorableAgentSessionIndex {
+        let decoder = JSONDecoder()
+        var resolved: [PanelKey: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval)] = [:]
+
+        for kind in RestorableAgentKind.allCases {
+            let fileURL = kind.hookStoreFileURL(homeDirectory: homeDirectory)
+            guard fileManager.fileExists(atPath: fileURL.path),
+                  let data = try? Data(contentsOf: fileURL),
+                  let state = try? decoder.decode(RestorableAgentHookSessionStoreFile.self, from: data) else {
+                continue
+            }
+
+            for record in state.sessions.values {
+                let normalizedSessionId = record.sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !normalizedSessionId.isEmpty,
+                      let workspaceId = UUID(uuidString: record.workspaceId),
+                      let panelId = UUID(uuidString: record.surfaceId) else {
+                    continue
+                }
+
+                let snapshot = SessionRestorableAgentSnapshot(
+                    kind: kind,
+                    sessionId: normalizedSessionId,
+                    workingDirectory: normalizedWorkingDirectory(record.cwd)
+                )
+                let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
+                if let existing = resolved[key], existing.updatedAt > record.updatedAt {
+                    continue
+                }
+                resolved[key] = (snapshot: snapshot, updatedAt: record.updatedAt)
+            }
+        }
+
+        return RestorableAgentSessionIndex(snapshotsByPanel: resolved.mapValues(\.snapshot))
+    }
+
+    private static func normalizedWorkingDirectory(_ rawValue: String?) -> String? {
+        guard let rawValue = rawValue?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawValue.isEmpty else {
+            return nil
+        }
+        return rawValue
+    }
+
+    private init(snapshotsByPanel: [PanelKey: SessionRestorableAgentSnapshot]) {
+        self.snapshotsByPanel = snapshotsByPanel
+    }
+}

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -224,6 +224,7 @@ struct SessionGitBranchSnapshot: Codable, Sendable {
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var scrollback: String?
+    var agent: SessionRestorableAgentSnapshot?
 }
 
 struct SessionBrowserPanelSnapshot: Codable, Sendable {
@@ -401,9 +402,48 @@ enum SessionPersistenceStore {
         try? FileManager.default.removeItem(at: fileURL)
     }
 
+    static func loadReopenSessionSnapshot(fileURL: URL? = nil) -> AppSessionSnapshot? {
+        if let manualRestoreSnapshot = load(fileURL: fileURL ?? manualRestoreSnapshotFileURL()) {
+            return manualRestoreSnapshot
+        }
+        return load()
+    }
+
+    static func syncManualRestoreSnapshotCache() {
+        guard let fileURL = manualRestoreSnapshotFileURL() else { return }
+        guard let snapshot = load() else {
+            removeSnapshot(fileURL: fileURL)
+            return
+        }
+        _ = save(snapshot, fileURL: fileURL)
+    }
+
     static func defaultSnapshotFileURL(
         bundleIdentifier: String? = Bundle.main.bundleIdentifier,
         appSupportDirectory: URL? = nil
+    ) -> URL? {
+        snapshotFileURL(
+            suffix: "",
+            bundleIdentifier: bundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        )
+    }
+
+    static func manualRestoreSnapshotFileURL(
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier,
+        appSupportDirectory: URL? = nil
+    ) -> URL? {
+        snapshotFileURL(
+            suffix: "-previous",
+            bundleIdentifier: bundleIdentifier,
+            appSupportDirectory: appSupportDirectory
+        )
+    }
+
+    private static func snapshotFileURL(
+        suffix: String,
+        bundleIdentifier: String?,
+        appSupportDirectory: URL?
     ) -> URL? {
         let resolvedAppSupport: URL
         if let appSupportDirectory {
@@ -423,7 +463,7 @@ enum SessionPersistenceStore {
         )
         return resolvedAppSupport
             .appendingPathComponent("cmux", isDirectory: true)
-            .appendingPathComponent("session-\(safeBundleId).json", isDirectory: false)
+            .appendingPathComponent("session-\(safeBundleId)\(suffix).json", isDirectory: false)
     }
 }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -6783,12 +6783,20 @@ extension TabManager {
         return hasher.finalize()
     }
 
-    func sessionSnapshot(includeScrollback: Bool) -> SessionTabManagerSnapshot {
+    func sessionSnapshot(
+        includeScrollback: Bool,
+        restorableAgentIndex: RestorableAgentSessionIndex
+    ) -> SessionTabManagerSnapshot {
         let restorableTabs = tabs
             .filter { !$0.isRemoteWorkspace }
             .prefix(SessionPersistencePolicy.maxWorkspacesPerWindow)
         let workspaceSnapshots = restorableTabs
-            .map { $0.sessionSnapshot(includeScrollback: includeScrollback) }
+            .map {
+                $0.sessionSnapshot(
+                    includeScrollback: includeScrollback,
+                    restorableAgentIndex: restorableAgentIndex
+                )
+            }
         let selectedWorkspaceIndex = selectedTabId.flatMap { selectedTabId in
             restorableTabs.firstIndex(where: { $0.id == selectedTabId })
         }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -129,6 +129,7 @@ class TerminalController {
 
     private static let focusIntentV2Methods: Set<String> = [
         "window.focus",
+        "session.restore_previous",
         "workspace.select",
         "workspace.next",
         "workspace.previous",
@@ -2109,6 +2110,8 @@ class TerminalController {
             return v2Result(id: id, self.v2WorkspaceRemoteStatus(params: params))
         case "workspace.remote.terminal_session_end":
             return v2Result(id: id, self.v2WorkspaceRemoteTerminalSessionEnd(params: params))
+        case "session.restore_previous":
+            return v2Result(id: id, self.v2SessionRestorePrevious())
 
         // Settings
         case "settings.open":
@@ -2482,6 +2485,7 @@ class TerminalController {
             "workspace.remote.disconnect",
             "workspace.remote.status",
             "workspace.remote.terminal_session_end",
+            "session.restore_previous",
             "settings.open",
             "feedback.open",
             "feedback.submit",
@@ -6936,6 +6940,17 @@ class TerminalController {
             FeedbackComposerBridge.openComposer(in: targetWindow)
         }
         return .ok(["opened": true])
+    }
+
+    private func v2SessionRestorePrevious() -> V2CallResult {
+        var restored = false
+        DispatchQueue.main.sync {
+            restored = AppDelegate.shared?.reopenPreviousSession() ?? false
+        }
+        guard restored else {
+            return .err(code: "not_found", message: "No previous session snapshot available", data: nil)
+        }
+        return .ok(["restored": true])
     }
 
     private func v2SettingsOpen(params: [String: Any]) -> V2CallResult {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -247,7 +247,10 @@ extension Workspace {
         )
     }
 
-    func sessionSnapshot(includeScrollback: Bool) -> SessionWorkspaceSnapshot {
+    func sessionSnapshot(
+        includeScrollback: Bool,
+        restorableAgentIndex: RestorableAgentSessionIndex?
+    ) -> SessionWorkspaceSnapshot {
         let tree = bonsplitController.treeSnapshot()
         let layout = sessionLayoutSnapshot(from: tree)
 
@@ -263,7 +266,13 @@ extension Workspace {
 
         let panelSnapshots = allPanelIds
             .prefix(SessionPersistencePolicy.maxPanelsPerWorkspace)
-            .compactMap { sessionPanelSnapshot(panelId: $0, includeScrollback: includeScrollback) }
+            .compactMap { panelId in
+                sessionPanelSnapshot(
+                    panelId: panelId,
+                    includeScrollback: includeScrollback,
+                    restorableAgent: restorableAgentIndex?.snapshot(workspaceId: id, panelId: panelId)
+                )
+            }
 
         let statusSnapshots = statusEntries.values
             .sorted { lhs, rhs in lhs.key < rhs.key }
@@ -312,6 +321,7 @@ extension Workspace {
 
     func restoreSessionSnapshot(_ snapshot: SessionWorkspaceSnapshot) {
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
+        restoredAgentSnapshotsByPanelId.removeAll(keepingCapacity: false)
 
         let normalizedCurrentDirectory = snapshot.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         if !normalizedCurrentDirectory.isEmpty {
@@ -429,12 +439,21 @@ extension Workspace {
         return decoded.id
     }
 
-    private func sessionPanelSnapshot(panelId: UUID, includeScrollback: Bool) -> SessionPanelSnapshot? {
+    private func sessionPanelSnapshot(
+        panelId: UUID,
+        includeScrollback: Bool,
+        restorableAgent: SessionRestorableAgentSnapshot?
+    ) -> SessionPanelSnapshot? {
         guard let panel = panels[panelId] else { return nil }
+
+        let effectiveRestorableAgent = restorableAgent ?? restoredAgentSnapshotsByPanelId[panelId]
+        if let restorableAgent {
+            restoredAgentSnapshotsByPanelId[panelId] = restorableAgent
+        }
 
         let panelTitle = panelTitle(panelId: panelId)
         let customTitle = panelCustomTitles[panelId]
-        let directory = panelDirectories[panelId]
+        let directory = panelDirectories[panelId] ?? effectiveRestorableAgent?.workingDirectory
         let isPinned = pinnedPanelIds.contains(panelId)
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
         let branchSnapshot = panelGitBranches[panelId].map {
@@ -469,8 +488,9 @@ extension Workspace {
                 allowFallbackScrollback: shouldPersistScrollback
             )
             terminalSnapshot = SessionTerminalPanelSnapshot(
-                workingDirectory: panelDirectories[panelId],
-                scrollback: resolvedScrollback
+                workingDirectory: directory,
+                scrollback: resolvedScrollback,
+                agent: effectiveRestorableAgent
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -641,7 +661,11 @@ extension Workspace {
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {
         switch snapshot.type {
         case .terminal:
-            let workingDirectory = snapshot.terminal?.workingDirectory ?? snapshot.directory ?? currentDirectory
+            let workingDirectory =
+                snapshot.terminal?.workingDirectory
+                ?? snapshot.terminal?.agent?.workingDirectory
+                ?? snapshot.directory
+                ?? currentDirectory
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: snapshot.terminal?.scrollback
             )
@@ -659,7 +683,15 @@ extension Workspace {
             } else {
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: terminalPanel.id)
             }
+            if let restorableAgent = snapshot.terminal?.agent {
+                restoredAgentSnapshotsByPanelId[terminalPanel.id] = restorableAgent
+            } else {
+                restoredAgentSnapshotsByPanelId.removeValue(forKey: terminalPanel.id)
+            }
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
+            if let resumeCommand = snapshot.terminal?.agent?.resumeCommand {
+                sendInputWhenReady(resumeCommand + "\n", to: terminalPanel)
+            }
             return terminalPanel.id
         case .browser:
             guard let browserPanel = newBrowserSurface(
@@ -6620,6 +6652,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// Used for stale-session detection: if the PID is dead, the status entry is cleared.
     var agentPIDs: [String: pid_t] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
+    private var restoredAgentSnapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot] = [:]
 
     private func sidebarObservationSignal<Value: Equatable>(
         _ publisher: Published<Value>.Publisher
@@ -7809,6 +7842,9 @@ final class Workspace: Identifiable, ObservableObject {
         remoteDetectedSurfaceIds = remoteDetectedSurfaceIds.filter { validSurfaceIds.contains($0) }
         panelShellActivityStates = panelShellActivityStates.filter { validSurfaceIds.contains($0.key) }
         panelPullRequests = panelPullRequests.filter { validSurfaceIds.contains($0.key) }
+        restoredAgentSnapshotsByPanelId = restoredAgentSnapshotsByPanelId.filter {
+            validSurfaceIds.contains($0.key)
+        }
         syncRemotePortScanTTYs()
         recomputeListeningPorts()
     }
@@ -11760,6 +11796,7 @@ extension Workspace: BonsplitDelegate {
         surfaceTTYNames.removeValue(forKey: panelId)
         syncRemotePortScanTTYs()
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+        restoredAgentSnapshotsByPanelId.removeValue(forKey: panelId)
         PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
         terminalInheritanceFontPointsByPanelId.removeValue(forKey: panelId)
         if lastTerminalConfigInheritancePanelId == panelId {
@@ -11913,6 +11950,7 @@ extension Workspace: BonsplitDelegate {
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+                restoredAgentSnapshotsByPanelId.removeValue(forKey: panelId)
                 PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
             }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -650,6 +650,12 @@ struct cmuxApp: App {
                     workspaceCommandMenuContent(manager: activeTabManager)
                 }
 
+                splitCommandButton(title: String(localized: "menu.file.reopenPreviousSession", defaultValue: "Reopen Previous Session"), shortcut: menuShortcut(for: .reopenPreviousSession)) {
+                    if AppDelegate.shared?.reopenPreviousSession() != true {
+                        NSSound.beep()
+                    }
+                }
+
                 splitCommandButton(title: String(localized: "menu.file.reopenClosedBrowserPanel", defaultValue: "Reopen Closed Browser Panel"), shortcut: menuShortcut(for: .reopenClosedBrowserPanel)) {
                     _ = activeTabManager.reopenMostRecentlyClosedBrowserPanel()
                 }

--- a/tests/test_restore_session_relaunches_codex_resume.py
+++ b/tests/test_restore_session_relaunches_codex_resume.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""
+Regression: restore-session should reopen the previous workspace graph and
+relaunch resumable Codex sessions after a blank relaunch overwrites the primary
+session snapshot.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from cmux import cmux
+
+
+def _bundle_id(app_path: Path) -> str:
+    info_path = app_path / "Contents" / "Info.plist"
+    if not info_path.exists():
+        raise RuntimeError(f"Missing Info.plist at {info_path}")
+    with info_path.open("rb") as f:
+        info = plistlib.load(f)
+    bundle_id = str(info.get("CFBundleIdentifier", "")).strip()
+    if not bundle_id:
+        raise RuntimeError("Missing CFBundleIdentifier")
+    return bundle_id
+
+
+def _snapshot_path(bundle_id: str, suffix: str = "") -> Path:
+    safe_bundle = re.sub(r"[^A-Za-z0-9._-]", "_", bundle_id)
+    return Path.home() / "Library/Application Support/cmux" / f"session-{safe_bundle}{suffix}.json"
+
+
+def _socket_reachable(socket_path: Path) -> bool:
+    if not socket_path.exists():
+        return False
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(0.3)
+        sock.connect(str(socket_path))
+        sock.sendall(b"ping\n")
+        data = sock.recv(1024)
+        return b"PONG" in data
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def _wait_for_socket(socket_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _socket_reachable(socket_path):
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Socket did not become reachable: {socket_path}")
+
+
+def _wait_for_socket_closed(socket_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _socket_reachable(socket_path):
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Socket still reachable after quit: {socket_path}")
+
+
+def _kill_existing(app_path: Path) -> None:
+    exe = app_path / "Contents" / "MacOS" / "cmux DEV"
+    subprocess.run(["pkill", "-f", str(exe)], capture_output=True, text=True)
+    time.sleep(1.0)
+
+
+def _launch(app_path: Path, socket_path: Path, env_overrides: dict[str, str] | None = None) -> None:
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    command = ["open", "-na", str(app_path)]
+    full_env = dict(env_overrides or {})
+    full_env["CMUX_SOCKET_PATH"] = str(socket_path)
+    full_env["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+    for key, value in full_env.items():
+        command.extend(["--env", f"{key}={value}"])
+    subprocess.run(command, check=True)
+    _wait_for_socket(socket_path)
+    time.sleep(1.5)
+
+
+def _quit(bundle_id: str, socket_path: Path) -> None:
+    subprocess.run(
+        ["osascript", "-e", f'tell application id "{bundle_id}" to quit'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _wait_for_socket_closed(socket_path)
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    time.sleep(0.8)
+
+
+def _connect(socket_path: Path) -> cmux:
+    client = cmux(socket_path=str(socket_path))
+    client.connect()
+    if not client.ping():
+        raise RuntimeError("ping failed")
+    return client
+
+
+def _read_scrollback(client: cmux) -> str:
+    return client._send_command("read_screen --scrollback")
+
+
+def _wait_for_condition(timeout: float, predicate) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def _write_fake_codex(fake_bin_dir: Path) -> None:
+    fake_bin_dir.mkdir(parents=True, exist_ok=True)
+    fake_codex = fake_bin_dir / "codex"
+    fake_codex.write_text(
+        "#!/bin/sh\n"
+        "printf 'CMUX_FAKE_CODEX_RESUME:%s\\n' \"$*\"\n",
+        encoding="utf-8",
+    )
+    fake_codex.chmod(0o755)
+
+
+def _write_hook_state(path: Path, session_id: str, workspace_id: str, surface_id: str, cwd: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "sessions": {
+            session_id: {
+                "sessionId": session_id,
+                "workspaceId": workspace_id,
+                "surfaceId": surface_id,
+                "cwd": cwd,
+                "updatedAt": time.time(),
+            }
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def main() -> int:
+    app_path_str = os.environ.get("CMUX_APP_PATH", "").strip()
+    if not app_path_str:
+        print("SKIP: set CMUX_APP_PATH to a built cmux DEV .app path")
+        return 0
+    app_path = Path(app_path_str)
+    if not app_path.exists():
+        print(f"SKIP: CMUX_APP_PATH does not exist: {app_path}")
+        return 0
+
+    cli_path = app_path / "Contents" / "Resources" / "bin" / "cmux"
+    if not cli_path.exists():
+        print(f"SKIP: bundled cmux CLI not found at {cli_path}")
+        return 0
+
+    bundle_id = _bundle_id(app_path)
+    socket_path = Path(f"/tmp/cmux-restore-session-codex-{bundle_id.replace('.', '-')}.sock")
+    snapshot = _snapshot_path(bundle_id)
+    previous_snapshot = _snapshot_path(bundle_id, suffix="-previous")
+    hook_state = Path.home() / ".cmuxterm" / "codex-hook-sessions.json"
+
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="cmux-restore-session-codex-") as td:
+        fake_bin_dir = Path(td) / "bin"
+        _write_fake_codex(fake_bin_dir)
+        launch_path = f"{fake_bin_dir}:{os.environ.get('PATH', '')}"
+
+        _kill_existing(app_path)
+        snapshot.unlink(missing_ok=True)
+        previous_snapshot.unlink(missing_ok=True)
+        hook_state.unlink(missing_ok=True)
+
+        try:
+            _launch(app_path, socket_path, env_overrides={"PATH": launch_path})
+            client = _connect(socket_path)
+            try:
+                original_workspace_id = client.current_workspace()
+                surfaces = client.list_surfaces()
+                if not surfaces:
+                    failures.append("expected at least one surface in the initial workspace")
+                else:
+                    surface_id = surfaces[0][1]
+                    _write_hook_state(
+                        hook_state,
+                        session_id="codex-session-restore-2923",
+                        workspace_id=original_workspace_id,
+                        surface_id=surface_id,
+                        cwd=os.getcwd(),
+                    )
+
+                client.new_workspace()
+                time.sleep(0.4)
+                client.select_workspace(original_workspace_id)
+                time.sleep(0.4)
+            finally:
+                client.close()
+            _quit(bundle_id, socket_path)
+
+            _launch(
+                app_path,
+                socket_path,
+                env_overrides={
+                    "PATH": launch_path,
+                    "CMUX_DISABLE_SESSION_RESTORE": "1",
+                },
+            )
+            client = _connect(socket_path)
+            try:
+                blank_workspaces = client.list_workspaces()
+                if len(blank_workspaces) != 1:
+                    failures.append(
+                        f"expected blank relaunch to start with 1 workspace, got {len(blank_workspaces)}"
+                    )
+
+                time.sleep(9.5)
+
+                restore_env = dict(os.environ)
+                restore_env["CMUX_SOCKET_PATH"] = str(socket_path)
+                restore_proc = subprocess.run(
+                    [str(cli_path), "restore-session"],
+                    capture_output=True,
+                    text=True,
+                    env=restore_env,
+                )
+                if restore_proc.returncode != 0:
+                    failures.append(
+                        "restore-session failed:\n"
+                        f"stdout:\n{restore_proc.stdout}\n"
+                        f"stderr:\n{restore_proc.stderr}"
+                    )
+                elif restore_proc.stdout.strip() != "OK":
+                    failures.append(f"unexpected restore-session stdout: {restore_proc.stdout!r}")
+
+                def restored() -> bool:
+                    workspaces = client.list_workspaces()
+                    if len(workspaces) < 2:
+                        return False
+                    client.select_workspace(0)
+                    return "CMUX_FAKE_CODEX_RESUME:resume codex-session-restore-2923" in _read_scrollback(client)
+
+                if not _wait_for_condition(12.0, restored):
+                    client.select_workspace(0)
+                    scrollback_tail = "\n".join(_read_scrollback(client).splitlines()[-20:])
+                    failures.append(
+                        "restore-session did not relaunch the saved Codex session; "
+                        f"workspace_count={len(client.list_workspaces())} tail:\n{scrollback_tail}"
+                    )
+            finally:
+                client.close()
+            _quit(bundle_id, socket_path)
+        finally:
+            _kill_existing(app_path)
+            socket_path.unlink(missing_ok=True)
+            snapshot.unlink(missing_ok=True)
+            previous_snapshot.unlink(missing_ok=True)
+            hook_state.unlink(missing_ok=True)
+
+    if failures:
+        print("FAIL:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: restore-session reopens saved workspaces and resumes codex")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_session_relaunch_resumes_agent_sessions.py
+++ b/tests/test_session_relaunch_resumes_agent_sessions.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""
+Regression: normal relaunch should resume saved Claude/Codex sessions.
+
+Repro for issue #2923:
+1) Launch cmux and seed workspaces with tracked Claude/Codex sessions.
+2) Quit the app normally so the session snapshot is saved.
+3) Relaunch cmux the next day.
+4) Verify the restored panels automatically run the saved resume commands.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import plistlib
+import re
+import socket
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+from cmux import cmux
+
+
+def _bundle_id(app_path: Path) -> str:
+    info_path = app_path / "Contents" / "Info.plist"
+    if not info_path.exists():
+        raise RuntimeError(f"Missing Info.plist at {info_path}")
+    with info_path.open("rb") as f:
+        info = plistlib.load(f)
+    bundle_id = str(info.get("CFBundleIdentifier", "")).strip()
+    if not bundle_id:
+        raise RuntimeError("Missing CFBundleIdentifier")
+    return bundle_id
+
+
+def _snapshot_path(bundle_id: str, suffix: str = "") -> Path:
+    safe_bundle = re.sub(r"[^A-Za-z0-9._-]", "_", bundle_id)
+    return Path.home() / "Library/Application Support/cmux" / f"session-{safe_bundle}{suffix}.json"
+
+
+def _socket_reachable(socket_path: Path) -> bool:
+    if not socket_path.exists():
+        return False
+    sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    try:
+        sock.settimeout(0.3)
+        sock.connect(str(socket_path))
+        sock.sendall(b"ping\n")
+        data = sock.recv(1024)
+        return b"PONG" in data
+    except OSError:
+        return False
+    finally:
+        sock.close()
+
+
+def _wait_for_socket(socket_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if _socket_reachable(socket_path):
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Socket did not become reachable: {socket_path}")
+
+
+def _wait_for_socket_closed(socket_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not _socket_reachable(socket_path):
+            return
+        time.sleep(0.2)
+    raise RuntimeError(f"Socket still reachable after quit: {socket_path}")
+
+
+def _kill_existing(app_path: Path) -> None:
+    exe = app_path / "Contents" / "MacOS" / "cmux DEV"
+    subprocess.run(["pkill", "-f", str(exe)], capture_output=True, text=True)
+    time.sleep(1.0)
+
+
+def _launch(app_path: Path, socket_path: Path, env_overrides: dict[str, str] | None = None) -> None:
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+
+    command = ["open", "-na", str(app_path)]
+    full_env = dict(env_overrides or {})
+    full_env["CMUX_SOCKET_PATH"] = str(socket_path)
+    full_env["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+    for key, value in full_env.items():
+        command.extend(["--env", f"{key}={value}"])
+    subprocess.run(command, check=True)
+    _wait_for_socket(socket_path)
+    time.sleep(1.5)
+
+
+def _quit(bundle_id: str, socket_path: Path) -> None:
+    subprocess.run(
+        ["osascript", "-e", f'tell application id "{bundle_id}" to quit'],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    _wait_for_socket_closed(socket_path)
+    try:
+        socket_path.unlink()
+    except FileNotFoundError:
+        pass
+    time.sleep(0.8)
+
+
+def _connect(socket_path: Path) -> cmux:
+    client = cmux(socket_path=str(socket_path))
+    client.connect()
+    if not client.ping():
+        raise RuntimeError("ping failed")
+    return client
+
+
+def _read_scrollback(client: cmux) -> str:
+    return client._send_command("read_screen --scrollback")
+
+
+def _wait_for_condition(timeout: float, predicate) -> bool:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if predicate():
+            return True
+        time.sleep(0.25)
+    return False
+
+
+def _write_fake_agent(fake_bin_dir: Path, binary_name: str, prefix: str) -> None:
+    fake_bin_dir.mkdir(parents=True, exist_ok=True)
+    fake_binary = fake_bin_dir / binary_name
+    fake_binary.write_text(
+        "#!/bin/sh\n"
+        f"printf '{prefix}:%s\\n' \"$*\"\n",
+        encoding="utf-8",
+    )
+    fake_binary.chmod(0o755)
+
+
+def _write_hook_state(path: Path, session_id: str, workspace_id: str, surface_id: str, cwd: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "version": 1,
+        "sessions": {
+            session_id: {
+                "sessionId": session_id,
+                "workspaceId": workspace_id,
+                "surfaceId": surface_id,
+                "cwd": cwd,
+                "updatedAt": time.time(),
+            }
+        },
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def main() -> int:
+    app_path_str = os.environ.get("CMUX_APP_PATH", "").strip()
+    if not app_path_str:
+        print("SKIP: set CMUX_APP_PATH to a built cmux DEV .app path")
+        return 0
+    app_path = Path(app_path_str)
+    if not app_path.exists():
+        print(f"SKIP: CMUX_APP_PATH does not exist: {app_path}")
+        return 0
+
+    bundle_id = _bundle_id(app_path)
+    socket_path = Path(f"/tmp/cmux-session-relaunch-agents-{bundle_id.replace('.', '-')}.sock")
+    snapshot = _snapshot_path(bundle_id)
+    previous_snapshot = _snapshot_path(bundle_id, suffix="-previous")
+    codex_hook_state = Path.home() / ".cmuxterm" / "codex-hook-sessions.json"
+    claude_hook_state = Path.home() / ".cmuxterm" / "claude-hook-sessions.json"
+
+    codex_expected = "CMUX_FAKE_CODEX_RESUME:resume codex-session-relaunch-2923"
+    claude_expected = "CMUX_FAKE_CLAUDE_RESUME:--resume claude-session-relaunch-2923"
+
+    failures: list[str] = []
+
+    with tempfile.TemporaryDirectory(prefix="cmux-session-relaunch-agents-") as td:
+        fake_bin_dir = Path(td) / "bin"
+        _write_fake_agent(fake_bin_dir, "codex", "CMUX_FAKE_CODEX_RESUME")
+        _write_fake_agent(fake_bin_dir, "claude", "CMUX_FAKE_CLAUDE_RESUME")
+        launch_path = f"{fake_bin_dir}:{os.environ.get('PATH', '')}"
+
+        _kill_existing(app_path)
+        snapshot.unlink(missing_ok=True)
+        previous_snapshot.unlink(missing_ok=True)
+        codex_hook_state.unlink(missing_ok=True)
+        claude_hook_state.unlink(missing_ok=True)
+
+        try:
+            _launch(app_path, socket_path, env_overrides={"PATH": launch_path})
+            client = _connect(socket_path)
+            try:
+                codex_workspace_id = client.current_workspace()
+                codex_surfaces = client.list_surfaces()
+                if not codex_surfaces:
+                    failures.append("expected a Codex workspace surface during setup")
+                else:
+                    _write_hook_state(
+                        codex_hook_state,
+                        session_id="codex-session-relaunch-2923",
+                        workspace_id=codex_workspace_id,
+                        surface_id=codex_surfaces[0][1],
+                        cwd=os.getcwd(),
+                    )
+
+                claude_workspace_id = client.new_workspace()
+                time.sleep(0.4)
+                client.select_workspace(claude_workspace_id)
+                time.sleep(0.4)
+                claude_surfaces = client.list_surfaces()
+                if not claude_surfaces:
+                    failures.append("expected a Claude workspace surface during setup")
+                else:
+                    _write_hook_state(
+                        claude_hook_state,
+                        session_id="claude-session-relaunch-2923",
+                        workspace_id=claude_workspace_id,
+                        surface_id=claude_surfaces[0][1],
+                        cwd=os.getcwd(),
+                    )
+
+                client.select_workspace(codex_workspace_id)
+                time.sleep(0.4)
+            finally:
+                client.close()
+            _quit(bundle_id, socket_path)
+
+            # Prove the relaunch uses the persisted cmux snapshot, not the live hook files.
+            codex_hook_state.unlink(missing_ok=True)
+            claude_hook_state.unlink(missing_ok=True)
+
+            _launch(app_path, socket_path, env_overrides={"PATH": launch_path})
+            client = _connect(socket_path)
+            try:
+                workspaces = client.list_workspaces()
+                if len(workspaces) < 2:
+                    failures.append(f"expected >=2 restored workspaces after relaunch, got {len(workspaces)}")
+
+                def workspace_contains(index: int, expected: str) -> bool:
+                    if len(client.list_workspaces()) <= index:
+                        return False
+                    client.select_workspace(index)
+                    return expected in _read_scrollback(client)
+
+                if not _wait_for_condition(12.0, lambda: workspace_contains(0, codex_expected)):
+                    client.select_workspace(0)
+                    scrollback_tail = "\n".join(_read_scrollback(client).splitlines()[-20:])
+                    failures.append(
+                        "normal relaunch did not resume the saved Codex session; "
+                        f"tail:\n{scrollback_tail}"
+                    )
+
+                if not _wait_for_condition(12.0, lambda: workspace_contains(1, claude_expected)):
+                    client.select_workspace(1)
+                    scrollback_tail = "\n".join(_read_scrollback(client).splitlines()[-20:])
+                    failures.append(
+                        "normal relaunch did not resume the saved Claude session; "
+                        f"tail:\n{scrollback_tail}"
+                    )
+            finally:
+                client.close()
+            _quit(bundle_id, socket_path)
+        finally:
+            _kill_existing(app_path)
+            socket_path.unlink(missing_ok=True)
+            snapshot.unlink(missing_ok=True)
+            previous_snapshot.unlink(missing_ok=True)
+            codex_hook_state.unlink(missing_ok=True)
+            claude_hook_state.unlink(missing_ok=True)
+
+    if failures:
+        print("FAIL:")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: normal relaunch resumes saved Claude and Codex sessions")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -465,6 +465,7 @@
               "toggleSidebar",
               "newTab",
               "openFolder",
+              "reopenPreviousSession",
               "goToWorkspace",
               "commandPalette",
               "sendFeedback",

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -48,6 +48,11 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "newTab", combos: [["⌘", "N"]], description: { en: "New workspace", ja: "新規ワークスペース" } },
       { id: "openFolder", combos: [["⌘", "O"]], description: { en: "Open folder", ja: "フォルダを開く" } },
       {
+        id: "reopenPreviousSession",
+        combos: [["⌘", "⇧", "O"]],
+        description: { en: "Reopen previous session", ja: "前回のセッションを再度開く" },
+      },
+      {
         id: "goToWorkspace",
         combos: [["⌘", "P"]],
         description: { en: "Go to workspace", ja: "ワークスペースへ移動" },


### PR DESCRIPTION
## Summary
- restore the previous saved cmux session from relaunch, `File > Reopen Previous Session`, `⌘⇧O`, or `cmux restore-session`
- persist Claude Code and Codex resume metadata in session snapshots so restored panels relaunch those sessions automatically
- add a direct overnight-relaunch regression and update the README to document the shipped behavior

Closes #2923.

## Testing
- `python3 -m py_compile tests/test_session_relaunch_resumes_agent_sessions.py`
- existing regression coverage in `tests/test_restore_session_relaunches_codex_resume.py`
- attempted `./scripts/reload.sh --tag issue-2923-reopen-sessions` but local `xcodebuild` stalled in the Xcode environment before producing a compile result


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore the last saved session and auto-resume Claude/Codex panels on relaunch or on demand. Adds a quick “Reopen Previous Session” flow to bring back windows, panes, and agent sessions.

- **New Features**
  - Added File menu item, Command Palette action, and default shortcut ⌘ ⇧ O to reopen the previous session.
  - Introduced `cmux restore-session` CLI; restores into a running app or launches and restores if not running.
  - Persisted agent resume data in session snapshots; restored terminals run the appropriate resume command for Claude/Codex.
  - Added socket API method `session.restore_previous` for programmatic restores.
  - Hardened restore by caching a “previous” snapshot and skipping autosave during restore to avoid clobbering state.
  - Updated README, i18n strings, shortcut schema/UI, and added regression tests for overnight relaunch and manual restore.

<sup>Written for commit 09d19411b81c3fb76389d8b98dadc2e7771c8589. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Reopen Previous Session" feature accessible via ⌘⇧O shortcut, menu, and command palette
  * Session restoration now preserves Claude and Codex agent sessions with working directories
  * Added `cmux restore-session` CLI command for manual session restoration

* **Documentation**
  * Updated with new keyboard shortcut and session restoration details

* **Localization**
  * Added English and Japanese translations for reopen session feature

<!-- end of auto-generated comment: release notes by coderabbit.ai -->