### PR TITLE
Route Files panel opens through editor settings

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2837,6 +2837,16 @@ struct ContentView: View {
                 sessionIndexStore: sessionIndexStore,
                 onResumeSession: { entry in
                     resumeSession(entry: entry)
+                },
+                onOpenMarkdown: { path in
+                    guard let workspace = tabManager.selectedWorkspace,
+                          let panelId = workspace.focusedPanelId else {
+                        PreferredEditorSettings.open(URL(fileURLWithPath: path))
+                        return
+                    }
+                    if workspace.openOrFocusMarkdownSplit(from: panelId, filePath: path) == nil {
+                        PreferredEditorSettings.open(URL(fileURLWithPath: path))
+                    }
                 }
             )
                 .frame(width: explorerVisible ? fileExplorerWidth : 0)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2839,8 +2839,15 @@ struct ContentView: View {
                     resumeSession(entry: entry)
                 },
                 onOpenMarkdown: { path in
-                    guard let workspace = tabManager.selectedWorkspace,
-                          let panelId = workspace.focusedPanelId else {
+                    guard let workspace = tabManager.selectedWorkspace else {
+                        PreferredEditorSettings.open(URL(fileURLWithPath: path))
+                        return
+                    }
+                    let panelId = workspace.focusedPanelId
+                        ?? workspace.bonsplitController.allPaneIds.first.flatMap {
+                            workspace.effectiveSelectedPanelId(inPane: $0)
+                        }
+                    guard let panelId else {
                         PreferredEditorSettings.open(URL(fileURLWithPath: path))
                         return
                     }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -10,9 +10,12 @@ import SwiftUI
 struct FileExplorerPanelView: NSViewRepresentable {
     @ObservedObject var store: FileExplorerStore
     @ObservedObject var state: FileExplorerState
+    /// Called when the user opens a markdown file and the cmux viewer should handle it.
+    /// The parent view routes this to Workspace.openOrFocusMarkdownSplit.
+    var onOpenMarkdown: ((String) -> Void)?
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(store: store, state: state)
+        Coordinator(store: store, state: state, onOpenMarkdown: onOpenMarkdown)
     }
 
     func makeNSView(context: Context) -> FileExplorerContainerView {
@@ -24,6 +27,7 @@ struct FileExplorerPanelView: NSViewRepresentable {
     func updateNSView(_ container: FileExplorerContainerView, context: Context) {
         context.coordinator.store = store
         context.coordinator.state = state
+        context.coordinator.onOpenMarkdown = onOpenMarkdown
         container.updateHeader(store: store)
         context.coordinator.reloadIfNeeded()
     }
@@ -33,15 +37,17 @@ struct FileExplorerPanelView: NSViewRepresentable {
     final class Coordinator: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate, NSMenuDelegate {
         var store: FileExplorerStore
         var state: FileExplorerState
+        var onOpenMarkdown: ((String) -> Void)?
         weak var containerView: FileExplorerContainerView?
         weak var outlineView: NSOutlineView?
         private var lastRootNodeCount: Int = -1
         private var observationCancellable: AnyCancellable?
         private var styleObserver: Any?
 
-        init(store: FileExplorerStore, state: FileExplorerState) {
+        init(store: FileExplorerStore, state: FileExplorerState, onOpenMarkdown: ((String) -> Void)?) {
             self.store = store
             self.state = state
+            self.onOpenMarkdown = onOpenMarkdown
             super.init()
             observeStore()
             styleObserver = NotificationCenter.default.addObserver(
@@ -269,7 +275,12 @@ struct FileExplorerPanelView: NSViewRepresentable {
 
         @objc private func contextMenuOpenInDefaultEditor(_ sender: NSMenuItem) {
             guard let node = sender.representedObject as? FileExplorerNode else { return }
-            NSWorkspace.shared.open(URL(fileURLWithPath: node.path))
+            if CmdClickMarkdownRouteSettings.shouldRoute(path: node.path),
+               let handler = onOpenMarkdown {
+                handler(node.path)
+                return
+            }
+            PreferredEditorSettings.open(URL(fileURLWithPath: node.path))
         }
 
         @objc private func contextMenuRevealInFinder(_ sender: NSMenuItem) {

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -27,6 +27,7 @@ struct RightSidebarPanelView: View {
     @ObservedObject var fileExplorerState: FileExplorerState
     @ObservedObject var sessionIndexStore: SessionIndexStore
     let onResumeSession: ((SessionEntry) -> Void)?
+    var onOpenMarkdown: ((String) -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -69,7 +70,7 @@ struct RightSidebarPanelView: View {
     private var contentForMode: some View {
         switch fileExplorerState.mode {
         case .files:
-            FileExplorerPanelView(store: fileExplorerStore, state: fileExplorerState)
+            FileExplorerPanelView(store: fileExplorerStore, state: fileExplorerState, onOpenMarkdown: onOpenMarkdown)
         case .sessions:
             SessionIndexView(store: sessionIndexStore, onResume: onResumeSession)
                 .onAppear {


### PR DESCRIPTION
Fixes #3067. Extends the markdown/editor routing from #2904 to the Files panel context menu.

"Open in Default Editor" in the Files panel now respects `app.preferredEditor` and `app.openMarkdownInCmuxViewer` settings. Previously these only applied to terminal cmd-click links.

Markdown files route to the built-in viewer split. Everything else goes through the configured editor, falling back to NSWorkspace.

## Test plan

- [ ] Set `app.preferredEditor` and `app.openMarkdownInCmuxViewer` in settings.json
- [ ] Right-click .md in Files panel -> opens in cmux markdown viewer
- [ ] Right-click .py/.go -> opens in configured editor
- [ ] Without settings, falls back to system default