### PR TITLE
feat: cmux attach — attach to surfaces on a remote cmux instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+daemon/remote/cmuxd-remote

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6552,7 +6552,7 @@ struct CMUXCLI {
     ) throws {
         // Parse options
         let (surfaceOpt, rem0) = parseOption(commandArgs, name: "--surface")
-        let (workspaceOpt, rem1) = parseOption(rem0, name: "--workspace")
+        let (_, rem1) = parseOption(rem0, name: "--workspace") // reserved for future use
         let (nameOpt, rem2) = parseOption(rem1, name: "--name")
         let listMode = rem2.contains("--list")
         let readOnly = rem2.contains("--read-only")

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6652,12 +6652,13 @@ struct CMUXCLI {
     }
 
     /// Builds the remote command for bridging to a host surface.
+    /// Uses cmuxd-remote's attach-bridge subcommand for full bidirectional PTY proxy.
     private func buildAttachBridgeCommand(relayPort: Int, surfaceRef: String, readOnly: Bool) -> String {
-        let readOnlyFlag = readOnly ? " --read-only" : ""
-        return [
-            "CMUX_HOST_SURFACE=\(surfaceRef)\(readOnlyFlag)",
-            "exec ~/.cmux/bin/cmuxd-remote/*/darwin-*/cmuxd-remote cli host-read --surface \(surfaceRef)",
-        ].joined(separator: " ")
+        var flags = "--surface \(surfaceRef)"
+        if readOnly {
+            flags += " --read-only"
+        }
+        return "exec ~/.cmux/bin/cmuxd-remote/*/darwin-*/cmuxd-remote attach-bridge \(flags)"
     }
 
     private func runRemoteDaemonStatus(commandArgs: [String], jsonOutput: Bool) throws {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6623,7 +6623,12 @@ struct CMUXCLI {
             "ssh_command": sshCommand,
             "mode": readOnly ? "read_only" : "interactive",
         ]
-        _ = try? client.sendV2(method: "workspace.remote.configure", params: configureParams)
+        do {
+            _ = try client.sendV2(method: "workspace.remote.configure", params: configureParams)
+        } catch {
+            // workspace.remote.configure may not exist on older cmux versions; log but continue
+            cliDebugLog("attach: workspace.remote.configure failed (non-fatal): \(error)")
+        }
 
         let wsHandle = handleForID(workspaceId, kind: .workspace) ?? workspaceId
         if jsonOutput {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2711,6 +2711,9 @@ struct CMUXCLI {
             // nested under `cmux vm`.
             try runVMSSHAttach(commandArgs: commandArgs, client: client)
 
+        case "attach":
+            try runAttach(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+
         case "new-workspace":
             let (commandOpt, rem0) = parseOption(commandArgs, name: "--command")
             let (cwdOpt, rem1) = parseOption(rem0, name: "--cwd")
@@ -6531,6 +6534,130 @@ struct CMUXCLI {
             "surface_id": surfaceId,
             "relay_port": relayPort,
         ])
+    }
+
+    // MARK: - cmux attach
+
+    /// `cmux attach <destination> --surface <ref>` creates a local workspace
+    /// that mirrors an existing surface on the remote host's cmux instance.
+    ///
+    /// This reuses the `cmux ssh` infrastructure (SSH ControlMaster, cmuxd-remote
+    /// deployment, relay) but instead of creating a new shell session, it connects
+    /// to an existing surface on the host cmux via cmuxd-remote's host.* RPC methods.
+    private func runAttach(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        // Parse options
+        let (surfaceOpt, rem0) = parseOption(commandArgs, name: "--surface")
+        let (workspaceOpt, rem1) = parseOption(rem0, name: "--workspace")
+        let (nameOpt, rem2) = parseOption(rem1, name: "--name")
+        let listMode = rem2.contains("--list")
+        let readOnly = rem2.contains("--read-only")
+        let remaining = rem2.filter { $0 != "--list" && $0 != "--read-only" }
+
+        guard let destination = remaining.first else {
+            throw CLIError(message: "attach requires a destination (e.g., cmux attach myhost --surface surface:4)")
+        }
+
+        // Step 1: Establish SSH connection (reuse cmux ssh infra)
+        // This deploys cmuxd-remote if needed and sets up the relay.
+        let localSocketPath = client.socketPath
+        let remoteRelayPort = generateRemoteRelayPort()
+        let relayID = UUID().uuidString.lowercased()
+        let relayToken = try randomHex(byteCount: 32)
+
+        // Build minimal SSH options for the attach connection
+        var sshArgs = ["--name", nameOpt ?? "attach:\(destination)"]
+        sshArgs += [destination]
+
+        let sshOptions = try parseSSHCommandOptions(sshArgs, localSocketPath: localSocketPath, remoteRelayPort: remoteRelayPort)
+
+        // Build the remote command that starts cmuxd-remote and then
+        // runs the appropriate host command
+        let remoteCommand: String
+        if listMode {
+            // --list mode: just list the host surfaces and exit
+            remoteCommand = buildAttachListCommand(relayPort: remoteRelayPort)
+        } else {
+            guard let surfaceRef = surfaceOpt else {
+                throw CLIError(message: "attach requires --surface <ref> (e.g., --surface surface:4). Use --list to see available surfaces.")
+            }
+            // Interactive mode: create a workspace that bridges to the host surface
+            remoteCommand = buildAttachBridgeCommand(
+                relayPort: remoteRelayPort,
+                surfaceRef: surfaceRef,
+                readOnly: readOnly
+            )
+        }
+
+        // Create a workspace with the SSH + attach command
+        let shellFeatures = scopedGhosttyShellFeaturesValue()
+        let sshCommand = buildSSHCommandText(sshOptions)
+        let startupCommand = try buildSSHStartupCommand(
+            sshCommand: sshCommand,
+            shellFeatures: shellFeatures,
+            remoteRelayPort: sshOptions.remoteRelayPort
+        )
+
+        let workspaceTitle = nameOpt ?? "attach:\(destination)/\(surfaceOpt ?? "list")"
+        let workspaceCreateParams: [String: Any] = [
+            "initial_command": startupCommand,
+            "title": workspaceTitle,
+        ]
+
+        let result = try client.sendV2(method: "workspace.create", params: workspaceCreateParams)
+        guard let workspaceId = result["workspace_id"] as? String, !workspaceId.isEmpty else {
+            throw CLIError(message: "workspace.create did not return workspace_id")
+        }
+
+        // Configure the workspace for remote attach
+        let configureParams: [String: Any] = [
+            "workspace_id": workspaceId,
+            "destination": destination,
+            "relay_port": remoteRelayPort,
+            "relay_id": relayID,
+            "relay_token": relayToken,
+            "ssh_command": sshCommand,
+            "mode": readOnly ? "read_only" : "interactive",
+        ]
+        _ = try? client.sendV2(method: "workspace.remote.configure", params: configureParams)
+
+        let wsHandle = handleForID(workspaceId, kind: .workspace) ?? workspaceId
+        if jsonOutput {
+            let output: [String: Any] = [
+                "workspace_id": workspaceId,
+                "workspace": wsHandle,
+                "target": destination,
+                "surface": surfaceOpt ?? "",
+                "state": "connecting",
+            ]
+            if let data = try? JSONSerialization.data(withJSONObject: output),
+               let str = String(data: data, encoding: .utf8) {
+                print(str)
+            }
+        } else {
+            print("OK workspace=\(wsHandle) target=\(destination) state=connecting")
+        }
+    }
+
+    /// Builds the remote command for listing host surfaces.
+    private func buildAttachListCommand(relayPort: Int) -> String {
+        return [
+            "~/.cmux/bin/cmuxd-remote/*/darwin-*/cmuxd-remote cli host-list 2>/dev/null",
+            "|| echo 'cmuxd-remote not found; run cmux ssh first to deploy it'",
+        ].joined(separator: " ")
+    }
+
+    /// Builds the remote command for bridging to a host surface.
+    private func buildAttachBridgeCommand(relayPort: Int, surfaceRef: String, readOnly: Bool) -> String {
+        let readOnlyFlag = readOnly ? " --read-only" : ""
+        return [
+            "CMUX_HOST_SURFACE=\(surfaceRef)\(readOnlyFlag)",
+            "exec ~/.cmux/bin/cmuxd-remote/*/darwin-*/cmuxd-remote cli host-read --surface \(surfaceRef)",
+        ].joined(separator: " ")
     }
 
     private func runRemoteDaemonStatus(commandArgs: [String], jsonOutput: Bool) throws {
@@ -20383,6 +20510,7 @@ export default CMUXSessionRestore;
           list-workspaces
           new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
+          attach <destination> --surface <ref> [--name <title>] [--workspace <ref>] [--read-only] [--list]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>]
           list-panes [--workspace <id|ref>]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2716,6 +2716,8 @@ class TerminalController {
 
         case "surface.read_text":
             return v2Result(id: id, self.v2SurfaceReadText(params: params))
+        case "surface.read_vt":
+            return v2Result(id: id, self.v2SurfaceReadVT(params: params))
 
 
 #if DEBUG
@@ -6799,6 +6801,95 @@ class TerminalController {
             ])
         }
 
+        return result
+    }
+
+    /// Reads the terminal screen with VT escape sequences preserved (ANSI colors, cursor, etc).
+    /// Used by `cmux attach` to achieve high-fidelity remote surface mirroring.
+    private func v2SurfaceReadVT(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        let lineLimit = v2Int(params, "lines")
+        if let lineLimit, lineLimit <= 0 {
+            return .err(code: "invalid_params", message: "lines must be greater than 0", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to read terminal VT", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let surfaceId: UUID?
+            if params["surface_id"] != nil {
+                surfaceId = v2UUID(params, "surface_id")
+                guard surfaceId != nil else {
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    return
+                }
+            } else {
+                surfaceId = ws.focusedPanelId
+            }
+            guard let surfaceId else {
+                result = .err(code: "not_found", message: "No focused surface", data: nil)
+                return
+            }
+            guard let terminalPanel = ws.terminalPanel(for: surfaceId) else {
+                result = .err(code: "invalid_params", message: "Surface is not a terminal", data: ["surface_id": surfaceId.uuidString])
+                return
+            }
+
+            guard let vtText = readTerminalTextFromVTExportForSnapshot(
+                terminalPanel: terminalPanel,
+                lineLimit: lineLimit
+            ) else {
+                // Fallback to plain text if VT export fails
+                let response = readTerminalTextBase64(
+                    terminalPanel: terminalPanel,
+                    includeScrollback: false,
+                    lineLimit: lineLimit
+                )
+                guard response.hasPrefix("OK ") else {
+                    result = .err(code: "internal_error", message: response, data: nil)
+                    return
+                }
+                let base64 = String(response.dropFirst(3)).trimmingCharacters(in: .whitespacesAndNewlines)
+                let decoded = Data(base64Encoded: base64).flatMap { String(data: $0, encoding: .utf8) }
+                guard let text = decoded ?? (base64.isEmpty ? "" : nil) else {
+                    result = .err(code: "internal_error", message: "Failed to decode terminal text", data: nil)
+                    return
+                }
+                let windowId = v2ResolveWindowId(tabManager: tabManager)
+                result = .ok([
+                    "text": text,
+                    "vt": false,
+                    "workspace_id": ws.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                    "surface_id": surfaceId.uuidString,
+                    "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                    "window_id": v2OrNull(windowId?.uuidString),
+                    "window_ref": v2Ref(kind: .window, uuid: windowId)
+                ])
+                return
+            }
+
+            let vtBase64 = Data(vtText.utf8).base64EncodedString()
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "text": vtText,
+                "base64": vtBase64,
+                "vt": true,
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId)
+            ])
+        }
         return result
     }
 

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -161,6 +161,20 @@ doneFlags:
 		return runOMCRelay(socketPath, cmdArgs, refreshAddr)
 	}
 
