### PR TITLE
cmux: hide overlay scrollbar when tmux pane-scrollbars is active

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -90136,13 +90136,115 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show Terminal Scroll Bar"
+            "value": "Terminal Scroll Bar"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルのスクロールバーを表示"
+            "value": "ターミナルのスクロールバー"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.option.always": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Always"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "常に表示"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.option.auto": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Auto"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "自動"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.option.never": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Never"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "表示しない"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.subtitleAlways": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows the cmux overlay scrollbar whenever shell scrollback is available, even if tmux pane-scrollbars is active. You can still hide it per workspace."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルのスクロールバックが利用できるときは、tmux の pane-scrollbars が有効でも cmux のオーバーレイスクロールバーを表示します。ワークスペースごとに隠すことは引き続きできます。"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.subtitleAuto": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shows the right-edge terminal scroll bar in shell scrollback, but hides it automatically for alternate-screen style TUI surfaces and when tmux pane-scrollbars is active."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "シェルのスクロールバックでは右端のターミナルスクロールバーを表示しますが、代替画面系の TUI や tmux の pane-scrollbars が有効なときは自動的に隠します。"
+          }
+        }
+      }
+    },
+    "settings.terminal.scrollBar.subtitleNever": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右端のターミナルスクロールバーを全体で非表示にします。変更はすぐに反映され、再起動後も保持されます。"
           }
         }
       }

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -133,6 +133,22 @@ _cmux_ports_kick_via_relay() {
     _cmux_relay_rpc_bg "surface.ports_kick" "$params"
 }
 
