### PR TITLE
Add master SSH kill-switch for corporate environments (refs #3071)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -54014,115 +54014,115 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux may establish outbound SSH connections for remote workspaces, the file explorer, and scp uploads."
+            "value": "cmux may establish outbound SSH connections for remote workspaces, the SSH file explorer, and scp uploads."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmuxはリモートワークスペース、ファイルエクスプローラー、scpアップロードのために送信SSH接続を確立できます。"
+            "value": "cmuxはリモートワークスペース、SSHファイルエクスプローラー、scpアップロードのために送信SSH接続を確立できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux 可以为远程工作区、文件浏览器和 scp 上传建立出站 SSH 连接。"
+            "value": "cmux 可以为远程工作区、SSH 文件浏览器和 scp 上传建立出站 SSH 连接。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux 可以為遠端工作區、檔案瀏覽器和 scp 上傳建立外送 SSH 連線。"
+            "value": "cmux 可以為遠端工作區、SSH 檔案瀏覽器和 scp 上傳建立外送 SSH 連線。"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux는 원격 워크스페이스, 파일 탐색기 및 scp 업로드를 위해 아웃바운드 SSH 연결을 설정할 수 있습니다."
+            "value": "cmux는 원격 워크스페이스, SSH 파일 탐색기 및 scp 업로드를 위해 아웃바운드 SSH 연결을 설정할 수 있습니다."
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux kann ausgehende SSH-Verbindungen für entfernte Arbeitsbereiche, den Datei-Explorer und scp-Uploads herstellen."
+            "value": "cmux kann ausgehende SSH-Verbindungen für entfernte Arbeitsbereiche, den SSH-Datei-Explorer und scp-Uploads herstellen."
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux puede establecer conexiones SSH salientes para espacios de trabajo remotos, el explorador de archivos y las cargas scp."
+            "value": "cmux puede establecer conexiones SSH salientes para espacios de trabajo remotos, el explorador de archivos SSH y las cargas scp."
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux peut établir des connexions SSH sortantes pour les espaces de travail distants, l'explorateur de fichiers et les téléversements scp."
+            "value": "cmux peut établir des connexions SSH sortantes pour les espaces de travail distants, l'explorateur de fichiers SSH et les téléversements scp."
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux può stabilire connessioni SSH in uscita per spazi di lavoro remoti, esploratore file e caricamenti scp."
+            "value": "cmux può stabilire connessioni SSH in uscita per spazi di lavoro remoti, esploratore file SSH e caricamenti scp."
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux kan oprette udgående SSH-forbindelser til eksterne arbejdsområder, filfinderen og scp-uploads."
+            "value": "cmux kan oprette udgående SSH-forbindelser til eksterne arbejdsområder, SSH-filfinderen og scp-uploads."
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux może nawiązywać wychodzące połączenia SSH dla zdalnych obszarów roboczych, eksploratora plików i przesyłania scp."
+            "value": "cmux może nawiązywać wychodzące połączenia SSH dla zdalnych obszarów roboczych, eksploratora plików SSH i przesyłania scp."
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux может устанавливать исходящие SSH-соединения для удалённых рабочих областей, файлового проводника и загрузок scp."
+            "value": "cmux может устанавливать исходящие SSH-соединения для удалённых рабочих областей, файлового проводника SSH и загрузок scp."
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux može uspostaviti odlazne SSH veze za udaljene radne prostore, pretraživač datoteka i scp prijenose."
+            "value": "cmux može uspostaviti odlazne SSH veze za udaljene radne prostore, SSH pretraživač datoteka i scp prijenose."
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "يمكن لـ cmux إنشاء اتصالات SSH الصادرة لمساحات العمل البعيدة ومستعرض الملفات وعمليات رفع scp."
+            "value": "يمكن لـ cmux إنشاء اتصالات SSH الصادرة لمساحات العمل البعيدة ومستعرض ملفات SSH وعمليات رفع scp."
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux kan opprette utgående SSH-tilkoblinger for eksterne arbeidsområder, filutforskeren og scp-opplastinger."
+            "value": "cmux kan opprette utgående SSH-tilkoblinger for eksterne arbeidsområder, SSH-filutforskeren og scp-opplastinger."
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux pode estabelecer conexões SSH de saída para espaços de trabalho remotos, o explorador de arquivos e uploads scp."
+            "value": "cmux pode estabelecer conexões SSH de saída para espaços de trabalho remotos, o explorador de arquivos SSH e uploads scp."
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux อาจสร้างการเชื่อมต่อ SSH ขาออกสำหรับเวิร์กสเปซระยะไกล ตัวจัดการไฟล์ และการอัปโหลด scp"
+            "value": "cmux อาจสร้างการเชื่อมต่อ SSH ขาออกสำหรับเวิร์กสเปซระยะไกล ตัวจัดการไฟล์ SSH และการอัปโหลด scp"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux, uzak çalışma alanları, dosya gezgini ve scp yüklemeleri için giden SSH bağlantıları kurabilir."
+            "value": "cmux, uzak çalışma alanları, SSH dosya gezgini ve scp yüklemeleri için giden SSH bağlantıları kurabilir."
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "cmux може встановлювати вихідні SSH-з'єднання для віддалених робочих просторів, файлового провідника та завантажень scp."
+            "value": "cmux може встановлювати вихідні SSH-з'єднання для віддалених робочих просторів, файлового провідника SSH та завантажень scp."
           }
         }
       }
