### PR TITLE
Revert "Reduce idle overlay animation log churn"

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1795,13 +1795,6 @@ private final class WindowTmuxWorkspacePaneOverlayController: NSObject {
 }
 
 @MainActor
-private func existingTmuxWorkspacePaneWindowOverlayController(
-    for window: NSWindow
-) -> WindowTmuxWorkspacePaneOverlayController? {
-    objc_getAssociatedObject(window, &tmuxWorkspacePaneWindowOverlayKey) as? WindowTmuxWorkspacePaneOverlayController
-}
-
-@MainActor
 private func tmuxWorkspacePaneWindowOverlayController(for window: NSWindow) -> WindowTmuxWorkspacePaneOverlayController {
     if let existing = objc_getAssociatedObject(window, &tmuxWorkspacePaneWindowOverlayKey) as? WindowTmuxWorkspacePaneOverlayController {
         return existing
@@ -3804,12 +3797,8 @@ struct ContentView: View {
 
         view = AnyView(view.background(WindowAccessor(dedupeByWindow: false) { window in
             MainActor.assumeIsolated {
-                if let tmuxOverlayState = tmuxWorkspacePaneWindowOverlayState(for: window) {
-                    let tmuxOverlayController = tmuxWorkspacePaneWindowOverlayController(for: window)
-                    tmuxOverlayController.update(state: tmuxOverlayState)
-                } else {
-                    existingTmuxWorkspacePaneWindowOverlayController(for: window)?.update(state: nil)
-                }
+                let tmuxOverlayController = tmuxWorkspacePaneWindowOverlayController(for: window)
+                tmuxOverlayController.update(state: tmuxWorkspacePaneWindowOverlayState(for: window))
                 let overlayController = commandPaletteWindowOverlayController(for: window)
                 overlayController.update(rootView: AnyView(commandPaletteOverlay), isVisible: isCommandPalettePresented)
             }

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -152,51 +152,27 @@ struct TmuxWorkspacePaneOverlayView: View {
     let flashReason: WorkspaceAttentionFlashReason?
 
     var body: some View {
-        overlayContent
-            .allowsHitTesting(false)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
+        TimelineView(.animation) { timeline in
+            Canvas { context, _ in
+                for rect in unreadRects {
+                    drawUnreadRing(in: &context, rect: rect)
+                }
 
-    @ViewBuilder
-    private var overlayContent: some View {
-        if shouldAnimateFlash, let flashStartedAt {
-            TimelineView(TmuxWorkspacePaneFlashTimelineSchedule(startDate: flashStartedAt)) { timeline in
-                overlayCanvas(timelineDate: timeline.date)
+                guard let flashRect,
+                      let flashStartedAt else { return }
+                let elapsed = timeline.date.timeIntervalSince(flashStartedAt)
+                let opacity = FocusFlashPattern.opacity(at: elapsed)
+                guard opacity > 0.001 else { return }
+                drawFlashRing(
+                    in: &context,
+                    rect: flashRect,
+                    opacity: opacity,
+                    reason: flashReason ?? .notificationArrival
+                )
             }
-        } else if !unreadRects.isEmpty {
-            overlayCanvas(timelineDate: nil)
-        } else {
-            Color.clear
         }
-    }
-
-    private var shouldAnimateFlash: Bool {
-        guard let flashRect,
-              flashRect.width > 0,
-              flashRect.height > 0,
-              let flashStartedAt else { return false }
-        return Date() <= flashStartedAt.addingTimeInterval(FocusFlashPattern.duration)
-    }
-
-    private func overlayCanvas(timelineDate: Date?) -> some View {
-        Canvas { context, _ in
-            for rect in unreadRects {
-                drawUnreadRing(in: &context, rect: rect)
-            }
-
-            guard let flashRect,
-                  let flashStartedAt,
-                  let timelineDate else { return }
-            let elapsed = timelineDate.timeIntervalSince(flashStartedAt)
-            let opacity = FocusFlashPattern.opacity(at: elapsed)
-            guard opacity > 0.001 else { return }
-            drawFlashRing(
-                in: &context,
-                rect: flashRect,
-                opacity: opacity,
-                reason: flashReason ?? .notificationArrival
-            )
-        }
+        .allowsHitTesting(false)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     private func drawUnreadRing(in context: inout GraphicsContext, rect: CGRect) {
@@ -241,32 +217,6 @@ struct TmuxWorkspacePaneOverlayView: View {
             roundedRect: PanelOverlayRingMetrics.pathRect(in: rect),
             cornerRadius: PanelOverlayRingMetrics.cornerRadius
         )
-    }
-}
-
-private struct TmuxWorkspacePaneFlashTimelineSchedule: TimelineSchedule {
-    let startDate: Date
-
-    func entries(from requestedStartDate: Date, mode: Mode) -> Entries {
-        let firstDate = requestedStartDate > startDate ? requestedStartDate : startDate
-        return Entries(
-            nextDate: firstDate,
-            endDate: startDate.addingTimeInterval(FocusFlashPattern.duration),
-            interval: 1.0 / 60.0
-        )
-    }
-
-    struct Entries: Sequence, IteratorProtocol {
-        var nextDate: Date
-        let endDate: Date
-        let interval: TimeInterval
-
-        mutating func next() -> Date? {
-            guard nextDate <= endDate else { return nil }
-            let date = nextDate
-            nextDate = nextDate.addingTimeInterval(interval)
-            return date
-        }
     }
 }
 


### PR DESCRIPTION
Reverts manaflow-ai/cmux#3078

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Reintroduces continuous overlay rendering updates (via `TimelineView(.animation)` and always-instantiated window overlay controllers), which could increase idle CPU/battery usage and affect window overlay lifecycle/perf.
> 
> **Overview**
> Reverts the tmux workspace pane overlay back to **always using** `TimelineView(.animation)` with a single `Canvas` path, removing the conditional flash-only timeline scheduling and the custom `TmuxWorkspacePaneFlashTimelineSchedule`.
> 
> Simplifies window overlay management by removing the “update existing controller only when needed” path and always retrieving/creating the `WindowTmuxWorkspacePaneOverlayController`, then calling `update(state:)` with either a computed state or `nil`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ba3dc0468ae8bdafab970785a80e7a6f6e7a19d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated tmux workspace pane overlay rendering implementation with consolidated animation handling
  * Simplified overlay state update logic for improved code maintainability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the idle tmux overlay animation throttling to restore continuous rendering and always-on window overlay controllers. Simplifies overlay updates, with a likely increase in idle CPU/battery usage.

- **Refactors**
  - Restores `TimelineView(.animation)` in `TmuxWorkspacePaneOverlayView` and draws unread + flash rings in a single `Canvas`.
  - Removes `TmuxWorkspacePaneFlashTimelineSchedule` and the conditional/flash-only timeline logic.
  - Always creates/returns `WindowTmuxWorkspacePaneOverlayController` and calls `update(state:)`; drops `existingTmuxWorkspacePaneWindowOverlayController` and the “update only when needed” path.

<sup>Written for commit 8ba3dc0468ae8bdafab970785a80e7a6f6e7a19d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

