### PR TITLE
fix(tmux-compat): expand single-char format codes (#S/#I/#W/#P/...) — fixes #2750

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 )
@@ -166,19 +165,68 @@ func parseTmuxArgs(args []string, valueFlags, boolFlags []string) *tmuxParsed {
 
 // --- Format string rendering ---
 
-var tmuxFormatVarRe = regexp.MustCompile(`#\{[^}]+\}`)
+// tmuxShortFormKeys maps tmux single-char format codes (#S #I etc) to
+// context keys populated by tmuxFormatContext. See tmux(1) FORMATS.
+// Unknown short forms fall through and are emitted as the literal characters.
+var tmuxShortFormKeys = map[byte]string{
+	'S': "session_name",
+	'I': "window_index",
+	'W': "window_name",
+	'P': "pane_index",
+	'D': "pane_id",
+	'F': "window_flags",
+	'h': "host_short",
+	'H': "host",
+	'T': "pane_title",
+}
 
+// tmuxRenderFormat substitutes tmux format placeholders. A single-pass scanner
+// recognizes '##' (literal '#'), '#{name}' (long form), and '#X' (short form).
+// Unresolved variables collapse to empty (matching prior long-form behavior).
 func tmuxRenderFormat(format string, context map[string]string, fallback string) string {
 	if format == "" {
 		return fallback
 	}
-	rendered := format
-	for key, value := range context {
-		rendered = strings.ReplaceAll(rendered, "#{"+key+"}", value)
+	var b strings.Builder
+	b.Grow(len(format))
+	n := len(format)
+	for i := 0; i < n; {
+		c := format[i]
+		if c != '#' || i+1 >= n {
+			b.WriteByte(c)
+			i++
+			continue
+		}
+		next := format[i+1]
+		switch {
+		case next == '#':
+			b.WriteByte('#')
+			i += 2
+		case next == '{':
+			end := strings.IndexByte(format[i+2:], '}')
+			if end < 0 {
+				b.WriteByte(c)
+				i++
+				continue
+			}
+			key := format[i+2 : i+2+end]
+			if v, ok := context[key]; ok {
+				b.WriteString(v)
+			}
+			i += end + 3
+		default:
+			if key, ok := tmuxShortFormKeys[next]; ok {
+				if v, ok2 := context[key]; ok2 {
+					b.WriteString(v)
+				}
+				i += 2
+				continue
+			}
+			b.WriteByte(c)
+			i++
+		}
 	}
-	// Remove any remaining unresolved #{...} variables
-	rendered = tmuxFormatVarRe.ReplaceAllString(rendered, "")
-	rendered = strings.TrimSpace(rendered)
+	rendered := strings.TrimSpace(b.String())
 	if rendered == "" {
 		return fallback
 	}
@@ -201,6 +249,14 @@ func tmuxFormatContext(rc *rpcContext, workspaceId string, paneId string, surfac
 		"window_active": "1",
 		"window_flags":  "*",
 		"pane_active":   "1",
+	}
+	if host, hostErr := os.Hostname(); hostErr == nil && host != "" {
+		ctx["host"] = host
+		short := host
+		if dot := strings.IndexByte(short, '.'); dot > 0 {
+			short = short[:dot]
+		}
+		ctx["host_short"] = short
 	}
 
 	// Get workspace list for index/title


### PR DESCRIPTION
Fixes #2750.

## Problem

`__tmux-compat display-message` only substituted long-form `#{name}` placeholders. Single-char tmux format codes (`#S`, `#I`, `#W`, `#P`, `#D`, `#F`, `#h`, `#H`, `#T`) and `##` escapes were emitted verbatim.

This breaks downstream tools that probe context with the canonical short-form syntax — most visibly **oh-my-claudecode's `omc team`** runtime, which calls `tmux display-message -p '#S:#I'` to discover its session and was getting the literal string `#S:#I` back, then failing with:

> Failed to resolve tmux context: \"#S:#I %<paneId>\"

(This is the symptom users hit when running ``cmux omc team 1:codex,1:gemini "..."`` — the team runtime can't bootstrap because session/window resolution returns garbage.)

## Fix

Replace `tmuxRenderFormat` with a single-pass scanner that recognizes:
- `##` → literal `#`
- `#{name}` → context substitution (existing behavior, preserved)
- `#X` → short-form context substitution via the new `tmuxShortFormKeys` map (per [`tmux(1)` FORMATS](https://man.openbsd.org/tmux.1#FORMATS))

Short-form key mapping:

| Code | Context key |
|---|---|
| `#S` | `session_name` |
| `#I` | `window_index` |
| `#W` | `window_name` |
| `#P` | `pane_index` |
| `#D` | `pane_id` |
| `#F` | `window_flags` |
| `#h` | `host_short` (new) |
| `#H` | `host` (new) |
| `#T` | `pane_title` |

`tmuxFormatContext` now also populates `host` and `host_short` via `os.Hostname()` so `#h`/`#H` resolve. Dropped the now-unused `regexp` import.

Unknown short forms emit raw characters (no panic). Unresolved keys collapse to empty (consistent with prior long-form behavior).

## Verification

End-to-end against the patched daemon binary running inside a cmux pane:

\`\`\`
\$ /tmp/cmuxd-remote-fixed __tmux-compat display-message -p '#S:#I'
cmux:0
\$ /tmp/cmuxd-remote-fixed __tmux-compat display-message -p '#S'
cmux
\$ /tmp/cmuxd-remote-fixed __tmux-compat display-message -p \\
    'session=#S window=#I pane=#P host=#h'
session=cmux window=0 pane=0 host=Mac
\$ /tmp/cmuxd-remote-fixed __tmux-compat display-message -p 'literal: ##'
literal: #
\$ # current released binary for comparison:
\$ cmux __tmux-compat display-message -p '#S:#I'
#S:#I
\`\`\`

The pre-existing `TestTmuxRenderFormat` suite still passes — no regression in long-form behavior:

\`\`\`
=== RUN   TestTmuxRenderFormat
--- PASS: TestTmuxRenderFormat (0.00s)
PASS
\`\`\`

## Test additions (follow-up)

I have a complete table-driven test suite drafted (short-form coverage, mixed forms, `##` escape, trailing-`#`, unknown `#X`, the exact `#S:#I` regression case from #2750) but my local agent harness has a guard against modifying `*_test.go` files, so I'd appreciate it if a maintainer either applies them in the same PR or in a follow-up. Happy to paste them here for review on request.

## Compatibility

- No public API change.
- Long-form `#{name}` semantics unchanged.
- Behavior for inputs that previously parsed correctly is byte-identical.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved tmux placeholder resolution with more efficient single-pass processing
  * Extended placeholder support to include hostname-based context variables
  * Refined handling of unresolved placeholders for improved reliability
  * Enhanced performance in terminal formatting operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands tmux short-form format codes in `__tmux-compat display-message` to match tmux behavior and unblock tools expecting `#S/#I` output. Fixes #2750.

- **Bug Fixes**
  - Replaced `tmuxRenderFormat` with a single-pass scanner that handles `##`, `#{name}`, and `#X`.
  - Added `tmuxShortFormKeys` for `#S/#I/#W/#P/#D/#F/#h/#H/#T`.
  - Populated `host` and `host_short` in `tmuxFormatContext` via `os.Hostname()`.
  - Unresolved variables render empty; unknown short forms emit literal characters.
  - Removed unused `regexp`; long-form behavior unchanged.

<sup>Written for commit 1b6ed0fcf1b0a642539888829cdd94d7f15679a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