+	// Host attach commands (bridge to host machine's local cmux)
+	if cmdName == "host-list" {
+		return runHostList(socketPath, cmdArgs, jsonOutput, refreshAddr)
+	}
+	if cmdName == "host-read" {
+		return runHostRead(socketPath, cmdArgs, jsonOutput, refreshAddr)
+	}
+	if cmdName == "host-send" {
+		return runHostSend(socketPath, cmdArgs, refreshAddr)
+	}
+	if cmdName == "host-send-key" {
+		return runHostSendKey(socketPath, cmdArgs, refreshAddr)
+	}
+
 	// Tmux compatibility layer (used by agent shims)
 	if cmdName == "__tmux-compat" {
 		return runTmuxCompat(socketPath, cmdArgs, refreshAddr)
@@ -779,4 +793,10 @@ func cliUsage() {
 	fmt.Fprintln(os.Stderr, "  omx [args...]              Launch Oh My Codex with cmux integration")
 	fmt.Fprintln(os.Stderr, "  omc [args...]              Launch Oh My Claude Code with cmux integration")
 	fmt.Fprintln(os.Stderr, "  rpc <method> [json-params] Send arbitrary JSON-RPC")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "Host attach (bridge to host machine's local cmux):")
+	fmt.Fprintln(os.Stderr, "  host-list                 List surfaces on the host cmux")
+	fmt.Fprintln(os.Stderr, "  host-read --surface <ref>  Read screen of a host cmux surface")
+	fmt.Fprintln(os.Stderr, "  host-send --surface <ref> <text>  Send text to a host surface")
+	fmt.Fprintln(os.Stderr, "  host-send-key --surface <ref> <key>  Send key to a host surface")
 }

