### PR TITLE
Fix #3075: accept named colors in cmux.json and degrade gracefully on parse errors

### DIFF
--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -4,6 +4,21 @@ import Foundation
 
 struct CmuxConfigFile: Codable, Sendable {
     var commands: [CmuxCommandDefinition]
+
+    /// Parse cmux.json data, tolerating per-command decode failures.
+    /// Returns the config (nil if the top-level JSON shape is unusable) and a list of
+    /// human-readable warnings describing any entries that were skipped. Callers should
+    /// surface the warnings via logging so misconfigured commands are visible to users
+    /// instead of silently nuking the entire file.
+    static func parseLenient(_ data: Data) -> (file: CmuxConfigFile?, warnings: [String]) {
+        // Strict-pass-through implementation; made tolerant in the follow-up fix commit.
+        do {
+            let file = try JSONDecoder().decode(CmuxConfigFile.self, from: data)
+            return (file, [])
+        } catch {
+            return (nil, [String(describing: error)])
+        }
+    }
 }
 
 struct CmuxCommandDefinition: Codable, Sendable, Identifiable {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -5,19 +5,69 @@ import Foundation
 struct CmuxConfigFile: Codable, Sendable {
     var commands: [CmuxCommandDefinition]
 
+    private enum CodingKeys: String, CodingKey { case commands }
+
+    init(commands: [CmuxCommandDefinition]) {
+        self.commands = commands
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.commands = try container.decode([CmuxCommandDefinition].self, forKey: .commands)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(commands, forKey: .commands)
+    }
+
     /// Parse cmux.json data, tolerating per-command decode failures.
     /// Returns the config (nil if the top-level JSON shape is unusable) and a list of
     /// human-readable warnings describing any entries that were skipped. Callers should
     /// surface the warnings via logging so misconfigured commands are visible to users
     /// instead of silently nuking the entire file.
     static func parseLenient(_ data: Data) -> (file: CmuxConfigFile?, warnings: [String]) {
-        // Strict-pass-through implementation; made tolerant in the follow-up fix commit.
+        struct TopLevel: Decodable {
+            var commands: [LenientCommand]
+        }
+        struct LenientCommand: Decodable {
+            let result: Result<CmuxCommandDefinition, Error>
+            let fallbackName: String?
+
+            init(from decoder: Decoder) throws {
+                // Try to capture the command's `name` (if present) before decoding, so we can
+                // produce a human-readable warning even when the rest of the command is invalid.
+                let nameContainer = try? decoder.container(keyedBy: NameKey.self)
+                fallbackName = try? nameContainer?.decodeIfPresent(String.self, forKey: .name)
+                do {
+                    result = .success(try CmuxCommandDefinition(from: decoder))
+                } catch {
+                    result = .failure(error)
+                }
+            }
+
+            private enum NameKey: String, CodingKey { case name }
+        }
+
+        let top: TopLevel
         do {
-            let file = try JSONDecoder().decode(CmuxConfigFile.self, from: data)
-            return (file, [])
+            top = try JSONDecoder().decode(TopLevel.self, from: data)
         } catch {
             return (nil, [String(describing: error)])
         }
+
+        var commands: [CmuxCommandDefinition] = []
+        var warnings: [String] = []
+        for (index, lenient) in top.commands.enumerated() {
+            switch lenient.result {
+            case .success(let command):
+                commands.append(command)
+            case .failure(let error):
+                let label = lenient.fallbackName.map { "\"\($0)\"" } ?? "commands[\(index)]"
+                warnings.append("Skipped command \(label): \(error)")
+            }
+        }
+        return (CmuxConfigFile(commands: commands), warnings)
     }
 }
 
@@ -125,17 +175,34 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
         layout = try container.decodeIfPresent(CmuxLayoutNode.self, forKey: .layout)
 
         if let rawColor = try container.decodeIfPresent(String.self, forKey: .color) {
-            guard let normalized = WorkspaceTabColorSettings.normalizedHex(rawColor) else {
+            guard let normalized = CmuxWorkspaceDefinition.resolveColor(rawColor) else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .color,
                     in: container,
-                    debugDescription: "Invalid color \"\(rawColor)\". Expected 6-digit hex format: #RRGGBB"
+                    debugDescription: "Invalid color \"\(rawColor)\". Expected 6-digit hex (#RRGGBB) or a named palette color (e.g. \"Indigo\", \"Navy\")."
                 )
             }
             color = normalized
         } else {
             color = nil
         }
