### PR TITLE
Fix #3011 blank terminal after workspace selection

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10415,6 +10415,10 @@ final class GhosttySurfaceScrollView: NSView {
                 window.makeFirstResponder(nil)
             }
         } else {
+            // Workspace/sidebar selection can make an already-sized terminal visible again
+            // without a portal frame delta or a focus handoff. Reuse the portal refresh
+            // path so the Metal layer is nudged immediately on plain visibility restores.
+            refreshSurfaceNow(reason: "setVisibleInUI")
             scheduleAutomaticFirstResponderApply(reason: "setVisibleInUI")
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3652,6 +3652,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
     private var needsConfirmCloseOverrideForTesting: Bool?
     private var runtimeSurfaceFreedOutOfBandForTesting = false
+    private let debugForceRefreshCountLock = NSLock()
+    private var debugForceRefreshCountValue = 0
 #endif
     private enum PortalLifecycleState: String {
         case live
@@ -4107,8 +4109,6 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
     private static let surfaceLogPath = "/tmp/cmux-ghostty-surface.log"
     private static let sizeLogPath = "/tmp/cmux-ghostty-size.log"
-    private static let forceRefreshCountLock = NSLock()
-    private static var forceRefreshCounts: [UUID: Int] = [:]
 
     func debugCurrentPixelSize() -> (width: UInt32, height: UInt32) {
         (lastPixelWidth, lastPixelHeight)
@@ -4119,22 +4119,22 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     func debugForceRefreshCount() -> Int {
-        Self.forceRefreshCountLock.lock()
-        defer { Self.forceRefreshCountLock.unlock() }
-        return Self.forceRefreshCounts[id, default: 0]
+        debugForceRefreshCountLock.lock()
+        defer { debugForceRefreshCountLock.unlock() }
+        return debugForceRefreshCountValue
     }
 
     @MainActor
     func resetDebugForceRefreshCount() {
-        Self.forceRefreshCountLock.lock()
-        Self.forceRefreshCounts[id] = 0
-        Self.forceRefreshCountLock.unlock()
+        debugForceRefreshCountLock.lock()
+        debugForceRefreshCountValue = 0
+        debugForceRefreshCountLock.unlock()
     }
 
     private func recordDebugForceRefresh() {
-        Self.forceRefreshCountLock.lock()
-        Self.forceRefreshCounts[id, default: 0] += 1
-        Self.forceRefreshCountLock.unlock()
+        debugForceRefreshCountLock.lock()
+        debugForceRefreshCountValue += 1
+        debugForceRefreshCountLock.unlock()
     }
 
     private static func surfaceLog(_ message: String) {
@@ -10415,10 +10415,12 @@ final class GhosttySurfaceScrollView: NSView {
                 window.makeFirstResponder(nil)
             }
         } else {
-            // Workspace/sidebar selection can make an already-sized terminal visible again
-            // without a portal frame delta or a focus handoff. Reuse the portal refresh
-            // path so the Metal layer is nudged immediately on plain visibility restores.
-            refreshSurfaceNow(reason: "setVisibleInUI")
+            if !wasVisible {
+                // Workspace/sidebar selection can make an already-sized terminal visible again
+                // without a portal frame delta or a focus handoff. Reuse the portal refresh
+                // path so the Metal layer is nudged immediately on plain visibility restores.
+                refreshSurfaceNow(reason: "setVisibleInUI")
+            }
             scheduleAutomaticFirstResponderApply(reason: "setVisibleInUI")
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4107,6 +4107,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
     private static let surfaceLogPath = "/tmp/cmux-ghostty-surface.log"
     private static let sizeLogPath = "/tmp/cmux-ghostty-size.log"
+    private static let forceRefreshCountLock = NSLock()
+    private static var forceRefreshCounts: [UUID: Int] = [:]
 
     func debugCurrentPixelSize() -> (width: UInt32, height: UInt32) {
         (lastPixelWidth, lastPixelHeight)
@@ -4114,6 +4116,25 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func debugDesiredFocusState() -> Bool {
         desiredFocusState
+    }
+
+    func debugForceRefreshCount() -> Int {
+        Self.forceRefreshCountLock.lock()
+        defer { Self.forceRefreshCountLock.unlock() }
+        return Self.forceRefreshCounts[id, default: 0]
+    }
+
+    @MainActor
+    func resetDebugForceRefreshCount() {
+        Self.forceRefreshCountLock.lock()
+        Self.forceRefreshCounts[id] = 0
+        Self.forceRefreshCountLock.unlock()
+    }
+
+    private func recordDebugForceRefresh() {
+        Self.forceRefreshCountLock.lock()
+        Self.forceRefreshCounts[id, default: 0] += 1
+        Self.forceRefreshCountLock.unlock()
     }
 
     private static func surfaceLog(_ message: String) {
@@ -4677,6 +4698,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
               view.bounds.height > 0 else {
             return
         }
+#if DEBUG
+        recordDebugForceRefresh()
+#endif
         guard let currentSurface = self.surface else { return }
 
         // Re-read self.surface before each ghostty call to guard against the surface

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2014,6 +2014,11 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         hostedView.layoutSubtreeIfNeeded()
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
+        XCTAssertNotNil(
+            surface.surface,
+            "Expected runtime surface before measuring visibility-restore redraws"
+        )
+
         hostedView.setActive(false)
         hostedView.setVisibleInUI(false)
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
@@ -2025,7 +2030,7 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         DispatchQueue.main.async { drained.fulfill() }
         wait(for: [drained], timeout: 1.0)
 
-        XCTAssertGreaterThanOrEqual(
+        XCTAssertEqual(
             surface.debugForceRefreshCount(),
             1,
             "Restoring panel visibility should force a redraw even when focus recovery is inactive"

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2014,7 +2014,6 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         hostedView.layoutSubtreeIfNeeded()
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
 
-        surface.resetDebugForceRefreshCount()
         hostedView.setActive(false)
         hostedView.setVisibleInUI(false)
         RunLoop.current.run(until: Date().addingTimeInterval(0.05))
@@ -2026,7 +2025,7 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         DispatchQueue.main.async { drained.fulfill() }
         wait(for: [drained], timeout: 1.0)
 
-        XCTAssertEqual(
+        XCTAssertGreaterThanOrEqual(
             surface.debugForceRefreshCount(),
             1,
             "Restoring panel visibility should force a redraw even when focus recovery is inactive"

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1986,6 +1986,55 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         throw XCTSkip("Debug-only regression test")
 #endif
     }
+
+    func testVisibilityRestoreRefreshesSurfaceWhileTerminalIsInactive() throws {
+#if DEBUG
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        surface.resetDebugForceRefreshCount()
+        hostedView.setActive(false)
+        hostedView.setVisibleInUI(false)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        surface.resetDebugForceRefreshCount()
+        hostedView.setVisibleInUI(true)
+
+        let drained = expectation(description: "visible toggle drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertEqual(
+            surface.debugForceRefreshCount(),
+            1,
+            "Restoring panel visibility should force a redraw even when focus recovery is inactive"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- add a debug-only regression for restoring terminal visibility while the surface stays inactive
- force a terminal refresh when `setVisibleInUI(true)` restores an already-sized surface without any frame delta
- reuse the existing portal refresh path so workspace/sidebar selection redraws the Metal surface immediately

## Testing
- Not run locally per repo policy
- Final verification build/launch uses `./scripts/reload.sh --tag issue-3011-blank-terminal-select --launch`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal surface refresh behavior on UI visibility transitions, which could introduce extra redraws or timing-sensitive regressions in rendering/focus handling. Changes are scoped and backed by a new debug-only regression test and instrumentation.
> 
> **Overview**
> Fixes a blank-terminal case by triggering `refreshSurfaceNow(reason: "setVisibleInUI")` when `setVisibleInUI(true)` transitions from hidden to visible, even if there’s no frame delta or focus handoff.
> 
> Adds DEBUG-only instrumentation (`debugForceRefreshCount`, reset, and a locked counter incremented from `TerminalSurface.forceRefresh`) plus a regression test asserting a redraw occurs when visibility is restored while the terminal is inactive.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37522241fbfd0044419d0674278736e79cef6a94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3011 by forcing an immediate redraw when a previously hidden, already-sized, inactive terminal becomes visible again after workspace/sidebar selection. Reuses the portal refresh path and adds a debug-only counter with a regression test to validate the behavior.

- **Bug Fixes**
  - On `setVisibleInUI(true)` from hidden→visible, call `refreshSurfaceNow("setVisibleInUI")` to nudge the Metal layer without frame/focus changes.
  - Reuse the portal refresh path for consistent redraws on visibility restores.
  - Add a thread-safe, resettable DEBUG force-refresh counter and a regression test asserting exactly one refresh when visibility is restored while inactive.

<sup>Written for commit 37522241fbfd0044419d0674278736e79cef6a94. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal display refresh so a previously hidden or inactive terminal view reliably redraws when restored (e.g., workspace or sidebar visibility changes), preventing stale or missing renders.

* **Tests**
  * Added a regression test that verifies visibility restores trigger a terminal surface redraw to prevent future regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->