### PR TITLE
Fix idle thread and memory growth from background workspace priming

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1772,27 +1772,14 @@ struct MountedWorkspacePresentation: Equatable {
 enum MountedWorkspacePresentationPolicy {
     static func resolve(
         isSelectedWorkspace: Bool,
-        isRetiringWorkspace: Bool,
-        shouldPrimeInBackground: Bool
+        isRetiringWorkspace: Bool
     ) -> MountedWorkspacePresentation {
         let isRenderedVisible = isSelectedWorkspace || isRetiringWorkspace
-        let renderOpacity: Double = {
-            if isRenderedVisible {
-                return 1
-            }
-            if shouldPrimeInBackground {
-                // Keep the workspace mounted long enough to warm the terminal surface, but do
-                // not mark it panel-visible. Visible portal entries intentionally survive
-                // transient anchor loss during bonsplit drag/reparent churn.
-                return 0.001
-            }
-            return 0
-        }()
 
         return MountedWorkspacePresentation(
             isRenderedVisible: isRenderedVisible,
             isPanelVisible: isRenderedVisible,
-            renderOpacity: renderOpacity
+            renderOpacity: isRenderedVisible ? 1 : 0
         )
     }
 }
@@ -2761,11 +2748,9 @@ struct ContentView: View {
                 ForEach(mountedWorkspaces) { tab in
                     let isSelectedWorkspace = selectedWorkspaceId == tab.id
                     let isRetiringWorkspace = retiringWorkspaceId == tab.id
-                    let shouldPrimeInBackground = tabManager.pendingBackgroundWorkspaceLoadIds.contains(tab.id)
                     let presentation = MountedWorkspacePresentationPolicy.resolve(
                         isSelectedWorkspace: isSelectedWorkspace,
-                        isRetiringWorkspace: isRetiringWorkspace,
-                        shouldPrimeInBackground: shouldPrimeInBackground
+                        isRetiringWorkspace: isRetiringWorkspace
                     )
                     // Keep the retiring workspace visible during handoff, but never input-active.
                     // Allowing both selected+retiring workspaces to be input-active lets the
@@ -2793,9 +2778,6 @@ struct ContentView: View {
                     .allowsHitTesting(isSelectedWorkspace)
                     .accessibilityHidden(!presentation.isRenderedVisible)
                     .zIndex(isSelectedWorkspace ? 2 : (isRetiringWorkspace ? 1 : 0))
-                    .task(id: shouldPrimeInBackground ? tab.id : nil) {
-                        await primeBackgroundWorkspaceIfNeeded(workspaceId: tab.id)
-                    }
                 }
             }
             .opacity(sidebarSelectionState.selection == .tabs ? 1 : 0)
@@ -3349,6 +3331,12 @@ struct ContentView: View {
             reconcileMountedWorkspaceIds()
         })
 
+        // Prime background workspaces off-screen. Rendering them just to run a `.task`
+        // mounts every keepAllAlive tab view and can materialize hidden terminal surfaces.
+        view = AnyView(view.task(id: pendingBackgroundWorkspaceLoadTaskKey) {
+            await primePendingBackgroundWorkspaces()
+        })
+
         view = AnyView(view.onReceive(tabManager.$debugPinnedWorkspaceLoadIds) { _ in
             reconcileMountedWorkspaceIds()
         })
@@ -3828,7 +3816,6 @@ struct ContentView: View {
         let effectiveSelectedId = selectedId ?? tabManager.selectedTabId
         let handoffPinnedIds = retiringWorkspaceId.map { Set([ $0 ]) } ?? []
         let pinnedIds = handoffPinnedIds
-            .union(tabManager.pendingBackgroundWorkspaceLoadIds)
             .union(tabManager.debugPinnedWorkspaceLoadIds)
         let isCycleHot = tabManager.isWorkspaceCycleHot
         let shouldKeepHandoffPair = isCycleHot && !handoffPinnedIds.isEmpty
@@ -3920,8 +3907,8 @@ struct ContentView: View {
             return .completed(reason: "workspace_removed")
         }
 
-        workspace.requestBackgroundTerminalSurfaceStartIfNeeded()
-        guard workspace.hasLoadedTerminalSurface() else {
+        workspace.requestBackgroundPrimeTerminalSurfaceStartIfNeeded()
+        guard workspace.hasLoadedBackgroundPrimeTerminalSurface() else {
             return .pending
         }
 
@@ -4034,6 +4021,25 @@ struct ContentView: View {
             Task { @MainActor in
                 evaluate()
             }
+        }
+    }
+
+    private var pendingBackgroundWorkspaceLoadTaskKey: [String] {
+        tabManager.pendingBackgroundWorkspaceLoadIds
+            .map(\.uuidString)
+            .sorted()
+    }
+
+    private func primePendingBackgroundWorkspaces() async {
+        let workspaceIds = await MainActor.run {
+            tabManager.pendingBackgroundWorkspaceLoadIds.sorted { lhs, rhs in
+                lhs.uuidString < rhs.uuidString
+            }
+        }
+
+        for workspaceId in workspaceIds {
+            guard !Task.isCancelled else { return }
+            await primeBackgroundWorkspaceIfNeeded(workspaceId: workspaceId)
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7401,10 +7401,57 @@ final class Workspace: Identifiable, ObservableObject {
         return surfaceKind(for: panel)
     }
 
+    private func backgroundPrimeTerminalPanels() -> [TerminalPanel] {
+        var orderedTargets: [TerminalPanel] = []
+        var seenPanelIds: Set<UUID> = []
+
+        // Background priming only needs the tabs that would actually be visible if this
+        // workspace were selected. Starting every terminal panel eagerly would also start
+        // hidden keepAllAlive tabs and balloon thread/memory usage while the workspace is idle.
+        for paneId in bonsplitController.allPaneIds {
+            guard let selectedTabId =
+                    bonsplitController.selectedTab(inPane: paneId)?.id
+                    ?? bonsplitController.tabs(inPane: paneId).first?.id,
+                  let panelId = panelIdFromSurfaceId(selectedTabId),
+                  let terminalPanel = panels[panelId] as? TerminalPanel,
+                  seenPanelIds.insert(panelId).inserted else {
+                continue
+            }
+            orderedTargets.append(terminalPanel)
+        }
+
+        if !orderedTargets.isEmpty {
+            return orderedTargets
+        }
+
+        if let focusedPanelId,
+           let focusedTerminal = panels[focusedPanelId] as? TerminalPanel {
+            return [focusedTerminal]
+        }
+
+        if let fallback = panels.values.compactMap({ $0 as? TerminalPanel }).first {
+            return [fallback]
+        }
+
+        return []
+    }
+
     func requestBackgroundTerminalSurfaceStartIfNeeded() {
         for terminalPanel in panels.values.compactMap({ $0 as? TerminalPanel }) {
             terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()
         }
+    }
+
+    func requestBackgroundPrimeTerminalSurfaceStartIfNeeded() {
+        for terminalPanel in backgroundPrimeTerminalPanels() {
+            terminalPanel.surface.requestBackgroundSurfaceStartIfNeeded()
+        }
+    }
+
+    func hasLoadedBackgroundPrimeTerminalSurface() -> Bool {
+        let targets = backgroundPrimeTerminalPanels()
+        guard !targets.isEmpty else { return true }
+        return targets.allSatisfy { $0.surface.surface != nil }
     }
 
     @discardableResult

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -9,17 +9,19 @@ import Bonsplit
 #endif
 
 final class WorkspaceContentViewVisibilityTests: XCTestCase {
-    func testBackgroundPrimedWorkspaceStaysMountedButNotPanelVisible() {
+    func testNonSelectedNonRetiringWorkspaceIsFullyHidden() {
+        // Background priming no longer mounts workspaces in the SwiftUI tree, so a
+        // mounted workspace that is neither selected nor retiring must render fully
+        // hidden rather than ghosting in at 0.001 opacity.
         XCTAssertEqual(
             MountedWorkspacePresentationPolicy.resolve(
                 isSelectedWorkspace: false,
-                isRetiringWorkspace: false,
-                shouldPrimeInBackground: true
+                isRetiringWorkspace: false
             ),
             MountedWorkspacePresentation(
                 isRenderedVisible: false,
                 isPanelVisible: false,
-                renderOpacity: 0.001
+                renderOpacity: 0
             )
         )
     }
@@ -28,8 +30,7 @@ final class WorkspaceContentViewVisibilityTests: XCTestCase {
         XCTAssertEqual(
             MountedWorkspacePresentationPolicy.resolve(
                 isSelectedWorkspace: false,
-                isRetiringWorkspace: true,
-                shouldPrimeInBackground: false
+                isRetiringWorkspace: true
             ),
             MountedWorkspacePresentation(
                 isRenderedVisible: true,

--- a/tests_v2/test_background_workspace_idle_thread_footprint.py
+++ b/tests_v2/test_background_workspace_idle_thread_footprint.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Regression: background workspace priming must not load every hidden terminal tab."""
+
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+WORKSPACE_COUNT = 10
+SURFACES_PER_WORKSPACE = 4
+SETTLE_SECONDS = 2.0
+IDLE_SECONDS = 8.0
+THREAD_BUDGET_PER_WORKSPACE = 6
+THREAD_BUDGET_OVERHEAD = 12
+IDLE_THREAD_GROWTH_BUDGET = 6
+FOOTPRINT_BUDGET_PER_WORKSPACE_MB = 24
+IDLE_FOOTPRINT_GROWTH_BUDGET_MB = 64
+
+
+@dataclass(frozen=True)
+class ProcessMetrics:
+    thread_count: int
+    physical_footprint_bytes: int
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _run(cmd: list[str]) -> str:
+    proc = subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        merged = f"{proc.stdout}\n{proc.stderr}".strip()
+        raise cmuxError(f"Command failed ({' '.join(cmd)}): {merged}")
+    return proc.stdout
+
+
+def _socket_owner_pid(socket_path: str) -> int:
+    output = _run(["lsof", "-t", socket_path])
+    for raw in output.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        pid = int(line)
+        if pid != os.getpid():
+            return pid
+    raise cmuxError(f"Could not resolve cmux PID from socket owner list: {output!r}")
+
+
+def _thread_count(pid: int) -> int:
+    output = _run(["ps", "-M", "-p", str(pid)])
+    lines = [line for line in output.splitlines() if line.strip()]
+    if len(lines) < 2:
+        raise cmuxError(f"Unexpected ps -M output for PID {pid}: {output!r}")
+    return len(lines) - 1
+
+
+def _unit_multiplier(unit: str) -> int:
+    return {
+        "K": 1024,
+        "M": 1024 ** 2,
+        "G": 1024 ** 3,
+        "T": 1024 ** 4,
+    }[unit]
+
+
+def _physical_footprint_bytes(pid: int) -> int:
+    output = _run(["vmmap", "--summary", str(pid)])
+    match = re.search(r"Physical footprint:\s*([0-9.]+)([KMGT])", output)
+    if not match:
+        raise cmuxError(f"Could not parse physical footprint from vmmap output: {output[:400]!r}")
+    value = float(match.group(1))
+    unit = match.group(2)
+    return int(value * _unit_multiplier(unit))
+
+
+def _capture_metrics(pid: int) -> ProcessMetrics:
+    return ProcessMetrics(
+        thread_count=_thread_count(pid),
+        physical_footprint_bytes=_physical_footprint_bytes(pid),
+    )
+
+
+def _layout_payload() -> dict:
+    return {
+        "pane": {
+            "surfaces": [
+                {
+                    "type": "terminal",
+                    "name": f"bg-tab-{index + 1}",
+                }
+                for index in range(SURFACES_PER_WORKSPACE)
+            ],
+        },
+    }
+
+
+def _mb(value: int) -> float:
+    return value / (1024.0 * 1024.0)
+
+
+def main() -> int:
+    created_workspaces: list[str] = []
+
+    with cmux(SOCKET_PATH) as client:
+        baseline_workspace = client.current_workspace()
+        pid = _socket_owner_pid(client.socket_path)
+        before = _capture_metrics(pid)
+
+        try:
+            for index in range(WORKSPACE_COUNT):
+                payload = client._call(
+                    "workspace.create",
+                    {
+                        "title": f"idle-bg-regression-{index + 1}",
+                        "layout": _layout_payload(),
+                    },
+                ) or {}
+                workspace_id = str(payload.get("workspace_id") or "")
+                _must(bool(workspace_id), f"workspace.create returned no workspace_id: {payload}")
+                created_workspaces.append(workspace_id)
+                _must(
+                    client.current_workspace() == baseline_workspace,
+                    "workspace.create should preserve the selected workspace during background priming",
+                )
+
+            time.sleep(SETTLE_SECONDS)
+            after_settle = _capture_metrics(pid)
+
+            time.sleep(IDLE_SECONDS)
+            after_idle = _capture_metrics(pid)
+
+            absolute_thread_growth = after_idle.thread_count - before.thread_count
+            idle_thread_growth = after_idle.thread_count - after_settle.thread_count
+            absolute_footprint_growth = (
+                after_idle.physical_footprint_bytes - before.physical_footprint_bytes
+            )
+            idle_footprint_growth = (
+                after_idle.physical_footprint_bytes - after_settle.physical_footprint_bytes
+            )
+
+            thread_budget = (
+                WORKSPACE_COUNT * THREAD_BUDGET_PER_WORKSPACE + THREAD_BUDGET_OVERHEAD
+            )
+            footprint_budget_bytes = (
+                WORKSPACE_COUNT
+                * FOOTPRINT_BUDGET_PER_WORKSPACE_MB
+                * 1024
+                * 1024
+            )
+            idle_footprint_budget_bytes = IDLE_FOOTPRINT_GROWTH_BUDGET_MB * 1024 * 1024
+
+            _must(
+                absolute_thread_growth <= thread_budget,
+                "Background workspace priming spawned too many threads while idle: "
+                f"before={before.thread_count} after={after_idle.thread_count} "
+                f"delta={absolute_thread_growth} budget={thread_budget}",
+            )
+            _must(
+                idle_thread_growth <= IDLE_THREAD_GROWTH_BUDGET,
+                "Thread count kept growing after background workspace creation settled: "
+                f"settled={after_settle.thread_count} after_idle={after_idle.thread_count} "
+                f"delta={idle_thread_growth} budget={IDLE_THREAD_GROWTH_BUDGET}",
+            )
+            _must(
+                absolute_footprint_growth <= footprint_budget_bytes,
+                "Background workspace priming grew physical footprint too much: "
+                f"before={_mb(before.physical_footprint_bytes):.1f}MB "
+                f"after={_mb(after_idle.physical_footprint_bytes):.1f}MB "
+                f"delta={_mb(absolute_footprint_growth):.1f}MB "
+                f"budget={FOOTPRINT_BUDGET_PER_WORKSPACE_MB * WORKSPACE_COUNT}MB",
+            )
+            _must(
+                idle_footprint_growth <= idle_footprint_budget_bytes,
+                "Physical footprint kept growing while the app was idle: "
+                f"settled={_mb(after_settle.physical_footprint_bytes):.1f}MB "
+                f"after_idle={_mb(after_idle.physical_footprint_bytes):.1f}MB "
+                f"delta={_mb(idle_footprint_growth):.1f}MB "
+                f"budget={IDLE_FOOTPRINT_GROWTH_BUDGET_MB}MB",
+            )
+            _must(
+                client.current_workspace() == baseline_workspace,
+                "background workspace priming should not switch the selected workspace",
+            )
+        finally:
+            for workspace_id in reversed(created_workspaces):
+                try:
+                    client.close_workspace(workspace_id)
+                except Exception:
+                    pass
+
+    print("PASS: background workspace priming keeps idle thread and footprint growth bounded")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a regression test that creates background workspaces with multiple hidden terminal tabs and checks idle thread/physical-footprint growth
- stop mounting pending background workspaces just to run the prime task
- limit background priming to the selected terminal tabs for each pane instead of every terminal panel in the workspace

## Root cause
A source-history bisect narrowed the regression to the March 5 background-workspace priming change (`990b6ba1`). That change pinned pending background workspaces into the mounted SwiftUI tree so a per-workspace `.task` could run. Because workspaces use Bonsplit `keepAllAlive`, mounting a hidden workspace also mounted every hidden tab view, and cmux then materialized Ghostty runtime surfaces for tabs that were never visible. The old helper compounded that by explicitly calling `requestBackgroundSurfaceStartIfNeeded()` on every terminal panel in the workspace.

## Testing
- not run locally (per repo policy)
- `python3 -m py_compile tests_v2/test_background_workspace_idle_thread_footprint.py`
- `git diff --check`

Closes #3018.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workspace mounting/visibility and background priming logic, which can affect perceived UI responsiveness and terminal surface readiness; risk is mitigated by added regression coverage and mostly targeted behavior changes.
> 
> **Overview**
> Fixes idle thread/memory growth during background workspace priming by **no longer mounting non-selected workspaces in the SwiftUI tree just to run a per-workspace `.task`**. Background priming is now driven by a single off-screen `.task` keyed by `pendingBackgroundWorkspaceLoadIds`, processing pending IDs sequentially and cancellably.
> 
> Background priming is narrowed to start/check terminal surfaces only for tabs that would be visible (per-pane selected tab with focused/first-tab fallbacks) via new `Workspace` helpers, and hidden non-selected/non-retiring workspaces now render fully hidden (opacity `0`), with updated tests plus a new Python regression test that asserts thread and physical-footprint growth stays bounded while idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5e3704d5cd77acb93a7f5e052042880d1661eade. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3018 by stopping idle thread and memory growth from background workspace priming. Hidden workspaces are no longer mounted or ghost-rendered, and priming only starts surfaces for tabs that would be visible.

- **Bug Fixes**
  - Prime pending background workspaces via a single off-screen `.task` keyed by pending IDs; runs sequentially with cancellation.
  - Do not mount or pin hidden workspaces; non-selected/non-retiring workspaces render fully hidden (no 0.001 opacity). Update `MountedWorkspacePresentationPolicy` tests to the new two-arg signature.
  - Limit terminal priming to the per-pane selected tab, with focused/first-terminal fallbacks.
  - Add `requestBackgroundPrimeTerminalSurfaceStartIfNeeded()` and `hasLoadedBackgroundPrimeTerminalSurface()`. Include a regression test that keeps idle thread and footprint growth within budget.

<sup>Written for commit 5e3704d5cd77acb93a7f5e052042880d1661eade. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Behavior**
  * Hidden (non-selected, non-retiring) background workspaces are now fully hidden (no partial rendering).
  * Background priming of pending workspaces is performed centrally, deterministically, sequentially, and cancellable.

* **Tests**
  * Added a regression test that measures resource impact (threads/memory) of background workspace priming.

* **Refactor**
  * Simplified background priming and workspace retention logic to limit which workspaces are retained.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->