### PR TITLE
fix(surface): accept surface_ref and surface aliases in send/read RPCs (related #2045)

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5664,10 +5664,11 @@ class TerminalController {
                 return
             }
             let surfaceId: UUID?
-            if params["surface_id"] != nil {
-                surfaceId = v2UUID(params, "surface_id")
+            let rawSurface = params["surface_id"] ?? params["surface_ref"] ?? params["surface"]
+            if rawSurface != nil {
+                surfaceId = v2UUIDAny(rawSurface)
                 guard surfaceId != nil else {
-                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id/surface_ref/surface", data: nil)
                     return
                 }
             } else {
@@ -5724,10 +5725,11 @@ class TerminalController {
                 return
             }
             let surfaceId: UUID?
-            if params["surface_id"] != nil {
-                surfaceId = v2UUID(params, "surface_id")
+            let rawSurface = params["surface_id"] ?? params["surface_ref"] ?? params["surface"]
+            if rawSurface != nil {
+                surfaceId = v2UUIDAny(rawSurface)
                 guard surfaceId != nil else {
-                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id/surface_ref/surface", data: nil)
                     return
                 }
             } else {
@@ -5766,10 +5768,11 @@ class TerminalController {
                 return
             }
             let surfaceId: UUID?
-            if params["surface_id"] != nil {
-                surfaceId = v2UUID(params, "surface_id")
+            let rawSurface = params["surface_id"] ?? params["surface_ref"] ?? params["surface"]
+            if rawSurface != nil {
+                surfaceId = v2UUIDAny(rawSurface)
                 guard surfaceId != nil else {
-                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id/surface_ref/surface", data: nil)
                     return
                 }
             } else {
@@ -5826,10 +5829,11 @@ class TerminalController {
             }
 
             let surfaceId: UUID?
-            if params["surface_id"] != nil {
-                surfaceId = v2UUID(params, "surface_id")
+            let rawSurface = params["surface_id"] ?? params["surface_ref"] ?? params["surface"]
+            if rawSurface != nil {
+                surfaceId = v2UUIDAny(rawSurface)
                 guard surfaceId != nil else {
-                    result = .err(code: "not_found", message: "Surface not found for the given surface_id", data: nil)
+                    result = .err(code: "not_found", message: "Surface not found for the given surface_id/surface_ref/surface", data: nil)
                     return
                 }
             } else {


### PR DESCRIPTION
Related #2045 (same class of asymmetric targeting bug).

## Problem

`surface.send_text`, `surface.send_key`, `surface.read_text`, and `surface.clear_history` only inspected `params[\"surface_id\"]` when resolving the target surface. If absent, they fell back to `ws.focusedPanelId` (the caller's own pane).

This makes the input/output schemas asymmetric: responses already include **both** `surface_id` (UUID) and `surface_ref` (short ref like `surface:12`), but inputs only accept `surface_id`. Callers passing `surface_ref` or `surface` had their target silently ignored — the RPC operated on the wrong pane and the bug was easy to miss because no error fired.

### Reproducer (the silent retargeting that this fixes)

\`\`\`
\$ cmux new-pane --type terminal --direction right --id-format both
OK surface:12 pane:11 workspace:5

\$ cmux rpc surface.send_text '{\"surface\":\"surface:12\",\"text\":\"x\\\\n\"}'
{
  \"workspace_ref\" : \"workspace:5\",
  \"surface_ref\" : \"surface:7\",         ← caller's own surface, not surface:12
  \"surface_id\" : \"9E1F1A31-...\",       ← caller's own UUID
  ...
}
\`\`\`

In practice this hits OMC / Claude Code orchestration sessions hard: an orchestrator trying to drive a worker pane via RPC ends up typing into its **own** prompt box, which then gets submitted as user input on the next newline. The bug is invisible in the response shape because the response always echoes a valid surface_id+surface_ref pair (just the wrong one).

## Fix

Replace the `params[\"surface_id\"]` check in all four handlers (`v2SurfaceSendText`, `v2SurfaceSendKey`, `v2SurfaceClearHistory`, `v2SurfaceReadText`) with a fallback chain:

\`\`\`swift
let rawSurface = params[\"surface_id\"] ?? params[\"surface_ref\"] ?? params[\"surface\"]
if rawSurface != nil {
    surfaceId = v2UUIDAny(rawSurface)
    guard surfaceId != nil else {
        result = .err(code: \"not_found\", message: \"Surface not found for the given surface_id/surface_ref/surface\", data: nil)
        return
    }
} else {
    surfaceId = ws.focusedPanelId
}
\`\`\`

Uses the existing `v2UUIDAny` helper (line 3136), which already accepts UUIDs **and** short-form handle refs via `v2ResolveHandleRef`. No new helpers, no new dependencies.

## Compatibility

- Existing `surface_id` callers: behavior unchanged (still hit the chain first).
- New `surface_ref` / `surface` callers: now resolve correctly instead of silently retargeting.
- Response shape unchanged.
- `tab_id` and other parameters: untouched.

## Files changed

| File | Change |
|---|---|
| `Sources/TerminalController.swift` | 4 identical handler patches via fallback-chain pattern |

## Verification

I do not have an Xcode build chain locally, so this PR has been **code-reviewed but not Xcode-built**. The change is a mechanical pattern substitution using a helper (`v2UUIDAny`) that already exists and is already used elsewhere in the file (e.g. lines 3136–3144). I'd appreciate a maintainer applying the existing build/test pipeline. The companion test additions for `tmux_split_ref_test.go`-style coverage are in scope for a follow-up — happy to draft them once the approach here is validated.

## Related

- Sibling PR for the `__tmux-compat display-message` short-form bug (#2750) — together these two fixes unblock \`cmux omc team 1:codex,1:gemini \"...\"\` end-to-end.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced surface-targeting handlers to accept multiple parameter formats for surface identifiers, improving compatibility and error messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accepts `surface_ref` and `surface` in `surface.send_text`, `surface.send_key`, `surface.read_text`, and `surface.clear_history` so RPCs target the correct surface instead of falling back to the caller’s pane. Aligns inputs with outputs and addresses the asymmetric targeting bug (related to #2045).

- **Bug Fixes**
  - Added fallback chain: `surface_id` → `surface_ref` → `surface`, resolved via `v2UUIDAny`.
  - Return `not_found` when the ref is invalid; stop defaulting to `ws.focusedPanelId`.
  - No response changes; existing `surface_id` callers are unaffected.

<sup>Written for commit cf02ce7253bf6582226ff4560ad7f7e83efd49a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

