### PR TITLE
Add setting to disable SSH file upload (scp drag-and-drop)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53770,6 +53770,363 @@
         }
       }
     },
+    "settings.app.sshFileUpload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH File Upload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHファイルアップロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 文件上传"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 檔案上傳"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 파일 업로드"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Dateiupload"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carga de archivos por SSH"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfert de fichiers SSH"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento file SSH"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopload"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesyłanie plików SSH"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка файлов по SSH"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH prijenos datoteka"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رفع الملفات عبر SSH"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopplasting"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upload de arquivos SSH"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัปโหลดไฟล์ผ่าน SSH"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH Dosya Yükleme"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантаження файлів через SSH"
+          }
+        }
+      }
+    },
+    "settings.app.sshFileUpload.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH file upload is disabled. Dragged files insert their local path instead."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHファイルアップロードは無効です。ドラッグされたファイルはローカルパスとして挿入されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 文件上传已禁用。拖放的文件将插入本地路径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 檔案上傳已停用。拖放的檔案將插入本機路徑。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 파일 업로드가 비활성화되었습니다. 드래그한 파일은 로컬 경로로 삽입됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Dateiupload ist deaktiviert. Gezogene Dateien werden als lokaler Pfad eingefügt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La carga SSH está desactivada. Los archivos arrastrados insertan su ruta local."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le transfert SSH est désactivé. Les fichiers glissés insèrent leur chemin local."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il caricamento SSH è disabilitato. I file trascinati inseriscono il loro percorso locale."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopload er deaktiveret. Trukne filer indsætter deres lokale sti."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesyłanie plików SSH jest wyłączone. Przeciągnięte pliki wstawiają lokalną ścieżkę."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка файлов по SSH отключена. Перетащенные файлы вставляют локальный путь."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH prijenos datoteka je onemogućen. Prevučene datoteke umjesto toga umeću lokalni put."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رفع الملفات عبر SSH معطّل. تُدرج الملفات المسحوبة مسارها المحلي بدلاً من ذلك."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopplasting er deaktivert. Dragte filer setter inn den lokale banen i stedet."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upload SSH está desativado. Arquivos arrastados inserem o caminho local."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การอัปโหลดไฟล์ผ่าน SSH ถูกปิดใช้งาน ไฟล์ที่ลากจะแทรกเส้นทางในเครื่องแทน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH dosya yükleme devre dışı. Sürüklenen dosyalar yerel yollarını ekler."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантаження файлів через SSH вимкнено. Перетягнуті файли вставляють локальний шлях."
+          }
+        }
+      }
+    },
+    "settings.app.sshFileUpload.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files dragged into SSH sessions are uploaded via scp."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHセッションにドラッグされたファイルはscpでアップロードされます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖放到 SSH 会话的文件将通过 scp 上传。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖放到 SSH 工作階段的檔案將透過 scp 上傳。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 세션으로 드래그한 파일은 scp를 통해 업로드됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In SSH-Sitzungen gezogene Dateien werden per scp hochgeladen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los archivos arrastrados a sesiones SSH se suben mediante scp."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fichiers glissés dans les sessions SSH sont téléversés via scp."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I file trascinati nelle sessioni SSH vengono caricati tramite scp."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer trukket ind i SSH-sessioner uploades via scp."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pliki przeciągnięte do sesji SSH są przesyłane przez scp."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файлы, перетащенные в SSH-сессии, загружаются по scp."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datoteke prevučene u SSH sesije prenose se putem scp."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتم رفع الملفات المسحوبة إلى جلسات SSH عبر scp."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer dradd inn i SSH-sesjoner lastes opp via scp."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivos arrastados para sessões SSH são enviados via scp."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไฟล์ที่ลากเข้าไปในเซสชัน SSH จะถูกอัปโหลดผ่าน scp"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH oturumlarına sürüklenen dosyalar scp aracılığıyla yüklenir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файли, перетягнуті в SSH-сесії, завантажуються через scp."
+          }
+        }
+      }
+    },
     "settings.app.theme": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -36,6 +36,7 @@ final class CmuxSettingsFileStore {
         "app.openMarkdownInCmuxViewer",
         "app.reorderOnNotification",
         "app.sendAnonymousTelemetry",
+        "app.enableSSHFileUpload",
         "app.warnBeforeQuit",
         "app.renameSelectsExistingName",
         "app.commandPaletteSearchesAllSurfaces",

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -440,6 +440,9 @@ final class CmuxSettingsFileStore {
         if let value = jsonBool(section["sendAnonymousTelemetry"]) {
             snapshot.managedUserDefaults[TelemetrySettings.sendAnonymousTelemetryKey] = .bool(value)
         }
+        if let value = jsonBool(section["enableSSHFileUpload"]) {
+            snapshot.managedUserDefaults[SSHFileUploadSettings.enabledKey] = .bool(value)
+        }
         if let value = jsonBool(section["warnBeforeQuit"]) {
             snapshot.managedUserDefaults[QuitWarningSettings.warnBeforeQuitKey] = .bool(value)
         }
@@ -1365,6 +1368,7 @@ final class CmuxSettingsFileStore {
                     "openMarkdownInCmuxViewer": CmdClickMarkdownRouteSettings.defaultValue,
                     "reorderOnNotification": WorkspaceAutoReorderSettings.defaultValue,
                     "sendAnonymousTelemetry": TelemetrySettings.defaultSendAnonymousTelemetry,
+                    "enableSSHFileUpload": SSHFileUploadSettings.defaultEnabled,
                     "warnBeforeQuit": QuitWarningSettings.defaultWarnBeforeQuit,
                     "renameSelectsExistingName": CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus,
                     "commandPaletteSearchesAllSurfaces": CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces,

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -347,7 +347,8 @@ extension TerminalSurface {
         if workspace.isRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }
-        if let ttyName = workspace.surfaceTTYNames[id],
+        if SSHFileUploadSettings.isEnabled(),
+           let ttyName = workspace.surfaceTTYNames[id],
            let session = TerminalSSHSessionDetector.detect(forTTY: ttyName) {
             return .remote(.detectedSSH(session))
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -344,11 +344,18 @@ extension TerminalSurface {
     @MainActor
     func resolvedImageTransferTarget() -> TerminalImageTransferTarget {
         guard let workspace = owningWorkspace() else { return .local }
+        // Both remote paths below are scp-backed: the workspace-remote path
+        // goes through `uploadDroppedFilesLocked` in Workspace.swift, which
+        // calls scp, and the detected-SSH path goes through
+        // TerminalSSHSessionDetector.uploadDroppedFiles, which also calls scp.
+        // So the upload toggle must be evaluated *before* picking either
+        // remote branch, otherwise the workspace-remote path silently
+        // bypasses the setting.
+        guard SSHFileUploadSettings.isEnabled() else { return .local }
         if workspace.isRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }
-        if SSHFileUploadSettings.isEnabled(),
-           let ttyName = workspace.surfaceTTYNames[id],
+        if let ttyName = workspace.surfaceTTYNames[id],
            let session = TerminalSSHSessionDetector.detect(forTTY: ttyName) {
             return .remote(.detectedSSH(session))
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4133,6 +4133,18 @@ enum TelemetrySettings {
     static let enabledForCurrentLaunch = isEnabled()
 }
 
+enum SSHFileUploadSettings {
+    static let enabledKey = "enableSSHFileUpload"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+}
+
 enum CmdClickMarkdownRouteSettings {
     static let key = "openMarkdownInCmuxViewer"
     static let defaultValue = false
@@ -4398,6 +4410,8 @@ struct SettingsView: View {
     private var geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
+    @AppStorage(SSHFileUploadSettings.enabledKey)
+    private var enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
     @AppStorage(CmdClickMarkdownRouteSettings.key) private var openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
@@ -5329,6 +5343,20 @@ struct SettingsView: View {
                                 : String(localized: "settings.app.telemetry.subtitle", defaultValue: "Share anonymized crash and usage data to help improve cmux.")
                         ) {
                             Toggle("", isOn: $sendAnonymousTelemetry)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.enableSSHFileUpload"),
+                            String(localized: "settings.app.sshFileUpload", defaultValue: "SSH File Upload"),
+                            subtitle: enableSSHFileUpload
+                                ? String(localized: "settings.app.sshFileUpload.subtitleOn", defaultValue: "Files dragged into SSH sessions are uploaded via scp.")
+                                : String(localized: "settings.app.sshFileUpload.subtitleOff", defaultValue: "SSH file upload is disabled. Dragged files insert their local path instead.")
+                        ) {
+                            Toggle("", isOn: $enableSSHFileUpload)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -6565,6 +6593,7 @@ struct SettingsView: View {
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
+        enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
         preferredEditorCommand = ""
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue


### PR DESCRIPTION
## Summary

Adds a narrow-scoped **SSH File Upload** toggle in Settings → General. When off, files dragged into a terminal pane where cmux has auto-detected an active `ssh` process fall back to inserting their local shell-escaped path instead of being uploaded via `scp`.

**Scope is deliberately narrow** — see caveat below.

## Motivation

Corporate IT policies frequently flag application-initiated `scp` uploads from developer machines. Drag-and-drop-to-upload is the most visible and easily-triggered SSH exfiltration vector in cmux today (it happens on a stray drop gesture, no command typed). Giving users an in-app switch to disable it closes the most common accidental-exfil path without requiring OS-level firewall rules.

Partially addresses #3071.

## Scope caveat — what this PR does NOT do

This PR gates a single call site: `TerminalImageTransfer.swift` → `resolvedImageTransferTarget()` → `TerminalSSHSessionDetector.detect()`. That covers drag-and-drop in auto-detected SSH panes only.

It does **not** disable other SSH functionality in cmux, including:

- The `cmux ssh user@remote` CLI command and `WorkspaceRemoteSessionController`
- SSH ControlMaster setup, reverse TCP tunneling (`ssh -R`)
- Remote port scanning and remote daemon bootstrap
- Workspace-remote file uploads (separate code path from the detector-based one)
- SSH-based file explorer / git status over SSH
- The CLI relay server that forwards commands from remote → local

If a broader "disable all SSH features" kill-switch is desired for enterprise deployments, that should be a separate, larger feature discussion. I've left notes to that effect on #3071.

## Changes

| File | Change |
|---|---|
| `Sources/cmuxApp.swift` | `SSHFileUploadSettings` enum; `@AppStorage` property; Settings UI row; reset handler |
| `Sources/TerminalImageTransfer.swift` | Gate `resolvedImageTransferTarget()` behind the setting |
| `Sources/KeyboardShortcutSettingsFileStore.swift` | JSON config key `app.enableSSHFileUpload` |
| `Resources/Localizable.xcstrings` | 3 new string keys × 18 locales |

Setting takes effect immediately — no restart required.

## Test plan

- [ ] Toggle off → drag a file into an auto-detected SSH session → local path is inserted, no scp
- [ ] Toggle on → drag a file into an auto-detected SSH session → scp upload proceeds as before
- [ ] Set `app.enableSSHFileUpload: false` in `~/.config/cmux/settings.json` → setting is respected
- [ ] Reset All Settings → toggle returns to `true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a toggleable SSH file upload setting in app preferences, allowing users to control SSH file transfer functionality
  * Extended localization support for SSH file upload settings across all supported languages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->