### PR TITLE
Fix AX window polling stalls with app hierarchy caching

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -84,11 +84,13 @@ final class CmuxApplicationAccessibilityHierarchyCache {
 
     static let shared = CmuxApplicationAccessibilityHierarchyCache()
 
+    private let notificationCenter: NotificationCenter
     private var cachedStateToken: StateToken?
     private var cachedSnapshot: Snapshot?
     private var windowCloseObserver: NSObjectProtocol?
 
     init(notificationCenter: NotificationCenter = .default) {
+        self.notificationCenter = notificationCenter
         // Drop strong refs to any window the instant it closes so the cache
         // never keeps a closed NSWindow alive between AX polls.
         windowCloseObserver = notificationCenter.addObserver(
@@ -102,7 +104,7 @@ final class CmuxApplicationAccessibilityHierarchyCache {
 
     deinit {
         if let windowCloseObserver {
-            NotificationCenter.default.removeObserver(windowCloseObserver)
+            notificationCenter.removeObserver(windowCloseObserver)
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -44,8 +44,12 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
-/// Caches the application-level accessibility window hierarchy so repeated AX polls
-/// can reuse the same snapshot while the app window graph is unchanged.
+/// Caches `AXWindows` responses so repeated AX polls can reuse the same
+/// snapshot while the app window graph is unchanged. Only `.windows` is
+/// cached; `.children` and `.visibleChildren` fall through to AppKit so the
+/// menu bar stays present in the accessibility tree for VoiceOver and other
+/// AX clients. `.mainWindow` / `.focusedWindow` also fall through, so AppKit
+/// remains authoritative on focus transitions.
 final class CmuxApplicationAccessibilityHierarchyCache {
     enum Resolution {
         case passthrough
@@ -61,10 +65,8 @@ final class CmuxApplicationAccessibilityHierarchyCache {
 
     struct StateToken: Equatable {
         let windows: [WindowToken]
-        let mainWindow: ObjectIdentifier?
-        let focusedWindow: ObjectIdentifier?
 
-        init(windows: [NSWindow], mainWindow: NSWindow?, focusedWindow: NSWindow?) {
+        init(windows: [NSWindow]) {
             self.windows = windows.map {
                 WindowToken(
                     identity: ObjectIdentifier($0),
@@ -73,38 +75,48 @@ final class CmuxApplicationAccessibilityHierarchyCache {
                     isMiniaturized: $0.isMiniaturized
                 )
             }
-            self.mainWindow = mainWindow.map(ObjectIdentifier.init)
-            self.focusedWindow = focusedWindow.map(ObjectIdentifier.init)
         }
     }
 
     struct Snapshot {
         let windows: [NSWindow]
-        let visibleChildren: [NSWindow]
-        let mainWindow: NSWindow?
-        let focusedWindow: NSWindow?
     }
 
     static let shared = CmuxApplicationAccessibilityHierarchyCache()
 
     private var cachedStateToken: StateToken?
     private var cachedSnapshot: Snapshot?
+    private var windowCloseObserver: NSObjectProtocol?
+
+    init(notificationCenter: NotificationCenter = .default) {
+        // Drop strong refs to any window the instant it closes so the cache
+        // never keeps a closed NSWindow alive between AX polls.
+        windowCloseObserver = notificationCenter.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.invalidate()
+        }
+    }
+
+    deinit {
+        if let windowCloseObserver {
+            NotificationCenter.default.removeObserver(windowCloseObserver)
+        }
+    }
+
+    func invalidate() {
+        cachedStateToken = nil
+        cachedSnapshot = nil
+    }
 
     func resolve(attribute: NSAccessibility.Attribute, application: NSApplication) -> Resolution {
         guard Self.supportsCaching(attribute) else { return .passthrough }
         let windows = application.windows
-        let stateToken = StateToken(
-            windows: windows,
-            mainWindow: application.mainWindow,
-            focusedWindow: application.keyWindow
-        )
+        let stateToken = StateToken(windows: windows)
         let value = value(for: attribute, stateToken: stateToken) {
-            Snapshot(
-                windows: windows,
-                visibleChildren: windows.filter { $0.isVisible && !$0.isMiniaturized },
-                mainWindow: application.mainWindow,
-                focusedWindow: application.keyWindow
-            )
+            Snapshot(windows: windows)
         }
         return .handled(value)
     }
@@ -126,31 +138,15 @@ final class CmuxApplicationAccessibilityHierarchyCache {
         }
 
         switch attribute.rawValue {
-        case NSAccessibility.Attribute.windows.rawValue,
-             NSAccessibility.Attribute.children.rawValue:
+        case NSAccessibility.Attribute.windows.rawValue:
             return snapshot.windows
-        case NSAccessibility.Attribute.visibleChildren.rawValue:
-            return snapshot.visibleChildren
-        case NSAccessibility.Attribute.mainWindow.rawValue:
-            return snapshot.mainWindow
-        case NSAccessibility.Attribute.focusedWindow.rawValue:
-            return snapshot.focusedWindow
         default:
             return nil
         }
     }
 
     private static func supportsCaching(_ attribute: NSAccessibility.Attribute) -> Bool {
-        switch attribute.rawValue {
-        case NSAccessibility.Attribute.windows.rawValue,
-             NSAccessibility.Attribute.children.rawValue,
-             NSAccessibility.Attribute.visibleChildren.rawValue,
-             NSAccessibility.Attribute.mainWindow.rawValue,
-             NSAccessibility.Attribute.focusedWindow.rawValue:
-            return true
-        default:
-            return false
-        }
+        attribute.rawValue == NSAccessibility.Attribute.windows.rawValue
     }
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -44,6 +44,116 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+/// Caches the application-level accessibility window hierarchy so repeated AX polls
+/// can reuse the same snapshot while the app window graph is unchanged.
+final class CmuxApplicationAccessibilityHierarchyCache {
+    enum Resolution {
+        case passthrough
+        case handled(Any?)
+    }
+
+    struct WindowToken: Equatable {
+        let identity: ObjectIdentifier
+        let windowNumber: Int
+        let isVisible: Bool
+        let isMiniaturized: Bool
+    }
+
+    struct StateToken: Equatable {
+        let windows: [WindowToken]
+        let mainWindow: ObjectIdentifier?
+        let focusedWindow: ObjectIdentifier?
+
+        init(windows: [NSWindow], mainWindow: NSWindow?, focusedWindow: NSWindow?) {
+            self.windows = windows.map {
+                WindowToken(
+                    identity: ObjectIdentifier($0),
+                    windowNumber: $0.windowNumber,
+                    isVisible: $0.isVisible,
+                    isMiniaturized: $0.isMiniaturized
+                )
+            }
+            self.mainWindow = mainWindow.map(ObjectIdentifier.init)
+            self.focusedWindow = focusedWindow.map(ObjectIdentifier.init)
+        }
+    }
+
+    struct Snapshot {
+        let windows: [NSWindow]
+        let visibleChildren: [NSWindow]
+        let mainWindow: NSWindow?
+        let focusedWindow: NSWindow?
+    }
+
+    static let shared = CmuxApplicationAccessibilityHierarchyCache()
+
+    private var cachedStateToken: StateToken?
+    private var cachedSnapshot: Snapshot?
+
+    func resolve(attribute: NSAccessibility.Attribute, application: NSApplication) -> Resolution {
+        guard Self.supportsCaching(attribute) else { return .passthrough }
+        let windows = application.windows
+        let stateToken = StateToken(
+            windows: windows,
+            mainWindow: application.mainWindow,
+            focusedWindow: application.keyWindow
+        )
+        let value = value(for: attribute, stateToken: stateToken) {
+            Snapshot(
+                windows: windows,
+                visibleChildren: windows.filter { $0.isVisible && !$0.isMiniaturized },
+                mainWindow: application.mainWindow,
+                focusedWindow: application.keyWindow
+            )
+        }
+        return .handled(value)
+    }
+
+    func value(
+        for attribute: NSAccessibility.Attribute,
+        stateToken: StateToken,
+        builder: () -> Snapshot
+    ) -> Any? {
+        guard Self.supportsCaching(attribute) else { return nil }
+
+        let snapshot: Snapshot
+        if cachedStateToken == stateToken, let cachedSnapshot {
+            snapshot = cachedSnapshot
+        } else {
+            snapshot = builder()
+            cachedStateToken = stateToken
+            cachedSnapshot = snapshot
+        }
+
+        switch attribute.rawValue {
+        case NSAccessibility.Attribute.windows.rawValue,
+             NSAccessibility.Attribute.children.rawValue:
+            return snapshot.windows
+        case NSAccessibility.Attribute.visibleChildren.rawValue:
+            return snapshot.visibleChildren
+        case NSAccessibility.Attribute.mainWindow.rawValue:
+            return snapshot.mainWindow
+        case NSAccessibility.Attribute.focusedWindow.rawValue:
+            return snapshot.focusedWindow
+        default:
+            return nil
+        }
+    }
+
+    private static func supportsCaching(_ attribute: NSAccessibility.Attribute) -> Bool {
+        switch attribute.rawValue {
+        case NSAccessibility.Attribute.windows.rawValue,
+             NSAccessibility.Attribute.children.rawValue,
+             NSAccessibility.Attribute.visibleChildren.rawValue,
+             NSAccessibility.Attribute.mainWindow.rawValue,
+             NSAccessibility.Attribute.focusedWindow.rawValue:
+            return true
+        default:
+            return false
+        }
+    }
+}
+
 private enum CmuxThemeNotifications {
     static let reloadConfig = Notification.Name("com.cmuxterm.themes.reload-config")
 }
@@ -2345,6 +2455,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let targetClass: AnyClass = NSApplication.self
         let originalSelector = #selector(NSApplication.sendEvent(_:))
         let swizzledSelector = #selector(NSApplication.cmux_applicationSendEvent(_:))
+        guard let originalMethod = class_getInstanceMethod(targetClass, originalSelector),
+              let swizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector) else {
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }()
+    private static let didInstallApplicationAccessibilitySwizzle: Void = {
+        let targetClass: AnyClass = NSApplication.self
+        let originalSelector = #selector(NSApplication.accessibilityAttributeValue(_:))
+        let swizzledSelector = #selector(NSApplication.cmux_accessibilityAttributeValue(_:))
         guard let originalMethod = class_getInstanceMethod(targetClass, originalSelector),
               let swizzledMethod = class_getInstanceMethod(targetClass, swizzledSelector) else {
             return
@@ -10239,6 +10359,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     static func installWindowResponderSwizzlesForTesting() {
+        _ = didInstallApplicationAccessibilitySwizzle
         _ = didInstallWindowKeyEquivalentSwizzle
         _ = didInstallWindowFirstResponderSwizzle
         _ = didInstallWindowSendEventSwizzle
@@ -10257,6 +10378,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     private func installWindowResponderSwizzles() {
+        _ = Self.didInstallApplicationAccessibilitySwizzle
         _ = Self.didInstallApplicationSendEventSwizzle
         _ = Self.didInstallWindowKeyEquivalentSwizzle
         _ = Self.didInstallWindowFirstResponderSwizzle
@@ -14057,6 +14179,22 @@ private final class CmuxFieldEditorOwningWebViewBox: NSObject {
 }
 
 private extension NSApplication {
+    @objc func cmux_accessibilityAttributeValue(_ attribute: NSAccessibility.Attribute) -> Any? {
+        if Thread.isMainThread {
+            switch CmuxApplicationAccessibilityHierarchyCache.shared.resolve(
+                attribute: attribute,
+                application: self
+            ) {
+            case .handled(let value):
+                return value
+            case .passthrough:
+                break
+            }
+        }
+
+        return cmux_accessibilityAttributeValue(attribute)
+    }
+
     @objc func cmux_applicationSendEvent(_ event: NSEvent) {
 #if DEBUG
         let typingTimingStart = event.type == .keyDown ? CmuxTypingTiming.start() : nil

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1437,4 +1437,142 @@ final class TmuxWorkspacePaneOverlayTests: XCTestCase {
         )
     }
 }
+
+@MainActor
+final class ApplicationAccessibilityHierarchyCacheTests: XCTestCase {
+    private func makeWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        return window
+    }
+
+    private func assertWindowsEqual(_ actual: Any?, _ expected: [NSWindow], file: StaticString = #filePath, line: UInt = #line) {
+        guard let actualWindows = actual as? [NSWindow] else {
+            XCTFail("Expected NSWindow array", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(actualWindows.count, expected.count, file: file, line: line)
+        for (lhs, rhs) in zip(actualWindows, expected) {
+            XCTAssertTrue(lhs === rhs, file: file, line: line)
+        }
+    }
+
+    func testRepeatedAttributeQueriesReuseSingleHierarchyBuildUntilStateChanges() {
+        let firstWindow = makeWindow()
+        let secondWindow = makeWindow()
+        defer {
+            firstWindow.orderOut(nil)
+            secondWindow.orderOut(nil)
+        }
+
+        let cache = CmuxApplicationAccessibilityHierarchyCache()
+        let state = CmuxApplicationAccessibilityHierarchyCache.StateToken(
+            windows: [firstWindow, secondWindow],
+            mainWindow: firstWindow,
+            focusedWindow: secondWindow
+        )
+        var buildCount = 0
+
+        let windowsValue = cache.value(for: .windows, stateToken: state) {
+            buildCount += 1
+            return .init(
+                windows: [firstWindow, secondWindow],
+                visibleChildren: [firstWindow],
+                mainWindow: firstWindow,
+                focusedWindow: secondWindow
+            )
+        }
+        let childrenValue = cache.value(for: .children, stateToken: state) {
+            XCTFail("Expected cached snapshot for repeated state")
+            return .init(
+                windows: [],
+                visibleChildren: [],
+                mainWindow: nil,
+                focusedWindow: nil
+            )
+        }
+        let focusedValue = cache.value(for: .focusedWindow, stateToken: state) {
+            XCTFail("Expected cached snapshot for repeated state")
+            return .init(
+                windows: [],
+                visibleChildren: [],
+                mainWindow: nil,
+                focusedWindow: nil
+            )
+        }
+        let visibleChildrenValue = cache.value(for: .visibleChildren, stateToken: state) {
+            XCTFail("Expected cached snapshot for repeated state")
+            return .init(
+                windows: [],
+                visibleChildren: [],
+                mainWindow: nil,
+                focusedWindow: nil
+            )
+        }
+
+        assertWindowsEqual(windowsValue, [firstWindow, secondWindow])
+        assertWindowsEqual(childrenValue, [firstWindow, secondWindow])
+        XCTAssertTrue((focusedValue as? NSWindow) === secondWindow)
+        assertWindowsEqual(visibleChildrenValue, [firstWindow])
+        XCTAssertEqual(buildCount, 1, "Expected a single hierarchy build for repeated AX queries with no invalidation")
+    }
+
+    func testChangedStateTokenInvalidatesCachedHierarchySnapshot() {
+        let window = makeWindow()
+        let otherWindow = makeWindow()
+        defer {
+            window.orderOut(nil)
+            otherWindow.orderOut(nil)
+        }
+
+        let cache = CmuxApplicationAccessibilityHierarchyCache()
+        let initialState = CmuxApplicationAccessibilityHierarchyCache.StateToken(
+            windows: [window],
+            mainWindow: window,
+            focusedWindow: window
+        )
+        let updatedState = CmuxApplicationAccessibilityHierarchyCache.StateToken(
+            windows: [window, otherWindow],
+            mainWindow: otherWindow,
+            focusedWindow: otherWindow
+        )
+        var buildCount = 0
+
+        _ = cache.value(for: .windows, stateToken: initialState) {
+            buildCount += 1
+            return .init(
+                windows: [window],
+                visibleChildren: [window],
+                mainWindow: window,
+                focusedWindow: window
+            )
+        }
+        let updatedWindowsValue = cache.value(for: .windows, stateToken: updatedState) {
+            buildCount += 1
+            return .init(
+                windows: [window, otherWindow],
+                visibleChildren: [window, otherWindow],
+                mainWindow: otherWindow,
+                focusedWindow: otherWindow
+            )
+        }
+        let updatedMainValue = cache.value(for: .mainWindow, stateToken: updatedState) {
+            XCTFail("Expected updated state to stay cached after rebuild")
+            return .init(
+                windows: [],
+                visibleChildren: [],
+                mainWindow: nil,
+                focusedWindow: nil
+            )
+        }
+
+        assertWindowsEqual(updatedWindowsValue, [window, otherWindow])
+        XCTAssertTrue((updatedMainValue as? NSWindow) === otherWindow)
+        XCTAssertEqual(buildCount, 2, "Expected the cache to rebuild once after the hierarchy token changes")
+    }
+}
 #endif

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1455,13 +1455,16 @@ final class ApplicationAccessibilityHierarchyCacheTests: XCTestCase {
             XCTFail("Expected NSWindow array", file: file, line: line)
             return
         }
-        XCTAssertEqual(actualWindows.count, expected.count, file: file, line: line)
+        guard actualWindows.count == expected.count else {
+            XCTFail("Expected \(expected.count) windows, got \(actualWindows.count)", file: file, line: line)
+            return
+        }
         for (lhs, rhs) in zip(actualWindows, expected) {
             XCTAssertTrue(lhs === rhs, file: file, line: line)
         }
     }
 
-    func testRepeatedAttributeQueriesReuseSingleHierarchyBuildUntilStateChanges() {
+    func testRepeatedWindowsQueriesReuseSingleHierarchyBuildUntilStateChanges() {
         let firstWindow = makeWindow()
         let secondWindow = makeWindow()
         defer {
@@ -1470,54 +1473,20 @@ final class ApplicationAccessibilityHierarchyCacheTests: XCTestCase {
         }
 
         let cache = CmuxApplicationAccessibilityHierarchyCache()
-        let state = CmuxApplicationAccessibilityHierarchyCache.StateToken(
-            windows: [firstWindow, secondWindow],
-            mainWindow: firstWindow,
-            focusedWindow: secondWindow
-        )
+        let state = CmuxApplicationAccessibilityHierarchyCache.StateToken(windows: [firstWindow, secondWindow])
         var buildCount = 0
 
-        let windowsValue = cache.value(for: .windows, stateToken: state) {
+        let firstValue = cache.value(for: .windows, stateToken: state) {
             buildCount += 1
-            return .init(
-                windows: [firstWindow, secondWindow],
-                visibleChildren: [firstWindow],
-                mainWindow: firstWindow,
-                focusedWindow: secondWindow
-            )
+            return .init(windows: [firstWindow, secondWindow])
         }
-        let childrenValue = cache.value(for: .children, stateToken: state) {
+        let secondValue = cache.value(for: .windows, stateToken: state) {
             XCTFail("Expected cached snapshot for repeated state")
-            return .init(
-                windows: [],
-                visibleChildren: [],
-                mainWindow: nil,
-                focusedWindow: nil
-            )
-        }
-        let focusedValue = cache.value(for: .focusedWindow, stateToken: state) {
-            XCTFail("Expected cached snapshot for repeated state")
-            return .init(
-                windows: [],
-                visibleChildren: [],
-                mainWindow: nil,
-                focusedWindow: nil
-            )
-        }
-        let visibleChildrenValue = cache.value(for: .visibleChildren, stateToken: state) {
-            XCTFail("Expected cached snapshot for repeated state")
-            return .init(
-                windows: [],
-                visibleChildren: [],
-                mainWindow: nil,
-                focusedWindow: nil
-            )
+            return .init(windows: [])
         }
 
-        assertWindowsEqual(windowsValue, [firstWindow, secondWindow])
-        assertWindowsEqual(childrenValue, [firstWindow, secondWindow])
-        XCTAssertTrue((focusedValue as? NSWindow) === secondWindow)
-        assertWindowsEqual(visibleChildrenValue, [firstWindow])
+        assertWindowsEqual(firstValue, [firstWindow, secondWindow])
+        assertWindowsEqual(secondValue, [firstWindow, secondWindow])
         XCTAssertEqual(buildCount, 1, "Expected a single hierarchy build for repeated AX queries with no invalidation")
     }
 
@@ -1530,49 +1499,56 @@ final class ApplicationAccessibilityHierarchyCacheTests: XCTestCase {
         }
 
         let cache = CmuxApplicationAccessibilityHierarchyCache()
-        let initialState = CmuxApplicationAccessibilityHierarchyCache.StateToken(
-            windows: [window],
-            mainWindow: window,
-            focusedWindow: window
-        )
-        let updatedState = CmuxApplicationAccessibilityHierarchyCache.StateToken(
-            windows: [window, otherWindow],
-            mainWindow: otherWindow,
-            focusedWindow: otherWindow
-        )
+        let initialState = CmuxApplicationAccessibilityHierarchyCache.StateToken(windows: [window])
+        let updatedState = CmuxApplicationAccessibilityHierarchyCache.StateToken(windows: [window, otherWindow])
         var buildCount = 0
 
         _ = cache.value(for: .windows, stateToken: initialState) {
             buildCount += 1
-            return .init(
-                windows: [window],
-                visibleChildren: [window],
-                mainWindow: window,
-                focusedWindow: window
-            )
+            return .init(windows: [window])
         }
         let updatedWindowsValue = cache.value(for: .windows, stateToken: updatedState) {
             buildCount += 1
-            return .init(
-                windows: [window, otherWindow],
-                visibleChildren: [window, otherWindow],
-                mainWindow: otherWindow,
-                focusedWindow: otherWindow
-            )
-        }
-        let updatedMainValue = cache.value(for: .mainWindow, stateToken: updatedState) {
-            XCTFail("Expected updated state to stay cached after rebuild")
-            return .init(
-                windows: [],
-                visibleChildren: [],
-                mainWindow: nil,
-                focusedWindow: nil
-            )
+            return .init(windows: [window, otherWindow])
         }
 
         assertWindowsEqual(updatedWindowsValue, [window, otherWindow])
-        XCTAssertTrue((updatedMainValue as? NSWindow) === otherWindow)
         XCTAssertEqual(buildCount, 2, "Expected the cache to rebuild once after the hierarchy token changes")
+    }
+
+    func testNonWindowsAttributesStayPassthrough() {
+        let cache = CmuxApplicationAccessibilityHierarchyCache()
+
+        for attribute: NSAccessibility.Attribute in [.children, .visibleChildren, .mainWindow, .focusedWindow] {
+            switch cache.resolve(attribute: attribute, application: NSApp) {
+            case .passthrough:
+                break
+            case .handled:
+                XCTFail("Expected \(attribute.rawValue) to fall back to AppKit")
+            }
+        }
+    }
+
+    func testWindowCloseNotificationInvalidatesCache() {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let center = NotificationCenter()
+        let cache = CmuxApplicationAccessibilityHierarchyCache(notificationCenter: center)
+        let state = CmuxApplicationAccessibilityHierarchyCache.StateToken(windows: [window])
+        var buildCount = 0
+
+        _ = cache.value(for: .windows, stateToken: state) {
+            buildCount += 1
+            return .init(windows: [window])
+        }
+        center.post(name: NSWindow.willCloseNotification, object: window)
+        _ = cache.value(for: .windows, stateToken: state) {
+            buildCount += 1
+            return .init(windows: [window])
+        }
+
+        XCTAssertEqual(buildCount, 2, "Expected NSWindow.willCloseNotification to invalidate the cache")
     }
 }
 #endif


### PR DESCRIPTION
Closes #2985.

## Summary
- Cache `AXWindows` responses on `NSApplication` so repeated AX polls (Raycast / AltTab / VoiceOver / etc. — ~32/s per `sample(1)`) reuse a single snapshot while the window graph is unchanged.
- Swizzle `NSApplication.accessibilityAttributeValue(_:)` and answer `.windows` from a cached snapshot fingerprinted by window identity + number + visibility + miniaturized state.
- Invalidate the cached snapshot on `NSWindow.willCloseNotification` so closed windows are never retained between polls.
- Deliberately scoped to `.windows` only — `.children`, `.visibleChildren`, `.mainWindow`, and `.focusedWindow` all pass through to AppKit. This keeps `AXMenuBar` in the NSApplication AX tree (VoiceOver etc.) and leaves AppKit authoritative on focus transitions.

## Testing
- `ApplicationAccessibilityHierarchyCacheTests`
  - repeated `.windows` queries with an unchanged state token reuse a single snapshot build
  - a changed state token triggers a rebuild
  - `.children` / `.visibleChildren` / `.mainWindow` / `.focusedWindow` stay passthrough
  - `NSWindow.willCloseNotification` invalidates the cache
- Not run locally (per repo policy).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an accessibility-aware application window hierarchy cache that reuses snapshots when window state is unchanged and clears cached state when windows close.
  * Added a main-thread interception of application accessibility queries to serve cached window results while deferring unsupported attributes.

* **Tests**
  * Added tests confirming cache reuse, rebuild when window state changes, passthrough behavior for unsupported attributes, and invalidation on window close.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Swizzles `NSApplication.accessibilityAttributeValue(_:)` and changes how `.windows` AX queries are answered, which can affect accessibility clients and window enumeration if the cache/invalidation is wrong.
> 
> **Overview**
> Reduces repeated accessibility-window polling overhead by **caching `NSApplication`’s `.windows` AX attribute** behind a new `CmuxApplicationAccessibilityHierarchyCache`, keyed by a window-state token (identity/number/visibility/miniaturized) and invalidated on `NSWindow.willCloseNotification`.
> 
> Installs a new `NSApplication.accessibilityAttributeValue(_:)` swizzle that serves cached results *only on the main thread* for `.windows`, while leaving `.children`, `.visibleChildren`, `.mainWindow`, and `.focusedWindow` as AppKit passthrough. Adds unit tests covering cache reuse, invalidation on state change and window close, and passthrough behavior for non-window attributes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d8ad3acd557c83f242a722456b07cc8a1413526. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->