### PR TITLE
Fix SwiftTerm scrollbar resize oscillation

### DIFF
--- a/Sources/TerminalView.swift
+++ b/Sources/TerminalView.swift
@@ -43,6 +43,17 @@ class FocusableTerminalView: NSView {
     private var scrollMonitor: Any?
     private var lastScrollerValue: Double = 0
 
+    private static func fallbackScrollerWidth() -> CGFloat {
+        // SwiftTerm's macOS TerminalView currently creates a regular legacy
+        // NSScroller internally, even though cmux fades it like an overlay.
+        NSScroller.scrollerWidth(for: .regular, scrollerStyle: .legacy)
+    }
+
+    private func reservedScrollerWidth() -> CGFloat {
+        let measuredWidth = scroller?.frame.width ?? 0
+        return measuredWidth > 0 ? measuredWidth : Self.fallbackScrollerWidth()
+    }
+
     override var acceptsFirstResponder: Bool { true }
 
     override func becomeFirstResponder() -> Bool {
@@ -61,17 +72,13 @@ class FocusableTerminalView: NSView {
 
     override func layout() {
         super.layout()
-        if let tv = terminalView, bounds.size.width > 0, bounds.size.height > 0 {
-            tv.setFrameSize(bounds.size)
-            setupScrollerTracking(in: tv)
-        }
+        updateTerminalFrame()
     }
 
     override func viewDidMoveToWindow() {
         super.viewDidMoveToWindow()
-        if window != nil, let tv = terminalView, bounds.size.width > 0 {
-            tv.setFrameSize(bounds.size)
-            setupScrollerTracking(in: tv)
+        if window != nil {
+            updateTerminalFrame()
             setupScrollMonitor()
         }
     }
@@ -81,6 +88,23 @@ class FocusableTerminalView: NSView {
         if newWindow == nil, let monitor = scrollMonitor {
             NSEvent.removeMonitor(monitor)
             scrollMonitor = nil
+        }
+    }
+
+    private func updateTerminalFrame() {
+        guard let tv = terminalView, bounds.size.width > 0, bounds.size.height > 0 else { return }
+        setupScrollerTracking(in: tv)
+
+        let reservedWidth = reservedScrollerWidth()
+        let terminalSize = NSSize(
+            width: max(0, bounds.size.width - reservedWidth),
+            height: bounds.size.height
+        )
+        if tv.frame.origin != .zero {
+            tv.setFrameOrigin(.zero)
+        }
+        if tv.frame.size != terminalSize {
+            tv.setFrameSize(terminalSize)
         }
     }
 


### PR DESCRIPTION
## Summary
- Reserve the measured SwiftTerm scroller width when sizing `FocusableTerminalView`'s hosted terminal view.
- Use the actual internal scroller frame width when available, with a dynamic regular legacy `NSScroller` fallback instead of a hardcoded 15px value.
- Apply the stable terminal sizing from both layout and window attachment paths.

## Testing
- Not run locally per repo policy.
- Regression test skipped: `Sources/TerminalView.swift` is not part of the active Xcode app target, and adding this legacy SwiftTerm wrapper plus a new SwiftTerm package product to the target only for test visibility would create extra production surface beyond the fix.

Fixes #3051

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved terminal view layout management by consolidating frame setup logic and optimizing scroller width calculations for more reliable rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes scrollbar/PTY resize oscillation in the `SwiftTerm` terminal by reserving scroller width and applying stable frame updates during layout and window attach. Fixes #3051.

- **Bug Fixes**
  - Reserve the measured internal scroller width; fall back to `NSScroller.scrollerWidth(for: .regular, scrollerStyle: .legacy)` (no hardcoded 15px).
  - Centralize sizing in `updateTerminalFrame()`, called from `layout()` and `viewDidMoveToWindow()`; keeps origin at `.zero` and only resizes when needed.
  - Set up scroller tracking before sizing so the width is known and oscillation is avoided.

<sup>Written for commit f507678df74c1ea69109fba83be3f2445d3424f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

