### PR TITLE
Fix #3080: blank window + terminal after CLI notify reopen

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -21,7 +21,10 @@ private let cliNotificationDebugLogger = Logger(
 )
 
 private func cliNotificationDebugLog(_ message: String) {
-    cliNotificationDebugLogger.debug("\(message, privacy: .public)")
+    // See AppDelegate.notificationDebugLog — default String interpolation
+    // privacy (`.private`) keeps bundle identifiers, pids, and argv payloads
+    // redacted in release unified logs.
+    cliNotificationDebugLogger.debug("\(message)")
 }
 
 struct CLIError: Error, CustomStringConvertible {
@@ -3305,7 +3308,12 @@ struct CMUXCLI {
             cliNotificationDebugLog(
                 "cli.activateApp.existing bundleId=\(bundleIdentifier) pid=\(running.processIdentifier) activated=\(activated ? 1 : 0)"
             )
-            return
+            if activated {
+                return
+            }
+            cliNotificationDebugLog(
+                "cli.activateApp.fallback bundleId=\(bundleIdentifier) reason=activate_returned_false"
+            )
         }
 #endif
         let process = Process()

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1,6 +1,10 @@
 import Foundation
 import CryptoKit
 import Darwin
+import OSLog
+#if canImport(AppKit)
+import AppKit
+#endif
 #if canImport(LocalAuthentication)
 import LocalAuthentication
 #endif
@@ -10,6 +14,15 @@ import Security
 #if canImport(Sentry)
 import Sentry
 #endif
+
+private let cliNotificationDebugLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "notification-debug"
+)
+
+private func cliNotificationDebugLog(_ message: String) {
+    cliNotificationDebugLogger.debug("\(message, privacy: .public)")
+}
 
 struct CLIError: Error, CustomStringConvertible {
     let message: String
@@ -3263,17 +3276,44 @@ struct CMUXCLI {
     }
 
     private func launchApp() throws {
+        let bundleIdentifier = currentCmuxAppBundleIdentifier()
+#if canImport(AppKit)
+        if let bundleIdentifier,
+           let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first {
+            cliNotificationDebugLog(
+                "cli.launchApp.running bundleId=\(bundleIdentifier) pid=\(running.processIdentifier) active=\(running.isActive ? 1 : 0)"
+            )
+            return
+        }
+#endif
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = ["-a", "cmux"]
+        process.arguments = bundleIdentifier.map { ["-b", $0] } ?? ["-a", "cmux"]
+        cliNotificationDebugLog(
+            "cli.launchApp.spawn bundleId=\(bundleIdentifier ?? "nil") args=\(process.arguments?.joined(separator: " ") ?? "")"
+        )
         try process.run()
         process.waitUntilExit()
     }
 
     private func activateApp() throws {
+        let bundleIdentifier = currentCmuxAppBundleIdentifier()
+#if canImport(AppKit)
+        if let bundleIdentifier,
+           let running = NSRunningApplication.runningApplications(withBundleIdentifier: bundleIdentifier).first {
+            let activated = running.activate(options: [.activateAllWindows])
+            cliNotificationDebugLog(
+                "cli.activateApp.existing bundleId=\(bundleIdentifier) pid=\(running.processIdentifier) activated=\(activated ? 1 : 0)"
+            )
+            return
+        }
+#endif
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        process.arguments = ["-a", "cmux"]
+        process.arguments = bundleIdentifier.map { ["-b", $0] } ?? ["-a", "cmux"]
+        cliNotificationDebugLog(
+            "cli.activateApp.spawn bundleId=\(bundleIdentifier ?? "nil") args=\(process.arguments?.joined(separator: " ") ?? "")"
+        )
         try process.run()
         process.waitUntilExit()
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4920,6 +4920,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+#if DEBUG
+    func debugWindowSnapshot() -> [String: Any] {
+        let anyValue: (Any?) -> Any = { value in
+            value ?? NSNull()
+        }
+        let windows: [[String: Any]] = NSApp.windows.enumerated().map { index, window in
+            let context = contextForMainTerminalWindow(window, reindex: false)
+            return [
+                "index": index,
+                "window_number": window.windowNumber,
+                "identifier": anyValue(window.identifier?.rawValue),
+                "title": anyValue(window.title.isEmpty ? nil : window.title),
+                "class": String(describing: type(of: window)),
+                "visible": window.isVisible,
+                "key": window.isKeyWindow,
+                "main": window.isMainWindow,
+                "miniaturized": window.isMiniaturized,
+                "occluded": !window.occlusionState.contains(.visible),
+                "registered_main_window_id": anyValue(context?.windowId.uuidString),
+                "registered_workspace_count": anyValue(context?.tabManager.tabs.count),
+            ]
+        }
+
+        return [
+            "ns_window_count": NSApp.windows.count,
+            "main_window_context_count": mainWindowContexts.count,
+            "windows": windows,
+        ]
+    }
+#endif
+
     func windowMoveTargets(referenceWindowId: UUID?) -> [WindowMoveTarget] {
         let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
         let labels = windowLabelsById(orderedSummaries: orderedSummaries, referenceWindowId: referenceWindowId)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -16,7 +16,12 @@ private let notificationDebugLogger = Logger(
 )
 
 private func notificationDebugLog(_ message: String) {
-    notificationDebugLogger.debug("\(message, privacy: .public)")
+    // Default OSLog privacy for dynamic strings is `.private`: messages stay
+    // redacted as `<private>` in release builds unless the system is explicitly
+    // configured to show private data for our subsystem. Developers diagnosing
+    // the notification path locally can toggle that via
+    // `log config --mode "private_data:on" --subsystem com.manaflow.cmux`.
+    notificationDebugLogger.debug("\(message)")
 }
 
 func cmuxJavaScriptStringLiteral(_ value: String?) -> String? {
@@ -5016,25 +5021,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 line.trimmingCharacters(in: .whitespacesAndNewlines)
             }
             .joined(separator: " | ")
-    }
-
-    private func activeMainWindowContext(containing tabId: UUID) -> MainWindowContext? {
-        if let activeManager = tabManager,
-           let context = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }),
-           context.tabManager.tabs.contains(where: { $0.id == tabId }) {
-            return context
-        }
-
-        for candidateWindow in [NSApp.keyWindow, NSApp.mainWindow] {
-            guard let candidateWindow,
-                  let context = contextForMainTerminalWindow(candidateWindow),
-                  context.tabManager.tabs.contains(where: { $0.id == tabId }) else {
-                continue
-            }
-            return context
-        }
-
-        return nil
     }
 
     func windowMoveTargets(referenceWindowId: UUID?) -> [WindowMoveTarget] {
@@ -12909,13 +12895,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return UUID(uuidString: surfaceIdString)
         }()
