### PR TITLE
Fix sessions panel CPU loop on nightly

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12741,9 +12741,47 @@ enum SidebarTrailingAccessoryWidthPolicy {
 // and bridge only sidebar-visible workspace changes into local state.
 // Do NOT add @EnvironmentObject or new @Binding without updating ==.
 // Do NOT remove .equatable() from the ForEach call site in VerticalTabsSidebar.
+struct SidebarWorkspaceSnapshotBuilder {
+    struct VerticalBranchDirectoryLine: Equatable {
+        let branch: String?
+        let directory: String?
+    }
+
+    struct PullRequestDisplay: Identifiable, Equatable {
+        let id: String
+        let number: Int
+        let label: String
+        let url: URL
+        let status: SidebarPullRequestStatus
+        let isStale: Bool
+    }
+
+    struct Snapshot: Equatable {
+        let title: String
+        let customDescription: String?
+        let isPinned: Bool
+        let customColorHex: String?
+        let remoteWorkspaceSidebarText: String?
+        let remoteConnectionStatusText: String
+        let remoteStateHelpText: String
+        let copyableSidebarSSHError: String?
+        let metadataEntries: [SidebarStatusEntry]
+        let metadataBlocks: [SidebarMetadataBlock]
+        let latestLog: SidebarLogEntry?
+        let progress: SidebarProgressState?
+        let compactGitBranchSummaryText: String?
+        let compactBranchDirectoryRow: String?
+        let branchDirectoryLines: [VerticalBranchDirectoryLine]
+        let branchLinesContainBranch: Bool
+        let pullRequestRows: [PullRequestDisplay]
+        let listeningPorts: [Int]
+    }
+}
+
 private final class SidebarTabItemContextMenuState: ObservableObject {
     var isVisible = false
     var hasDeferredWorkspaceObservationInvalidation = false
+    var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
 
 private struct TabItemView: View, Equatable {
@@ -12802,7 +12840,7 @@ private struct TabItemView: View, Equatable {
     let settings: SidebarTabItemSettingsSnapshot
     let livePresentation: SidebarTabItemPresentationSnapshot
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
-    @State private var workspaceObservationGeneration: UInt64 = 0
+    @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
     @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
@@ -12841,6 +12879,10 @@ private struct TabItemView: View, Equatable {
 
     private var sidebarShowSSH: Bool {
         settings.showsSSH
+    }
+
+    private var workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot {
+        workspaceSnapshotStorage ?? makeWorkspaceSnapshot()
     }
 
     private var activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
@@ -12995,7 +13037,8 @@ private struct TabItemView: View, Equatable {
 
     @ViewBuilder
     private var remoteWorkspaceSection: some View {
-        if sidebarShowSSH, let remoteWorkspaceSidebarText {
+        let workspaceSnapshot = self.workspaceSnapshot
+        if sidebarShowSSH, let remoteWorkspaceSidebarText = workspaceSnapshot.remoteWorkspaceSidebarText {
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     Text(remoteWorkspaceSidebarText)
@@ -13006,14 +13049,14 @@ private struct TabItemView: View, Equatable {
 
                     Spacer(minLength: 0)
 
-                    Text(remoteConnectionStatusText)
+                    Text(workspaceSnapshot.remoteConnectionStatusText)
                         .font(.system(size: 9, weight: .medium))
                         .foregroundColor(activeSecondaryColor(0.58))
                         .lineLimit(1)
                 }
             }
             .padding(.top, latestNotificationText == nil ? 1 : 2)
-            .safeHelp(remoteStateHelpText)
+            .safeHelp(workspaceSnapshot.remoteStateHelpText)
         }
     }
 
@@ -13028,13 +13071,13 @@ private struct TabItemView: View, Equatable {
     }
 
     var body: some View {
-        let _ = workspaceObservationGeneration
+        let workspaceSnapshot = self.workspaceSnapshot
         let closeWorkspaceTooltip = String(localized: "sidebar.closeWorkspace.tooltip", defaultValue: "Close Workspace")
         let protectedWorkspaceTooltip = String(
             localized: "sidebar.pinnedWorkspaceProtected.tooltip",
             defaultValue: "Pinned workspace. Closing requires confirmation."
         )
-        let closeButtonTooltip = tab.isPinned
+        let closeButtonTooltip = workspaceSnapshot.isPinned
             ? protectedWorkspaceTooltip
             : KeyboardShortcutSettings.Action.closeWorkspace.tooltip(closeWorkspaceTooltip)
         let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
@@ -13043,43 +13086,6 @@ private struct TabItemView: View, Equatable {
         let latestNotificationSubtitle = latestNotificationText
         let effectiveSubtitle = latestNotificationSubtitle
         let detailVisibility = visibleAuxiliaryDetails
-        let orderedPanelIds: [UUID]? = (detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests)
-            ? tab.sidebarOrderedPanelIds()
-            : nil
-        let compactGitBranchSummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  sidebarShowGitBranch,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return gitBranchSummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactDirectorySummaryText: String? = {
-            guard detailVisibility.showsBranchDirectory,
-                  !sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return nil
-            }
-            return directorySummaryText(orderedPanelIds: orderedPanelIds)
-        }()
-        let compactBranchDirectoryRow = branchDirectoryRow(
-            gitSummary: compactGitBranchSummaryText,
-            directorySummary: compactDirectorySummaryText
-        )
-        let branchDirectoryLines: [VerticalBranchDirectoryLine] = {
-            guard detailVisibility.showsBranchDirectory,
-                  sidebarBranchVerticalLayout,
-                  let orderedPanelIds else {
-                return []
-            }
-            return verticalBranchDirectoryLines(orderedPanelIds: orderedPanelIds)
-        }()
-        let branchLinesContainBranch = sidebarShowGitBranch && branchDirectoryLines.contains { $0.branch != nil }
-        let pullRequestRows: [PullRequestDisplay] = {
-            guard detailVisibility.showsPullRequests, let orderedPanelIds else { return [] }
-            return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
-        }()
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
@@ -13094,14 +13100,14 @@ private struct TabItemView: View, Equatable {
                     .frame(width: 16, height: 16)
                 }
 
-                if tab.isPinned {
+                if workspaceSnapshot.isPinned {
                     Image(systemName: "pin.fill")
                         .font(.system(size: 9, weight: .semibold))
                         .foregroundColor(activeSecondaryColor(0.8))
                         .safeHelp(protectedWorkspaceTooltip)
                 }
 
-                Text(tab.title)
+                Text(workspaceSnapshot.title)
                     .font(.system(size: 12.5, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
@@ -13140,7 +13146,7 @@ private struct TabItemView: View, Equatable {
                 .frame(width: trailingAccessoryWidth, height: 16, alignment: .trailing)
             }
 
-            if let description = tab.customDescription {
+            if let description = workspaceSnapshot.customDescription {
                 SidebarWorkspaceDescriptionText(
                     markdown: description,
                     isActive: usesInvertedActiveForeground
@@ -13160,8 +13166,8 @@ private struct TabItemView: View, Equatable {
             remoteWorkspaceSection
 
             if detailVisibility.showsMetadata {
-                let metadataEntries = tab.sidebarStatusEntriesInDisplayOrder()
-                let metadataBlocks = tab.sidebarMetadataBlocksInDisplayOrder()
+                let metadataEntries = workspaceSnapshot.metadataEntries
+                let metadataBlocks = workspaceSnapshot.metadataBlocks
                 if !metadataEntries.isEmpty {
                     SidebarMetadataRows(
                         entries: metadataEntries,
@@ -13181,7 +13187,7 @@ private struct TabItemView: View, Equatable {
             }
 
             // Latest log entry
-            if detailVisibility.showsLog, let latestLog = tab.logEntries.last {
+            if detailVisibility.showsLog, let latestLog = workspaceSnapshot.latestLog {
                 HStack(spacing: 4) {
                     Image(systemName: logLevelIcon(latestLog.level))
                         .font(.system(size: 8))
@@ -13196,7 +13202,7 @@ private struct TabItemView: View, Equatable {
             }
 
             // Progress bar
-            if detailVisibility.showsProgress, let progress = tab.progress {
+            if detailVisibility.showsProgress, let progress = workspaceSnapshot.progress {
                 VStack(alignment: .leading, spacing: 2) {
                     GeometryReader { geo in
                         ZStack(alignment: .leading) {
@@ -13222,15 +13228,15 @@ private struct TabItemView: View, Equatable {
             // Branch + directory row
             if detailVisibility.showsBranchDirectory {
                 if sidebarBranchVerticalLayout {
-                    if !branchDirectoryLines.isEmpty {
+                    if !workspaceSnapshot.branchDirectoryLines.isEmpty {
                         HStack(alignment: .top, spacing: 3) {
-                            if sidebarShowGitBranchIcon, branchLinesContainBranch {
+                            if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
                                 Image(systemName: "arrow.triangle.branch")
                                     .font(.system(size: 9))
                                     .foregroundColor(activeSecondaryColor(0.6))
                             }
                             VStack(alignment: .leading, spacing: 1) {
-                                ForEach(Array(branchDirectoryLines.enumerated()), id: \.offset) { _, line in
+                                ForEach(Array(workspaceSnapshot.branchDirectoryLines.enumerated()), id: \.offset) { _, line in
                                     HStack(spacing: 3) {
                                         if let branch = line.branch {
                                             Text(branch)
@@ -13257,9 +13263,9 @@ private struct TabItemView: View, Equatable {
                             }
                         }
                     }
-                } else if let dirRow = compactBranchDirectoryRow {
+                } else if let dirRow = workspaceSnapshot.compactBranchDirectoryRow {
                     HStack(spacing: 3) {
-                        if sidebarShowGitBranchIcon, compactGitBranchSummaryText != nil {
+                        if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
                             Image(systemName: "arrow.triangle.branch")
                                 .font(.system(size: 9))
                                 .foregroundColor(activeSecondaryColor(0.6))
@@ -13274,9 +13280,9 @@ private struct TabItemView: View, Equatable {
             }
 
             // Pull request rows
-            if detailVisibility.showsPullRequests, !pullRequestRows.isEmpty {
+            if detailVisibility.showsPullRequests, !workspaceSnapshot.pullRequestRows.isEmpty {
                 VStack(alignment: .leading, spacing: 1) {
-                    ForEach(pullRequestRows) { pullRequest in
+                    ForEach(workspaceSnapshot.pullRequestRows) { pullRequest in
                         Button(action: {
                             openPullRequestLink(pullRequest.url)
                         }) {
@@ -13304,9 +13310,9 @@ private struct TabItemView: View, Equatable {
             }
 
             // Ports row
-            if detailVisibility.showsPorts, !tab.listeningPorts.isEmpty {
+            if detailVisibility.showsPorts, !workspaceSnapshot.listeningPorts.isEmpty {
                 HStack(spacing: 4) {
-                    ForEach(tab.listeningPorts, id: \.self) { port in
+                    ForEach(workspaceSnapshot.listeningPorts, id: \.self) { port in
                         Button(action: {
                             openPortLink(port)
                         }) {
@@ -13323,9 +13329,9 @@ private struct TabItemView: View, Equatable {
                 .lineLimit(1)
             }
         }
-        .animation(.easeInOut(duration: 0.2), value: tab.logEntries.count)
-        .animation(.easeInOut(duration: 0.2), value: tab.progress != nil)
-        .animation(.easeInOut(duration: 0.2), value: tab.metadataBlocks.count)
+        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.latestLog)
+        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.progress != nil)
+        .animation(.easeInOut(duration: 0.2), value: workspaceSnapshot.metadataBlocks.count)
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background(
@@ -13377,6 +13383,9 @@ private struct TabItemView: View, Equatable {
                     .offset(y: index == 0 ? 0 : -(rowSpacing / 2))
             }
         }
+        .onAppear {
+            refreshWorkspaceSnapshot(force: true)
+        }
         .onReceive(
             tab.sidebarImmediateObservationPublisher
                 .receive(on: RunLoop.main)
@@ -13391,7 +13400,7 @@ private struct TabItemView: View, Equatable {
                 "desc=\"\(debugCommandPaletteTextPreview(description))\""
             )
 #endif
-            scheduleWorkspaceObservationInvalidation()
+            refreshWorkspaceSnapshot()
         }
         .onReceive(
             tab.sidebarObservationPublisher
@@ -13411,7 +13420,10 @@ private struct TabItemView: View, Equatable {
                 "desc=\"\(debugCommandPaletteTextPreview(description))\""
             )
 #endif
-            scheduleWorkspaceObservationInvalidation()
+            refreshWorkspaceSnapshot()
+        }
+        .onChange(of: settings) { _ in
+            refreshWorkspaceSnapshot(force: true)
         }
         .onDrag {
             #if DEBUG
@@ -13459,6 +13471,7 @@ private struct TabItemView: View, Equatable {
                 .onAppear {
                     contextMenuState.isVisible = true
                     contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
+                    contextMenuState.pendingWorkspaceSnapshot = nil
                     frozenPresentation = livePresentation
                 }
                 .onDisappear {
@@ -13472,19 +13485,29 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private func scheduleWorkspaceObservationInvalidation() {
-        // Keep the context menu stable while background workspace telemetry keeps arriving.
+    private func refreshWorkspaceSnapshot(force: Bool = false) {
+        let nextSnapshot = makeWorkspaceSnapshot()
+
         if contextMenuState.isVisible {
-            contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
+            if force || nextSnapshot != workspaceSnapshot {
+                contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
+                contextMenuState.pendingWorkspaceSnapshot = nextSnapshot
+            }
             return
         }
-        workspaceObservationGeneration &+= 1
+
+        if force || workspaceSnapshotStorage != nextSnapshot {
+            workspaceSnapshotStorage = nextSnapshot
+        }
     }
 
     private func flushDeferredWorkspaceObservationInvalidation() {
         guard contextMenuState.hasDeferredWorkspaceObservationInvalidation else { return }
         contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-        workspaceObservationGeneration &+= 1
+        if let pendingSnapshot = contextMenuState.pendingWorkspaceSnapshot {
+            workspaceSnapshotStorage = pendingSnapshot
+        }
+        contextMenuState.pendingWorkspaceSnapshot = nil
     }
 
     private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {
@@ -13649,7 +13672,7 @@ private struct TabItemView: View, Equatable {
             }
         }
 
-        if let copyableSidebarSSHError {
+        if let copyableSidebarSSHError = workspaceSnapshot.copyableSidebarSSHError {
             Button(String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error")) {
                 copyTextToPasteboard(copyableSidebarSSHError)
             }
@@ -13782,7 +13805,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var resolvedCustomTabColor: Color? {
-        guard let hex = tab.customColor else { return nil }
+        guard let hex = workspaceSnapshot.customColorHex else { return nil }
         return WorkspaceTabColorSettings.displayColor(
             hex: hex,
             colorScheme: colorScheme,
@@ -13814,7 +13837,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var accessibilityTitle: String {
-        String(localized: "accessibility.workspacePosition", defaultValue: "\(tab.title), workspace \(index + 1) of \(accessibilityWorkspaceCount)")
+        String(localized: "accessibility.workspacePosition", defaultValue: "\(workspaceSnapshot.title), workspace \(index + 1) of \(accessibilityWorkspaceCount)")
     }
 
     private func moveBy(_ delta: Int) {
@@ -13994,6 +14017,68 @@ private struct TabItemView: View, Equatable {
             )
         }
     }
+
+    private func makeWorkspaceSnapshot() -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+        let detailVisibility = visibleAuxiliaryDetails
+        let orderedPanelIds: [UUID]? = (detailVisibility.showsBranchDirectory || detailVisibility.showsPullRequests)
+            ? tab.sidebarOrderedPanelIds()
+            : nil
+        let compactGitBranchSummaryText: String? = {
+            guard detailVisibility.showsBranchDirectory,
+                  !sidebarBranchVerticalLayout,
+                  sidebarShowGitBranch,
+                  let orderedPanelIds else {
+                return nil
+            }
+            return gitBranchSummaryText(orderedPanelIds: orderedPanelIds)
+        }()
+        let compactDirectorySummaryText: String? = {
+            guard detailVisibility.showsBranchDirectory,
+                  !sidebarBranchVerticalLayout,
+                  let orderedPanelIds else {
+                return nil
+            }
+            return directorySummaryText(orderedPanelIds: orderedPanelIds)
+        }()
+        let compactBranchDirectoryRow = branchDirectoryRow(
+            gitSummary: compactGitBranchSummaryText,
+            directorySummary: compactDirectorySummaryText
+        )
+        let branchDirectoryLines: [SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine] = {
+            guard detailVisibility.showsBranchDirectory,
+                  sidebarBranchVerticalLayout,
+                  let orderedPanelIds else {
+                return []
+            }
+            return verticalBranchDirectoryLines(orderedPanelIds: orderedPanelIds)
+        }()
+        let branchLinesContainBranch = sidebarShowGitBranch && branchDirectoryLines.contains { $0.branch != nil }
+        let pullRequestRows: [SidebarWorkspaceSnapshotBuilder.PullRequestDisplay] = {
+            guard detailVisibility.showsPullRequests, let orderedPanelIds else { return [] }
+            return pullRequestDisplays(orderedPanelIds: orderedPanelIds)
+        }()
+
+        return SidebarWorkspaceSnapshotBuilder.Snapshot(
+            title: tab.title,
+            customDescription: tab.customDescription,
+            isPinned: tab.isPinned,
+            customColorHex: tab.customColor,
+            remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
+            remoteConnectionStatusText: remoteConnectionStatusText,
+            remoteStateHelpText: remoteStateHelpText,
+            copyableSidebarSSHError: copyableSidebarSSHError,
+            metadataEntries: detailVisibility.showsMetadata ? tab.sidebarStatusEntriesInDisplayOrder() : [],
+            metadataBlocks: detailVisibility.showsMetadata ? tab.sidebarMetadataBlocksInDisplayOrder() : [],
+            latestLog: detailVisibility.showsLog ? tab.logEntries.last : nil,
+            progress: detailVisibility.showsProgress ? tab.progress : nil,
+            compactGitBranchSummaryText: compactGitBranchSummaryText,
+            compactBranchDirectoryRow: compactBranchDirectoryRow,
+            branchDirectoryLines: branchDirectoryLines,
+            branchLinesContainBranch: branchLinesContainBranch,
+            pullRequestRows: pullRequestRows,
+            listeningPorts: detailVisibility.showsPorts ? tab.listeningPorts : []
+        )
+    }
     private func moveWorkspaces(_ workspaceIds: [UUID], toWindow windowId: UUID) {
         guard let app = AppDelegate.shared else { return }
         let orderedWorkspaceIds = tabManager.tabs.compactMap { workspaceIds.contains($0.id) ? $0.id : nil }
@@ -14064,12 +14149,7 @@ private struct TabItemView: View, Equatable {
         }
     }
 
-    private struct VerticalBranchDirectoryLine {
-        let branch: String?
-        let directory: String?
-    }
-
-    private func verticalBranchDirectoryLines(orderedPanelIds: [UUID]) -> [VerticalBranchDirectoryLine] {
+    private func verticalBranchDirectoryLines(orderedPanelIds: [UUID]) -> [SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine] {
         let entries = tab.sidebarBranchDirectoryEntriesInDisplayOrder(orderedPanelIds: orderedPanelIds)
         let home = SidebarPathFormatter.homeDirectoryPath
         return entries.compactMap { entry in
@@ -14086,11 +14166,11 @@ private struct TabItemView: View, Equatable {
 
             switch (branchText, directoryText) {
             case let (branch?, directory?):
-                return VerticalBranchDirectoryLine(branch: branch, directory: directory)
+                return SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine(branch: branch, directory: directory)
             case let (branch?, nil):
-                return VerticalBranchDirectoryLine(branch: branch, directory: nil)
+                return SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine(branch: branch, directory: nil)
             case let (nil, directory?):
-                return VerticalBranchDirectoryLine(branch: nil, directory: directory)
+                return SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine(branch: nil, directory: directory)
             default:
                 return nil
             }
@@ -14106,18 +14186,9 @@ private struct TabItemView: View, Equatable {
         return entries.isEmpty ? nil : entries.joined(separator: " | ")
     }
 
-    private struct PullRequestDisplay: Identifiable {
-        let id: String
-        let number: Int
-        let label: String
-        let url: URL
-        let status: SidebarPullRequestStatus
-        let isStale: Bool
-    }
-
-    private func pullRequestDisplays(orderedPanelIds: [UUID]) -> [PullRequestDisplay] {
+    private func pullRequestDisplays(orderedPanelIds: [UUID]) -> [SidebarWorkspaceSnapshotBuilder.PullRequestDisplay] {
         tab.sidebarPullRequestsInDisplayOrder(orderedPanelIds: orderedPanelIds).map { pullRequest in
-            PullRequestDisplay(
+            SidebarWorkspaceSnapshotBuilder.PullRequestDisplay(
                 id: "\(pullRequest.label.lowercased())#\(pullRequest.number)|\(pullRequest.url.absoluteString)",
                 number: pullRequest.number,
                 label: pullRequest.label,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13489,7 +13489,8 @@ private struct TabItemView: View, Equatable {
         let nextSnapshot = makeWorkspaceSnapshot()
 
         if contextMenuState.isVisible {
-            if force || nextSnapshot != workspaceSnapshot {
+            let deferredBaseline = contextMenuState.pendingWorkspaceSnapshot ?? workspaceSnapshotStorage
+            if force || deferredBaseline != nextSnapshot {
                 contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
                 contextMenuState.pendingWorkspaceSnapshot = nextSnapshot
             }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -271,14 +271,21 @@ struct DirectorySnapshot: Sendable {
 
 @MainActor
 final class SessionIndexStore: ObservableObject {
-    @Published private(set) var entries: [SessionEntry] = []
+    @Published private(set) var entries: [SessionEntry] = [] {
+        didSet { invalidateSectionsCache() }
+    }
     @Published private(set) var isLoading: Bool = false
-    @Published var scopeToCurrentDirectory: Bool = false
-    @Published var currentDirectory: String? = nil
+    @Published var scopeToCurrentDirectory: Bool = false {
+        didSet { invalidateSectionsCache() }
+    }
+    @Published var currentDirectory: String? = nil {
+        didSet { invalidateSectionsCache() }
+    }
 
     @Published var grouping: SessionGrouping {
         didSet {
             UserDefaults.standard.set(grouping.rawValue, forKey: Self.groupingKey)
+            invalidateSectionsCache()
             // Switching into directory grouping can expose cwds that were never
             // backfilled while the user was viewing agent grouping.
             if grouping == .directory { backfillDirectoryOrderFromEntries() }
@@ -287,17 +294,26 @@ final class SessionIndexStore: ObservableObject {
 
     /// Persisted order for agent sections.
     @Published var agentOrder: [SessionAgent] {
-        didSet { Self.persistAgentOrder(agentOrder) }
+        didSet {
+            Self.persistAgentOrder(agentOrder)
+            invalidateSectionsCache()
+        }
     }
 
     /// Persisted order for directory sections (absolute paths; "" means "no folder").
     @Published var directoryOrder: [String] {
-        didSet { Self.persistDirectoryOrder(directoryOrder) }
+        didSet {
+            Self.persistDirectoryOrder(directoryOrder)
+            invalidateSectionsCache()
+        }
     }
 
     private static let groupingKey = "sessionIndex.grouping"
     private static let agentOrderDefaultsKey = "sessionIndex.agentOrder"
     private static let directoryOrderDefaultsKey = "sessionIndex.directoryOrder"
+    private var sectionsCacheRevision: UInt64 = 0
+    private var cachedSectionsRevision: UInt64?
+    private var cachedSections: [IndexSection] = []
 
     init() {
         self.agentOrder = Self.loadAgentOrder()
@@ -308,10 +324,15 @@ final class SessionIndexStore: ObservableObject {
 
     /// Returns the sections for the current grouping mode, in the user-saved order.
     func sectionsForCurrentGrouping() -> [IndexSection] {
+        if cachedSectionsRevision == sectionsCacheRevision {
+            return cachedSections
+        }
+
         let visible = filteredEntriesForCurrentScope()
+        let sections: [IndexSection]
         switch grouping {
         case .agent:
-            return agentOrder.map { agent in
+            sections = agentOrder.map { agent in
                 IndexSection(
                     key: .agent(agent),
                     title: agent.displayName,
@@ -336,7 +357,7 @@ final class SessionIndexStore: ObservableObject {
                     let rMax = buckets[rhs]?.map(\.modified).max() ?? .distantPast
                     return lMax > rMax
                 }
-            return (directoryOrder + unknownSorted)
+            sections = (directoryOrder + unknownSorted)
                 .filter { buckets[$0] != nil }
                 .map { path in
                     IndexSection(
@@ -347,6 +368,10 @@ final class SessionIndexStore: ObservableObject {
                     )
                 }
         }
+
+        cachedSections = sections
+        cachedSectionsRevision = sectionsCacheRevision
+        return sections
     }
 
     /// Extend `directoryOrder` with any cwds seen in `entries` that aren't
@@ -368,6 +393,10 @@ final class SessionIndexStore: ObservableObject {
         guard !additions.isEmpty else { return }
         additions.sort { $0.latest > $1.latest }
         directoryOrder.append(contentsOf: additions.map(\.path))
+    }
+
+    private func invalidateSectionsCache() {
+        sectionsCacheRevision &+= 1
     }
 
     private func filteredEntriesForCurrentScope() -> [SessionEntry] {

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -272,18 +272,28 @@ struct DirectorySnapshot: Sendable {
 @MainActor
 final class SessionIndexStore: ObservableObject {
     @Published private(set) var entries: [SessionEntry] = [] {
-        didSet { invalidateSectionsCache() }
+        didSet {
+            guard entries != oldValue else { return }
+            invalidateSectionsCache()
+        }
     }
     @Published private(set) var isLoading: Bool = false
     @Published var scopeToCurrentDirectory: Bool = false {
-        didSet { invalidateSectionsCache() }
+        didSet {
+            guard scopeToCurrentDirectory != oldValue else { return }
+            invalidateSectionsCache()
+        }
     }
     @Published var currentDirectory: String? = nil {
-        didSet { invalidateSectionsCache() }
+        didSet {
+            guard scopeToCurrentDirectory, currentDirectory != oldValue else { return }
+            invalidateSectionsCache()
+        }
     }
 
     @Published var grouping: SessionGrouping {
         didSet {
+            guard grouping != oldValue else { return }
             UserDefaults.standard.set(grouping.rawValue, forKey: Self.groupingKey)
             invalidateSectionsCache()
             // Switching into directory grouping can expose cwds that were never
@@ -295,6 +305,7 @@ final class SessionIndexStore: ObservableObject {
     /// Persisted order for agent sections.
     @Published var agentOrder: [SessionAgent] {
         didSet {
+            guard agentOrder != oldValue else { return }
             Self.persistAgentOrder(agentOrder)
             invalidateSectionsCache()
         }
@@ -303,6 +314,7 @@ final class SessionIndexStore: ObservableObject {
     /// Persisted order for directory sections (absolute paths; "" means "no folder").
     @Published var directoryOrder: [String] {
         didSet {
+            guard directoryOrder != oldValue else { return }
             Self.persistDirectoryOrder(directoryOrder)
             invalidateSectionsCache()
         }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -982,9 +982,16 @@ private struct PopoverRow: View, Equatable {
         return out
     }
 
+    fileprivate static func refreshInterval(for modified: Date, now: Date = .now) -> TimeInterval {
+        let age = max(0, now.timeIntervalSince(modified))
+        if age < 3_600 { return 60 }
+        if age < 86_400 { return 3_600 }
+        return 86_400
+    }
+
     @ViewBuilder
     private var modifiedText: some View {
-        TimelineView(.periodic(from: entry.modified, by: 60)) { context in
+        TimelineView(RelativeTimestampSchedule(modified: entry.modified)) { context in
             Text(SessionIndexView.relativeFormatter.localizedString(for: entry.modified, relativeTo: context.date))
         }
         .font(.system(size: 11).monospacedDigit())
@@ -1024,6 +1031,25 @@ private struct PopoverRow: View, Equatable {
         .help(entry.cwdLabel ?? entry.displayTitle)
         .contextMenu {
             sessionRowMenuItems(entry: entry, onResume: { _ in onActivate() })
+        }
+    }
+}
+
+private struct RelativeTimestampSchedule: TimelineSchedule {
+    let modified: Date
+
+    func entries(from startDate: Date, mode: Mode) -> Entries {
+        Entries(current: startDate, modified: modified)
+    }
+
+    struct Entries: Sequence, IteratorProtocol {
+        var current: Date
+        let modified: Date
+
+        mutating func next() -> Date? {
+            let date = current
+            current = current.addingTimeInterval(PopoverRow.refreshInterval(for: modified, now: date))
+            return date
         }
     }
 }
@@ -1155,6 +1181,7 @@ struct SectionPopoverHost: NSViewRepresentable {
         @Binding var isPresented: Bool
         weak var anchorView: NSView?
         private(set) var debugRefreshContentCallCount = 0
+        var debugIsPopoverShown: Bool { popover?.isShown == true }
 
         private let hostingController: NSHostingController<AnyView> = {
             NSHostingController(rootView: AnyView(EmptyView()))
@@ -1176,6 +1203,8 @@ struct SectionPopoverHost: NSViewRepresentable {
         private var currentSearch: SessionSearchFn?
         private var currentLoadSnapshot: DirectorySnapshotFn?
         private var currentOnResume: ((SessionEntry) -> Void)?
+        private var lastRenderedSection: IndexSection?
+        private var lastRenderedPresentationCount: Int?
         /// Bumped on every present(). Used as the SwiftUI view identity so each
         /// open gets fresh @State (empty query, fresh focus, no stale results).
         private var presentationCount = 0
@@ -1198,6 +1227,12 @@ struct SectionPopoverHost: NSViewRepresentable {
             // Rewriting rootView + forcing layout on every parent re-render was
             // the 100% CPU loop behind #3010.
             guard popover?.isShown == true else { return }
+            // Rows capture stable closure bundles above the list boundary, so
+            // the section snapshot is the meaningful input here. Skipping
+            // identical visible-section updates avoids re-laying out the popover
+            // during unrelated parent re-renders while still refreshing when the
+            // visible content actually changes.
+            guard lastRenderedSection != section || lastRenderedPresentationCount != presentationCount else { return }
             refreshContent()
         }
 
@@ -1221,6 +1256,8 @@ struct SectionPopoverHost: NSViewRepresentable {
                 // the prior open's @State (typed query, scrolled position, etc.).
                 .id(identity)
             )
+            lastRenderedSection = section
+            lastRenderedPresentationCount = presentationCount
             hostingController.view.invalidateIntrinsicContentSize()
             hostingController.view.layoutSubtreeIfNeeded()
             updateContentSize()

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -982,6 +982,16 @@ private struct PopoverRow: View, Equatable {
         return out
     }
 
+    @ViewBuilder
+    private var modifiedText: some View {
+        TimelineView(.periodic(from: entry.modified, by: 60)) { context in
+            Text(SessionIndexView.relativeFormatter.localizedString(for: entry.modified, relativeTo: context.date))
+        }
+        .font(.system(size: 11).monospacedDigit())
+        .foregroundColor(.secondary.opacity(0.7))
+        .fixedSize()
+    }
+
     var body: some View {
         HStack(spacing: 6) {
             Image(entry.agent.assetName)
@@ -999,10 +1009,7 @@ private struct PopoverRow: View, Equatable {
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 8)
-            Text(SessionIndexView.relativeFormatter.localizedString(for: entry.modified, relativeTo: Date()))
-                .font(.system(size: 11).monospacedDigit())
-                .foregroundColor(.secondary.opacity(0.7))
-                .fixedSize()
+            modifiedText
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 5)
@@ -1106,7 +1113,7 @@ private func sessionDragItemProvider(for entry: SessionEntry) -> NSItemProvider 
 /// Hosts SectionPopoverView in a real NSPopover. SwiftUI's native `.popover()`
 /// doesn't reliably let the embedded TextField become first responder in cmux's
 /// focus-managed environment — the terminal keeps grabbing focus back.
-private struct SectionPopoverHost: NSViewRepresentable {
+struct SectionPopoverHost: NSViewRepresentable {
     @Binding var isPresented: Bool
     let section: IndexSection
     /// Closure-typed search handle passed through to the SwiftUI popover
@@ -1147,6 +1154,7 @@ private struct SectionPopoverHost: NSViewRepresentable {
     final class Coordinator: NSObject, NSPopoverDelegate {
         @Binding var isPresented: Bool
         weak var anchorView: NSView?
+        private(set) var debugRefreshContentCallCount = 0
 
         private let hostingController: NSHostingController<AnyView> = {
             NSHostingController(rootView: AnyView(EmptyView()))
@@ -1186,6 +1194,10 @@ private struct SectionPopoverHost: NSViewRepresentable {
             currentSearch = search
             currentLoadSnapshot = loadSnapshot
             currentOnResume = onResume
+            // When hidden, defer rebuilding the hosting view until `present()`.
+            // Rewriting rootView + forcing layout on every parent re-render was
+            // the 100% CPU loop behind #3010.
+            guard popover?.isShown == true else { return }
             refreshContent()
         }
 
@@ -1193,6 +1205,7 @@ private struct SectionPopoverHost: NSViewRepresentable {
             guard let section = currentSection,
                   let search = currentSearch,
                   let loadSnapshot = currentLoadSnapshot else { return }
+            debugRefreshContentCallCount += 1
             let onResume = currentOnResume
             let identity = presentationCount
             hostingController.rootView = AnyView(

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -875,7 +875,6 @@ class TabManager: ObservableObject {
     private nonisolated static let initialWorkspaceGitProbeDelays: [TimeInterval] = [0, 0.5, 1.5, 3.0, 6.0, 10.0]
     private nonisolated static let backgroundPollInterval: TimeInterval = 60
     private nonisolated static let selectedPollInterval: TimeInterval = 10
-    private nonisolated static let workspacePullRequestPollTickInterval: TimeInterval = 1
     private nonisolated static let workspacePullRequestRepoCacheLifetime: TimeInterval = 15
     private nonisolated static let workspacePullRequestRepoCachePruneLifetime: TimeInterval = 60
     private nonisolated static let workspacePullRequestRepoPageSize = 100
@@ -1062,7 +1061,7 @@ class TabManager: ObservableObject {
         startAgentPIDSweepTimer()
         startWorkspaceGitMetadataPollTimer()
         startSelectedWorkspaceGitMetadataPollTimer()
-        startWorkspacePullRequestPollTimer()
+        updateWorkspacePullRequestPollTimer()
 #if DEBUG
         setupUITestFocusShortcutsIfNeeded()
         setupSplitCloseRightUITestIfNeeded()
@@ -1135,18 +1134,37 @@ class TabManager: ObservableObject {
         selectedWorkspaceGitMetadataPollTimer = timer
     }
 
-    private func startWorkspacePullRequestPollTimer() {
-        let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
-        let interval = Self.workspacePullRequestPollTickInterval
-        timer.schedule(deadline: .now() + interval, repeating: interval)
-        timer.setEventHandler { [weak self] in
-            guard let self else { return }
-            DispatchQueue.main.async { [weak self] in
-                self?.refreshTrackedWorkspacePullRequestsIfNeeded(reason: "timer")
-            }
+    private func updateWorkspacePullRequestPollTimer() {
+        guard workspacePullRequestRefreshTask == nil else {
+            workspacePullRequestPollTimer?.cancel()
+            workspacePullRequestPollTimer = nil
+            return
         }
-        timer.resume()
-        workspacePullRequestPollTimer = timer
+
+        guard let nextPollAt = workspacePullRequestNextPollAtByKey.values.min() else {
+            workspacePullRequestPollTimer?.cancel()
+            workspacePullRequestPollTimer = nil
+            return
+        }
+
+        if workspacePullRequestPollTimer == nil {
+            let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+            timer.setEventHandler { [weak self] in
+                guard let self else { return }
+                DispatchQueue.main.async { [weak self] in
+                    self?.refreshTrackedWorkspacePullRequestsIfNeeded(reason: "timer")
+                }
+            }
+            timer.resume()
+            workspacePullRequestPollTimer = timer
+        }
+
+        let delay = max(0.25, nextPollAt.timeIntervalSinceNow)
+        workspacePullRequestPollTimer?.schedule(
+            deadline: .now() + delay,
+            repeating: .never,
+            leeway: .milliseconds(250)
+        )
     }
 
     private func refreshTrackedWorkspaceGitMetadata() {
@@ -1252,7 +1270,16 @@ class TabManager: ObservableObject {
         }
 
         pruneWorkspacePullRequestTracking(validKeys: validKeys)
-        guard !candidates.isEmpty, workspacePullRequestRefreshTask == nil else { return }
+        guard workspacePullRequestRefreshTask == nil else {
+            updateWorkspacePullRequestPollTimer()
+            return
+        }
+        guard !candidates.isEmpty else {
+            updateWorkspacePullRequestPollTimer()
+            return
+        }
+        workspacePullRequestPollTimer?.cancel()
+        workspacePullRequestPollTimer = nil
         for key in requestedKeys {
             workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: false)
         }
@@ -1481,6 +1508,8 @@ class TabManager: ObservableObject {
             )
 #endif
         }
+
+        updateWorkspacePullRequestPollTimer()
     }
 
     private func scheduleNextWorkspacePullRequestPoll(
@@ -1531,6 +1560,7 @@ class TabManager: ObservableObject {
         workspacePullRequestRepoCacheBySlug = workspacePullRequestRepoCacheBySlug.filter {
             $0.value.fetchedAt >= repoCacheCutoff
         }
+        updateWorkspacePullRequestPollTimer()
     }
 
     private func clearWorkspacePullRequestTracking(for key: WorkspaceGitProbeKey) {
@@ -1538,6 +1568,7 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey.removeValue(forKey: key)
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
         workspacePullRequestTransientFailureCountByKey.removeValue(forKey: key)
+        updateWorkspacePullRequestPollTimer()
     }
 
     private func clearWorkspacePullRequestTracking(workspaceId: UUID) {
@@ -1545,6 +1576,7 @@ class TabManager: ObservableObject {
         workspacePullRequestProbeStateByKey = workspacePullRequestProbeStateByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestLastTerminalStateRefreshAtByKey = workspacePullRequestLastTerminalStateRefreshAtByKey.filter { $0.key.workspaceId != workspaceId }
         workspacePullRequestTransientFailureCountByKey = workspacePullRequestTransientFailureCountByKey.filter { $0.key.workspaceId != workspaceId }
+        updateWorkspacePullRequestPollTimer()
     }
 
     private func resetWorkspacePullRequestRefreshState() {
@@ -1556,6 +1588,7 @@ class TabManager: ObservableObject {
         workspacePullRequestTransientFailureCountByKey.removeAll()
         workspacePullRequestRepoCacheBySlug.removeAll()
         workspacePullRequestFollowUpShouldBypassRepoCache = false
+        updateWorkspacePullRequestPollTimer()
     }
 
     private var activeWorkspaceGitProbeKeys: Set<WorkspaceGitProbeKey> {

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -1,5 +1,6 @@
-import XCTest
+import AppKit
 import SwiftUI
+import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -10,7 +11,75 @@ import SwiftUI
 @MainActor
 final class SessionIndexViewTests: XCTestCase {
     func testSectionPopoverHostCoordinatorSkipsHiddenRefreshes() {
-        var isPresented = false
+        let harness = makeHarness()
+        let coordinator = harness.host.makeCoordinator()
+
+        coordinator.update(
+            section: harness.section,
+            search: harness.search,
+            loadSnapshot: harness.loadSnapshot,
+            onResume: nil
+        )
+        coordinator.update(
+            section: harness.section,
+            search: harness.search,
+            loadSnapshot: harness.loadSnapshot,
+            onResume: nil
+        )
+
+        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+    }
+
+    func testSectionPopoverHostCoordinatorRefreshesOnceWhenPresented() {
+        let harness = makeHarness(isPresented: true)
+        let coordinator = harness.host.makeCoordinator()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let anchor = NSView(frame: NSRect(x: 20, y: 20, width: 160, height: 80))
+        window.contentView?.addSubview(anchor)
+        coordinator.anchorView = anchor
+
+        defer {
+            coordinator.dismiss()
+            pumpRunLoop()
+            window.orderOut(nil)
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        pumpRunLoop()
+
+        coordinator.update(
+            section: harness.section,
+            search: harness.search,
+            loadSnapshot: harness.loadSnapshot,
+            onResume: nil
+        )
+        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+
+        coordinator.present()
+        pumpRunLoop()
+
+        XCTAssertTrue(coordinator.debugIsPopoverShown)
+        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 1)
+
+        coordinator.update(
+            section: harness.section,
+            search: harness.search,
+            loadSnapshot: harness.loadSnapshot,
+            onResume: nil
+        )
+
+        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 1)
+    }
+
+    private func makeHarness(isPresented: Bool = false) -> SessionPopoverHarness {
+        var isPresented = isPresented
         let binding = Binding(
             get: { isPresented },
             set: { isPresented = $0 }
@@ -18,43 +87,32 @@ final class SessionIndexViewTests: XCTestCase {
         let section = IndexSection(
             key: .directory("/tmp"),
             title: "tmp",
-            icon: .folder,
-            entries: []
+            icon: .folder
         )
+        let search: SessionSearchFn = { _, _, _, _ in
+            SessionIndexStore.SearchOutcome(entries: [], errors: [])
+        }
+        let loadSnapshot: DirectorySnapshotFn = { cwd in
+            DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
+        }
         let host = SectionPopoverHost(
             isPresented: binding,
             section: section,
-            search: { _, _, _, _ in
-                SessionIndexStore.SearchOutcome(entries: [], errors: [])
-            },
-            loadSnapshot: { cwd in
-                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
-            },
+            search: search,
+            loadSnapshot: loadSnapshot,
             onResume: nil
         )
-        let coordinator = host.makeCoordinator()
-
-        coordinator.update(
-            section: section,
-            search: { _, _, _, _ in
-                SessionIndexStore.SearchOutcome(entries: [], errors: [])
-            },
-            loadSnapshot: { cwd in
-                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
-            },
-            onResume: nil
-        )
-        coordinator.update(
-            section: section,
-            search: { _, _, _, _ in
-                SessionIndexStore.SearchOutcome(entries: [], errors: [])
-            },
-            loadSnapshot: { cwd in
-                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
-            },
-            onResume: nil
-        )
-
-        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+        return SessionPopoverHarness(host: host, section: section, search: search, loadSnapshot: loadSnapshot)
     }
+
+    private func pumpRunLoop() {
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+    }
+}
+
+private struct SessionPopoverHarness {
+    let host: SectionPopoverHost
+    let section: IndexSection
+    let search: SessionSearchFn
+    let loadSnapshot: DirectorySnapshotFn
 }

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+import SwiftUI
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class SessionIndexViewTests: XCTestCase {
+    func testSectionPopoverHostCoordinatorSkipsHiddenRefreshes() {
+        var isPresented = false
+        let binding = Binding(
+            get: { isPresented },
+            set: { isPresented = $0 }
+        )
+        let section = IndexSection(
+            key: .directory("/tmp"),
+            title: "tmp",
+            icon: .folder,
+            entries: []
+        )
+        let host = SectionPopoverHost(
+            isPresented: binding,
+            section: section,
+            search: { _, _, _, _ in
+                SessionIndexStore.SearchOutcome(entries: [], errors: [])
+            },
+            loadSnapshot: { cwd in
+                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
+            },
+            onResume: nil
+        )
+        let coordinator = host.makeCoordinator()
+
+        coordinator.update(
+            section: section,
+            search: { _, _, _, _ in
+                SessionIndexStore.SearchOutcome(entries: [], errors: [])
+            },
+            loadSnapshot: { cwd in
+                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
+            },
+            onResume: nil
+        )
+        coordinator.update(
+            section: section,
+            search: { _, _, _, _ in
+                SessionIndexStore.SearchOutcome(entries: [], errors: [])
+            },
+            loadSnapshot: { cwd in
+                DirectorySnapshot(cwd: cwd ?? "", entries: [], errors: [])
+            },
+            onResume: nil
+        )
+
+        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+    }
+}


### PR DESCRIPTION
## Summary
- stop the Sessions popover host from rebuilding its SwiftUI hosting view while hidden, and skip redundant visible refreshes for identical section snapshots
- cache `SessionIndexStore.sectionsForCurrentGrouping()` results so unchanged section rows can short-circuit without reallocation churn
- replace inline `Date()` evaluation in popover rows with an adaptive relative-time timeline schedule
- keep sidebar tab rows on immutable workspace snapshots and replace the fixed 1s PR polling tick with next-deadline scheduling to cut unrelated background churn
- add regression coverage for both the hidden and shown popover coordinator paths

## Review feedback addressed
- `TabItemView.refreshWorkspaceSnapshot()` now compares against the stored or pending snapshot while the context menu is open, so deferred flushes cannot apply stale intermediate state
- `SessionIndexStore` now invalidates its section cache only when the effective grouping/filter inputs actually change
- `SectionPopoverHost.Coordinator` now skips identical visible-section updates, which makes the positive-path regression test assert the intended behavior directly
- `SessionIndexViewTests` now cover both the hidden fast-return path and the shown-popover refresh path, and the invalid `IndexSection` initializer usage is removed

## Context
- fixes #3010
- follow-on from #2586
- regression was introduced with the Sessions panel work from #2936, with #2970 only partially mitigating it

## Testing
- not run locally (per repo policy)
- attempted `./scripts/reload.sh --tag issue-3010-nightly-100cpu --launch`, but the local tagged build was interrupted with `xcodebuild` exit `143` before launch, so idle-CPU verification is still pending locally