### PR TITLE
Use workspace color for selected sidebar rows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -238,7 +238,7 @@ func sidebarWorkspaceRowBackgroundStyle(
         if let customBackground {
             return SidebarWorkspaceRowBackgroundStyle(
                 color: customBackground,
-                opacity: isMultiSelected ? 0.28 : 0.16
+                opacity: 1
             )
         }
         if isMultiSelected {
@@ -13073,10 +13073,6 @@ private struct TabItemView: View, Equatable {
         .semibold
     }
 
-    private var showsLeadingRail: Bool {
-        explicitRailColor != nil
-    }
-
     private var activeBorderLineWidth: CGFloat {
         switch activeTabIndicatorStyle {
         case .leftRail:
@@ -13504,16 +13500,6 @@ private struct TabItemView: View, Equatable {
                 .overlay {
                     RoundedRectangle(cornerRadius: 6)
                         .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
-                }
-                .overlay(alignment: .leading) {
-                    if showsLeadingRail {
-                        Capsule(style: .continuous)
-                            .fill(railColor)
-                            .frame(width: 3)
-                            .padding(.leading, 4)
-                            .padding(.vertical, 5)
-                            .offset(x: -1)
-                    }
                 }
         )
         .padding(.horizontal, 6)
@@ -13955,27 +13941,6 @@ private struct TabItemView: View, Equatable {
         )
         guard let color = style.color else { return .clear }
         return Color(nsColor: color).opacity(style.opacity)
-    }
-
-    private var railColor: Color {
-        explicitRailColor ?? .clear
-    }
-
-    private var explicitRailColor: Color? {
-        guard activeTabIndicatorStyle == .leftRail,
-              let custom = resolvedCustomTabColor else {
-            return nil
-        }
-        return custom.opacity(0.95)
-    }
-
-    private var resolvedCustomTabColor: Color? {
-        guard let hex = workspaceSnapshot.customColorHex else { return nil }
-        return WorkspaceTabColorSettings.displayColor(
-            hex: hex,
-            colorScheme: colorScheme,
-            forceBright: activeTabIndicatorStyle == .leftRail
-        )
     }
 
     private func tabColorSwatchColor(for hex: String) -> NSColor {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -238,7 +238,7 @@ func sidebarWorkspaceRowBackgroundStyle(
         if let customBackground {
             return SidebarWorkspaceRowBackgroundStyle(
                 color: customBackground,
-                opacity: 1
+                opacity: isMultiSelected ? 0.35 : 0.7
             )
         }
         if isMultiSelected {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -75,6 +75,66 @@ func cmuxAccentColor() -> Color {
     Color(nsColor: cmuxAccentNSColor())
 }
 
+private func sidebarSelectedWorkspaceRelativeLuminance(_ color: NSColor) -> CGFloat {
+    let rgbColor = color.usingColorSpace(.sRGB) ?? color
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+    rgbColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+
+    func linearized(_ component: CGFloat) -> CGFloat {
+        if component <= 0.03928 {
+            return component / 12.92
+        }
+        return pow((component + 0.055) / 1.055, 2.4)
+    }
+
+    let linearRed = linearized(red)
+    let linearGreen = linearized(green)
+    let linearBlue = linearized(blue)
+    return (0.2126 * linearRed) + (0.7152 * linearGreen) + (0.0722 * linearBlue)
+}
+
+private func sidebarSelectedWorkspaceContrastRatio(
+    between first: NSColor,
+    and second: NSColor
+) -> CGFloat {
+    let firstLuminance = sidebarSelectedWorkspaceRelativeLuminance(first)
+    let secondLuminance = sidebarSelectedWorkspaceRelativeLuminance(second)
+    let lighter = max(firstLuminance, secondLuminance)
+    let darker = min(firstLuminance, secondLuminance)
+    return (lighter + 0.05) / (darker + 0.05)
+}
+
+private func sidebarSelectedWorkspaceReadableBackgroundNSColor(_ color: NSColor) -> NSColor {
+    let minimumContrast: CGFloat = 4.5
+    var adjusted = color.usingColorSpace(.sRGB) ?? color
+    var iteration = 0
+
+    while sidebarSelectedWorkspaceContrastRatio(between: adjusted, and: NSColor.white) < minimumContrast,
+          iteration < 12 {
+        guard let darkened = adjusted.blended(withFraction: 0.12, of: .black) else { break }
+        adjusted = darkened.usingColorSpace(.sRGB) ?? darkened
+        iteration += 1
+    }
+
+    return adjusted
+}
+
+private func sidebarSelectedWorkspaceCustomBackgroundNSColor(
+    hex: String,
+    colorScheme: ColorScheme
+) -> NSColor? {
+    guard let color = WorkspaceTabColorSettings.displayNSColor(
+        hex: hex,
+        colorScheme: colorScheme
+    ) else {
+        return nil
+    }
+    return sidebarSelectedWorkspaceReadableBackgroundNSColor(color)
+}
+
 struct SidebarRemoteErrorCopyEntry: Equatable {
     let workspaceTitle: String
     let target: String
@@ -114,8 +174,16 @@ enum SidebarRemoteErrorCopySupport {
 
 func sidebarSelectedWorkspaceBackgroundNSColor(
     for colorScheme: ColorScheme,
+    customHex: String? = nil,
     sidebarSelectionColorHex: String? = UserDefaults.standard.string(forKey: "sidebarSelectionColorHex")
 ) -> NSColor {
+    if let customHex,
+       let customColor = sidebarSelectedWorkspaceCustomBackgroundNSColor(
+        hex: customHex,
+        colorScheme: colorScheme
+       ) {
+        return customColor
+    }
     if let hex = sidebarSelectionColorHex,
        let parsed = NSColor(hex: hex) {
         return parsed
@@ -168,7 +236,14 @@ func sidebarWorkspaceRowBackgroundStyle(
 
     case .solidFill:
         if isActive {
-            return SidebarWorkspaceRowBackgroundStyle(color: selectedBackground, opacity: 1)
+            return SidebarWorkspaceRowBackgroundStyle(
+                color: sidebarSelectedWorkspaceBackgroundNSColor(
+                    for: colorScheme,
+                    customHex: customColorHex,
+                    sidebarSelectionColorHex: sidebarSelectionColorHex
+                ),
+                opacity: 1
+            )
         }
         if let customBackground {
             return SidebarWorkspaceRowBackgroundStyle(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -223,11 +223,23 @@ func sidebarWorkspaceRowBackgroundStyle(
             forceBright: activeTabIndicatorStyle == .leftRail
         )
     }
+    let selectedCustomBackground = customColorHex.flatMap {
+        sidebarSelectedWorkspaceCustomBackgroundNSColor(hex: $0, colorScheme: colorScheme)
+    }
 
     switch activeTabIndicatorStyle {
     case .leftRail:
         if isActive {
-            return SidebarWorkspaceRowBackgroundStyle(color: selectedBackground, opacity: 1)
+            return SidebarWorkspaceRowBackgroundStyle(
+                color: selectedCustomBackground ?? selectedBackground,
+                opacity: 1
+            )
+        }
+        if let customBackground {
+            return SidebarWorkspaceRowBackgroundStyle(
+                color: customBackground,
+                opacity: isMultiSelected ? 0.28 : 0.16
+            )
         }
         if isMultiSelected {
             return SidebarWorkspaceRowBackgroundStyle(color: accentBackground, opacity: 0.25)
@@ -237,11 +249,7 @@ func sidebarWorkspaceRowBackgroundStyle(
     case .solidFill:
         if isActive {
             return SidebarWorkspaceRowBackgroundStyle(
-                color: sidebarSelectedWorkspaceBackgroundNSColor(
-                    for: colorScheme,
-                    customHex: customColorHex,
-                    sidebarSelectionColorHex: sidebarSelectionColorHex
-                ),
+                color: selectedCustomBackground ?? selectedBackground,
                 opacity: 1
             )
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13654,6 +13654,17 @@ private struct TabItemView: View, Equatable {
 
         if contextMenuState.isVisible {
             let deferredBaseline = contextMenuState.pendingWorkspaceSnapshot ?? workspaceSnapshotStorage
+            // Color changes are driven by explicit clicks in the Workspace Color
+            // submenu, and SwiftUI's context-menu content does not reliably fire
+            // `.onDisappear` after a button tap (issue #3037). Apply color
+            // changes immediately so the row reflects the user's selection
+            // instead of waiting on a flush that may never happen.
+            if deferredBaseline?.customColorHex != nextSnapshot.customColorHex {
+                workspaceSnapshotStorage = nextSnapshot
+                contextMenuState.pendingWorkspaceSnapshot = nil
+                contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
+                return
+            }
             if force || deferredBaseline != nextSnapshot {
                 contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
                 contextMenuState.pendingWorkspaceSnapshot = nextSnapshot

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -112,8 +112,11 @@ enum SidebarRemoteErrorCopySupport {
     }
 }
 
-func sidebarSelectedWorkspaceBackgroundNSColor(for colorScheme: ColorScheme) -> NSColor {
-    if let hex = UserDefaults.standard.string(forKey: "sidebarSelectionColorHex"),
+func sidebarSelectedWorkspaceBackgroundNSColor(
+    for colorScheme: ColorScheme,
+    sidebarSelectionColorHex: String? = UserDefaults.standard.string(forKey: "sidebarSelectionColorHex")
+) -> NSColor {
+    if let hex = sidebarSelectionColorHex,
        let parsed = NSColor(hex: hex) {
         return parsed
     }
@@ -123,6 +126,61 @@ func sidebarSelectedWorkspaceBackgroundNSColor(for colorScheme: ColorScheme) -> 
 func sidebarSelectedWorkspaceForegroundNSColor(opacity: CGFloat) -> NSColor {
     let clampedOpacity = max(0, min(opacity, 1))
     return NSColor.white.withAlphaComponent(clampedOpacity)
+}
+
+struct SidebarWorkspaceRowBackgroundStyle {
+    let color: NSColor?
+    let opacity: Double
+
+    static let clear = Self(color: nil, opacity: 0)
+}
+
+func sidebarWorkspaceRowBackgroundStyle(
+    activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle,
+    isActive: Bool,
+    isMultiSelected: Bool,
+    customColorHex: String?,
+    colorScheme: ColorScheme,
+    sidebarSelectionColorHex: String?
+) -> SidebarWorkspaceRowBackgroundStyle {
+    let selectedBackground = sidebarSelectedWorkspaceBackgroundNSColor(
+        for: colorScheme,
+        sidebarSelectionColorHex: sidebarSelectionColorHex
+    )
+    let accentBackground = cmuxAccentNSColor(for: colorScheme)
+    let customBackground = customColorHex.flatMap {
+        WorkspaceTabColorSettings.displayNSColor(
+            hex: $0,
+            colorScheme: colorScheme,
+            forceBright: activeTabIndicatorStyle == .leftRail
+        )
+    }
+
+    switch activeTabIndicatorStyle {
+    case .leftRail:
+        if isActive {
+            return SidebarWorkspaceRowBackgroundStyle(color: selectedBackground, opacity: 1)
+        }
+        if isMultiSelected {
+            return SidebarWorkspaceRowBackgroundStyle(color: accentBackground, opacity: 0.25)
+        }
+        return .clear
+
+    case .solidFill:
+        if isActive {
+            return SidebarWorkspaceRowBackgroundStyle(color: selectedBackground, opacity: 1)
+        }
+        if let customBackground {
+            return SidebarWorkspaceRowBackgroundStyle(
+                color: customBackground,
+                opacity: isMultiSelected ? 0.35 : 0.7
+            )
+        }
+        if isMultiSelected {
+            return SidebarWorkspaceRowBackgroundStyle(color: accentBackground, opacity: 0.25)
+        }
+        return .clear
+    }
 }
 
 #if compiler(>=6.2)
@@ -13792,28 +13850,17 @@ private struct TabItemView: View, Equatable {
         .disabled(!hasLatestNotifications(in: targetIds))
     }
 
-    private var selectionBackgroundColor: NSColor {
-        if let hex = sidebarSelectionColorHex, let parsed = NSColor(hex: hex) {
-            return parsed
-        }
-        return cmuxAccentNSColor(for: colorScheme)
-    }
-
     private var backgroundColor: Color {
-        switch activeTabIndicatorStyle {
-        case .leftRail:
-            if isActive        { return Color(nsColor: selectionBackgroundColor) }
-            if isMultiSelected { return cmuxAccentColor().opacity(0.25) }
-            return Color.clear
-        case .solidFill:
-            if isActive { return Color(nsColor: selectionBackgroundColor) }
-            if let custom = resolvedCustomTabColor {
-                if isMultiSelected { return custom.opacity(0.35) }
-                return custom.opacity(0.7)
-            }
-            if isMultiSelected { return cmuxAccentColor().opacity(0.25) }
-            return Color.clear
-        }
+        let style = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: activeTabIndicatorStyle,
+            isActive: isActive,
+            isMultiSelected: isMultiSelected,
+            customColorHex: workspaceSnapshot.customColorHex,
+            colorScheme: colorScheme,
+            sidebarSelectionColorHex: sidebarSelectionColorHex
+        )
+        guard let color = style.color else { return .clear }
+        return Color(nsColor: color).opacity(style.opacity)
     }
 
     private var railColor: Color {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -91,6 +91,38 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
         withExtendedLifetime(cancellable) {}
     }
+
+    @MainActor
+    func testSetTabColorFeedsSelectedDefaultSidebarBackground() {
+        let manager = TabManager()
+        guard let workspace = manager.tabs.first else {
+            XCTFail("Expected TabManager to initialise with a workspace")
+            return
+        }
+
+        var observedSidebarInvalidation = false
+        let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
+            observedSidebarInvalidation = true
+        }
+
+        manager.setTabColor(tabId: workspace.id, color: "#C0392B")
+
+        XCTAssertEqual(workspace.customColor, "#C0392B")
+        XCTAssertTrue(observedSidebarInvalidation)
+
+        let background = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .leftRail,
+            isActive: true,
+            isMultiSelected: false,
+            customColorHex: workspace.customColor,
+            colorScheme: .light,
+            sidebarSelectionColorHex: nil
+        )
+
+        XCTAssertEqual(background.color?.hexString(), "#C0392B")
+        XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
+        withExtendedLifetime(cancellable) {}
+    }
 }
 
 

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -59,6 +59,38 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         XCTAssertEqual(color.blueComponent, 1.0, accuracy: 0.001)
         XCTAssertEqual(color.alphaComponent, 0.65, accuracy: 0.001)
     }
+
+    @MainActor
+    func testSetTabColorFeedsSelectedSolidFillSidebarBackground() {
+        let manager = TabManager()
+        guard let workspace = manager.tabs.first else {
+            XCTFail("Expected TabManager to initialise with a workspace")
+            return
+        }
+
+        var observedSidebarInvalidation = false
+        let cancellable = workspace.sidebarImmediateObservationPublisher.sink {
+            observedSidebarInvalidation = true
+        }
+
+        manager.setTabColor(tabId: workspace.id, color: "#C0392B")
+
+        XCTAssertEqual(workspace.customColor, "#C0392B")
+        XCTAssertTrue(observedSidebarInvalidation)
+
+        let background = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: true,
+            isMultiSelected: false,
+            customColorHex: workspace.customColor,
+            colorScheme: .light,
+            sidebarSelectionColorHex: nil
+        )
+
+        XCTAssertEqual(background.color?.hexString(), "#C0392B")
+        XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
+        withExtendedLifetime(cancellable) {}
+    }
 }
 
 


### PR DESCRIPTION
## Summary
- route selected sidebar row background resolution through the current workspace custom color in `solidFill` mode
- keep left-rail behavior unchanged and preserve selection-color fallback when no workspace color is set
- add regression coverage proving `TabManager.setTabColor` publishes the color consumed by the sidebar row resolver

Closes #3037

## Testing
- Not run locally per repo policy; CI should show the first commit red and the fix commit green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Uses each workspace’s custom color for sidebar rows in both `solidFill` and default modes; in default mode, rows fill solid (no left rail) with tuned opacity for inactive and multi‑select states. Changes apply immediately from the color picker and fall back to the sidebar selection color when none is set; closes #3037.

- **New Features**
  - Centralizes row background style in `SidebarWorkspaceRowBackgroundStyle` used by `TabItemView`.
  - Ensures selected custom colors meet 4.5:1 contrast; sets inactive custom-color opacity to 0.7 (0.35 when multi-select).
  - Applies color picker changes immediately and adds regression tests for both sidebar modes.

<sup>Written for commit 3aa1c91dee43993cf34c841ac8ae2f6ac5acad9f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-workspace custom color override for sidebar selected backgrounds.

* **Improvements**
  * Auto-adjusts custom colors for contrast/readability and applies sensible opacity based on style, selection state, and multi-selection.
  * Centralized sidebar-row background resolution with clearer fallback behavior and consistent handling across indicator styles.
  * Context-menu snapshot flow now applies visible custom-color changes immediately and clears deferred state.

* **Tests**
  * Unit tests verifying tab color propagation to selected sidebar backgrounds for both indicator styles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->