+_cmux_report_tmux_scrollbar_via_relay() {
+    local active="$1"
+    [[ "$active" == "on" || "$active" == "off" ]] || return 1
+    _cmux_socket_uses_remote_relay || return 1
+    local workspace_id=""
+    workspace_id="$(_cmux_relay_workspace_id)" || return 1
+    local active_json="false"
+    [[ "$active" == "on" ]] && active_json="true"
+    local params="{\"workspace_id\":\"$workspace_id\",\"active\":$active_json"
+    if [[ -n "$CMUX_PANEL_ID" ]]; then
+        params+=",\"surface_id\":\"$CMUX_PANEL_ID\""
+    fi
+    params+="}"
+    _cmux_relay_rpc_bg "surface.report_tmux_scrollbar" "$params"
+}
+
 _cmux_restore_scrollback_once() {
     local path="${CMUX_RESTORE_SCROLLBACK_FILE:-}"
     [[ -n "$path" ]] || return 0
@@ -197,6 +213,7 @@ _CMUX_PORTS_LAST_RUN="${_CMUX_PORTS_LAST_RUN:-0}"
 _CMUX_SHELL_ACTIVITY_LAST="${_CMUX_SHELL_ACTIVITY_LAST:-}"
 _CMUX_TTY_NAME="${_CMUX_TTY_NAME:-}"
 _CMUX_TTY_REPORTED="${_CMUX_TTY_REPORTED:-0}"
+_CMUX_TMUX_SCROLLBAR_STATE_LAST="${_CMUX_TMUX_SCROLLBAR_STATE_LAST:-}"
 _CMUX_TMUX_PUSH_SIGNATURE="${_CMUX_TMUX_PUSH_SIGNATURE:-}"
 _CMUX_TMUX_PULL_SIGNATURE="${_CMUX_TMUX_PULL_SIGNATURE:-}"
 _CMUX_TMUX_SYNC_KEYS=(
@@ -303,6 +320,7 @@ _cmux_tmux_refresh_cmux_environment() {
     if (( did_change )); then
         _CMUX_TTY_REPORTED=0
         _CMUX_SHELL_ACTIVITY_LAST=""
+        _CMUX_TMUX_SCROLLBAR_STATE_LAST=""
         _CMUX_PWD_LAST_PWD=""
         _CMUX_GIT_LAST_PWD=""
         _CMUX_GIT_HEAD_LAST_PWD=""
@@ -389,6 +407,60 @@ _cmux_report_tty_once() {
         # the target surface before command-start kicks begin their scan burst.
         _cmux_report_tty_via_relay || return 0
         _CMUX_TTY_REPORTED=1
+    fi
+}
+
+_cmux_tmux_scrollbar_state() {
+    if [[ -n "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
+        local mode
+        mode="$(tmux show-options -qv pane-scrollbars 2>/dev/null | head -n 1)"
+        mode="$(printf '%s' "$mode" | tr '[:upper:]' '[:lower:]')"
+        case "$mode" in
+            ""|off)
+                printf '%s\n' "off"
+                ;;
+            *)
+                printf '%s\n' "on"
+                ;;
+        esac
+        return 0
+    fi
+    printf '%s\n' "off"
+}
+
+_cmux_report_tmux_scrollbar_payload() {
+    local active="$1"
+    [[ "$active" == "on" || "$active" == "off" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+
+    local payload="report_tmux_scrollbar $active --tab=$CMUX_TAB_ID"
+    if [[ -z "$TMUX" ]]; then
+        [[ -n "$CMUX_PANEL_ID" ]] || return 0
+        payload+=" --panel=$CMUX_PANEL_ID"
+    fi
+
+    printf '%s\n' "$payload"
+}
+
+_cmux_report_tmux_scrollbar_state() {
+    _cmux_has_port_scan_transport || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+
+    local active=""
+    active="$(_cmux_tmux_scrollbar_state)"
+    [[ -n "$active" ]] || return 0
+    [[ "$_CMUX_TMUX_SCROLLBAR_STATE_LAST" == "$active" ]] && return 0
+    _CMUX_TMUX_SCROLLBAR_STATE_LAST="$active"
+
+    if _cmux_socket_is_unix; then
+        local payload=""
+        payload="$(_cmux_report_tmux_scrollbar_payload "$active")"
+        [[ -n "$payload" ]] || return 0
+        {
+            _cmux_send "$payload"
+        } >/dev/null 2>&1 & disown
+    else
+        _cmux_report_tmux_scrollbar_via_relay "$active" || return 0
     fi
 }
 
@@ -966,6 +1038,7 @@ _cmux_prompt_command() {
         _cmux_report_shell_activity_state prompt
     fi
     _cmux_report_tty_once
+    _cmux_report_tmux_scrollbar_state
 
     local now
     now="$(_cmux_now)"

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -140,6 +140,22 @@ _cmux_ports_kick_via_relay() {
     _cmux_relay_rpc_bg "surface.ports_kick" "$params"
 }
 
+_cmux_report_tmux_scrollbar_via_relay() {
+    local active="$1"
+    [[ "$active" == "on" || "$active" == "off" ]] || return 1
+    _cmux_socket_uses_remote_relay || return 1
+    local workspace_id=""
+    workspace_id="$(_cmux_relay_workspace_id)" || return 1
+    local active_json="false"
+    [[ "$active" == "on" ]] && active_json="true"
+    local params="{\"workspace_id\":\"$workspace_id\",\"active\":$active_json"
+    if [[ -n "$CMUX_PANEL_ID" ]]; then
+        params+=",\"surface_id\":\"$CMUX_PANEL_ID\""
+    fi
+    params+="}"
+    _cmux_relay_rpc_bg "surface.report_tmux_scrollbar" "$params"
+}
+
 _cmux_restore_scrollback_once() {
     local path="${CMUX_RESTORE_SCROLLBACK_FILE:-}"
     [[ -n "$path" ]] || return 0
@@ -201,6 +217,7 @@ typeset -g _CMUX_CMD_START=0
 typeset -g _CMUX_SHELL_ACTIVITY_LAST=""
 typeset -g _CMUX_TTY_NAME=""
 typeset -g _CMUX_TTY_REPORTED=0
+typeset -g _CMUX_TMUX_SCROLLBAR_STATE_LAST=""
 typeset -g _CMUX_GHOSTTY_SEMANTIC_PATCHED=0
 typeset -g _CMUX_WINCH_GUARD_INSTALLED=0
 typeset -g _CMUX_TMUX_PUSH_SIGNATURE=""
@@ -308,6 +325,7 @@ _cmux_tmux_refresh_cmux_environment() {
     if (( did_change )); then
         _CMUX_TTY_REPORTED=0
         _CMUX_SHELL_ACTIVITY_LAST=""
+        _CMUX_TMUX_SCROLLBAR_STATE_LAST=""
         _CMUX_PWD_LAST_PWD=""
         _CMUX_GIT_LAST_PWD=""
         _CMUX_GIT_HEAD_LAST_PWD=""
@@ -488,6 +506,58 @@ _cmux_report_tty_once() {
         # the target surface before command-start kicks begin their scan burst.
         _cmux_report_tty_via_relay || return 0
         _CMUX_TTY_REPORTED=1
+    fi
+}
+
+_cmux_tmux_scrollbar_state() {
+    if [[ -n "$TMUX" ]] && command -v tmux >/dev/null 2>&1; then
+        local mode
+        mode="$(tmux show-options -qv pane-scrollbars 2>/dev/null | head -n 1)"
+        mode="${mode:l}"
+        case "$mode" in
+            ""|off)
+                print -r -- "off"
+                ;;
+            *)
+                print -r -- "on"
+                ;;
+        esac
+        return 0
+    fi
+    print -r -- "off"
+}
+
+_cmux_report_tmux_scrollbar_payload() {
+    local active="$1"
+    [[ "$active" == "on" || "$active" == "off" ]] || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+
+    local payload="report_tmux_scrollbar $active --tab=$CMUX_TAB_ID"
+    if [[ -z "$TMUX" ]]; then
+        [[ -n "$CMUX_PANEL_ID" ]] || return 0
+        payload+=" --panel=$CMUX_PANEL_ID"
+    fi
+
+    print -r -- "$payload"
+}
+
+_cmux_report_tmux_scrollbar_state() {
+    _cmux_has_port_scan_transport || return 0
+    [[ -n "$CMUX_TAB_ID" ]] || return 0
+
+    local active=""
+    active="$(_cmux_tmux_scrollbar_state)"
+    [[ -n "$active" ]] || return 0
+    [[ "$_CMUX_TMUX_SCROLLBAR_STATE_LAST" == "$active" ]] && return 0
+    _CMUX_TMUX_SCROLLBAR_STATE_LAST="$active"
+
+    if _cmux_socket_is_unix; then
+        local payload=""
+        payload="$(_cmux_report_tmux_scrollbar_payload "$active")"
+        [[ -n "$payload" ]] || return 0
+        _cmux_send_bg "$payload"
+    else
+        _cmux_report_tmux_scrollbar_via_relay "$active" || return 0
     fi
 }
 
@@ -1127,6 +1197,7 @@ _cmux_precmd() {
     fi
 
     _cmux_report_tty_once
+    _cmux_report_tmux_scrollbar_state
 
     local now="$(_cmux_now)"
     local cmd_start="$_CMUX_CMD_START"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3778,6 +3778,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
     @Published private(set) var keyboardCopyModeActive: Bool = false
+    private(set) var tmuxPaneScrollbarActive: Bool = false
     private var searchNeedleCancellable: AnyCancellable?
     var currentKeyStateIndicatorText: String? { surfaceView.currentKeyStateIndicatorText }
 
@@ -5190,6 +5191,16 @@ final class TerminalSurface: Identifiable, ObservableObject {
             keyboardCopyModeActive = active
         }
         hostedView.syncKeyStateIndicator(text: surfaceView.currentKeyStateIndicatorText)
+    }
+
+    @MainActor
+    func setTmuxPaneScrollbarActive(_ active: Bool) {
+        guard tmuxPaneScrollbarActive != active else { return }
+        tmuxPaneScrollbarActive = active
+        NotificationCenter.default.post(
+            name: .terminalSurfaceTmuxPaneScrollbarDidChange,
+            object: self
+        )
     }
 
     func hasSelection() -> Bool {
@@ -8826,6 +8837,9 @@ extension Notification.Name {
     static let ghosttyDidUpdateCellSize = Notification.Name("ghosttyDidUpdateCellSize")
     static let ghosttyDidReceiveWheelScroll = Notification.Name("ghosttyDidReceiveWheelScroll")
     static let ghosttySearchFocus = Notification.Name("ghosttySearchFocus")
+    static let terminalSurfaceTmuxPaneScrollbarDidChange = Notification.Name(
+        "terminalSurfaceTmuxPaneScrollbarDidChange"
+    )
     static let ghosttyConfigDidReload = Notification.Name("ghosttyConfigDidReload")
     static let ghosttyDefaultBackgroundDidChange = Notification.Name("ghosttyDefaultBackgroundDidChange")
     static let browserSearchFocus = Notification.Name("browserSearchFocus")
@@ -9476,6 +9490,19 @@ final class GhosttySurfaceScrollView: NSView {
             queue: .main
         ) { [weak self] _ in
             self?.handleTerminalScrollBarPreferenceChange()
+        })
+
+        observers.append(NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceTmuxPaneScrollbarDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self,
+                  let surface = notification.object as? TerminalSurface,
+                  surface === self.surfaceView.terminalSurface else {
+                return
+            }
+            self.handleTerminalScrollBarPreferenceChange()
         })
 
     }
@@ -11826,8 +11853,12 @@ final class GhosttySurfaceScrollView: NSView {
 
     private func terminalScrollBarAllowedBySettings() -> Bool {
         guard GhosttyApp.shared.scrollbarVisibility() != .never else { return false }
-        guard TerminalScrollBarSettings.isVisible() else { return false }
+        let mode = TerminalScrollBarSettings.mode()
+        guard mode != .never else { return false }
         guard owningWorkspace()?.terminalScrollBarHidden != true else { return false }
+        if mode == .auto, surfaceView.terminalSurface?.tmuxPaneScrollbarActive == true {
+            return false
+        }
         return true
     }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -39,6 +39,7 @@ final class CmuxSettingsFileStore {
         "app.warnBeforeQuit",
         "app.renameSelectsExistingName",
         "app.commandPaletteSearchesAllSurfaces",
+        "cmux.scrollbar",
         "terminal.showScrollBar",
         "notifications.dockBadge",
         "notifications.showInMenuBar",
@@ -355,6 +356,9 @@ final class CmuxSettingsFileStore {
         if let terminalSection = root["terminal"] as? [String: Any] {
             parseTerminalSection(terminalSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
+        if let cmuxSection = root["cmux"] as? [String: Any] {
+            parseCmuxSection(cmuxSection, sourcePath: sourcePath, snapshot: &snapshot)
+        }
         if let notificationsSection = root["notifications"] as? [String: Any] {
             parseNotificationsSection(notificationsSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
@@ -490,9 +494,27 @@ final class CmuxSettingsFileStore {
         snapshot: inout ResolvedSettingsSnapshot
     ) {
         if let value = jsonBool(section["showScrollBar"]) {
-            snapshot.managedUserDefaults[TerminalScrollBarSettings.showScrollBarKey] = .bool(value)
+            snapshot.managedUserDefaults[TerminalScrollBarSettings.modeKey] = .string(
+                TerminalScrollBarSettings.mode(forLegacyVisible: value).rawValue
+            )
         } else if section.keys.contains("showScrollBar") {
             logInvalid("terminal.showScrollBar", sourcePath: sourcePath)
+        }
+    }
+
+    private func parseCmuxSection(
+        _ section: [String: Any],
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        if let raw = jsonString(section["scrollbar"]) {
+            guard let mode = TerminalScrollBarSettings.Mode(rawValue: raw) else {
+                logInvalid("cmux.scrollbar", sourcePath: sourcePath)
+                return
+            }
+            snapshot.managedUserDefaults[TerminalScrollBarSettings.modeKey] = .string(mode.rawValue)
+        } else if section.keys.contains("scrollbar") {
+            logInvalid("cmux.scrollbar", sourcePath: sourcePath)
         }
     }
 
@@ -1180,7 +1202,7 @@ final class CmuxSettingsFileStore {
             }
         }
 
-        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey, didMutateStoredValue {
+        if defaultsKey == TerminalScrollBarSettings.modeKey, didMutateStoredValue {
             TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
         }
 
@@ -1226,7 +1248,7 @@ final class CmuxSettingsFileStore {
             defaults.set(value, forKey: defaultsKey)
         }
 
-        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey {
+        if defaultsKey == TerminalScrollBarSettings.modeKey {
             TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
         }
 
@@ -1371,8 +1393,8 @@ final class CmuxSettingsFileStore {
                 ],
             ],
             [
-                "terminal": [
-                    "showScrollBar": TerminalScrollBarSettings.defaultShowScrollBar,
+                "cmux": [
+                    "scrollbar": TerminalScrollBarSettings.defaultMode.rawValue,
                 ],
             ],
             [

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -3985,6 +3985,18 @@ class TabManager: ObservableObject {
         }
     }
 
+    func updateSurfaceTmuxPaneScrollbar(
+        tabId: UUID,
+        surfaceId: UUID,
+        active: Bool
+    ) {
+        guard let tab = tabs.first(where: { $0.id == tabId }),
+              let terminalSurface = tab.terminalPanel(for: surfaceId)?.surface else {
+            return
+        }
+        terminalSurface.setTmuxPaneScrollbarActive(active)
+    }
+
     func handleWorkspacePullRequestCommandHint(
         tabId: UUID,
         surfaceId: UUID,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -428,8 +428,10 @@ class TerminalController {
         private let queue = DispatchQueue(label: "com.cmux.socket-fast-path")
         private var lastReportedDirectories: [SocketSurfaceKey: String] = [:]
         private var lastReportedShellStates: [SocketSurfaceKey: Workspace.PanelShellActivityState] = [:]
+        private var lastReportedTmuxPaneScrollbarStates: [SocketSurfaceKey: Bool] = [:]
         private let maxTrackedDirectories = 4096
         private let maxTrackedShellStates = 4096
+        private let maxTrackedTmuxPaneScrollbarStates = 4096
 
         func shouldPublishDirectory(workspaceId: UUID, panelId: UUID, directory: String) -> Bool {
             let key = SocketSurfaceKey(workspaceId: workspaceId, panelId: panelId)
@@ -459,6 +461,24 @@ class TerminalController {
                     lastReportedShellStates.removeAll(keepingCapacity: true)
                 }
                 lastReportedShellStates[key] = state
+                return true
+            }
+        }
+
+        func shouldPublishTmuxPaneScrollbar(
+            workspaceId: UUID,
+            panelId: UUID,
+            active: Bool
+        ) -> Bool {
+            let key = SocketSurfaceKey(workspaceId: workspaceId, panelId: panelId)
+            return queue.sync {
+                if lastReportedTmuxPaneScrollbarStates[key] == active {
+                    return false
+                }
+                if lastReportedTmuxPaneScrollbarStates.count >= maxTrackedTmuxPaneScrollbarStates {
+                    lastReportedTmuxPaneScrollbarStates.removeAll(keepingCapacity: true)
+                }
+                lastReportedTmuxPaneScrollbarStates[key] = active
                 return true
             }
         }
@@ -541,6 +561,17 @@ class TerminalController {
             return .command
         case "refresh", "prompt", "idle":
             return .refresh
+        default:
+            return nil
+        }
+    }
+
+    nonisolated static func parseReportedTmuxPaneScrollbarState(_ rawState: String) -> Bool? {
+        switch rawState.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "on", "active", "true", "1", "modal":
+            return true
+        case "off", "inactive", "false", "0":
+            return false
         default:
             return nil
         }
@@ -1819,6 +1850,9 @@ class TerminalController {
         case "report_tty":
             return reportTTY(args)
 
+        case "report_tmux_scrollbar":
+            return reportTmuxScrollbar(args)
+
         case "ports_kick":
             return portsKick(args)
 
@@ -2182,6 +2216,8 @@ class TerminalController {
             return v2Result(id: id, self.v2SurfaceSendKey(params: params))
         case "surface.report_tty":
             return v2Result(id: id, self.v2SurfaceReportTTY(params: params))
+        case "surface.report_tmux_scrollbar":
+            return v2Result(id: id, self.v2SurfaceReportTmuxScrollbar(params: params))
         case "surface.ports_kick":
             return v2Result(id: id, self.v2SurfacePortsKick(params: params))
         case "surface.clear_history":
@@ -2531,6 +2567,7 @@ class TerminalController {
             "surface.send_text",
             "surface.send_key",
             "surface.report_tty",
+            "surface.report_tmux_scrollbar",
             "surface.ports_kick",
             "surface.read_text",
             "surface.clear_history",
@@ -4258,6 +4295,77 @@ class TerminalController {
                 "surface_id": surfaceId.uuidString,
                 "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
                 "tty_name": ttyName,
+            ])
+        }
+
+        return result
+    }
+
+    private func v2SurfaceReportTmuxScrollbar(params: [String: Any]) -> V2CallResult {
+        guard let workspaceId = v2UUID(params, "workspace_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid workspace_id", data: nil)
+        }
+        let requestedSurfaceId = v2UUID(params, "surface_id")
+        if v2HasNonNullParam(params, "surface_id"), requestedSurfaceId == nil {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+        guard let active = v2Bool(params, "active") else {
+            return .err(code: "invalid_params", message: "Missing or invalid active", data: nil)
+        }
+
+        var result: V2CallResult = .err(
+            code: "not_found",
+            message: "Workspace not found",
+            data: [
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                "surface_id": v2OrNull(requestedSurfaceId?.uuidString),
+                "surface_ref": v2Ref(kind: .surface, uuid: requestedSurfaceId),
+            ]
+        )
+
+        v2MainSync {
+            guard let tab = self.tabForSidebarMutation(id: workspaceId) else {
+                return
+            }
+            let validSurfaceIds = Set(tab.panels.keys)
+            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+
+            let surfaceId = self.resolveReportedSurfaceId(
+                in: tab,
+                requestedSurfaceId: requestedSurfaceId,
+                validSurfaceIds: validSurfaceIds
+            )
+            guard let surfaceId, validSurfaceIds.contains(surfaceId) else {
+                result = .err(
+                    code: "not_found",
+                    message: "Surface not found",
+                    data: [
+                        "workspace_id": workspaceId.uuidString,
+                        "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                        "surface_id": v2OrNull(requestedSurfaceId?.uuidString),
+                        "surface_ref": v2Ref(kind: .surface, uuid: requestedSurfaceId),
+                    ]
+                )
+                return
+            }
+
+            guard let terminalSurface = tab.terminalPanel(for: surfaceId)?.surface else {
+                result = .err(
+                    code: "invalid_params",
+                    message: "Surface is not a terminal",
+                    data: ["surface_id": surfaceId.uuidString]
+                )
+                return
+            }
+
+            terminalSurface.setTmuxPaneScrollbarActive(active)
+            result = .ok([
+                "workspace_id": workspaceId.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                "active": active,
             ])
         }
 
@@ -11505,6 +11613,7 @@ class TerminalController {
           clear_pr [--tab=X] [--panel=Y] - Clear pull request
           report_ports <port1> [port2...] [--tab=X] [--panel=Y] - Report listening ports
           report_tty <tty_name> [--tab=X] [--panel=Y] - Register TTY for batched port scanning
+          report_tmux_scrollbar <on|off> [--tab=X] [--panel=Y] - Report whether tmux pane-scrollbars is active in the surface
           ports_kick [--tab=X] [--panel=Y] [--reason=command|refresh] - Request batched port scan for panel
           report_shell_state <prompt|running> [--tab=X] [--panel=Y] - Report whether the shell is idle at a prompt or running a command
           report_pr_action <merge|close|reopen|create|checkout|ready|edit|view> [--target=X] [--tab=X] [--panel=Y] - Hint that a PR-affecting command completed in the panel
@@ -15443,6 +15552,81 @@ class TerminalController {
             }
 
             tabManager.updateSurfaceShellActivity(tabId: tab.id, surfaceId: surfaceId, state: state)
+        }
+        return result
+    }
+
+    private func reportTmuxScrollbar(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        guard let rawState = parsed.positional.first, !rawState.isEmpty else {
+            return "ERROR: Missing tmux scrollbar state — usage: report_tmux_scrollbar <on|off> [--tab=X] [--panel=Y]"
+        }
+        guard let active = Self.parseReportedTmuxPaneScrollbarState(rawState) else {
+            return "ERROR: Invalid tmux scrollbar state '\(rawState)' — expected on or off"
+        }
+
+        if let scope = Self.explicitSocketScope(options: parsed.options) {
+            guard Self.socketFastPathState.shouldPublishTmuxPaneScrollbar(
+                workspaceId: scope.workspaceId,
+                panelId: scope.panelId,
+                active: active
+            ) else {
+                return "OK"
+            }
+            DispatchQueue.main.async {
+                guard let tabManager = AppDelegate.shared?.tabManagerFor(tabId: scope.workspaceId) else { return }
+                tabManager.updateSurfaceTmuxPaneScrollbar(
+                    tabId: scope.workspaceId,
+                    surfaceId: scope.panelId,
+                    active: active
+                )
+            }
+            return "OK"
+        }
+
+        guard let tabManager else { return "ERROR: TabManager not available" }
+
+        var result = "OK"
+        DispatchQueue.main.sync {
+            guard let tab = resolveTabForReport(args) else {
+                result = parsed.options["tab"] != nil ? "ERROR: Tab not found" : "ERROR: No tab selected"
+                return
+            }
+
+            let validSurfaceIds = Set(tab.panels.keys)
+            tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
+
+            let panelArg = parsed.options["panel"] ?? parsed.options["surface"]
+            let surfaceId: UUID
+            if let panelArg {
+                if panelArg.isEmpty {
+                    result = "ERROR: Missing panel id — usage: report_tmux_scrollbar <on|off> [--tab=X] [--panel=Y]"
+                    return
+                }
+                guard let parsedId = UUID(uuidString: panelArg) else {
+                    result = "ERROR: Invalid panel id '\(panelArg)'"
+                    return
+                }
+                surfaceId = parsedId
+            } else {
+                guard let focused = tab.focusedPanelId else {
+                    result = "ERROR: Missing panel id (no focused surface)"
+                    return
+                }
+                surfaceId = focused
+            }
+
+            guard validSurfaceIds.contains(surfaceId) else {
+                result = "ERROR: Panel not found '\(surfaceId.uuidString)'"
+                return
+            }
+
+            guard let terminalSurface = tab.terminalPanel(for: surfaceId)?.surface else {
+                result = "ERROR: No terminal panel available"
+                return
+            }
+
+            terminalSurface.setTmuxPaneScrollbarActive(active)
         }
         return result
     }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -97,15 +97,60 @@ enum PaneFirstClickFocusSettings {
 }
 
 enum TerminalScrollBarSettings {
-    static let showScrollBarKey = "terminal.showScrollBar"
-    static let defaultShowScrollBar = true
+    enum Mode: String, CaseIterable {
+        case auto
+        case always
+        case never
+
+        var displayName: String {
+            switch self {
+            case .auto:
+                return String(localized: "settings.terminal.scrollBar.option.auto", defaultValue: "Auto")
+            case .always:
+                return String(localized: "settings.terminal.scrollBar.option.always", defaultValue: "Always")
+            case .never:
+                return String(localized: "settings.terminal.scrollBar.option.never", defaultValue: "Never")
+            }
+        }
+    }
+
+    static let modeKey = "cmux.scrollbar"
+    static let legacyShowScrollBarKey = "terminal.showScrollBar"
+    static let defaultMode: Mode = .auto
     static let didChangeNotification = Notification.Name("cmux.terminalScrollBarSettingsDidChange")
 
-    static func isVisible(defaults: UserDefaults = .standard) -> Bool {
-        if defaults.object(forKey: showScrollBarKey) == nil {
-            return defaultShowScrollBar
+    static func mode(for rawValue: String?) -> Mode {
+        guard let rawValue else { return defaultMode }
+        return Mode(rawValue: rawValue) ?? defaultMode
+    }
+
+    static func mode(defaults: UserDefaults = .standard) -> Mode {
+        if let rawValue = defaults.string(forKey: modeKey) {
+            return mode(for: rawValue)
         }
-        return defaults.bool(forKey: showScrollBarKey)
+        if let legacyValue = defaults.object(forKey: legacyShowScrollBarKey) as? Bool {
+            return mode(forLegacyVisible: legacyValue)
+        }
+        return defaultMode
+    }
+
+    static func isVisible(defaults: UserDefaults = .standard) -> Bool {
+        mode(defaults: defaults) != .never
+    }
+
+    static func mode(forLegacyVisible visible: Bool) -> Mode {
+        visible ? .auto : .never
+    }
+
+    static func initializeStoredModeIfNeeded(defaults: UserDefaults = .standard) {
+        guard defaults.string(forKey: modeKey) == nil else { return }
+        let initialMode: Mode
+        if let legacyValue = defaults.object(forKey: legacyShowScrollBarKey) as? Bool {
+            initialMode = mode(forLegacyVisible: legacyValue)
+        } else {
+            initialMode = defaultMode
+        }
+        defaults.set(initialMode.rawValue, forKey: modeKey)
     }
 
     static func notifyDidChange(notificationCenter: NotificationCenter = .default) {
@@ -210,6 +255,7 @@ struct cmuxApp: App {
             SocketControlPasswordStore.migrateLegacyKeychainPasswordIfNeeded(defaults: defaults)
         }
         migrateSidebarAppearanceDefaultsIfNeeded(defaults: defaults)
+        TerminalScrollBarSettings.initializeStoredModeIfNeeded(defaults: defaults)
 
         // UI tests depend on AppDelegate wiring happening even if SwiftUI view appearance
         // callbacks (e.g. `.onAppear`) are delayed or skipped.
@@ -4436,8 +4482,8 @@ struct SettingsView: View {
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(PaneFirstClickFocusSettings.enabledKey)
     private var paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
-    @AppStorage(TerminalScrollBarSettings.showScrollBarKey)
-    private var showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
+    @AppStorage(TerminalScrollBarSettings.modeKey)
+    private var terminalScrollBarMode = TerminalScrollBarSettings.defaultMode.rawValue
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
@@ -4553,15 +4599,40 @@ struct SettingsView: View {
         )
     }
 
-    private var showTerminalScrollBarBinding: Binding<Bool> {
+    private var selectedTerminalScrollBarMode: TerminalScrollBarSettings.Mode {
+        TerminalScrollBarSettings.mode(for: terminalScrollBarMode)
+    }
+
+    private var terminalScrollBarModeSelection: Binding<String> {
         Binding(
-            get: { showTerminalScrollBar },
+            get: { selectedTerminalScrollBarMode.rawValue },
             set: { newValue in
-                guard showTerminalScrollBar != newValue else { return }
-                showTerminalScrollBar = newValue
+                let resolvedMode = TerminalScrollBarSettings.mode(for: newValue)
+                guard terminalScrollBarMode != resolvedMode.rawValue else { return }
+                terminalScrollBarMode = resolvedMode.rawValue
                 TerminalScrollBarSettings.notifyDidChange()
             }
         )
+    }
+
+    private var terminalScrollBarSubtitle: String {
+        switch selectedTerminalScrollBarMode {
+        case .auto:
+            return String(
+                localized: "settings.terminal.scrollBar.subtitleAuto",
+                defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback, but hides it automatically for alternate-screen style TUI surfaces and when tmux pane-scrollbars is active."
+            )
+        case .always:
+            return String(
+                localized: "settings.terminal.scrollBar.subtitleAlways",
+                defaultValue: "Shows the cmux overlay scrollbar whenever shell scrollback is available, even if tmux pane-scrollbars is active. You can still hide it per workspace."
+            )
+        case .never:
+            return String(
+                localized: "settings.terminal.scrollBar.subtitleNever",
+                defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches."
+            )
+        }
     }
 
     private var selectedSidebarActiveTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
@@ -5545,20 +5616,17 @@ struct SettingsView: View {
 
                     SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))
                     SettingsCard {
-                        SettingsCardRow(
-                            configurationReview: .json("terminal.showScrollBar"),
-                            String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"),
-                            subtitle: showTerminalScrollBar
-                                ? String(localized: "settings.terminal.scrollBar.subtitleOn", defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace.")
-                                : String(localized: "settings.terminal.scrollBar.subtitleOff", defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches.")
+                        SettingsPickerRow(
+                            configurationReview: .json("cmux.scrollbar", "terminal.showScrollBar"),
+                            String(localized: "settings.terminal.scrollBar", defaultValue: "Terminal Scroll Bar"),
+                            subtitle: terminalScrollBarSubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: terminalScrollBarModeSelection,
+                            accessibilityId: "SettingsTerminalScrollBarPicker"
                         ) {
-                            Toggle("", isOn: showTerminalScrollBarBinding)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityIdentifier("SettingsTerminalScrollBarToggle")
-                                .accessibilityLabel(
-                                    String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar")
-                                )
+                            ForEach(TerminalScrollBarSettings.Mode.allCases, id: \.rawValue) { mode in
+                                Text(mode.displayName).tag(mode.rawValue)
+                            }
                         }
                     }
 
@@ -6604,9 +6672,9 @@ struct SettingsView: View {
         defaults.removeObject(forKey: WorkspaceButtonFadeSettings.legacyPaneTabBarControlsVisibilityModeKey)
         closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
         paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
-        let previousShowTerminalScrollBar = showTerminalScrollBar
-        showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
-        if previousShowTerminalScrollBar != showTerminalScrollBar {
+        let previousTerminalScrollBarMode = terminalScrollBarMode
+        terminalScrollBarMode = TerminalScrollBarSettings.defaultMode.rawValue
+        if previousTerminalScrollBarMode != terminalScrollBarMode {
             TerminalScrollBarSettings.notifyDidChange()
         }
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3325,6 +3325,69 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
     }
 
+    func testShellIntegrationRelayReportsTmuxScrollbarStateInZsh() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-relay-tmux-scrollbar-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            if [ "$1" = "show-options" ] && [ "$2" = "-qv" ] && [ "$3" = "pane-scrollbars" ]; then
+              printf '%s\\n' 'on'
+              exit 0
+            fi
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            : > "\(logPath.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
+            _cmux_precmd
+            repeat 20; do
+              [[ -s "\(logPath.path)" ]] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMUX": "/tmp/tmux-current,123,0",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertTrue(output.contains("rpc surface.report_tmux_scrollbar"), output)
+        XCTAssertTrue(output.contains(#""workspace_id":"11111111-1111-1111-1111-111111111111""#), output)
+        XCTAssertTrue(output.contains(#""surface_id":"22222222-2222-2222-2222-222222222222""#), output)
+        XCTAssertTrue(output.contains(#""active":true"#), output)
+    }
+
     func testShellIntegrationRelayReportTTYUsesWorkspaceIDInBash() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -3465,6 +3528,68 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
             result.stdout.contains(#"rpc surface.ports_kick {"workspace_id":"11111111-1111-1111-1111-111111111111","reason":"refresh","surface_id":"22222222-2222-2222-2222-222222222222"}"#),
             result.stdout
         )
+    }
+
+    func testShellIntegrationRelayReportsTmuxScrollbarStateInBash() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-bash-relay-tmux-scrollbar-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("relay.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("cmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            if [ "$1" = "show-options" ] && [ "$2" = "-qv" ] && [ "$3" = "pane-scrollbars" ]; then
+              printf '%s\\n' 'modal'
+              exit 0
+            fi
+            exit 0
+            """
+        )
+
+        let result = try runInteractiveBash(
+            cmuxLoadShellIntegration: true,
+            command: """
+            : > "\(logPath.path)"
+            _CMUX_TTY_REPORTED=1
+            _CMUX_PORTS_LAST_RUN="$(_cmux_now)"
+            _cmux_prompt_command
+            for _cmux_i in $(seq 1 20); do
+              [ -s "\(logPath.path)" ] && break
+              sleep 0.05
+            done
+            cat "\(logPath.path)"
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "TMUX": "/tmp/tmux-current,123,0",
+                "CMUX_SOCKET_PATH": "127.0.0.1:64011",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertTrue(result.stdout.contains("rpc surface.report_tmux_scrollbar"), result.stdout)
+        XCTAssertTrue(result.stdout.contains(#""workspace_id":"11111111-1111-1111-1111-111111111111""#), result.stdout)
+        XCTAssertTrue(result.stdout.contains(#""surface_id":"22222222-2222-2222-2222-222222222222""#), result.stdout)
+        XCTAssertTrue(result.stdout.contains(#""active":true"#), result.stdout)
     }
 
     private func runInteractiveZsh(cmuxLoadGhosttyIntegration: Bool) throws -> String {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2541,6 +2541,83 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
         )
     }
 
+    func testTmuxPaneScrollbarHidesOverlayScrollbarInAutoModeButNotAlways() {
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: TerminalScrollBarSettings.modeKey)
+        let previousLegacyValue = defaults.object(forKey: TerminalScrollBarSettings.legacyShowScrollBarKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: TerminalScrollBarSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: TerminalScrollBarSettings.modeKey)
+            }
+            if let previousLegacyValue {
+                defaults.set(previousLegacyValue, forKey: TerminalScrollBarSettings.legacyShowScrollBarKey)
+            } else {
+                defaults.removeObject(forKey: TerminalScrollBarSettings.legacyShowScrollBarKey)
+            }
+            TerminalScrollBarSettings.notifyDidChange()
+        }
+
+        defaults.set(TerminalScrollBarSettings.Mode.auto.rawValue, forKey: TerminalScrollBarSettings.modeKey)
+        TerminalScrollBarSettings.notifyDidChange()
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let scrollView = hostedView.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView else {
+            XCTFail("Expected hosted terminal scroll view")
+            return
+        }
+
+        NotificationCenter.default.post(
+            name: .ghosttyDidUpdateScrollbar,
+            object: scrollView.documentView,
+            userInfo: [GhosttyNotificationKey.scrollbar: makeScrollbar(total: 100, offset: 90, len: 10)]
+        )
+        waitUntil(description: "initial overlay scrollbar visible") {
+            scrollView.hasVerticalScroller
+        }
+
+        surface.setTmuxPaneScrollbarActive(true)
+        waitUntil(description: "auto mode hides overlay scrollbar when tmux pane-scrollbars is active") {
+            !scrollView.hasVerticalScroller
+        }
+
+        defaults.set(TerminalScrollBarSettings.Mode.always.rawValue, forKey: TerminalScrollBarSettings.modeKey)
+        TerminalScrollBarSettings.notifyDidChange()
+        waitUntil(description: "always mode keeps overlay scrollbar visible") {
+            scrollView.hasVerticalScroller
+        }
+    }
+
     func testWindowResignKeyClearsFocusedTerminalFirstResponder() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -292,6 +292,70 @@ final class TerminalControllerSocketSecurityTests: XCTestCase {
         XCTAssertEqual(portsKickResult["surface_id"] as? String, focusedPanelId.uuidString)
     }
 
+    func testReportTmuxScrollbarCommandReturnsOKWhenPanelIsOmittedInsideWorkspaceScope() throws {
+        let socketPath = makeSocketPath("tmux-scrollbar")
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: true)
+
+        defer {
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        TerminalController.shared.start(
+            tabManager: manager,
+            socketPath: socketPath,
+            accessMode: .allowAll
+        )
+        try waitForSocket(at: socketPath)
+
+        let responses = try sendCommands(
+            ["report_tmux_scrollbar on --tab=\(workspace.id.uuidString)"],
+            to: socketPath
+        )
+
+        XCTAssertEqual(responses, ["OK"])
+    }
+
+    func testSurfaceReportTmuxScrollbarRelayRPCResolvesFocusedSurfaceWhenSurfaceIDOmitted() async throws {
+        let socketPath = makeSocketPath("relay-tmux-scroll")
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: true)
+
+        defer {
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        guard let focusedPanelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with a focused panel")
+            return
+        }
+
+        TerminalController.shared.start(
+            tabManager: manager,
+            socketPath: socketPath,
+            accessMode: .allowAll
+        )
+        try waitForSocket(at: socketPath)
+
+        let response = try await sendV2RequestAsync(
+            method: "surface.report_tmux_scrollbar",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "active": true
+            ],
+            to: socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "Unexpected JSON-RPC response: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "Unexpected JSON-RPC response: \(response)")
+        XCTAssertEqual(result["surface_id"] as? String, focusedPanelId.uuidString)
+        XCTAssertEqual(result["active"] as? Bool, true)
+    }
+
     func testSurfaceRelayRPCsRejectExplicitUnknownSurfaceID() async throws {
         let socketPath = makeSocketPath("relay-invalid")
         let manager = TabManager()

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1357,6 +1357,109 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertNil(defaults.data(forKey: settingsFileBackupsDefaultsKey))
     }
 
+    func testSettingsFileStoreParsesCmuxScrollbarMode() throws {
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: "cmux.scrollbar")
+        let previousLegacyValue = defaults.object(forKey: "terminal.showScrollBar")
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: "cmux.scrollbar")
+            } else {
+                defaults.removeObject(forKey: "cmux.scrollbar")
+            }
+            if let previousLegacyValue {
+                defaults.set(previousLegacyValue, forKey: "terminal.showScrollBar")
+            } else {
+                defaults.removeObject(forKey: "terminal.showScrollBar")
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: "cmux.scrollbar")
+        defaults.removeObject(forKey: "terminal.showScrollBar")
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "cmux": {
+                "scrollbar": "never"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(defaults.string(forKey: "cmux.scrollbar"), "never")
+        XCTAssertNil(defaults.object(forKey: "terminal.showScrollBar"))
+    }
+
+    func testSettingsFileStoreMapsLegacyTerminalScrollBarFlagOntoCmuxScrollbarMode() throws {
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: "cmux.scrollbar")
+        let previousLegacyValue = defaults.object(forKey: "terminal.showScrollBar")
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: "cmux.scrollbar")
+            } else {
+                defaults.removeObject(forKey: "cmux.scrollbar")
+            }
+            if let previousLegacyValue {
+                defaults.set(previousLegacyValue, forKey: "terminal.showScrollBar")
+            } else {
+                defaults.removeObject(forKey: "terminal.showScrollBar")
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        defaults.removeObject(forKey: "cmux.scrollbar")
+        defaults.removeObject(forKey: "terminal.showScrollBar")
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "terminal": {
+                "showScrollBar": false
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(defaults.string(forKey: "cmux.scrollbar"), "never")
+    }
+
     func testSettingsFileStoreAppliesWorkspaceColorDictionaryAndAllowsRemovingDefaults() throws {
         let defaults = UserDefaults.standard
         let previousPalette = defaults.dictionary(forKey: WorkspaceTabColorSettings.paletteKey) as? [String: String]

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -120,16 +120,30 @@
         }
       }
     },
+    "cmux": {
+      "title": "cmux",
+      "description": "cmux-specific UI presentation settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "scrollbar": {
+          "type": "string",
+          "enum": ["auto", "always", "never"],
+          "default": "auto",
+          "description": "Control the cmux overlay scrollbar for terminal surfaces. auto keeps current behavior and also hides the overlay when tmux pane-scrollbars is active."
+        }
+      }
+    },
     "terminal": {
       "title": "terminal",
-      "description": "Terminal presentation settings from Settings > Terminal.",
+      "description": "Legacy terminal presentation aliases from older cmux settings files.",
       "type": "object",
       "additionalProperties": false,
       "properties": {
         "showScrollBar": {
           "type": "boolean",
           "default": true,
-          "description": "Show the right-edge terminal scroll bar when scrollback is available. cmux automatically suppresses it for alternate-screen style TUI surfaces."
+          "description": "Legacy alias for cmux.scrollbar. true maps to auto and false maps to never."
         }
       }
     },


### PR DESCRIPTION
## Summary
- add a new `cmux.scrollbar` setting with `auto`, `always`, and `never`, while still accepting the legacy `terminal.showScrollBar` alias
- detect tmux pane-scrollbars through shell integration and report that state over both the local socket and relay RPC paths
- hide the cmux overlay scrollbar for a terminal surface in `auto` mode while tmux pane-scrollbars is active, and cover the plumbing with regression tests

Fixes #3092

## Testing
- not run locally (per repo policy)
- `zsh -n Resources/shell-integration/cmux-zsh-integration.zsh`
- `bash -n Resources/shell-integration/cmux-bash-integration.bash`
- `jq empty Resources/Localizable.xcstrings web/data/cmux-settings.schema.json`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes user-defaults migration, shell-integration prompt hooks, and adds new socket/JSON-RPC commands that affect terminal UI behavior across local and relay transports.
> 
> **Overview**
> Adds a new `cmux.scrollbar` preference with `auto`/`always`/`never` (migrating/aliasing the legacy `terminal.showScrollBar`) and updates the Settings UI, localization strings, and JSON schema accordingly.
> 
> Extends bash/zsh shell integration to detect tmux `pane-scrollbars` and report that state to the app over both the local socket and relay RPC, adds corresponding `report_tmux_scrollbar`/`surface.report_tmux_scrollbar` handlers, and updates terminal rendering so *auto* mode suppresses the cmux overlay scrollbar while tmux pane scrollbars are active.
> 
> Adds regression tests covering settings parsing/migration, shell relay reporting, socket/RPC resolution behavior, and the auto-vs-always overlay scrollbar visibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7fb6cef5f47144187e873d01438430e6d020446. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Terminal scrollbar now supports three display modes: Auto, Always, and Never
  - Auto mode intelligently hides the terminal scrollbar when tmux displays its own scrollbar

* **Improvements**
  - Settings file format updated with new scrollbar configuration options
  - Legacy scrollbar settings automatically migrated to the new format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the cmux overlay scrollbar when tmux pane-scrollbars is active, and add a new `cmux.scrollbar` setting with `auto`, `always`, and `never` modes. Includes shell integration to detect tmux state and updates over both socket and relay paths. Fixes #3092.

- New Features
  - Added `cmux.scrollbar` setting; `auto` hides the overlay when tmux pane-scrollbars is on, `always` shows it, `never` hides it.
  - Kept legacy `terminal.showScrollBar` as an alias (true → `auto`, false → `never`).
  - Bash/zsh integration detects `tmux pane-scrollbars` and reports via `report_tmux_scrollbar` and JSON-RPC `surface.report_tmux_scrollbar`.
  - UI switched from a toggle to a mode picker with localized labels and subtitles.
  - Tests cover config parsing, socket/RPC handling, and UI behavior in auto vs always.

- Migration
  - Prefer `cmux.scrollbar` over `terminal.showScrollBar`; the legacy key still works and maps automatically.
  - Update UI tests to use the picker’s accessibility id `SettingsTerminalScrollBarPicker` (replaces the old toggle).

<sup>Written for commit a7fb6cef5f47144187e873d01438430e6d020446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