--- a/daemon/remote/cmd/cmuxd-remote/host_attach.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach.go
@@ -1,0 +1,487 @@
+package main
+
+// host_attach.go implements RPC methods for attaching to surfaces on the host
+// machine's local cmux instance. This enables `cmux attach <host>` — a local
+// cmux surface whose PTY I/O is transparently bridged to an existing surface
+// on the remote cmux via cmuxd-remote.
+//
+// Architecture:
+//
+//   Local cmux ──SSH──▶ cmuxd-remote ──Unix socket──▶ Host cmux
+//                           │                             │
+//   local surface ◀─ base64 I/O relay ─▶ host surface PTY
+//
+// The host cmux socket is auto-discovered from the standard path
+// ~/Library/Application Support/cmux/cmux.sock or overridden via
+// CMUX_HOST_SOCKET_PATH. The socket must be in "automation" or
+// "allowAll" mode for external processes to connect.
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// hostAttachState tracks an active attach session bridging a local cmux
+// surface to a host cmux surface.
+type hostAttachState struct {
+	mu         sync.Mutex
+	conn       net.Conn        // connection to host cmux socket
+	reader     *bufio.Reader   // buffered reader on the socket
+	surfaceRef string          // e.g. "surface:4"
+	stopCh     chan struct{}    // signals the output pump to stop
+	stopped    bool
+}
+
+// discoverHostSocketPath returns the path to the host machine's cmux Unix socket.
+func discoverHostSocketPath() string {
+	if envPath := os.Getenv("CMUX_HOST_SOCKET_PATH"); envPath != "" {
+		return envPath
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, "Library", "Application Support", "cmux", "cmux.sock")
+}
+
+// dialHostCmux connects to the host cmux's Unix socket.
+func dialHostCmux() (net.Conn, error) {
+	socketPath := discoverHostSocketPath()
+	if socketPath == "" {
+		return nil, fmt.Errorf("cannot determine host cmux socket path")
+	}
+	conn, err := net.DialTimeout("unix", socketPath, 5*time.Second)
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to host cmux at %s: %w", socketPath, err)
+	}
+	return conn, nil
+}
+
+// hostCmuxRoundTrip sends a V2 JSON-RPC request to the host cmux socket
+// and returns the parsed response.
+func hostCmuxRoundTrip(method string, params map[string]any) (map[string]any, error) {
+	conn, err := dialHostCmux()
+	if err != nil {
+		return nil, err
+	}
+	defer conn.Close()
+
+	id := randomHex(8)
+	req := map[string]any{
+		"id":     id,
+		"method": method,
+		"params": params,
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request: %w", err)
+	}
+
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write(append(payload, '\n')); err != nil {
+		return nil, fmt.Errorf("failed to send request: %w", err)
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(15 * time.Second))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(line), &resp); err != nil {
+		return nil, fmt.Errorf("invalid response JSON: %w", err)
+	}
+
+	if ok, _ := resp["ok"].(bool); !ok {
+		if errObj, _ := resp["error"].(map[string]any); errObj != nil {
+			code, _ := errObj["code"].(string)
+			msg, _ := errObj["message"].(string)
+			return nil, fmt.Errorf("host cmux error [%s]: %s", code, msg)
+		}
+		return nil, fmt.Errorf("host cmux returned error")
+	}
+
+	result, _ := resp["result"].(map[string]any)
+	return result, nil
+}
+
+// handleHostSurfaceList lists surfaces on the host cmux by calling surface.list
+// and tree via the host socket.
+func (s *rpcServer) handleHostSurfaceList(req rpcRequest) rpcResponse {
+	// Try tree --all equivalent: workspace.tree
+	params := map[string]any{"all": true}
+	if wsID, ok := getStringParam(req.Params, "workspace_id"); ok {
+		params["workspace_id"] = wsID
+	}
+
+	result, err := hostCmuxRoundTrip("workspace.tree", params)
+	if err != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return rpcResponse{
+		ID:     req.ID,
+		OK:     true,
+		Result: result,
+	}
+}
+
+// handleHostSurfaceReadScreen reads the screen content of a host cmux surface.
+func (s *rpcServer) handleHostSurfaceReadScreen(req rpcRequest) rpcResponse {
+	surfaceID, ok := getStringParam(req.Params, "surface_id")
+	if !ok || surfaceID == "" {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.surface.read_screen requires surface_id",
+			},
+		}
+	}
+
+	params := map[string]any{"surface_id": surfaceID}
+	if scrollback, ok := req.Params["scrollback"]; ok {
+		params["scrollback"] = scrollback
+	}
+	if lines, ok := getIntParam(req.Params, "lines"); ok {
+		params["lines"] = lines
+	}
+
+	result, err := hostCmuxRoundTrip("surface.read_screen", params)
+	if err != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return rpcResponse{
+		ID:     req.ID,
+		OK:     true,
+		Result: result,
+	}
+}
+
+// handleHostSurfaceSendText sends text input to a host cmux surface.
+func (s *rpcServer) handleHostSurfaceSendText(req rpcRequest) rpcResponse {
+	surfaceID, ok := getStringParam(req.Params, "surface_id")
+	if !ok || surfaceID == "" {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.surface.send_text requires surface_id",
+			},
+		}
+	}
+
+	text, ok := getStringParam(req.Params, "text")
+	if !ok {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.surface.send_text requires text",
+			},
+		}
+	}
+
+	result, err := hostCmuxRoundTrip("surface.send_text", map[string]any{
+		"surface_id": surfaceID,
+		"text":       text,
+	})
+	if err != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return rpcResponse{
+		ID:     req.ID,
+		OK:     true,
+		Result: result,
+	}
+}
+
+// handleHostSurfaceSendKey sends a key event to a host cmux surface.
+func (s *rpcServer) handleHostSurfaceSendKey(req rpcRequest) rpcResponse {
+	surfaceID, ok := getStringParam(req.Params, "surface_id")
+	if !ok || surfaceID == "" {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.surface.send_key requires surface_id",
+			},
+		}
+	}
+
+	key, ok := getStringParam(req.Params, "key")
+	if !ok {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.surface.send_key requires key",
+			},
+		}
+	}
+
+	result, err := hostCmuxRoundTrip("surface.send_key", map[string]any{
+		"surface_id": surfaceID,
+		"key":        key,
+	})
+	if err != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: err.Error(),
+			},
+		}
+	}
+
+	return rpcResponse{
+		ID:     req.ID,
+		OK:     true,
+		Result: result,
+	}
+}
+
+// handleHostAttach starts a streaming attach session to a host cmux surface.
+// It connects to the host cmux socket, subscribes to the surface's PTY output,
+// and pumps data back to the local cmux as base64-encoded stream events.
+//
+// The caller can write to the surface via host.surface.send_text and
+// host.surface.send_key while the attach stream is active.
+func (s *rpcServer) handleHostAttach(req rpcRequest) rpcResponse {
+	surfaceID, ok := getStringParam(req.Params, "surface_id")
+	if !ok || surfaceID == "" {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.attach requires surface_id",
+			},
+		}
+	}
+
+	// Verify surface exists by reading its screen
+	_, err := hostCmuxRoundTrip("surface.read_screen", map[string]any{
+		"surface_id": surfaceID,
+	})
+	if err != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: fmt.Sprintf("cannot access host surface %s: %v", surfaceID, err),
+			},
+		}
+	}
+
+	// Create a persistent connection for output streaming
+	conn, dialErr := dialHostCmux()
+	if dialErr != nil {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "host_error",
+				Message: dialErr.Error(),
+			},
+		}
+	}
+
+	s.mu.Lock()
+	attachID := fmt.Sprintf("attach-%d", s.nextStreamID)
+	s.nextStreamID++
+
+	state := &hostAttachState{
+		conn:       conn,
+		reader:     bufio.NewReader(conn),
+		surfaceRef: surfaceID,
+		stopCh:     make(chan struct{}),
+	}
+	if s.hostAttachments == nil {
+		s.hostAttachments = make(map[string]*hostAttachState)
+	}
+	s.hostAttachments[attachID] = state
+	s.mu.Unlock()
+
+	// Start output polling pump in background
+	go s.hostAttachPump(attachID, state)
+
+	return rpcResponse{
+		ID: req.ID,
+		OK: true,
+		Result: map[string]any{
+			"attach_id":  attachID,
+			"surface_id": surfaceID,
+			"status":     "attached",
+		},
+	}
+}
+
+// handleHostDetach stops an active host attach session.
+func (s *rpcServer) handleHostDetach(req rpcRequest) rpcResponse {
+	attachID, ok := getStringParam(req.Params, "attach_id")
+	if !ok || attachID == "" {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "invalid_params",
+				Message: "host.detach requires attach_id",
+			},
+		}
+	}
+
+	s.mu.Lock()
+	state, exists := s.hostAttachments[attachID]
+	if exists {
+		delete(s.hostAttachments, attachID)
+	}
+	s.mu.Unlock()
+
+	if !exists {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "not_found",
+				Message: "attach session not found",
+			},
+		}
+	}
+
+	state.mu.Lock()
+	if !state.stopped {
+		state.stopped = true
+		close(state.stopCh)
+	}
+	state.mu.Unlock()
+	_ = state.conn.Close()
+
+	return rpcResponse{
+		ID: req.ID,
+		OK: true,
+		Result: map[string]any{
+			"attach_id": attachID,
+			"detached":  true,
+		},
+	}
+}
+
+// hostAttachPump polls the host surface's screen and emits stream events
+// with the screen content. This provides a near-real-time view of the
+// remote surface.
+//
+// Future optimization: if cmux adds a streaming/subscribe API for surface
+// output, this can be replaced with a true event-driven pump instead of polling.
+func (s *rpcServer) hostAttachPump(attachID string, state *hostAttachState) {
+	defer func() {
+		s.mu.Lock()
+		delete(s.hostAttachments, attachID)
+		s.mu.Unlock()
+		_ = state.conn.Close()
+	}()
+
+	var lastScreen string
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-state.stopCh:
+			_ = s.frameWriter.writeEvent(rpcEvent{
+				Event:    "host.attach.eof",
+				StreamID: attachID,
+			})
+			return
+		case <-ticker.C:
+			result, err := hostCmuxRoundTrip("surface.read_screen", map[string]any{
+				"surface_id": state.surfaceRef,
+			})
+			if err != nil {
+				_ = s.frameWriter.writeEvent(rpcEvent{
+					Event:    "host.attach.error",
+					StreamID: attachID,
+					Error:    err.Error(),
+				})
+				return
+			}
+
+			// Extract screen text from result
+			screen := extractScreenText(result)
+			if screen != lastScreen {
+				lastScreen = screen
+				_ = s.frameWriter.writeEvent(rpcEvent{
+					Event:      "host.attach.data",
+					StreamID:   attachID,
+					DataBase64: base64.StdEncoding.EncodeToString([]byte(screen)),
+				})
+			}
+		}
+	}
+}
+
+// extractScreenText pulls the screen content string from a read_screen result.
+func extractScreenText(result map[string]any) string {
+	if result == nil {
+		return ""
+	}
+	// The read_screen result may be a string directly or nested
+	if text, ok := result["text"].(string); ok {
+		return text
+	}
+	if content, ok := result["content"].(string); ok {
+		return content
+	}
+	// Fallback: try to find any string value
+	for _, v := range result {
+		if s, ok := v.(string); ok && len(s) > 10 {
+			return s
+		}
+	}
+	return ""
+}
+
+// Helper to check if a string looks like a host:port TCP address.
+func isHostSocketTCP(addr string) bool {
+	return strings.Contains(addr, ":") && !strings.HasPrefix(addr, "/")
+}

--- a/daemon/remote/cmd/cmuxd-remote/host_attach.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach.go
@@ -319,9 +319,6 @@ func (s *rpcServer) handleHostAttach(req rpcRequest) rpcResponse {
 		surfaceRef: surfaceID,
 		stopCh:     make(chan struct{}),
 	}
-	if s.hostAttachments == nil {
-		s.hostAttachments = make(map[string]*hostAttachState)
-	}
 	s.hostAttachments[attachID] = state
 	s.mu.Unlock()
 

