### PR TITLE
Fix Cmd+C copy after mosh -> tmux drag selection

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -105,8 +105,7 @@ func cmuxTerminalSelectionCopyIntentAvailable(
     selectionActive: Bool,
     recentSelectionDragCompleted: Bool
 ) -> Bool {
-    let _ = recentSelectionDragCompleted
-    return selectionActive
+    selectionActive || recentSelectionDragCompleted
 }
 
 func cmuxShouldSuppressTerminalCommandPathHover(
@@ -5335,6 +5334,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var keyTables: [String] = []
     fileprivate private(set) var keyboardCopyModeActive = false
     private var wordPathHoverActive = false
+    // A just-finished drag selection should treat the next stationary Cmd press
+    // as copy intent, not as cmd-hover/cmd-click intent, until the pointer
+    // moves again.
+    private var suppressCommandPathHoverUntilMouseMove = false
+    private var leftMouseDragSelectionInProgress = false
     private var keyboardCopyModeConsumedKeyUps: Set<UInt16> = []
     private var keyboardCopyModeInputState = TerminalKeyboardCopyModeInputState()
     private var keyboardCopyModeViewportRow: Int?
@@ -6172,7 +6176,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // MARK: - Input Handling
 
     @IBAction func copy(_ sender: Any?) {
-        _ = performBindingAction("copy_to_clipboard")
+        if performBindingAction("copy_to_clipboard") {
+            return
+        }
+        guard let snapshot = readSelectionSnapshot(), !snapshot.string.isEmpty else { return }
+        GhosttyPasteboardHelper.writeString(snapshot.string, to: GHOSTTY_CLIPBOARD_STANDARD)
     }
 
     // MARK: - Clipboard paste
@@ -6192,8 +6200,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     func validateUserInterfaceItem(_ item: NSValidatedUserInterfaceItem) -> Bool {
         switch item.action {
         case #selector(copy(_:)):
-            guard let surface = surface else { return false }
-            return ghostty_surface_has_selection(surface)
+            return canCopySelectionFromCurrentSurface()
         case #selector(paste(_:)):
             return GhosttyPasteboardHelper.hasString(for: GHOSTTY_CLIPBOARD_STANDARD)
         case #selector(pasteAsPlainText(_:)):
@@ -7190,8 +7197,25 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     private func shouldSuppressCommandPathHover(for flags: NSEvent.ModifierFlags) -> Bool {
-        guard flags.contains(.command), let surface else { return false }
-        return ghostty_surface_has_selection(surface)
+        guard let surface else { return false }
+        return cmuxShouldSuppressTerminalCommandPathHover(
+            modifierFlags: flags,
+            selectionActive: ghostty_surface_has_selection(surface),
+            recentSelectionDragCompleted: suppressCommandPathHoverUntilMouseMove
+        )
+    }
+
+    private func canCopySelectionFromCurrentSurface() -> Bool {
+        guard let surface else { return false }
+        return cmuxTerminalSelectionCopyIntentAvailable(
+            selectionActive: ghostty_surface_has_selection(surface),
+            recentSelectionDragCompleted: suppressCommandPathHoverUntilMouseMove
+        )
+    }
+
+    private func clearCompletedSelectionDragSuppressionIfNeeded() {
+        guard suppressCommandPathHoverUntilMouseMove, NSEvent.pressedMouseButtons == 0 else { return }
+        suppressCommandPathHoverUntilMouseMove = false
     }
 
     private func hoverModsFromFlags(
@@ -7467,6 +7491,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // repairs workspace/pane active state before key routing runs.
         requestPointerFocusRecovery()
         window?.makeFirstResponder(self)
+        leftMouseDragSelectionInProgress = false
+        suppressCommandPathHoverUntilMouseMove = false
         if let terminalSurface {
             AppDelegate.shared?.tabManager?.dismissNotificationOnDirectInteraction(
                 tabId: terminalSurface.tabId,
@@ -7491,6 +7517,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         guard let surface = surface else { return }
         let point = convert(event.locationInWindow, from: nil)
         let consumed = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, modsFromEvent(event))
+        suppressCommandPathHoverUntilMouseMove = leftMouseDragSelectionInProgress
+        leftMouseDragSelectionInProgress = false
         _ = handleCommandClickRelease(at: point, modifierFlags: event.modifierFlags, ghosttyConsumed: consumed)
     }
 
@@ -8235,6 +8263,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     override func mouseMoved(with event: NSEvent) {
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
+        clearCompletedSelectionDragSuppressionIfNeeded()
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
@@ -8258,6 +8287,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         super.mouseEntered(with: event)
         maybeRequestFirstResponderForMouseFocus()
         guard let surface = surface else { return }
+        clearCompletedSelectionDragSuppressionIfNeeded()
         let suppressCommandPathHover = shouldSuppressCommandPathHover(for: event.modifierFlags)
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
@@ -8308,6 +8338,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func mouseDragged(with event: NSEvent) {
         guard let surface = surface else { return }
+        leftMouseDragSelectionInProgress = true
         let eventPoint = convert(event.locationInWindow, from: nil)
         trackMousePointIfUsable(eventPoint)
         // Forward the raw drag coordinates, including out-of-bounds positions.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -100,6 +100,26 @@ func cmuxGhosttyModifierActionForFlagsChanged(
 
     return sidePressed ? GHOSTTY_ACTION_PRESS : GHOSTTY_ACTION_RELEASE
 }
+
+func cmuxTerminalSelectionCopyIntentAvailable(
+    selectionActive: Bool,
+    recentSelectionDragCompleted: Bool
+) -> Bool {
+    let _ = recentSelectionDragCompleted
+    return selectionActive
+}
+
+func cmuxShouldSuppressTerminalCommandPathHover(
+    modifierFlags: NSEvent.ModifierFlags,
+    selectionActive: Bool,
+    recentSelectionDragCompleted: Bool
+) -> Bool {
+    modifierFlags.contains(.command) &&
+        cmuxTerminalSelectionCopyIntentAvailable(
+            selectionActive: selectionActive,
+            recentSelectionDragCompleted: recentSelectionDragCompleted
+        )
+}
 #endif
 
 private func cmuxRuntimeReadClipboardCallback(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1332,6 +1332,43 @@ final class GhosttyBackgroundThemeTests: XCTestCase {
 }
 
 
+final class TerminalCommandHoverSuppressionPolicyTests: XCTestCase {
+    func testRecentDragKeepsCommandHoverSuppressedUntilPointerMoves() {
+        XCTAssertTrue(
+            cmuxShouldSuppressTerminalCommandPathHover(
+                modifierFlags: [.command],
+                selectionActive: false,
+                recentSelectionDragCompleted: true
+            ),
+            "Cmd+C immediately after a drag-selection should stay on the copy path even if the live selection probe has not caught up yet"
+        )
+        XCTAssertTrue(
+            cmuxTerminalSelectionCopyIntentAvailable(
+                selectionActive: false,
+                recentSelectionDragCompleted: true
+            ),
+            "The edit menu should keep Copy enabled during the post-drag copy-intent window"
+        )
+    }
+
+    func testSuppressesOnlyWhenCommandOrSelectionCopyIntentIsPresent() {
+        XCTAssertFalse(
+            cmuxShouldSuppressTerminalCommandPathHover(
+                modifierFlags: [],
+                selectionActive: true,
+                recentSelectionDragCompleted: true
+            )
+        )
+        XCTAssertFalse(
+            cmuxTerminalSelectionCopyIntentAvailable(
+                selectionActive: false,
+                recentSelectionDragCompleted: false
+            )
+        )
+    }
+}
+
+
 final class GhosttyResponderResolutionTests: XCTestCase {
     private final class FocusProbeView: NSView {
         override var acceptsFirstResponder: Bool { true }


### PR DESCRIPTION
## Summary
- add regression coverage for the post-drag `Cmd+C` copy-intent window
- keep cmux's cmd-hover/cmd-click path suppressed immediately after a drag selection, even if the synchronous selection probe has not caught up yet
- keep `Edit > Copy` enabled across that window and fall back to direct selection readback if Ghostty's binding path misses the just-finished selection

## Root cause
cmux adds a `flagsChanged` cmd-hover/cmd-click refresh path that upstream Ghostty does not run. In the `mosh -> tmux` case, a just-finished drag selection can leave a brief gap where `ghostty_surface_has_selection` is false during the immediate `Cmd` press. That re-enters the cmd-hover path and disables `Edit > Copy` right when the user hits `Cmd+C`, so the clipboard stays empty.

## Testing
- added `TerminalCommandHoverSuppressionPolicyTests`
- not run locally per repo policy

Closes #3016.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input/selection and clipboard behavior, so regressions could affect common interactions like Cmd-hover path opening and Copy menu enablement, but the change is scoped and covered by targeted unit tests.
> 
> **Overview**
> Fixes a timing gap where a just-finished drag selection could briefly report no active selection, causing a stationary Cmd press to re-enable cmd-hover/cmd-click behavior and break `Cmd+C`.
> 
> Adds a post-drag “copy intent” window by tracking drag selection completion (`suppressCommandPathHoverUntilMouseMove`) and using it to (1) keep cmd-hover suppressed until the mouse moves, and (2) keep `Edit > Copy` enabled via a unified `cmuxTerminalSelectionCopyIntentAvailable` policy.
> 
> Updates `copy(_:)` to fall back to directly reading the selection snapshot and writing it to the pasteboard when the Ghostty binding path doesn’t capture the just-finished selection, and adds `TerminalCommandHoverSuppressionPolicyTests` for the new suppression/copy-intent rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4dff32d0d7c064e64db7e59a354fbce2bfa665b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+C copy right after a drag selection in `mosh` → `tmux` by treating the first stationary Cmd press as copy intent and keeping Edit > Copy enabled until the mouse moves. Closes #3016.

- **Bug Fixes**
  - Suppress `cmux` command-hover/click right after a left-drag selection, track drag state, and clear on mouse move to keep the copy path active.
  - Keep Edit > Copy enabled during this window; if the binding path misses, fall back to the selection snapshot in `copy(_:)`.
  - Added tests (`TerminalCommandHoverSuppressionPolicyTests`) covering post-drag suppression, copy availability, and Command-only suppression.

<sup>Written for commit 4dff32d0d7c064e64db7e59a354fbce2bfa665b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Copy now prefers the app's native copy path with a reliable clipboard fallback.
  * Command-hover (path) UI is suppressed appropriately during and immediately after text drag selections to avoid accidental triggers.
  * Selection state handling refined to prevent unintended hover interactions and improve copy availability after recent drags.

* **Tests**
  * Added unit tests covering hover-suppression and copy-intent timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->