### PR TITLE
Auto-resume agent sessions on app restore

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -513,6 +513,26 @@ final class SessionIndexStore: ObservableObject {
         }
     }
 
+    // MARK: - Agent resume command lookup
+
+    /// Find the most recent session entries for a specific agent and cwd.
+    /// Runs the same loaders used by the sidebar scan but scoped to a single
+    /// agent + cwd, so it's cheap. Called from Workspace when an agent PID is
+    /// registered to cache the resume command off the autosave hot path.
+    nonisolated static func latestEntries(
+        agent: SessionAgent, cwd: String, limit: Int = 1
+    ) async -> [SessionEntry] {
+        let bag = ErrorBag()
+        switch agent {
+        case .claude:
+            return await loadClaudeEntries(needle: "", cwdFilter: cwd, offset: 0, limit: limit)
+        case .codex:
+            return await loadCodexEntries(needle: "", cwdFilter: cwd, offset: 0, limit: limit, errorBag: bag)
+        case .opencode:
+            return loadOpenCodeEntries(needle: "", cwdFilter: cwd, offset: 0, limit: limit, errorBag: bag)
+        }
+    }
+
     // MARK: - Directory snapshot cache
 
     private var directorySnapshotCache: [String: DirectorySnapshot] = [:]

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -224,6 +224,10 @@ struct SessionGitBranchSnapshot: Codable, Sendable {
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var scrollback: String?
+    /// Shell command to resume the agent session that was running in this terminal
+    /// (e.g. `claude --resume <id>`). Populated at snapshot time by matching agent
+    /// PIDs to terminal TTYs, then looking up the session entry on disk.
+    var agentResumeCommand: String?
 }
 
 struct SessionBrowserPanelSnapshot: Codable, Sendable {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -14692,6 +14692,7 @@ class TerminalController {
                 if let pidValue {
                     tab.agentPIDs[key] = pidValue
                     controller.refreshTrackedAgentPorts(for: tab)
+                    tab.resolveAndCacheResumeCommand(agentKey: key, pid: pidValue)
                 }
                 return
             }
@@ -14708,6 +14709,7 @@ class TerminalController {
             if let pidValue {
                 tab.agentPIDs[key] = pidValue
                 controller.refreshTrackedAgentPorts(for: tab)
+                tab.resolveAndCacheResumeCommand(agentKey: key, pid: pidValue)
             }
         }
         return "OK"
@@ -14749,6 +14751,7 @@ class TerminalController {
         scheduleSidebarMutation(target: target) { controller, tab in
             tab.agentPIDs[key] = pid
             controller.refreshTrackedAgentPorts(for: tab)
+            tab.resolveAndCacheResumeCommand(agentKey: key, pid: pid)
         }
         return "OK"
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -469,10 +469,11 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback
             )
+            let isRemoteBacked = remoteDetectedSurfaceIds.contains(panelId) || isRemoteTerminalSurface(panelId)
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: panelDirectories[panelId],
                 scrollback: resolvedScrollback,
-                agentResumeCommand: agentResumeCommand(forPanelId: panelId)
+                agentResumeCommand: isRemoteBacked ? nil : agentResumeCommand(forPanelId: panelId)
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -549,12 +550,6 @@ extension Workspace {
 
     // MARK: - Agent resume command cache
 
-    /// Cached resume commands for terminal panels running known agents, keyed by panel ID.
-    /// Populated asynchronously when agent PIDs are registered via the socket API
-    /// (set_agent_pid / report_status). Read during session snapshot to persist
-    /// without blocking the autosave hot path.
-    var cachedAgentResumeCommands: [UUID: String] = [:]
-
     /// Returns the cached resume command for a panel, if one was resolved.
     private func agentResumeCommand(forPanelId panelId: UUID) -> String? {
         cachedAgentResumeCommands[panelId]
@@ -585,6 +580,7 @@ extension Workspace {
     /// Called from TerminalController when agent PIDs are registered. Runs the
     /// SessionIndexStore lookup off-main, then stores the result on the main actor.
     func resolveAndCacheResumeCommand(agentKey: String, pid: pid_t) {
+        guard !isRemoteWorkspace else { return }
         guard let agent = Self.sessionAgentForKey(agentKey) else { return }
         guard pid > 0 else { return }
 
@@ -6680,6 +6676,7 @@ final class Workspace: Identifiable, ObservableObject {
     /// PIDs associated with agent status entries (e.g. claude_code), keyed by status key.
     /// Used for stale-session detection: if the PID is dead, the status entry is cleared.
     var agentPIDs: [String: pid_t] = [:]
+    var cachedAgentResumeCommands: [UUID: String] = [:]
     private var restoredTerminalScrollbackByPanelId: [UUID: String] = [:]
 
     private func sidebarObservationSignal<Value: Equatable>(
@@ -11972,6 +11969,7 @@ extension Workspace: BonsplitDelegate {
         surfaceTTYNames.removeValue(forKey: panelId)
         syncRemotePortScanTTYs()
         restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+        cachedAgentResumeCommands.removeValue(forKey: panelId)
         PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
         terminalInheritanceFontPointsByPanelId.removeValue(forKey: panelId)
         if lastTerminalConfigInheritancePanelId == panelId {
@@ -12125,6 +12123,7 @@ extension Workspace: BonsplitDelegate {
                 surfaceTTYNames.removeValue(forKey: panelId)
                 surfaceListeningPorts.removeValue(forKey: panelId)
                 restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
+                cachedAgentResumeCommands.removeValue(forKey: panelId)
                 PortScanner.shared.unregisterPanel(workspaceId: id, panelId: panelId)
             }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -347,6 +347,7 @@ extension Workspace {
         statusEntries.removeAll()
         agentPIDs.removeAll()
         agentListeningPorts.removeAll()
+        cachedAgentResumeCommands.removeAll()
         logEntries = snapshot.logEntries.map { entry in
             SidebarLogEntry(
                 message: entry.message,
@@ -546,29 +547,21 @@ extension Workspace {
         return resolved
     }
 
-    // MARK: - Agent resume command detection
+    // MARK: - Agent resume command cache
 
-    /// Returns the agent resume command for a terminal panel, if the panel is running
-    /// a known agent. Matches agent PIDs (tracked by the socket API) to terminal TTYs
-    /// to identify which panel hosts the agent process.
+    /// Cached resume commands for terminal panels running known agents, keyed by panel ID.
+    /// Populated asynchronously when agent PIDs are registered via the socket API
+    /// (set_agent_pid / report_status). Read during session snapshot to persist
+    /// without blocking the autosave hot path.
+    var cachedAgentResumeCommands: [UUID: String] = [:]
+
+    /// Returns the cached resume command for a panel, if one was resolved.
     private func agentResumeCommand(forPanelId panelId: UUID) -> String? {
-        guard !agentPIDs.isEmpty else { return nil }
-        guard let panelTTY = surfaceTTYNames[panelId], !panelTTY.isEmpty else { return nil }
-
-        // Find which agent key is running in this panel by matching PID -> TTY -> panel
-        for (key, pid) in agentPIDs {
-            guard pid > 0 else { continue }
-            guard let pidTTY = Self.ttyForPID(pid), pidTTY == panelTTY else { continue }
-
-            let agent = Self.sessionAgentForKey(key)
-            guard let cwd = currentDirectory.isEmpty ? nil : currentDirectory else { continue }
-            return Self.lookupResumeCommand(agent: agent, cwd: cwd)
-        }
-        return nil
+        cachedAgentResumeCommands[panelId]
     }
 
     /// Map agent status keys to session agent types.
-    private static func sessionAgentForKey(_ key: String) -> SessionAgent? {
+    static func sessionAgentForKey(_ key: String) -> SessionAgent? {
         switch key {
         case "claude_code": return .claude
         case "codex": return .codex
@@ -578,7 +571,7 @@ extension Workspace {
     }
 
     /// Get the controlling TTY for a PID via sysctl.
-    nonisolated private static func ttyForPID(_ pid: pid_t) -> String? {
+    nonisolated static func ttyForPID(_ pid: pid_t) -> String? {
         var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
         var info = kinfo_proc()
         var size = MemoryLayout<kinfo_proc>.size
@@ -588,123 +581,27 @@ extension Workspace {
         return "ttys\(String(format: "%03d", devNum & 0xFFFFFF))"
     }
 
-    /// Look up the most recent session file and construct a resume command.
-    nonisolated private static func lookupResumeCommand(agent: SessionAgent?, cwd: String) -> String? {
-        guard let agent else { return nil }
-        switch agent {
-        case .claude: return claudeResumeCommand(cwd: cwd)
-        case .codex: return codexResumeCommand(cwd: cwd)
-        case .opencode: return opencodeResumeCommand(cwd: cwd)
-        }
-    }
+    /// Resolve the resume command for an agent PID and cache it for the matching panel.
+    /// Called from TerminalController when agent PIDs are registered. Runs the
+    /// SessionIndexStore lookup off-main, then stores the result on the main actor.
+    func resolveAndCacheResumeCommand(agentKey: String, pid: pid_t) {
+        guard let agent = Self.sessionAgentForKey(agentKey) else { return }
+        guard pid > 0 else { return }
 
-    /// Find the most recent Claude Code session for the given cwd and return its resume command.
-    nonisolated private static func claudeResumeCommand(cwd: String) -> String? {
-        let projectsRoot = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/projects")
-        let projectDir = encodeClaudeProjectDir(cwd)
-        let dirPath = (projectsRoot as NSString).appendingPathComponent(projectDir)
-        return newestSessionResumeCommand(
-            directory: dirPath,
-            suffix: ".jsonl",
-            builder: { sessionId, _ in "claude --resume \(sessionId)" }
-        )
-    }
+        // Match PID to panel via TTY
+        guard let pidTTY = Self.ttyForPID(pid) else { return }
+        let matchedPanelId: UUID? = surfaceTTYNames.first(where: { $0.value == pidTTY })?.key
+        guard let panelId = matchedPanelId else { return }
+        let panelCwd = panelDirectories[panelId] ?? currentDirectory
+        guard !panelCwd.isEmpty else { return }
 
-    /// Find the most recent Codex session for the given cwd and return its resume command.
-    nonisolated private static func codexResumeCommand(cwd: String) -> String? {
-        let sessionsRoot = (NSHomeDirectory() as NSString).appendingPathComponent(".codex/sessions")
-        let fm = FileManager.default
-        // Codex stores sessions under YYYY/MM/DD/rollout-*.jsonl; scan all dates
-        guard let years = try? fm.contentsOfDirectory(atPath: sessionsRoot) else { return nil }
-        var newest: (url: URL, mtime: Date)? = nil
-        for year in years.sorted().reversed().prefix(2) {
-            let yearPath = (sessionsRoot as NSString).appendingPathComponent(year)
-            guard let months = try? fm.contentsOfDirectory(atPath: yearPath) else { continue }
-            for month in months.sorted().reversed() {
-                let monthPath = (yearPath as NSString).appendingPathComponent(month)
-                guard let days = try? fm.contentsOfDirectory(atPath: monthPath) else { continue }
-                for day in days.sorted().reversed() {
-                    let dayPath = (monthPath as NSString).appendingPathComponent(day)
-                    guard let files = try? fm.contentsOfDirectory(atPath: dayPath) else { continue }
-                    for file in files where file.hasPrefix("rollout-") && file.hasSuffix(".jsonl") {
-                        let filePath = (dayPath as NSString).appendingPathComponent(file)
-                        guard let attrs = try? fm.attributesOfItem(atPath: filePath),
-                              let mtime = attrs[.modificationDate] as? Date else { continue }
-                        // Check cwd matches by peeking into the session file
-                        if let current = newest, mtime <= current.mtime { continue }
-                        let url = URL(fileURLWithPath: filePath)
-                        if codexSessionMatchesCwd(url: url, cwd: cwd) {
-                            newest = (url, mtime)
-                        }
-                    }
-                }
-                if newest != nil { break }
+        Task {
+            let entries = await SessionIndexStore.latestEntries(agent: agent, cwd: panelCwd, limit: 1)
+            guard let entry = entries.first else { return }
+            await MainActor.run {
+                self.cachedAgentResumeCommands[panelId] = entry.resumeCommand
             }
-            if newest != nil { break }
         }
-        guard let match = newest else { return nil }
-        let sessionId = match.url.deletingPathExtension().lastPathComponent
-            .replacingOccurrences(of: "rollout-", with: "")
-        return "codex resume \(sessionId)"
-    }
-
-    nonisolated private static func codexSessionMatchesCwd(url: URL, cwd: String) -> Bool {
-        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return false }
-        let head = String(data: data.prefix(8192), encoding: .utf8) ?? ""
-        for line in head.split(separator: "\n", maxSplits: 10) {
-            guard let lineData = line.data(using: .utf8),
-                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
-                  let sessionMeta = obj["session_meta"] as? [String: Any],
-                  let payload = sessionMeta["payload"] as? [String: Any],
-                  let sessionCwd = payload["cwd"] as? String else { continue }
-            return (sessionCwd as NSString).standardizingPath == (cwd as NSString).standardizingPath
-        }
-        return false
-    }
-
-    nonisolated private static func opencodeResumeCommand(cwd: String) -> String? {
-        let dbPath = (NSHomeDirectory() as NSString).appendingPathComponent(".local/share/opencode/opencode.db")
-        guard FileManager.default.fileExists(atPath: dbPath) else { return nil }
-        var db: OpaquePointer? = nil
-        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else { return nil }
-        defer { sqlite3_close(db) }
-        let query = "SELECT id FROM sessions WHERE directory = ? ORDER BY updated_at DESC LIMIT 1"
-        var stmt: OpaquePointer? = nil
-        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else { return nil }
-        defer { sqlite3_finalize(stmt) }
-        let SQLITE_TRANSIENT_FN = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
-        sqlite3_bind_text(stmt, 1, cwd, -1, SQLITE_TRANSIENT_FN)
-        guard sqlite3_step(stmt) == SQLITE_ROW,
-              let idPtr = sqlite3_column_text(stmt, 0) else { return nil }
-        let sessionId = String(cString: idPtr)
-        return "opencode --session \(sessionId)"
-    }
-
-    /// Encode a cwd path into the Claude project directory name format.
-    nonisolated private static func encodeClaudeProjectDir(_ path: String) -> String {
-        path.replacingOccurrences(of: "/", with: "-")
-    }
-
-    /// Find the newest file with the given suffix in a directory and build a resume command.
-    nonisolated private static func newestSessionResumeCommand(
-        directory: String,
-        suffix: String,
-        builder: (_ sessionId: String, _ url: URL) -> String
-    ) -> String? {
-        let fm = FileManager.default
-        guard let contents = try? fm.contentsOfDirectory(atPath: directory) else { return nil }
-        var newest: (name: String, mtime: Date)? = nil
-        for name in contents where name.hasSuffix(suffix) {
-            let filePath = (directory as NSString).appendingPathComponent(name)
-            guard let attrs = try? fm.attributesOfItem(atPath: filePath),
-                  let mtime = attrs[.modificationDate] as? Date else { continue }
-            if let current = newest, mtime <= current.mtime { continue }
-            newest = (name, mtime)
-        }
-        guard let match = newest else { return nil }
-        let sessionId = String(match.name.dropLast(suffix.count))
-        let url = URL(fileURLWithPath: (directory as NSString).appendingPathComponent(match.name))
-        return builder(sessionId, url)
     }
 
     private func restoreSessionLayout(_ layout: SessionWorkspaceLayoutSnapshot) -> [SessionPaneRestoreEntry] {
@@ -7875,6 +7772,7 @@ final class Workspace: Identifiable, ObservableObject {
         statusEntries.removeAll()
         agentPIDs.removeAll()
         agentListeningPorts.removeAll()
+        cachedAgentResumeCommands.removeAll()
         logEntries.removeAll()
         progress = nil
         gitBranch = nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -470,7 +470,8 @@ extension Workspace {
             )
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: panelDirectories[panelId],
-                scrollback: resolvedScrollback
+                scrollback: resolvedScrollback,
+                agentResumeCommand: agentResumeCommand(forPanelId: panelId)
             )
             browserSnapshot = nil
             markdownSnapshot = nil
@@ -543,6 +544,167 @@ extension Workspace {
             restoredTerminalScrollbackByPanelId.removeValue(forKey: panelId)
         }
         return resolved
+    }
+
+    // MARK: - Agent resume command detection
+
+    /// Returns the agent resume command for a terminal panel, if the panel is running
+    /// a known agent. Matches agent PIDs (tracked by the socket API) to terminal TTYs
+    /// to identify which panel hosts the agent process.
+    private func agentResumeCommand(forPanelId panelId: UUID) -> String? {
+        guard !agentPIDs.isEmpty else { return nil }
+        guard let panelTTY = surfaceTTYNames[panelId], !panelTTY.isEmpty else { return nil }
+
+        // Find which agent key is running in this panel by matching PID -> TTY -> panel
+        for (key, pid) in agentPIDs {
+            guard pid > 0 else { continue }
+            guard let pidTTY = Self.ttyForPID(pid), pidTTY == panelTTY else { continue }
+
+            let agent = Self.sessionAgentForKey(key)
+            guard let cwd = currentDirectory.isEmpty ? nil : currentDirectory else { continue }
+            return Self.lookupResumeCommand(agent: agent, cwd: cwd)
+        }
+        return nil
+    }
+
+    /// Map agent status keys to session agent types.
+    private static func sessionAgentForKey(_ key: String) -> SessionAgent? {
+        switch key {
+        case "claude_code": return .claude
+        case "codex": return .codex
+        case "opencode": return .opencode
+        default: return nil
+        }
+    }
+
+    /// Get the controlling TTY for a PID via sysctl.
+    nonisolated private static func ttyForPID(_ pid: pid_t) -> String? {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_PID, pid]
+        var info = kinfo_proc()
+        var size = MemoryLayout<kinfo_proc>.size
+        guard sysctl(&mib, UInt32(mib.count), &info, &size, nil, 0) == 0 else { return nil }
+        let devNum = info.kp_eproc.e_tdev
+        guard devNum != 0, devNum != UInt32.max else { return nil }
+        return "ttys\(String(format: "%03d", devNum & 0xFFFFFF))"
+    }
+
+    /// Look up the most recent session file and construct a resume command.
+    nonisolated private static func lookupResumeCommand(agent: SessionAgent?, cwd: String) -> String? {
+        guard let agent else { return nil }
+        switch agent {
+        case .claude: return claudeResumeCommand(cwd: cwd)
+        case .codex: return codexResumeCommand(cwd: cwd)
+        case .opencode: return opencodeResumeCommand(cwd: cwd)
+        }
+    }
+
+    /// Find the most recent Claude Code session for the given cwd and return its resume command.
+    nonisolated private static func claudeResumeCommand(cwd: String) -> String? {
+        let projectsRoot = (NSHomeDirectory() as NSString).appendingPathComponent(".claude/projects")
+        let projectDir = encodeClaudeProjectDir(cwd)
+        let dirPath = (projectsRoot as NSString).appendingPathComponent(projectDir)
+        return newestSessionResumeCommand(
+            directory: dirPath,
+            suffix: ".jsonl",
+            builder: { sessionId, _ in "claude --resume \(sessionId)" }
+        )
+    }
+
+    /// Find the most recent Codex session for the given cwd and return its resume command.
+    nonisolated private static func codexResumeCommand(cwd: String) -> String? {
+        let sessionsRoot = (NSHomeDirectory() as NSString).appendingPathComponent(".codex/sessions")
+        let fm = FileManager.default
+        // Codex stores sessions under YYYY/MM/DD/rollout-*.jsonl; scan all dates
+        guard let years = try? fm.contentsOfDirectory(atPath: sessionsRoot) else { return nil }
+        var newest: (url: URL, mtime: Date)? = nil
+        for year in years.sorted().reversed().prefix(2) {
+            let yearPath = (sessionsRoot as NSString).appendingPathComponent(year)
+            guard let months = try? fm.contentsOfDirectory(atPath: yearPath) else { continue }
+            for month in months.sorted().reversed() {
+                let monthPath = (yearPath as NSString).appendingPathComponent(month)
+                guard let days = try? fm.contentsOfDirectory(atPath: monthPath) else { continue }
+                for day in days.sorted().reversed() {
+                    let dayPath = (monthPath as NSString).appendingPathComponent(day)
+                    guard let files = try? fm.contentsOfDirectory(atPath: dayPath) else { continue }
+                    for file in files where file.hasPrefix("rollout-") && file.hasSuffix(".jsonl") {
+                        let filePath = (dayPath as NSString).appendingPathComponent(file)
+                        guard let attrs = try? fm.attributesOfItem(atPath: filePath),
+                              let mtime = attrs[.modificationDate] as? Date else { continue }
+                        // Check cwd matches by peeking into the session file
+                        if let current = newest, mtime <= current.mtime { continue }
+                        let url = URL(fileURLWithPath: filePath)
+                        if codexSessionMatchesCwd(url: url, cwd: cwd) {
+                            newest = (url, mtime)
+                        }
+                    }
+                }
+                if newest != nil { break }
+            }
+            if newest != nil { break }
+        }
+        guard let match = newest else { return nil }
+        let sessionId = match.url.deletingPathExtension().lastPathComponent
+            .replacingOccurrences(of: "rollout-", with: "")
+        return "codex resume \(sessionId)"
+    }
+
+    nonisolated private static func codexSessionMatchesCwd(url: URL, cwd: String) -> Bool {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else { return false }
+        let head = String(data: data.prefix(8192), encoding: .utf8) ?? ""
+        for line in head.split(separator: "\n", maxSplits: 10) {
+            guard let lineData = line.data(using: .utf8),
+                  let obj = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+                  let sessionMeta = obj["session_meta"] as? [String: Any],
+                  let payload = sessionMeta["payload"] as? [String: Any],
+                  let sessionCwd = payload["cwd"] as? String else { continue }
+            return (sessionCwd as NSString).standardizingPath == (cwd as NSString).standardizingPath
+        }
+        return false
+    }
+
+    nonisolated private static func opencodeResumeCommand(cwd: String) -> String? {
+        let dbPath = (NSHomeDirectory() as NSString).appendingPathComponent(".local/share/opencode/opencode.db")
+        guard FileManager.default.fileExists(atPath: dbPath) else { return nil }
+        var db: OpaquePointer? = nil
+        guard sqlite3_open_v2(dbPath, &db, SQLITE_OPEN_READONLY, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_close(db) }
+        let query = "SELECT id FROM sessions WHERE directory = ? ORDER BY updated_at DESC LIMIT 1"
+        var stmt: OpaquePointer? = nil
+        guard sqlite3_prepare_v2(db, query, -1, &stmt, nil) == SQLITE_OK else { return nil }
+        defer { sqlite3_finalize(stmt) }
+        let SQLITE_TRANSIENT_FN = unsafeBitCast(OpaquePointer(bitPattern: -1), to: sqlite3_destructor_type.self)
+        sqlite3_bind_text(stmt, 1, cwd, -1, SQLITE_TRANSIENT_FN)
+        guard sqlite3_step(stmt) == SQLITE_ROW,
+              let idPtr = sqlite3_column_text(stmt, 0) else { return nil }
+        let sessionId = String(cString: idPtr)
+        return "opencode --session \(sessionId)"
+    }
+
+    /// Encode a cwd path into the Claude project directory name format.
+    nonisolated private static func encodeClaudeProjectDir(_ path: String) -> String {
+        path.replacingOccurrences(of: "/", with: "-")
+    }
+
+    /// Find the newest file with the given suffix in a directory and build a resume command.
+    nonisolated private static func newestSessionResumeCommand(
+        directory: String,
+        suffix: String,
+        builder: (_ sessionId: String, _ url: URL) -> String
+    ) -> String? {
+        let fm = FileManager.default
+        guard let contents = try? fm.contentsOfDirectory(atPath: directory) else { return nil }
+        var newest: (name: String, mtime: Date)? = nil
+        for name in contents where name.hasSuffix(suffix) {
+            let filePath = (directory as NSString).appendingPathComponent(name)
+            guard let attrs = try? fm.attributesOfItem(atPath: filePath),
+                  let mtime = attrs[.modificationDate] as? Date else { continue }
+            if let current = newest, mtime <= current.mtime { continue }
+            newest = (name, mtime)
+        }
+        guard let match = newest else { return nil }
+        let sessionId = String(match.name.dropLast(suffix.count))
+        let url = URL(fileURLWithPath: (directory as NSString).appendingPathComponent(match.name))
+        return builder(sessionId, url)
     }
 
     private func restoreSessionLayout(_ layout: SessionWorkspaceLayoutSnapshot) -> [SessionPaneRestoreEntry] {
@@ -645,10 +807,12 @@ extension Workspace {
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: snapshot.terminal?.scrollback
             )
+            let resumeInput = snapshot.terminal?.agentResumeCommand.map { $0 + "\n" }
             guard let terminalPanel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
                 workingDirectory: workingDirectory,
+                initialInput: resumeInput,
                 startupEnvironment: replayEnvironment
             ) else {
                 return nil


### PR DESCRIPTION
Persists resume commands for Claude Code, Codex, and OpenCode in the session snapshot. On restore, agent sessions automatically resume in their original panes via `initialInput`.

Resume commands are cached when agent PIDs are registered (socket API), not at snapshot time, so the autosave hot path stays zero-cost. Remote-backed panels are excluded. Cache entries are pruned when panels close.

## Test plan

- [ ] Run Claude Code in a pane, quit cmux, relaunch - session resumes
- [ ] Same for Codex and OpenCode
- [ ] Remote-backed panels don't get agent resume commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sessions now automatically capture and restore agent command history, ensuring previously executed commands are replayed when sessions are restored.
  * Session persistence improved to include agent state preservation, maintaining workflow continuity across restarts and reducing friction in agent-assisted development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->