### PR TITLE
Drop stale merged PR from sidebar badge selection (#3054)

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -817,7 +817,7 @@ class TabManager: ObservableObject {
     }
 
     private struct WorkspacePullRequestRESTItem: Decodable, Sendable {
-        struct Head: Decodable, Sendable {
+        struct Ref: Decodable, Sendable {
             let ref: String
         }
 
@@ -826,7 +826,8 @@ class TabManager: ObservableObject {
         let htmlURL: String
         let updatedAt: String?
         let mergedAt: String?
-        let head: Head
+        let head: Ref
+        let base: Ref?
 
         enum CodingKeys: String, CodingKey {
             case number
@@ -835,6 +836,7 @@ class TabManager: ObservableObject {
             case updatedAt = "updated_at"
             case mergedAt = "merged_at"
             case head
+            case base
         }
     }
 
@@ -843,20 +845,26 @@ class TabManager: ObservableObject {
         let state: String
         let url: String
         let updatedAt: String?
+        let mergedAt: String?
         let headRefName: String?
+        let baseRefName: String?
 
         init(
             number: Int,
             state: String,
             url: String,
             updatedAt: String?,
-            headRefName: String? = nil
+            mergedAt: String? = nil,
+            headRefName: String? = nil,
+            baseRefName: String? = nil
         ) {
             self.number = number
             self.state = state
             self.url = url
             self.updatedAt = updatedAt
+            self.mergedAt = mergedAt
             self.headRefName = headRefName
+            self.baseRefName = baseRefName
         }
     }
 
@@ -2836,7 +2844,9 @@ class TabManager: ObservableObject {
             state: rawState,
             url: pullRequest.htmlURL,
             updatedAt: pullRequest.updatedAt,
-            headRefName: pullRequest.head.ref
+            mergedAt: pullRequest.mergedAt,
+            headRefName: pullRequest.head.ref,
+            baseRefName: pullRequest.base?.ref
         )
     }
 
@@ -2891,8 +2901,16 @@ class TabManager: ObservableObject {
         return "Bearer \(token)"
     }
 
+    nonisolated static func pullRequestMapByNormalizedBranchForTesting(
+        from pullRequests: [GitHubPullRequestProbeItem],
+        now: Date
+    ) -> [String: GitHubPullRequestProbeItem] {
+        pullRequestMapByNormalizedBranch(from: pullRequests, now: now)
+    }
+
     private nonisolated static func pullRequestMapByNormalizedBranch(
-        from pullRequests: [GitHubPullRequestProbeItem]
+        from pullRequests: [GitHubPullRequestProbeItem],
+        now: Date = Date()
     ) -> [String: GitHubPullRequestProbeItem] {
         var pullRequestsByBranch: [String: GitHubPullRequestProbeItem] = [:]
 
@@ -2904,7 +2922,10 @@ class TabManager: ObservableObject {
             }
 
             if let currentBest = pullRequestsByBranch[branch] {
-                pullRequestsByBranch[branch] = preferredPullRequest(from: [currentBest, pullRequest]) ?? currentBest
+                pullRequestsByBranch[branch] = preferredPullRequest(
+                    from: [currentBest, pullRequest],
+                    now: now
+                ) ?? currentBest
             } else {
                 pullRequestsByBranch[branch] = pullRequest
             }
@@ -2914,7 +2935,8 @@ class TabManager: ObservableObject {
     }
 
     nonisolated static func preferredPullRequest(
-        from pullRequests: [GitHubPullRequestProbeItem]
+        from pullRequests: [GitHubPullRequestProbeItem],
+        now: Date = Date()
     ) -> GitHubPullRequestProbeItem? {
         func statusPriority(_ status: SidebarPullRequestStatus) -> Int {
             switch status {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -890,6 +890,7 @@ class TabManager: ObservableObject {
     private nonisolated static let workspacePullRequestTerminalStateSweepInterval: TimeInterval = 15 * 60
     private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
+    private nonisolated static let mergedPullRequestBadgeStaleAfter: TimeInterval = 14 * 24 * 60 * 60
     @Published var selectedTabId: UUID? {
         willSet {
 #if DEBUG
@@ -2916,8 +2917,7 @@ class TabManager: ObservableObject {
 
         for pullRequest in pullRequests {
             guard let branch = normalizedBranchName(pullRequest.headRefName),
-                  pullRequestStatus(from: pullRequest.state) != nil,
-                  URL(string: pullRequest.url) != nil else {
+                  isSidebarPullRequestCandidate(pullRequest, now: now) else {
                 continue
             }
 
@@ -2975,8 +2975,7 @@ class TabManager: ObservableObject {
 
         var best: GitHubPullRequestProbeItem?
         for pullRequest in pullRequests {
-            guard pullRequestStatus(from: pullRequest.state) != nil,
-                  URL(string: pullRequest.url) != nil else {
+            guard isSidebarPullRequestCandidate(pullRequest, now: now) else {
                 continue
             }
             guard let currentBest = best else {
@@ -2988,6 +2987,41 @@ class TabManager: ObservableObject {
             }
         }
         return best
+    }
+
+    private nonisolated static func isSidebarPullRequestCandidate(
+        _ pullRequest: GitHubPullRequestProbeItem,
+        now: Date
+    ) -> Bool {
+        guard pullRequestStatus(from: pullRequest.state) != nil,
+              URL(string: pullRequest.url) != nil else {
+            return false
+        }
+        return !isStaleMergedPullRequest(pullRequest, now: now)
+    }
+
+    private nonisolated static func isStaleMergedPullRequest(
+        _ pullRequest: GitHubPullRequestProbeItem,
+        now: Date
+    ) -> Bool {
+        guard pullRequestStatus(from: pullRequest.state) == .merged,
+              let mergedAt = githubTimestampDate(from: pullRequest.mergedAt) else {
+            return false
+        }
+        return now.timeIntervalSince(mergedAt) > mergedPullRequestBadgeStaleAfter
+    }
+
+    private nonisolated static func githubTimestampDate(from rawTimestamp: String?) -> Date? {
+        let timestamp = rawTimestamp?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !timestamp.isEmpty else { return nil }
+
+        let formatter = ISO8601DateFormatter()
+        if let date = formatter.date(from: timestamp) {
+            return date
+        }
+
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.date(from: timestamp)
     }
 
     private nonisolated static func pullRequestStatus(

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -393,6 +393,47 @@ final class TabManagerPullRequestProbeTests: XCTestCase {
         )
     }
 
+    func testPullRequestMapDropsStaleMergedHeadPullRequestForLongLivedBaseBranch() throws {
+        let now = try XCTUnwrap(ISO8601DateFormatter().date(from: "2026-04-20T12:00:00Z"))
+        let pullRequests = [
+            TabManager.GitHubPullRequestProbeItem(
+                number: 2400,
+                state: "MERGED",
+                url: "https://github.com/manaflow-ai/cmux/pull/2400",
+                updatedAt: "2026-03-06T12:00:00Z",
+                mergedAt: "2026-03-06T12:00:00Z",
+                headRefName: "develop",
+                baseRefName: "main"
+            ),
+            TabManager.GitHubPullRequestProbeItem(
+                number: 2501,
+                state: "MERGED",
+                url: "https://github.com/manaflow-ai/cmux/pull/2501",
+                updatedAt: "2026-04-19T12:00:00Z",
+                mergedAt: "2026-04-19T12:00:00Z",
+                headRefName: "feature/recent-one",
+                baseRefName: "develop"
+            ),
+            TabManager.GitHubPullRequestProbeItem(
+                number: 2502,
+                state: "OPEN",
+                url: "https://github.com/manaflow-ai/cmux/pull/2502",
+                updatedAt: "2026-04-20T12:00:00Z",
+                headRefName: "feature/recent-two",
+                baseRefName: "develop"
+            ),
+        ]
+
+        let pullRequestsByBranch = TabManager.pullRequestMapByNormalizedBranchForTesting(
+            from: pullRequests,
+            now: now
+        )
+
+        XCTAssertNil(pullRequestsByBranch["develop"])
+        XCTAssertEqual(pullRequestsByBranch["feature/recent-one"]?.number, 2501)
+        XCTAssertEqual(pullRequestsByBranch["feature/recent-two"]?.number, 2502)
+    }
+
     func testShouldSkipWorkspacePullRequestLookupOnlyForExactMainAndMaster() {
         XCTAssertTrue(TabManager.shouldSkipWorkspacePullRequestLookup(branch: "main"))
         XCTAssertTrue(TabManager.shouldSkipWorkspacePullRequestLookup(branch: "master"))


### PR DESCRIPTION
## Summary

Fixes #3054 by filtering stale merged PRs out of the sidebar PR badge selection path.

## Reporter Scenario

Before: a long-lived `develop` workspace could keep showing an old merged `head=develop` PR indefinitely, even while newer `feature/* -> develop` PRs existed, because badge selection grouped candidates by PR head branch and had no stale merged cutoff.

After: merged PR candidates with `mergedAt` older than 14 days are dropped before per-branch selection. If that leaves no candidate for `develop`, the sidebar shows no PR badge instead of falling back to the stale merged PR.

## Tests

- Added a deterministic unit regression with an old merged `head=develop` PR plus newer `feature/*` PRs targeting `develop`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops stale merged PRs from the sidebar badge selection to stop long‑lived branches from showing outdated badges. If no recent PR exists for a branch (e.g., `develop`), the badge is hidden. Addresses #3054.

- **Bug Fixes**
  - Excludes merged PRs older than 14 days from candidate selection using `isSidebarPullRequestCandidate`.
  - Adds `mergedAt` and `baseRefName` to PR probe items and parses `mergedAt` from REST.
  - Adds robust ISO8601 parsing (with fractional seconds) for timestamps.
  - Adds a unit test to verify stale merged `head=develop` is dropped while newer `feature/* -> develop` PRs are kept.

<sup>Written for commit 27ddb7220e9d9d56d6b1e8a159081b24d3f9e469. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced pull request management by introducing age-based filtering for merged pull requests. Merged PRs older than a configured threshold are now automatically excluded from sidebar candidate selection, keeping the interface focused on recent changes and reducing noise.

* **Tests**
  * Added comprehensive test coverage for merged pull request staleness filtering and candidate selection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->