### PR TITLE
Fix sidebar 'Needs input' getting stuck after idle_prompt (#1027)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -326,6 +326,11 @@ private struct ClaudeHookSessionRecord: Codable {
     var pid: Int?
     var lastSubtitle: String?
     var lastBody: String?
+    // True while Claude is blocked on an AskUserQuestion tool call (set by
+    // PreToolUse, cleared by Stop/UserPromptSubmit). Lets the Notification
+    // handler tell a real input-needed event apart from Claude Code's 60s
+    // idle_prompt that fires after Stop has already marked the session Idle.
+    var pendingQuestion: Bool?
     var startedAt: TimeInterval
     var updatedAt: TimeInterval
 }
@@ -373,7 +378,8 @@ private final class ClaudeHookSessionStore {
         cwd: String?,
         pid: Int? = nil,
         lastSubtitle: String? = nil,
-        lastBody: String? = nil
+        lastBody: String? = nil,
+        pendingQuestion: Bool? = nil
     ) throws {
         let normalized = normalizeSessionId(sessionId)
         guard !normalized.isEmpty else { return }
@@ -387,6 +393,7 @@ private final class ClaudeHookSessionStore {
                 pid: nil,
                 lastSubtitle: nil,
                 lastBody: nil,
+                pendingQuestion: nil,
                 startedAt: now,
                 updatedAt: now
             )
@@ -405,6 +412,9 @@ private final class ClaudeHookSessionStore {
             }
             if let body = normalizeOptional(lastBody) {
                 record.lastBody = body
+            }
+            if let pendingQuestion {
+                record.pendingQuestion = pendingQuestion
             }
             record.updatedAt = now
             state.sessions[normalized] = record
@@ -12504,7 +12514,8 @@ struct CMUXCLI {
                         surfaceId: surfaceId,
                         cwd: parsedInput.cwd,
                         lastSubtitle: completion.subtitle,
-                        lastBody: completion.body
+                        lastBody: completion.body,
+                        pendingQuestion: false
                     )
                 }
 
@@ -12541,6 +12552,16 @@ struct CMUXCLI {
                 fallback: workspaceArg,
                 client: client
             )
+            if let sessionId = parsedInput.sessionId {
+                let existingSurfaceId = mappedSession?.surfaceId ?? ""
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: existingSurfaceId,
+                    cwd: parsedInput.cwd,
+                    pendingQuestion: false
+                )
+            }
             _ = try sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
             try setClaudeStatus(
                 client: client,
@@ -12561,8 +12582,17 @@ struct CMUXCLI {
                 fallback: workspaceArg,
                 client: client
             )
+            // Distinguish a real blocking notification from Claude Code's 60s
+            // idle_prompt. Permission prompts are always blocking; idle_prompts
+            // after Stop only restate that Claude is idle. AskUserQuestion is
+            // tracked separately via pendingQuestion in the session record.
+            let isPermissionPrompt = summary.subtitle == "Permission"
+            let hasPendingQuestion = mappedSession?.pendingQuestion == true
+            let isBlockingInput = isPermissionPrompt || hasPendingQuestion
+
             if let mappedSession,
                let savedBody = mappedSession.lastBody, !savedBody.isEmpty,
+               hasPendingQuestion,
                summary.body.contains("needs your attention") || summary.body.contains("needs your input") {
                 summary = (subtitle: mappedSession.lastSubtitle ?? summary.subtitle, body: savedBody)
             }
@@ -12591,13 +12621,15 @@ struct CMUXCLI {
             }
 
             let response = try client.send(command: "notify_target \(workspaceId) \(surfaceId) \(payload)")
-            _ = try? setClaudeStatus(
-                client: client,
-                workspaceId: workspaceId,
-                value: "Needs input",
-                icon: "bell.fill",
-                color: "#4C8DFF"
-            )
+            if isBlockingInput {
+                _ = try? setClaudeStatus(
+                    client: client,
+                    workspaceId: workspaceId,
+                    value: "Needs input",
+                    icon: "bell.fill",
+                    color: "#4C8DFF"
+                )
+            }
             print(response)
 
         case "session-end":
@@ -12662,12 +12694,24 @@ struct CMUXCLI {
                     surfaceId: existingSurfaceId,
                     cwd: parsedInput.cwd,
                     lastSubtitle: "Waiting",
-                    lastBody: question
+                    lastBody: question,
+                    pendingQuestion: true
                 )
                 // Don't clear notifications or set status here.
                 // The Notification hook fires right after and will use the saved question.
                 print("OK")
                 return
+            }
+
+            if let sessionId = parsedInput.sessionId {
+                let existingSurfaceId = mappedSession?.surfaceId ?? ""
+                try? sessionStore.upsert(
+                    sessionId: sessionId,
+                    workspaceId: workspaceId,
+                    surfaceId: existingSurfaceId,
+                    cwd: parsedInput.cwd,
+                    pendingQuestion: false
+                )
             }
 
             _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)