@@ -54242,6 +54242,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Завантаження файлів через SSH"
+          }
+        }
+      }
+    },
+    "settings.app.sshFileUpload.subtitleDisabledBySSHFeatures": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH features are disabled. No scp uploads occur regardless of this toggle."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH機能は無効です。このトグルの状態に関係なく、scpアップロードは実行されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能已禁用。无论此开关状态如何，都不会进行 scp 上传。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能已停用。無論此切換狀態如何，都不會進行 scp 上傳。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 기능이 비활성화되었습니다. 이 토글 상태와 관계없이 scp 업로드가 수행되지 않습니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Funktionen sind deaktiviert. Unabhängig von dieser Umschaltoption finden keine scp-Uploads statt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las funciones SSH están deshabilitadas. No se producen cargas scp independientemente de este interruptor."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fonctionnalités SSH sont désactivées. Aucun téléversement scp ne se produit, quel que soit l'état de ce bouton."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le funzionalità SSH sono disabilitate. Non vengono effettuati caricamenti scp indipendentemente da questo interruttore."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funktioner er deaktiveret. Der udføres ingen scp-uploads uanset denne kontakts tilstand."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funkcje SSH są wyłączone. Przesyłanie scp nie następuje niezależnie od stanu tego przełącznika."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функции SSH отключены. Загрузки scp не выполняются независимо от состояния этого переключателя."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH funkcije su onemogućene. Nema scp prijenosa bez obzira na stanje ovog prekidača."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وظائف SSH معطلة. لا تحدث عمليات رفع scp بغض النظر عن حالة هذا المفتاح."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funksjoner er deaktivert. Ingen scp-opplastinger skjer uavhengig av denne bryterens tilstand."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As funcionalidades SSH estão desativadas. Nenhum upload scp ocorre independentemente deste interruptor."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฟังก์ชัน SSH ถูกปิดใช้งาน ไม่มีการอัปโหลด scp ไม่ว่าสวิตช์นี้จะเป็นอย่างไร"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH işlevleri devre dışı. Bu anahtarın durumundan bağımsız olarak scp yüklemesi yapılmaz."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функції SSH вимкнено. Завантаження scp не виконуються незалежно від стану цього перемикача."
           }
         }
       }
@@ -86473,6 +86592,125 @@
           "stringUnit": {
             "state": "translated",
             "value": "Вставляти нові робочі області на початок списку."
+          }
+        }
+      }
+    },
+    "workspace.remote.sshFeaturesDisabled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH features are disabled in Settings."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH機能は設定で無効になっています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能已在设置中禁用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能已在設定中停用。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 기능이 설정에서 비활성화되었습니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Funktionen sind in den Einstellungen deaktiviert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Las funciones SSH están deshabilitadas en Ajustes."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fonctionnalités SSH sont désactivées dans les Réglages."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le funzionalità SSH sono disabilitate nelle Impostazioni."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funktioner er deaktiveret i Indstillinger."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funkcje SSH są wyłączone w Ustawieniach."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функции SSH отключены в настройках."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH funkcije su onemogućene u Postavkama."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "وظائف SSH معطلة في الإعدادات."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funksjoner er deaktivert i Innstillinger."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "As funcionalidades SSH estão desativadas nas Configurações."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฟังก์ชัน SSH ถูกปิดใช้งานในการตั้งค่า"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH işlevleri Ayarlar'da devre dışı."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функції SSH вимкнено в Налаштуваннях."
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53770,6 +53770,363 @@
         }
       }
     },
