### PR TITLE
Fix main CI by deferring file-drop overlay retries

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1858,6 +1858,26 @@ func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) -> Bool
     return true
 }
 
+private func installFileDropOverlayWhenReady(
+    on window: NSWindow,
+    tabManager: TabManager,
+    remainingAttempts: Int = 16
+) {
+    guard !installFileDropOverlay(on: window, tabManager: tabManager),
+          remainingAttempts > 0 else { return }
+
+    // Defer retrying until the next main-loop turn so we don't mutate the
+    // NSThemeFrame hierarchy while SwiftUI/AppKit is still attaching views.
+    DispatchQueue.main.async { [weak window, weak tabManager] in
+        guard let window, let tabManager else { return }
+        installFileDropOverlayWhenReady(
+            on: window,
+            tabManager: tabManager,
+            remainingAttempts: remainingAttempts - 1
+        )
+    }
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -3796,12 +3816,7 @@ struct ContentView: View {
                 sidebarState: sidebarState,
                 sidebarSelectionState: sidebarSelectionState
             )
-        }))
-
-        // Install the file-drop overlay once the window hierarchy is ready, outside the
-        // high-frequency body-level window styling accessor above.
-        view = AnyView(view.background(WindowSetupAccessor { window in
-            installFileDropOverlay(on: window, tabManager: tabManager)
+            installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
         }))
 
         return view

--- a/Sources/WindowAccessor.swift
+++ b/Sources/WindowAccessor.swift
@@ -36,48 +36,6 @@ struct WindowAccessor: NSViewRepresentable {
     }
 }
 
-/// Replays the window callback until setup succeeds, then dedupes future updates for that window.
-struct WindowSetupAccessor: NSViewRepresentable {
-    let onWindow: (NSWindow) -> Bool
-
-    init(onWindow: @escaping (NSWindow) -> Bool) {
-        self.onWindow = onWindow
-    }
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator()
-    }
-
-    func makeNSView(context: Context) -> WindowObservingView {
-        let view = WindowObservingView()
-        view.onWindow = { window in
-            guard context.coordinator.completedWindow !== window else { return }
-            if onWindow(window) {
-                context.coordinator.completedWindow = window
-            }
-        }
-        return view
-    }
-
-    func updateNSView(_ nsView: WindowObservingView, context: Context) {
-        nsView.onWindow = { window in
-            guard context.coordinator.completedWindow !== window else { return }
-            if onWindow(window) {
-                context.coordinator.completedWindow = window
-            }
-        }
-        if let window = nsView.window {
-            nsView.onWindow?(window)
-        }
-    }
-}
-
-extension WindowSetupAccessor {
-    final class Coordinator {
-        weak var completedWindow: NSWindow?
-    }
-}
-
 extension WindowAccessor {
     final class Coordinator {
         weak var lastWindow: NSWindow?


### PR DESCRIPTION
## Summary
- remove the synchronous `WindowSetupAccessor` path added for file-drop overlay retries
- retry file-drop overlay installation asynchronously from the existing deduped `WindowAccessor`
- keep the retry bounded so startup can recover once the theme frame exists without mutating the window tree mid-attachment

## Root cause
`main` CI started failing in the `tests` job on the two latest merge commits:
- `24597524739` (`26892bd0`)
- `24597559538` (`060eafd6`)

The shared regression started with `70618b0f` (`Fix file drop overlay startup installation`).

The new `WindowSetupAccessor` called `installFileDropOverlay` while `WindowObservingView.viewWillMove(toWindow:)` / SwiftUI update was still attaching the window hierarchy. In the failing CI logs that produced:
- `NSWindow warning: adding an unknown subview: <cmux_DEV.FileDropOverlayView ...>`
- `NSHostingView is being laid out reentrantly while rendering its SwiftUI content`

Once that attachment path became re-entrant, unrelated unit suites started failing broadly because window/layout state and Ghostty surface setup were no longer stable.

## Validation
- required local setup completed: `./scripts/setup.sh`
- attempted tagged debug build twice via `./scripts/reload.sh --tag fix-main-ci-window-overlay`
- local verification was limited by an Xcode build-service crash/hang on this machine before compilation completed; PR CI should provide the authoritative signal

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes window-setup timing and introduces bounded async retry logic during startup; risk is moderate due to potential for missed/late overlay installation or subtle lifecycle timing issues in SwiftUI/AppKit.
> 
> **Overview**
> Defers file-drop overlay installation until the `NSWindow` view hierarchy is stable by adding `installFileDropOverlayWhenReady`, which retries installation on the next main-loop turn with a bounded attempt count.
> 
> Removes the synchronous retry path (`WindowSetupAccessor`) and installs the overlay from the existing window accessor callback, avoiding re-entrant mutations of the `NSThemeFrame`/hosting view tree during attachment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c866bd4238e1207281f28be3c9dd6f2bdb28cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defers file-drop overlay installation to the next run-loop and retries until the window is ready, preventing reentrant layout during SwiftUI attach. This fixes the CI failures caused by mutating the window hierarchy at startup.

- **Bug Fixes**
  - Replaced synchronous setup with `installFileDropOverlayWhenReady` (async with 16 bounded retries).
  - Routed overlay install through the existing `WindowAccessor`; removed `WindowSetupAccessor`.
  - Eliminates NSWindow “unknown subview” and NSHostingView reentrant layout warnings seen in CI.

<sup>Written for commit 5c866bd4238e1207281f28be3c9dd6f2bdb28cbd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced file drop functionality with improved overlay installation reliability using automatic retry logic. Ensures consistent and reliable operation across various system states and conditions.

**Refactor**
- Consolidated internal window setup architecture by streamlining components and removing redundant patterns. All user-facing functionality is maintained while improving code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->