### PR TITLE
fix(claude wrapper): store NODE_OPTIONS guard under Application Support (not $TMPDIR)

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -92,8 +92,13 @@ fi
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
 ensure_node_options_restore_module() {
-    local guard_dir="${TMPDIR:-/tmp}"
-    guard_dir="${guard_dir%/}/cmux-claude-node-options"
+    # Use a persistent location rather than $TMPDIR. macOS `periodic` reaps
+    # files under /var/folders/.../T/ after ~3 days of no access, which
+    # breaks NODE_OPTIONS=--require=... for any `node` invocation from a
+    # long-running Claude session (most visibly from Stop/PreToolUse hooks
+    # that spawn `node`). Storing the guard under Application Support
+    # keeps the injected require target valid for the session's lifetime.
+    local guard_dir="${HOME:-/tmp}/Library/Application Support/cmux/node-options"
     local guard_path="$guard_dir/restore-node-options.cjs"
     mkdir -p "$guard_dir" || return 1
     local temp_path


### PR DESCRIPTION
## Summary
- Move the `NODE_OPTIONS=--require=…` restore shim out of `$TMPDIR` and into `~/Library/Application Support/cmux/node-options/`.
- Fixes recurring hook failures in long-running Claude sessions after macOS `periodic` reaps the temp file.

## The bug

`Resources/bin/claude` writes a small `restore-node-options.cjs` into `${TMPDIR}/cmux-claude-node-options/` and injects `NODE_OPTIONS=--require=<that file>` before `exec`-ing Claude. The injection lives for the entire session, but on macOS the file path is under `/var/folders/<user>/T/`, and `periodic` (the launchd job `com.apple.periodic-daily`) reaps files there after ~3 days of no access.

Once the file is gone, every `node` invocation from Claude hooks (Stop, PreToolUse async, session-end, etc.) crashes on module resolution:

```
Error: Cannot find module '/var/folders/cp/…/T/cmux-claude-node-options/restore-node-options.cjs'
Require stack:
- internal/preload
    at Module._resolveFilename (node:internal/modules/cjs/loader:1475:15)
    …
Node.js v25.9.0
```

Reproducer:
1. Start a Claude session inside a cmux terminal and leave it running for several days.
2. Wait for macOS to reap `$TMPDIR` (or just `rm` the guard dir manually).
3. End the session — all Stop hooks fail with *"Failed with non-blocking status code"*; same from PreToolUse when Claude resumes after a permission grant.

The errors are non-blocking, but they show up in hook output, break `cmux claude-hook stop`/`session-end` reporting, and make troubleshooting noisy.

## The fix

Store the guard under `~/Library/Application Support/cmux/node-options/` instead. That path matches the convention cmux already uses (`cmux.sock` is under `~/Library/Application Support/cmux/`) and is not subject to `periodic` cleanup, so the require target stays valid for the full session lifetime — which is the lifetime this env-var contract actually needs.

No other behavior change: the file contents, `merge_node_options` logic, `CMUX_ORIGINAL_NODE_OPTIONS*` semantics, and `chmod`/`cmp`/`mv` atomic-replace dance are unchanged.

## Test plan
- [ ] Launch Claude inside a cmux terminal; confirm `~/Library/Application Support/cmux/node-options/restore-node-options.cjs` is created.
- [ ] Verify `echo $NODE_OPTIONS` inside Claude points at the new path.
- [ ] Trigger a Stop hook (exit the session) and confirm no `MODULE_NOT_FOUND` error.
- [ ] Delete the file mid-session and re-open Claude — the wrapper re-creates it on next launch (unchanged behavior).
- [ ] Unset `HOME` (simulated): wrapper falls back to `/tmp/Library/Application Support/cmux/node-options` — `mkdir -p` still succeeds.

## Notes
- This does not clean up stale guard files in `$TMPDIR` from prior versions; those are harmless and macOS reaps them on its own schedule.
- Per CLAUDE.md "Test quality policy", I did not add a regression test — the behavior is a bash-level storage-path change with no practical runtime seam to test through without mocking filesystem cleanup policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the NODE_OPTIONS restore shim from $TMPDIR to ~/Library/Application Support/cmux/node-options to keep the --require target persistent and stop module-not-found errors in long-running Claude sessions. Fixes hook failures (Stop, PreToolUse, session-end) caused by macOS periodic reaping the temp file.

<sup>Written for commit 78bd484ee861b399e80a1592aa055abda6e61725. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Node.js configuration handling in long-running Claude sessions by ensuring critical configuration files persist across the session lifetime, preventing configuration loss.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->