### PR TITLE
Pin regular-weight Japanese auto-fallback face

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2136,6 +2136,16 @@ class GhosttyApp {
         ) != nil
     }
 
+    /// Stub: returns the input family name unchanged. Replaced by the pinning
+    /// implementation in the follow-up fix commit.
+    static func resolvedInjectedCJKFontName(
+        named name: String,
+        size: CGFloat = 12
+    ) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? name : trimmed
+    }
+
     private static func configuredCTFont(
         named name: String,
         size: CGFloat = 12
@@ -2156,6 +2166,34 @@ class GhosttyApp {
         }
 
         return font
+    }
+
+    /// Mirror Ghostty's family-name CoreText discovery path so injected
+    /// `font-codepoint-map` values are validated against the same lookup mode.
+    static func discoveredCTFont(
+        named name: String,
+        size: CGFloat = 12,
+        weightTrait: CGFloat? = nil
+    ) -> CTFont? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        var attributes: [CFString: Any] = [
+            kCTFontFamilyNameAttribute: trimmed,
+            kCTFontSizeAttribute: size,
+        ]
+        if let weightTrait {
+            attributes[kCTFontTraitsAttribute] = [
+                kCTFontWeightTrait: weightTrait,
+            ] as CFDictionary
+        }
+
+        let descriptor = CTFontDescriptorCreateWithAttributes(attributes as CFDictionary)
+        let collection = CTFontCollectionCreateWithFontDescriptors([descriptor] as CFArray, nil)
+        guard let match = (CTFontCollectionCreateMatchingFontDescriptors(collection) as? [CTFontDescriptor])?.first else {
+            return nil
+        }
+        return CTFontCreateWithFontDescriptor(match, size, nil)
     }
 
     private static func fontContainsGlyphs(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1960,8 +1960,14 @@ class GhosttyApp {
     private func loadCJKFontFallbackIfNeeded(_ config: ghostty_config_t) {
         guard let mappings = Self.autoInjectedCJKFontMappings() else { return }
 
+        var resolvedFonts: [String: String] = [:]
         let lines = mappings.map { range, font in
-            "font-codepoint-map = \(range)=\(font)"
+            let resolvedFont = resolvedFonts[font] ?? {
+                let resolved = Self.resolvedInjectedCJKFontName(named: font)
+                resolvedFonts[font] = resolved
+                return resolved
+            }()
+            return "font-codepoint-map = \(range)=\(resolvedFont)"
         }.joined(separator: "\n")
         loadInlineGhosttyConfig(
             lines,
@@ -2136,14 +2142,43 @@ class GhosttyApp {
         ) != nil
     }
 
-    /// Stub: returns the input family name unchanged. Replaced by the pinning
-    /// implementation in the follow-up fix commit.
+    /// Resolve auto-injected CJK families through the regular-weight descriptor
+    /// path first so locale-sensitive families such as Hiragino Sans don't fall
+    /// back to ultra-light faces like W0 when Ghostty later matches by name.
     static func resolvedInjectedCJKFontName(
         named name: String,
         size: CGFloat = 12
     ) -> String {
         let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? name : trimmed
+        guard !trimmed.isEmpty else { return name }
+        guard let regularWeightFont = discoveredCTFont(named: trimmed, size: size, weightTrait: 0.0) else {
+            return trimmed
+        }
+
+        let candidateNames = [
+            CTFontCopyName(regularWeightFont, kCTFontFullNameKey) as String?,
+            CTFontCopyName(regularWeightFont, kCTFontPostScriptNameKey) as String?,
+        ].compactMap { $0 }
+        let expectedFullName = CTFontCopyFullName(regularWeightFont) as String
+        let expectedPostScriptName = CTFontCopyPostScriptName(regularWeightFont) as String
+
+        for candidate in candidateNames {
+            guard let verifiedFont = discoveredCTFont(named: candidate, size: size) else { continue }
+            let verifiedNames = [
+                CTFontCopyName(verifiedFont, kCTFontFamilyNameKey) as String?,
+                CTFontCopyName(verifiedFont, kCTFontFullNameKey) as String?,
+                CTFontCopyName(verifiedFont, kCTFontPostScriptNameKey) as String?,
+            ].compactMap { $0 }
+            let matchesRegularWeightFace = verifiedNames.contains {
+                normalizedFontName($0) == normalizedFontName(expectedFullName) ||
+                normalizedFontName($0) == normalizedFontName(expectedPostScriptName)
+            }
+            if matchesRegularWeightFace {
+                return candidate
+            }
+        }
+
+        return trimmed
     }
 
     private static func configuredCTFont(

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import CoreText
 import WebKit
 import Darwin
 
@@ -2328,6 +2329,38 @@ final class GhosttyMouseFocusTests: XCTestCase {
         XCTAssertTrue(hiraginoRanges.contains("U+4E00-U+9FFF"), "Shared CJK → first lang font")
         XCTAssertFalse(mappings.contains { $0.1 == "Apple SD Gothic Neo" }, "No Korean font mapping")
         XCTAssertFalse(hiraginoRanges.contains("U+AC00-U+D7AF"), "Hangul NOT in Hiragino")
+    }
+
+    func testResolvedInjectedCJKFontNamePinsRegularWeightForHiraginoSans() throws {
+        guard let plain = GhosttyApp.discoveredCTFont(named: "Hiragino Sans"),
+              let pinned = GhosttyApp.discoveredCTFont(
+                  named: GhosttyApp.resolvedInjectedCJKFontName(named: "Hiragino Sans")
+              ) else {
+            throw XCTSkip("Hiragino Sans is unavailable on this runner")
+        }
+
+        let plainFullName = CTFontCopyFullName(plain) as String
+        let pinnedFullName = CTFontCopyFullName(pinned) as String
+
+        XCTAssertEqual(CTFontCopyFamilyName(pinned) as String, "Hiragino Sans")
+        XCTAssertFalse(pinnedFullName.contains(" W0"))
+        if plainFullName.contains(" W0") {
+            XCTAssertNotEqual(
+                CTFontCopyPostScriptName(plain) as String,
+                CTFontCopyPostScriptName(pinned) as String
+            )
+        }
+    }
+
+    func testResolvedInjectedCJKFontNameLeavesPingFangSCStable() throws {
+        guard GhosttyApp.discoveredCTFont(named: "PingFang SC") != nil else {
+            throw XCTSkip("PingFang SC is unavailable on this runner")
+        }
+
+        XCTAssertEqual(
+            GhosttyApp.resolvedInjectedCJKFontName(named: "PingFang SC"),
+            "PingFang SC"
+        )
     }
 
     // MARK: autoInjectedCJKFontMappings


### PR DESCRIPTION
## Summary
- resolve auto-injected CJK fallback families through a regular-weight CoreText descriptor before emitting `font-codepoint-map` lines
- avoid the locale-sensitive `Hiragino Sans W0` match by round-tripping the regular-weight face name and only using it when Ghostty can discover it by name
- add runtime unit coverage for the Hiragino regular-weight resolution and keep PingFang unchanged

## Repro / Investigation
- `gh issue view 3014 --repo manaflow-ai/cmux`
- confirmed the cmux auto-injection path from #2755 is locale-conditioned: Japanese preferred languages inject `Hiragino Sans`, Chinese inject `PingFang`, non-CJK locales inject nothing
- standalone CoreText probe reproduced the thin-face selection without needing to guess: a plain family descriptor for `Hiragino Sans` resolves to `Hiragino Sans W0`, while the same descriptor with `kCTFontWeightTrait = 0.0` resolves to `Hiragino Sans W3`
- visual render diff from the probe showed the expected stroke-weight jump between `W0` and `W3`

## Testing
- not run locally per repo policy

Closes #3014
Related #2755
Related #2162
Related #338

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CoreText font discovery/name resolution for injected CJK fallbacks, which can impact text rendering across different macOS font installs/locales. Adds tests, but behavior is platform/font-dependent so regressions are possible.
> 
> **Overview**
> Ensures auto-injected CJK `font-codepoint-map` entries emit a *regular-weight, name-discoverable* font face by resolving injected family names through a CoreText descriptor lookup (with caching), preventing locale-sensitive matches like `Hiragino Sans W0`.
> 
> Adds CoreText helpers (`discoveredCTFont`, `resolvedInjectedCJKFontName`) and unit tests that assert Hiragino is pinned away from `W0` while `PingFang SC` remains unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8ce724885c9332d6784b8a838aa9097699dd9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pin the auto-injected Japanese fallback Hiragino Sans to a regular weight by resolving through CoreText before emitting `font-codepoint-map`, preventing W0 under Japanese locales. Implements `resolvedInjectedCJKFontName` with `discoveredCTFont` and adds tests; `PingFang SC` remains unchanged (per #3014).

<sup>Written for commit e8ce724885c9332d6784b8a838aa9097699dd9b3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CJK font fallback handling: deduplicates and resolves injected CJK font family names so rendered characters use verified system font matches for more consistent display.

* **Tests**
  * Added tests validating CJK font resolution behavior and ensuring resolved fallbacks produce stable, expected font identity results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->