-        let resolvedContext = contextContainingTabId(tabId)
-        let resolvedWindow = resolvedContext.flatMap { $0.window ?? windowForMainWindowId($0.windowId) }
-        notificationDebugLog(
-            "notification.response action=\(response.actionIdentifier) tabId=\(tabId.uuidString) " +
-                "surfaceId=\(surfaceId?.uuidString ?? "nil") context={\(notificationDebugContextSummary(resolvedContext))} " +
-                "window={\(notificationDebugWindowSummary(resolvedWindow))}"
-        )
+        let actionIdentifier = response.actionIdentifier
+        // mainWindowContexts, NSApp.windows and per-window AppKit properties are
+        // main-actor state. UNUserNotificationCenter may deliver didReceive off
+        // the main queue, so resolve + log on main before racing with the open
+        // path below (which already hops to main for its own work).
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            let resolvedContext = self.contextContainingTabId(tabId)
+            let resolvedWindow = resolvedContext.flatMap { $0.window ?? self.windowForMainWindowId($0.windowId) }
+            notificationDebugLog(
+                "notification.response action=\(actionIdentifier) tabId=\(tabId.uuidString) " +
+                    "surfaceId=\(surfaceId?.uuidString ?? "nil") context={\(self.notificationDebugContextSummary(resolvedContext))} " +
+                    "window={\(self.notificationDebugWindowSummary(resolvedWindow))}"
+            )
+        }
 
         switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier, TerminalNotificationStore.actionShowIdentifier:
@@ -13335,23 +13329,31 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func openNotificationFallback(tabId: UUID, surfaceId: UUID?, notificationId: UUID?) -> Bool {
-        // If the owning window context hasn't been registered yet, fall back to the "active" window.
-        guard let context = activeMainWindowContext(containing: tabId) else {
+        // This fallback is reached only when openNotification()'s
+        // contextContainingTabId lookup misses — i.e. no registered
+        // MainWindowContext currently owns the tab. That happens in the
+        // app-relaunch / startup race, so any context-based resolution would
+        // miss the same way. Instead route through the active TabManager if
+        // the tab lives there, focusing the app's key / first main-terminal
+        // window.
+        guard let focusTabManager = tabManager,
+              focusTabManager.tabs.contains(where: { $0.id == tabId }) else {
+            let reason = tabManager == nil ? "missing_tabManager" : "tab_not_in_active_manager"
             notificationDebugLog(
                 "notification.open.fallback.miss tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
-                    "activeTabManagerTabs=\(tabManager?.tabs.count ?? -1) mainContextCount=\(mainWindowContexts.count)"
+                    "activeTabManagerTabs=\(tabManager?.tabs.count ?? -1) mainContextCount=\(mainWindowContexts.count) " +
+                    "reason=\(reason)"
             )
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
-                writeJumpUnreadTestData(["jumpUnreadFallbackFail": "missing_tabManager"])
+                writeJumpUnreadTestData(["jumpUnreadFallbackFail": reason])
             }
 #endif
             return false
         }
-        guard let window = context.window ?? windowForMainWindowId(context.windowId) else {
+        guard let focusWindow = NSApp.keyWindow ?? NSApp.windows.first(where: { isMainTerminalWindow($0) }) else {
             notificationDebugLog(
-                "notification.open.fallback.windowMissing tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
-                    "context={\(notificationDebugContextSummary(context))}"
+                "notification.open.fallback.windowMissing tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil")"
             )
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
@@ -13363,12 +13365,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         notificationDebugLog(
             "notification.open.fallback tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
-                "context={\(notificationDebugContextSummary(context))} window={\(notificationDebugWindowSummary(window))}"
+                "window={\(notificationDebugWindowSummary(focusWindow))} " +
+                "activeTabManagerTabs=\(focusTabManager.tabs.count)"
         )
 
-        context.sidebarSelectionState.selection = .tabs
-        bringToFront(window)
-        guard context.tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+        sidebarSelectionState?.selection = .tabs
+        bringToFront(focusWindow)
+        guard focusTabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
                 writeJumpUnreadTestData([
@@ -13382,7 +13385,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
 #if DEBUG
         recordJumpUnreadFocusFromModelIfNeeded(
-            tabManager: context.tabManager,
+            tabManager: focusTabManager,
             tabId: tabId,
             expectedSurfaceId: surfaceId
         )
@@ -13393,18 +13396,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 notificationId: notificationId,
                 tabId: tabId,
                 surfaceId: surfaceId,
-                tabManager: context.tabManager,
+                tabManager: focusTabManager,
                 notificationStore: store
             )
         }
-#if DEBUG
-        recordMultiWindowNotificationFocusIfNeeded(
-            windowId: context.windowId,
-            tabId: tabId,
-            surfaceId: surfaceId,
-            sidebarSelection: context.sidebarSelectionState.selection
-        )
-#endif
 #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
             writeJumpUnreadTestData(["jumpUnreadOpenInFallback": "1", "jumpUnreadOpenResult": "1"])

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8,6 +8,16 @@ import WebKit
 import Combine
 import ObjectiveC.runtime
 import Darwin
+import OSLog
+
+private let notificationDebugLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "notification-debug"
+)
+
+private func notificationDebugLog(_ message: String) {
+    notificationDebugLogger.debug("\(message, privacy: .public)")
+}
 
 func cmuxJavaScriptStringLiteral(_ value: String?) -> String? {
     guard let value else { return nil }
@@ -2961,6 +2971,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
     }
 
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        let targetWindow: NSWindow? = {
+            if let keyWindow = sender.keyWindow, isMainTerminalWindow(keyWindow) {
+                return keyWindow
+            }
+            if let mainWindow = sender.mainWindow, isMainTerminalWindow(mainWindow) {
+                return mainWindow
+            }
+            if let context = mainWindowContexts.values.first(where: { resolvedWindow(for: $0)?.isVisible == true }) {
+                return resolvedWindow(for: context)
+            }
+            return flag ? sender.windows.first(where: { $0.isVisible }) : nil
+        }()
+
+        notificationDebugLog(
+            "app.reopen hasVisibleWindows=\(flag ? 1 : 0) target={\(notificationDebugWindowSummary(targetWindow))} " +
+                "nsWindowCount=\(sender.windows.count) mainContextCount=\(mainWindowContexts.count)"
+        )
+
+        guard let targetWindow else { return false }
+
+        if isMainTerminalWindow(targetWindow) {
+            bringToFront(targetWindow)
+        } else {
+            if targetWindow.isMiniaturized {
+                targetWindow.deminiaturize(nil)
+            }
+            targetWindow.makeKeyAndOrderFront(nil)
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
+        }
+
+        return true
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
@@ -4950,6 +4994,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ]
     }
 #endif