--- a/daemon/remote/cmd/cmuxd-remote/host_attach.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach.go
@@ -24,7 +24,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 )
@@ -33,8 +32,6 @@ import (
 // surface to a host cmux surface.
 type hostAttachState struct {
 	mu         sync.Mutex
-	conn       net.Conn        // connection to host cmux socket
-	reader     *bufio.Reader   // buffered reader on the socket
 	surfaceRef string          // e.g. "surface:4"
 	stopCh     chan struct{}    // signals the output pump to stop
 	stopped    bool
@@ -314,26 +311,11 @@ func (s *rpcServer) handleHostAttach(req rpcRequest) rpcResponse {
 		}
 	}
 
-	// Create a persistent connection for output streaming
-	conn, dialErr := dialHostCmux()
-	if dialErr != nil {
-		return rpcResponse{
-			ID: req.ID,
-			OK: false,
-			Error: &rpcError{
-				Code:    "host_error",
-				Message: dialErr.Error(),
-			},
-		}
-	}
-
 	s.mu.Lock()
 	attachID := fmt.Sprintf("attach-%d", s.nextStreamID)
 	s.nextStreamID++
 
 	state := &hostAttachState{
-		conn:       conn,
-		reader:     bufio.NewReader(conn),
 		surfaceRef: surfaceID,
 		stopCh:     make(chan struct{}),
 	}
@@ -395,7 +377,6 @@ func (s *rpcServer) handleHostDetach(req rpcRequest) rpcResponse {
 		close(state.stopCh)
 	}
 	state.mu.Unlock()
-	_ = state.conn.Close()
 
 	return rpcResponse{
 		ID: req.ID,
@@ -418,7 +399,6 @@ func (s *rpcServer) hostAttachPump(attachID string, state *hostAttachState) {
 		s.mu.Lock()
 		delete(s.hostAttachments, attachID)
 		s.mu.Unlock()
-		_ = state.conn.Close()
 	}()
 
 	var lastScreen string
@@ -461,27 +441,17 @@ func (s *rpcServer) hostAttachPump(attachID string, state *hostAttachState) {
 }
 
 // extractScreenText pulls the screen content string from a read_screen result.
+// It checks well-known keys in a deterministic order.
 func extractScreenText(result map[string]any) string {
 	if result == nil {
 		return ""
 	}
-	// The read_screen result may be a string directly or nested
-	if text, ok := result["text"].(string); ok {
-		return text
-	}
-	if content, ok := result["content"].(string); ok {
-		return content
-	}
-	// Fallback: try to find any string value
-	for _, v := range result {
-		if s, ok := v.(string); ok && len(s) > 10 {
-			return s
+	// Check well-known keys in priority order
+	for _, key := range []string{"text", "content", "screen", "data", "output"} {
+		if text, ok := result[key].(string); ok {
+			return text
 		}
 	}
 	return ""
 }
 
-// Helper to check if a string looks like a host:port TCP address.
-func isHostSocketTCP(addr string) bool {
-	return strings.Contains(addr, ":") && !strings.HasPrefix(addr, "/")
-}

--- a/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestExtractScreenText(t *testing.T) {
+	tests := []struct {
+		name     string
+		result   map[string]any
+		expected string
+	}{
+		{
+			name:     "nil result",
+			result:   nil,
+			expected: "",
+		},
+		{
+			name:     "text field",
+			result:   map[string]any{"text": "hello world\n$ "},
+			expected: "hello world\n$ ",
+		},
+		{
+			name:     "content field",
+			result:   map[string]any{"content": "screen content here"},
+			expected: "screen content here",
+		},
+		{
+			name:     "fallback to long string",
+			result:   map[string]any{"screen_data": "this is long enough to be screen content"},
+			expected: "this is long enough to be screen content",
+		},
+		{
+			name:     "empty result",
+			result:   map[string]any{},
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractScreenText(tt.result)
+			if got != tt.expected {
+				t.Errorf("extractScreenText() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestDiscoverHostSocketPath(t *testing.T) {
+	path := discoverHostSocketPath()
+	if path == "" {
+		t.Skip("no home directory available")
+	}
+	// Just verify it returns a non-empty path that looks reasonable
+	if len(path) < 10 {
+		t.Errorf("discoverHostSocketPath() = %q, seems too short", path)
+	}
+}
+
+func TestHostAttachRPCRouting(t *testing.T) {
+	// Verify the new RPC methods are routed correctly (without actual socket)
+	server := &rpcServer{
+		nextStreamID:  1,
+		nextSessionID: 1,
+		streams:       map[string]*streamState{},
+		sessions:      map[string]*sessionState{},
+	}
+
+	// host.surface.list should fail gracefully (no socket) but not panic
+	resp := server.handleRequest(rpcRequest{
+		ID:     "test-1",
+		Method: "host.surface.list",
+		Params: map[string]any{},
+	})
+	if resp.OK {
+		t.Error("host.surface.list should fail without host cmux socket")
+	}
+
+	// host.surface.send_text should validate params
+	resp = server.handleRequest(rpcRequest{
+		ID:     "test-2",
+		Method: "host.surface.send_text",
+		Params: map[string]any{},
+	})
+	if resp.OK {
+		t.Error("host.surface.send_text should fail without surface_id")
+	}
+	if resp.Error == nil || resp.Error.Code != "invalid_params" {
+		t.Errorf("expected invalid_params error, got %v", resp.Error)
+	}
+
+	// host.attach should validate params
+	resp = server.handleRequest(rpcRequest{
+		ID:     "test-3",
+		Method: "host.attach",
+		Params: map[string]any{},
+	})
+	if resp.OK {
+		t.Error("host.attach should fail without surface_id")
+	}
+
+	// host.detach should handle missing attach_id
+	resp = server.handleRequest(rpcRequest{
+		ID:     "test-4",
+		Method: "host.detach",
+		Params: map[string]any{},
+	})
+	if resp.OK {
+		t.Error("host.detach should fail without attach_id")
+	}
+}
+
+func TestHostAttachCapability(t *testing.T) {
+	server := &rpcServer{
+		nextStreamID:  1,
+		nextSessionID: 1,
+		streams:       map[string]*streamState{},
+		sessions:      map[string]*sessionState{},
+	}
+
+	resp := server.handleRequest(rpcRequest{
+		ID:     "hello-1",
+		Method: "hello",
+	})
+	if !resp.OK {
+		t.Fatal("hello should succeed")
+	}
+
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("hello result should be a map")
+	}
+
+	caps, ok := result["capabilities"].([]string)
+	if !ok {
+		t.Fatal("capabilities should be a string slice")
+	}
+
+	found := false
+	for _, c := range caps {
+		if c == "host.attach" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		capsJSON, _ := json.Marshal(caps)
+		t.Errorf("host.attach capability not found in %s", capsJSON)
+	}
+}

--- a/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
@@ -137,20 +137,27 @@ func TestHostAttachCapability(t *testing.T) {
 		t.Fatal("hello result should be a map")
 	}
 
-	caps, ok := result["capabilities"].([]string)
-	if !ok {
-		t.Fatal("capabilities should be a string slice")
-	}
-
 	found := false
-	for _, c := range caps {
-		if c == "host.attach" {
-			found = true
-			break
+	switch caps := result["capabilities"].(type) {
+	case []string:
+		for _, c := range caps {
+			if c == "host.attach" {
+				found = true
+				break
+			}
 		}
+	case []any:
+		for _, c := range caps {
+			if s, ok := c.(string); ok && s == "host.attach" {
+				found = true
+				break
+			}
+		}
+	default:
+		t.Fatalf("unexpected capabilities type %T", result["capabilities"])
 	}
 	if !found {
-		capsJSON, _ := json.Marshal(caps)
+		capsJSON, _ := json.Marshal(result["capabilities"])
 		t.Errorf("host.attach capability not found in %s", capsJSON)
 	}
 }

--- a/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_attach_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"path/filepath"
 	"testing"
 )
 
@@ -27,9 +28,9 @@ func TestExtractScreenText(t *testing.T) {
 			expected: "screen content here",
 		},
 		{
-			name:     "fallback to long string",
-			result:   map[string]any{"screen_data": "this is long enough to be screen content"},
-			expected: "this is long enough to be screen content",
+			name:     "screen field",
+			result:   map[string]any{"screen": "screen content here"},
+			expected: "screen content here",
 		},
 		{
 			name:     "empty result",
@@ -67,6 +68,9 @@ func TestHostAttachRPCRouting(t *testing.T) {
 		streams:       map[string]*streamState{},
 		sessions:      map[string]*sessionState{},
 	}
+
+	// Force isolation: point to a non-existent socket so tests don't depend on host cmux
+	t.Setenv("CMUX_HOST_SOCKET_PATH", filepath.Join(t.TempDir(), "nope.sock"))
 
 	// host.surface.list should fail gracefully (no socket) but not panic
 	resp := server.handleRequest(rpcRequest{

--- a/daemon/remote/cmd/cmuxd-remote/host_bridge.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_bridge.go
@@ -1,0 +1,466 @@
+package main
+
+// host_bridge.go implements a transparent terminal bridge between the local
+// terminal's PTY and a remote cmux surface. When run as `cmuxd-remote attach-bridge`,
+// it makes the current terminal act as if directly connected to the remote surface.
+//
+// This is the core of `cmux attach` — the local Ghostty surface runs SSH,
+// which runs this bridge, which connects to the host cmux socket, creating
+// a seamless terminal proxy chain:
+//
+//   User ↔ Local Ghostty PTY ↔ SSH ↔ attach-bridge ↔ Host cmux socket ↔ Remote surface
+
+import (
+	"bufio"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// runAttachBridge is the entry point for `cmuxd-remote attach-bridge --surface <ref>`.
+func runAttachBridge(args []string) int {
+	var surfaceRef string
+	var readOnly bool
+	var pollMs int = 150
+	var useVT bool = true
+
+	for i := 0; i < len(args); i++ {
+		switch args[i] {
+		case "--surface":
+			if i+1 < len(args) {
+				surfaceRef = args[i+1]
+				i++
+			}
+		case "--read-only":
+			readOnly = true
+		case "--poll-ms":
+			if i+1 < len(args) {
+				fmt.Sscanf(args[i+1], "%d", &pollMs)
+				i++
+			}
+		case "--no-vt":
+			useVT = false
+		}
+	}
+
+	if surfaceRef == "" {
+		fmt.Fprintln(os.Stderr, "attach-bridge: --surface is required")
+		return 2
+	}
+	if pollMs < 50 {
+		pollMs = 50
+	}
+
+	bridge := &attachBridge{
+		surfaceRef: surfaceRef,
+		readOnly:   readOnly,
+		pollMs:     pollMs,
+		useVT:      useVT,
+		stopCh:     make(chan struct{}),
+	}
+
+	return bridge.run()
+}
+
+type attachBridge struct {
+	surfaceRef string
+	readOnly   bool
+	pollMs     int
+	useVT      bool
+	stopCh     chan struct{}
+
+	mu          sync.Mutex
+	lastScreen  string
+	origTermios syscall.Termios
+	rawMode     bool
+}
+
+func (b *attachBridge) run() int {
+	// Connect to host cmux socket
+	socketPath := discoverHostSocketPath()
+	if socketPath == "" {
+		fmt.Fprintln(os.Stderr, "attach-bridge: cannot find host cmux socket")
+		return 1
+	}
+
+	// Verify surface exists
+	result, err := hostCmuxRoundTrip("surface.read_text", map[string]any{
+		"surface_id": b.surfaceRef,
+	})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "attach-bridge: cannot access surface %s: %v\n", b.surfaceRef, err)
+		return 1
+	}
+	_ = result
+
+	// Set terminal to raw mode for input forwarding
+	if !b.readOnly {
+		if err := b.enableRawMode(); err != nil {
+			fmt.Fprintf(os.Stderr, "attach-bridge: failed to set raw mode: %v\n", err)
+			// Continue in cooked mode
+		}
+		defer b.restoreTerminal()
+	}
+
+	// Handle SIGWINCH for terminal resize
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGWINCH, syscall.SIGINT, syscall.SIGTERM)
+
+	// Start output pump (screen reader)
+	go b.outputPump()
+
+	// Start input pump (keyboard reader)
+	if !b.readOnly {
+		go b.inputPump()
+	}
+
+	// Wait for signal
+	for {
+		select {
+		case sig := <-sigCh:
+			switch sig {
+			case syscall.SIGWINCH:
+				// Forward resize to remote surface
+				b.handleResize()
+			case syscall.SIGINT:
+				// Forward Ctrl+C to remote surface
+				_, _ = hostCmuxRoundTrip("surface.send_key", map[string]any{
+					"surface_id": b.surfaceRef,
+					"key":        "ctrl+c",
+				})
+			case syscall.SIGTERM:
+				close(b.stopCh)
+				return 0
+			}
+		case <-b.stopCh:
+			return 0
+		}
+	}
+}
+
+// outputPump continuously reads the remote surface's screen and writes it to stdout.
+func (b *attachBridge) outputPump() {
+	ticker := time.NewTicker(time.Duration(b.pollMs) * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		case <-ticker.C:
+			b.refreshScreen()
+		}
+	}
+}
+
+// refreshScreen reads the remote surface and redraws the local terminal.
+func (b *attachBridge) refreshScreen() {
+	var screen string
+
+	if b.useVT {
+		// Try VT mode first (includes ANSI escape codes)
+		result, err := hostCmuxRoundTrip("surface.read_vt", map[string]any{
+			"surface_id": b.surfaceRef,
+		})
+		if err == nil {
+			if text, ok := result["text"].(string); ok {
+				screen = text
+			}
+		}
+	}
+
+	if screen == "" {
+		// Fallback to plain text
+		result, err := hostCmuxRoundTrip("surface.read_text", map[string]any{
+			"surface_id": b.surfaceRef,
+		})
+		if err != nil {
+			return
+		}
+		if text, ok := result["text"].(string); ok {
+			screen = text
+		}
+	}
+
+	b.mu.Lock()
+	changed := screen != b.lastScreen
+	b.lastScreen = screen
+	b.mu.Unlock()
+
+	if !changed {
+		return
+	}
+
+	// Clear screen and redraw
+	// ESC[2J = clear screen, ESC[H = cursor home
+	os.Stdout.WriteString("\033[2J\033[H")
+	os.Stdout.WriteString(screen)
+	os.Stdout.Sync()
+}
+
+// inputPump reads raw keyboard input and forwards it to the remote surface.
+func (b *attachBridge) inputPump() {
+	reader := bufio.NewReader(os.Stdin)
+	buf := make([]byte, 256)
+
+	for {
+		select {
+		case <-b.stopCh:
+			return
+		default:
+		}
+
+		n, err := reader.Read(buf)
+		if err != nil {
+			return
+		}
+		if n == 0 {
+			continue
+		}
+
+		input := buf[:n]
+
+		// Check for detach sequence: Ctrl+\ (0x1c)
+		if n == 1 && input[0] == 0x1c {
+			close(b.stopCh)
+			return
+		}
+
+		// Translate raw bytes to cmux key events or text
+		b.forwardInput(input)
+	}
+}
+
+// forwardInput sends raw terminal input bytes to the remote cmux surface.
+func (b *attachBridge) forwardInput(data []byte) {
+	// Handle special key sequences
+	if len(data) == 1 {
+		switch data[0] {
+		case 0x0d: // Enter
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "Enter",
+			})
+			return
+		case 0x09: // Tab
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "Tab",
+			})
+			return
+		case 0x7f: // Backspace
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "Backspace",
+			})
+			return
+		case 0x1b: // Escape
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "Escape",
+			})
+			return
+		case 0x03: // Ctrl+C
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "ctrl+c",
+			})
+			return
+		case 0x04: // Ctrl+D
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        "ctrl+d",
+			})
+			return
+		}
+	}
+
+	// Handle arrow keys and other escape sequences
+	if len(data) == 3 && data[0] == 0x1b && data[1] == 0x5b {
+		var key string
+		switch data[2] {
+		case 'A':
+			key = "Up"
+		case 'B':
+			key = "Down"
+		case 'C':
+			key = "Right"
+		case 'D':
+			key = "Left"
+		}
+		if key != "" {
+			hostCmuxRoundTrip("surface.send_key", map[string]any{
+				"surface_id": b.surfaceRef,
+				"key":        key,
+			})
+			return
+		}
+	}
+
+	// Default: send as text
+	text := string(data)
+	hostCmuxRoundTrip("surface.send_text", map[string]any{
+		"surface_id": b.surfaceRef,
+		"text":       text,
+	})
+}
+
+// handleResize reads the current terminal size and notifies the remote surface.
+func (b *attachBridge) handleResize() {
+	cols, rows := getTerminalSize()
+	if cols > 0 && rows > 0 {
+		// TODO: cmux doesn't have a surface.resize RPC yet.
+		// When it does, we can forward the resize here.
+		_ = cols
+		_ = rows
+	}
+}
+
+// enableRawMode puts the terminal into raw mode for direct keystroke capture.
+func (b *attachBridge) enableRawMode() error {
+	fd := int(os.Stdin.Fd())
+	var termios syscall.Termios
+	if err := ioctl(fd, syscall.TIOCGETA, uintptr(unsafe.Pointer(&termios))); err != nil {
+		return err
+	}
+	b.origTermios = termios
+
+	// Set raw mode: disable echo, canonical mode, signals, etc.
+	termios.Iflag &^= syscall.IGNBRK | syscall.BRKINT | syscall.PARMRK | syscall.ISTRIP | syscall.INLCR | syscall.IGNCR | syscall.ICRNL | syscall.IXON
+	termios.Oflag &^= syscall.OPOST
+	termios.Lflag &^= syscall.ECHO | syscall.ECHONL | syscall.ICANON | syscall.ISIG | syscall.IEXTEN
+	termios.Cflag &^= syscall.CSIZE | syscall.PARENB
+	termios.Cflag |= syscall.CS8
+	termios.Cc[syscall.VMIN] = 1
+	termios.Cc[syscall.VTIME] = 0
+
+	if err := ioctl(fd, syscall.TIOCSETA, uintptr(unsafe.Pointer(&termios))); err != nil {
+		return err
+	}
+	b.rawMode = true
+	return nil
+}
+
+// restoreTerminal restores the terminal to its original mode.
+func (b *attachBridge) restoreTerminal() {
+	if !b.rawMode {
+		return
+	}
+	fd := int(os.Stdin.Fd())
+	_ = ioctl(fd, syscall.TIOCSETA, uintptr(unsafe.Pointer(&b.origTermios)))
+	// Clear screen and show cursor
+	os.Stdout.WriteString("\033[2J\033[H\033[?25h")
+	os.Stdout.Sync()
+}
+
+// getTerminalSize returns the current terminal dimensions.
+func getTerminalSize() (cols, rows int) {
+	var ws struct {
+		Row    uint16
+		Col    uint16
+		Xpixel uint16
+		Ypixel uint16
+	}
+	fd := int(os.Stdout.Fd())
+	if err := ioctl(fd, syscall.TIOCGWINSZ, uintptr(unsafe.Pointer(&ws))); err != nil {
+		return 0, 0
+	}
+	return int(ws.Col), int(ws.Row)
+}
+
+// ioctl wrapper for terminal control.
+func ioctl(fd int, request uint64, argp uintptr) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(request), argp)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}
+
+// hostCmuxRoundTripRaw sends a V2 JSON-RPC request to the host cmux socket
+// and returns the raw JSON response. Used by the bridge for efficient polling.
+func hostCmuxRoundTripRaw(method string, params map[string]any) (string, error) {
+	conn, err := dialHostCmux()
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	id := randomHex(8)
+	req := map[string]any{
+		"id":     id,
+		"method": method,
+		"params": params,
+	}
+	payload, err := json.Marshal(req)
+	if err != nil {
+		return "", err
+	}
+
+	_ = conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
+	if _, err := conn.Write(append(payload, '\n')); err != nil {
+		return "", err
+	}
+
+	_ = conn.SetReadDeadline(time.Now().Add(15 * time.Second))
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimRight(line, "\n"), nil
+}
+
+// dialHostCmuxPersistent creates a persistent connection to the host cmux socket.
+// Used for streaming scenarios where creating a new connection per request is too expensive.
+func dialHostCmuxPersistent() (net.Conn, *bufio.Reader, error) {
+	conn, err := dialHostCmux()
+	if err != nil {
+		return nil, nil, err
+	}
+	return conn, bufio.NewReader(conn), nil
+}
+
+// VT response helpers
+func decodeVTResponse(raw string) (text string, isVT bool, err error) {
+	var resp map[string]any
+	if err := json.Unmarshal([]byte(raw), &resp); err != nil {
+		return "", false, err
+	}
+
+	ok, _ := resp["ok"].(bool)
+	if !ok {
+		if errObj, _ := resp["error"].(map[string]any); errObj != nil {
+			msg, _ := errObj["message"].(string)
+			return "", false, fmt.Errorf("host cmux error: %s", msg)
+		}
+		return "", false, fmt.Errorf("host cmux returned error")
+	}
+
+	result, _ := resp["result"].(map[string]any)
+	if result == nil {
+		return "", false, nil
+	}
+
+	// Check if base64 is available (more reliable for VT data with special chars)
+	if b64, ok := result["base64"].(string); ok && b64 != "" {
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err == nil {
+			vt, _ := result["vt"].(bool)
+			return string(decoded), vt, nil
+		}
+	}
+
+	text, _ = result["text"].(string)
+	vt, _ := result["vt"].(bool)
+	return text, vt, nil
+}

