### PR TITLE
Trim Stack Auth env values before StackServerApp

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -1,16 +1,21 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
+// `.trim()` guards against trailing whitespace/newlines in Vercel env var
+// values, which has tripped Stack Auth's UUID validator ("Invalid project
+// ID: <uuid>\n") on production deploys.
+const trimmedString = () => z.string().trim().min(1);
+
 export const env = createEnv({
   server: {
-    RESEND_API_KEY: z.string().min(1),
-    CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
-    CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
-    STACK_SECRET_SERVER_KEY: z.string().min(1),
+    RESEND_API_KEY: trimmedString(),
+    CMUX_FEEDBACK_FROM_EMAIL: z.string().trim().email(),
+    CMUX_FEEDBACK_RATE_LIMIT_ID: trimmedString(),
+    STACK_SECRET_SERVER_KEY: trimmedString(),
   },
   client: {
-    NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
-    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: z.string().min(1),
+    NEXT_PUBLIC_STACK_PROJECT_ID: trimmedString(),
+    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: trimmedString(),
   },
   runtimeEnv: {
     RESEND_API_KEY: process.env.RESEND_API_KEY,

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -1,29 +1,31 @@
 import { createEnv } from "@t3-oss/env-nextjs";
 import { z } from "zod";
 
-// `.trim()` guards against trailing whitespace/newlines in Vercel env var
-// values, which has tripped Stack Auth's UUID validator ("Invalid project
-// ID: <uuid>\n") on production deploys.
-const trimmedString = () => z.string().trim().min(1);
+// Trim at the runtimeEnv source so every consumer — including paths that
+// run when validation is skipped (VERCEL_ENV === "preview") — sees clean
+// values. A trailing newline in Vercel env vars has tripped Stack Auth's
+// UUID parser and malformed the stack-refresh-<project-id> cookie key.
+const trimEnv = (value: string | undefined): string | undefined =>
+  typeof value === "string" ? value.trim() : value;
 
 export const env = createEnv({
   server: {
-    RESEND_API_KEY: trimmedString(),
-    CMUX_FEEDBACK_FROM_EMAIL: z.string().trim().email(),
-    CMUX_FEEDBACK_RATE_LIMIT_ID: trimmedString(),
-    STACK_SECRET_SERVER_KEY: trimmedString(),
+    RESEND_API_KEY: z.string().min(1),
+    CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
+    CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
+    STACK_SECRET_SERVER_KEY: z.string().min(1),
   },
   client: {
-    NEXT_PUBLIC_STACK_PROJECT_ID: trimmedString(),
-    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: trimmedString(),
+    NEXT_PUBLIC_STACK_PROJECT_ID: z.string().min(1),
+    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: z.string().min(1),
   },
   runtimeEnv: {
-    RESEND_API_KEY: process.env.RESEND_API_KEY,
-    CMUX_FEEDBACK_FROM_EMAIL: process.env.CMUX_FEEDBACK_FROM_EMAIL,
-    CMUX_FEEDBACK_RATE_LIMIT_ID: process.env.CMUX_FEEDBACK_RATE_LIMIT_ID,
-    NEXT_PUBLIC_STACK_PROJECT_ID: process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
-    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
-    STACK_SECRET_SERVER_KEY: process.env.STACK_SECRET_SERVER_KEY,
+    RESEND_API_KEY: trimEnv(process.env.RESEND_API_KEY),
+    CMUX_FEEDBACK_FROM_EMAIL: trimEnv(process.env.CMUX_FEEDBACK_FROM_EMAIL),
+    CMUX_FEEDBACK_RATE_LIMIT_ID: trimEnv(process.env.CMUX_FEEDBACK_RATE_LIMIT_ID),
+    NEXT_PUBLIC_STACK_PROJECT_ID: trimEnv(process.env.NEXT_PUBLIC_STACK_PROJECT_ID),
+    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: trimEnv(process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY),
+    STACK_SECRET_SERVER_KEY: trimEnv(process.env.STACK_SECRET_SERVER_KEY),
   },
   skipValidation:
     process.env.SKIP_ENV_VALIDATION === "1" ||

--- a/web/app/lib/stack.ts
+++ b/web/app/lib/stack.ts
@@ -1,10 +1,14 @@
 import { StackServerApp } from "@stackframe/stack";
 import { env } from "../env";
 
+// `.trim()` at the consumption site too: `env` can skip zod validation in
+// preview builds (VERCEL_ENV === "preview"), which would pass unprocessed
+// values through. A trailing newline in a Vercel env var has tripped Stack
+// Auth's UUID parser ("Invalid project ID: <uuid>\n") during builds.
 export const stackServerApp = new StackServerApp({
-  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
-  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
-  secretServerKey: env.STACK_SECRET_SERVER_KEY,
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID.trim(),
+  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY.trim(),
+  secretServerKey: env.STACK_SECRET_SERVER_KEY.trim(),
   tokenStore: "nextjs-cookie",
   urls: {
     afterSignIn: "/handler/after-sign-in",

--- a/web/app/lib/stack.ts
+++ b/web/app/lib/stack.ts
@@ -1,14 +1,13 @@
 import { StackServerApp } from "@stackframe/stack";
 import { env } from "../env";
 
-// `.trim()` at the consumption site too: `env` can skip zod validation in
-// preview builds (VERCEL_ENV === "preview"), which would pass unprocessed
-// values through. A trailing newline in a Vercel env var has tripped Stack
-// Auth's UUID parser ("Invalid project ID: <uuid>\n") during builds.
+// env.ts now trims every runtimeEnv source, so consumers receive sanitized
+// values regardless of whether zod validation is skipped. No point-of-use
+// trim needed here.
 export const stackServerApp = new StackServerApp({
-  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID.trim(),
-  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY.trim(),
-  secretServerKey: env.STACK_SECRET_SERVER_KEY.trim(),
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
+  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
+  secretServerKey: env.STACK_SECRET_SERVER_KEY,
   tokenStore: "nextjs-cookie",
   urls: {
     afterSignIn: "/handler/after-sign-in",


### PR DESCRIPTION
## Summary
Production Vercel builds are failing after the merge of https://github.com/manaflow-ai/cmux/pull/3027 with:

```
Error: Invalid project ID: 9790718f-14cd-4f7e-824d-eaf527a82b82
.
```

The UUID is valid — the value in the Vercel dashboard has a trailing newline. Stack Auth's UUID parser rejects the un-trimmed string at module-evaluation time, so `/handler/[...stack]` page-data collection crashes the build.

Fix: two layers of trimming so whitespace typos in the env dashboard can't reach `StackServerApp`:

1. `web/app/env.ts` schemas switch to `z.string().trim().min(1)` (plus `.email()` for the feedback address) so trimmed values flow to every consumer.
2. `web/app/lib/stack.ts` also `.trim()`s at construction. Necessary because env.ts skips validation when `VERCEL_ENV === "preview"`, which would otherwise pass the raw runtime value straight through.

The Vercel dashboard env var should also be corrected to remove the trailing newline — this PR just stops that typo from being load-bearing.

## Test plan
- [x] `bun run build` with a deliberately-newlined `NEXT_PUBLIC_STACK_PROJECT_ID` completes end-to-end instead of failing at `/handler/[...stack]`.
- [ ] Vercel Preview for this PR builds green.
- [ ] Production `https://cmux.com/handler/sign-in` returns 200 after merging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatically trims leading/trailing whitespace from environment variables to prevent credential parsing failures caused by extra spaces or newlines.
  * Improved initialization sanitization so API keys and identifiers are normalized reliably without changing public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trims Stack Auth env vars at the `runtimeEnv` source so trailing whitespace never reaches `StackServerApp`, fixing Vercel build failures (“Invalid project ID: <uuid>\n”) and preventing malformed cookie keys.

- **Bug Fixes**
  - In `web/app/env.ts`, add `trimEnv` and wrap all critical `runtimeEnv` values to ensure clean strings even when `@t3-oss/env-nextjs` validation is skipped (e.g., preview).
  - In `web/app/lib/stack.ts`, remove point-of-use `.trim()` since env is already sanitized.

<sup>Written for commit 6980a90414a675a228eb2f956beb6f5fdee321bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

