### PR TITLE
Raise all cmux windows on auth callback, Settings on top

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2529,6 +2529,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 } catch {
                     NSLog("auth.callback failed: %@", "\(error)")
                 }
+                self.focusAppAfterAuthCallback()
             }
         }
 
@@ -6776,6 +6777,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if !didAttemptStartupSessionRestore {
             startupSessionSnapshot = nil
             didAttemptStartupSessionRestore = true
+        }
+    }
+
+    private func focusAppAfterAuthCallback() {
+        // When the sign-in deeplink returns through the browser only the
+        // Settings window gets re-fronted by default, leaving any regular
+        // cmux workspace windows buried behind other apps. Activate the
+        // app, re-front every visible cmux window in back-to-front order
+        // to preserve relative z-order, then raise Settings on top.
+        NSApplication.shared.activate(ignoringOtherApps: true)
+
+        let settingsWindow = SettingsWindowController.shared.window
+        let visible = NSApp.orderedWindows.filter { $0.isVisible }
+        for window in visible.reversed() where window !== settingsWindow {
+            window.orderFront(nil)
+        }
+        if let settingsWindow, settingsWindow.isVisible {
+            settingsWindow.makeKeyAndOrderFront(nil)
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6799,17 +6799,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     /// user's workspace windows keep their relative z-order and the
     /// Settings window lands on top.
     private func raiseWindowsAfterAuthCallback() {
-        // Second activate to catch the case where the activation request
-        // was queued during the synchronous handler but hadn't landed yet.
         NSApp.activate()
         NSRunningApplication.current.activate(options: [.activateAllWindows])
 
         let settingsWindow = SettingsWindowController.shared.window
         let visible = NSApp.orderedWindows.filter { $0.isVisible }
-        // Iterate back-to-front so `makeKeyAndOrderFront` on the first
-        // workspace window forces activation (where `orderFrontRegardless`
-        // alone does not), and subsequent windows layer above it in their
-        // original relative order.
         let workspaceWindows = visible.reversed().filter { $0 !== settingsWindow }
         for (idx, window) in workspaceWindows.enumerated() {
             if idx == 0 {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6781,17 +6781,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func focusAppAfterAuthCallback() {
-        // When the sign-in deeplink returns through the browser only the
-        // Settings window gets re-fronted by default, leaving any regular
-        // cmux workspace windows buried behind other apps. Activate the
-        // app, re-front every visible cmux window in back-to-front order
-        // to preserve relative z-order, then raise Settings on top.
-        NSApplication.shared.activate(ignoringOtherApps: true)
+        // The default URL-open activation only brings the Settings window
+        // forward, leaving workspace windows buried behind other apps.
+        // .activateAllWindows is the macOS 14+ idiom for "this app is
+        // foreground again, bring every one of its windows along." The
+        // deprecated NSApp.activate(ignoringOtherApps:) falls back to
+        // cooperative activation on recent macOS and drops non-key windows.
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
 
         let settingsWindow = SettingsWindowController.shared.window
+        // orderedWindows is front-to-back. Iterate reversed so each
+        // orderFrontRegardless moves a back window forward without
+        // shuffling relative z-order.
         let visible = NSApp.orderedWindows.filter { $0.isVisible }
         for window in visible.reversed() where window !== settingsWindow {
-            window.orderFront(nil)
+            window.orderFrontRegardless()
         }
         if let settingsWindow, settingsWindow.isVisible {
             settingsWindow.makeKeyAndOrderFront(nil)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2522,6 +2522,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func application(_ application: NSApplication, open urls: [URL]) {
         let authCallbacks = urls.filter(AuthCallbackRouter.isAuthCallbackURL)
+        if !authCallbacks.isEmpty {
+            // macOS 14+ only grants activate() in response to a user event
+            // when the call fires synchronously inside the event handler.
+            // Once we hop to a Task {} the "user event context" is gone
+            // and cooperative activation refuses. Activate here first,
+            // then re-order windows after handleCallbackURL finishes.
+            focusAppForAuthCallback()
+        }
         for url in authCallbacks {
             Task { @MainActor in
                 do {
@@ -2529,7 +2537,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 } catch {
                     NSLog("auth.callback failed: %@", "\(error)")
                 }
-                self.focusAppAfterAuthCallback()
+                self.raiseWindowsAfterAuthCallback()
             }
         }
 
@@ -6780,22 +6788,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    private func focusAppAfterAuthCallback() {
-        // The default URL-open activation only brings the Settings window
-        // forward, leaving workspace windows buried behind other apps.
-        // .activateAllWindows is the macOS 14+ idiom for "this app is
-        // foreground again, bring every one of its windows along." The
-        // deprecated NSApp.activate(ignoringOtherApps:) falls back to
-        // cooperative activation on recent macOS and drops non-key windows.
+    /// Synchronous, runs inside `application(_:open:)` so macOS 14+
+    /// cooperative activation still sees the user-event context.
+    private func focusAppForAuthCallback() {
+        NSApp.activate()
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
+    }
+
+    /// Runs after `handleCallbackURL` completes. Re-orders windows so the
+    /// user's workspace windows keep their relative z-order and the
+    /// Settings window lands on top.
+    private func raiseWindowsAfterAuthCallback() {
+        // Second activate to catch the case where the activation request
+        // was queued during the synchronous handler but hadn't landed yet.
+        NSApp.activate()
         NSRunningApplication.current.activate(options: [.activateAllWindows])
 
         let settingsWindow = SettingsWindowController.shared.window
-        // orderedWindows is front-to-back. Iterate reversed so each
-        // orderFrontRegardless moves a back window forward without
-        // shuffling relative z-order.
         let visible = NSApp.orderedWindows.filter { $0.isVisible }
-        for window in visible.reversed() where window !== settingsWindow {
-            window.orderFrontRegardless()
+        // Iterate back-to-front so `makeKeyAndOrderFront` on the first
+        // workspace window forces activation (where `orderFrontRegardless`
+        // alone does not), and subsequent windows layer above it in their
+        // original relative order.
+        let workspaceWindows = visible.reversed().filter { $0 !== settingsWindow }
+        for (idx, window) in workspaceWindows.enumerated() {
+            if idx == 0 {
+                window.makeKeyAndOrderFront(nil)
+            } else {
+                window.orderFrontRegardless()
+            }
         }
         if let settingsWindow, settingsWindow.isVisible {
             settingsWindow.makeKeyAndOrderFront(nil)


### PR DESCRIPTION
## Summary

After completing the Stack Auth sign-in and clicking "Return to cmux" on the browser handoff page, only the Settings window got focused. Any workspace windows stayed buried behind whatever app was in front before — the flow surfaced the Settings row UI update, but the rest of cmux was lost.

`AppDelegate.application(_:open:)` now calls `focusAppAfterAuthCallback()` once `handleCallbackURL` resolves:
1. `NSApp.activate(ignoringOtherApps: true)` brings cmux to the foreground.
2. Iterate `NSApp.orderedWindows.reversed()`, calling `orderFront(nil)` on each visible non-Settings window so their relative z-order is preserved.
3. `makeKeyAndOrderFront(nil)` on the Settings window so the just-signed-in row lands on top.

## Test plan
- [x] Build is green locally.
- [ ] Sign out, open multiple workspace windows (order A front, B behind), open Settings, click Sign In…, complete in the browser, click Return to cmux. Workspace A should be in front, B behind, Settings above everything.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Synchronously activate cmux on the Stack Auth callback, then restore all windows with workspace order preserved and Settings on top. Fixes cases where only Settings came forward and other windows stayed behind other apps.

- **Bug Fixes**
  - Activate inside `application(_:open:)` using `NSApp.activate()` and `NSRunningApplication.current.activate(options: [.activateAllWindows])` so macOS 14+ grants focus.
  - After `handleCallbackURL`, re-order visible windows back-to-front (`makeKeyAndOrderFront` first workspace, `orderFrontRegardless` others) and make Settings key and front.

<sup>Written for commit 249c4a6e92ff3cd463a57e3fe38d9e164b75f6c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved app focus and window ordering after completing browser-based authentication. The app now immediately regains focus before handling callbacks, reactivates and restores visible windows after each callback, preserves their relative order, and ensures the Settings window is brought forward and made key when visible for a smoother post-authentication experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->