--- a/tests/test_claude_hook_notification_status.py
+++ b/tests/test_claude_hook_notification_status.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""
+Regression test for issue #1027: sidebar "Needs input" indicator stays lit
+after Claude goes idle.
+
+Claude Code's Notification hook fires for two distinct scenarios:
+
+    1. permission_prompt — Claude is blocked waiting for tool-use approval.
+    2. idle_prompt        — fires ~60s after the prompt input has been idle.
+
+Only (1) (and AskUserQuestion, which is surfaced via PreToolUse) should flip
+the sidebar status to "Needs input". Before the fix, every Notification —
+including idle_prompts that fire long after Stop already marked the session
+Idle — overrode the status to "Needs input", producing the stuck indicator
+reported in the bug.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from cmux import cmux, cmuxError
+
+
+def resolve_cmux_cli() -> str:
+    explicit = os.environ.get("CMUX_CLI_BIN") or os.environ.get("CMUX_CLI")
+    if explicit and os.path.exists(explicit) and os.access(explicit, os.X_OK):
+        return explicit
+
+    candidates: list[str] = []
+    candidates.extend(glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/*/Build/Products/Debug/cmux")))
+    candidates.extend(glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux"))
+
+    candidates = [p for p in candidates if os.path.exists(p) and os.access(p, os.X_OK)]
+    if candidates:
+        candidates.sort(key=os.path.getmtime, reverse=True)
+        return candidates[0]
+
+    in_path = shutil.which("cmux")
+    if in_path:
+        return in_path
+
+    raise RuntimeError("Unable to find cmux CLI binary. Set CMUX_CLI_BIN.")
+
+
+def run_claude_hook(
+    cli_path: str,
+    socket_path: str,
+    subcommand: str,
+    payload: dict,
+    env: dict[str, str],
+) -> str:
+    proc = subprocess.run(
+        [cli_path, "--socket", socket_path, "claude-hook", subcommand],
+        input=json.dumps(payload),
+        text=True,
+        capture_output=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"cmux claude-hook {subcommand} failed:\n"
+            f"exit={proc.returncode}\nstdout={proc.stdout}\nstderr={proc.stderr}"
+        )
+    return proc.stdout.strip()
+
+
+def claude_code_status_value(client: cmux, workspace_id: str) -> str | None:
+    """Return the current value of the `claude_code` sidebar status, or None."""
+    response = client._send_command(f"list_status --tab={workspace_id}")
+    if response.startswith("ERROR"):
+        raise cmuxError(response)
+    if response == "No status entries":
+        return None
+    for line in response.splitlines():
+        key, _, rest = line.partition("=")
+        if key != "claude_code":
+            continue
+        # rest looks like "Running priority=0" — the value may contain spaces,
+        # but the appended metadata tokens are whitespace-separated key=value
+        # pairs. Strip those off.
+        tokens = rest.rsplit(" ", 1)
+        if len(tokens) == 2 and "=" in tokens[1]:
+            return tokens[0]
+        return rest
+    return None
+
+
+def fail(message: str) -> int:
+    print(f"FAIL: {message}")
+    return 1
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        return fail(str(exc))
+
+    state_path = Path(tempfile.gettempdir()) / f"cmux_claude_hook_status_{os.getpid()}.json"
+    lock_path = Path(str(state_path) + ".lock")
+    try:
+        if state_path.exists():
+            state_path.unlink()
+        if lock_path.exists():
+            lock_path.unlink()
+    except OSError:
+        pass
+
+    project_dir = Path(tempfile.gettempdir()) / f"cmux_claude_status_project_{os.getpid()}"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    session_id = f"sess-{uuid.uuid4().hex}"
+
+    try:
+        with cmux() as client:
+            client.set_app_focus(False)
+            client.clear_notifications()
+
+            workspace_id = client.new_workspace()
+            surfaces = client.list_surfaces()
+            if not surfaces:
+                return fail("Expected at least one surface in new workspace")
+
+            focused = next((s for s in surfaces if s[2]), surfaces[0])
+            surface_id = focused[1]
+
+            hook_env = os.environ.copy()
+            hook_env["CMUX_SOCKET_PATH"] = client.socket_path
+            hook_env["CMUX_WORKSPACE_ID"] = workspace_id
+            hook_env["CMUX_SURFACE_ID"] = surface_id
+            hook_env["CMUX_CLAUDE_HOOK_STATE_PATH"] = str(state_path)
+
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "session-start",
+                {"session_id": session_id, "cwd": str(project_dir)},
+                hook_env,
+            )
+
+            # Simulate a full turn: the user submits a prompt, Claude finishes,
+            # Stop fires. Status should now be "Idle".
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "prompt-submit",
+                {"session_id": session_id, "cwd": str(project_dir)},
+                hook_env,
+            )
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "stop",
+                {"session_id": session_id},
+                hook_env,
+            )
+
+            idle_status = claude_code_status_value(client, workspace_id)
+            if idle_status != "Idle":
+                return fail(f"Expected status 'Idle' after stop, got {idle_status!r}")
+
+            # Claude Code's idle_prompt fires after 60s of inactivity, with a
+            # generic message. This must NOT flip the sidebar to "Needs input"
+            # because the agent is not actually blocked — Stop already ran.
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "notification",
+                {
+                    "session_id": session_id,
+                    "message": "Claude is waiting for your input",
+                },
+                hook_env,
+            )
+
+            post_idle_status = claude_code_status_value(client, workspace_id)
+            if post_idle_status == "Needs input":
+                return fail(
+                    "idle_prompt notification incorrectly overrode status to 'Needs input' "
+                    "(expected status to stay 'Idle' — this is issue #1027)"
+                )
+            if post_idle_status != "Idle":
+                return fail(
+                    f"Expected status to stay 'Idle' after idle_prompt, got {post_idle_status!r}"
+                )
+
+            # A permission_prompt (tool-use approval) IS a real blocking event —
+            # the status must flip to "Needs input".
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "notification",
+                {
+                    "session_id": session_id,
+                    "message": "Claude needs your permission to use Bash",
+                },
+                hook_env,
+            )
+
+            permission_status = claude_code_status_value(client, workspace_id)
+            if permission_status != "Needs input":
+                return fail(
+                    f"Expected status 'Needs input' after permission_prompt, "
+                    f"got {permission_status!r}"
+                )
+
+            # AskUserQuestion goes through PreToolUse (not Notification). The
+            # Notification hook that fires right after — even with an
+            # idle-looking message — should still mark the agent as needing
+            # input, because we tracked that a question is pending.
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "prompt-submit",
+                {"session_id": session_id, "cwd": str(project_dir)},
+                hook_env,
+            )
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "pre-tool-use",
+                {
+                    "session_id": session_id,
+                    "cwd": str(project_dir),
+                    "tool_name": "AskUserQuestion",
+                    "tool_input": {
+                        "question": "Pick one",
+                        "header": "Pick",
+                        "multiSelect": False,
+                        "options": [
+                            {"label": "Yes", "description": "Yes"},
+                            {"label": "No", "description": "No"},
+                        ],
+                    },
+                },
+                hook_env,
+            )
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "notification",
+                {
+                    "session_id": session_id,
+                    "message": "Claude is waiting for your input",
+                },
+                hook_env,
+            )
+
+            ask_question_status = claude_code_status_value(client, workspace_id)
+            if ask_question_status != "Needs input":
+                return fail(
+                    f"Expected status 'Needs input' after AskUserQuestion + notification, "
+                    f"got {ask_question_status!r}"
+                )
+
+            # And once the next turn starts (user submits a reply), the
+            # pending-question flag must be cleared so the next idle_prompt
+            # doesn't get treated as blocking.
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "prompt-submit",
+                {"session_id": session_id, "cwd": str(project_dir)},
+                hook_env,
+            )
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "stop",
+                {"session_id": session_id},
+                hook_env,
+            )
+            run_claude_hook(
+                cli_path,
+                client.socket_path,
+                "notification",
+                {
+                    "session_id": session_id,
+                    "message": "Claude is waiting for your input",
+                },
+                hook_env,
+            )
+            cleared_status = claude_code_status_value(client, workspace_id)
+            if cleared_status == "Needs input":
+                return fail(
+                    "Pending-question flag was not cleared after next Stop — "
+                    "idle_prompt should no longer be treated as blocking"
+                )
+
+            print("PASS: Claude hook Notification status respects idle_prompt vs permission_prompt")
+            return 0
+
+    except (cmuxError, RuntimeError) as exc:
+        return fail(str(exc))
+    finally:
+        try:
+            if state_path.exists():
+                state_path.unlink()
+            if lock_path.exists():
+                lock_path.unlink()
+        except OSError:
+            pass
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes #1027.

## Summary

The sidebar `claude_code` status sometimes stayed on **Needs input** long after Claude had finished its turn. Root cause: Claude Code's `Notification` hook fires for two unrelated scenarios and the cmux handler treated both the same way.

| Notification flavor | What it actually means | Previous cmux behavior | New cmux behavior |
| --- | --- | --- | --- |
| `permission_prompt` (`Claude needs your permission to use X`) | Claude is genuinely blocked awaiting approval | Sets status → **Needs input** | Unchanged — sets status → **Needs input** |
| `idle_prompt` (`Claude is waiting for your input`, fires ~60s after prompt input goes idle) | Nothing — inactivity timer, agent already idle via `Stop` | Overrides status → **Needs input** ❌ | Leaves status alone (stays **Idle**) ✅ |
| `AskUserQuestion` tool (surfaced via `PreToolUse`, then a `Notification` follow-up) | Claude is blocked waiting for a structured answer | Happened to work because every Notification set **Needs input** | Still sets **Needs input**, now via an explicit `pendingQuestion` flag |

This matches the analysis from the issue thread (`kyleawayan`): the hook handler didn't distinguish permission vs idle, so idle after Stop would flip the indicator back on even though nothing was actually blocking.

## Implementation

- Adds a `pendingQuestion: Bool?` field to `ClaudeHookSessionRecord` (persisted in `~/.cmuxterm/claude-hook-sessions.json`).
- `PreToolUse(AskUserQuestion)` sets it `true`; every other hook that represents forward progress (`Stop`, `UserPromptSubmit`, non-Ask `PreToolUse`) clears it.
- The `Notification` handler only overrides the sidebar status to `Needs input` when the classification is `Permission`, or when `pendingQuestion == true`. Everything else (idle_prompt, completed, error, generic attention) leaves the existing status untouched.
- The notification toast itself still fires as before — only the sidebar status override is gated.

Out of scope for this PR: the two other sub-issues in #1027 (stale `Running` when the Claude process dies without Stop, and `Needs Input` failing to appear in rarer races). Those need a separate liveness-check/timeout fix; this PR targets the specific false-positive that the top comment on the issue identifies as the most common cause.

## Test plan

Added `tests/test_claude_hook_notification_status.py` (v1 socket test) covering four scenarios end-to-end through the real `cmux claude-hook` CLI:

1. `prompt-submit` → `stop` → `notification` (idle_prompt payload) — status must stay `Idle`, **not** flip to `Needs input` (this is the regression).
2. `notification` with a permission payload — status must flip to `Needs input`.
3. `pre-tool-use` for `AskUserQuestion` followed by a generic `notification` — status must flip to `Needs input` (via `pendingQuestion`).
4. Next `prompt-submit` + `stop`, then another idle-style `notification` — status must no longer be `Needs input` (flag is cleared).

Per repo policy (`CLAUDE.md` → _Regression test commit policy_) the test lands in a separate commit before the fix so CI can show it fails without the fix.

- [x] Added regression test (`tests/test_claude_hook_notification_status.py`)
- [x] Local `xcodebuild -scheme cmux -configuration Debug build` succeeds with the fix applied
- [ ] CI green on both commits (test red on commit 1, green on commit 2)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the sidebar "Needs input" indicator getting stuck after an `idle_prompt` by distinguishing idle vs permission notifications and tracking pending questions. The sidebar now stays "Idle" after a normal stop and only flips to "Needs input" when input is truly required.

- **Bug Fixes**
  - Only set status to "Needs input" for permission prompts or when an `AskUserQuestion` is pending; ignore `idle_prompt` after `Stop`.
  - Add `pendingQuestion` to `ClaudeHookSessionRecord`; set on `PreToolUse(AskUserQuestion)` and clear on `Stop`/`UserPromptSubmit`.
  - Keep notification toasts unchanged; only gate the sidebar status override.
  - Add regression test `tests/test_claude_hook_notification_status.py` covering idle vs permission prompts, pending question flow, and flag clearing.

<sup>Written for commit a183d67fe99c97b41e698eaa7f309d8869070424. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed sidebar status display to accurately show "Needs input" only when user input is actually required, such as for permission prompts or pending questions from Claude.
  * Improved tracking and persistence of pending question state across session workflows to ensure status remains synchronized with actual user interaction needs.

* **Tests**
  * Added regression test to validate sidebar status transitions across various notification and interaction scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->