--- a/daemon/remote/cmd/cmuxd-remote/host_bridge.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_bridge.go
@@ -76,6 +76,7 @@ type attachBridge struct {
 	pollMs     int
 	useVT      bool
 	stopCh     chan struct{}
+	stopOnce   sync.Once
 
 	mu          sync.Mutex
 	lastScreen  string
@@ -130,20 +131,23 @@ func (b *attachBridge) run() int {
 			case syscall.SIGWINCH:
 				// Forward resize to remote surface
 				b.handleResize()
-			case syscall.SIGINT:
-				// Forward Ctrl+C to remote surface
-				_, _ = hostCmuxRoundTrip("surface.send_key", map[string]any{
-					"surface_id": b.surfaceRef,
-					"key":        "ctrl+c",
-				})
-			case syscall.SIGTERM:
-				close(b.stopCh)
+			case syscall.SIGINT, syscall.SIGTERM:
+				// External signal: exit the bridge (raw mode disables ISIG,
+				// so Ctrl+C is handled as a keystroke in inputPump, not as SIGINT)
+				b.stop()
 				return 0
 			}
 		case <-b.stopCh:
 			return 0
 		}
 	}
+}
+
+// stop safely closes stopCh exactly once, preventing double-close panics.
+func (b *attachBridge) stop() {
+	b.stopOnce.Do(func() {
+		close(b.stopCh)
+	})
 }
 
 // outputPump continuously reads the remote surface's screen and writes it to stdout.
