### PR TITLE
Fix Cmd/Ctrl shortcut hint parity (#2992)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10488,10 +10488,14 @@ enum ShortcutHintModifierPolicy {
     ) -> Bool {
         let normalized = modifierFlags.intersection(.deviceIndependentFlagsMask)
             .subtracting([.numericPad, .function, .capsLock])
-        guard normalized == [.command] else {
+        switch normalized {
+        case [.command]:
+            return ShortcutHintDebugSettings.showHintsOnCommandHoldEnabled(defaults: defaults)
+        case [.control]:
+            return ShortcutHintDebugSettings.showHintsOnControlHoldEnabled(defaults: defaults)
+        default:
             return false
         }
-        return ShortcutHintDebugSettings.showHintsOnCommandHoldEnabled(defaults: defaults)
     }
 
     static func isCurrentWindow(
@@ -10534,6 +10538,7 @@ enum ShortcutHintDebugSettings {
     static let paneHintYKey = "shortcutHintPaneTabYOffset"
     static let alwaysShowHintsKey = "shortcutHintAlwaysShow"
     static let showHintsOnCommandHoldKey = "shortcutHintShowOnCommandHold"
+    static let showHintsOnControlHoldKey = "shortcutHintShowOnControlHold"
 
     static let defaultSidebarHintX = 0.0
     static let defaultSidebarHintY = 0.0
@@ -10543,6 +10548,7 @@ enum ShortcutHintDebugSettings {
     static let defaultPaneHintY = 0.0
     static let defaultAlwaysShowHints = false
     static let defaultShowHintsOnCommandHold = true
+    static let defaultShowHintsOnControlHold = true
 
     static let offsetRange: ClosedRange<Double> = -20...20
 
@@ -10557,9 +10563,17 @@ enum ShortcutHintDebugSettings {
         return defaults.bool(forKey: showHintsOnCommandHoldKey)
     }
 
+    static func showHintsOnControlHoldEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: showHintsOnControlHoldKey) != nil else {
+            return defaultShowHintsOnControlHold
+        }
+        return defaults.bool(forKey: showHintsOnControlHoldKey)
+    }
+
     static func resetVisibilityDefaults(defaults: UserDefaults = .standard) {
         defaults.set(defaultAlwaysShowHints, forKey: alwaysShowHintsKey)
         defaults.set(defaultShowHintsOnCommandHold, forKey: showHintsOnCommandHoldKey)
+        defaults.set(defaultShowHintsOnControlHold, forKey: showHintsOnControlHoldKey)
     }
 }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -831,6 +831,7 @@ final class CmuxSettingsFileStore {
 
         if let value = jsonBool(section["showModifierHoldHints"]) {
             snapshot.managedUserDefaults[ShortcutHintDebugSettings.showHintsOnCommandHoldKey] = .bool(value)
+            snapshot.managedUserDefaults[ShortcutHintDebugSettings.showHintsOnControlHoldKey] = .bool(value)
         }
 
         var bindings = section["bindings"] as? [String: Any] ?? [:]
@@ -1453,7 +1454,8 @@ final class CmuxSettingsFileStore {
             ],
             [
                 "shortcuts": [
-                    "showModifierHoldHints": ShortcutHintDebugSettings.defaultShowHintsOnCommandHold,
+                    "showModifierHoldHints": ShortcutHintDebugSettings.defaultShowHintsOnCommandHold &&
+                        ShortcutHintDebugSettings.defaultShowHintsOnControlHold,
                     "bindings": shortcutsBindings,
                 ],
             ],

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6275,14 +6275,14 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .json("shortcuts.showModifierHoldHints"),
                             String(localized: "settings.shortcuts.showHints", defaultValue: "Show Cmd/Ctrl-Hold Shortcut Hints"),
-                            subtitle: (showShortcutHintsOnCommandHold && showShortcutHintsOnControlHold)
+                            subtitle: (showShortcutHintsOnCommandHold || showShortcutHintsOnControlHold)
                                 ? String(localized: "settings.shortcuts.showHints.subtitleOn", defaultValue: "Holding Cmd (sidebar/titlebar) or Ctrl/Cmd (pane tabs) shows shortcut hint pills.")
                                 : String(localized: "settings.shortcuts.showHints.subtitleOff", defaultValue: "Holding Cmd or Ctrl keeps shortcut hint pills hidden.")
                         ) {
                             Toggle(
                                 "",
                                 isOn: Binding(
-                                    get: { showShortcutHintsOnCommandHold && showShortcutHintsOnControlHold },
+                                    get: { showShortcutHintsOnCommandHold || showShortcutHintsOnControlHold },
                                     set: { newValue in
                                         showShortcutHintsOnCommandHold = newValue
                                         showShortcutHintsOnControlHold = newValue

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1660,6 +1660,7 @@ private enum DebugWindowConfigSnapshot {
         shortcutHintPaneTabYOffset=\(String(format: "%.1f", doubleValue(defaults, key: ShortcutHintDebugSettings.paneHintYKey, fallback: ShortcutHintDebugSettings.defaultPaneHintY)))
         shortcutHintAlwaysShow=\(boolValue(defaults, key: ShortcutHintDebugSettings.alwaysShowHintsKey, fallback: ShortcutHintDebugSettings.defaultAlwaysShowHints))
         shortcutHintShowOnCommandHold=\(boolValue(defaults, key: ShortcutHintDebugSettings.showHintsOnCommandHoldKey, fallback: ShortcutHintDebugSettings.defaultShowHintsOnCommandHold))
+        shortcutHintShowOnControlHold=\(boolValue(defaults, key: ShortcutHintDebugSettings.showHintsOnControlHoldKey, fallback: ShortcutHintDebugSettings.defaultShowHintsOnControlHold))
         """
 
         let backgroundPayload = """
@@ -4450,6 +4451,8 @@ struct SettingsView: View {
     private var openSidebarPortLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser
     @AppStorage(ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
     private var showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+    @AppStorage(ShortcutHintDebugSettings.showHintsOnControlHoldKey)
+    private var showShortcutHintsOnControlHold = ShortcutHintDebugSettings.defaultShowHintsOnControlHold
     @AppStorage("sidebarShowSSH") private var sidebarShowSSH = true
     @AppStorage("sidebarShowPorts") private var sidebarShowPorts = true
     @AppStorage("sidebarShowLog") private var sidebarShowLog = true
@@ -6272,11 +6275,20 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .json("shortcuts.showModifierHoldHints"),
                             String(localized: "settings.shortcuts.showHints", defaultValue: "Show Cmd/Ctrl-Hold Shortcut Hints"),
-                            subtitle: showShortcutHintsOnCommandHold
+                            subtitle: (showShortcutHintsOnCommandHold && showShortcutHintsOnControlHold)
                                 ? String(localized: "settings.shortcuts.showHints.subtitleOn", defaultValue: "Holding Cmd (sidebar/titlebar) or Ctrl/Cmd (pane tabs) shows shortcut hint pills.")
                                 : String(localized: "settings.shortcuts.showHints.subtitleOff", defaultValue: "Holding Cmd or Ctrl keeps shortcut hint pills hidden.")
                         ) {
-                            Toggle("", isOn: $showShortcutHintsOnCommandHold)
+                            Toggle(
+                                "",
+                                isOn: Binding(
+                                    get: { showShortcutHintsOnCommandHold && showShortcutHintsOnControlHold },
+                                    set: { newValue in
+                                        showShortcutHintsOnCommandHold = newValue
+                                        showShortcutHintsOnControlHold = newValue
+                                    }
+                                )
+                            )
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -6581,6 +6593,7 @@ struct SettingsView: View {
         openSidebarPullRequestLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser
         openSidebarPortLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser
         showShortcutHintsOnCommandHold = ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        showShortcutHintsOnControlHold = ShortcutHintDebugSettings.defaultShowHintsOnControlHold
         sidebarShowSSH = true
         sidebarShowPorts = true
         sidebarShowLog = true

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -811,6 +811,14 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
         }
     }
 
+    func testShortcutHintShowsForControlModifier() {
+        withDefaultsSuite { defaults in
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+        }
+    }
+
     func testCommandHintCanBeDisabledInSettings() {
         withDefaultsSuite { defaults in
             defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -796,12 +796,13 @@ final class CommandPaletteSelectionScrollBehaviorTests: XCTestCase {
 
 
 final class ShortcutHintModifierPolicyTests: XCTestCase {
-    func testShortcutHintRequiresEnabledCommandOnlyModifier() {
+    func testShortcutHintRequiresEnabledCommandOrControlOnlyModifier() {
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command, .shift], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control, .shift], defaults: defaults))
@@ -814,30 +815,43 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
     func testShortcutHintShowsForControlModifier() {
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
-    func testCommandHintCanBeDisabledInSettings() {
+    func testCommandHintCanBeDisabledIndependently() {
         withDefaultsSuite { defaults in
             defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
-    func testCommandHintDefaultsToEnabledWhenSettingMissing() {
+    func testControlHintCanBeDisabledIndependently() {
         withDefaultsSuite { defaults in
-            defaults.removeObject(forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
             XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
-    func testShortcutHintStaysCommandOnlyWhenWorkspaceShortcutIsCustomized() {
+    func testCommandAndControlHintsDefaultToEnabledWhenSettingsAreMissing() {
+        withDefaultsSuite { defaults in
+            defaults.removeObject(forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.removeObject(forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
+
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+        }
+    }
+
+    func testShortcutHintIgnoresCustomizedWorkspaceShortcutModifiers() {
         let action = KeyboardShortcutSettings.Action.selectWorkspaceByNumber
         let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
         defer {
@@ -851,13 +865,14 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
 
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
-    func testShortcutHintStaysCommandOnlyWhenWorkspaceShortcutUsesChord() {
+    func testShortcutHintIgnoresWorkspaceShortcutChords() {
         let action = KeyboardShortcutSettings.Action.selectWorkspaceByNumber
         let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
         defer {
@@ -882,9 +897,10 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
 
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.command], defaults: defaults))
-            XCTAssertFalse(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
+            XCTAssertTrue(ShortcutHintModifierPolicy.shouldShowHints(for: [.control], defaults: defaults))
         }
     }
 
@@ -924,6 +940,7 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
     func testWindowScopedShortcutHintsUseKeyWindowWhenNoEventWindowIsAvailable() {
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+            defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
             XCTAssertTrue(
                 ShortcutHintModifierPolicy.shouldShowHints(
@@ -948,17 +965,6 @@ final class ShortcutHintModifierPolicyTests: XCTestCase {
             )
 
             XCTAssertTrue(
-                ShortcutHintModifierPolicy.shouldShowHints(
-                    for: [.command],
-                    hostWindowNumber: 42,
-                    hostWindowIsKey: true,
-                    eventWindowNumber: nil,
-                    keyWindowNumber: 42,
-                    defaults: defaults
-                )
-            )
-
-            XCTAssertFalse(
                 ShortcutHintModifierPolicy.shouldShowHints(
                     for: [.control],
                     hostWindowNumber: 42,
@@ -1002,6 +1008,7 @@ final class ShortcutHintDebugSettingsTests: XCTestCase {
         XCTAssertEqual(ShortcutHintDebugSettings.defaultPaneHintY, 0.0)
         XCTAssertFalse(ShortcutHintDebugSettings.defaultAlwaysShowHints)
         XCTAssertTrue(ShortcutHintDebugSettings.defaultShowHintsOnCommandHold)
+        XCTAssertTrue(ShortcutHintDebugSettings.defaultShowHintsOnControlHold)
     }
 
     func testShowHintsOnCommandHoldSettingRespectsStoredValue() {
@@ -1024,7 +1031,27 @@ final class ShortcutHintDebugSettingsTests: XCTestCase {
         XCTAssertTrue(ShortcutHintDebugSettings.showHintsOnCommandHoldEnabled(defaults: defaults))
     }
 
-    func testResetVisibilityDefaultsRestoresAlwaysShowAndCommandHoldFlags() {
+    func testShowHintsOnControlHoldSettingRespectsStoredValue() {
+        let suiteName = "ShortcutHintDebugSettingsTests-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create defaults suite")
+            return
+        }
+
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.removeObject(forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
+        XCTAssertTrue(ShortcutHintDebugSettings.showHintsOnControlHoldEnabled(defaults: defaults))
+
+        defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
+        XCTAssertFalse(ShortcutHintDebugSettings.showHintsOnControlHoldEnabled(defaults: defaults))
+
+        defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
+        XCTAssertTrue(ShortcutHintDebugSettings.showHintsOnControlHoldEnabled(defaults: defaults))
+    }
+
+    func testResetVisibilityDefaultsRestoresAlwaysShowAndHoldFlags() {
         let suiteName = "ShortcutHintDebugSettingsTests-\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
             XCTFail("Failed to create defaults suite")
@@ -1036,6 +1063,7 @@ final class ShortcutHintDebugSettingsTests: XCTestCase {
 
         defaults.set(true, forKey: ShortcutHintDebugSettings.alwaysShowHintsKey)
         defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)
+        defaults.set(false, forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey)
 
         ShortcutHintDebugSettings.resetVisibilityDefaults(defaults: defaults)
 
@@ -1046,6 +1074,10 @@ final class ShortcutHintDebugSettingsTests: XCTestCase {
         XCTAssertEqual(
             defaults.object(forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey) as? Bool,
             ShortcutHintDebugSettings.defaultShowHintsOnCommandHold
+        )
+        XCTAssertEqual(
+            defaults.object(forKey: ShortcutHintDebugSettings.showHintsOnControlHoldKey) as? Bool,
+            ShortcutHintDebugSettings.defaultShowHintsOnControlHold
         )
     }
 }


### PR DESCRIPTION
## Summary
- reveal sidebar, titlebar, and pane shortcut hint pills when either pure command or pure control is held
- keep each pill rendering its stored shortcut modifier glyphs and wire the new control-hold default through settings/defaults
- add the requested regression coverage and update the Bonsplit submodule to the merged control-hold parity fix

## Testing
- not run locally (per repo policy)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to shortcut-hint visibility logic and related settings/defaults wiring, with updated unit tests to cover the new Ctrl-hold behavior.
> 
> **Overview**
> Shortcut hint pills can now be revealed by holding either *pure* Cmd or *pure* Ctrl via updated `ShortcutHintModifierPolicy` logic.
> 
> Adds a new `shortcutHintShowOnControlHold` UserDefaults setting (default on), updates the Settings toggle to control both Cmd/Ctrl hold visibility, and wires the flag through settings reset, debug snapshot payload, and settings-file management (mapping `shortcuts.showModifierHoldHints` onto both flags and updating the generated template default).
> 
> Expands unit tests to cover Ctrl-hold behavior, independent enable/disable of Cmd vs Ctrl, and default/reset semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3a08724c2b3b7a1a3eb8011a79f09a14d5a0f40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show shortcut hint pills when holding either Cmd or Ctrl across sidebar, titlebar, and pane tabs, matching the UI hints. Addresses #2992.

- **Bug Fixes**
  - Extend hint logic to Ctrl-only holds; add `shortcutHintShowOnControlHold` (default true).
  - Settings toggle controls both modifiers in sync; combined toggle/subtitle now show “on” when either is enabled (OR), and defaults/reset/debug snapshot include the new flag.
  - Settings file store maps `shortcuts.showModifierHoldHints` to both flags; export uses the combined value.
  - Update tests for Ctrl-hold parity, independent toggles, and defaults; bump `bonsplit`.

<sup>Written for commit c3a08724c2b3b7a1a3eb8011a79f09a14d5a0f40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shortcut hints now appear when holding the Control key, in addition to Command.

* **Chores / Settings**
  * Settings expose independent controls for Command‑hold and Control‑hold hint visibility; preferences and stored defaults are synchronized and reset together.
  * Settings UI now reflects the combined hint visibility state.

* **Tests**
  * Test coverage extended to validate control-hold behavior, independent toggles, and default values.

* **Chores**
  * Updated a vendored dependency pointer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->