### PR TITLE
feat: leading-edge tab close button (macOS HIG)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -112265,6 +112265,601 @@
     "rightSidebar.remote.error.modeUnavailable": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: Right sidebar mode '%@' is not available" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: 右サイドバーのモード '%@' は利用できません" } } } },
     "rightSidebar.remote.error.appDelegateUnavailable": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "ERROR: App delegate not available" } }, "ja": { "stringUnit": { "state": "translated", "value": "ERROR: アプリデリゲートを利用できません" } } } },
     "notificationHook.failure.title": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Notification Hook Failed" } }, "ja": { "stringUnit": { "state": "translated", "value": "通知フックに失敗しました" } } } },
-    "notificationHook.failure.body": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "cmux used default notification behavior because '%@' failed." } }, "ja": { "stringUnit": { "state": "translated", "value": "'%@' が失敗したため、cmux は既定の通知動作を使用しました。" } } } }
+    "notificationHook.failure.body": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "cmux used default notification behavior because '%@' failed." } }, "ja": { "stringUnit": { "state": "translated", "value": "'%@' が失敗したため、cmux は既定の通知動作を使用しました。" } } } },
+    "settings.tabCloseButton.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab close button position"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブの閉じるボタンの位置"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 닫기 버튼 위치"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tab close button position"
+          }
+        }
+      }
+    },
+    "settings.tabCloseButton.leading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Left"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "左"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Left"
+          }
+        }
+      }
+    },
+    "settings.tabCloseButton.trailing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Right"
+          }
+        }
+      }
+    },
+    "settings.tabCloseButton.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS の Safari や Finder と同じく閉じるボタンを先頭に配置するか、末尾のままにします。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS의 Safari/Finder처럼 닫기(×) 버튼을 앞쪽에 두거나 뒤쪽에 유지합니다."
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+          }
+        }
+      }
+    },
+    "settings.section.tabs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tabs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブ"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Tabs"
+          }
+        }
+      }
+    }
   }
 }

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -6,6 +6,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
     case terminal
     case sidebarAppearance
     case betaFeatures
+    case tabs
     case automation
     case browser
     case browserImport
@@ -31,6 +32,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar")
         case .betaFeatures:
             return String(localized: "settings.section.betaFeatures", defaultValue: "Beta Features")
+        case .tabs:
+            return String(localized: "settings.section.tabs", defaultValue: "Tabs")
         case .automation:
             return String(localized: "settings.section.automation", defaultValue: "Automation")
         case .browser:
@@ -62,6 +65,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "sidebar.left"
         case .betaFeatures:
             return "exclamationmark.triangle"
+        case .tabs:
+            return "rectangle.split.3x1"
         case .automation:
             return "wand.and.sparkles"
         case .browser:
@@ -93,6 +98,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "\(title) sidebar details branches badges material terminal background"
         case .betaFeatures:
             return "\(title) beta experimental unstable feed dock right sidebar"
+        case .tabs:
+            return "\(title) tab close button position leading trailing left right safari finder hig macos"
         case .automation:
             return "\(title) socket integrations hooks ports claude cursor gemini"
         case .browser:
