### PR TITLE
Fix ghost WKWebView on workspace switch (#3085)

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1,8 +1,14 @@
 import AppKit
 import Bonsplit
 import ObjectiveC
+import os
 import SwiftUI
 import WebKit
+
+private let browserSurfaceLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "browser-surface"
+)
 
 private var cmuxWindowBrowserPortalKey: UInt8 = 0
 private var cmuxWindowBrowserPortalCloseObserverKey: UInt8 = 0
@@ -10,11 +16,14 @@ private var cmuxBrowserSearchOverlayPanelIdAssociationKey: UInt8 = 0
 private var cmuxBrowserPortalNeedsRenderingStateReattachKey: UInt8 = 0
 private var cmuxWindowInteractiveSplitDividerDragKey: UInt8 = 0
 
+private func browserPortalObjectToken(_ object: AnyObject?) -> String {
+    guard let object else { return "nil" }
+    return String(describing: Unmanaged.passUnretained(object).toOpaque())
+}
+
 #if DEBUG
 private func browserPortalDebugToken(_ view: NSView?) -> String {
-    guard let view else { return "nil" }
-    let ptr = Unmanaged.passUnretained(view).toOpaque()
-    return String(describing: ptr)
+    browserPortalObjectToken(view)
 }
 
 private func browserPortalDebugFrame(_ rect: NSRect) -> String {
@@ -2668,6 +2677,31 @@ final class WindowBrowserPortal: NSObject {
         }
     }
 
