### PR TITLE
Reserve scroller inset so terminal text isn't clipped on the right

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -130,6 +130,7 @@
 						E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 					1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */; };
 					46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
+					90E6AF1B61106A3758E5599A /* TerminalScrollerInsetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D805685A2E4FD15CB84E054E /* TerminalScrollerInsetTests.swift */; };
 					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
 					063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 					1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */; };
@@ -337,6 +338,7 @@
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPanelTests.swift; sourceTree = "<group>"; };
 				02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
+				D805685A2E4FD15CB84E054E /* TerminalScrollerInsetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalScrollerInsetTests.swift; sourceTree = "<group>"; };
 				71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutAndCommandPaletteTests.swift; sourceTree = "<group>"; };
@@ -624,6 +626,7 @@
 					970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
 					58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
 					02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
+					D805685A2E4FD15CB84E054E /* TerminalScrollerInsetTests.swift */,
 					71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 					BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
 					6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
@@ -933,6 +936,7 @@
 					E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 					1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
 					46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,
+					90E6AF1B61106A3758E5599A /* TerminalScrollerInsetTests.swift in Sources */,
 					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */,
 					063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 					1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9468,6 +9468,38 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
+    /// Width to reserve on the right edge of the terminal surface so that a
+    /// persistently-visible vertical scroller does not render on top of
+    /// terminal content. Returns 0 when the scroller is either absent or
+    /// transient (overlay style that fades out), in which case briefly
+    /// overlapping content is acceptable and we keep the full terminal width.
+    ///
+    /// `preferredScrollerStyle == .legacy` is the signal for "persistently
+    /// visible": macOS reports legacy when the user's Show Scroll Bars
+    /// preference is Always, or Automatic with a mouse attached. cmux forces
+    /// the NSScrollView to overlay style to avoid a reserved legacy gutter,
+    /// which means AppKit will not subtract the scroller width for us, so we
+    /// do it here.
+    static func verticalScrollerInsetWidth(
+        hasVerticalScroller: Bool,
+        preferredScrollerStyle: NSScroller.Style,
+        scrollerWidth: CGFloat
+    ) -> CGFloat {
+        guard hasVerticalScroller else { return 0 }
+        guard preferredScrollerStyle == .legacy else { return 0 }
+        return max(0, scrollerWidth)
+    }
+
+    private func verticalScrollerInsetWidth() -> CGFloat {
+        let style = NSScroller.preferredScrollerStyle
+        let width = NSScroller.scrollerWidth(for: .regular, scrollerStyle: style)
+        return Self.verticalScrollerInsetWidth(
+            hasVerticalScroller: scrollView.hasVerticalScroller,
+            preferredScrollerStyle: style,
+            scrollerWidth: width
+        )
+    }
+
     @discardableResult
     private func synchronizeGeometryAndContent() -> Bool {
         CATransaction.begin()
@@ -9478,7 +9510,11 @@ final class GhosttySurfaceScrollView: NSView {
         let previousSurfaceSize = surfaceView.frame.size
         _ = setFrameIfNeeded(backgroundView, to: bounds)
         _ = setFrameIfNeeded(scrollView, to: bounds)
-        let targetSize = scrollView.bounds.size
+        let scrollerInset = verticalScrollerInsetWidth()
+        let targetSize = CGSize(
+            width: max(0, scrollView.bounds.width - scrollerInset),
+            height: scrollView.bounds.height
+        )
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
@@ -11463,6 +11499,9 @@ final class GhosttySurfaceScrollView: NSView {
 
     /// Match upstream Ghostty behavior: use content area width (excluding non-content
     /// regions such as scrollbar space) when telling libghostty the terminal size.
+    /// `surfaceView.frame` is pre-shrunk by `verticalScrollerInsetWidth()` inside
+    /// `synchronizeGeometryAndContent` so that a persistent vertical scroller does
+    /// not render over the rightmost terminal column.
     @discardableResult
     private func synchronizeCoreSurface() -> Bool {
         let width = max(0, surfaceView.frame.width)
@@ -11637,12 +11676,11 @@ final class GhosttySurfaceScrollView: NSView {
             return
         }
 
-        synchronizeScrollbarAppearance()
-
-        // Retile just the scroll view so contentSize reflects the current
-        // scroller preference without perturbing hosted terminal geometry.
-        scrollView.tile()
-        _ = synchronizeCoreSurface()
+        // Re-run the full geometry pass: the scroller inset we reserve on the
+        // right edge of the terminal depends on preferredScrollerStyle, so the
+        // surface frame needs to resize when legacy/overlay toggles (e.g. the
+        // user plugs in a mouse or flips Show Scroll Bars).
+        _ = synchronizeGeometryAndContent()
     }
 
     private func handleTerminalScrollBarPreferenceChange() {

--- a/cmuxTests/TerminalScrollerInsetTests.swift
+++ b/cmuxTests/TerminalScrollerInsetTests.swift
@@ -1,0 +1,59 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression tests for https://github.com/manaflow-ai/cmux/issues/1082 and
+/// https://github.com/manaflow-ai/cmux/issues/2997. A persistent vertical
+/// scroller rendered on top of the rightmost terminal column because the
+/// surface width passed to libghostty did not account for the scroller gutter.
+/// The terminal reserves the inset only when macOS is going to render a
+/// persistent (legacy) scroller; transient overlay scrollers that fade out
+/// keep the full terminal width.
+final class TerminalScrollerInsetTests: XCTestCase {
+    func testReservesNothingWhenScrollerIsAbsent() {
+        let inset = GhosttySurfaceScrollView.verticalScrollerInsetWidth(
+            hasVerticalScroller: false,
+            preferredScrollerStyle: .legacy,
+            scrollerWidth: 15
+        )
+        XCTAssertEqual(inset, 0)
+    }
+
+    func testReservesNothingForTransientOverlayScrollers() {
+        // Trackpad / transient-overlay case: scroller fades out when idle, so
+        // briefly overlapping content during scroll is acceptable in exchange
+        // for keeping the full terminal width.
+        let inset = GhosttySurfaceScrollView.verticalScrollerInsetWidth(
+            hasVerticalScroller: true,
+            preferredScrollerStyle: .overlay,
+            scrollerWidth: 15
+        )
+        XCTAssertEqual(inset, 0)
+    }
+
+    func testReservesScrollerWidthForPersistentLegacyScrollers() {
+        // macOS reports legacy when "Show scroll bars" is Always, or Automatic
+        // with a mouse attached — in both cases the scroller is permanently
+        // visible, so we must shrink the terminal surface by its width.
+        let inset = GhosttySurfaceScrollView.verticalScrollerInsetWidth(
+            hasVerticalScroller: true,
+            preferredScrollerStyle: .legacy,
+            scrollerWidth: 15
+        )
+        XCTAssertEqual(inset, 15)
+    }
+
+    func testClampsNegativeScrollerWidthToZero() {
+        let inset = GhosttySurfaceScrollView.verticalScrollerInsetWidth(
+            hasVerticalScroller: true,
+            preferredScrollerStyle: .legacy,
+            scrollerWidth: -4
+        )
+        XCTAssertEqual(inset, 0)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #1082 and #2997. When macOS renders a persistent vertical scroller — either because *Show Scroll Bars* is set to *Always*, or because the user has a mouse attached with *Automatic* — the rightmost terminal column currently renders underneath the scrollbar. cmux forces the `NSScrollView` to overlay style to avoid a reserved legacy gutter, which means AppKit does not subtract the scroller width for us; meanwhile `synchronizeGeometryAndContent` was handing libghostty the full scrollview width.

This PR shrinks `surfaceView.frame.width` by the scroller width when `NSScroller.preferredScrollerStyle == .legacy` and a vertical scroller is mounted. Transient overlay scrollers that fade out keep the full terminal width — the brief overlap during a scroll is the explicit tradeoff for not losing a column on every trackpad-only session.

`handlePreferredScrollerStyleChange` now re-runs the full geometry pass, so the terminal resizes live when the user plugs in a mouse or flips the system preference.

- `GhosttySurfaceScrollView.verticalScrollerInsetWidth(...)` — small static helper, pure function, easy to unit-test
- `synchronizeGeometryAndContent` uses it to compute `targetSize`
- `synchronizeCoreSurface` reads `surfaceView.frame.width` as before, which is now pre-shrunk

### Note on commit structure

The CLAUDE.md regression-test policy recommends a two-commit structure (test red → fix green). That doesn't cleanly apply here because the testable seam (`verticalScrollerInsetWidth`) is introduced by the fix itself, so the test cannot compile at commit-1. The new tests verify observable runtime behavior of the pure helper (per the "no source-text assertions" rule) rather than shape.

## Test plan

- [ ] `xcodebuild -scheme cmux-unit` passes locally (new `TerminalScrollerInsetTests` covers all four branches of the helper)
- [ ] Manual: with a mouse attached on macOS Tahoe, open a full-screen TUI (claude code / btop / mc) and confirm text no longer clips under the scrollbar
- [ ] Manual: toggle *System Settings → Appearance → Show scroll bars* between *Always* and *When scrolling* and confirm the terminal resizes live
- [ ] Manual: trackpad-only session keeps the full terminal width (no persistent 1-column loss)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1082 and #2997 by reserving a right-edge inset when macOS shows a persistent vertical scrollbar so the rightmost terminal column isn’t clipped. The inset applies only for legacy scrollers; overlay scrollers keep full width, and the terminal resizes live when the style changes.

- **Bug Fixes**
  - Subtract a vertical scroller inset in `synchronizeGeometryAndContent`, shrinking `surfaceView.frame.width` only when a vertical scroller is present and `NSScroller.preferredScrollerStyle == .legacy`.
  - Add `GhosttySurfaceScrollView.verticalScrollerInsetWidth(...)` (pure helper) with unit tests for absent, overlay, legacy, and negative-width cases.
  - Re-run the full geometry pass on preferred scroller style changes so width updates immediately.

<sup>Written for commit 943c221d89b809b7dff01523f667dff9dc16af37. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed vertical scrollers overlapping terminal content when using legacy scroller style.
  * Improved terminal width calculation to properly account for scroller insets.
  * Enhanced responsiveness when scroller style preferences change.

* **Tests**
  * Added comprehensive test coverage for scroller inset behavior across different scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->