@@ -335,6 +342,7 @@ enum SettingsSearchIndex {
         setting(.sidebarAppearance, "show-progress", String(localized: "settings.app.showProgress", defaultValue: "Show Progress in Sidebar"), "progress bar"),
         setting(.sidebarAppearance, "show-metadata", String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar"), "report meta status block"),
         setting(.betaFeatures, "dock", String(localized: "settings.betaFeatures.dock", defaultValue: "Dock"), "dock right sidebar terminal controls tui"),
+        setting(.tabs, "close-button-position", String(localized: "settings.tabCloseButton.label", defaultValue: "Tab close button position"), "tab close button leading trailing left right safari finder hig position macos"),
         setting(.automation, "socket-mode", String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"), "unix socket api access password auth"),
         setting(.automation, "socket-password", String(localized: "settings.automation.socketPassword", defaultValue: "Socket Password"), "socket auth credential"),
         setting(.automation, "claude-code", String(localized: "settings.automation.claudeCode", defaultValue: "Claude Code Integration"), "agent hooks notifications"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -11,6 +11,8 @@ enum SettingsSearchAliasIndex {
             return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "sidebar left rail navigation details branches badges material terminal background")
         case .betaFeatures:
             return localized("settings.search.alias.section.betaFeatures", defaultValue: "beta experimental unstable preview dock right sidebar")
+        case .tabs:
+            return localized("settings.search.alias.section.tabs", defaultValue: "tab close button position leading trailing left right safari finder hig macos x mark")
         case .automation:
             return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports")
         case .browser:
@@ -84,6 +86,7 @@ enum SettingsSearchAliasIndex {
         "sidebarAppearance:show-progress": localized("settings.search.alias.setting.app.show-progress", defaultValue: "sidebar.showProgress progress bar percent status set_progress"),
         "sidebarAppearance:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
         "betaFeatures:dock": localized("settings.search.alias.setting.betaFeatures.dock", defaultValue: "dock right sidebar terminal controls tui beta unstable"),
+        "tabs:close-button-position": localized("settings.search.alias.setting.tabs.close-button-position", defaultValue: "tab close button position leading trailing left right edge safari finder hig macos x mark dismiss"),
         "automation:socket-mode": localized("settings.search.alias.setting.automation.socket-mode", defaultValue: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),
         "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),
         "automation:claude-code": localized("settings.search.alias.setting.automation.claude-code", defaultValue: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -292,6 +292,60 @@ enum WorkspaceWorkingDirectoryInheritanceSettings {
     }
 }
 
+enum TabCloseButtonPosition: String, CaseIterable, Identifiable {
+    case leading
+    case trailing
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .leading:
+            return String(
+                localized: "settings.tabCloseButton.leading",
+                defaultValue: "Left"
+            )
+        case .trailing:
+            return String(
+                localized: "settings.tabCloseButton.trailing",
+                defaultValue: "Right"
+            )
+        }
+    }
+
+    var bonsplitValue: BonsplitConfiguration.CloseButtonPosition {
+        switch self {
+        case .leading: return .leading
+        case .trailing: return .trailing
+        }
+    }
+}
+
+enum TabCloseButtonPositionSettings {
+    /// `@AppStorage` key.
+    static let storageKey = "tabCloseButtonPosition"
+
+    /// Default matches the macOS Safari/Finder convention.
+    static let defaultPosition: TabCloseButtonPosition = .leading
+
+    static let didChangeNotification = Notification.Name("cmux.tabCloseButtonPositionSettingsDidChange")
+
+    static func resolved(rawValue: String?) -> TabCloseButtonPosition {
+        guard let rawValue, let value = TabCloseButtonPosition(rawValue: rawValue) else {
+            return defaultPosition
+        }
+        return value
+    }
+
+    static func current(defaults: UserDefaults = .standard) -> TabCloseButtonPosition {
+        resolved(rawValue: defaults.string(forKey: storageKey))
+    }
+
+    static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
+        notificationCenter.post(name: didChangeNotification, object: nil)
+    }
+}
+
 struct WorkspaceTabColorEntry: Equatable, Identifiable {
     let name: String
     let hex: String

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7587,10 +7587,30 @@ final class Workspace: Identifiable, ObservableObject {
             "border=\(colors.borderHex ?? "nil")"
     }
 
+    /// Production wrapper that reads the close-button preference from the
+    /// global `UserDefaults.standard` suite via `TabCloseButtonPositionSettings`.
+    /// Tests should call the pure factory overload below with an explicit
+    /// `closeButtonPosition` instead.
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
         backgroundOpacity: Double,
         tabTitleFontSize: CGFloat = 11
+    ) -> BonsplitConfiguration.Appearance {
+        bonsplitAppearance(
+            backgroundColor: backgroundColor,
+            backgroundOpacity: backgroundOpacity,
+            tabTitleFontSize: tabTitleFontSize,
+            closeButtonPosition: TabCloseButtonPositionSettings.current()
+        )
+    }
+
+    /// Pure factory overload that does not touch `UserDefaults` for the close-button
+    /// preference, useful for tests that need to assert appearance for a specific position.
+    static func bonsplitAppearance(
+        backgroundColor: NSColor,
+        backgroundOpacity: Double,
+        tabTitleFontSize: CGFloat,
+        closeButtonPosition: TabCloseButtonPosition
     ) -> BonsplitConfiguration.Appearance {
         let sharesWindowBackdrop = usesWindowRootTerminalBackdrop()
         let renderingMode = WindowAppearanceSnapshot.terminalRenderingMode(
@@ -7609,7 +7629,8 @@ final class Workspace: Identifiable, ObservableObject {
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,
             chromeColors: chromeColors,
-            usesSharedBackdrop: sharesWindowBackdrop
+            usesSharedBackdrop: sharesWindowBackdrop,
+            closeButtonPosition: closeButtonPosition.bonsplitValue
         )
     }
 
@@ -7860,7 +7881,17 @@ final class Workspace: Identifiable, ObservableObject {
             bonsplitController.selectTab(initialTabId)
         }
         tmuxLayoutSnapshot = bonsplitController.layoutSnapshot()
+
+        tabCloseButtonPositionObserver = NotificationCenter.default.addObserver(
+            forName: TabCloseButtonPositionSettings.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.applyTabCloseButtonPosition()
+        }
     }
+
+    private var tabCloseButtonPositionObserver: NSObjectProtocol?
 
     deinit {
         for registrations in pendingTerminalInputObserversByPanelId.values {
@@ -7870,8 +7901,34 @@ final class Workspace: Identifiable, ObservableObject {
                 }
             }
         }
+        if let tabCloseButtonPositionObserver {
+            NotificationCenter.default.removeObserver(tabCloseButtonPositionObserver)
+        }
         activeRemoteSessionControllerID = nil
         remoteSessionController?.stop()
+    }
+
+    @MainActor
+    func applyTabCloseButtonPosition() {
+        Workspace.applyTabCloseButtonPosition(
+            to: bonsplitController,
+            position: TabCloseButtonPositionSettings.current()
+        )
+    }
+
+    /// Push the configured `TabCloseButtonPosition` onto a Bonsplit controller's appearance.
+    /// Exposed as a static helper so the live-update flow is unit-testable without
+    /// constructing a full `Workspace`.
+    @discardableResult
+    @MainActor
+    static func applyTabCloseButtonPosition(
+        to controller: BonsplitController,
+        position: TabCloseButtonPosition
+    ) -> Bool {
+        let next = position.bonsplitValue
+        guard controller.configuration.appearance.closeButtonPosition != next else { return false }
+        controller.configuration.appearance.closeButtonPosition = next
+        return true
     }
 
     func refreshSplitButtonTooltips() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5055,6 +5055,8 @@ struct SettingsView: View {
     @AppStorage(SidebarBranchLayoutSettings.key) private var sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+    @AppStorage(TabCloseButtonPositionSettings.storageKey)
+    private var tabCloseButtonPositionRaw = TabCloseButtonPositionSettings.defaultPosition.rawValue
     @AppStorage("sidebarSelectionColorHex") private var sidebarSelectionColorHex: String?
     @AppStorage("sidebarNotificationBadgeColorHex") private var sidebarNotificationBadgeColorHex: String?
     @AppStorage("sidebarShowBranchDirectory") private var sidebarShowBranchDirectory = SidebarWorkspaceDetailDefaults.showBranchDirectory
@@ -5213,6 +5215,17 @@ struct SettingsView: View {
         Binding(
             get: { selectedSidebarActiveTabIndicatorStyle.rawValue },
             set: { sidebarActiveTabIndicatorStyle = $0 }
+        )
+    }
+
+    private var tabCloseButtonPositionSelection: Binding<String> {
+        Binding(
+            get: { TabCloseButtonPositionSettings.resolved(rawValue: tabCloseButtonPositionRaw).rawValue },
+            set: { newValue in
+                guard tabCloseButtonPositionRaw != newValue else { return }
+                tabCloseButtonPositionRaw = newValue
+                TabCloseButtonPositionSettings.notifyDidChange()
+            }
         )
     }
 
@@ -6432,6 +6445,24 @@ struct SettingsView: View {
                         dockEnabled: $rightSidebarDockEnabled
                     )
 
+                    SettingsSectionHeader(title: String(localized: "settings.section.tabs", defaultValue: "Tabs"))
+                    SettingsCard {
+                        SettingsPickerRow(
+                            configurationReview: .settingsOnly,
+                            String(localized: "settings.tabCloseButton.label", defaultValue: "Tab close button position"),
+                            subtitle: String(
+                                localized: "settings.tabCloseButton.subtitle",
+                                defaultValue: "Match macOS Safari/Finder by placing the close (×) on the leading edge, or keep it on the trailing edge."
+                            ),
+                            controlWidth: pickerColumnWidth,
+                            selection: tabCloseButtonPositionSelection
+                        ) {
+                            ForEach(TabCloseButtonPosition.allCases) { position in
+                                Text(position.displayName).tag(position.rawValue)
+                            }
+                        }
+                    }
+
                     SettingsSectionHeader(title: String(localized: "settings.section.automation", defaultValue: "Automation"))
                         .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .automation))
                     SettingsCard {
@@ -7364,6 +7395,11 @@ struct SettingsView: View {
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout
         sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
+        let previousTabCloseButtonPositionRaw = tabCloseButtonPositionRaw
+        tabCloseButtonPositionRaw = TabCloseButtonPositionSettings.defaultPosition.rawValue
+        if previousTabCloseButtonPositionRaw != tabCloseButtonPositionRaw {
+            TabCloseButtonPositionSettings.notifyDidChange()
+        }
         sidebarSelectionColorHex = nil
         sidebarNotificationBadgeColorHex = nil
         sidebarShowBranchDirectory = SidebarWorkspaceDetailDefaults.showBranchDirectory

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6446,6 +6446,7 @@ struct SettingsView: View {
                     )
 
                     SettingsSectionHeader(title: String(localized: "settings.section.tabs", defaultValue: "Tabs"))
+                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .tabs))
                     SettingsCard {
                         SettingsPickerRow(
                             configurationReview: .settingsOnly,
@@ -6461,6 +6462,7 @@ struct SettingsView: View {
                                 Text(position.displayName).tag(position.rawValue)
                             }
                         }
+                        .settingsSearchAnchor(SettingsSearchIndex.settingID(for: .tabs, idSuffix: "close-button-position"))
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.automation", defaultValue: "Automation"))

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -2547,3 +2547,136 @@ final class TabManagerReopenClosedBrowserFocusTests: XCTestCase {
         XCTAssertEqual(result, .completed)
     }
 }
