### PR TITLE
Add unified config settings utility window

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		FE003103 /* RightSidebarPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003003 /* RightSidebarPanelView.swift */; };
 		FE002101 /* FileExplorerRootResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002001 /* FileExplorerRootResolverTests.swift */; };
 		FE002102 /* FileExplorerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002002 /* FileExplorerStoreTests.swift */; };
+		3023A1003023A1003023A100 /* ConfigSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1003023B1003023B100 /* ConfigSource.swift */; };
+		3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1013023B1013023B101 /* ConfigSettingsView.swift */; };
 			A5001001 /* cmuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001011 /* cmuxApp.swift */; };
 			A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 			E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */; };
@@ -221,6 +223,8 @@
 		FE003003 /* RightSidebarPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelView.swift; sourceTree = "<group>"; };
 		FE002001 /* FileExplorerRootResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerRootResolverTests.swift; sourceTree = "<group>"; };
 		FE002002 /* FileExplorerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerStoreTests.swift; sourceTree = "<group>"; };
+		3023B1003023B1003023B100 /* ConfigSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSource.swift; sourceTree = "<group>"; };
+		3023B1013023B1013023B101 /* ConfigSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSettingsView.swift; sourceTree = "<group>"; };
 			A5001000 /* cmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 			F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 			7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -474,6 +478,8 @@
 			A5001041 /* Sources */ = {
 				isa = PBXGroup;
 				children = (
+					3023B1003023B1003023B100 /* ConfigSource.swift */,
+					3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
 					A5001011 /* cmuxApp.swift */,
 					A5001012 /* ContentView.swift */,
 					9AD52285508B1D6A9875E7B3 /* SidebarSelectionState.swift */,
@@ -809,6 +815,8 @@
 				isa = PBXSourcesBuildPhase;
 				buildActionMask = 2147483647;
 				files = (
+					3023A1003023A1003023A100 /* ConfigSource.swift in Sources */,
+					3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */,
 					A5001001 /* cmuxApp.swift in Sources */,
 					A5001002 /* ContentView.swift in Sources */,
 					E62155868BB29FEB5DAAAF25 /* SidebarSelectionState.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -49016,6 +49016,329 @@
         }
       }
     },
+    "settings.app.configWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal Config"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル設定"
+          }
+        }
+      }
+    },
+    "settings.app.configWindow.openButton": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open Config Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構成ウインドウを開く"
+          }
+        }
+      }
+    },
+    "settings.app.configWindow.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open the cmux config, standalone Ghostty config, and merged preview in one utility window."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux の設定、単体の Ghostty 設定、マージ後のプレビューを 1 つのユーティリティウインドウで開きます。"
+          }
+        }
+      }
+    },
+    "settings.config.action.openEditor": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Editor…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エディタで開く…"
+          }
+        }
+      }
+    },
+    "settings.config.action.reload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再読み込み"
+          }
+        }
+      }
+    },
+    "settings.config.action.revealFinder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで表示"
+          }
+        }
+      }
+    },
+    "settings.config.action.save": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        }
+      }
+    },
+    "settings.config.banner.ghostty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This file belongs to standalone Ghostty. cmux does not read it, so edits here do not affect cmux."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このファイルは単体の Ghostty 用です。cmux はこれを読み込まないため、ここでの編集は cmux に反映されません。"
+          }
+        }
+      }
+    },
+    "settings.config.banner.ghosttyMissing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No standalone Ghostty config file was found at the preferred path. cmux still does not read standalone Ghostty config."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "優先パスに単体の Ghostty 設定ファイルが見つかりませんでした。cmux は単体の Ghostty 設定を読み込みません。"
+          }
+        }
+      }
+    },
+    "settings.config.banner.synced": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a generated preview of the effective config. Edit the cmux tab to change what cmux reads."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これは実効設定の生成プレビューです。cmux が読み込む内容を変更するには cmux タブを編集してください。"
+          }
+        }
+      }
+    },
+    "settings.config.banner.syncedNoGhostty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is a generated preview of the effective config. No standalone Ghostty config file was found, so only cmux overrides are shown."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これは実効設定の生成プレビューです。単体の Ghostty 設定ファイルが見つからなかったため、cmux の上書き設定のみを表示しています。"
+          }
+        }
+      }
+    },
+    "settings.config.source.cmux": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        }
+      }
+    },
+    "settings.config.source.ghostty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ghostty"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ghostty"
+          }
+        }
+      }
+    },
+    "settings.config.source.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Config Source"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構成ソース"
+          }
+        }
+      }
+    },
+    "settings.config.source.synced": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "synced"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "同期"
+          }
+        }
+      }
+    },
+    "settings.config.status.reloaded": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reloaded configuration from disk."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスクから構成を再読み込みしました。"
+          }
+        }
+      }
+    },
+    "settings.config.status.saveFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't save the cmux config."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 設定を保存できませんでした。"
+          }
+        }
+      }
+    },
+    "settings.config.status.saved": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved to cmux config and reloaded."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 設定に保存し、再読み込みしました。"
+          }
+        }
+      }
+    },
+    "settings.config.windowTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Config"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構成"
+          }
+        }
+      }
+    },
     "settings.app.commandPaletteSearchAllSurfaces": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -49135,6 +49135,23 @@
         }
       }
     },
+    "settings.config.banner.cmux": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This is the config file cmux reads. Edit it here, then Save to reload cmux."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これは cmux が読み込む設定ファイルです。ここで編集し、保存すると cmux が再読み込みされます。"
+          }
+        }
+      }
+    },
     "settings.config.banner.ghostty": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Settings/ConfigSettingsView.swift
+++ b/Sources/Settings/ConfigSettingsView.swift
@@ -22,7 +22,10 @@ struct ConfigSettingsView: View {
     private var currentBannerText: String? {
         switch configSource {
         case .cmux:
-            return nil
+            return String(
+                localized: "settings.config.banner.cmux",
+                defaultValue: "This is the config file cmux reads. Edit it here, then Save to reload cmux."
+            )
         case .ghostty:
             if currentSnapshot.hasBackingFile {
                 return String(
@@ -84,21 +87,12 @@ struct ConfigSettingsView: View {
 
             Group {
                 if configSource == .cmux {
-                    TextEditor(text: $cmuxDraft)
-                        .font(.system(size: 12, weight: .regular, design: .monospaced))
-                        .scrollContentBackground(.hidden)
-                        .padding(10)
+                    ConfigSettingsTextView(text: $cmuxDraft, isEditable: true)
                         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                         .background(editorBackground)
                         .accessibilityIdentifier("ConfigSettingsCmuxEditor")
                 } else {
-                    ScrollView {
-                        Text(verbatim: currentSnapshot.contents)
-                            .font(.system(size: 12, weight: .regular, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(12)
-                    }
+                    ConfigSettingsTextView(text: .constant(currentSnapshot.contents), isEditable: false)
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     .background(editorBackground)
                     .accessibilityIdentifier("ConfigSettingsReadOnlyView")
@@ -107,6 +101,7 @@ struct ConfigSettingsView: View {
             .overlay(
                 RoundedRectangle(cornerRadius: 10)
                     .stroke(Color(nsColor: .separatorColor).opacity(0.25), lineWidth: 1)
+                    .allowsHitTesting(false)
             )
             .clipShape(RoundedRectangle(cornerRadius: 10))
 
@@ -295,6 +290,77 @@ private struct ConfigSettingsBanner: View {
             RoundedRectangle(cornerRadius: 10)
                 .fill(Color(nsColor: .controlBackgroundColor))
         )
+    }
+}
+
+private struct ConfigSettingsTextView: NSViewRepresentable {
+    @Binding var text: String
+    let isEditable: Bool
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(text: $text)
+    }
+
+    func makeNSView(context: Context) -> NSScrollView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+
+        let textView = NSTextView()
+        textView.isRichText = false
+        textView.importsGraphics = false
+        textView.allowsUndo = true
+        textView.isEditable = isEditable
+        textView.isSelectable = true
+        textView.string = text
+        textView.font = .monospacedSystemFont(ofSize: 12, weight: .regular)
+        textView.textColor = .textColor
+        textView.backgroundColor = .textBackgroundColor
+        textView.insertionPointColor = .textColor
+        textView.textContainerInset = NSSize(width: 10, height: 10)
+        textView.autoresizingMask = [.width]
+        textView.isVerticallyResizable = true
+        textView.isHorizontallyResizable = false
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
+        textView.textContainer?.widthTracksTextView = true
+        textView.textContainer?.containerSize = NSSize(
+            width: scrollView.contentSize.width,
+            height: CGFloat.greatestFiniteMagnitude
+        )
+        textView.delegate = context.coordinator
+
+        scrollView.documentView = textView
+        return scrollView
+    }
+
+    func updateNSView(_ scrollView: NSScrollView, context: Context) {
+        context.coordinator.text = $text
+
+        guard let textView = scrollView.documentView as? NSTextView else { return }
+        if textView.string != text {
+            textView.string = text
+        }
+        textView.isEditable = isEditable
+        textView.isSelectable = true
+        textView.backgroundColor = .textBackgroundColor
+        textView.textColor = .textColor
+        textView.insertionPointColor = .textColor
+    }
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var text: Binding<String>
+
+        init(text: Binding<String>) {
+            self.text = text
+        }
+
+        func textDidChange(_ notification: Notification) {
+            guard let textView = notification.object as? NSTextView else { return }
+            text.wrappedValue = textView.string
+        }
     }
 }
 

--- a/Sources/Settings/ConfigSettingsView.swift
+++ b/Sources/Settings/ConfigSettingsView.swift
@@ -1,0 +1,312 @@
+import AppKit
+import SwiftUI
+
+struct ConfigSettingsView: View {
+    static let windowID = "config-editor"
+
+    @State private var configSource: ConfigSource = .cmux
+    @State private var snapshots: [ConfigSource: ConfigSourceSnapshot] = [:]
+    @State private var cmuxDraft = ""
+    @State private var cmuxLastLoadedContents = ""
+    @State private var statusMessage = ""
+    @State private var statusIsError = false
+
+    private var currentSnapshot: ConfigSourceSnapshot {
+        snapshots[configSource] ?? configSource.snapshot(environment: .live())
+    }
+
+    private var hasUnsavedCmuxChanges: Bool {
+        cmuxDraft != cmuxLastLoadedContents
+    }
+
+    private var currentBannerText: String? {
+        switch configSource {
+        case .cmux:
+            return nil
+        case .ghostty:
+            if currentSnapshot.hasBackingFile {
+                return String(
+                    localized: "settings.config.banner.ghostty",
+                    defaultValue: "This file belongs to standalone Ghostty. cmux does not read it, so edits here do not affect cmux."
+                )
+            }
+            return String(
+                localized: "settings.config.banner.ghosttyMissing",
+                defaultValue: "No standalone Ghostty config file was found at the preferred path. cmux still does not read standalone Ghostty config."
+            )
+        case .synced:
+            if currentSnapshot.hasStandaloneGhosttyConfig {
+                return String(
+                    localized: "settings.config.banner.synced",
+                    defaultValue: "This is a generated preview of the effective config. Edit the cmux tab to change what cmux reads."
+                )
+            }
+            return String(
+                localized: "settings.config.banner.syncedNoGhostty",
+                defaultValue: "This is a generated preview of the effective config. No standalone Ghostty config file was found, so only cmux overrides are shown."
+            )
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            HStack {
+                Spacer(minLength: 0)
+                Picker(
+                    String(localized: "settings.config.source.label", defaultValue: "Config Source"),
+                    selection: $configSource
+                ) {
+                    ForEach(ConfigSource.allCases) { source in
+                        Text(source.localizedTitle).tag(source)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .frame(width: 280)
+                Spacer(minLength: 0)
+            }
+
+            Divider()
+
+            VStack(alignment: .leading, spacing: 4) {
+                ForEach(currentSnapshot.displayPaths, id: \.self) { path in
+                    Text(verbatim: path)
+                        .font(.system(size: 12, weight: .regular, design: .monospaced))
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let bannerText = currentBannerText {
+                ConfigSettingsBanner(text: bannerText)
+            }
+
+            Group {
+                if configSource == .cmux {
+                    TextEditor(text: $cmuxDraft)
+                        .font(.system(size: 12, weight: .regular, design: .monospaced))
+                        .scrollContentBackground(.hidden)
+                        .padding(10)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .background(editorBackground)
+                        .accessibilityIdentifier("ConfigSettingsCmuxEditor")
+                } else {
+                    ScrollView {
+                        Text(verbatim: currentSnapshot.contents)
+                            .font(.system(size: 12, weight: .regular, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(12)
+                    }
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                    .background(editorBackground)
+                    .accessibilityIdentifier("ConfigSettingsReadOnlyView")
+                }
+            }
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(Color(nsColor: .separatorColor).opacity(0.25), lineWidth: 1)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            HStack(spacing: 8) {
+                if !statusMessage.isEmpty {
+                    Text(statusMessage)
+                        .font(.caption)
+                        .foregroundColor(statusIsError ? .red : .secondary)
+                }
+
+                Spacer(minLength: 0)
+
+                Button(String(localized: "settings.config.action.openEditor", defaultValue: "Open in Editor…")) {
+                    openCurrentSourceInEditor()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(String(localized: "settings.config.action.revealFinder", defaultValue: "Reveal in Finder")) {
+                    revealCurrentSourceInFinder()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(String(localized: "settings.config.action.reload", defaultValue: "Reload")) {
+                    reloadFromDisk()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button(String(localized: "settings.config.action.save", defaultValue: "Save")) {
+                    saveCmuxConfig()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(configSource != .cmux || !hasUnsavedCmuxChanges)
+            }
+        }
+        .padding(16)
+        .frame(minWidth: 760, minHeight: 540)
+        .background(Color(nsColor: .windowBackgroundColor).ignoresSafeArea())
+        .background(
+            WindowAccessor { window in
+                configureWindow(window)
+            }
+        )
+        .onAppear {
+            refreshSnapshots(preserveCmuxDraft: false)
+        }
+        .onChange(of: configSource) { _ in
+            statusMessage = ""
+            statusIsError = false
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
+            refreshSnapshots(preserveCmuxDraft: true)
+        }
+    }
+
+    private var editorBackground: some View {
+        RoundedRectangle(cornerRadius: 10)
+            .fill(Color(nsColor: .textBackgroundColor))
+    }
+
+    private func configureWindow(_ window: NSWindow) {
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.configEditor")
+        window.minSize = NSSize(width: 700, height: 500)
+        window.tabbingMode = .disallowed
+        window.animationBehavior = .utilityWindow
+        window.level = .floating
+        window.collectionBehavior.insert(.fullScreenAuxiliary)
+    }
+
+    private func refreshSnapshots(preserveCmuxDraft: Bool) {
+        let wasDirty = hasUnsavedCmuxChanges
+        let environment = ConfigSourceEnvironment.live()
+        let newSnapshots = Dictionary(
+            uniqueKeysWithValues: ConfigSource.allCases.map { source in
+                (source, source.snapshot(environment: environment))
+            }
+        )
+        snapshots = newSnapshots
+
+        let latestCmuxContents = newSnapshots[.cmux]?.contents ?? ""
+        if !preserveCmuxDraft || !wasDirty {
+            cmuxDraft = latestCmuxContents
+        }
+        cmuxLastLoadedContents = latestCmuxContents
+    }
+
+    private func reloadFromDisk() {
+        refreshSnapshots(preserveCmuxDraft: false)
+        GhosttyApp.shared.reloadConfiguration(source: "settings.configWindow.reload")
+        statusMessage = String(
+            localized: "settings.config.status.reloaded",
+            defaultValue: "Reloaded configuration from disk."
+        )
+        statusIsError = false
+    }
+
+    private func saveCmuxConfig() {
+        let environment = ConfigSourceEnvironment.live()
+        let url = environment.cmuxConfigURL
+
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            try cmuxDraft.write(to: url, atomically: true, encoding: .utf8)
+            cmuxLastLoadedContents = cmuxDraft
+            refreshSnapshots(preserveCmuxDraft: true)
+            GhosttyApp.shared.reloadConfiguration(source: "settings.configWindow.save")
+            statusMessage = String(
+                localized: "settings.config.status.saved",
+                defaultValue: "Saved to cmux config and reloaded."
+            )
+            statusIsError = false
+        } catch {
+            NSSound.beep()
+            statusMessage = String(
+                localized: "settings.config.status.saveFailed",
+                defaultValue: "Couldn't save the cmux config."
+            )
+            statusIsError = true
+        }
+    }
+
+    private func openCurrentSourceInEditor() {
+        PreferredEditorSettings.open(materializedCurrentURL())
+    }
+
+    private func revealCurrentSourceInFinder() {
+        let url = materializedCurrentURL()
+        if FileManager.default.fileExists(atPath: url.path) {
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        } else {
+            NSWorkspace.shared.open(url.deletingLastPathComponent())
+        }
+    }
+
+    private func materializedCurrentURL() -> URL {
+        switch configSource {
+        case .cmux:
+            let url = ConfigSourceEnvironment.live().cmuxConfigURL
+            materializeEmptyFileIfNeeded(at: url)
+            return url
+        case .ghostty:
+            return currentSnapshot.primaryURL
+        case .synced:
+            refreshSnapshots(preserveCmuxDraft: true)
+            return snapshots[.synced]?.primaryURL ?? currentSnapshot.primaryURL
+        }
+    }
+
+    private func materializeEmptyFileIfNeeded(at url: URL) {
+        guard !FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            try "".write(to: url, atomically: true, encoding: .utf8)
+        } catch {
+            NSSound.beep()
+        }
+    }
+}
+
+private struct ConfigSettingsBanner: View {
+    let text: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "info.circle")
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .controlBackgroundColor))
+        )
+    }
+}
+
+private extension ConfigSource {
+    var localizedTitle: String {
+        switch self {
+        case .cmux:
+            return String(localized: "settings.config.source.cmux", defaultValue: "cmux")
+        case .ghostty:
+            return String(localized: "settings.config.source.ghostty", defaultValue: "ghostty")
+        case .synced:
+            return String(localized: "settings.config.source.synced", defaultValue: "synced")
+        }
+    }
+}

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -1,0 +1,241 @@
+import Foundation
+
+struct ConfigSourceEnvironment {
+    let homeDirectoryURL: URL
+    let previewDirectoryURL: URL
+    let fileManager: FileManager
+
+    init(
+        homeDirectoryURL: URL,
+        previewDirectoryURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) {
+        let standardizedHome = homeDirectoryURL.standardizedFileURL
+        self.homeDirectoryURL = standardizedHome
+        self.fileManager = fileManager
+        self.previewDirectoryURL = previewDirectoryURL?.standardizedFileURL
+            ?? standardizedHome
+                .appendingPathComponent("Library", isDirectory: true)
+                .appendingPathComponent("Application Support", isDirectory: true)
+                .appendingPathComponent("com.cmuxterm.app", isDirectory: true)
+    }
+
+    static func live(fileManager: FileManager = .default) -> Self {
+        Self(homeDirectoryURL: fileManager.homeDirectoryForCurrentUser, fileManager: fileManager)
+    }
+
+    var cmuxConfigURL: URL {
+        applicationSupportDirectoryURL(forBundleIdentifier: "com.cmuxterm.app")
+            .appendingPathComponent("config", isDirectory: false)
+    }
+
+    var standaloneGhosttyDisplayURL: URL {
+        existingRegularFileURL(in: standaloneGhosttyDisplayCandidates) ?? standaloneGhosttyDisplayCandidates[0]
+    }
+
+    var standaloneGhosttyDisplayCandidates: [URL] {
+        [
+            homeDirectoryURL
+                .appendingPathComponent(".config", isDirectory: true)
+                .appendingPathComponent("ghostty", isDirectory: true)
+                .appendingPathComponent("config", isDirectory: false),
+            homeDirectoryURL
+                .appendingPathComponent(".config", isDirectory: true)
+                .appendingPathComponent("ghostty", isDirectory: true)
+                .appendingPathComponent("config.ghostty", isDirectory: false),
+            applicationSupportDirectoryURL(forBundleIdentifier: "com.mitchellh.ghostty")
+                .appendingPathComponent("config", isDirectory: false),
+            applicationSupportDirectoryURL(forBundleIdentifier: "com.mitchellh.ghostty")
+                .appendingPathComponent("config.ghostty", isDirectory: false),
+        ]
+    }
+
+    var syncedPreviewURL: URL {
+        previewDirectoryURL.appendingPathComponent("config.synced-preview", isDirectory: false)
+    }
+
+    func abbreviatedPath(for url: URL) -> String {
+        let path = url.path
+        let homePath = homeDirectoryURL.path
+        if path == homePath {
+            return "~"
+        }
+        let prefix = homePath.hasSuffix("/") ? homePath : homePath + "/"
+        guard path.hasPrefix(prefix) else { return path }
+        return "~/" + path.dropFirst(prefix.count)
+    }
+
+    func isRegularFile(at url: URL) -> Bool {
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              let type = attributes[.type] as? FileAttributeType else {
+            return false
+        }
+        return type == .typeRegular
+    }
+
+    private func applicationSupportDirectoryURL(forBundleIdentifier bundleIdentifier: String) -> URL {
+        homeDirectoryURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Application Support", isDirectory: true)
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+    }
+
+    private func existingRegularFileURL(in urls: [URL]) -> URL? {
+        urls.first(where: isRegularFile(at:))
+    }
+}
+
+struct ConfigSourceSnapshot {
+    let source: ConfigSource
+    let primaryURL: URL
+    let displayPaths: [String]
+    let contents: String
+    let isEditable: Bool
+    let hasBackingFile: Bool
+    let hasStandaloneGhosttyConfig: Bool
+}
+
+enum ConfigSource: String, CaseIterable, Identifiable {
+    case cmux
+    case ghostty
+    case synced
+
+    var id: Self { self }
+
+    var isEditable: Bool {
+        self == .cmux
+    }
+
+    func snapshot(environment: ConfigSourceEnvironment = .live()) -> ConfigSourceSnapshot {
+        switch self {
+        case .cmux:
+            let url = environment.cmuxConfigURL
+            return ConfigSourceSnapshot(
+                source: self,
+                primaryURL: url,
+                displayPaths: [url.path],
+                contents: Self.readContents(at: url),
+                isEditable: true,
+                hasBackingFile: environment.isRegularFile(at: url),
+                hasStandaloneGhosttyConfig: environment.isRegularFile(at: environment.standaloneGhosttyDisplayURL)
+            )
+        case .ghostty:
+            let url = environment.standaloneGhosttyDisplayURL
+            let hasBackingFile = environment.isRegularFile(at: url)
+            return ConfigSourceSnapshot(
+                source: self,
+                primaryURL: url,
+                displayPaths: [url.path],
+                contents: Self.readContents(at: url),
+                isEditable: false,
+                hasBackingFile: hasBackingFile,
+                hasStandaloneGhosttyConfig: hasBackingFile
+            )
+        case .synced:
+            let ghosttyURL = environment.standaloneGhosttyDisplayURL
+            let hasStandaloneGhosttyConfig = environment.isRegularFile(at: ghosttyURL)
+            let renderedContents = Self.renderSyncedPreview(
+                ghosttyURL: hasStandaloneGhosttyConfig ? ghosttyURL : nil,
+                cmuxURL: environment.cmuxConfigURL,
+                environment: environment
+            )
+            Self.materializeSyncedPreview(
+                contents: renderedContents,
+                previewURL: environment.syncedPreviewURL,
+                fileManager: environment.fileManager
+            )
+            return ConfigSourceSnapshot(
+                source: self,
+                primaryURL: environment.syncedPreviewURL,
+                displayPaths: [environment.syncedPreviewURL.path],
+                contents: renderedContents,
+                isEditable: false,
+                hasBackingFile: environment.isRegularFile(at: environment.syncedPreviewURL),
+                hasStandaloneGhosttyConfig: hasStandaloneGhosttyConfig
+            )
+        }
+    }
+
+    private static func readContents(at url: URL) -> String {
+        guard let contents = try? String(contentsOf: url, encoding: .utf8) else {
+            return ""
+        }
+        return contents
+    }
+
+    private static func materializeSyncedPreview(
+        contents: String,
+        previewURL: URL,
+        fileManager: FileManager
+    ) {
+        do {
+            try fileManager.createDirectory(
+                at: previewURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true,
+                attributes: nil
+            )
+            try contents.write(to: previewURL, atomically: true, encoding: .utf8)
+        } catch {
+            // Best-effort preview materialization. The in-memory snapshot remains usable.
+        }
+    }
+
+    private static func renderSyncedPreview(
+        ghosttyURL: URL?,
+        cmuxURL: URL,
+        environment: ConfigSourceEnvironment
+    ) -> String {
+        // Preserve Ghostty key order, then overlay cmux entries using last-wins precedence.
+        var effectiveEntriesByKey: [String: ParsedConfigEntry] = [:]
+        var orderedKeys: [String] = []
+
+        for sourceURL in [ghosttyURL, cmuxURL].compactMap({ $0 }) {
+            for entry in parsedEntries(from: sourceURL) {
+                if effectiveEntriesByKey[entry.key] == nil {
+                    orderedKeys.append(entry.key)
+                }
+                effectiveEntriesByKey[entry.key] = entry
+            }
+        }
+
+        return orderedKeys.compactMap { key in
+            guard let entry = effectiveEntriesByKey[key] else { return nil }
+            let sourceLabel = environment.abbreviatedPath(for: entry.sourceURL)
+            return "\(entry.key) = \(entry.value)  # from: \(sourceLabel):\(entry.lineNumber)"
+        }
+        .joined(separator: "\n")
+    }
+
+    private static func parsedEntries(from sourceURL: URL) -> [ParsedConfigEntry] {
+        let contents = readContents(at: sourceURL)
+        guard !contents.isEmpty else { return [] }
+
+        return contents
+            .components(separatedBy: .newlines)
+            .enumerated()
+            .compactMap { index, line in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty, !trimmed.hasPrefix("#") else {
+                    return nil
+                }
+                let parts = trimmed.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+                guard parts.count == 2 else { return nil }
+                let key = parts[0].trimmingCharacters(in: .whitespaces)
+                let value = parts[1].trimmingCharacters(in: .whitespaces)
+                guard !key.isEmpty else { return nil }
+                return ParsedConfigEntry(
+                    key: key,
+                    value: value,
+                    sourceURL: sourceURL,
+                    lineNumber: index + 1
+                )
+            }
+    }
+}
+
+private struct ParsedConfigEntry {
+    let key: String
+    let value: String
+    let sourceURL: URL
+    let lineNumber: Int
+}

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -838,6 +838,10 @@ struct cmuxApp: App {
                 }
             }
         }
+
+        Window(String(localized: "settings.config.windowTitle", defaultValue: "Config"), id: ConfigSettingsView.windowID) {
+            ConfigSettingsView()
+        }
     }
 
     private func showAboutPanel() {
@@ -4376,6 +4380,7 @@ struct SettingsView: View {
     private let pickerColumnWidth: CGFloat = 196
     private let notificationSoundControlWidth: CGFloat = 280
     private let shortcutChordsDocsURL = URL(string: "https://cmux.com/docs/keyboard-shortcuts#shortcut-chords")!
+    @Environment(\.openWindow) private var openWindow
 
     @AppStorage(LanguageSettings.languageKey) private var appLanguage = LanguageSettings.defaultLanguage.rawValue
     @AppStorage(AppearanceSettings.appearanceModeKey) private var appearanceMode = AppearanceSettings.defaultMode.rawValue
@@ -5099,6 +5104,23 @@ struct SettingsView: View {
                             )
                             .textFieldStyle(.roundedBorder)
                             .frame(width: 200)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .action,
+                            String(localized: "settings.app.configWindow", defaultValue: "Terminal Config"),
+                            subtitle: String(
+                                localized: "settings.app.configWindow.subtitle",
+                                defaultValue: "Open the cmux config, standalone Ghostty config, and merged preview in one utility window."
+                            )
+                        ) {
+                            Button(String(localized: "settings.app.configWindow.openButton", defaultValue: "Open Config Window")) {
+                                openWindow(id: ConfigSettingsView.windowID)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
 
                         SettingsCardDivider()

--- a/tests_v2/config_source_probe.swift
+++ b/tests_v2/config_source_probe.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 private struct SnapshotPayload: Encodable {
@@ -18,7 +19,7 @@ private struct ConfigSourceProbe {
     static func main() throws {
         guard CommandLine.arguments.count >= 2 else {
             fputs("usage: config_source_probe <home-directory>\n", stderr)
-            Foundation.exit(64)
+            Darwin.exit(64)
         }
 
         let homeDirectoryURL = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)

--- a/tests_v2/config_source_probe.swift
+++ b/tests_v2/config_source_probe.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+private struct SnapshotPayload: Encodable {
+    let path: String
+    let displayPaths: [String]
+    let contents: String
+    let isEditable: Bool
+}
+
+private struct Payload: Encodable {
+    let cmux: SnapshotPayload
+    let ghostty: SnapshotPayload
+    let synced: SnapshotPayload
+}
+
+@main
+private struct ConfigSourceProbe {
+    static func main() throws {
+        guard CommandLine.arguments.count >= 2 else {
+            fputs("usage: config_source_probe <home-directory>\n", stderr)
+            Foundation.exit(64)
+        }
+
+        let homeDirectoryURL = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let previewDirectoryURL = homeDirectoryURL
+            .appendingPathComponent("Library", isDirectory: true)
+            .appendingPathComponent("Caches", isDirectory: true)
+            .appendingPathComponent("cmux-config-probe", isDirectory: true)
+        let environment = ConfigSourceEnvironment(
+            homeDirectoryURL: homeDirectoryURL,
+            previewDirectoryURL: previewDirectoryURL
+        )
+
+        let payload = Payload(
+            cmux: encodedSnapshot(for: .cmux, environment: environment),
+            ghostty: encodedSnapshot(for: .ghostty, environment: environment),
+            synced: encodedSnapshot(for: .synced, environment: environment)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(payload)
+        FileHandle.standardOutput.write(data)
+    }
+
+    private static func encodedSnapshot(
+        for source: ConfigSource,
+        environment: ConfigSourceEnvironment
+    ) -> SnapshotPayload {
+        let snapshot = source.snapshot(environment: environment)
+        return SnapshotPayload(
+            path: snapshot.primaryURL.path,
+            displayPaths: snapshot.displayPaths,
+            contents: snapshot.contents,
+            isEditable: snapshot.isEditable
+        )
+    }
+}

--- a/tests_v2/test_config_settings_sources_and_sync.py
+++ b/tests_v2/test_config_settings_sources_and_sync.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""
+Regression test: unified config settings resolves the right files and renders
+the synced preview with cmux overrides on top of Ghostty base values.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+def get_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode == 0:
+        return Path(result.stdout.strip())
+    return Path(__file__).resolve().parents[1]
+
+
+def compile_probe(repo_root: Path, output_path: Path) -> None:
+    probe_sources = [
+        repo_root / "Sources" / "Settings" / "ConfigSource.swift",
+        repo_root / "tests_v2" / "config_source_probe.swift",
+    ]
+    command = ["xcrun", "swiftc", *map(str, probe_sources), "-o", str(output_path)]
+    subprocess.run(
+        command,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+def write_text(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def run_probe(executable: Path, home_directory: Path) -> dict:
+    result = subprocess.run(
+        [str(executable), str(home_directory)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def expect(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def test_prefers_dotconfig_ghostty_and_overlays_cmux(executable: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-config-settings-") as tmp:
+        home = Path(tmp)
+        cmux_config = home / "Library" / "Application Support" / "com.cmuxterm.app" / "config"
+        ghostty_config = home / ".config" / "ghostty" / "config"
+
+        write_text(
+            ghostty_config,
+            "theme = Solarized Light\nbackground = #111111\nfont-size = 13\n",
+        )
+        write_text(
+            cmux_config,
+            "background = #222222\ncopy-on-select = clipboard\n",
+        )
+
+        payload = run_probe(executable, home)
+
+        expect(payload["cmux"]["path"] == str(cmux_config), f"unexpected cmux path: {payload}")
+        expect(payload["ghostty"]["path"] == str(ghostty_config), f"unexpected ghostty path: {payload}")
+
+        synced_path = Path(payload["synced"]["path"])
+        expect(synced_path.exists(), f"synced preview path should exist: {payload}")
+
+        synced_contents = str(payload["synced"]["contents"])
+        expect(
+            "theme = Solarized Light  # from: ~/.config/ghostty/config:1" in synced_contents,
+            f"synced preview should keep Ghostty-only keys with provenance: {synced_contents}",
+        )
+        expect(
+            "background = #222222  # from: ~/Library/Application Support/com.cmuxterm.app/config:1"
+            in synced_contents,
+            f"synced preview should use cmux override for duplicate keys: {synced_contents}",
+        )
+        expect(
+            "copy-on-select = clipboard  # from: ~/Library/Application Support/com.cmuxterm.app/config:2"
+            in synced_contents,
+            f"synced preview should include cmux-only keys: {synced_contents}",
+        )
+        expect(
+            "background = #111111" not in synced_contents,
+            f"overridden Ghostty value should not survive in synced preview: {synced_contents}",
+        )
+
+
+def test_falls_back_to_app_support_ghostty_when_dotconfig_missing(executable: Path) -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-config-settings-") as tmp:
+        home = Path(tmp)
+        cmux_config = home / "Library" / "Application Support" / "com.cmuxterm.app" / "config"
+        ghostty_app_support = (
+            home
+            / "Library"
+            / "Application Support"
+            / "com.mitchellh.ghostty"
+            / "config"
+        )
+
+        write_text(ghostty_app_support, "font-size = 14\nselection-background = #333333\n")
+        write_text(cmux_config, "font-size = 17\n")
+
+        payload = run_probe(executable, home)
+
+        expect(
+            payload["ghostty"]["path"] == str(ghostty_app_support),
+            f"ghostty resolver should fall back to app support config: {payload}",
+        )
+
+        synced_contents = str(payload["synced"]["contents"])
+        expect(
+            "font-size = 17  # from: ~/Library/Application Support/com.cmuxterm.app/config:1"
+            in synced_contents,
+            f"cmux override should win over Ghostty base font-size: {synced_contents}",
+        )
+        expect(
+            "selection-background = #333333  # from: ~/Library/Application Support/com.mitchellh.ghostty/config:2"
+            in synced_contents,
+            f"Ghostty-only key should remain in synced preview: {synced_contents}",
+        )
+
+
+def main() -> int:
+    repo_root = get_repo_root()
+    with tempfile.TemporaryDirectory(prefix="cmux-config-source-probe-") as tmp:
+        executable = Path(tmp) / "config_source_probe"
+        compile_probe(repo_root, executable)
+        test_prefers_dotconfig_ghostty_and_overlays_cmux(executable)
+        test_falls_back_to_app_support_ghostty_when_dotconfig_missing(executable)
+
+    print("PASS: config settings resolves cmux/ghostty paths and synced preview precedence correctly")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a dedicated config utility window with cmux, ghostty, and synced tabs
- wire save/reload/open/reveal actions to the cmux config and merged preview model
- add a regression harness for path resolution and synced precedence

Closes #3023

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches configuration reload and file I/O paths (create/write config, generate preview) and adds a new window surface; failures could cause confusing reload behavior or unintended file creation, though changes are mostly additive and scoped.
> 
> **Overview**
> Adds a new floating **Config utility window** (`ConfigSettingsView`) that lets users switch between `cmux`, `ghostty`, and `synced` views; edit/save the cmux config; and open/reveal/reload configs while showing status/banners.
> 
> Introduces a `ConfigSource` model that resolves cmux vs standalone Ghostty config locations, and generates/materializes a merged *synced preview* by parsing `key = value` entries and applying cmux last-wins overrides with provenance comments.
> 
> Wires the window into the app (`Window` scene + Settings button via `openWindow`), adds new localized strings, updates the Xcode project to build the new sources, and adds a small Swift probe + Python regression test to verify file resolution and merge precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52ef63db2afc0b3677a5242cf964b36b0e0d2bc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dedicated Config window to view/edit multiple configuration sources, see merged/effective preview, and perform open/reveal/reload/save actions from Settings.

* **Localization**
  * Added English and Japanese strings for the Config UI, banners, actions, and status messages.

* **Tests**
  * Added a probe tool and regression tests to validate config source resolution and synced-preview behavior.

* **Chores**
  * Project updated to include the new Config UI components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->