### PR TITLE
Fix main-thread blocking in workspace PR refresh

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4950,6 +4950,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
             self.backgroundSurfaceStartQueued = false
             guard self.allowsRuntimeSurfaceCreation() else { return }
             guard self.surface == nil, let view = self.attachedView else { return }
+            guard view.window != nil else {
+                #if DEBUG
+                dlog(
+                    "surface.background_start.defer surface=\(self.id.uuidString.prefix(8)) reason=noWindow"
+                )
+                #endif
+                return
+            }
             #if DEBUG
             let startedAt = ProcessInfo.processInfo.systemUptime
             #endif

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -729,13 +729,19 @@ class TabManager: ObservableObject {
         let pullRequest: WorkspacePullRequestSnapshot
     }
 
-    private struct CommandResult {
+    struct CommandResult: Sendable {
         let stdout: String?
         let stderr: String?
         let exitStatus: Int32?
         let timedOut: Bool
         let executionError: String?
     }
+
+#if DEBUG
+    nonisolated(unsafe) static var commandRunnerForTesting: (
+        @Sendable (String, String, [String], TimeInterval?) -> CommandResult?
+    )?
+#endif
 
     private struct WorkspaceGitProbeKey: Hashable, Sendable {
         let workspaceId: UUID
@@ -3081,6 +3087,11 @@ class TabManager: ObservableObject {
         arguments: [String],
         timeout: TimeInterval? = nil
     ) -> CommandResult? {
+#if DEBUG
+        if let commandRunnerForTesting {
+            return commandRunnerForTesting(directory, executable, arguments, timeout)
+        }
+#endif
         let process = Process()
         let stdout = Pipe()
         let stderr = Pipe()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -760,6 +760,19 @@ class TabManager: ObservableObject {
         let repoSlugs: [String]
     }
 
+    private struct WorkspacePullRequestCandidateSeed: Sendable {
+        let workspaceId: UUID
+        let panelId: UUID
+        let branch: String
+        let directory: String?
+    }
+
+    private struct WorkspacePullRequestCandidateResolution: Sendable {
+        let candidates: [WorkspacePullRequestCandidate]
+        let candidateBranchesByRepo: [String: Set<String>]
+        let repoDirectoriesBySlug: [String: String]
+    }
+
     private struct WorkspacePullRequestResolvedItem: Sendable {
         let number: Int
         let urlString: String
@@ -1216,9 +1229,7 @@ class TabManager: ObservableObject {
         allowCachedResultsOverride: Bool? = nil
     ) {
         let now = Date()
-        var candidates: [WorkspacePullRequestCandidate] = []
-        var candidateBranchesByRepo: [String: Set<String>] = [:]
-        var repoDirectoriesBySlug: [String: String] = [:]
+        var candidateSeeds: [WorkspacePullRequestCandidateSeed] = []
         var requestedKeys: [WorkspaceGitProbeKey] = []
         var validKeys: Set<WorkspaceGitProbeKey> = []
 
@@ -1257,21 +1268,13 @@ class TabManager: ObservableObject {
                     continue
                 }
 
-                let candidate = workspacePullRequestCandidate(
+                let candidateSeed = workspacePullRequestCandidateSeed(
                     workspace: workspace,
                     panelId: panelId,
                     branch: branch
                 )
-                candidates.append(candidate)
+                candidateSeeds.append(candidateSeed)
                 requestedKeys.append(key)
-                for repoSlug in candidate.repoSlugs {
-                    candidateBranchesByRepo[repoSlug, default: []].insert(candidate.branch)
-                }
-                if let directory = gitProbeDirectory(for: workspace, panelId: panelId) {
-                    for repoSlug in candidate.repoSlugs where repoDirectoriesBySlug[repoSlug] == nil {
-                        repoDirectoriesBySlug[repoSlug] = directory
-                    }
-                }
             }
         }
 
@@ -1280,7 +1283,7 @@ class TabManager: ObservableObject {
             updateWorkspacePullRequestPollTimer()
             return
         }
-        guard !candidates.isEmpty else {
+        guard !candidateSeeds.isEmpty else {
             updateWorkspacePullRequestPollTimer()
             return
         }
@@ -1293,16 +1296,18 @@ class TabManager: ObservableObject {
         let cacheBySlug = workspacePullRequestRepoCacheBySlug
         let allowCachedResults = allowCachedResultsOverride
             ?? Self.workspacePullRequestRefreshAllowsRepoCache(reason: reason)
-        workspacePullRequestRefreshTask = Task { [weak self] in
+        workspacePullRequestRefreshTask = Task.detached(priority: .utility) { [weak self] in
+            let candidateResolution = await Self.resolveWorkspacePullRequestCandidateSeeds(candidateSeeds)
+            guard !Task.isCancelled else { return }
             let repoResults = await Self.fetchWorkspacePullRequestRepoResults(
-                repoDirectoriesBySlug: repoDirectoriesBySlug,
-                candidateBranchesByRepo: candidateBranchesByRepo,
+                repoDirectoriesBySlug: candidateResolution.repoDirectoriesBySlug,
+                candidateBranchesByRepo: candidateResolution.candidateBranchesByRepo,
                 cacheBySlug: cacheBySlug,
                 now: now,
                 allowCachedResults: allowCachedResults
             )
             let results = Self.resolveWorkspacePullRequestRefreshResults(
-                candidates: candidates,
+                candidates: candidateResolution.candidates,
                 repoResults: repoResults
             )
             guard !Task.isCancelled else { return }
@@ -1334,18 +1339,65 @@ class TabManager: ObservableObject {
         )
     }
 
-    private func workspacePullRequestCandidate(
+    private func workspacePullRequestCandidateSeed(
         workspace: Workspace,
         panelId: UUID,
         branch: String
-    ) -> WorkspacePullRequestCandidate {
+    ) -> WorkspacePullRequestCandidateSeed {
         let directory = gitProbeDirectory(for: workspace, panelId: panelId)
-        let repoSlugs = directory.map(Self.githubRepositorySlugs(directory:)) ?? []
-        return WorkspacePullRequestCandidate(
+        return WorkspacePullRequestCandidateSeed(
             workspaceId: workspace.id,
             panelId: panelId,
             branch: branch,
-            repoSlugs: repoSlugs
+            directory: directory
+        )
+    }
+
+    private nonisolated static func resolveWorkspacePullRequestCandidateSeeds(
+        _ seeds: [WorkspacePullRequestCandidateSeed]
+    ) async -> WorkspacePullRequestCandidateResolution {
+        var candidates: [WorkspacePullRequestCandidate] = []
+        candidates.reserveCapacity(seeds.count)
+        var candidateBranchesByRepo: [String: Set<String>] = [:]
+        var repoDirectoriesBySlug: [String: String] = [:]
+        var repoSlugsByDirectory: [String: [String]] = [:]
+
+        for seed in seeds {
+            let repoSlugs: [String]
+            if let directory = seed.directory {
+                if let cachedRepoSlugs = repoSlugsByDirectory[directory] {
+                    repoSlugs = cachedRepoSlugs
+                } else {
+                    let resolvedRepoSlugs = await githubRepositorySlugs(directory: directory)
+                    repoSlugsByDirectory[directory] = resolvedRepoSlugs
+                    repoSlugs = resolvedRepoSlugs
+                }
+            } else {
+                repoSlugs = []
+            }
+
+            candidates.append(
+                WorkspacePullRequestCandidate(
+                    workspaceId: seed.workspaceId,
+                    panelId: seed.panelId,
+                    branch: seed.branch,
+                    repoSlugs: repoSlugs
+                )
+            )
+            for repoSlug in repoSlugs {
+                candidateBranchesByRepo[repoSlug, default: []].insert(seed.branch)
+            }
+            if let directory = seed.directory {
+                for repoSlug in repoSlugs where repoDirectoriesBySlug[repoSlug] == nil {
+                    repoDirectoriesBySlug[repoSlug] = directory
+                }
+            }
+        }
+
+        return WorkspacePullRequestCandidateResolution(
+            candidates: candidates,
+            candidateBranchesByRepo: candidateBranchesByRepo,
+            repoDirectoriesBySlug: repoDirectoriesBySlug
         )
     }
 
@@ -2232,9 +2284,10 @@ class TabManager: ObservableObject {
             return
         }
 
-        initialWorkspaceGitProbeQueue.async { [weak self] in
-            let snapshot = Self.initialWorkspaceGitMetadataSnapshot(for: expectedDirectory)
-            Task { @MainActor [weak self] in
+        Task.detached(priority: .utility) { [weak self] in
+            let snapshot = await Self.initialWorkspaceGitMetadataSnapshot(for: expectedDirectory)
+            guard !Task.isCancelled else { return }
+            await MainActor.run { [weak self] in
                 self?.applyWorkspaceGitMetadataSnapshot(
                     snapshot,
                     probeKey: probeKey,
@@ -2423,8 +2476,9 @@ class TabManager: ObservableObject {
 
     private nonisolated static func initialWorkspaceGitMetadataSnapshot(
         for directory: String
-    ) -> InitialWorkspaceGitMetadataSnapshot {
-        let branch = normalizedBranchName(runGitCommand(directory: directory, arguments: ["branch", "--show-current"]))
+    ) async -> InitialWorkspaceGitMetadataSnapshot {
+        let branchOutput = await runGitCommand(directory: directory, arguments: ["branch", "--show-current"])
+        let branch = normalizedBranchName(branchOutput)
         guard let branch else {
             return InitialWorkspaceGitMetadataSnapshot(
                 branch: nil,
@@ -2433,7 +2487,7 @@ class TabManager: ObservableObject {
             )
         }
 
-        let statusOutput = runGitCommand(directory: directory, arguments: ["status", "--porcelain", "-uno"])
+        let statusOutput = await runGitCommand(directory: directory, arguments: ["status", "--porcelain", "-uno"])
         let isDirty = !(statusOutput?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
         return InitialWorkspaceGitMetadataSnapshot(
             branch: branch,
@@ -2442,8 +2496,8 @@ class TabManager: ObservableObject {
         )
     }
 
-    private nonisolated static func runGitCommand(directory: String, arguments: [String]) -> String? {
-        runCommand(
+    private nonisolated static func runGitCommand(directory: String, arguments: [String]) async -> String? {
+        await runCommand(
             directory: directory,
             executable: "git",
             arguments: arguments
@@ -2463,7 +2517,7 @@ class TabManager: ObservableObject {
         configuration.timeoutIntervalForRequest = max(Self.workspacePullRequestProbeTimeout, 8)
         configuration.timeoutIntervalForResource = max(Self.workspacePullRequestProbeTimeout, 8)
         let session = URLSession(configuration: configuration)
-        let authHeader = workspacePullRequestAuthHeaderValue()
+        let authHeader = await workspacePullRequestAuthHeaderValue()
         var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
 
         let fetchedResults = await withTaskGroup(
@@ -2877,7 +2931,7 @@ class TabManager: ObservableObject {
         }
     }
 
-    private nonisolated static func workspacePullRequestAuthHeaderValue() -> String? {
+    private nonisolated static func workspacePullRequestAuthHeaderValue() async -> String? {
         let environment = ProcessInfo.processInfo.environment
         if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
             let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -2887,7 +2941,7 @@ class TabManager: ObservableObject {
         }
 
         let directory = FileManager.default.currentDirectoryPath
-        let token = runCommand(
+        let token = await runCommand(
             directory: directory,
             executable: "gh",
             arguments: ["auth", "token"],
@@ -3061,13 +3115,122 @@ class TabManager: ObservableObject {
         return nil
     }
 
+    private final class CommandRunState: @unchecked Sendable {
+        private typealias Continuation = CheckedContinuation<CommandResult?, Never>
+
+        private let lock = NSLock()
+        private var continuation: Continuation?
+        private var stdoutData: Data?
+        private var stderrData: Data?
+        private var exitStatus: Int32?
+        private var didTerminate = false
+        private var didResume = false
+        private var timeoutWorkItem: DispatchWorkItem?
+
+        init(continuation: Continuation) {
+            self.continuation = continuation
+        }
+
+        func setTimeoutWorkItem(_ item: DispatchWorkItem?) {
+            guard let item else { return }
+            lock.lock()
+            if didResume {
+                lock.unlock()
+                item.cancel()
+                return
+            }
+            timeoutWorkItem = item
+            lock.unlock()
+        }
+
+        func hasResumed() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return didResume
+        }
+
+        func completeStdout(_ data: Data) {
+            complete {
+                stdoutData = data
+            }
+        }
+
+        func completeStderr(_ data: Data) {
+            complete {
+                stderrData = data
+            }
+        }
+
+        func completeTermination(exitStatus: Int32) {
+            complete {
+                self.exitStatus = exitStatus
+                didTerminate = true
+            }
+        }
+
+        func resume(returning result: CommandResult?) {
+            var continuationToResume: Continuation?
+            var timeoutToCancel: DispatchWorkItem?
+            lock.lock()
+            guard !didResume else {
+                lock.unlock()
+                return
+            }
+            didResume = true
+            continuationToResume = continuation
+            continuation = nil
+            timeoutToCancel = timeoutWorkItem
+            timeoutWorkItem = nil
+            lock.unlock()
+
+            timeoutToCancel?.cancel()
+            continuationToResume?.resume(returning: result)
+        }
+
+        private func complete(_ mutate: () -> Void) {
+            var continuationToResume: Continuation?
+            var timeoutToCancel: DispatchWorkItem?
+            var resultToResume: CommandResult?
+
+            lock.lock()
+            guard !didResume else {
+                lock.unlock()
+                return
+            }
+
+            mutate()
+            if let stdoutData,
+               let stderrData,
+               didTerminate {
+                didResume = true
+                resultToResume = CommandResult(
+                    stdout: String(data: stdoutData, encoding: .utf8),
+                    stderr: String(data: stderrData, encoding: .utf8),
+                    exitStatus: exitStatus,
+                    timedOut: false,
+                    executionError: nil
+                )
+                continuationToResume = continuation
+                continuation = nil
+                timeoutToCancel = timeoutWorkItem
+                timeoutWorkItem = nil
+            }
+            lock.unlock()
+
+            timeoutToCancel?.cancel()
+            if let resultToResume {
+                continuationToResume?.resume(returning: resultToResume)
+            }
+        }
+    }
+
     private nonisolated static func runCommand(
         directory: String,
         executable: String,
         arguments: [String],
         timeout: TimeInterval? = nil
-    ) -> String? {
-        let result = runCommandResult(
+    ) async -> String? {
+        let result = await runCommandResult(
             directory: directory,
             executable: executable,
             arguments: arguments,
@@ -3086,70 +3249,92 @@ class TabManager: ObservableObject {
         executable: String,
         arguments: [String],
         timeout: TimeInterval? = nil
-    ) -> CommandResult? {
+    ) async -> CommandResult? {
 #if DEBUG
+        assert(!Thread.isMainThread, "TabManager.runCommandResult must not run on the main thread")
         if let commandRunnerForTesting {
             return commandRunnerForTesting(directory, executable, arguments, timeout)
         }
 #endif
-        let process = Process()
-        let stdout = Pipe()
-        let stderr = Pipe()
-        if let resolvedExecutable = resolvedCommandPath(executable: executable) {
-            process.executableURL = URL(fileURLWithPath: resolvedExecutable)
-            process.arguments = arguments
-        } else {
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [executable] + arguments
-        }
-        process.currentDirectoryURL = URL(fileURLWithPath: directory)
-        process.standardOutput = stdout
-        process.standardError = stderr
-
-        let completion = DispatchSemaphore(value: 0)
-        process.terminationHandler = { _ in
-            completion.signal()
-        }
-
-        do {
-            try process.run()
-        } catch {
-            return CommandResult(
-                stdout: nil,
-                stderr: nil,
-                exitStatus: nil,
-                timedOut: false,
-                executionError: String(describing: error)
-            )
-        }
-
-        if let timeout,
-           completion.wait(timeout: .now() + timeout) == .timedOut {
-            process.terminate()
-            if completion.wait(timeout: .now() + 0.2) == .timedOut {
-                kill(process.processIdentifier, SIGKILL)
-                _ = completion.wait(timeout: .now() + 0.2)
+        return await withCheckedContinuation { continuation in
+            let process = Process()
+            let stdout = Pipe()
+            let stderr = Pipe()
+            if let resolvedExecutable = resolvedCommandPath(executable: executable) {
+                process.executableURL = URL(fileURLWithPath: resolvedExecutable)
+                process.arguments = arguments
+            } else {
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+                process.arguments = [executable] + arguments
             }
-            return CommandResult(
-                stdout: nil,
-                stderr: nil,
-                exitStatus: nil,
-                timedOut: true,
-                executionError: nil
-            )
-        } else if timeout == nil {
-            completion.wait()
-        }
+            process.currentDirectoryURL = URL(fileURLWithPath: directory)
+            process.standardInput = FileHandle.nullDevice
+            process.standardOutput = stdout
+            process.standardError = stderr
 
-        let stdoutData = stdout.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderr.fileHandleForReading.readDataToEndOfFile()
-        return CommandResult(
-            stdout: String(data: stdoutData, encoding: .utf8),
-            stderr: String(data: stderrData, encoding: .utf8),
-            exitStatus: process.terminationStatus,
-            timedOut: false,
-            executionError: nil
-        )
+            let state = CommandRunState(continuation: continuation)
+            let timeoutWorkItem = timeout.map { _ in
+                DispatchWorkItem { [state, process] in
+                    guard !state.hasResumed() else { return }
+                    guard process.isRunning else { return }
+                    process.terminate()
+                    DispatchQueue.global(qos: .utility).asyncAfter(deadline: .now() + 0.2) {
+                        if process.isRunning {
+                            kill(process.processIdentifier, SIGKILL)
+                        }
+                    }
+                    state.resume(
+                        returning: CommandResult(
+                            stdout: nil,
+                            stderr: nil,
+                            exitStatus: nil,
+                            timedOut: true,
+                            executionError: nil
+                        )
+                    )
+                }
+            }
+            state.setTimeoutWorkItem(timeoutWorkItem)
+            process.terminationHandler = { terminatedProcess in
+                state.completeTermination(exitStatus: terminatedProcess.terminationStatus)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                try? stdout.fileHandleForWriting.close()
+                try? stderr.fileHandleForWriting.close()
+                state.resume(
+                    returning: CommandResult(
+                        stdout: nil,
+                        stderr: nil,
+                        exitStatus: nil,
+                        timedOut: false,
+                        executionError: String(describing: error)
+                    )
+                )
+                return
+            }
+
+            try? stdout.fileHandleForWriting.close()
+            try? stderr.fileHandleForWriting.close()
+
+            DispatchQueue.global(qos: .utility).async {
+                let data = stdout.fileHandleForReading.readDataToEndOfFile()
+                state.completeStdout(data)
+            }
+            DispatchQueue.global(qos: .utility).async {
+                let data = stderr.fileHandleForReading.readDataToEndOfFile()
+                state.completeStderr(data)
+            }
+            if let timeout,
+               let timeoutWorkItem {
+                DispatchQueue.global(qos: .utility).asyncAfter(
+                    deadline: .now() + timeout,
+                    execute: timeoutWorkItem
+                )
+            }
+        }
     }
 
     nonisolated static func githubRepositorySlugs(fromGitRemoteVOutput output: String) -> [String] {
@@ -3193,8 +3378,8 @@ class TabManager: ObservableObject {
         return orderedSlugs
     }
 
-    private nonisolated static func githubRepositorySlugs(directory: String) -> [String] {
-        guard let output = runGitCommand(directory: directory, arguments: ["remote", "-v"]) else {
+    private nonisolated static func githubRepositorySlugs(directory: String) async -> [String] {
+        guard let output = await runGitCommand(directory: directory, arguments: ["remote", "-v"]) else {
             return []
         }
         return githubRepositorySlugs(fromGitRemoteVOutput: output)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3116,7 +3116,7 @@ class TabManager: ObservableObject {
     }
 
     private final class CommandRunState: @unchecked Sendable {
-        private typealias Continuation = CheckedContinuation<CommandResult?, Never>
+        fileprivate typealias Continuation = CheckedContinuation<CommandResult?, Never>
 
         private let lock = NSLock()
         private var continuation: Continuation?
@@ -3127,7 +3127,7 @@ class TabManager: ObservableObject {
         private var didResume = false
         private var timeoutWorkItem: DispatchWorkItem?
 
-        init(continuation: Continuation) {
+        fileprivate init(continuation: Continuation) {
             self.continuation = continuation
         }
 

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -6,6 +6,23 @@ import XCTest
 @testable import cmux
 #endif
 
+private final class CommandRunnerInvocationCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storedValue = 0
+
+    func increment() {
+        lock.lock()
+        storedValue += 1
+        lock.unlock()
+    }
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storedValue
+    }
+}
+
 @MainActor
 final class WorkspacePullRequestSidebarTests: XCTestCase {
     func testSidebarPullRequestsIgnoreStaleWorkspaceLevelCacheWithoutPanelState() throws {
@@ -77,6 +94,89 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
                     branch: "feature/work"
                 )
             ]
+        )
+    }
+
+    func testPullRequestRefreshRepositoryDiscoveryDoesNotBlockMainRunLoop() throws {
+        let invocationCounter = CommandRunnerInvocationCounter()
+        let commandDelay: TimeInterval = 0.03
+        TabManager.commandRunnerForTesting = { _, executable, arguments, _ in
+            if executable == "git", arguments == ["remote", "-v"] {
+                invocationCounter.increment()
+                Thread.sleep(forTimeInterval: commandDelay)
+                return TabManager.CommandResult(
+                    stdout: "origin\tssh://example.invalid/not-github.git (fetch)\n",
+                    stderr: "",
+                    exitStatus: 0,
+                    timedOut: false,
+                    executionError: nil
+                )
+            }
+            return TabManager.CommandResult(
+                stdout: "",
+                stderr: "",
+                exitStatus: 0,
+                timedOut: false,
+                executionError: nil
+            )
+        }
+        defer {
+            TabManager.commandRunnerForTesting = nil
+        }
+
+        let manager = TabManager()
+        var seededPanels: [(workspaceId: UUID, panelId: UUID)] = []
+        let workspaceCount = 45
+        var workspaces = manager.tabs
+        while workspaces.count < workspaceCount {
+            workspaces.append(manager.addWorkspace(select: false, eagerLoadTerminal: false))
+        }
+
+        for (index, workspace) in workspaces.enumerated() {
+            let panelId = try XCTUnwrap(workspace.focusedPanelId)
+            workspace.updatePanelDirectory(
+                panelId: panelId,
+                directory: "/tmp/cmux-pr-refresh-main-thread-\(index)"
+            )
+            workspace.updatePanelGitBranch(
+                panelId: panelId,
+                branch: "issue-3033-\(index)",
+                isDirty: false
+            )
+            seededPanels.append((workspace.id, panelId))
+        }
+
+        let monitorDuration: TimeInterval = 0.7
+        let allowedMainThreadGap: TimeInterval = 0.25
+        let finishedMonitoring = expectation(description: "main run loop remained responsive")
+        let monitorStartedAt = Date()
+        var lastTickAt = monitorStartedAt
+        var maxTickGap: TimeInterval = 0
+        let timer = Timer.scheduledTimer(withTimeInterval: 0.01, repeats: true) { timer in
+            let now = Date()
+            maxTickGap = max(maxTickGap, now.timeIntervalSince(lastTickAt))
+            lastTickAt = now
+            if now.timeIntervalSince(monitorStartedAt) >= monitorDuration {
+                timer.invalidate()
+                finishedMonitoring.fulfill()
+            }
+        }
+
+        let triggerPanel = try XCTUnwrap(seededPanels.first)
+        manager.updateSurfaceShellActivity(
+            tabId: triggerPanel.workspaceId,
+            surfaceId: triggerPanel.panelId,
+            state: .promptIdle
+        )
+
+        let result = XCTWaiter().wait(for: [finishedMonitoring], timeout: monitorDuration + 1.5)
+        timer.invalidate()
+        XCTAssertEqual(result, .completed)
+        XCTAssertGreaterThan(invocationCounter.value, 0)
+        XCTAssertLessThan(
+            maxTickGap,
+            allowedMainThreadGap,
+            "Pull request refresh blocked the main run loop for \(maxTickGap) seconds"
         )
     }
 }


### PR DESCRIPTION
## Summary
- Add a regression test that seeds 45 workspaces, triggers the PR refresh, and fails when repository discovery stalls the main run loop.
- Move workspace PR repository discovery and initial git metadata subprocess probes off the main actor.
- Replace the semaphore-based Process wait in TabManager.runCommandResult with async continuation completion and background pipe drains, plus a debug main-thread assertion.

Fixes #3033.

## Testing
- Not run locally per repo policy.
- Required tagged dev build/launch will be run after PR creation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and subprocess execution paths used during pull request discovery; mistakes could cause missed PR updates, hung tasks, or orphaned processes despite being largely performance-focused.
> 
> **Overview**
> Prevents UI stalls during workspace pull-request refresh by moving repository discovery and initial git metadata probes off the main actor into `.utility` detached tasks, and by deduplicating per-directory repo-slug resolution via a new seed→resolution step.
> 
> Reworks `runCommandResult`/`runCommand` and related git/GitHub helpers to be fully async with continuation-based completion, background pipe drains, timeout termination, and a DEBUG assertion plus injectable command runner for tests. Adds a regression test that seeds many workspaces and fails if PR refresh blocks the main run loop, and defers background surface creation when the view is not yet in a window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 842e0ca15b19d1829b71224ad01e27a81598094e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves PR repo discovery and git metadata probes off the main thread with async subprocess I/O, and defers background surface creation until a window exists to keep the UI responsive during PR refreshes and in headless CI. Adds a regression test; fixes #3033.

- **Bug Fixes**
  - Run repository discovery and initial git probes in detached `.utility` tasks.
  - Replace semaphore waits with async continuations, non‑blocking pipe drains, and timeout termination in `runCommandResult` (with a DEBUG main‑thread assertion).
  - Defer background surface creation in `TerminalSurface` when `view.window == nil` to prevent main‑thread stalls in headless runs.
  - Add a regression test that seeds 45 workspaces and verifies the main run loop stays responsive even with a slow `git remote -v`.

- **Refactors**
  - Introduce a seed→resolution flow that resolves repo slugs off the main actor and deduplicates per-directory lookups.
  - Convert helpers to async: `runCommandResult`, `runGitCommand`, `githubRepositorySlugs`, `workspacePullRequestAuthHeaderValue`, `initialWorkspaceGitMetadataSnapshot`.
  - Make `CommandResult` `Sendable`, add `TabManager.commandRunnerForTesting`, and set `CommandRunState` init to `fileprivate` to satisfy access control.

<sup>Written for commit 842e0ca15b19d1829b71224ad01e27a81598094e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved async handling for repository and pull-request operations to make discovery and updates more responsive and non‑blocking.

* **Bug Fix**
  * Prevents attempting to create background surfaces for detached terminal views, avoiding errors when views aren’t yet attached.

* **Tests**
  * Added a test verifying the main run‑loop remains responsive during heavy repository discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->