### PR TITLE
Fix DebugEventLog NSFileHandle ObjC exception crash

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1634,9 +1634,9 @@ class GhosttyApp {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: initLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(Data(line.utf8))
-            handle.closeFile()
+            defer { try? handle.close() }
+            guard (try? handle.seekToEnd()) != nil else { return }
+            try? handle.write(contentsOf: Data(line.utf8))
         } else {
             FileManager.default.createFile(atPath: initLogPath, contents: line.data(using: .utf8))
         }
@@ -4141,9 +4141,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: surfaceLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(Data(line.utf8))
-            handle.closeFile()
+            defer { try? handle.close() }
+            guard (try? handle.seekToEnd()) != nil else { return }
+            try? handle.write(contentsOf: Data(line.utf8))
         } else {
             FileManager.default.createFile(atPath: surfaceLogPath, contents: line.data(using: .utf8))
         }
@@ -4155,9 +4155,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         let timestamp = ISO8601DateFormatter().string(from: Date())
         let line = "[\(timestamp)] \(message)\n"
         if let handle = FileHandle(forWritingAtPath: sizeLogPath) {
-            handle.seekToEndOfFile()
-            handle.write(Data(line.utf8))
-            handle.closeFile()
+            defer { try? handle.close() }
+            guard (try? handle.seekToEnd()) != nil else { return }
+            try? handle.write(contentsOf: Data(line.utf8))
         } else {
             FileManager.default.createFile(atPath: sizeLogPath, contents: line.data(using: .utf8))
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3472,7 +3472,7 @@ class GhosttyApp {
             }
             if let handle = try? FileHandle(forWritingTo: backgroundLogURL) {
                 defer { try? handle.close() }
-                try? handle.seekToEnd()
+                guard (try? handle.seekToEnd()) != nil else { return }
                 try? handle.write(contentsOf: data)
             }
         }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -695,9 +695,9 @@ extension WorkspaceContentView {
             let line = "[\(ts)] PANEL NOT FOUND for tabId=\(tab.id) ws=\(workspace.id) panelCount=\(workspace.panels.count)\n"
             let logPath = "/tmp/cmux-panel-debug.log"
             if let handle = FileHandle(forWritingAtPath: logPath) {
-                handle.seekToEndOfFile()
-                handle.write(Data(line.utf8))
-                handle.closeFile()
+                defer { try? handle.close() }
+                guard (try? handle.seekToEnd()) != nil else { return }
+                try? handle.write(contentsOf: Data(line.utf8))
             } else {
                 FileManager.default.createFile(atPath: logPath, contents: line.data(using: .utf8))
             }


### PR DESCRIPTION
Fixes #1924.

Depends on the companion bonsplit PR: https://github.com/manaflow-ai/bonsplit/pull/99

## Problem

`DebugEventLog.log(_:)` (and three mirror call sites in the outer repo) used the deprecated Objective-C-style `FileHandle` APIs: `seekToEndOfFile()`, `write(_:)`, and `closeFile()`. When those fail (log file unlinked, disk full, permission issue, etc.) they raise `NSFileHandleOperationException`. Objective-C exceptions are not caught by Swift `do/catch`, so the exception propagates out of the Swift runtime and the uncaught-exception handler calls `abort()`. That is the crash reported in #1924.

## Fix

Switch every call site to the Swift-throwing replacements and guard appropriately:

- `try? handle.seekToEnd()` (not `seekToEndOfFile()`)
- `try? handle.write(contentsOf: data)` (not `write(_:)`)
- `try? handle.close()` in `defer` (not `closeFile()`)
- `guard (try? handle.seekToEnd()) != nil else { return }` so we never blindly append at offset 0 when the seek throws

These APIs throw Swift errors instead of raising ObjC exceptions, so a transient log-write failure silently drops the entry instead of crashing the app. Changes stay inside the existing `#if DEBUG` guards.

## Why this replaces #1931

[#1931](https://github.com/manaflow-ai/cmux/pull/1931) from an external contributor only touched the two outer-repo files and stalled on rebase. It did **not** fix the actual root crash site at `vendor/bonsplit/Sources/Bonsplit/Public/DebugEventLog.swift` (the `dlog(...)` implementation), which is where the most frequent crash path originates.

## Changed call sites

1. **`vendor/bonsplit`** submodule bump — `Sources/Bonsplit/Public/DebugEventLog.swift` (root cause, picks up the fix from the bonsplit PR)
2. **`Sources/GhosttyTerminalView.swift`** — three call sites: `initLog`, `surfaceLog`, `sizeLog`
3. **`Sources/WorkspaceContentView.swift`** — one call site: `debugPanelLookup`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to `#if DEBUG` file logging and primarily swap APIs with defensive error handling; production behavior should be unaffected.
> 
> **Overview**
> Prevents DEBUG-only logging from crashing the app by replacing deprecated Objective-C `FileHandle` calls (`seekToEndOfFile()`, `write(_:)`, `closeFile()`) with Swift-throwing equivalents (`seekToEnd()`, `write(contentsOf:)`, `close()` in `defer`) in `GhosttyTerminalView` and `WorkspaceContentView`.
> 
> Log appends now *guard* against seek failures (dropping the log entry rather than writing at offset 0 / triggering an uncaught ObjC exception) while preserving existing log-file creation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b65623b6dd6be1c39a752f39d041ebf6dfa7213. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent a crash in debug logging caused by ObjC `NSFileHandle` exceptions by switching all debug log writes to Swift-throwing APIs and guarding seek failures, including the background log writer. Fixes #1924.

- **Bug Fixes**
  - Replace `seekToEndOfFile()`/`write(_:)`/`closeFile()` with `try? seekToEnd()`, `try? write(contentsOf:)`, and `defer { try? close() }`.
  - Guard seek failures and drop the entry on error instead of crashing; remains within `#if DEBUG`.
  - Update call sites: four in `Sources/GhosttyTerminalView.swift` (initLog, background log, surfaceLog, sizeLog) and one in `Sources/WorkspaceContentView.swift` (debugPanelLookup).
  - Bump `vendor/bonsplit` to include the `DebugEventLog` fix.

<sup>Written for commit 2b65623b6dd6be1c39a752f39d041ebf6dfa7213. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug log file handling to prevent resource leaks and crashes: safer open/append logic, guarded early-return when appending fails, and ensured handles are closed; preserves existing fallback file creation.

* **Chores**
  * Updated a vendored dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->