### PR TITLE
Suppress Claude Code idle notifications by default (toggle in Automation)

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -204,7 +204,15 @@ fi
 # - SessionEnd: cleanup when Claude exits (covers Ctrl+C where Stop doesn't fire)
 # - UserPromptSubmit: clears "Needs input" and sets "Running" on new prompt
 # - PreToolUse: clears "Needs input" when Claude resumes after permission grant (async to avoid latency)
-HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}]}}'
+# - Notification: matcher-gated. By default only permission_prompt / elicitation_dialog fire
+#   the hook; idle_prompt and auth_success are ignored to avoid spurious "Needs input".
+#   When CMUX_CLAUDE_IDLE_NOTIFICATIONS=1, the catch-all matcher is used (classic behavior).
+if [[ "${CMUX_CLAUDE_IDLE_NOTIFICATIONS:-0}" == "1" ]]; then
+    NOTIFICATION_HOOKS='[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}]'
+else
+    NOTIFICATION_HOOKS='[{"matcher":"permission_prompt","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]},{"matcher":"elicitation_dialog","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook notification","timeout":10}]}]'
+fi
+HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook stop","timeout":10}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook session-end","timeout":1}]}],"Notification":'"$NOTIFICATION_HOOKS"',"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" claude-hook pre-tool-use","timeout":5,"async":true}]}]}}'
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
     exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4344,6 +4344,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         if !claudeHooksEnabled {
             setManagedEnvironmentValue("CMUX_CLAUDE_HOOKS_DISABLED", "1")
         }
+        if ClaudeCodeIntegrationSettings.idleNotificationsEnabled() {
+            setManagedEnvironmentValue("CMUX_CLAUDE_IDLE_NOTIFICATIONS", "1")
+        }
         if let customClaudePath = ClaudeCodeIntegrationSettings.customClaudePath() {
             setManagedEnvironmentValue("CMUX_CUSTOM_CLAUDE_PATH", customClaudePath)
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4070,6 +4070,8 @@ enum ClaudeCodeIntegrationSettings {
     static let hooksEnabledKey = "claudeCodeHooksEnabled"
     static let defaultHooksEnabled = true
     static let customClaudePathKey = "claudeCodeCustomClaudePath"
+    static let idleNotificationsEnabledKey = "claudeCodeIdleNotificationsEnabled"
+    static let defaultIdleNotificationsEnabled = false
 
     static func hooksEnabled(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: hooksEnabledKey) == nil {
@@ -4082,6 +4084,13 @@ enum ClaudeCodeIntegrationSettings {
         let value = defaults.string(forKey: customClaudePathKey)?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         return value.isEmpty ? nil : value
+    }
+
+    static func idleNotificationsEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: idleNotificationsEnabledKey) == nil {
+            return defaultIdleNotificationsEnabled
+        }
+        return defaults.bool(forKey: idleNotificationsEnabledKey)
     }
 }
 