+
+    private func notificationDebugWindowSummary(_ window: NSWindow?) -> String {
+        guard let window else { return "nil" }
+        let identifier = window.identifier?.rawValue ?? "nil"
+        return "num=\(window.windowNumber) id=\(identifier) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0) visible=\(window.isVisible ? 1 : 0)"
+    }
+
+    private func notificationDebugContextSummary(_ context: MainWindowContext?) -> String {
+        guard let context else { return "nil" }
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        let selected = context.tabManager.selectedTabId?.uuidString ?? "nil"
+        return "windowId=\(context.windowId.uuidString) window={\(notificationDebugWindowSummary(window))} tabs=\(context.tabManager.tabs.count) selected=\(selected)"
+    }
+
+    private func notificationDebugCallStack(limit: Int = 6) -> String {
+        Thread.callStackSymbols
+            .dropFirst()
+            .prefix(limit)
+            .map { line in
+                line.trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            .joined(separator: " | ")
+    }
+
+    private func activeMainWindowContext(containing tabId: UUID) -> MainWindowContext? {
+        if let activeManager = tabManager,
+           let context = mainWindowContexts.values.first(where: { $0.tabManager === activeManager }),
+           context.tabManager.tabs.contains(where: { $0.id == tabId }) {
+            return context
+        }
+
+        for candidateWindow in [NSApp.keyWindow, NSApp.mainWindow] {
+            guard let candidateWindow,
+                  let context = contextForMainTerminalWindow(candidateWindow),
+                  context.tabManager.tabs.contains(where: { $0.id == tabId }) else {
+                continue
+            }
+            return context
+        }
+
+        return nil
+    }
 
     func windowMoveTargets(referenceWindowId: UUID?) -> [WindowMoveTarget] {
         let orderedSummaries = orderedMainWindowSummaries(referenceWindowId: referenceWindowId)
@@ -7147,6 +7233,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sessionWindowSnapshot: SessionWindowSnapshot? = nil
     ) -> UUID {
         let windowId = UUID()
+        notificationDebugLog(
+            "mainWindow.create windowId=\(windowId.uuidString) initialWorkingDirectory=\(initialWorkingDirectory ?? "nil") " +
+                "restoreSnapshot=\(sessionWindowSnapshot != nil ? 1 : 0) nsWindowCountBefore=\(NSApp.windows.count) " +
+                "mainContextCountBefore=\(mainWindowContexts.count) stack=\(notificationDebugCallStack())"
+        )
         let tabManager = TabManager(initialWorkingDirectory: initialWorkingDirectory)
         if let tabManagerSnapshot = sessionWindowSnapshot?.tabManager {
             tabManager.restoreSessionSnapshot(tabManagerSnapshot)
@@ -7283,6 +7374,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
 #endif
         }
+        notificationDebugLog(
+            "mainWindow.create.complete windowId=\(windowId.uuidString) window={\(notificationDebugWindowSummary(window))} " +
+                "nsWindowCountAfter=\(NSApp.windows.count) mainContextCountAfter=\(mainWindowContexts.count)"
+        )
         return windowId
     }
 
@@ -12814,6 +12909,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             return UUID(uuidString: surfaceIdString)
         }()
+        let resolvedContext = contextContainingTabId(tabId)
+        let resolvedWindow = resolvedContext.flatMap { $0.window ?? windowForMainWindowId($0.windowId) }
+        notificationDebugLog(
+            "notification.response action=\(response.actionIdentifier) tabId=\(tabId.uuidString) " +
+                "surfaceId=\(surfaceId?.uuidString ?? "nil") context={\(notificationDebugContextSummary(resolvedContext))} " +
+                "window={\(notificationDebugWindowSummary(resolvedWindow))}"
+        )
 
         switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier, TerminalNotificationStore.actionShowIdentifier:
@@ -13127,6 +13229,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ])
         }
 #endif
