### PR TITLE
Issue 3081 workspace color left rail

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -239,9 +239,6 @@ func sidebarWorkspaceRowBackgroundStyle(
             forceBright: activeTabIndicatorStyle == .leftRail
         )
     }
-    let selectedCustomBackground = customColorHex.flatMap {
-        sidebarSelectedWorkspaceCustomBackgroundNSColor(hex: $0, colorScheme: colorScheme)
-    }
 
     switch activeTabIndicatorStyle {
     case .leftRail:
@@ -259,7 +256,7 @@ func sidebarWorkspaceRowBackgroundStyle(
     case .solidFill:
         if isActive {
             return SidebarWorkspaceRowBackgroundStyle(
-                color: selectedCustomBackground ?? selectedBackground,
+                color: selectedBackground,
                 opacity: 1
             )
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -203,6 +203,22 @@ struct SidebarWorkspaceRowBackgroundStyle {
     static let clear = Self(color: nil, opacity: 0)
 }
 
+func sidebarWorkspaceRowExplicitRailNSColor(
+    activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle,
+    customColorHex: String?,
+    colorScheme: ColorScheme
+) -> NSColor? {
+    guard activeTabIndicatorStyle == .leftRail,
+          let customColorHex else {
+        return nil
+    }
+    return WorkspaceTabColorSettings.displayNSColor(
+        hex: customColorHex,
+        colorScheme: colorScheme,
+        forceBright: true
+    )
+}
+
 func sidebarWorkspaceRowBackgroundStyle(
     activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle,
     isActive: Bool,
@@ -231,14 +247,8 @@ func sidebarWorkspaceRowBackgroundStyle(
     case .leftRail:
         if isActive {
             return SidebarWorkspaceRowBackgroundStyle(
-                color: selectedCustomBackground ?? selectedBackground,
+                color: selectedBackground,
                 opacity: 1
-            )
-        }
-        if let customBackground {
-            return SidebarWorkspaceRowBackgroundStyle(
-                color: customBackground,
-                opacity: isMultiSelected ? 0.35 : 0.7
             )
         }
         if isMultiSelected {
@@ -13073,6 +13083,10 @@ private struct TabItemView: View, Equatable {
         .semibold
     }
 
+    private var showsLeadingRail: Bool {
+        explicitRailColor != nil
+    }
+
     private var activeBorderLineWidth: CGFloat {
         switch activeTabIndicatorStyle {
         case .leftRail:
@@ -13500,6 +13514,16 @@ private struct TabItemView: View, Equatable {
                 .overlay {
                     RoundedRectangle(cornerRadius: 6)
                         .strokeBorder(activeBorderColor, lineWidth: activeBorderLineWidth)
+                }
+                .overlay(alignment: .leading) {
+                    if showsLeadingRail {
+                        Capsule(style: .continuous)
+                            .fill(railColor)
+                            .frame(width: 3)
+                            .padding(.leading, 4)
+                            .padding(.vertical, 5)
+                            .offset(x: -1)
+                    }
                 }
         )
         .padding(.horizontal, 6)
@@ -13941,6 +13965,21 @@ private struct TabItemView: View, Equatable {
         )
         guard let color = style.color else { return .clear }
         return Color(nsColor: color).opacity(style.opacity)
+    }
+
+    private var railColor: Color {
+        explicitRailColor ?? .clear
+    }
+
+    private var explicitRailColor: Color? {
+        guard let railColor = sidebarWorkspaceRowExplicitRailNSColor(
+            activeTabIndicatorStyle: activeTabIndicatorStyle,
+            customColorHex: workspaceSnapshot.customColorHex,
+            colorScheme: colorScheme
+        ) else {
+            return nil
+        }
+        return Color(nsColor: railColor).opacity(0.95)
     }
 
     private func tabColorSwatchColor(for hex: String) -> NSColor {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -61,7 +61,7 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
     }
 
     @MainActor
-    func testSetTabColorFeedsSelectedSolidFillSidebarBackground() {
+    func testSolidFillKeepsSelectedBackgroundForActiveCustomColoredWorkspaceRow() {
         let manager = TabManager()
         guard let workspace = manager.tabs.first else {
             XCTFail("Expected TabManager to initialise with a workspace")
@@ -87,7 +87,10 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
             sidebarSelectionColorHex: nil
         )
 
-        XCTAssertEqual(background.color?.hexString(), "#C0392B")
+        XCTAssertEqual(
+            background.color?.hexString(),
+            sidebarSelectedWorkspaceBackgroundNSColor(for: .light).hexString()
+        )
         XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
         withExtendedLifetime(cancellable) {}
     }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -93,7 +93,7 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
     }
 
     @MainActor
-    func testSetTabColorFeedsSelectedDefaultSidebarBackground() {
+    func testLeftRailKeepsSelectedBackgroundForActiveCustomColoredWorkspaceRow() {
         let manager = TabManager()
         guard let workspace = manager.tabs.first else {
             XCTFail("Expected TabManager to initialise with a workspace")
@@ -119,7 +119,10 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
             sidebarSelectionColorHex: nil
         )
 
-        XCTAssertEqual(background.color?.hexString(), "#C0392B")
+        XCTAssertEqual(
+            background.color?.hexString(),
+            sidebarSelectedWorkspaceBackgroundNSColor(for: .light).hexString()
+        )
         XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
         withExtendedLifetime(cancellable) {}
     }
@@ -145,6 +148,26 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
 
         XCTAssertNil(background.color)
         XCTAssertEqual(background.opacity, 0, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testLeftRailResolvesExplicitRailColorForCustomColoredWorkspaceRow() {
+        let manager = TabManager()
+        guard let workspace = manager.tabs.first else {
+            XCTFail("Expected TabManager to initialise with a workspace")
+            return
+        }
+
+        manager.setTabColor(tabId: workspace.id, color: "#C0392B")
+
+        let railColor = sidebarWorkspaceRowExplicitRailNSColor(
+            activeTabIndicatorStyle: .leftRail,
+            customColorHex: workspace.customColor,
+            colorScheme: .light
+        )
+
+        XCTAssertNotNil(railColor)
+        XCTAssertEqual(railColor?.hexString(), "#C0392B")
     }
 
     @MainActor

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -123,6 +123,52 @@ final class SidebarSelectedWorkspaceColorTests: XCTestCase {
         XCTAssertEqual(background.opacity, 1.0, accuracy: 0.001)
         withExtendedLifetime(cancellable) {}
     }
+
+    @MainActor
+    func testLeftRailLeavesInactiveCustomColoredWorkspaceRowTransparent() {
+        let manager = TabManager()
+        guard let workspace = manager.tabs.first else {
+            XCTFail("Expected TabManager to initialise with a workspace")
+            return
+        }
+
+        manager.setTabColor(tabId: workspace.id, color: "#C0392B")
+
+        let background = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .leftRail,
+            isActive: false,
+            isMultiSelected: false,
+            customColorHex: workspace.customColor,
+            colorScheme: .light,
+            sidebarSelectionColorHex: nil
+        )
+
+        XCTAssertNil(background.color)
+        XCTAssertEqual(background.opacity, 0, accuracy: 0.001)
+    }
+
+    @MainActor
+    func testSolidFillUsesInactiveCustomWorkspaceColorAsBackground() {
+        let manager = TabManager()
+        guard let workspace = manager.tabs.first else {
+            XCTFail("Expected TabManager to initialise with a workspace")
+            return
+        }
+
+        manager.setTabColor(tabId: workspace.id, color: "#C0392B")
+
+        let background = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: false,
+            isMultiSelected: false,
+            customColorHex: workspace.customColor,
+            colorScheme: .light,
+            sidebarSelectionColorHex: nil
+        )
+
+        XCTAssertEqual(background.color?.hexString(), "#C0392B")
+        XCTAssertEqual(background.opacity, 0.7, accuracy: 0.001)
+    }
 }
 
 


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change to sidebar workspace row rendering, with updated unit tests covering the new left-rail vs solid-fill behavior.
> 
> **Overview**
> Updates sidebar workspace row styling so **active rows no longer use the workspace’s custom color as the selection background** in either `leftRail` or `solidFill` mode; selection now always uses `sidebarSelectedWorkspaceBackgroundNSColor`.
> 
> For `leftRail`, custom workspace colors are now rendered as an *explicit leading rail* (new `sidebarWorkspaceRowExplicitRailNSColor` + a leading `Capsule` overlay), while inactive custom-colored rows remain transparent. Unit tests are updated/added to lock in the new selection/background vs rail behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b32086f381e046ca977214870d90eb1e3e18feeb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visual color indicator rail on the sidebar for workspaces with custom colors

* **Bug Fixes**
  * Refined background styling for custom-colored workspaces in different selection states
  * Fixed background color behavior in left-rail layout for inactive workspaces

* **Tests**
  * Enhanced test coverage for workspace color display across different states

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the sidebar to show workspace colors as a left-rail indicator and made the selected row background consistent across styles. Addresses Linear 3081 by removing custom-color fills for active rows and adding a clear color rail in left-rail mode.

- New Features
  - Added an explicit leading color rail in `leftRail` using the workspace’s custom color.

- Bug Fixes
  - Active rows now always use `sidebarSelectedWorkspaceBackgroundNSColor` in both `leftRail` and `solidFill`.
  - In `leftRail`, inactive custom-colored rows stay transparent; in `solidFill`, they use the custom color at 0.7 opacity. Unit tests added to lock this behavior.

<sup>Written for commit b32086f381e046ca977214870d90eb1e3e18feeb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