+    }
+
+    /// Resolves a cmux.json color string to a normalized hex value.
+    /// Accepts either a 6-digit hex string (with or without `#`) or a named entry
+    /// from the default workspace tab color palette (case-insensitive).
+    static func resolveColor(_ raw: String) -> String? {
+        if let hex = WorkspaceTabColorSettings.normalizedHex(raw) {
+            return hex
+        }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        if let entry = WorkspaceTabColorSettings.defaultPalette.first(where: {
+            $0.name.caseInsensitiveCompare(trimmed) == .orderedSame
+        }) {
+            return entry.hex
+        }
+        return nil
     }
 }
 
@@ -406,12 +473,14 @@ final class CmuxConfigStore: ObservableObject {
               !data.isEmpty else {
             return nil
         }
-        do {
-            return try JSONDecoder().decode(CmuxConfigFile.self, from: data)
-        } catch {
-            NSLog("[CmuxConfig] parse error at %@: %@", path, String(describing: error))
-            return nil
+        let (file, warnings) = CmuxConfigFile.parseLenient(data)
+        for warning in warnings {
+            NSLog("[CmuxConfig] %@: %@", path, warning)
         }
+        if file == nil {
+            NSLog("[CmuxConfig] parse error at %@: top-level JSON could not be decoded", path)
+        }
+        return file
     }
 
     // MARK: - File watching (local)

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -508,6 +508,120 @@ final class CmuxConfigDecodingTests: XCTestCase {
         """
         XCTAssertThrowsError(try decode(json))
     }
+
+    // MARK: Named colors (regression for #3075)
+
+    func testDecodeNamedIndigoColorResolvesToPaletteHex() throws {
+        let json = """
+        {
+          "commands": [{
+            "name": "IndigoWorkspace",
+            "workspace": { "color": "Indigo" }
+          }]
+        }
+        """
+        let config = try decode(json)
+        XCTAssertEqual(config.commands[0].workspace?.color, "#283593")
+    }
+
+    func testDecodeNamedNavyColorResolvesToPaletteHex() throws {
+        let json = """
+        {
+          "commands": [{
+            "name": "NavyWorkspace",
+            "workspace": { "color": "Navy" }
+          }]
+        }
+        """
+        let config = try decode(json)
+        XCTAssertEqual(config.commands[0].workspace?.color, "#1A5276")
+    }
+
+    func testDecodeNamedColorIsCaseInsensitive() throws {
+        let json = """
+        {
+          "commands": [{
+            "name": "LowerIndigo",
+            "workspace": { "color": "indigo" }
+          }]
+        }
+        """
+        let config = try decode(json)
+        XCTAssertEqual(config.commands[0].workspace?.color, "#283593")
+    }
+}
+
+// MARK: - Lenient parsing (regression for #3075)
+
+final class CmuxConfigLenientParseTests: XCTestCase {
+
+    private func data(_ json: String) -> Data {
+        json.data(using: .utf8)!
+    }
+
+    func testParseLenientLoadsValidConfig() {
+        let (file, warnings) = CmuxConfigFile.parseLenient(data("""
+        {
+          "commands": [
+            { "name": "Build", "command": "make build" },
+            { "name": "Test", "command": "make test" }
+          ]
+        }
+        """))
+        XCTAssertNotNil(file)
+        XCTAssertEqual(file?.commands.map(\.name), ["Build", "Test"])
+        XCTAssertTrue(warnings.isEmpty, "valid config should produce no warnings")
+    }
+
+    func testParseLenientPreservesSiblingsWhenOneCommandHasInvalidColor() {
+        let (file, warnings) = CmuxConfigFile.parseLenient(data("""
+        {
+          "commands": [
+            { "name": "BadColor", "workspace": { "color": "NotARealColorXYZ" } },
+            { "name": "Echo",     "command": "echo hi" }
+          ]
+        }
+        """))
+        XCTAssertNotNil(file, "a single bad command must not reject the entire file")
+        // The well-formed `Echo` command must still load.
+        XCTAssertEqual(file?.commands.contains(where: { $0.name == "Echo" }), true)
+        XCTAssertFalse(warnings.isEmpty, "skipped command should produce a warning")
+    }
+
+    func testParseLenientAcceptsNamedColorsEndToEnd() {
+        let (file, warnings) = CmuxConfigFile.parseLenient(data("""
+        {
+          "commands": [
+            { "name": "IndigoWS", "workspace": { "color": "Indigo" } },
+            { "name": "Echo",     "command": "echo hi" }
+          ]
+        }
+        """))
+        XCTAssertNotNil(file)
+        XCTAssertEqual(file?.commands.count, 2)
+        XCTAssertEqual(
+            file?.commands.first(where: { $0.name == "IndigoWS" })?.workspace?.color,
+            "#283593"
+        )
+        XCTAssertTrue(warnings.isEmpty, "named colors must not produce warnings")
+    }
+
+    func testParseLenientSkipsCommandWithInvalidLayoutButKeepsOthers() {
+        let (file, warnings) = CmuxConfigFile.parseLenient(data("""
+        {
+          "commands": [
+            {
+              "name": "BadLayout",
+              "workspace": { "layout": { "invalid": true } }
+            },
+            { "name": "Echo", "command": "echo hi" }
+          ]
+        }
+        """))
+        XCTAssertNotNil(file, "a single bad command must not reject the entire file")
+        XCTAssertEqual(file?.commands.contains(where: { $0.name == "Echo" }), true)
+        XCTAssertFalse(warnings.isEmpty)
+    }
 }
 
 // MARK: - Command identity


### PR DESCRIPTION
## Summary

Fixes #3075. Before this PR, a single command in `cmux.json` with a named color (e.g. `"color": "Indigo"`) caused the entire config file to be silently rejected — no commands loaded, `cmux reload-config` returned OK, and the sidebar showed no error. The decoder only accepted `#RRGGBB` hex strings, and one rejected command failed the whole top-level `JSONDecoder().decode(CmuxConfigFile.self, ...)` call.

Two-part fix:

- **Accept named palette colors.** `CmuxWorkspaceDefinition` now resolves the `color` field via a new `resolveColor(_:)` helper that accepts either a 6-digit hex (with/without `#`) or a case-insensitive match against `WorkspaceTabColorSettings.defaultPalette` (Red, Navy, Indigo, Purple, Charcoal, ...). `"Indigo"` now resolves to `#283593`.
- **Degrade gracefully on parse errors.** New `CmuxConfigFile.parseLenient(_:)` decodes each command independently. One malformed command (bad color, bad layout, missing fields, etc.) no longer poisons its siblings — it is returned as a warning alongside the commands that did load. `CmuxConfigStore.parseConfig` now uses this path and logs each warning via `NSLog` so misconfigured entries are visible.

This matches the issue's expected behavior: "Both commands appear, or at minimum Echo still appears and a parse warning is logged."

## Two-commit structure (per project policy)

1. First commit adds failing regression tests only (named-color resolution + lenient parsing). CI should be red.
2. Second commit adds the fix. CI should be green.

## Repro (from the issue)

```json
{
  "commands": [
    {
      "name": "Indigo Workspace",
      "workspace": { "name": "Indigo", "color": "Indigo" }
    },
    { "name": "Echo", "command": "echo hi" }
  ]
}
```

- Before: neither command appeared; no error shown.
- After: both commands appear; the Indigo workspace uses `#283593`. If the color were a typo like `"Indigoo"`, only that command is skipped (with a logged warning), and `Echo` still appears.

## Test plan

- [ ] CI: unit tests in `cmuxTests/CmuxConfigTests.swift` pass on the fix commit.
- [ ] CI: the first commit fails the new tests (proves the tests exercise the bug).
- [ ] Manual: place the repro `cmux.json` in the project root, `cmux reload-config`, confirm both commands appear in the command palette with the Indigo color on the workspace.
- [ ] Manual: swap `"Indigo"` for `"NotARealColor"` and confirm `Echo` still appears in the palette and the system log shows a `[CmuxConfig] Skipped command` warning.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config decoding behavior and error handling, which can affect which commands load from user `cmux.json` files. Risk is mitigated by added unit tests covering named colors and partial-failure parsing.
> 
> **Overview**
> Fixes `cmux.json` regressions by **accepting named palette colors** (e.g. `"Indigo"`, case-insensitive) for workspace `color`, resolving them to normalized hex.
> 
> Updates config loading to **degrade gracefully on per-command decode failures** via `CmuxConfigFile.parseLenient`, so malformed commands are skipped with logged warnings while valid sibling commands still load, instead of rejecting the entire file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 62b87418c2da090af5915e4416351ea684c919a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for named workspace colors (e.g., "Indigo", "Navy") with case-insensitive matching.

* **Bug Fixes**
  * Configuration parsing is now more resilient; invalid individual commands no longer prevent the entire configuration from loading, with warnings logged for skipped items.

* **Tests**
  * Added test coverage for named color resolution and lenient parsing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix #3075 by accepting named palette colors in `cmux.json` and making config loading tolerant. A bad command no longer drops the whole file; valid commands still load and a warning is logged.

- **Bug Fixes**
  - Color resolution: `CmuxWorkspaceDefinition.resolveColor` accepts 6-digit hex (with/without `#`) and case-insensitive names from `WorkspaceTabColorSettings.defaultPalette` (e.g. "Indigo" -> `#283593`).
  - Lenient loading: `CmuxConfigFile.parseLenient` decodes commands independently and returns warnings; `CmuxConfigStore.parseConfig` uses it and logs each warning via `NSLog`.

<sup>Written for commit 62b87418c2da090af5915e4416351ea684c919a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