+        notificationDebugLog(
+            "notification.open.request tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                "notificationId=\(notificationId?.uuidString ?? "nil") activeTabManagerTabs=\(tabManager?.tabs.count ?? -1) " +
+                "mainContextCount=\(mainWindowContexts.count)"
+        )
         guard let context = contextContainingTabId(tabId) else {
 #if DEBUG
             recordMultiWindowNotificationOpenFailureIfNeeded(
@@ -13160,6 +13267,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func openNotificationInContext(_ context: MainWindowContext, tabId: UUID, surfaceId: UUID?, notificationId: UUID?) -> Bool {
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
+        notificationDebugLog(
+            "notification.open.context tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                "context={\(notificationDebugContextSummary(context))} window={\(notificationDebugWindowSummary(window))}"
+        )
         guard let window else {
 #if DEBUG
             recordMultiWindowNotificationOpenFailureIfNeeded(
@@ -13225,7 +13336,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func openNotificationFallback(tabId: UUID, surfaceId: UUID?, notificationId: UUID?) -> Bool {
         // If the owning window context hasn't been registered yet, fall back to the "active" window.
-        guard let tabManager else {
+        guard let context = activeMainWindowContext(containing: tabId) else {
+            notificationDebugLog(
+                "notification.open.fallback.miss tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                    "activeTabManagerTabs=\(tabManager?.tabs.count ?? -1) mainContextCount=\(mainWindowContexts.count)"
+            )
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
                 writeJumpUnreadTestData(["jumpUnreadFallbackFail": "missing_tabManager"])
@@ -13233,15 +13348,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
             return false
         }
-        guard tabManager.tabs.contains(where: { $0.id == tabId }) else {
-#if DEBUG
-            if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
-                writeJumpUnreadTestData(["jumpUnreadFallbackFail": "tab_not_in_active_manager"])
-            }
-#endif
-            return false
-        }
-        guard let window = (NSApp.keyWindow ?? NSApp.windows.first(where: { isMainTerminalWindow($0) })) else {
+        guard let window = context.window ?? windowForMainWindowId(context.windowId) else {
+            notificationDebugLog(
+                "notification.open.fallback.windowMissing tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                    "context={\(notificationDebugContextSummary(context))}"
+            )
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
                 writeJumpUnreadTestData(["jumpUnreadFallbackFail": "missing_window"])
@@ -13250,9 +13361,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        sidebarSelectionState?.selection = .tabs
+        notificationDebugLog(
+            "notification.open.fallback tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                "context={\(notificationDebugContextSummary(context))} window={\(notificationDebugWindowSummary(window))}"
+        )
+
+        context.sidebarSelectionState.selection = .tabs
         bringToFront(window)
-        guard tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
+        guard context.tabManager.focusTabFromNotification(tabId, surfaceId: surfaceId) else {
 #if DEBUG
             if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
                 writeJumpUnreadTestData([
@@ -13266,7 +13382,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
 #if DEBUG
         recordJumpUnreadFocusFromModelIfNeeded(
-            tabManager: tabManager,
+            tabManager: context.tabManager,
             tabId: tabId,
             expectedSurfaceId: surfaceId
         )
@@ -13277,10 +13393,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 notificationId: notificationId,
                 tabId: tabId,
                 surfaceId: surfaceId,
-                tabManager: tabManager,
+                tabManager: context.tabManager,
                 notificationStore: store
             )
         }
+#if DEBUG
+        recordMultiWindowNotificationFocusIfNeeded(
+            windowId: context.windowId,
+            tabId: tabId,
+            surfaceId: surfaceId,
+            sidebarSelection: context.sidebarSelectionState.selection
+        )
+#endif
 #if DEBUG
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_JUMP_UNREAD_SETUP"] == "1" {
             writeJumpUnreadTestData(["jumpUnreadOpenInFallback": "1", "jumpUnreadOpenResult": "1"])

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10,7 +10,17 @@ import Carbon.HIToolbox
 import Sentry
 import Bonsplit
 import IOSurface
+import OSLog
 import UniformTypeIdentifiers
+
+private let notificationSurfaceLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "notification-debug"
+)
+
+private func notificationSurfaceLog(_ message: String) {
+    notificationSurfaceLogger.debug("\(message, privacy: .public)")
+}
 
 @_silgen_name("ghostty_surface_clear_selection")
 private func ghostty_surface_clear_selection_compat(_ surface: ghostty_surface_t) -> Bool
@@ -9563,6 +9573,11 @@ final class GhosttySurfaceScrollView: NSView {
     /// Request an immediate terminal redraw after geometry updates so stale IOSurface
     /// contents do not remain stretched during live resize churn.
     func refreshSurfaceNow(reason: String = "portal.refreshSurfaceNow") {
+        notificationSurfaceLog(
+            "surface.refreshSurfaceNow surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") " +
+                "reason=\(reason) visibleInUI=\(surfaceView.isVisibleInUI ? 1 : 0) " +
+                "inWindow=\(window != nil ? 1 : 0)"
+        )
         // Portal reparent/reveal can settle geometry a tick before AppKit finishes
         // realizing the terminal subtree's backing layer state. Flush display for the
         // hosted subtree first so forceRefresh does not race a still-unrealized layer.
@@ -10455,6 +10470,10 @@ final class GhosttySurfaceScrollView: NSView {
 
     func setVisibleInUI(_ visible: Bool) {
         let wasVisible = surfaceView.isVisibleInUI
+        notificationSurfaceLog(
+            "surface.setVisibleInUI surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") " +
+                "transition=\(wasVisible ? 1 : 0)->\(visible ? 1 : 0) inWindow=\(window != nil ? 1 : 0)"
+        )
         surfaceView.setVisibleInUI(visible)
         isHidden = !visible
         if wasVisible != visible, lastRequestedPortalOcclusionVisible != visible {
@@ -12462,11 +12481,13 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let coordinator = context.coordinator
         let previousDesiredIsActive = coordinator.desiredIsActive
         let previousDesiredIsVisibleInUI = coordinator.desiredIsVisibleInUI
+        let previousDesiredShowsUnreadNotificationRing = coordinator.desiredShowsUnreadNotificationRing
         let previousDesiredPortalZPriority = coordinator.desiredPortalZPriority
         let desiredStateChanged =
             previousDesiredIsActive != isActive ||
             previousDesiredIsVisibleInUI != isVisibleInUI ||
             previousDesiredPortalZPriority != portalZPriority
+        let notificationRingChanged = previousDesiredShowsUnreadNotificationRing != showsUnreadNotificationRing
         coordinator.desiredIsActive = isActive
         coordinator.desiredIsVisibleInUI = isVisibleInUI
         coordinator.desiredShowsUnreadNotificationRing = showsUnreadNotificationRing
@@ -12495,6 +12516,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
 #endif
 
         let hostContainer = nsView as? HostContainerView
+        let currentHostId = hostContainer.map { String(describing: ObjectIdentifier($0)) } ?? "nil"
+        let previousHostId = coordinator.lastBoundHostId.map { String(describing: $0) } ?? "nil"
         let hostOwnsPortalNow = hostContainer.map { host in
             terminalSurface.claimPortalHost(
                 hostId: ObjectIdentifier(host),
@@ -12505,6 +12528,17 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 reason: "update"
             )
         } ?? true
+        if notificationRingChanged || desiredStateChanged {
+            let guardState = hostedView.portalBindingGuardState()
+            notificationSurfaceLog(
+                "ghostty.update.enter surface=\(terminalSurface.id.uuidString) hostId=\(currentHostId) " +
+                    "prevHostId=\(previousHostId) visible=\(isVisibleInUI ? 1 : 0) active=\(isActive ? 1 : 0) " +
+                    "ring=\(showsUnreadNotificationRing ? 1 : 0) prevRing=\(previousDesiredShowsUnreadNotificationRing ? 1 : 0) " +
+                    "guardState=\(guardState.state) guardGeneration=\(guardState.generation.map { String($0) } ?? "nil") " +
+                    "hostOwns=\(hostOwnsPortalNow ? 1 : 0) hostedInWindow=\(hostedView.window != nil ? 1 : 0) " +
+                    "hostedHasSuperview=\(hostedView.superview != nil ? 1 : 0)"
+            )
+        }
 
         // Keep the surface lifecycle and handlers updated even if we defer re-parenting.
         hostedView.attachSurface(terminalSurface)
@@ -12554,6 +12588,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
 
         coordinator.attachGeneration += 1
         let generation = coordinator.attachGeneration
+        var didBindOnUpdate = false
+        var didRefreshAfterNotificationUpdate = false
+        var didDeferBindVisibilityUpdate = false
 
         if let host = hostContainer {
             host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
@@ -12657,6 +12694,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                         expectedSurfaceId: portalExpectedSurfaceId,
                         expectedGeneration: portalExpectedGeneration
                     )
+                    didBindOnUpdate = true
                     coordinator.lastBoundHostId = hostId
                     coordinator.lastSynchronizedHostGeometryRevision = geometryRevision
                 } else if portalBindingLive && coordinator.lastSynchronizedHostGeometryRevision != geometryRevision {
@@ -12683,6 +12721,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     for: hostedView,
                     visibleInUI: coordinator.desiredIsVisibleInUI
                 )
+                didDeferBindVisibilityUpdate = true
             }
         }
 
@@ -12712,6 +12751,27 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 )
             }
 #endif
+        }
+        let shouldRefreshAfterNotificationUpdate =
+            portalBindingStillLive() &&
+            isVisibleInUI &&
+            hostOwnsPortalNow &&
+            isBoundToCurrentHost &&
+            hostedView.window != nil &&
+            (notificationRingChanged || didBindOnUpdate)
+        if shouldRefreshAfterNotificationUpdate {
+            let reason = notificationRingChanged ? "notificationRing.updateNSView" : "notificationPortal.rebind"
+            hostedView.refreshSurfaceNow(reason: reason)
+            didRefreshAfterNotificationUpdate = true
+        }
+        if notificationRingChanged || didBindOnUpdate || didDeferBindVisibilityUpdate || desiredStateChanged {
+            notificationSurfaceLog(
+                "ghostty.update.exit surface=\(terminalSurface.id.uuidString) hostId=\(currentHostId) " +
+                    "boundToCurrent=\(isBoundToCurrentHost ? 1 : 0) hostOwns=\(hostOwnsPortalNow ? 1 : 0) " +
+                    "didBind=\(didBindOnUpdate ? 1 : 0) deferVisibility=\(didDeferBindVisibilityUpdate ? 1 : 0) " +
+                    "refreshed=\(didRefreshAfterNotificationUpdate ? 1 : 0) visible=\(isVisibleInUI ? 1 : 0) " +
+                    "active=\(isActive ? 1 : 0) ring=\(showsUnreadNotificationRing ? 1 : 0)"
+            )
         }
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -19,7 +19,9 @@ private let notificationSurfaceLogger = Logger(
 )
 
 private func notificationSurfaceLog(_ message: String) {
-    notificationSurfaceLogger.debug("\(message, privacy: .public)")
+    // Default String-interpolation privacy is `.private`; surface UUIDs and
+    // portal binding tokens stay redacted in release unified logs.
+    notificationSurfaceLogger.debug("\(message)")
 }
 
 @_silgen_name("ghostty_surface_clear_selection")

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -11265,12 +11265,14 @@ class TerminalController {
     }
 
     private func v2DebugWindowSnapshot() -> V2CallResult {
-        let payload: [String: Any] = v2MainSync {
-            AppDelegate.shared?.debugWindowSnapshot() ?? [
-                "ns_window_count": NSApp.windows.count,
-                "main_window_context_count": 0,
-                "windows": [],
-            ]
+        // NSApp.windows, AppDelegate.mainWindowContexts, and per-window AppKit
+        // properties are main-actor state; the exact-snapshot contract for this
+        // debug RPC requires synchronous main-thread execution.
+        let payload: [String: Any]? = v2MainSync {
+            AppDelegate.shared?.debugWindowSnapshot()
+        }
+        guard let payload else {
+            return .err(code: "unavailable", message: "AppDelegate.debugWindowSnapshot unavailable", data: nil)
         }
         return .ok(payload)
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2459,6 +2459,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugResetEmptyPanelCount())
         case "debug.notification.focus":
             return v2Result(id: id, self.v2DebugFocusNotification(params: params))
+        case "debug.window.snapshot":
+            return v2Result(id: id, self.v2DebugWindowSnapshot())
         case "debug.flash.count":
             return v2Result(id: id, self.v2DebugFlashCount(params: params))
         case "debug.flash.reset":
@@ -2665,6 +2667,7 @@ class TerminalController {
             "debug.empty_panel.count",
             "debug.empty_panel.reset",
             "debug.notification.focus",
+            "debug.window.snapshot",
             "debug.flash.count",
             "debug.flash.reset",
             "debug.panel_snapshot",
@@ -11259,6 +11262,17 @@ class TerminalController {
         let args = surfaceId != nil ? "\(wsId) \(surfaceId!)" : wsId
         let resp = focusFromNotification(args)
         return resp == "OK" ? .ok([:]) : .err(code: "internal_error", message: resp, data: nil)
+    }
+
+    private func v2DebugWindowSnapshot() -> V2CallResult {
+        let payload: [String: Any] = v2MainSync {
+            AppDelegate.shared?.debugWindowSnapshot() ?? [
+                "ns_window_count": NSApp.windows.count,
+                "main_window_context_count": 0,
+                "windows": [],
+            ]
+        }
+        return .ok(payload)
     }
 
     private func v2DebugFlashCount(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -11265,9 +11265,12 @@ class TerminalController {
     }
 
     private func v2DebugWindowSnapshot() -> V2CallResult {
+#if DEBUG
         // NSApp.windows, AppDelegate.mainWindowContexts, and per-window AppKit
         // properties are main-actor state; the exact-snapshot contract for this
         // debug RPC requires synchronous main-thread execution.
+        // AppDelegate.debugWindowSnapshot() is itself `#if DEBUG`, so this body
+        // must be guarded too or release builds fail to link.
         let payload: [String: Any]? = v2MainSync {
             AppDelegate.shared?.debugWindowSnapshot()
         }
@@ -11275,6 +11278,9 @@ class TerminalController {
             return .err(code: "unavailable", message: "AppDelegate.debugWindowSnapshot unavailable", data: nil)
         }
         return .ok(payload)
+#else
+        return .err(code: "unavailable", message: "debug.window.snapshot is DEBUG-only", data: nil)
+#endif
     }
 
     private func v2DebugFlashCount(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1,7 +1,17 @@
 import AppKit
 import Foundation
+import OSLog
 import UserNotifications
 import Bonsplit
+
+private let notificationStoreLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "notification-debug"
+)
+
+private func notificationStoreLog(_ message: String) {
+    notificationStoreLogger.debug("\(message, privacy: .public)")
+}
 
 // UNUserNotificationCenter.removeDeliveredNotifications(withIdentifiers:) and
 // removePendingNotificationRequests(withIdentifiers:) perform synchronous XPC to
@@ -916,6 +926,10 @@ final class TerminalNotificationStore: ObservableObject {
            let resolvedCooldownInterval,
            let lastNotificationDate = lastNotificationDateByCooldownKey[cooldownKey],
            now.timeIntervalSince(lastNotificationDate) < resolvedCooldownInterval {
+            notificationStoreLog(
+                "notification.store.skipCooldown tabId=\(tabId.uuidString) " +
+                    "surfaceId=\(surfaceId?.uuidString ?? "nil") cooldownKey=\(cooldownKey)"
+            )
             return
         }
 
@@ -938,6 +952,12 @@ final class TerminalNotificationStore: ObservableObject {
         let isFocusedPanel = isActiveTab && isFocusedSurface
         let isAppFocused = AppFocusState.isAppFocused()
         let shouldSuppressExternalDelivery = isAppFocused && isFocusedPanel
+        notificationStoreLog(
+            "notification.store.add tabId=\(tabId.uuidString) surfaceId=\(surfaceId?.uuidString ?? "nil") " +
+                "activeTab=\(isActiveTab ? 1 : 0) focusedSurface=\(isFocusedSurface ? 1 : 0) " +
+                "focusedPanel=\(isFocusedPanel ? 1 : 0) appFocused=\(isAppFocused ? 1 : 0) " +
+                "suppressExternal=\(shouldSuppressExternalDelivery ? 1 : 0) existingCount=\(notifications.count)"
+        )
         if shouldSuppressExternalDelivery {
             setFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         }
@@ -965,6 +985,11 @@ final class TerminalNotificationStore: ObservableObject {
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
+        notificationStoreLog(
+            "notification.store.commit notificationId=\(notification.id.uuidString) tabId=\(tabId.uuidString) " +
+                "surfaceId=\(surfaceId?.uuidString ?? "nil") cleared=\(idsToClear.count) " +
+                "newCount=\(notifications.count) unread=\(indexes.unreadCount)"
+        )
         if shouldSuppressExternalDelivery {
             suppressedNotificationFeedbackHandler(self, notification)
         } else {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -10,7 +10,9 @@ private let notificationStoreLogger = Logger(
 )
 
 private func notificationStoreLog(_ message: String) {
-    notificationStoreLogger.debug("\(message, privacy: .public)")
+    // Default String-interpolation privacy is `.private`, which redacts tab /
+    // surface / notification UUIDs in release unified logs.
+    notificationStoreLogger.debug("\(message)")
 }
 
 // UNUserNotificationCenter.removeDeliveredNotifications(withIdentifiers:) and

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -11,7 +11,9 @@ private let notificationPortalLogger = Logger(
 )
 
 private func notificationPortalLog(_ message: String) {
-    notificationPortalLogger.debug("\(message, privacy: .public)")
+    // Default String-interpolation privacy is `.private`; hosted-view pointers
+    // and window numbers stay redacted in release unified logs.
+    notificationPortalLogger.debug("\(message)")
 }
 
 private func notificationPortalObjectToken(_ object: AnyObject?) -> String {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1,8 +1,23 @@
 import AppKit
 import ObjectiveC
+import OSLog
 #if DEBUG
 import Bonsplit
 #endif
+
+private let notificationPortalLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "notification-debug"
+)
+
+private func notificationPortalLog(_ message: String) {
+    notificationPortalLogger.debug("\(message, privacy: .public)")
+}
+
+private func notificationPortalObjectToken(_ object: AnyObject?) -> String {
+    guard let object else { return "nil" }
+    return String(describing: Unmanaged.passUnretained(object).toOpaque())
+}
 
 private var cmuxWindowTerminalPortalKey: UInt8 = 0
 private var cmuxWindowTerminalPortalCloseObserverKey: UInt8 = 0
@@ -1898,6 +1913,13 @@ enum TerminalWindowPortalRegistry {
 
         let windowId = ObjectIdentifier(window)
         let hostedId = ObjectIdentifier(hostedView)
+        let mappedWindowBefore = hostedToWindowId[hostedId].map { String(describing: $0) } ?? "nil"
+        notificationPortalLog(
+            "portal.bind.request hosted=\(notificationPortalObjectToken(hostedView)) " +
+                "anchor=\(notificationPortalObjectToken(anchorView)) window=\(window.windowNumber) " +
+                "mappedWindowBefore=\(mappedWindowBefore) visible=\(visibleInUI ? 1 : 0) z=\(zPriority) " +
+                "expectedSurface=\(expectedSurfaceId?.uuidString ?? "nil") expectedGeneration=\(expectedGeneration.map { String($0) } ?? "nil")"
+        )
         let guardState = hostedView.portalBindingGuardState()
         guard hostedView.canAcceptPortalBinding(
             expectedSurfaceId: expectedSurfaceId,
@@ -1936,6 +1958,17 @@ enum TerminalWindowPortalRegistry {
         nextPortal.bind(hostedView: hostedView, to: anchorView, visibleInUI: visibleInUI, zPriority: zPriority)
         hostedToWindowId[hostedId] = windowId
         pruneHostedMappings(for: windowId, validHostedIds: nextPortal.hostedIds())
+#if DEBUG
+        let portalEntryCountAfterBind = nextPortal.debugEntryCount()
+#else
+        let portalEntryCountAfterBind = -1
+#endif
+        notificationPortalLog(
+            "portal.bind.result hosted=\(notificationPortalObjectToken(hostedView)) " +
+                "anchor=\(notificationPortalObjectToken(anchorView)) window=\(window.windowNumber) " +
+                "mappedWindowAfter=\(hostedToWindowId[hostedId].map { String(describing: $0) } ?? "nil") " +
+                "portalEntryCount=\(portalEntryCountAfterBind) hostedSuperview=\(hostedView.superview != nil ? 1 : 0)"
+        )
     }
 
     static func synchronizeForAnchor(_ anchorView: NSView) {
@@ -2006,6 +2039,16 @@ enum TerminalWindowPortalRegistry {
         let hostedId = ObjectIdentifier(hostedView)
         guard let windowId = hostedToWindowId[hostedId],
               let portal = portalsByWindowId[windowId] else { return }
+#if DEBUG
+        let portalEntryCount = portal.debugEntryCount()
+#else
+        let portalEntryCount = -1
+#endif
+        notificationPortalLog(
+            "portal.visibility.update hosted=\(notificationPortalObjectToken(hostedView)) " +
+                "mappedWindow=\(String(describing: windowId)) visible=\(visibleInUI ? 1 : 0) " +
+                "portalEntryCount=\(portalEntryCount)"
+        )
         portal.updateEntryVisibility(forHostedId: hostedId, visibleInUI: visibleInUI)
     }
 

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -956,6 +956,9 @@ class cmux:
     def activate_app(self) -> None:
         self._call("debug.app.activate")
 
+    def window_snapshot(self) -> dict:
+        return dict(self._call("debug.window.snapshot") or {})
+
     def open_command_palette_rename_tab_input(self, window_id: Optional[str] = None) -> None:
         params: Dict[str, Any] = {}
         if window_id is not None:

--- a/tests_v2/test_cli_notification_reopen_no_blank_window.py
+++ b/tests_v2/test_cli_notification_reopen_no_blank_window.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Callable
+from typing import Callable, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
 from cmux import cmux, cmuxError
@@ -99,19 +99,26 @@ def _find_app_bundle(cli: str) -> tuple[str, str]:
     raise cmuxError(f"Could not locate a cmux app bundle next to CLI: {cli}")
 
 
-def _run_cli(cli: str, args: list[str]) -> str:
+def _run_cli(cli: str, args: list[str], *, timeout_s: float = 10.0) -> str:
     env = dict(os.environ)
     env.pop("CMUX_WORKSPACE_ID", None)
     env.pop("CMUX_SURFACE_ID", None)
     env.pop("CMUX_TAB_ID", None)
 
-    proc = subprocess.run(
-        [cli, "--socket", SOCKET_PATH] + args,
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-    )
+    try:
+        proc = subprocess.run(
+            [cli, "--socket", SOCKET_PATH, *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=timeout_s,
+        )
+    except subprocess.TimeoutExpired as exc:
+        partial = f"stdout={exc.stdout or ''} stderr={exc.stderr or ''}".strip()
+        raise cmuxError(
+            f"CLI timed out after {timeout_s}s ({' '.join(args)}): {partial}"
+        ) from exc
     merged = f"{proc.stdout}\n{proc.stderr}".strip()
     if proc.returncode != 0:
         raise cmuxError(f"CLI failed ({' '.join(args)}): {merged}")
@@ -212,6 +219,7 @@ def main() -> int:
     notify_title = f"{token}_TITLE"
     render_marker = f"{token}_RENDER"
 
+    background_window: Optional[str] = None
     with cmux(SOCKET_PATH) as c:
         try:
             c.activate_app()
@@ -259,20 +267,36 @@ def main() -> int:
             before_reopen = c.window_snapshot()
             expected_window_count = _window_count(before_reopen)
 
-            reopen = subprocess.run(
-                ["open", "-b", bundle_id],
-                capture_output=True,
-                text=True,
-                check=False,
-            )
+            try:
+                reopen = subprocess.run(
+                    ["/usr/bin/open", "-b", bundle_id],
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=10.0,
+                )
+            except subprocess.TimeoutExpired as exc:
+                raise cmuxError(
+                    f"Timed out reopening app bundle {bundle_id}: {exc}"
+                ) from exc
             if reopen.returncode != 0:
                 raise cmuxError(
                     "Failed to reopen app for notification regression.\n"
                     f"bundle_id={bundle_id}\nstdout={reopen.stdout}\nstderr={reopen.stderr}"
                 )
 
-            time.sleep(0.8)
-            after_reopen = c.window_snapshot()
+            # The reopen path is async; poll for at least the minimum grace
+            # window so a spurious window would have time to appear. If the
+            # count ever exceeds expected, fail immediately — the regression
+            # we're guarding against is an extra window, not a missing one.
+            poll_deadline = time.time() + 2.5
+            last_snapshot: dict = before_reopen
+            while time.time() < poll_deadline:
+                last_snapshot = c.window_snapshot()
+                if _window_count(last_snapshot) > expected_window_count:
+                    break
+                time.sleep(0.1)
+            after_reopen = last_snapshot
             actual_window_count = _window_count(after_reopen)
             _must(
                 actual_window_count == expected_window_count,
@@ -286,10 +310,21 @@ def main() -> int:
             _assert_terminal_mounted(c, target_surface, context="after reopen focus")
             _assert_renders_after_reopen(c, target_surface, render_marker)
         finally:
+            if background_window:
+                try:
+                    c.close_window(background_window)
+                except Exception as exc:
+                    print(
+                        f"WARN: failed to close test background window {background_window}: {exc}",
+                        file=sys.stderr,
+                    )
             try:
                 c.set_app_focus(None)
-            except Exception:
-                pass
+            except Exception as exc:
+                print(
+                    f"WARN: failed to reset app focus override: {exc}",
+                    file=sys.stderr,
+                )
 
     print("PASS: notify + app reopen does not create a blank extra window or blank the target terminal")
     return 0

--- a/tests_v2/test_cli_notification_reopen_no_blank_window.py
+++ b/tests_v2/test_cli_notification_reopen_no_blank_window.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Regression: notify + app reopen must not create a blank extra window or blank the target terminal."""
+
+from __future__ import annotations
+
+import glob
+import os
+import plistlib
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float,
+    cadence_s: float = 0.05,
+    label: str,
+) -> None:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        if predicate():
+            return
+        time.sleep(cadence_s)
+    raise cmuxError(f"Timed out waiting for {label}")
+
+
+def _must(condition: bool, message: str) -> None:
+    if not condition:
+        raise cmuxError(message)
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    fixed = os.path.expanduser("~/Library/Developer/Xcode/DerivedData/cmux-tests-v2/Build/Products/Debug/cmux")
+    if os.path.isfile(fixed) and os.access(fixed, os.X_OK):
+        return fixed
+
+    candidates = glob.glob(
+        os.path.expanduser("~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"),
+        recursive=True,
+    )
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _find_app_bundle(cli: str) -> tuple[str, str]:
+    cli_path = Path(cli).resolve()
+
+    for parent in [cli_path.parent] + list(cli_path.parents):
+        if parent.suffix != ".app":
+            continue
+        info_plist = parent / "Contents" / "Info.plist"
+        if not info_plist.exists():
+            continue
+        with info_plist.open("rb") as fh:
+            info = plistlib.load(fh)
+        bundle_id = str(info.get("CFBundleIdentifier") or "").strip()
+        if bundle_id:
+            return str(parent), bundle_id
+
+    product_dir = cli_path.parent
+    candidates = sorted(
+        {
+            str(path)
+            for pattern in ("cmux*.app", "*.app")
+            for path in product_dir.glob(pattern)
+            if path.is_dir()
+        },
+        key=os.path.getmtime,
+        reverse=True,
+    )
+    for candidate in candidates:
+        info_plist = Path(candidate) / "Contents" / "Info.plist"
+        if not info_plist.exists():
+            continue
+        with info_plist.open("rb") as fh:
+            info = plistlib.load(fh)
+        bundle_id = str(info.get("CFBundleIdentifier") or "").strip()
+        if bundle_id:
+            return candidate, bundle_id
+
+    raise cmuxError(f"Could not locate a cmux app bundle next to CLI: {cli}")
+
+
+def _run_cli(cli: str, args: list[str]) -> str:
+    env = dict(os.environ)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+
+    proc = subprocess.run(
+        [cli, "--socket", SOCKET_PATH] + args,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    merged = f"{proc.stdout}\n{proc.stderr}".strip()
+    if proc.returncode != 0:
+        raise cmuxError(f"CLI failed ({' '.join(args)}): {merged}")
+    return (proc.stdout or "").strip()
+
+
+def _window_count(snapshot: dict) -> int:
+    return int(snapshot.get("ns_window_count") or 0)
+
+
+def _wait_for_notification(c: cmux, title: str, surface_id: str) -> None:
+    surface_id = surface_id.lower()
+
+    def seen() -> bool:
+        for item in c.list_notifications():
+            if str(item.get("title") or "") != title:
+                continue
+            if str(item.get("surface_id") or "").lower() == surface_id:
+                return True
+        return False
+
+    _wait_for(seen, timeout_s=5.0, label=f"notification {title!r}")
+
+
+def _debug_terminal_row(c: cmux, surface_id: str) -> dict:
+    surface_id = surface_id.lower()
+    payload = c._call("debug.terminals") or {}
+    for row in payload.get("terminals") or []:
+        if str(row.get("surface_id") or "").lower() == surface_id:
+            return dict(row)
+    raise cmuxError(f"debug.terminals missing surface {surface_id}")
+
+
+def _assert_terminal_mounted(c: cmux, surface_id: str, *, context: str) -> None:
+    row = _debug_terminal_row(c, surface_id)
+    failures: list[str] = []
+
+    for key in (
+        "mapped",
+        "tree_visible",
+        "runtime_surface_ready",
+        "hosted_view_in_window",
+        "hosted_view_has_superview",
+        "hosted_view_visible_in_ui",
+    ):
+        if row.get(key) is not True:
+            failures.append(f"{key}={row.get(key)!r}")
+
+    if str(row.get("portal_binding_state") or "") != "live":
+        failures.append(f"portal_binding_state={row.get('portal_binding_state')!r}")
+
+    if failures:
+        raise cmuxError(
+            f"{context}: target terminal is not visibly mounted after notify/reopen.\n"
+            f"surface_id={surface_id}\n"
+            f"failures={', '.join(failures)}\n"
+            f"row={row}"
+        )
+
+
+def _wait_for_terminal_text(c: cmux, surface_id: str, text: str) -> None:
+    _wait_for(
+        lambda: text in c.read_terminal_text(surface_id),
+        timeout_s=5.0,
+        label=f"terminal text {text!r}",
+    )
+
+
+def _assert_renders_after_reopen(c: cmux, surface_id: str, marker: str) -> None:
+    c.panel_snapshot_reset(surface_id)
+    before = c.panel_snapshot(surface_id, "notify_reopen_before")
+    baseline_present = int(c.render_stats(surface_id).get("presentCount") or 0)
+
+    c.send_surface(surface_id, f"printf '{marker}\\n'\n")
+    _wait_for_terminal_text(c, surface_id, marker)
+    _wait_for(
+        lambda: int(c.render_stats(surface_id).get("presentCount") or 0) > baseline_present,
+        timeout_s=3.0,
+        label="new layer presentation",
+    )
+
+    after = c.panel_snapshot(surface_id, "notify_reopen_after")
+    changed_pixels = int(after.get("changed_pixels") or 0)
+    if changed_pixels < 50:
+        raise cmuxError(
+            "Expected visible terminal pixels to change after notify/reopen.\n"
+            f"changed_pixels={changed_pixels}\n"
+            f"before={before}\n"
+            f"after={after}"
+        )
+
+
+def main() -> int:
+    cli = _find_cli_binary()
+    _app_path, bundle_id = _find_app_bundle(cli)
+
+    token = f"CMUX_NOTIFY_REOPEN_{int(time.time() * 1000)}"
+    notify_title = f"{token}_TITLE"
+    render_marker = f"{token}_RENDER"
+
+    with cmux(SOCKET_PATH) as c:
+        try:
+            c.activate_app()
+            time.sleep(0.25)
+
+            foreground_window = c.current_window()
+            baseline_snapshot = c.window_snapshot()
+            baseline_window_count = _window_count(baseline_snapshot)
+            _must(baseline_window_count >= 1, f"Expected at least one app window, got {baseline_snapshot}")
+
+            background_window = c.new_window()
+            time.sleep(0.35)
+
+            workspaces = c.list_workspaces(window_id=background_window)
+            _must(bool(workspaces), f"Expected new window to expose a workspace: {workspaces}")
+            target_workspace = workspaces[0][1]
+
+            surfaces = c.list_surfaces(target_workspace)
+            _must(bool(surfaces), f"Expected target workspace to contain a surface: {surfaces}")
+            target_surface = surfaces[0][1]
+
+            c.focus_window(foreground_window)
+            time.sleep(0.25)
+
+            c.set_app_focus(False)
+            output = _run_cli(
+                cli,
+                [
+                    "notify",
+                    "--workspace",
+                    target_workspace,
+                    "--surface",
+                    target_surface,
+                    "--title",
+                    notify_title,
+                    "--subtitle",
+                    "reopen-regression",
+                    "--body",
+                    "background-window",
+                ],
+            )
+            _must(output.startswith("OK"), f"Expected notify OK output, got: {output!r}")
+            _wait_for_notification(c, notify_title, target_surface)
+
+            before_reopen = c.window_snapshot()
+            expected_window_count = _window_count(before_reopen)
+
+            reopen = subprocess.run(
+                ["open", "-b", bundle_id],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if reopen.returncode != 0:
+                raise cmuxError(
+                    "Failed to reopen app for notification regression.\n"
+                    f"bundle_id={bundle_id}\nstdout={reopen.stdout}\nstderr={reopen.stderr}"
+                )
+
+            time.sleep(0.8)
+            after_reopen = c.window_snapshot()
+            actual_window_count = _window_count(after_reopen)
+            _must(
+                actual_window_count == expected_window_count,
+                "Reopening the app during a background notification created an extra window.\n"
+                f"before={before_reopen}\n"
+                f"after={after_reopen}"
+            )
+
+            c.focus_window(background_window)
+            time.sleep(0.3)
+            _assert_terminal_mounted(c, target_surface, context="after reopen focus")
+            _assert_renders_after_reopen(c, target_surface, render_marker)
+        finally:
+            try:
+                c.set_app_focus(None)
+            except Exception:
+                pass
+
+    print("PASS: notify + app reopen does not create a blank extra window or blank the target terminal")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_cli_notification_reopen_no_blank_window.py
+++ b/tests_v2/test_cli_notification_reopen_no_blank_window.py
@@ -223,7 +223,14 @@ def main() -> int:
     with cmux(SOCKET_PATH) as c:
         try:
             c.activate_app()
-            time.sleep(0.25)
+            # Replace a fixed activate-app sleep with a poll so slow CI runners
+            # don't hit `current_window()`'s no-window error before the first
+            # main terminal window has finished coming up.
+            _wait_for(
+                lambda: _window_count(c.window_snapshot()) >= 1,
+                timeout_s=3.0,
+                label="at least one app window after activate_app",
+            )
 
             foreground_window = c.current_window()
             baseline_snapshot = c.window_snapshot()


### PR DESCRIPTION
## Summary
Fixes #3080 — when a CLI `notify` fires against a surface in a background cmux window and the user reopens the app (via `open -b <bundle_id>`, Cmd+Tab, Dock click, etc.), two regressions could appear together:
1. A new blank `cmux` window popped up alongside the existing ones.
2. The target terminal went blank (the Ghostty portal stayed detached after the reopen).

### Fix (commit `9ba9f31a`, then refined in `4f6dff34`)
- **`applicationShouldHandleReopen`** (`Sources/AppDelegate.swift`): add the handler so AppKit's default "reopen → create untitled window" path no longer fires. The handler resolves the target via `keyWindow` → `mainWindow` → registered main-window contexts → first visible window, then brings that window forward (`bringToFront` for main terminal windows, `makeKeyAndOrderFront` + activate otherwise) and returns `true`.
- **`openNotificationFallback`** (`Sources/AppDelegate.swift`): reached only when `contextContainingTabId` has already missed. Now routes through the active `TabManager` + `NSApp.keyWindow` / first main-terminal window — the app-relaunch / startup race this fallback exists for. The intermediate `activeMainWindowContext` helper was dead code (same `mainWindowContexts` dict that the primary lookup already walked) and has been removed.
- **`GhosttyTerminalView.updateNSView`** (`Sources/GhosttyTerminalView.swift`): after a notification-ring or portal rebind on update, call `refreshSurfaceNow` when the portal binding is live, the surface is visible, and this host owns the portal — so the terminal repaints instead of staying on a stale / empty IOSurface. Complements #3048.
- **CLI `launchApp` / `activateApp`** (`CLI/cmux.swift`): when the app is already running, use `NSRunningApplication.activate` keyed by bundle identifier instead of shelling out to `/usr/bin/open -a cmux`. Falls back to `open -b <bundle>` if `activate(…)` returns `false`, and to `open -a cmux` if the bundle identifier is unknown.
- **Scoped OSLog** (`com.manaflow.cmux` / `notification-debug`) across AppDelegate, GhosttyTerminalView, TerminalWindowPortal, TerminalNotificationStore and the CLI. Uses default `.private` String-interpolation privacy, so UUIDs, working directories, pids, and portal tokens stay redacted in release unified logs; developers can toggle private data per-subsystem via `log config` for diagnosis.
- **Release-build safety**: `debug.window.snapshot` v2 socket command body is `#if DEBUG` (it calls `AppDelegate.debugWindowSnapshot()`, which is itself DEBUG-only), so release builds link.
- **Main-thread correctness**: the new `handleNotificationResponse` debug log now resolves `mainWindowContexts`, `TabManager.tabs`, and per-window AppKit properties inside `DispatchQueue.main.async`, matching the existing open-path hop.

### Regression test (commit `b75713f2`, hardened in `b13f8c75` + `4f6dff34`)
- `tests_v2/test_cli_notification_reopen_no_blank_window.py`: two-window setup, defocus the app, fire `cmux notify` at the surface in the background window, then `open -b <bundle_id>` and assert:
  - `ns_window_count` does not change after the reopen (no blank extra window).
  - The target surface is mounted and its portal is `live` after focus switches to the background window.
  - Pixels change after printing a marker (i.e. the terminal is actually rendering, not just "mounted but blank").
- Adds a DEBUG-only `debug.window.snapshot` v2 socket command + `cmux.window_snapshot()` Python helper. The RPC fails loudly (`unavailable` error) when `AppDelegate.shared` is nil so before/after snapshots can't silently compare-equal when no real snapshot was captured.
- Subprocess calls (`_run_cli`, `open -b`) are bounded by a 10s timeout that raises `cmuxError` on `TimeoutExpired`.
- The fixed `time.sleep(0.8)` after `open -b` is replaced with a 2.5s polling loop that fails fast if a spurious window appears, and the fixed 250ms sleep after `activate_app` is replaced with a `_wait_for` poll so slow CI runners don't race `current_window()`.
- `finally` closes the test's background window via `c.close_window(...)` and logs focus-override reset failures so the next test in the shared app session sees clean state.

Follows the repo's two-commit regression policy (red → green on the Commits tab) plus the review-fix commits stacked on top.

## Test plan
- [ ] `test-e2e` workflow runs `test_cli_notification_reopen_no_blank_window.py`: red on `b75713f2`, green on `9ba9f31a` / `4f6dff34`.
- [ ] Existing `test_terminal_notification_rendering.py` (#3048 regression) still passes.
- [ ] Release build compiles (verified by CI — `debug.window.snapshot` RPC is DEBUG-gated so the Release link doesn't pull in the missing symbol).
- [ ] Manual: open two cmux windows, cmd-tab to another app, trigger a `cmux notify` to the surface in the background window, cmd-tab back — no extra window, background surface renders on focus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Smarter app reopen and window-focusing to avoid creating blank windows and restore target terminals reliably.
  * Improved notification routing so notifications more consistently arrive on the correct surface/terminal.

* **Tests**
  * New end-to-end regression test verifying notification delivery, app reopen behavior, and rendering after reopen.

* **Chores**
  * Expanded debug and diagnostic logging and window-state inspection to aid troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS app reopen/window activation and notification-open fallback paths, plus forces terminal surface refresh after portal rebinds; mistakes here could regress window focus or rendering during startup/reopen races.
> 
> **Overview**
> Prevents AppKit’s default reopen behavior from creating an extra untitled window by adding `applicationShouldHandleReopen` to focus an existing appropriate window instead.
> 
> Hardens notification open behavior during startup/relaunch races by adjusting `openNotificationFallback` to route via the active `TabManager`/focused window, and ensures portal-hosted terminals repaint by triggering `refreshSurfaceNow` when a notification ring change or portal rebind occurs.
> 
> Improves CLI app launch/activation to prefer bundle-id based activation (and reuse an existing running app when possible), adds scoped unified logging for notification/portal paths, introduces a DEBUG-only `debug.window.snapshot` socket RPC for tests, and adds a new regression test covering the notify→reopen scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d1924e85f774d18b64742ead89b143f5897d7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->