+    private func detachHiddenHostedWebKitSubviewsIfNeeded(
+        in containerView: WindowBrowserSlotView,
+        primaryWebView: WKWebView,
+        reason: String
+    ) {
+        let hostedSubviews = hostedWebKitSubviews(
+            in: containerView,
+            primaryWebView: primaryWebView
+        )
+        guard !hostedSubviews.isEmpty else { return }
+
+        notifyHostedWebKitHidden(
+            in: containerView,
+            primaryWebView: primaryWebView,
+            reason: reason
+        )
+
+        for hostedSubview in hostedSubviews where hostedSubview.superview != nil {
+            browserSurfaceLogger.info(
+                "portal hide detach webView=\(browserPortalObjectToken(hostedSubview), privacy: .public) container=\(browserPortalObjectToken(containerView), privacy: .public) reason=\(reason, privacy: .public)"
+            )
+            hostedSubview.removeFromSuperview()
+        }
+    }
+
     private func ensureContainerView(for entry: Entry, webView: WKWebView) -> WindowBrowserSlotView {
         if let existing = entry.containerView {
             existing.setPaneDropContext(entry.paneDropContext)
@@ -2931,6 +2965,9 @@ final class WindowBrowserPortal: NSObject {
         if let anchor = entry.anchorView {
             webViewByAnchorId.removeValue(forKey: ObjectIdentifier(anchor))
         }
+        browserSurfaceLogger.info(
+            "portal detach webView=\(browserPortalObjectToken(entry.webView), privacy: .public) container=\(browserPortalObjectToken(entry.containerView), privacy: .public) anchor=\(browserPortalObjectToken(entry.anchorView), privacy: .public)"
+        )
 #if DEBUG
         let hadContainerSuperview = (entry.containerView?.superview === hostView) ? 1 : 0
         let hadWebSuperview = entry.webView?.superview == nil ? 0 : 1
@@ -2966,6 +3003,9 @@ final class WindowBrowserPortal: NSObject {
         }
 
         let portalOwnsWebView = entry.webView?.superview === entry.containerView
+        browserSurfaceLogger.info(
+            "portal discard webView=\(browserPortalObjectToken(entry.webView), privacy: .public) container=\(browserPortalObjectToken(entry.containerView), privacy: .public) anchor=\(browserPortalObjectToken(entry.anchorView), privacy: .public) source=\(source, privacy: .public) preserveSuperview=\(preserveCurrentSuperview)"
+        )
 #if DEBUG
         dlog(
             "browser.portal.discard web=\(browserPortalDebugToken(entry.webView)) " +
@@ -3014,6 +3054,9 @@ final class WindowBrowserPortal: NSObject {
         entry.visibleInUI = false
         entry.zPriority = 0
         entriesByWebViewId[webViewId] = entry
+        browserSurfaceLogger.info(
+            "portal hide webView=\(browserPortalObjectToken(entry.webView), privacy: .public) container=\(browserPortalObjectToken(entry.containerView), privacy: .public) source=\(source, privacy: .public)"
+        )
         synchronizeWebView(withId: webViewId, source: source)
     }
 
@@ -3098,6 +3141,9 @@ final class WindowBrowserPortal: NSObject {
 
     func bind(webView: WKWebView, to anchorView: NSView, visibleInUI: Bool, zPriority: Int = 0) {
         guard ensureInstalled() else { return }
+        browserSurfaceLogger.info(
+            "portal bind webView=\(browserPortalObjectToken(webView), privacy: .public) anchor=\(browserPortalObjectToken(anchorView), privacy: .public) visible=\(visibleInUI) zPriority=\(zPriority)"
+        )
 
         let webViewId = ObjectIdentifier(webView)
         let anchorId = ObjectIdentifier(anchorView)
@@ -3462,6 +3508,13 @@ final class WindowBrowserPortal: NSObject {
         }
         let shouldPreserveExternalFullscreenHost =
             webView.cmuxIsManagedByExternalFullscreenWindow(relativeTo: window)
+        if !entry.visibleInUI, webView.superview === containerView {
+            detachHiddenHostedWebKitSubviewsIfNeeded(
+                in: containerView,
+                primaryWebView: webView,
+                reason: "hidden:\(source)"
+            )
+        }
         let shouldPreserveExternalHostForHiddenEntry =
             !shouldPreserveExternalFullscreenHost &&
             !entry.visibleInUI &&

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4,8 +4,14 @@ import Combine
 import ImageIO
 import SwiftUI
 import ObjectiveC
+import os
 import UniformTypeIdentifiers
 import WebKit
+
+private let browserSurfaceLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "browser-surface"
+)
 
 private extension Color {
     init?(hex: String) {
@@ -4256,6 +4262,12 @@ struct ContentView: View {
         let generation = workspaceHandoffGeneration
         retiringWorkspaceId = oldSelectedId
         workspaceHandoffFallbackTask?.cancel()
+        browserSurfaceLogger.info(
+            "workspace handoff start oldWorkspace=\(oldSelectedId.uuidString, privacy: .public) newWorkspace=\(newSelectedId.uuidString, privacy: .public) generation=\(generation)"
+        )
+        if let retiringWorkspace = tabManager.tabs.first(where: { $0.id == oldSelectedId }) {
+            retiringWorkspace.hideAllBrowserPortalViews(source: "workspaceHandoffStart")
+        }
 
 #if DEBUG
         if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
@@ -4318,6 +4330,9 @@ struct ContentView: View {
         workspaceHandoffFallbackTask?.cancel()
         workspaceHandoffFallbackTask = nil
         let retiring = retiringWorkspaceId
+        browserSurfaceLogger.info(
+            "workspace handoff complete retiringWorkspace=\(retiring?.uuidString ?? "nil", privacy: .public) selectedWorkspace=\(tabManager.selectedTabId?.uuidString ?? "nil", privacy: .public) reason=\(reason, privacy: .public)"
+        )
 
         // Hide portal-hosted views for the retiring workspace BEFORE clearing
         // retiringWorkspaceId. Once cleared, reconcileMountedWorkspaceIds unmounts
@@ -4326,7 +4341,7 @@ struct ContentView: View {
         // portals from covering the newly selected workspace.
         if let retiring, let workspace = tabManager.tabs.first(where: { $0.id == retiring }) {
             workspace.hideAllTerminalPortalViews()
-            workspace.hideAllBrowserPortalViews()
+            workspace.hideAllBrowserPortalViews(source: "workspaceHandoffComplete")
         }
 
         retiringWorkspaceId = nil

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -3,9 +3,14 @@ import SwiftUI
 import WebKit
 import AppKit
 import ObjectiveC
+import os
 
 private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
+private let browserSurfaceLogger = Logger(
+    subsystem: "com.manaflow.cmux",
+    category: "browser-surface"
+)
 
 private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
     guard let object else { return "nil" }
@@ -5249,6 +5254,12 @@ struct WebViewRepresentable: NSViewRepresentable {
 
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
+            let hostID = browserPanelViewObjectID(self)
+            let windowID = browserPanelViewObjectID(window)
+            let hostedWebViewID = browserPanelViewObjectID(hostedWebView)
+            browserSurfaceLogger.info(
+                "host viewDidMoveToWindow host=\(hostID, privacy: .public) window=\(windowID, privacy: .public) hostedWebView=\(hostedWebViewID, privacy: .public)"
+            )
             if window == nil {
                 notifyHostedWebKitHidden(reason: "viewDidMoveToWindow")
                 clearActiveDividerCursor(restoreArrow: false)
@@ -5270,12 +5281,38 @@ struct WebViewRepresentable: NSViewRepresentable {
 
         override func viewDidMoveToSuperview() {
             super.viewDidMoveToSuperview()
+            let hostID = browserPanelViewObjectID(self)
+            let superviewID = browserPanelViewObjectID(superview)
+            let hostedWebViewID = browserPanelViewObjectID(hostedWebView)
+            browserSurfaceLogger.info(
+                "host viewDidMoveToSuperview host=\(hostID, privacy: .public) superview=\(superviewID, privacy: .public) hostedWebView=\(hostedWebViewID, privacy: .public)"
+            )
             scheduleHostedInspectorDividerReapply(reason: "viewDidMoveToSuperview")
             scheduleHostedInspectorDockConfigurationSync(reason: "viewDidMoveToSuperview")
             notifyGeometryChangedIfNeeded()
 #if DEBUG
             debugLogHostedInspectorLayoutIfNeeded(reason: "viewDidMoveToSuperview")
 #endif
+        }
+
+        override func viewWillMove(toSuperview newSuperview: NSView?) {
+            let hostID = browserPanelViewObjectID(self)
+            let newSuperviewID = browserPanelViewObjectID(newSuperview)
+            let hostedWebViewID = browserPanelViewObjectID(hostedWebView)
+            browserSurfaceLogger.info(
+                "host viewWillMoveToSuperview host=\(hostID, privacy: .public) newSuperview=\(newSuperviewID, privacy: .public) hostedWebView=\(hostedWebViewID, privacy: .public)"
+            )
+            super.viewWillMove(toSuperview: newSuperview)
+        }
+
+        override func viewWillMove(toWindow newWindow: NSWindow?) {
+            let hostID = browserPanelViewObjectID(self)
+            let newWindowID = browserPanelViewObjectID(newWindow)
+            let hostedWebViewID = browserPanelViewObjectID(hostedWebView)
+            browserSurfaceLogger.info(
+                "host viewWillMoveToWindow host=\(hostID, privacy: .public) newWindow=\(newWindowID, privacy: .public) hostedWebView=\(hostedWebViewID, privacy: .public)"
+            )
+            super.viewWillMove(toWindow: newWindow)
         }
 
         override func layout() {
@@ -6026,6 +6063,9 @@ struct WebViewRepresentable: NSViewRepresentable {
     func makeNSView(context: Context) -> NSView {
         let container = HostContainerView()
         container.wantsLayer = true
+        browserSurfaceLogger.info(
+            "makeNSView panel=\(panel.id.uuidString, privacy: .public) workspace=\(panel.workspaceId.uuidString, privacy: .public) host=\(browserPanelViewObjectID(container), privacy: .public) webView=\(browserPanelViewObjectID(panel.webView), privacy: .public)"
+        )
         return container
     }
 
@@ -6734,6 +6774,9 @@ struct WebViewRepresentable: NSViewRepresentable {
     static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
         coordinator.attachGeneration += 1
         clearPortalCallbacks(for: nsView)
+        browserSurfaceLogger.info(
+            "dismantleNSView.begin host=\(browserPanelViewObjectID(nsView), privacy: .public) panel=\(coordinator.panel?.id.uuidString ?? "nil", privacy: .public) workspace=\(coordinator.panel?.workspaceId.uuidString ?? "nil", privacy: .public) webView=\(browserPanelViewObjectID(coordinator.webView), privacy: .public)"
+        )
         if let panel = coordinator.panel, let host = nsView as? HostContainerView {
             panel.releasePortalHostIfOwned(
                 hostId: ObjectIdentifier(host),
@@ -6773,6 +6816,9 @@ struct WebViewRepresentable: NSViewRepresentable {
         BrowserWindowPortalRegistry.updateDropZoneOverlay(for: webView, zone: nil)
         coordinator.lastPortalHostId = nil
         coordinator.lastSynchronizedHostGeometryRevision = 0
+        browserSurfaceLogger.info(
+            "dismantleNSView.end host=\(browserPanelViewObjectID(nsView), privacy: .public) panel=\(panel?.id.uuidString ?? "nil", privacy: .public) workspace=\(panel?.workspaceId.uuidString ?? "nil", privacy: .public) webView=\(browserPanelViewObjectID(webView), privacy: .public)"
+        )
     }
 
     private func currentPaneDropContext() -> BrowserPaneDropContext? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10307,10 +10307,10 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    func hideAllBrowserPortalViews() {
+    func hideAllBrowserPortalViews(source: String = "workspaceRetire") {
         for panel in panels.values {
             guard let browser = panel as? BrowserPanel else { continue }
-            browser.hideBrowserPortalView(source: "workspaceRetire")
+            browser.hideBrowserPortalView(source: source)
         }
     }
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -3109,15 +3109,13 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         portal.synchronizeWebViewForAnchor(oldAnchor)
         advanceAnimations()
         XCTAssertTrue(slot.isHidden, "Workspace handoff should hide the retiring browser before unmount")
+        XCTAssertNil(webView.superview, "Hidden workspace browsers should leave the window hierarchy during handoff")
 
         oldAnchor.removeFromSuperview()
         portal.synchronizeWebViewForAnchor(oldAnchor)
         advanceAnimations()
 
-        XCTAssertTrue(
-            webView.superview === slot,
-            "Hidden workspace browsers should stay attached while their SwiftUI anchor is temporarily unmounted"
-        )
+        XCTAssertNil(webView.superview, "Hidden workspace browsers should stay detached while their anchor is unmounted")
         XCTAssertTrue(slot.isHidden, "Unmounted hidden workspace browser should remain hidden until rebound")
         XCTAssertEqual(portal.debugEntryCount(), 1, "Workspace handoff should keep the hidden browser portal entry alive")
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2089,6 +2089,17 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.25))
     }
 
+    private func containsDescendant(_ target: NSView, in root: NSView?) -> Bool {
+        guard let root else { return false }
+        if root === target {
+            return true
+        }
+        for subview in root.subviews where containsDescendant(target, in: subview) {
+            return true
+        }
+        return false
+    }
+
     private func dropZoneOverlay(in slot: WindowBrowserSlotView, excluding webView: WKWebView) -> NSView? {
         let candidates = slot.subviews + (slot.superview?.subviews ?? [])
         return candidates.first(where: {
@@ -3025,7 +3036,7 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         XCTAssertNil(webView.superview)
     }
 
-    func testRegistryHideKeepsPortalHostedWebViewAttachedButHidden() {
+    func testRegistryHideDetachesPortalHostedWebViewFromActiveWindowHierarchy() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
             styleMask: [.titled, .closable],
@@ -3056,7 +3067,11 @@ final class BrowserWindowPortalLifecycleTests: XCTestCase {
         BrowserWindowPortalRegistry.hide(webView: webView, source: "unitTest")
         advanceAnimations()
 
-        XCTAssertTrue(webView.superview === slot, "Hiding should preserve the hosted WKWebView attachment")
+        XCTAssertNil(webView.superview, "Hiding should detach the hosted WKWebView from the portal slot")
+        XCTAssertFalse(
+            containsDescendant(webView, in: window.contentView?.superview),
+            "Hiding should remove the WKWebView from the active window hierarchy so WebKit cannot leak a ghost layer"
+        )
         XCTAssertTrue(slot.isHidden, "Hiding should immediately hide the existing portal slot")
     }
 


### PR DESCRIPTION
## Summary
- Workspace switch now hides browser portals *before* retiring the old workspace in addition to the existing post-handoff pass, closing the window where a WKWebView could composite on top of the new workspace.
- `WindowBrowserPortal.synchronizeWebView` detaches hidden portal-hosted WebKit subviews from their container instead of leaving them as live children of the window hierarchy, so the remote Core Animation layer can't ghost.
- Added a `source` parameter to `Workspace.hideAllBrowserPortalViews` and `os_log` coverage at every browser portal bind / hide / detach / discard site so future regressions are diagnosable from the unified log.

Fixes #3085.

## Test plan
- [ ] `cmuxTests/BrowserPanelTests.swift` — `testRegistryHideDetachesPortalHostedWebViewFromActiveWindowHierarchy` (regression test committed in 574b3da6) passes after the fix.
- [ ] Updated `BrowserWindowPortalLifecycleTests` workspace-handoff assertion that hidden browsers detach from the slot.
- [ ] Manual repro from the issue: workspace A with a loaded browser pane, switch to a browser-less workspace B, confirm the previous WKWebView is no longer visible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes browser portal lifecycle/visibility behavior by detaching hidden `WKWebView` subviews and altering workspace handoff timing; mistakes could cause blank panes, lost focus, or rendering regressions during tab/workspace switches.
> 
> **Overview**
> Prevents *ghost* `WKWebView` compositing during workspace switches by hiding retiring workspaces’ browser portal views **at handoff start** and, in `WindowBrowserPortal.synchronizeWebView`, **detaching** hidden portal-hosted WebKit subviews from their slot (instead of leaving them attached but hidden).
> 
> Adds unified `os.Logger` instrumentation across browser portal lifecycle events (`bind`, `hide`, `detach`, `discard`, and host view window/superview moves), threads a `source` parameter through `Workspace.hideAllBrowserPortalViews`, and updates/extends browser portal tests to assert hidden web views are fully removed from the window hierarchy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4264e613ceeb9fe0f1759c4705b2d3a1bde5b228. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced browser view lifecycle management during workspace transitions with improved resource handling of hidden web views.

* **Tests**
  * Updated test expectations for browser portal view detachment behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops ghost WKWebView overlays during workspace switches by hiding portal views at handoff start and detaching hidden web views from the window hierarchy (fixes #3085).

- **Bug Fixes**
  - Hide browser portals at workspace handoff start to close the compositing window.
  - `WindowBrowserPortal` detaches hidden WebKit subviews so their remote CA layers can’t render over the new workspace.
  - Added a `source` parameter to `Workspace.hideAllBrowserPortalViews` and `os.Logger` coverage for bind/hide/detach/discard.
  - Updated tests to assert hidden web views detach and remain out of the active window during handoff.

<sup>Written for commit 4264e613ceeb9fe0f1759c4705b2d3a1bde5b228. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

