### PR TITLE
Reduce idle overlay animation log churn

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1788,6 +1788,13 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
 }
 
 @MainActor
+private func existingTmuxWorkspacePaneWindowOverlayController(
+    for window: NSWindow
+) -> WindowTmuxWorkspacePaneOverlayController? {
+    objc_getAssociatedObject(window, &tmuxWorkspacePaneWindowOverlayKey) as? WindowTmuxWorkspacePaneOverlayController
+}
+
+@MainActor
 private func tmuxWorkspacePaneWindowOverlayController(for window: NSWindow) -> WindowTmuxWorkspacePaneOverlayController {
     if let existing = objc_getAssociatedObject(window, &tmuxWorkspacePaneWindowOverlayKey) as? WindowTmuxWorkspacePaneOverlayController {
         return existing
@@ -3790,8 +3797,12 @@ struct ContentView: View {
 
         view = AnyView(view.background(WindowAccessor(dedupeByWindow: false) { window in
             MainActor.assumeIsolated {
-                let tmuxOverlayController = tmuxWorkspacePaneWindowOverlayController(for: window)
-                tmuxOverlayController.update(state: tmuxWorkspacePaneWindowOverlayState(for: window))
+                if let tmuxOverlayState = tmuxWorkspacePaneWindowOverlayState(for: window) {
+                    let tmuxOverlayController = tmuxWorkspacePaneWindowOverlayController(for: window)
+                    tmuxOverlayController.update(state: tmuxOverlayState)
+                } else {
+                    existingTmuxWorkspacePaneWindowOverlayController(for: window)?.update(state: nil)
+                }
                 let overlayController = commandPaletteWindowOverlayController(for: window)
                 overlayController.update(rootView: AnyView(commandPaletteOverlay), isVisible: isCommandPalettePresented)
             }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -152,27 +152,51 @@ struct TmuxWorkspacePaneOverlayView: View {
     let flashReason: WorkspaceAttentionFlashReason?
 
     var body: some View {
-        TimelineView(.animation) { timeline in
-            Canvas { context, _ in
-                for rect in unreadRects {
-                    drawUnreadRing(in: &context, rect: rect)
-                }
+        overlayContent
+            .allowsHitTesting(false)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
 
-                guard let flashRect,
-                      let flashStartedAt else { return }
-                let elapsed = timeline.date.timeIntervalSince(flashStartedAt)
-                let opacity = FocusFlashPattern.opacity(at: elapsed)
-                guard opacity > 0.001 else { return }
-                drawFlashRing(
-                    in: &context,
-                    rect: flashRect,
-                    opacity: opacity,
-                    reason: flashReason ?? .notificationArrival
-                )
+    @ViewBuilder
+    private var overlayContent: some View {
+        if shouldAnimateFlash, let flashStartedAt {
+            TimelineView(TmuxWorkspacePaneFlashTimelineSchedule(startDate: flashStartedAt)) { timeline in
+                overlayCanvas(timelineDate: timeline.date)
             }
+        } else if !unreadRects.isEmpty {
+            overlayCanvas(timelineDate: nil)
+        } else {
+            Color.clear
         }
-        .allowsHitTesting(false)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var shouldAnimateFlash: Bool {
+        guard let flashRect,
+              flashRect.width > 0,
+              flashRect.height > 0,
+              let flashStartedAt else { return false }
+        return Date() <= flashStartedAt.addingTimeInterval(FocusFlashPattern.duration)
+    }
+
+    private func overlayCanvas(timelineDate: Date?) -> some View {
+        Canvas { context, _ in
+            for rect in unreadRects {
+                drawUnreadRing(in: &context, rect: rect)
+            }
+
+            guard let flashRect,
+                  let flashStartedAt,
+                  let timelineDate else { return }
+            let elapsed = timelineDate.timeIntervalSince(flashStartedAt)
+            let opacity = FocusFlashPattern.opacity(at: elapsed)
+            guard opacity > 0.001 else { return }
+            drawFlashRing(
+                in: &context,
+                rect: flashRect,
+                opacity: opacity,
+                reason: flashReason ?? .notificationArrival
+            )
+        }
     }
 
     private func drawUnreadRing(in context: inout GraphicsContext, rect: CGRect) {
@@ -217,6 +241,32 @@ struct TmuxWorkspacePaneOverlayView: View {
             roundedRect: PanelOverlayRingMetrics.pathRect(in: rect),
             cornerRadius: PanelOverlayRingMetrics.cornerRadius
         )
+    }
+}
+
+private struct TmuxWorkspacePaneFlashTimelineSchedule: TimelineSchedule {
+    let startDate: Date
+
+    func entries(from requestedStartDate: Date, mode: Mode) -> Entries {
+        let firstDate = requestedStartDate > startDate ? requestedStartDate : startDate
+        return Entries(
+            nextDate: firstDate,
+            endDate: startDate.addingTimeInterval(FocusFlashPattern.duration),
+            interval: 1.0 / 60.0
+        )
+    }
+
+    struct Entries: Sequence, IteratorProtocol {
+        var nextDate: Date
+        let endDate: Date
+        let interval: TimeInterval
+
+        mutating func next() -> Date? {
+            guard nextDate <= endDate else { return nil }
+            let date = nextDate
+            nextDate = nextDate.addingTimeInterval(interval)
+            return date
+        }
     }
 }
 


### PR DESCRIPTION
Refs #3076

## Summary
- Avoid creating the tmux workspace-pane overlay controller when the overlay feature is inactive.
- Replace the always-mounted `TimelineView(.animation)` in `TmuxWorkspacePaneOverlayView` with static rendering when there is no active flash.
- Use a finite flash timeline so the overlay stops scheduling animation ticks after `FocusFlashPattern.duration`.

## Investigation notes
- Code audit found no cmux-owned `Logger`, `os_log`, `OSSignposter`, or signpost usage in `Sources/`; matches were only in the Ghostty macOS sources/wrappers.
- The noisy cmux-owned path was a SwiftUI/AppKit animation loop, not explicit cmux `os_log` calls.
- `ContentView` always created `WindowTmuxWorkspacePaneOverlayController`; its initial hidden root view still contained `TmuxWorkspacePaneOverlayView`, which always installed `TimelineView(.animation)` even with empty rects and no flash.

## Measurements

### CPU sampling
Three samples over ~30s unless noted.

| Phase | ecosystemd | ecosystemanalyticsd | Notes |
| --- | ---: | ---: | --- |
| Before tagged DEV build | 87.5%, 45.4%, 86.1% (avg 73.0%) | 6.6%, 6.7%, 19.5% (avg 10.9%) | User NIGHTLY PID 838 left running. |
| Pre-fix tagged DEV running | 78.6%, 79.0%, 76.7% (avg 78.1%) | original PID 760 had exited; current respawn sampled separately at 5.6% | Tagged DEV produced the log/signpost flood below. |
| Pre-fix tagged DEV quit | 89.8%, 88.1%, 85.8% (avg 87.9%) | 5.4%, 2.6%, 7.6% (avg 5.2%) | ecosystemd did not drop, so untouched cmux apps remained the baseline emitter. |
| Post-fix tagged DEV after 5 min | 87.2%, 90.6%, 88.7% (avg 88.8%) | 12.1%, 2.4%, 4.1% (avg 6.2%) | Production cmux PID 811 and NIGHTLY PID 838 were still running; tagged DEV was ~1.3% CPU at the 5-minute soak sample. |

I did not quit PID 838 or PID 811 because the task prohibited touching the user’s cmux NIGHTLY without confirmation. The daemon CPU therefore remains high on this machine even though the fixed tagged DEV build no longer contributes meaningful log/signpost volume.

### Unified log stream volume
Predicate: `process CONTAINS "cmux" OR sender CONTAINS "cmux" OR subsystem BEGINSWITH "com.cmuxterm" OR subsystem BEGINSWITH "ai.manaflow"`.

| Capture | Total lines / 60s | Lines/sec | Tagged DEV lines / 60s | Top subsystems |
| --- | ---: | ---: | ---: | --- |
| Pre-fix | 26,151 | 435.85 | 21,925 | `com.apple.runningboard:assertion` 21,854; then Network/CFNetwork/WebKit |
| Post-fix | 4,038 | 67.30 | 64 | Network/CFNetwork/WebKit; RunningBoard assertion category no longer present in the top histogram |

### Signpost stream volume
Predicate: `process CONTAINS "cmux" OR subsystem BEGINSWITH "com.cmuxterm" OR subsystem BEGINSWITH "ai.manaflow"` with `--signpost`.

| Capture | Total lines / 60s | Lines/sec | Tagged DEV lines / 60s | Remaining top emitters |
| --- | ---: | ---: | ---: | --- |
| Pre-fix | 126,100 | 2,101.67 | 42,389 | `com.apple.AppKit:UpdateCycle`, `com.apple.coreanimation:Transaction` |
| Post-fix | 84,879 | 1,414.65 | 344 | production cmux PID 811: 43,415; NIGHTLY PID 838: 39,471 |

## Verification
- Built and launched with `./scripts/reload.sh --tag issue-3076-ecosystemd-cpu-investigation --launch`.
- `git diff --check` passed.
- Local tests were not run per repo policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window overlay lifecycle and SwiftUI animation scheduling; risk is mainly UI regressions (overlay not appearing/clearing correctly) rather than data/security issues.
> 
> **Overview**
> Reduces idle UI churn from the tmux workspace-pane overlay by **only creating/updating the window overlay controller when the overlay feature is active**, and explicitly clearing any existing controller when inactive.
> 
> Refactors `TmuxWorkspacePaneOverlayView` to avoid an always-mounted `TimelineView(.animation)`: it now renders statically when only unread rings are present, and uses a **finite 60fps `TimelineSchedule`** for flash animation so ticks stop after `FocusFlashPattern.duration`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7aecc0c1eccbbe0cac82231926fe82b9dbd57ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved tmux workspace pane overlay management to display overlays only when relevant data is available
* Enhanced flash animation with better timing precision and rendering efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reduce idle animation and log/signpost churn in the tmux workspace-pane overlay, addressing #3076. We now avoid work when the overlay is inactive and stop flash ticks after their duration.

- **Bug Fixes**
  - Only create/update the overlay controller when the overlay is active; clear it when inactive.
  - Replace the always-on animation timeline with static rendering when no flash; use a finite 60fps schedule that ends after the flash duration.
  - Add a helper to fetch an existing overlay controller to allow clearing without recreating.
  - Impact: tagged DEV logs 21,925→64/60s; signposts 42,389→344/60s; DEV process ~1.3% CPU after 5 minutes.

<sup>Written for commit b7aecc0c1eccbbe0cac82231926fe82b9dbd57ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