@@ -4384,6 +4393,8 @@ struct SettingsView: View {
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+    @AppStorage(ClaudeCodeIntegrationSettings.idleNotificationsEnabledKey)
+    private var claudeCodeIdleNotificationsEnabled = ClaudeCodeIntegrationSettings.defaultIdleNotificationsEnabled
     @AppStorage(ClaudeCodeIntegrationSettings.customClaudePathKey)
     private var customClaudePath = ""
     @AppStorage(CursorIntegrationSettings.hooksEnabledKey)
@@ -5856,6 +5867,21 @@ struct SettingsView: View {
 
                         SettingsCardDivider()
 
+                        SettingsCardRow(
+                            String(localized: "settings.automation.claudeCode.idleNotifications", defaultValue: "Notify when idle waiting for input"),
+                            subtitle: claudeCodeIdleNotificationsEnabled
+                                ? String(localized: "settings.automation.claudeCode.idleNotifications.subtitleOn", defaultValue: "Shows a notification after ~5 minutes of inactivity (Claude Code default).")
+                                : String(localized: "settings.automation.claudeCode.idleNotifications.subtitleOff", defaultValue: "Suppresses idle \"waiting for input\" notifications. Permission prompts and MCP dialogs still notify.")
+                        ) {
+                            Toggle("", isOn: $claudeCodeIdleNotificationsEnabled)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .disabled(!claudeCodeHooksEnabled)
+                                .accessibilityIdentifier("SettingsClaudeCodeIdleNotificationsToggle")
+                        }
+
+                        SettingsCardDivider()
+
                         SettingsCardNote(String(localized: "settings.automation.claudeCode.note", defaultValue: "When enabled, cmux wraps the claude command to inject session tracking and notification hooks. Disable if you prefer to manage Claude Code hooks yourself."))
                     }
 
@@ -6521,6 +6547,7 @@ struct SettingsView: View {
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
+        claudeCodeIdleNotificationsEnabled = ClaudeCodeIntegrationSettings.defaultIdleNotificationsEnabled
         customClaudePath = ""
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -44,6 +44,7 @@ def run_wrapper(
     argv: list[str],
     node_options: str | None = None,
     tmpdir: str | None = None,
+    extra_env: dict[str, str] | None = None,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -166,6 +167,8 @@ exit 0
             env["TMPDIR"] = tmpdir
         if node_options is not None:
             env["NODE_OPTIONS"] = node_options
+        if extra_env:
+            env.update(extra_env)
 
         try:
             proc = subprocess.run(
@@ -351,6 +354,41 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def _notification_matchers(argv: list[str]) -> list[str]:
+    settings = parse_settings_arg(argv)
+    entries = settings.get("hooks", {}).get("Notification", [])
+    return [entry.get("matcher", "__missing__") for entry in entries]
+
+
+def test_idle_notifications_default_excludes_idle_prompt(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+    )
+    expect(code == 0, f"idle default: wrapper exited {code}: {stderr}", failures)
+    matchers = _notification_matchers(real_argv)
+    expect(
+        matchers == ["permission_prompt", "elicitation_dialog"],
+        f"idle default: expected matcher-gated Notification hooks, got {matchers}",
+        failures,
+    )
+
+
+def test_idle_notifications_opt_in_uses_catch_all(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+        extra_env={"CMUX_CLAUDE_IDLE_NOTIFICATIONS": "1"},
+    )
+    expect(code == 0, f"idle opt-in: wrapper exited {code}: {stderr}", failures)
+    matchers = _notification_matchers(real_argv)
+    expect(
+        matchers == [""],
+        f"idle opt-in: expected catch-all Notification matcher, got {matchers}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks(failures)
@@ -358,6 +396,8 @@ def main() -> int:
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_idle_notifications_default_excludes_idle_prompt(failures)
+    test_idle_notifications_opt_in_uses_catch_all(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
## Summary

- Replaces the catch-all Claude `Notification` hook with matcher-gated hooks for `permission_prompt` and `elicitation_dialog` only, so idle-prompt and auth-success variants no longer surface as \"Needs input\" badges/popups.
- Adds an Automation setting — **Notify when idle waiting for input** (off by default) — that re-registers the catch-all hook via `CMUX_CLAUDE_IDLE_NOTIFICATIONS=1` for users who prefer the classic chatty behavior.
- Handler logic in `CLI/cmux.swift` is untouched; filtering happens upstream in Claude Code via the hook `matcher` field, so the hook simply never fires for idle/auth events when the toggle is off.

Addresses the pain reported in #923 / #2543 where idle notifications every ~5 min are distracting without being informative. Takes a different angle than #2845 (which classifies in-handler) — this one filters upstream so the OSC bell is also silenced.

## Test plan

- [x] Wrapper self-test: sourcing the conditional block yields `[permission_prompt, elicitation_dialog]` by default and `[\"\"]` when `CMUX_CLAUDE_IDLE_NOTIFICATIONS=1`.
- [x] Python wrapper tests in `tests/test_claude_wrapper_hooks.py`: two new cases cover default and opt-in.
- [ ] Manual toggle off: let Claude idle >5 min → no popup/badge; request permission → popup + badge as before.
- [ ] Manual toggle on: idle → popup + badge restored to current behavior.
- [ ] Settings round-trip: flip toggle, reopen Claude, inspect `ps -p <pid> -o args=` to confirm matchers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses Claude Code idle “waiting for input” notifications by default to reduce noise; only permission prompts and MCP elicitation dialogs now trigger the “Needs input” badge and popup. Adds an Automation toggle to opt back in to the previous behavior.

- **New Features**
  - Matcher-gated `Notification` hooks allow `permission_prompt` and `elicitation_dialog` only; `idle_prompt` and `auth_success` are ignored by default.
  - New Automation setting: “Notify when idle waiting for input” (off by default). Enabling sets `CMUX_CLAUDE_IDLE_NOTIFICATIONS=1` to restore the catch‑all hook.
  - Filtering happens in the wrapper, so the `cmux` CLI handler is unchanged and the idle bell is silenced.

<sup>Written for commit a3ee195ce3a1f5977f4f22d165b4075023c024b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "Idle Notifications" toggle under Claude Code Integration settings to control whether notifications appear while waiting for input. This setting is only available when Claude Code hooks are enabled.

* **Tests**
  * Added test coverage for idle notification configuration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->