+    "settings.app.sshFileUpload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH File Upload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHファイルアップロード"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 文件上传"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 檔案上傳"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 파일 업로드"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Dateiupload"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Carga de archivos por SSH"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Transfert de fichiers SSH"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Caricamento file SSH"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopload"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesyłanie plików SSH"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка файлов по SSH"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH prijenos datoteka"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رفع الملفات عبر SSH"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopplasting"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upload de arquivos SSH"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "อัปโหลดไฟล์ผ่าน SSH"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH Dosya Yükleme"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантаження файлів через SSH"
+          }
+        }
+      }
+    },
+    "settings.app.sshFileUpload.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH file upload is disabled. Dragged files insert their local path instead."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHファイルアップロードは無効です。ドラッグされたファイルはローカルパスとして挿入されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 文件上传已禁用。拖放的文件将插入本地路径。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 檔案上傳已停用。拖放的檔案將插入本機路徑。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 파일 업로드가 비활성화되었습니다. 드래그한 파일은 로컬 경로로 삽입됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Dateiupload ist deaktiviert. Gezogene Dateien werden als lokaler Pfad eingefügt."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "La carga SSH está desactivada. Los archivos arrastrados insertan su ruta local."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Le transfert SSH est désactivé. Les fichiers glissés insèrent leur chemin local."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Il caricamento SSH è disabilitato. I file trascinati inseriscono il loro percorso locale."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopload er deaktiveret. Trukne filer indsætter deres lokale sti."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Przesyłanie plików SSH jest wyłączone. Przeciągnięte pliki wstawiają lokalną ścieżkę."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Загрузка файлов по SSH отключена. Перетащенные файлы вставляют локальный путь."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH prijenos datoteka je onemogućen. Prevučene datoteke umjesto toga umeću lokalni put."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "رفع الملفات عبر SSH معطّل. تُدرج الملفات المسحوبة مسارها المحلي بدلاً من ذلك."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-filopplasting er deaktivert. Dragte filer setter inn den lokale banen i stedet."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Upload SSH está desativado. Arquivos arrastados inserem o caminho local."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "การอัปโหลดไฟล์ผ่าน SSH ถูกปิดใช้งาน ไฟล์ที่ลากจะแทรกเส้นทางในเครื่องแทน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH dosya yükleme devre dışı. Sürüklenen dosyalar yerel yollarını ekler."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Завантаження файлів через SSH вимкнено. Перетягнуті файли вставляють локальний шлях."
+          }
+        }
+      }
+    },
+    "settings.app.sshFileUpload.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Files dragged into SSH sessions are uploaded via scp."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSHセッションにドラッグされたファイルはscpでアップロードされます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖放到 SSH 会话的文件将通过 scp 上传。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "拖放到 SSH 工作階段的檔案將透過 scp 上傳。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 세션으로 드래그한 파일은 scp를 통해 업로드됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In SSH-Sitzungen gezogene Dateien werden per scp hochgeladen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Los archivos arrastrados a sesiones SSH se suben mediante scp."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Les fichiers glissés dans les sessions SSH sont téléversés via scp."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I file trascinati nelle sessioni SSH vengono caricati tramite scp."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer trukket ind i SSH-sessioner uploades via scp."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pliki przeciągnięte do sesji SSH są przesyłane przez scp."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файлы, перетащенные в SSH-сессии, загружаются по scp."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datoteke prevučene u SSH sesije prenose se putem scp."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يتم رفع الملفات المسحوبة إلى جلسات SSH عبر scp."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Filer dradd inn i SSH-sesjoner lastes opp via scp."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Arquivos arrastados para sessões SSH são enviados via scp."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ไฟล์ที่ลากเข้าไปในเซสชัน SSH จะถูกอัปโหลดผ่าน scp"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH oturumlarına sürüklenen dosyalar scp aracılığıyla yüklenir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Файли, перетягнуті в SSH-сесії, завантажуються через scp."
+          }
+        }
+      }
+    },
     "settings.app.theme": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -53770,6 +53770,363 @@
         }
       }
     },
+    "settings.app.sshFeatures": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH Features"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH機能"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 功能"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH 기능"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-Funktionen"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funciones SSH"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Fonctionnalités SSH"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funzionalità SSH"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funktioner"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Funkcje SSH"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функции SSH"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH funkcije"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ميزات SSH"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH-funksjoner"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recursos SSH"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฟีเจอร์ SSH"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH Özellikleri"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Функції SSH"
+          }
+        }
+      }
+    },
+    "settings.app.sshFeatures.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All SSH functionality is disabled. `cmux ssh`, remote workspaces, the SSH file explorer, and scp uploads will be blocked."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "すべてのSSH機能は無効です。`cmux ssh`、リモートワークスペース、SSHファイルエクスプローラー、scpアップロードはブロックされます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有 SSH 功能已禁用。`cmux ssh`、远程工作区、SSH 文件浏览器和 scp 上传将被阻止。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "所有 SSH 功能已停用。`cmux ssh`、遠端工作區、SSH 檔案瀏覽器和 scp 上傳將被封鎖。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "모든 SSH 기능이 비활성화되었습니다. `cmux ssh`, 원격 워크스페이스, SSH 파일 탐색기 및 scp 업로드가 차단됩니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alle SSH-Funktionen sind deaktiviert. `cmux ssh`, entfernte Arbeitsbereiche, der SSH-Datei-Explorer und scp-Uploads werden blockiert."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toda la funcionalidad SSH está deshabilitada. Se bloquearán `cmux ssh`, los espacios de trabajo remotos, el explorador de archivos SSH y las cargas scp."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toutes les fonctionnalités SSH sont désactivées. `cmux ssh`, les espaces de travail distants, l'explorateur de fichiers SSH et les téléversements scp seront bloqués."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tutte le funzionalità SSH sono disabilitate. `cmux ssh`, gli spazi di lavoro remoti, l'esploratore di file SSH e i caricamenti scp verranno bloccati."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Al SSH-funktionalitet er deaktiveret. `cmux ssh`, eksterne arbejdsområder, SSH-filfinderen og scp-uploads vil blive blokeret."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cała funkcjonalność SSH jest wyłączona. `cmux ssh`, zdalne obszary robocze, eksplorator plików SSH i przesyłanie scp zostaną zablokowane."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вся функциональность SSH отключена. `cmux ssh`, удалённые рабочие области, файловый проводник SSH и загрузки scp будут заблокированы."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sva SSH funkcionalnost je onemogućena. `cmux ssh`, udaljeni radni prostori, SSH pretraživač datoteka i scp prijenosi bit će blokirani."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "تم تعطيل جميع وظائف SSH. سيتم حظر `cmux ssh` ومساحات العمل البعيدة ومستعرض ملفات SSH وعمليات رفع scp."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "All SSH-funksjonalitet er deaktivert. `cmux ssh`, eksterne arbeidsområder, SSH-filutforskeren og scp-opplastinger vil bli blokkert."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toda a funcionalidade SSH está desativada. `cmux ssh`, espaços de trabalho remotos, o explorador de arquivos SSH e uploads scp serão bloqueados."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ฟังก์ชัน SSH ทั้งหมดถูกปิดใช้งาน `cmux ssh` เวิร์กสเปซระยะไกล ตัวจัดการไฟล์ SSH และการอัปโหลด scp จะถูกบล็อก"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tüm SSH işlevselliği devre dışı. `cmux ssh`, uzak çalışma alanları, SSH dosya gezgini ve scp yüklemeleri engellenecek."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Усі функції SSH вимкнено. `cmux ssh`, віддалені робочі простори, файловий провідник SSH та завантаження scp будуть заблоковані."
+          }
+        }
+      }
+    },
+    "settings.app.sshFeatures.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux may establish outbound SSH connections for remote workspaces, the file explorer, and scp uploads."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxはリモートワークスペース、ファイルエクスプローラー、scpアップロードのために送信SSH接続を確立できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 可以为远程工作区、文件浏览器和 scp 上传建立出站 SSH 连接。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux 可以為遠端工作區、檔案瀏覽器和 scp 上傳建立外送 SSH 連線。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux는 원격 워크스페이스, 파일 탐색기 및 scp 업로드를 위해 아웃바운드 SSH 연결을 설정할 수 있습니다."
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux kann ausgehende SSH-Verbindungen für entfernte Arbeitsbereiche, den Datei-Explorer und scp-Uploads herstellen."
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux puede establecer conexiones SSH salientes para espacios de trabajo remotos, el explorador de archivos y las cargas scp."
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux peut établir des connexions SSH sortantes pour les espaces de travail distants, l'explorateur de fichiers et les téléversements scp."
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux può stabilire connessioni SSH in uscita per spazi di lavoro remoti, esploratore file e caricamenti scp."
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux kan oprette udgående SSH-forbindelser til eksterne arbejdsområder, filfinderen og scp-uploads."
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux może nawiązywać wychodzące połączenia SSH dla zdalnych obszarów roboczych, eksploratora plików i przesyłania scp."
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux может устанавливать исходящие SSH-соединения для удалённых рабочих областей, файлового проводника и загрузок scp."
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux može uspostaviti odlazne SSH veze za udaljene radne prostore, pretraživač datoteka i scp prijenose."
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "يمكن لـ cmux إنشاء اتصالات SSH الصادرة لمساحات العمل البعيدة ومستعرض الملفات وعمليات رفع scp."
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux kan opprette utgående SSH-tilkoblinger for eksterne arbeidsområder, filutforskeren og scp-opplastinger."
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux pode estabelecer conexões SSH de saída para espaços de trabalho remotos, o explorador de arquivos e uploads scp."
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux อาจสร้างการเชื่อมต่อ SSH ขาออกสำหรับเวิร์กสเปซระยะไกล ตัวจัดการไฟล์ และการอัปโหลด scp"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux, uzak çalışma alanları, dosya gezgini ve scp yüklemeleri için giden SSH bağlantıları kurabilir."
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux може встановлювати вихідні SSH-з'єднання для віддалених робочих просторів, файлового провідника та завантажень scp."
+          }
+        }
+      }
+    },
     "settings.app.sshFileUpload": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3267,7 +3267,7 @@ struct ContentView: View {
             sessionIndexStore.setCurrentDirectoryIfChanged(nil)
         }
 