+
+final class TabCloseButtonPositionSettingsTests: XCTestCase {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "TabCloseButtonPositionSettingsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    func testDefaultIsLeadingToMatchMacOSConvention() {
+        let defaults = makeDefaults()
+        XCTAssertEqual(TabCloseButtonPositionSettings.current(defaults: defaults), .leading)
+    }
+
+    func testResolvedReturnsStoredValue() {
+        let defaults = makeDefaults()
+        defaults.set("trailing", forKey: TabCloseButtonPositionSettings.storageKey)
+        XCTAssertEqual(TabCloseButtonPositionSettings.current(defaults: defaults), .trailing)
+    }
+
+    func testResolvedFallsBackWhenValueIsUnknown() {
+        let defaults = makeDefaults()
+        defaults.set("somethingElse", forKey: TabCloseButtonPositionSettings.storageKey)
+        XCTAssertEqual(TabCloseButtonPositionSettings.current(defaults: defaults), .leading)
+    }
+
+    func testBonsplitValueBridgeMapsLeadingAndTrailing() {
+        XCTAssertEqual(TabCloseButtonPosition.leading.bonsplitValue, .leading)
+        XCTAssertEqual(TabCloseButtonPosition.trailing.bonsplitValue, .trailing)
+    }
+}
+
+final class WorkspaceBonsplitAppearanceTests: XCTestCase {
+    @MainActor
+    func testLeadingPositionProducesLeadingAppearance() {
+        let appearance = Workspace.bonsplitAppearance(
+            backgroundColor: .black,
+            backgroundOpacity: 1.0,
+            tabTitleFontSize: 11,
+            closeButtonPosition: .leading
+        )
+        XCTAssertEqual(appearance.closeButtonPosition, .leading)
+    }
+
+    @MainActor
+    func testTrailingPositionProducesTrailingAppearance() {
+        let appearance = Workspace.bonsplitAppearance(
+            backgroundColor: .black,
+            backgroundOpacity: 1.0,
+            tabTitleFontSize: 11,
+            closeButtonPosition: .trailing
+        )
+        XCTAssertEqual(appearance.closeButtonPosition, .trailing)
+    }
+}
+
+final class TabCloseButtonPositionLiveUpdateTests: XCTestCase {
+    @MainActor
+    func testApplyTabCloseButtonPositionMutatesControllerConfiguration() {
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(
+                appearance: .init(closeButtonPosition: .trailing)
+            )
+        )
+        XCTAssertEqual(controller.configuration.appearance.closeButtonPosition, .trailing)
+
+        let changedToLeading = Workspace.applyTabCloseButtonPosition(to: controller, position: .leading)
+        XCTAssertTrue(changedToLeading)
+        XCTAssertEqual(controller.configuration.appearance.closeButtonPosition, .leading)
+
+        let unchangedOnRepeat = Workspace.applyTabCloseButtonPosition(to: controller, position: .leading)
+        XCTAssertFalse(unchangedOnRepeat, "repeat apply with same position should be a no-op")
+
+        let changedToTrailing = Workspace.applyTabCloseButtonPosition(to: controller, position: .trailing)
+        XCTAssertTrue(changedToTrailing)
+        XCTAssertEqual(controller.configuration.appearance.closeButtonPosition, .trailing)
+    }
+
+    @MainActor
+    func testNotifyDidChangePostsTheExpectedNotification() {
+        let expectation = XCTNSNotificationExpectation(
+            name: TabCloseButtonPositionSettings.didChangeNotification,
+            object: nil,
+            notificationCenter: .default
+        )
+        TabCloseButtonPositionSettings.notifyDidChange()
+        wait(for: [expectation], timeout: 1.0)
+    }
+
+    @MainActor
+    func testNotificationObservationUpdatesBonsplitController() {
+        // End-to-end simulation of Workspace's observer wiring: posting the
+        // notification should cause a subscriber to push the current setting
+        // onto its Bonsplit controller.
+        //
+        // Isolated from UserDefaults.standard and NotificationCenter.default
+        // so the test can't leak state onto the dev machine if it crashes and
+        // can't flake under parallel test execution.
+        let controller = BonsplitController(
+            configuration: BonsplitConfiguration(
+                appearance: .init(closeButtonPosition: .trailing)
+            )
+        )
+
+        let suiteName = "TabCloseButtonPositionLiveUpdateTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let notificationCenter = NotificationCenter()
+
+        let observer = notificationCenter.addObserver(
+            forName: TabCloseButtonPositionSettings.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Workspace.applyTabCloseButtonPosition(
+                to: controller,
+                position: TabCloseButtonPositionSettings.current(defaults: defaults)
+            )
+        }
+        defer { notificationCenter.removeObserver(observer) }
+
+        defaults.set(TabCloseButtonPosition.leading.rawValue, forKey: TabCloseButtonPositionSettings.storageKey)
+
+        TabCloseButtonPositionSettings.notifyDidChange(notificationCenter: notificationCenter)
+
+        // Drain the main queue so the observer block runs.
+        let drain = XCTestExpectation(description: "drain main queue after notification")
+        DispatchQueue.main.async { drain.fulfill() }
+        wait(for: [drain], timeout: 1.0)
+
+        XCTAssertEqual(controller.configuration.appearance.closeButtonPosition, .leading)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a user-configurable `Settings > Tabs > Tab close button position` toggle (`Left` default / `Right`) so the pane tab bar's close (×) button can sit on the leading edge, matching the macOS convention used by Safari 15+ and Xcode. Workspace sidebar rows are intentionally unchanged.

Closes #3060.

## Apple design basis

Apple's first-party macOS apps consistently place the tab close button on the **leading** edge:

- **Safari 15+** — favicon fades to × on hover/select in the same slot (no layout shift).
- **Xcode document tabs** — × on the leading side.

This PR implements the Safari 15+ pattern in the Bonsplit pane tab bar: the favicon slot doubles as the close-button slot. On hover or selection the favicon fades to `opacity: 0` and × overlays in the same slot — no extra gutter, no content shift, identical geometry whether close is on the left or right.

## Trailing accessory slot in leading mode

The trailing slot (used by the dirty / notification dot, pin glyph, and Cmd-N shortcut-hint pill) is **rendered conditionally** in leading mode:

- Dropped (zero-width) when nothing else needs it — avoids a phantom close-button-sized gap on the right edge of the tab.
- Kept when there is content to show (dirty / notification / pin / shortcut-hint).

Trailing mode always reserves the slot so the close × can fade in/out without layout shift.

## Out of scope: workspace sidebar ×

The sidebar workspace rows keep their current trailing × button. macOS sidebar list items (Finder Favorites, Mail mailboxes, Notes, Reminders, Xcode Navigator, Safari Tab Groups) don't follow a leading-× convention — trailing accessories (eject, badges) are the norm, and destructive actions live in context menus. Moving the sidebar × would diverge from platform norms without first-party precedent.

## Dependency

Depends on [manaflow-ai/bonsplit#100](https://github.com/manaflow-ai/bonsplit/pull/100) (`feat: add configurable tab close button position`). The submodule pointer in this PR references the bonsplit feature-branch tip; once the bonsplit PR merges to `main`, bump the pointer to the merged SHA before taking this PR out of draft.

## What changed

### Bonsplit submodule (`vendor/bonsplit`)
- `BonsplitConfiguration.CloseButtonPosition` public enum (library default `.trailing` for backward compat).
- `Appearance.closeButtonPosition` field + init param.
- `TabItemView`: two added lines on the favicon Group (`.opacity(…)` + `.overlay(…)`) — both no-ops when trailing, so upstream layout is preserved. One-line gate in `closeOrDirtyIndicator` skips the trailing close button when leading mode owns it. Trailing-slot render conditionally via `rendersTrailingAccessorySlot` (kept when dirty/notification/pin/shortcut-hint active).
- Unit tests cover default, round-trip, and `Codable`.

### cmux parent
- `TabCloseButtonPosition` enum + `TabCloseButtonPositionSettings` helper (`Sources/TabManager.swift`) backed by `@AppStorage("tabCloseButtonPosition")`, default `.leading`. Uses cmux's existing `TerminalScrollBarSettings`-style `notifyDidChange` + `didChangeNotification` pattern.
- `Workspace.bonsplitAppearance(…)` injects the current position into the Bonsplit `Appearance`; `Workspace.applyTabCloseButtonPosition()` observes the notification and updates `bonsplitController.configuration.appearance` live, so the setting takes effect without relaunch. Production wrapper is documented as deliberately tied to `UserDefaults.standard`; the pure factory overload accepts an explicit position for tests.
- Settings UI: new `Tabs` section with a `SettingsPickerRow` (`Left` / `Right`) between `Terminal` and `Workspace Colors` (`Sources/cmuxApp.swift`).
- Localization: `en`, `ja`, `ko` full; other supported locales get `state: "new"` placeholders with the English fallback so translators pick them up.

## Tests (CI + local `cmux-unit`)

Unit tests, 10/10 passing:
- `TabCloseButtonPositionSettingsTests` (5): default `.leading`, stored-value round-trip, unknown-value fallback, `allCases` completeness, bonsplit bridge.
- `WorkspaceBonsplitAppearanceTests` (2): pure factory maps enum → `BonsplitConfiguration.CloseButtonPosition`.
- `TabCloseButtonPositionLiveUpdateTests` (3): `applyTabCloseButtonPosition` mutates controller, `notifyDidChange` posts notification, end-to-end observe-and-update with isolated `UserDefaults(suiteName:)` + dedicated `NotificationCenter()` to avoid flakes.

Bonsplit-side tests (3) run in that repo's CI.

## Test plan

- [ ] CI `cmux-unit` passes
- [ ] Manual: with `Left` (default), hover on non-active tab → favicon fades, × overlays on the same slot, no layout shift
- [ ] Manual: active tab shows × permanently; favicon hidden under ×
- [ ] Manual: middle-click still closes
- [ ] Manual: `Cmd+W` still closes
- [ ] Manual: toggle to `Right` → × moves to the trailing edge live on all open workspaces (no relaunch needed)
- [ ] Manual: pinned tab keeps its pin affordance in either mode (× does not overlay on pinned)
- [ ] Manual: dirty indicator / notification badge / shortcut-hint pill still render correctly in both modes
- [ ] Localization: verify en / ja / ko strings render correctly in Settings

## Notes for reviewers

- Default behavior for existing users **changes** to leading on upgrade. Users who prefer the old placement can set `Right` in Settings.
- The `.opacity(1)` + empty `.overlay { if false { … } }` on the favicon Group in trailing mode are semantic no-ops under SwiftUI (`_ConditionalContent` with `EmptyView`). Upstream Bonsplit layout is preserved for default config.
- The vendored Bonsplit branch currently sits on top of an unmerged shared-backdrop branch (4 upstream commits) so the bonsplit PR diff temporarily includes those commits; they will disappear from the bonsplit PR once that work lands on bonsplit `main`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tabs setting to choose the tab close (×) button position (Left default / Right) to match macOS HIG with a leading-edge close. Uses a Safari-style overlay with no layout shift, updates live (including Reset to Defaults), and keeps sidebar rows unchanged (closes #3060).

- New Features
  - Settings > Tabs > "Tab close button position" (Left/Right). Changes apply live across open workspaces and on Reset to Defaults.
  - Tabs section is now visible in Settings navigation and is searchable (added aliases and anchors).
  - Safari-style overlay: favicon fades to × in the same slot; no layout shift; pinned tabs unaffected.
  - Localization for en, ja, ko; other locales fall back to English.

- Dependencies
  - Requires `bonsplit` support for configurable close button position; vendor `bonsplit` is pinned to the feature-branch tip and will move to `main` after upstream merges.

<sup>Written for commit 55ddf3bc2bdbb2d04e7ab4c23904200ddaa0f766. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a "Tab close button position" preference (leading/trailing) with a Settings picker, persistent storage, reset behavior, and live updates applied to open tabs.
* **Localization**
  * Added localization keys for the new Tabs UI (close button label, position labels, subtitle, section title) with translations for English, Japanese, and Korean and English fallbacks for other locales.
* **Tests**
  * Added unit tests for preference resolution, appearance mapping, live-update behavior, and notification delivery.
* **Chores**
  * Updated vendored Bonsplit revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
