### PR TITLE
Use site Geist fonts on Stack Auth handler pages

### DIFF
--- a/web/app/handler/layout.tsx
+++ b/web/app/handler/layout.tsx
@@ -1,6 +1,22 @@
 import { Suspense } from "react";
+import { Geist, Geist_Mono } from "next/font/google";
 import { StackProvider, StackTheme } from "@stackframe/stack";
 import { stackServerApp } from "../lib/stack";
+import "../globals.css";
+
+// Load the same Geist fonts the rest of the site uses so the Stack Auth
+// handler pages don't fall back to the browser's default serif. globals.css
+// is imported to pull in the Tailwind layer that declares the font-sans
+// utility these variables feed into.
+const geistSans = Geist({
+  variable: "--font-geist-sans",
+  subsets: ["latin"],
+});
+
+const geistMono = Geist_Mono({
+  variable: "--font-geist-mono",
+  subsets: ["latin"],
+});
 
 export default function HandlerLayout({
   children,
@@ -9,7 +25,9 @@ export default function HandlerLayout({
 }) {
   return (
     <html lang="en" suppressHydrationWarning>
-      <body>
+      <body
+        className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased`}
+      >
         <Suspense>
           <StackProvider app={stackServerApp}>
             <StackTheme>{children}</StackTheme>


### PR DESCRIPTION
## Summary

`/handler/sign-in` was rendering in Times New Roman because `web/app/handler/layout.tsx` emitted bare `<html>/<body>` with no font. Loaded `Geist` + `Geist_Mono` the same way `web/app/[locale]/layout.tsx` does, applied the `font-sans antialiased` Tailwind classes to the body, and imported `globals.css` so Tailwind's utilities are wired up on this route.

## Test plan
- [x] `bun run build` succeeds and emits `/handler/[...stack]` / `/handler/after-sign-in`.
- [ ] Vercel preview: sign-in page renders in Geist, not Times New Roman.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated typography across handler pages with the new Geist font family and applied text antialiasing for improved visual appearance and readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->