### PR TITLE
cli: allow external clients to connect to cmux socket (fixes #3089)

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14432,6 +14432,7 @@ struct CMUXCLI {
           Output defaults to refs; pass --id-format uuids or --id-format both to include UUIDs.
 
         Socket Auth:
+          Local Unix sockets default to same-user automation access. Change Socket Control Mode in Settings > Automation to require cmux-only ancestry or password auth.
           --password takes precedence, then CMUX_SOCKET_PASSWORD env var, then password saved in Settings.
 
         Commands:

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -363,8 +363,9 @@ struct SocketControlSettings {
             defaults.integer(forKey: modeDefaultMigrationDefaultsKey) < modeDefaultMigrationVersion
 
         defer {
-            guard requiresDefaultModeMigration else { return }
-            defaults.set(modeDefaultMigrationVersion, forKey: modeDefaultMigrationDefaultsKey)
+            if requiresDefaultModeMigration {
+                defaults.set(modeDefaultMigrationVersion, forKey: modeDefaultMigrationDefaultsKey)
+            }
         }
 
         if let stored = defaults.string(forKey: appStorageKey) {

--- a/Sources/SocketControlSettings.swift
+++ b/Sources/SocketControlSettings.swift
@@ -296,6 +296,8 @@ struct SocketControlSettings {
     static let socketPasswordEnvKey = "CMUX_SOCKET_PASSWORD"
     static let launchTagEnvKey = "CMUX_TAG"
     static let baseDebugBundleIdentifier = "com.cmuxterm.app.debug"
+    private static let modeDefaultMigrationDefaultsKey = "socketControlModeDefaultMigrationVersion"
+    private static let modeDefaultMigrationVersion = 1
     private static let socketDirectoryName = "cmux"
     private static let stableSocketFileName = "cmux.sock"
     private static let lastSocketPathFileName = "last-socket-path"
@@ -353,7 +355,36 @@ struct SocketControlSettings {
     }
 
     static var defaultMode: SocketControlMode {
-        return .cmuxOnly
+        return .automation
+    }
+
+    static func migratePersistedModeIfNeeded(defaults: UserDefaults = .standard) {
+        let requiresDefaultModeMigration =
+            defaults.integer(forKey: modeDefaultMigrationDefaultsKey) < modeDefaultMigrationVersion
+
+        defer {
+            guard requiresDefaultModeMigration else { return }
+            defaults.set(modeDefaultMigrationVersion, forKey: modeDefaultMigrationDefaultsKey)
+        }
+
+        if let stored = defaults.string(forKey: appStorageKey) {
+            let migrated = migrateMode(stored)
+            let resolvedMode: SocketControlMode
+            if requiresDefaultModeMigration && migrated == .cmuxOnly {
+                resolvedMode = .automation
+            } else {
+                resolvedMode = migrated
+            }
+
+            if resolvedMode.rawValue != stored {
+                defaults.set(resolvedMode.rawValue, forKey: appStorageKey)
+            }
+            return
+        }
+
+        if let legacy = defaults.object(forKey: legacyEnabledKey) as? Bool {
+            defaults.set((legacy ? defaultMode : .off).rawValue, forKey: appStorageKey)
+        }
     }
 
     private static var isDebugBuild: Bool {
@@ -671,7 +702,7 @@ struct SocketControlSettings {
             if let overrideMode = envOverrideMode(environment: environment) {
                 return overrideMode
             }
-            return userMode == .off ? .cmuxOnly : userMode
+            return userMode == .off ? defaultMode : userMode
         }
 
         if let overrideMode = envOverrideMode(environment: environment) {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -51,7 +51,7 @@ class TerminalController {
     private nonisolated let listenerStateLock = NSLock()
     private var clientHandlers: [Int32: Thread] = [:]
     private var tabManager: TabManager?
-    private var accessMode: SocketControlMode = .cmuxOnly
+    private var accessMode: SocketControlMode = SocketControlSettings.defaultMode
     private let myPid = getpid()
     private nonisolated(unsafe) static var socketCommandPolicyDepth: Int = 0
     private nonisolated(unsafe) static var socketCommandFocusAllowanceStack: [Bool] = []

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -189,17 +189,8 @@ struct cmuxApp: App {
         let startupAppearance = AppearanceSettings.resolvedMode()
         Self.applyAppearance(startupAppearance)
         _tabManager = StateObject(wrappedValue: TabManager())
-        // Migrate legacy and old-format socket mode values to the new enum.
         let defaults = UserDefaults.standard
-        if let stored = defaults.string(forKey: SocketControlSettings.appStorageKey) {
-            let migrated = SocketControlSettings.migrateMode(stored)
-            if migrated.rawValue != stored {
-                defaults.set(migrated.rawValue, forKey: SocketControlSettings.appStorageKey)
-            }
-        } else if let legacy = defaults.object(forKey: SocketControlSettings.legacyEnabledKey) as? Bool {
-            defaults.set(legacy ? SocketControlMode.cmuxOnly.rawValue : SocketControlMode.off.rawValue,
-                         forKey: SocketControlSettings.appStorageKey)
-        }
+        SocketControlSettings.migratePersistedModeIfNeeded(defaults: defaults)
         // Skip keychain migration for DEV/staging builds. Each tagged build gets a
         // unique bundle ID with its own UserDefaults domain, so migration would run
         // on every launch and trigger a macOS keychain access prompt (the legacy

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -1834,6 +1834,10 @@ final class RecentlyClosedBrowserStackTests: XCTestCase {
 }
 
 final class SocketControlSettingsTests: XCTestCase {
+    func testDefaultSocketModeSupportsExternalAutomation() {
+        XCTAssertEqual(SocketControlSettings.defaultMode, .automation)
+    }
+
     func testMigrateModeSupportsExpandedSocketModes() {
         XCTAssertEqual(SocketControlSettings.migrateMode("off"), .off)
         XCTAssertEqual(SocketControlSettings.migrateMode("cmuxOnly"), .cmuxOnly)
@@ -1854,6 +1858,16 @@ final class SocketControlSettingsTests: XCTestCase {
         XCTAssertEqual(SocketControlMode.allowAll.socketFilePermissions, 0o666)
     }
 
+    func testSocketEnableOverrideWithoutExplicitModeUsesDefaultMode() {
+        XCTAssertEqual(
+            SocketControlSettings.effectiveMode(
+                userMode: .off,
+                environment: ["CMUX_SOCKET_ENABLE": "1"]
+            ),
+            .automation
+        )
+    }
+
     func testInvalidEnvSocketModeDoesNotOverrideUserMode() {
         XCTAssertNil(
             SocketControlSettings.envOverrideMode(
@@ -1866,6 +1880,45 @@ final class SocketControlSettingsTests: XCTestCase {
                 environment: ["CMUX_SOCKET_MODE": "definitely-not-a-mode"]
             ),
             .password
+        )
+    }
+
+    func testPersistedCmuxOnlyMigratesToAutomationOnlyOnce() {
+        let suiteName = "cmux-socket-mode-migration-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(SocketControlMode.cmuxOnly.rawValue, forKey: SocketControlSettings.appStorageKey)
+        SocketControlSettings.migratePersistedModeIfNeeded(defaults: defaults)
+        XCTAssertEqual(
+            defaults.string(forKey: SocketControlSettings.appStorageKey),
+            SocketControlMode.automation.rawValue
+        )
+
+        defaults.set(SocketControlMode.cmuxOnly.rawValue, forKey: SocketControlSettings.appStorageKey)
+        SocketControlSettings.migratePersistedModeIfNeeded(defaults: defaults)
+        XCTAssertEqual(
+            defaults.string(forKey: SocketControlSettings.appStorageKey),
+            SocketControlMode.cmuxOnly.rawValue
+        )
+    }
+
+    func testLegacyEnabledMigrationUsesAutomationDefault() {
+        let suiteName = "cmux-socket-mode-legacy-\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Expected isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(true, forKey: SocketControlSettings.legacyEnabledKey)
+        SocketControlSettings.migratePersistedModeIfNeeded(defaults: defaults)
+        XCTAssertEqual(
+            defaults.string(forKey: SocketControlSettings.appStorageKey),
+            SocketControlMode.automation.rawValue
         )
     }
 

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -51,6 +51,46 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertEqual(try socketMode(at: restrictedPath), 0o600)
     }
 
+    func testCmuxOnlyRejectsDetachedExternalClient() throws {
+        let socketPath = makeSocketPath("cmux-detached")
+        let tabManager = TabManager()
+
+        TerminalController.shared.start(
+            tabManager: tabManager,
+            socketPath: socketPath,
+            accessMode: .cmuxOnly
+        )
+        try waitForSocket(at: socketPath)
+
+        let result = try runDetachedExternalPing(to: socketPath)
+        XCTAssertNotEqual(result.response, "PONG")
+        XCTAssertTrue(
+            result.response.isEmpty ||
+                result.response.localizedCaseInsensitiveContains("access denied") ||
+                result.response.localizedCaseInsensitiveContains("error"),
+            "Expected detached external client to be rejected in cmuxOnly mode, got: \(result.response)"
+        )
+    }
+
+    func testDefaultSocketModeAllowsDetachedExternalClient() throws {
+        let socketPath = makeSocketPath("default-detached")
+        let tabManager = TabManager()
+
+        TerminalController.shared.start(
+            tabManager: tabManager,
+            socketPath: socketPath,
+            accessMode: SocketControlSettings.defaultMode
+        )
+        try waitForSocket(at: socketPath)
+
+        let result = try runDetachedExternalPing(to: socketPath)
+        XCTAssertEqual(
+            result.response,
+            "PONG",
+            "Expected detached external client to succeed with the default socket mode, exit=\(result.exitCode), output=\(result.response)"
+        )
+    }
+
     func testPasswordModeRejectsUnauthenticatedCommands() throws {
         let socketPath = makeSocketPath("password-mode")
         let tabManager = TabManager()
@@ -447,6 +487,68 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         return responses
     }
 
+    private func runDetachedExternalPing(
+        to socketPath: String,
+        timeout: TimeInterval = 5.0
+    ) throws -> (response: String, exitCode: Int32) {
+        let fileManager = FileManager.default
+        let nohupPath = "/usr/bin/nohup"
+        let netcatPath = "/usr/bin/nc"
+
+        guard fileManager.isExecutableFile(atPath: nohupPath) else {
+            throw XCTSkip("Detached-client test requires \(nohupPath)")
+        }
+        guard fileManager.isExecutableFile(atPath: netcatPath) else {
+            throw XCTSkip("Detached-client test requires \(netcatPath)")
+        }
+
+        let tempRoot = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-detached-client-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: tempRoot, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: tempRoot) }
+
+        let scriptURL = tempRoot.appendingPathComponent("launch-detached.sh", isDirectory: false)
+        let outputURL = tempRoot.appendingPathComponent("output.txt", isDirectory: false)
+        let statusURL = tempRoot.appendingPathComponent("status.txt", isDirectory: false)
+
+        let script = """
+        #!/bin/sh
+        set -eu
+
+        SOCKET_PATH="$1"
+        OUTPUT_PATH="$2"
+        STATUS_PATH="$3"
+
+        "\(nohupPath)" /bin/sh -c '
+          sleep 0.5
+          printf "ping\\n" | "\(netcatPath)" -U "$1" > "$2" 2>&1
+          printf "%s\\n" "$?" > "$3"
+        ' _ "$SOCKET_PATH" "$OUTPUT_PATH" "$STATUS_PATH" >/dev/null 2>&1 &
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o755], ofItemAtPath: scriptURL.path)
+
+        let process = Process()
+        process.executableURL = scriptURL
+        process.arguments = [socketPath, outputURL.path, statusURL.path]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        try process.run()
+        process.waitUntilExit()
+        XCTAssertEqual(process.terminationStatus, 0, "Detached launcher failed")
+
+        try waitForFile(at: statusURL, timeout: timeout)
+
+        let exitCodeString = try String(contentsOf: statusURL, encoding: .utf8)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let output = (try? String(contentsOf: outputURL, encoding: .utf8)) ?? ""
+        return (
+            response: output.trimmingCharacters(in: .whitespacesAndNewlines),
+            exitCode: Int32(exitCodeString) ?? -1
+        )
+    }
+
     private nonisolated func sendV2Request(
         method: String,
         params: [String: Any],
@@ -534,6 +636,20 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
             throw error
         }
         return fd
+    }
+
+    private func waitForFile(at url: URL, timeout: TimeInterval = 5.0) throws {
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                FileManager.default.fileExists(atPath: url.path)
+            },
+            object: NSObject()
+        )
+        if XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed {
+            return
+        }
+        XCTFail("Timed out waiting for file at \(url.path)")
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(ETIMEDOUT))
     }
 
     private nonisolated func writeLine(_ command: String, to fd: Int32) throws {


### PR DESCRIPTION
## Summary
- switch the default local socket mode to same-user automation access and migrate legacy cmuxOnly installs forward once
- keep explicit cmuxOnly available for strict ancestry-only users and document the new default in `cmux --help`
- add detached-client socket tests that cover both rejection in `cmuxOnly` and success in the default mode

## Testing
- not run locally per repo policy
- `./scripts/reload.sh --tag issue-3089-cli-external-socket --launch` (build + launch succeeded)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default local socket access policy and adds one-time migration logic, which can broaden who can control the app on the same macOS user account if users relied on the stricter default. Includes added tests, but still touches security-sensitive socket authorization behavior.
> 
> **Overview**
> Switches the default local Unix socket control mode from `cmuxOnly` to `automation` (same-user external automation allowed), and updates `TerminalController` to initialize from `SocketControlSettings.defaultMode`.
> 
> Adds `SocketControlSettings.migratePersistedModeIfNeeded` to migrate persisted/legacy defaults, including a *one-time* forward-migration of existing `cmuxOnly` stored values to `automation`, and updates app startup to use this centralized migration.
> 
> Updates `cmux --help` text to document the new default, and adds new socket security tests that verify detached external clients are rejected in `cmuxOnly` but succeed under the new default mode (plus coverage for env override defaulting behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 195674249651ccd0c152becbae79e65d79ff6197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow external same‑user clients to connect to the `cmux` Unix socket by default to enable automation outside the app. Existing installs are migrated once from cmux‑only ancestry to same‑user automation; users can still choose `cmuxOnly` or password auth.

- **New Features**
  - Default socket mode is `automation` (same‑user external automation).
  - Updated `cmux --help` to explain socket auth modes.
  - Added tests for detached external clients (allowed by default; blocked in `cmuxOnly`).

- **Migration**
  - One‑time migration: persisted `cmuxOnly` becomes `automation`; explicit `cmuxOnly` remains available.
  - Legacy “enabled” setting now maps to `automation`; `CMUX_SOCKET_ENABLE` without a mode uses the default.

<sup>Written for commit 195674249651ccd0c152becbae79e65d79ff6197. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated CLI socket authentication guidance to direct users to Settings > Automation for configuring socket control mode.

* **Bug Fixes**
  * Local Unix sockets now default to automation access, enabling external automation connections.
  * Added automatic migration for existing configurations to the new default behavior.

* **Tests**
  * Added validation tests for socket control mode defaults and configuration migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->