@@ -207,8 +211,9 @@ func (b *attachBridge) refreshScreen() {
 }
 
 // inputPump reads raw keyboard input and forwards it to the remote surface.
+// It uses a small read timeout to coalesce multi-byte escape sequences
+// (e.g., arrow keys send \x1b[A as 3 bytes that may arrive separately).
 func (b *attachBridge) inputPump() {
-	reader := bufio.NewReader(os.Stdin)
 	buf := make([]byte, 256)
 
 	for {
@@ -218,7 +223,7 @@ func (b *attachBridge) inputPump() {
 		default:
 		}
 
-		n, err := reader.Read(buf)
+		n, err := os.Stdin.Read(buf)
 		if err != nil {
 			return
 		}
@@ -226,11 +231,24 @@ func (b *attachBridge) inputPump() {
 			continue
 		}
 
-		input := buf[:n]
+		input := make([]byte, n)
+		copy(input, buf[:n])
+
+		// If the first byte is ESC (0x1b), wait briefly for more bytes
+		// to coalesce a multi-byte escape sequence.
+		if n == 1 && input[0] == 0x1b {
+			os.Stdin.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
+			extra := make([]byte, 16)
+			en, _ := os.Stdin.Read(extra)
+			os.Stdin.SetReadDeadline(time.Time{})
+			if en > 0 {
+				input = append(input, extra[:en]...)
+			}
+		}
 
 		// Check for detach sequence: Ctrl+\ (0x1c)
-		if n == 1 && input[0] == 0x1c {
-			close(b.stopCh)
+		if len(input) == 1 && input[0] == 0x1c {
+			b.stop()
 			return
 		}
 
@@ -241,75 +259,60 @@ func (b *attachBridge) inputPump() {
 
 // forwardInput sends raw terminal input bytes to the remote cmux surface.
 func (b *attachBridge) forwardInput(data []byte) {
-	// Handle special key sequences
+	sendKey := func(key string) {
+		hostCmuxRoundTrip("surface.send_key", map[string]any{
+			"surface_id": b.surfaceRef,
+			"key":        key,
+		})
+	}
+
+	// Handle single-byte control characters
 	if len(data) == 1 {
 		switch data[0] {
-		case 0x0d: // Enter
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "Enter",
-			})
-			return
-		case 0x09: // Tab
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "Tab",
-			})
-			return
-		case 0x7f: // Backspace
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "Backspace",
-			})
-			return
-		case 0x1b: // Escape
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "Escape",
-			})
-			return
-		case 0x03: // Ctrl+C
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "ctrl+c",
-			})
-			return
-		case 0x04: // Ctrl+D
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        "ctrl+d",
-			})
-			return
+		case 0x0d:
+			sendKey("Enter"); return
+		case 0x09:
+			sendKey("Tab"); return
+		case 0x7f:
+			sendKey("Backspace"); return
+		case 0x1b:
+			// Lone ESC (after coalesce timeout in inputPump)
+			sendKey("Escape"); return
+		case 0x03:
+			sendKey("ctrl+c"); return
+		case 0x04:
+			sendKey("ctrl+d"); return
 		}
 	}
 
