### PR TITLE
Fix 100% CPU from ContentView publisher feedback loop (fixes #3020)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1888,14 +1888,17 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
         guard self.tabManager !== tabManager || cancellable == nil else { return }
         self.tabManager = tabManager
         cancellable = tabManager.$selectedTabId
-            .compactMap { [weak tabManager] tabId -> Workspace? in
+            .map { [weak tabManager] tabId -> Workspace? in
                 guard let tabId, let tabManager else { return nil }
                 return tabManager.tabs.first(where: { $0.id == tabId })
             }
-            .removeDuplicates(by: { $0.id == $1.id })
-            .map { workspace -> AnyPublisher<(UUID, String), Never> in
-                workspace.$currentDirectory
-                    .map { (workspace.id, $0) }
+            .removeDuplicates(by: { $0?.id == $1?.id })
+            .map { workspace -> AnyPublisher<(UUID?, String?), Never> in
+                guard let workspace else {
+                    return Just<(UUID?, String?)>((nil, nil)).eraseToAnyPublisher()
+                }
+                return workspace.$currentDirectory
+                    .map { (Optional(workspace.id), Optional($0)) }
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
@@ -1904,9 +1907,7 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
             }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                Task { @MainActor [weak self] in
-                    self?.directoryChangeGeneration &+= 1
-                }
+                self?.directoryChangeGeneration &+= 1
             }
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1878,6 +1878,39 @@ private func installFileDropOverlayWhenReady(
     }
 }
 
+@MainActor
+private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
+    @Published private(set) var directoryChangeGeneration: UInt64 = 0
+    private weak var tabManager: TabManager?
+    private var cancellable: AnyCancellable?
+
+    func wire(tabManager: TabManager) {
+        guard self.tabManager !== tabManager || cancellable == nil else { return }
+        self.tabManager = tabManager
+        cancellable = tabManager.$selectedTabId
+            .compactMap { [weak tabManager] tabId -> Workspace? in
+                guard let tabId, let tabManager else { return nil }
+                return tabManager.tabs.first(where: { $0.id == tabId })
+            }
+            .removeDuplicates(by: { $0.id == $1.id })
+            .map { workspace -> AnyPublisher<(UUID, String), Never> in
+                workspace.$currentDirectory
+                    .map { (workspace.id, $0) }
+                    .eraseToAnyPublisher()
+            }
+            .switchToLatest()
+            .removeDuplicates { previous, next in
+                previous.0 == next.0 && previous.1 == next.1
+            }
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.directoryChangeGeneration &+= 1
+                }
+            }
+    }
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -1900,6 +1933,7 @@ struct ContentView: View {
     @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
     @StateObject private var fileExplorerStore = FileExplorerStore()
     @StateObject private var sessionIndexStore = SessionIndexStore()
+    @StateObject private var selectedWorkspaceDirectoryObserver = SelectedWorkspaceDirectoryObserver()
     @State private var fileExplorerWidth: CGFloat = 220
     @State private var fileExplorerDragStartWidth: CGFloat?
     @State private var previousSelectedWorkspaceId: UUID?
@@ -3074,21 +3108,21 @@ struct ContentView: View {
               let tab = tabManager.tabs.first(where: { $0.id == selectedId }) else {
             // No selection means we have no local cwd to scope by; clear so the
             // sessions panel doesn't keep filtering by a stale previous tab.
-            sessionIndexStore.currentDirectory = nil
+            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
             return
         }
 
         let dir = tab.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !dir.isEmpty else {
-            sessionIndexStore.currentDirectory = nil
+            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
             return
         }
 
         fileExplorerStore.showHiddenFiles = true
         if !tab.isRemoteWorkspace {
-            sessionIndexStore.currentDirectory = dir
+            sessionIndexStore.setCurrentDirectoryIfChanged(dir)
         } else {
-            sessionIndexStore.currentDirectory = nil
+            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
         }
 
         if tab.isRemoteWorkspace {
@@ -3215,6 +3249,7 @@ struct ContentView: View {
         )
 
         view = AnyView(view.onAppear {
+            selectedWorkspaceDirectoryObserver.wire(tabManager: tabManager)
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()
             previousSelectedWorkspaceId = tabManager.selectedTabId
@@ -3309,21 +3344,8 @@ struct ContentView: View {
             syncSidebarSelectedWorkspaceIds()
         })
 
-        // File explorer: reactively sync CWD when selected workspace or its directory changes.
-        // Uses switchToLatest to automatically unsubscribe from the old workspace's publisher.
-        view = AnyView(view.onReceive(
-            tabManager.$selectedTabId
-                .compactMap { [weak tabManager] tabId -> Workspace? in
-                    guard let tabId, let tabManager else { return nil }
-                    return tabManager.tabs.first(where: { $0.id == tabId })
-                }
-                .map { workspace -> AnyPublisher<String, Never> in
-                    workspace.$currentDirectory.eraseToAnyPublisher()
-                }
-                .switchToLatest()
-                .removeDuplicates()
-                .receive(on: DispatchQueue.main)
-        ) { _ in
+        // File explorer: keep the Combine subscription stable across body re-evaluations.
+        view = AnyView(view.onChange(of: selectedWorkspaceDirectoryObserver.directoryChangeGeneration) { _ in
             syncFileExplorerDirectory()
         })
 

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -47,9 +47,7 @@ struct RightSidebarPanelView: View {
                     if fileExplorerState.mode != mode {
                         fileExplorerState.mode = mode
                         if mode == .sessions {
-                            sessionIndexStore.currentDirectory = fileExplorerStore.rootPath.isEmpty
-                                ? nil
-                                : fileExplorerStore.rootPath
+                            sessionIndexStore.setCurrentDirectoryIfChanged(sessionIndexDirectory)
                             if sessionIndexStore.entries.isEmpty {
                                 sessionIndexStore.reload()
                             }
@@ -73,11 +71,13 @@ struct RightSidebarPanelView: View {
         case .sessions:
             SessionIndexView(store: sessionIndexStore, onResume: onResumeSession)
                 .onAppear {
-                    sessionIndexStore.currentDirectory = fileExplorerStore.rootPath.isEmpty
-                        ? nil
-                        : fileExplorerStore.rootPath
+                    sessionIndexStore.setCurrentDirectoryIfChanged(sessionIndexDirectory)
                 }
         }
+    }
+
+    private var sessionIndexDirectory: String? {
+        fileExplorerStore.rootPath.isEmpty ? nil : fileExplorerStore.rootPath
     }
 }
 

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -291,6 +291,11 @@ final class SessionIndexStore: ObservableObject {
         }
     }
 
+    func setCurrentDirectoryIfChanged(_ next: String?) {
+        guard currentDirectory != next else { return }
+        currentDirectory = next
+    }
+
     @Published var grouping: SessionGrouping {
         didSet {
             guard grouping != oldValue else { return }

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import SwiftUI
 import XCTest
 
@@ -10,6 +11,20 @@ import XCTest
 
 @MainActor
 final class SessionIndexViewTests: XCTestCase {
+    func testCurrentDirectorySetterDoesNotPublishEqualValue() {
+        let store = SessionIndexStore()
+        var emittedValues: [String?] = []
+        let cancellable = store.$currentDirectory
+            .dropFirst()
+            .sink { emittedValues.append($0) }
+        defer { cancellable.cancel() }
+
+        store.currentDirectory = "/foo"
+        store.currentDirectory = "/foo"
+
+        XCTAssertEqual(emittedValues, ["/foo"])
+    }
+
     func testSectionPopoverHostCoordinatorSkipsHiddenRefreshes() {
         let harness = makeHarness()
         let coordinator = harness.host.makeCoordinator()

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -102,7 +102,8 @@ final class SessionIndexViewTests: XCTestCase {
         let section = IndexSection(
             key: .directory("/tmp"),
             title: "tmp",
-            icon: .folder
+            icon: .folder,
+            entries: []
         )
         let search: SessionSearchFn = { _, _, _, _ in
             SessionIndexStore.SearchOutcome(entries: [], errors: [])

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -19,8 +19,8 @@ final class SessionIndexViewTests: XCTestCase {
             .sink { emittedValues.append($0) }
         defer { cancellable.cancel() }
 
-        store.currentDirectory = "/foo"
-        store.currentDirectory = "/foo"
+        store.setCurrentDirectoryIfChanged("/foo")
+        store.setCurrentDirectoryIfChanged("/foo")
 
         XCTAssertEqual(emittedValues, ["/foo"])
     }


### PR DESCRIPTION
Fixes #3020.

## Summary
- Guard `SessionIndexStore.currentDirectory` writes behind `setCurrentDirectoryIfChanged(_:)` so equal values do not fire `@Published` from `syncFileExplorerDirectory()`.
- Move the selected-workspace/current-directory Combine chain out of `ContentView.body` into a stable `@StateObject` observer, so body re-evaluation no longer recreates the subscription and resets `removeDuplicates()`.
- Add an XCTest/Combine regression test for equal-value current-directory setter publishes.

## Verification
- Pushed branch to `origin` (`https://github.com/manaflow-ai/cmux.git`).
- Built and launched with `./scripts/reload.sh --tag issue-3020-content-view-cpu-loop --launch`.
- Opened Activity Monitor.
- Idle tagged `cmux DEV issue-3020-content-view-cpu-loop` process sampled at 14.4% CPU, then 11.8% CPU five seconds later, down from the reported 100% loop.

Tests were not run locally per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors SwiftUI/Combine state propagation for workspace directory changes; behavior changes around when `currentDirectory` publishes could affect sidebar/session filtering if edge cases are missed.
> 
> **Overview**
> Fixes a runaway SwiftUI/Combine update loop that could peg CPU when syncing the file explorer/session index scope to the selected workspace directory.
> 
> Moves the selected-workspace/`currentDirectory` Combine chain out of `ContentView.body` into a stable `@StateObject` (`SelectedWorkspaceDirectoryObserver`) and triggers `syncFileExplorerDirectory()` via a generation counter to avoid re-subscribing on every body re-evaluation.
> 
> Adds `SessionIndexStore.setCurrentDirectoryIfChanged(_:)` and switches call sites (including `RightSidebarPanelView`) to avoid equal-value `@Published` emissions, with a new Combine regression test ensuring duplicate sets don’t publish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3466936be1501bd18a2b3d0c93a7d1fcb58c4e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a 100% CPU spin caused by a Combine feedback loop when syncing the file explorer directory to the selected workspace (fixes #3020). Keeps the subscription stable and blocks equal-value publishes to stop cascading updates.

- **Bug Fixes**
  - Introduced `SelectedWorkspaceDirectoryObserver` as a `@StateObject` and switched to `onChange` of a generation counter to keep the subscription stable.
  - Guarded `SessionIndexStore.currentDirectory` with `setCurrentDirectoryIfChanged(_:)` and applied it in `ContentView` and `RightSidebarPanelView`.
  - Added a regression test to ensure equal-value sets do not publish, and fixed the `SessionIndexView` test harness section initializer to include `entries`.

<sup>Written for commit c3466936be1501bd18a2b3d0c93a7d1fcb58c4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Stabilized workspace-directory observation and file-explorer synchronization to keep subscriptions stable across view updates and avoid redundant directory writes, reducing unnecessary UI refreshes.

* **Tests**
  * Added coverage verifying directory-change notifications are only emitted when the directory actually changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->