-        if tab.isRemoteWorkspace {
+        if tab.isRemoteWorkspace && SSHFeaturesSettings.isEnabled() {
             let config = tab.remoteConfiguration
             let remotePath = tab.remoteDaemonStatus.remotePath
             let isReady = tab.remoteDaemonStatus.state == .ready

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -36,6 +36,8 @@ final class CmuxSettingsFileStore {
         "app.openMarkdownInCmuxViewer",
         "app.reorderOnNotification",
         "app.sendAnonymousTelemetry",
+        "app.enableSSHFileUpload",
+        "app.enableSSHFeatures",
         "app.warnBeforeQuit",
         "app.renameSelectsExistingName",
         "app.commandPaletteSearchesAllSurfaces",
@@ -442,6 +444,9 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonBool(section["enableSSHFileUpload"]) {
             snapshot.managedUserDefaults[SSHFileUploadSettings.enabledKey] = .bool(value)
+        }
+        if let value = jsonBool(section["enableSSHFeatures"]) {
+            snapshot.managedUserDefaults[SSHFeaturesSettings.enabledKey] = .bool(value)
         }
         if let value = jsonBool(section["warnBeforeQuit"]) {
             snapshot.managedUserDefaults[QuitWarningSettings.warnBeforeQuitKey] = .bool(value)
@@ -1369,6 +1374,7 @@ final class CmuxSettingsFileStore {
                     "reorderOnNotification": WorkspaceAutoReorderSettings.defaultValue,
                     "sendAnonymousTelemetry": TelemetrySettings.defaultSendAnonymousTelemetry,
                     "enableSSHFileUpload": SSHFileUploadSettings.defaultEnabled,
+                    "enableSSHFeatures": SSHFeaturesSettings.defaultEnabled,
                     "warnBeforeQuit": QuitWarningSettings.defaultWarnBeforeQuit,
                     "renameSelectsExistingName": CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus,
                     "commandPaletteSearchesAllSurfaces": CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -440,6 +440,9 @@ final class CmuxSettingsFileStore {
         if let value = jsonBool(section["sendAnonymousTelemetry"]) {
             snapshot.managedUserDefaults[TelemetrySettings.sendAnonymousTelemetryKey] = .bool(value)
         }
+        if let value = jsonBool(section["enableSSHFileUpload"]) {
+            snapshot.managedUserDefaults[SSHFileUploadSettings.enabledKey] = .bool(value)
+        }
         if let value = jsonBool(section["warnBeforeQuit"]) {
             snapshot.managedUserDefaults[QuitWarningSettings.warnBeforeQuitKey] = .bool(value)
         }
@@ -1365,6 +1368,7 @@ final class CmuxSettingsFileStore {
                     "openMarkdownInCmuxViewer": CmdClickMarkdownRouteSettings.defaultValue,
                     "reorderOnNotification": WorkspaceAutoReorderSettings.defaultValue,
                     "sendAnonymousTelemetry": TelemetrySettings.defaultSendAnonymousTelemetry,
+                    "enableSSHFileUpload": SSHFileUploadSettings.defaultEnabled,
                     "warnBeforeQuit": QuitWarningSettings.defaultWarnBeforeQuit,
                     "renameSelectsExistingName": CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus,
                     "commandPaletteSearchesAllSurfaces": CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3870,6 +3870,13 @@ class TerminalController {
     }
 
     private func v2WorkspaceRemoteConfigure(params: [String: Any]) -> V2CallResult {
+        guard SSHFeaturesSettings.isEnabled() else {
+            return .err(
+                code: "ssh_disabled",
+                message: "SSH features are disabled in Settings.",
+                data: nil
+            )
+        }
         let requestedWorkspaceId = v2UUID(params, "workspace_id")
         if v2HasNonNullParam(params, "workspace_id"), requestedWorkspaceId == nil {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
@@ -4021,6 +4028,13 @@ class TerminalController {
     }
 
     private func v2WorkspaceRemoteReconnect(params: [String: Any]) -> V2CallResult {
+        guard SSHFeaturesSettings.isEnabled() else {
+            return .err(
+                code: "ssh_disabled",
+                message: "SSH features are disabled in Settings.",
+                data: nil
+            )
+        }
         let requestedWorkspaceId = v2UUID(params, "workspace_id")
         if v2HasNonNullParam(params, "workspace_id"), requestedWorkspaceId == nil {
             return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3873,7 +3873,10 @@ class TerminalController {
         guard SSHFeaturesSettings.isEnabled() else {
             return .err(
                 code: "ssh_disabled",
-                message: "SSH features are disabled in Settings.",
+                message: String(
+                    localized: "workspace.remote.sshFeaturesDisabled",
+                    defaultValue: "SSH features are disabled in Settings."
+                ),
                 data: nil
             )
         }
@@ -4031,7 +4034,10 @@ class TerminalController {
         guard SSHFeaturesSettings.isEnabled() else {
             return .err(
                 code: "ssh_disabled",
-                message: "SSH features are disabled in Settings.",
+                message: String(
+                    localized: "workspace.remote.sshFeaturesDisabled",
+                    defaultValue: "SSH features are disabled in Settings."
+                ),
                 data: nil
             )
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -347,10 +347,12 @@ extension TerminalSurface {
         // Both remote paths below are scp-backed (workspace-remote via
         // `uploadDroppedFilesLocked` in Workspace.swift, detected-SSH via
         // `TerminalSSHSessionDetector.uploadDroppedFiles`). Evaluate the
-        // file-upload toggle *before* the workspace-remote branch so a
-        // disabled upload setting does not get bypassed by remote surfaces.
-        guard SSHFileUploadSettings.isEnabled() else { return .local }
+        // master SSH kill-switch and the file-upload toggle *before* the
+        // workspace-remote branch so disabled settings do not get bypassed
+        // by remote surfaces. Check the master switch first so a flipped
+        // master always wins regardless of the narrower toggle's state.
         guard SSHFeaturesSettings.isEnabled() else { return .local }
+        guard SSHFileUploadSettings.isEnabled() else { return .local }
         if workspace.isRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -347,7 +347,8 @@ extension TerminalSurface {
         if workspace.isRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }
-        if let ttyName = workspace.surfaceTTYNames[id],
+        if SSHFileUploadSettings.isEnabled(),
+           let ttyName = workspace.surfaceTTYNames[id],
            let session = TerminalSSHSessionDetector.detect(forTTY: ttyName) {
             return .remote(.detectedSSH(session))
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -344,11 +344,17 @@ extension TerminalSurface {
     @MainActor
     func resolvedImageTransferTarget() -> TerminalImageTransferTarget {
         guard let workspace = owningWorkspace() else { return .local }
+        // Both remote paths below are scp-backed (workspace-remote via
+        // `uploadDroppedFilesLocked` in Workspace.swift, detected-SSH via
+        // `TerminalSSHSessionDetector.uploadDroppedFiles`). Evaluate the
+        // file-upload toggle *before* the workspace-remote branch so a
+        // disabled upload setting does not get bypassed by remote surfaces.
+        guard SSHFileUploadSettings.isEnabled() else { return .local }
+        guard SSHFeaturesSettings.isEnabled() else { return .local }
         if workspace.isRemoteTerminalSurface(id) {
             return .remote(.workspaceRemote)
         }
-        if SSHFileUploadSettings.isEnabled(),
-           let ttyName = workspace.surfaceTTYNames[id],
+        if let ttyName = workspace.surfaceTTYNames[id],
            let session = TerminalSSHSessionDetector.detect(forTTY: ttyName) {
             return .remote(.detectedSSH(session))
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6968,11 +6968,36 @@ final class Workspace: Identifiable, ObservableObject {
             bonsplitController.selectTab(initialTabId)
         }
         tmuxLayoutSnapshot = bonsplitController.layoutSnapshot()
+
+        sshFeaturesSettingsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: UserDefaults.standard,
+            queue: .main
+        ) { [weak self] _ in
+            self?.tearDownRemoteSessionIfSSHFeaturesDisabled()
+        }
     }
 
     deinit {
+        if let sshFeaturesSettingsObserver {
+            NotificationCenter.default.removeObserver(sshFeaturesSettingsObserver)
+        }
         activeRemoteSessionControllerID = nil
         remoteSessionController?.stop()
+    }
+
+    private func tearDownRemoteSessionIfSSHFeaturesDisabled() {
+        guard !SSHFeaturesSettings.isEnabled() else { return }
+        guard let destination = remoteConfiguration?.destination else { return }
+        disconnectRemoteConnection(clearConfiguration: true)
+        applyRemoteConnectionStateUpdate(
+            .error,
+            detail: String(
+                localized: "workspace.remote.sshFeaturesDisabled",
+                defaultValue: "SSH features are disabled in Settings."
+            ),
+            target: destination
+        )
     }
 
     func refreshSplitButtonTooltips() {
@@ -7027,6 +7052,7 @@ final class Workspace: Identifiable, ObservableObject {
     private var debugDidMoveTabEventCount: UInt64 = 0
 #endif
     private var layoutFollowUpObservers: [NSObjectProtocol] = []
+    private var sshFeaturesSettingsObserver: NSObjectProtocol?
     private var layoutFollowUpPanelsCancellable: AnyCancellable?
     private var layoutFollowUpTimeoutWorkItem: DispatchWorkItem?
     private var layoutFollowUpReason: String?

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8115,6 +8115,20 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func configureRemoteConnection(_ configuration: WorkspaceRemoteConfiguration, autoConnect: Bool = true) {
+        guard SSHFeaturesSettings.isEnabled() else {
+            let previousController = remoteSessionController
+            activeRemoteSessionControllerID = nil
+            remoteSessionController = nil
+            previousController?.stop()
+            remoteConfiguration = nil
+            pendingRemoteForegroundAuthToken = nil
+            applyRemoteConnectionStateUpdate(
+                .error,
+                detail: "SSH features are disabled in Settings.",
+                target: configuration.destination
+            )
+            return
+        }
         skipControlMasterCleanupAfterDetachedRemoteTransfer = false
         remoteConfiguration = configuration
         seedInitialRemoteTerminalSessionIfNeeded(configuration: configuration)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8116,15 +8116,15 @@ final class Workspace: Identifiable, ObservableObject {
 
     func configureRemoteConnection(_ configuration: WorkspaceRemoteConfiguration, autoConnect: Bool = true) {
         guard SSHFeaturesSettings.isEnabled() else {
-            let previousController = remoteSessionController
-            activeRemoteSessionControllerID = nil
-            remoteSessionController = nil
-            previousController?.stop()
+            disconnectRemoteConnection(clearConfiguration: false)
             remoteConfiguration = nil
-            pendingRemoteForegroundAuthToken = nil
+            skipControlMasterCleanupAfterDetachedRemoteTransfer = false
             applyRemoteConnectionStateUpdate(
                 .error,
-                detail: "SSH features are disabled in Settings.",
+                detail: String(
+                    localized: "workspace.remote.sshFeaturesDisabled",
+                    defaultValue: "SSH features are disabled in Settings."
+                ),
                 target: configuration.destination
             )
             return

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6989,7 +6989,9 @@ final class Workspace: Identifiable, ObservableObject {
     private func tearDownRemoteSessionIfSSHFeaturesDisabled() {
         guard !SSHFeaturesSettings.isEnabled() else { return }
         guard let destination = remoteConfiguration?.destination else { return }
-        disconnectRemoteConnection(clearConfiguration: true)
+        disconnectRemoteConnection(clearConfiguration: false)
+        remoteConfiguration = nil
+        skipControlMasterCleanupAfterDetachedRemoteTransfer = false
         applyRemoteConnectionStateUpdate(
             .error,
             detail: String(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4133,6 +4133,18 @@ enum TelemetrySettings {
     static let enabledForCurrentLaunch = isEnabled()
 }
 
+enum SSHFileUploadSettings {
+    static let enabledKey = "enableSSHFileUpload"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+}
+
 enum CmdClickMarkdownRouteSettings {
     static let key = "openMarkdownInCmuxViewer"
     static let defaultValue = false
@@ -4398,6 +4410,8 @@ struct SettingsView: View {
     private var geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
     @AppStorage(TelemetrySettings.sendAnonymousTelemetryKey)
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
+    @AppStorage(SSHFileUploadSettings.enabledKey)
+    private var enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
     @AppStorage(CmdClickMarkdownRouteSettings.key) private var openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
@@ -5329,6 +5343,20 @@ struct SettingsView: View {
                                 : String(localized: "settings.app.telemetry.subtitle", defaultValue: "Share anonymized crash and usage data to help improve cmux.")
                         ) {
                             Toggle("", isOn: $sendAnonymousTelemetry)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.enableSSHFileUpload"),
+                            String(localized: "settings.app.sshFileUpload", defaultValue: "SSH File Upload"),
+                            subtitle: enableSSHFileUpload
+                                ? String(localized: "settings.app.sshFileUpload.subtitleOn", defaultValue: "Files dragged into SSH sessions are uploaded via scp.")
+                                : String(localized: "settings.app.sshFileUpload.subtitleOff", defaultValue: "SSH file upload is disabled. Dragged files insert their local path instead.")
+                        ) {
+                            Toggle("", isOn: $enableSSHFileUpload)
                                 .labelsHidden()
                                 .controlSize(.small)
                         }
@@ -6565,6 +6593,7 @@ struct SettingsView: View {
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
+        enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
         preferredEditorCommand = ""
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5387,9 +5387,11 @@ struct SettingsView: View {
                         SettingsCardRow(
                             configurationReview: .json("app.enableSSHFileUpload"),
                             String(localized: "settings.app.sshFileUpload", defaultValue: "SSH File Upload"),
-                            subtitle: enableSSHFileUpload
-                                ? String(localized: "settings.app.sshFileUpload.subtitleOn", defaultValue: "Files dragged into SSH sessions are uploaded via scp.")
-                                : String(localized: "settings.app.sshFileUpload.subtitleOff", defaultValue: "SSH file upload is disabled. Dragged files insert their local path instead.")
+                            subtitle: !enableSSHFeatures
+                                ? String(localized: "settings.app.sshFileUpload.subtitleDisabledBySSHFeatures", defaultValue: "SSH features are disabled. No scp uploads occur regardless of this toggle.")
+                                : (enableSSHFileUpload
+                                    ? String(localized: "settings.app.sshFileUpload.subtitleOn", defaultValue: "Files dragged into SSH sessions are uploaded via scp.")
+                                    : String(localized: "settings.app.sshFileUpload.subtitleOff", defaultValue: "SSH file upload is disabled. Dragged files insert their local path instead."))
                         ) {
                             Toggle("", isOn: $enableSSHFileUpload)
                                 .labelsHidden()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4145,6 +4145,25 @@ enum SSHFileUploadSettings {
     }
 }
 
+// Master kill-switch for all SSH-backed functionality in cmux.
+// When disabled, cmux will not initiate outbound SSH connections:
+// the `cmux ssh` CLI path, workspace remote session controller
+// (ControlMaster multiplexing, daemon install, port forwarding),
+// SSH file explorer provider, scp-based drag-and-drop upload, and
+// TTY-based SSH session detection are all gated off. Intended for
+// corporate environments that forbid SSH tunneling from this app.
+enum SSHFeaturesSettings {
+    static let enabledKey = "enableSSHFeatures"
+    static let defaultEnabled = true
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+}
+
 enum CmdClickMarkdownRouteSettings {
     static let key = "openMarkdownInCmuxViewer"
     static let defaultValue = false
@@ -4412,6 +4431,8 @@ struct SettingsView: View {
     private var sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
     @AppStorage(SSHFileUploadSettings.enabledKey)
     private var enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
+    @AppStorage(SSHFeaturesSettings.enabledKey)
+    private var enableSSHFeatures = SSHFeaturesSettings.defaultEnabled
     @AppStorage(PreferredEditorSettings.key) private var preferredEditorCommand = ""
     @AppStorage(CmdClickMarkdownRouteSettings.key) private var openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
     @AppStorage("cmuxPortBase") private var cmuxPortBase = 9100
@@ -5350,6 +5371,20 @@ struct SettingsView: View {
                         SettingsCardDivider()
 
                         SettingsCardRow(
+                            configurationReview: .json("app.enableSSHFeatures"),
+                            String(localized: "settings.app.sshFeatures", defaultValue: "SSH Features"),
+                            subtitle: enableSSHFeatures
+                                ? String(localized: "settings.app.sshFeatures.subtitleOn", defaultValue: "cmux may establish outbound SSH connections for remote workspaces, the file explorer, and scp uploads.")
+                                : String(localized: "settings.app.sshFeatures.subtitleOff", defaultValue: "All SSH functionality is disabled. `cmux ssh`, remote workspaces, the SSH file explorer, and scp uploads will be blocked.")
+                        ) {
+                            Toggle("", isOn: $enableSSHFeatures)
+                                .labelsHidden()
+                                .controlSize(.small)
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
                             configurationReview: .json("app.enableSSHFileUpload"),
                             String(localized: "settings.app.sshFileUpload", defaultValue: "SSH File Upload"),
                             subtitle: enableSSHFileUpload
@@ -5359,6 +5394,7 @@ struct SettingsView: View {
                             Toggle("", isOn: $enableSSHFileUpload)
                                 .labelsHidden()
                                 .controlSize(.small)
+                                .disabled(!enableSSHFeatures)
                         }
 
                         SettingsCardDivider()
@@ -6594,6 +6630,7 @@ struct SettingsView: View {
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry
         enableSSHFileUpload = SSHFileUploadSettings.defaultEnabled
+        enableSSHFeatures = SSHFeaturesSettings.defaultEnabled
         preferredEditorCommand = ""
         openMarkdownInCmuxViewer = CmdClickMarkdownRouteSettings.defaultValue
         browserSearchEngine = BrowserSearchSettings.defaultSearchEngine.rawValue


### PR DESCRIPTION
## Summary

Adds a single master Settings toggle — **SSH Features** (`app.enableSSHFeatures`, default `on`) — that blocks all outbound SSH functionality in cmux when disabled. Companion to #3072 (narrow SSH file-upload toggle); this one is the full kill-switch requested in #3071 for managed corporate deployments.

When disabled, cmux will not:
- Accept `workspace.remote.configure` / `workspace.remote.reconnect` socket commands (this is how the `cmux ssh` CLI path configures remote workspaces, so the CLI is covered too).
- Construct or start a `WorkspaceRemoteSessionController` — so ControlMaster multiplexing, cmuxd-remote build/upload, scp drop uploads, reverse port-forwarding, and heartbeat traffic never run.
- Attach an `SSHFileExplorerProvider` to remote workspace tabs.
- Route drag-and-drop uploads through scp in remote surfaces (`resolvedImageTransferTarget` falls back to local path insertion).

`SSHFileUploadSettings` (#3072) remains available as a finer-grained toggle inside the kill-switch — its UI row is disabled when the master switch is off.

## Changes

- **`Sources/cmuxApp.swift`** — new `SSHFeaturesSettings` enum (`enableSSHFeatures`, default `true`), `@AppStorage` binding, Settings UI row above the existing SSH File Upload row, reset handler.
- **`Sources/KeyboardShortcutSettingsFileStore.swift`** — registers `app.enableSSHFeatures` in `supportedSettingsJSONPaths`, parses the JSON key, adds it to the generated settings template. Also adds `app.enableSSHFileUpload` to `supportedSettingsJSONPaths` — it was missing from the allowlist in #3072 (flagged by CodeRabbit / cubic review bots on that PR).
- **`Sources/TerminalController.swift`** — gates the `workspace.remote.configure` and `workspace.remote.reconnect` socket handlers with an `ssh_disabled` error when the master toggle is off.
- **`Sources/Workspace.swift`** — gates `configureRemoteConnection` so the remote session controller is never instantiated; stops any live controller and surfaces an \"SSH features are disabled in Settings.\" error in the sidebar.
- **`Sources/ContentView.swift`** — gates `SSHFileExplorerProvider` construction behind the master toggle.
- **`Sources/TerminalImageTransfer.swift`** — evaluates `SSHFileUploadSettings.isEnabled()` **before** the workspace-remote branch in `resolvedImageTransferTarget()`. This also addresses a CodeRabbit finding on #3072: that PR's guard was placed after the `isRemoteTerminalSurface` check, so the workspace-remote path (which is also scp-based, see `Workspace.swift:uploadDroppedFilesLocked`) silently bypassed the file-upload toggle.
- **`Resources/Localizable.xcstrings`** — adds `settings.app.sshFeatures`, `.subtitleOn`, `.subtitleOff` across all 19 locales.

## Motivation

Issue #3071 requested an application-level opt-out for SSH-initiated network activity so IT teams don't have to rely on OS-level firewall rules. #3072 implements the narrow drag-and-drop case; this PR implements the broader \"Enable SSH features\" toggle also proposed in that issue.

## Test plan

- [ ] Toggle **Settings → General → SSH Features** off, then:
  - [ ] `cmux ssh user@host` — CLI reports an `ssh_disabled` error and does not spawn SSH.
  - [ ] Creating a new remote workspace via the UI — sidebar shows \"SSH features are disabled in Settings.\", no SSH process is started.
  - [ ] Remote file explorer — does not attempt to list a remote directory; falls back to local or empty.
  - [ ] Drop an image into a non-remote terminal with an interactive `ssh` foreground — the local path is inserted (no scp).
- [ ] Toggle back on, verify all paths resume.
- [ ] Toggle **SSH File Upload** off while **SSH Features** stays on — scp drop upload is blocked in both workspace-remote and detected-SSH surfaces; other SSH features continue to work.
- [ ] Set `app.enableSSHFeatures: false` in `~/.config/cmux/settings.json`, restart, verify no validation warning and behavior matches the UI toggle.
- [ ] **Settings → Reset All Settings** restores both SSH toggles to `true`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a master SSH kill‑switch to disable all outbound SSH across the app for managed deployments. When off, `cmux ssh`, remote workspaces, the SSH file explorer, and scp drag‑and‑drop are blocked; live remote sessions are torn down. Addresses #3071.

- **New Features**
  - New Settings → General toggle: SSH Features (`app.enableSSHFeatures`, default on). Disables the SSH File Upload row with a “disabled by SSH features” subtitle.
  - Blocks all SSH‑backed features: `cmux ssh`, remote session controller, SSH file explorer, scp uploads; `workspace.remote.configure`/`.reconnect` return a localized `ssh_disabled`.
  - Workspaces observe settings and disconnect active remote sessions when the master toggle flips off. JSON config support for `app.enableSSHFeatures` and `app.enableSSHFileUpload`; both reset with Reset All Settings. Localized strings added.

- **Bug Fixes**
  - Image transfer checks the master toggle before the file‑upload toggle, and both before remote paths, so scp routes can’t bypass disabled settings.
  - Toggling SSH features off now tears down live remote sessions without spawning ssh by skipping ControlMaster cleanup.

<sup>Written for commit 9256f27505056701e9ffe06db88c77ef7a4082e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added two settings: "SSH Features" and dependent "SSH File Upload" with reset-to-default support.
* **Behavior Changes / Bug Fixes**
  * When SSH is disabled, remote workspace/terminal remote paths and remote uploads are blocked; active remote sessions are disconnected and updated with an explanatory message.
* **Localization**
  * Added localized UI copy for SSH settings, states, file upload labels, and the workspace-disabled notice.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->