-	// Handle arrow keys and other escape sequences
-	if len(data) == 3 && data[0] == 0x1b && data[1] == 0x5b {
-		var key string
-		switch data[2] {
-		case 'A':
-			key = "Up"
-		case 'B':
-			key = "Down"
-		case 'C':
-			key = "Right"
-		case 'D':
-			key = "Left"
+	// Handle CSI escape sequences: ESC [ ...
+	if len(data) >= 3 && data[0] == 0x1b && data[1] == '[' {
+		csiMap := map[byte]string{
+			'A': "Up", 'B': "Down", 'C': "Right", 'D': "Left",
+			'H': "Home", 'F': "End",
 		}
-		if key != "" {
-			hostCmuxRoundTrip("surface.send_key", map[string]any{
-				"surface_id": b.surfaceRef,
-				"key":        key,
-			})
-			return
+		if len(data) == 3 {
+			if key, ok := csiMap[data[2]]; ok {
+				sendKey(key); return
+			}
+		}
+		// CSI sequences like ESC[3~ (Delete), ESC[5~ (PageUp), ESC[6~ (PageDown)
+		if len(data) == 4 && data[3] == '~' {
+			switch data[2] {
+			case '3':
+				sendKey("Delete"); return
+			case '5':
+				sendKey("PageUp"); return
+			case '6':
+				sendKey("PageDown"); return
+			}
 		}
 	}
 
-	// Default: send as text
-	text := string(data)
+	// Default: send as text (handles UTF-8/CJK/IME input)
 	hostCmuxRoundTrip("surface.send_text", map[string]any{
 		"surface_id": b.surfaceRef,
-		"text":       text,
+		"text":       string(data),
 	})
 }
 
@@ -377,7 +380,7 @@ func getTerminalSize() (cols, rows int) {
 }
 
 // ioctl wrapper for terminal control.
-func ioctl(fd int, request uint64, argp uintptr) error {
+func ioctl(fd int, request uintptr, argp uintptr) error {
 	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uintptr(request), argp)
 	if errno != 0 {
 		return errno

--- a/daemon/remote/cmd/cmuxd-remote/host_bridge.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_bridge.go
@@ -132,9 +132,10 @@ func (b *attachBridge) run() int {
 				// Forward resize to remote surface
 				b.handleResize()
 			case syscall.SIGINT:
-				if b.rawMode {
+				if b.rawMode || b.readOnly {
 					// In raw mode ISIG is disabled, so SIGINT comes from an
 					// external sender (kill -INT) — exit the bridge.
+					// In read-only mode, never send input to the remote.
 					b.stop()
 					return 0
 				}

--- a/daemon/remote/cmd/cmuxd-remote/host_bridge.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_bridge.go
@@ -131,9 +131,20 @@ func (b *attachBridge) run() int {
 			case syscall.SIGWINCH:
 				// Forward resize to remote surface
 				b.handleResize()
-			case syscall.SIGINT, syscall.SIGTERM:
-				// External signal: exit the bridge (raw mode disables ISIG,
-				// so Ctrl+C is handled as a keystroke in inputPump, not as SIGINT)
+			case syscall.SIGINT:
+				if b.rawMode {
+					// In raw mode ISIG is disabled, so SIGINT comes from an
+					// external sender (kill -INT) — exit the bridge.
+					b.stop()
+					return 0
+				}
+				// In cooked mode (raw setup failed), Ctrl+C generates SIGINT
+				// so forward it to the remote surface instead of exiting.
+				hostCmuxRoundTrip("surface.send_key", map[string]any{
+					"surface_id": b.surfaceRef,
+					"key":        "ctrl+c",
+				})
+			case syscall.SIGTERM:
 				b.stop()
 				return 0
 			}
@@ -236,14 +247,17 @@ func (b *attachBridge) inputPump() {
 
 		// If the first byte is ESC (0x1b), wait briefly for more bytes
 		// to coalesce a multi-byte escape sequence.
+		// Only attempt if SetReadDeadline is supported (regular files/pipes may not).
 		if n == 1 && input[0] == 0x1b {
-			os.Stdin.SetReadDeadline(time.Now().Add(50 * time.Millisecond))
-			extra := make([]byte, 16)
-			en, _ := os.Stdin.Read(extra)
-			os.Stdin.SetReadDeadline(time.Time{})
-			if en > 0 {
-				input = append(input, extra[:en]...)
+			if err := os.Stdin.SetReadDeadline(time.Now().Add(50 * time.Millisecond)); err == nil {
+				extra := make([]byte, 16)
+				en, _ := os.Stdin.Read(extra)
+				os.Stdin.SetReadDeadline(time.Time{})
+				if en > 0 {
+					input = append(input, extra[:en]...)
+				}
 			}
+			// If SetReadDeadline is unsupported, treat the lone ESC as Escape.
 		}
 
 		// Check for detach sequence: Ctrl+\ (0x1c)

--- a/daemon/remote/cmd/cmuxd-remote/host_cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_cli.go
@@ -53,8 +53,11 @@ func runHostRead(socketPath string, args []string, jsonOutput bool, refreshAddr 
 	}
 
 	params := map[string]any{"surface_id": surfaceID}
-	if lines, ok := parsed.flags["lines"]; ok {
-		params["lines"] = lines
+	if linesStr, ok := parsed.flags["lines"]; ok {
+		var linesInt int
+		if _, err := fmt.Sscanf(linesStr, "%d", &linesInt); err == nil && linesInt > 0 {
+			params["lines"] = linesInt
+		}
 	}
 
 	resp, err := socketRoundTripV2(socketPath, "host.surface.read_screen", params, refreshAddr)

--- a/daemon/remote/cmd/cmuxd-remote/host_cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/host_cli.go
@@ -1,0 +1,166 @@
+package main
+
+// host_cli.go implements CLI commands for the host attach feature.
+// These commands allow remote callers to interact with the host machine's
+// local cmux instance through cmuxd-remote's relay.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// runHostList lists surfaces on the host machine's cmux.
+func runHostList(socketPath string, args []string, jsonOutput bool, refreshAddr func() string) int {
+	params := map[string]any{"all": true}
+
+	parsed, err := parseFlags(args, []string{"workspace"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux host-list: %v\n", err)
+		return 2
+	}
+	if ws, ok := parsed.flags["workspace"]; ok {
+		params["workspace_id"] = ws
+	}
+
+	resp, err := socketRoundTripV2(socketPath, "host.surface.list", params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+
+	if jsonOutput {
+		fmt.Println(resp)
+	} else {
+		fmt.Println(formatHostList(resp))
+	}
+	return 0
+}
+
+// runHostRead reads the screen content of a host cmux surface.
+func runHostRead(socketPath string, args []string, jsonOutput bool, refreshAddr func() string) int {
+	parsed, err := parseFlags(args, []string{"surface", "lines"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux host-read: %v\n", err)
+		return 2
+	}
+
+	surfaceID, ok := parsed.flags["surface"]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "cmux host-read: --surface is required")
+		return 2
+	}
+
+	params := map[string]any{"surface_id": surfaceID}
+	if lines, ok := parsed.flags["lines"]; ok {
+		params["lines"] = lines
+	}
+
+	resp, err := socketRoundTripV2(socketPath, "host.surface.read_screen", params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+
+	if jsonOutput {
+		fmt.Println(resp)
+	} else {
+		// Try to extract just the screen text
+		var result map[string]any
+		if json.Unmarshal([]byte(resp), &result) == nil {
+			text := extractScreenText(result)
+			if text != "" {
+				fmt.Print(text)
+				if !strings.HasSuffix(text, "\n") {
+					fmt.Println()
+				}
+				return 0
+			}
+		}
+		fmt.Println(resp)
+	}
+	return 0
+}
+
+// runHostSend sends text to a host cmux surface.
+func runHostSend(socketPath string, args []string, refreshAddr func() string) int {
+	parsed, err := parseFlags(args, []string{"surface"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux host-send: %v\n", err)
+		return 2
+	}
+
+	surfaceID, ok := parsed.flags["surface"]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "cmux host-send: --surface is required")
+		return 2
+	}
+
+	if len(parsed.positional) == 0 {
+		fmt.Fprintln(os.Stderr, "cmux host-send: text argument is required")
+		return 2
+	}
+	text := strings.Join(parsed.positional, " ")
+
+	params := map[string]any{
+		"surface_id": surfaceID,
+		"text":       text,
+	}
+
+	_, err = socketRoundTripV2(socketPath, "host.surface.send_text", params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+	fmt.Printf("OK surface=%s\n", surfaceID)
+	return 0
+}
+
+// runHostSendKey sends a key event to a host cmux surface.
+func runHostSendKey(socketPath string, args []string, refreshAddr func() string) int {
+	parsed, err := parseFlags(args, []string{"surface"})
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux host-send-key: %v\n", err)
+		return 2
+	}
+
+	surfaceID, ok := parsed.flags["surface"]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "cmux host-send-key: --surface is required")
+		return 2
+	}
+
+	if len(parsed.positional) == 0 {
+		fmt.Fprintln(os.Stderr, "cmux host-send-key: key argument is required")
+		return 2
+	}
+	key := parsed.positional[0]
+
+	params := map[string]any{
+		"surface_id": surfaceID,
+		"key":        key,
+	}
+
+	_, err = socketRoundTripV2(socketPath, "host.surface.send_key", params, refreshAddr)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
+		return 1
+	}
+	fmt.Printf("OK surface=%s key=%s\n", surfaceID, key)
+	return 0
+}
+
+// formatHostList formats the host surface list response for human-readable output.
+func formatHostList(resp string) string {
+	var result any
+	if err := json.Unmarshal([]byte(resp), &result); err != nil {
+		return resp
+	}
+
+	encoded, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return resp
+	}
+	return string(encoded)
+}

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -179,6 +179,7 @@ func usage(w io.Writer) {
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --stdio")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote serve --ws --auth-lease-file <path> [--rpc-auth-lease-file <path>] [--listen 127.0.0.1:7777]")
 	_, _ = fmt.Fprintln(w, "  cmuxd-remote cli <command> [args...]")
+	_, _ = fmt.Fprintln(w, "  cmuxd-remote attach-bridge --surface <ref> [--read-only] [--poll-ms <ms>] [--no-vt]")
 }
 
 func runStdioServer(stdin io.Reader, stdout io.Writer) error {
@@ -186,11 +187,12 @@ func runStdioServer(stdin io.Reader, stdout io.Writer) error {
 		writer: bufio.NewWriter(stdout),
 	}
 	server := &rpcServer{
-		nextStreamID:  1,
-		nextSessionID: 1,
-		streams:       map[string]*streamState{},
-		sessions:      map[string]*sessionState{},
-		frameWriter:   writer,
+		nextStreamID:    1,
+		nextSessionID:   1,
+		streams:         map[string]*streamState{},
+		sessions:        map[string]*sessionState{},
+		hostAttachments: map[string]*hostAttachState{},
+		frameWriter:     writer,
 	}
 	defer server.closeAll()
 

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -64,12 +64,13 @@ type stdioFrameWriter struct {
 }
 
 type rpcServer struct {
-	mu            sync.Mutex
-	nextStreamID  uint64
-	nextSessionID uint64
-	streams       map[string]*streamState
-	sessions      map[string]*sessionState
-	frameWriter   rpcFrameWriter
+	mu              sync.Mutex
+	nextStreamID    uint64
+	nextSessionID   uint64
+	streams         map[string]*streamState
+	sessions        map[string]*sessionState
+	hostAttachments map[string]*hostAttachState
+	frameWriter     rpcFrameWriter
 }
 
 type sessionAttachment struct {
@@ -345,6 +346,7 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 					"proxy.socks5",
 					"proxy.stream",
 					"proxy.stream.push",
+					"host.attach",
 				},
 			},
 		}
@@ -376,6 +378,19 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 		return s.handleSessionDetach(req)
 	case "session.status":
 		return s.handleSessionStatus(req)
+	// Host attach: bridge to the host machine's local cmux instance
+	case "host.surface.list":
+		return s.handleHostSurfaceList(req)
+	case "host.surface.read_screen":
+		return s.handleHostSurfaceReadScreen(req)
+	case "host.surface.send_text":
+		return s.handleHostSurfaceSendText(req)
+	case "host.surface.send_key":
+		return s.handleHostSurfaceSendKey(req)
+	case "host.attach":
+		return s.handleHostAttach(req)
+	case "host.detach":
+		return s.handleHostDetach(req)
 	default:
 		return rpcResponse{
 			ID: req.ID,
@@ -1012,6 +1027,17 @@ func (s *rpcServer) closeAll() {
 	}
 	for id := range s.sessions {
 		delete(s.sessions, id)
+	}
+	// Clean up host attach sessions
+	for id, attach := range s.hostAttachments {
+		delete(s.hostAttachments, id)
+		attach.mu.Lock()
+		if !attach.stopped {
+			attach.stopped = true
+			close(attach.stopCh)
+		}
+		attach.mu.Unlock()
+		_ = attach.conn.Close()
 	}
 	s.mu.Unlock()
 	for _, conn := range streams {

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -1039,7 +1039,6 @@ func (s *rpcServer) closeAll() {
 			close(attach.stopCh)
 		}
 		attach.mu.Unlock()
-		_ = attach.conn.Close()
 	}
 	s.mu.Unlock()
 	for _, conn := range streams {

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -109,7 +109,7 @@ func shouldRunCLIForInvocation(argv0 string, args []string) bool {
 
 func isDaemonEntryCommand(arg string) bool {
 	switch arg {
-	case "version", "serve", "cli":
+	case "version", "serve", "cli", "attach-bridge":
 		return true
 	default:
 		return false
@@ -165,6 +165,8 @@ func run(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return 0
 	case "cli":
 		return runCLI(args[1:])
+	case "attach-bridge":
+		return runAttachBridge(args[1:])
 	default:
 		usage(stderr)
 		return 2


### PR DESCRIPTION
## Summary

Adds the foundation for `cmux attach <host> --surface <ref>`, which creates a local surface that mirrors an existing surface on a remote host's cmux instance. This enables cross-machine cmux surface interaction — viewing and controlling Claude Code sessions running on a headless Mac Mini from a laptop, for example.

- **Go daemon (cmuxd-remote)**: New `host.*` RPC methods that bridge to the host machine's local cmux socket, plus CLI commands (`host-list`, `host-read`, `host-send`, `host-send-key`)
- **Swift CLI**: New `cmux attach <destination>` command reusing `cmux ssh` infrastructure
- **Tests**: Full coverage for new RPC routing, capability advertisement, and screen text extraction. All 68 existing tests pass with no regressions.

## Architecture

```
Local cmux ──SSH──▶ cmuxd-remote ──Unix socket──▶ Host cmux
                        │                             │
local surface ◀─ base64 I/O relay ─▶ host surface PTY
```

The host cmux must be in `automation` or `allowAll` socket control mode for cmuxd-remote to connect.

## What's included

- `host.surface.list` / `host.surface.read_screen` / `host.surface.send_text` / `host.surface.send_key` RPC methods
- `host.attach` / `host.detach` for streaming attach sessions with 200ms polling
- `host.attach` capability advertised in `hello` response
- CLI: `cmux attach home --surface surface:4 --name "my-agent"`
- CLI: `cmux attach home --list` to discover remote surfaces

## What's needed next (not in this PR)

- **Swift app side**: `surface.attach_remote` RPC handler to create a Ghostty surface whose PTY I/O is bridged through the relay (requires deep Ghostty integration)
- **True streaming**: Replace polling with a cmux socket subscription API when available
- **Resize propagation**: Forward SIGWINCH from local surface to remote surface

Closes #3003

## Test plan

- [x] `go test ./cmd/cmuxd-remote/ -v` — all 68 tests pass
- [x] Go code builds cleanly with `go build ./cmd/cmuxd-remote/`
- [ ] Manual test: deploy cmuxd-remote to a host with cmux in automation mode, verify `host-list` and `host-read` commands work
- [ ] Manual test: verify `cmux attach` creates workspace and connects

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cmux attach` to mirror and control a surface on a remote machine’s `cmux` from your local `cmux`, with a bidirectional PTY bridge and VT-aware screen mirroring. Implements #3003 to enable cross‑machine session attach without screen sharing.

- **New Features**
  - Swift CLI: `cmux attach <destination> --surface <ref> [--name] [--workspace] [--read-only] [--list]`; reuses `cmux ssh` relay and runs `cmuxd-remote attach-bridge` for interactive attach.
  - `cmuxd-remote`: new `attach-bridge` subcommand with raw keystroke forwarding, VT-aware redraw (~150ms polling), Ctrl+\ to detach; RPCs `host.surface.list/read_screen/send_text/send_key`, `host.attach`/`host.detach`; `hello` now advertises `host.attach`.
  - App API: `surface.read_vt` returning VT text plus `base64` for high‑fidelity mirroring, with plain‑text fallback.
  - Remote CLI: `host-list`, `host-read`, `host-send`, `host-send-key`; tests for routing, capability, and screen extraction.

- **Bug Fixes**
  - Fixed connection leak; deterministic screen extraction; parse `--lines` as int in `host-read`; isolate tests via `CMUX_HOST_SOCKET_PATH`; log failures from `workspace.remote.configure`.
  - Prevented double‑close panic in `attach-bridge`; coalesced ESC sequences to avoid fragmented arrows/keys; added Home/End/Delete/PageUp/PageDown; fixed ioctl param type.
  - SIGINT handling: exits the bridge in raw mode; in cooked mode (when raw setup fails) forwards Ctrl+C to the remote surface; in read‑only mode exits instead of forwarding.
  - ESC coalesce now guards `SetReadDeadline` to avoid blocking on unsupported inputs.
  - Initialized `hostAttachments` in the server literal; added `attach-bridge` to `cmuxd-remote` usage; tightened capability assertion in tests; documented `--workspace` as reserved; ignored `daemon/remote/cmuxd-remote` in `.gitignore`.

<sup>Written for commit 9232bada4cdddaedf7708bea9d0154ed373bfa08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New attach CLI to connect/bridge into host surfaces (interactive detach key, read-only mode, JSON/plain output) and an attach-bridge mode that polls and forwards terminal I/O (optional VT-preserving output).
  * New host-side CLI commands to list, read, send text, and send keys to host surfaces; supports JSON and human-readable formatting.
* **Tests**
  * Unit tests for host-attach RPCs and screen extraction/behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->