### PR TITLE
fix: skip appIcon apply during CmuxSettingsFileStore init (fixes macOS 26 crash on launch)

### DIFF
--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -132,6 +132,13 @@ final class CmuxSettingsFileStore {
     private var activeManagedUserDefaults: [String: ManagedSettingsValue] = [:]
     private var activeManagedCustomSettings = ManagedCustomSettings()
     private var isApplyingManagedSettings = false
+    // Set to true after the first reload() in init() completes. Used to defer
+    // AppIcon application: on macOS 26 (build 25D771280a+), applicationDidFinishLaunching
+    // can fire before cmuxApp.init() body finishes, so isApplicationFinishedLaunching()
+    // returns true while we're still in App.init() re-entrancy — calling NSApplication
+    // APIs at that point crashes. AppDelegate.ensureApplicationIcon() handles the initial
+    // apply once it's truly safe.
+    private var isInitializationComplete = false
     private(set) var activeSourcePath: String?
 
     init(
@@ -148,6 +155,7 @@ final class CmuxSettingsFileStore {
 
         bootstrapPrimaryTemplateIfNeeded()
         reload()
+        isInitializationComplete = true
         guard startWatching else { return }
 
         primaryWatcher = ShortcutSettingsFileWatcher(path: primaryPath, fileManager: fileManager) { [weak self] in
@@ -1189,6 +1197,7 @@ final class CmuxSettingsFileStore {
             let language = AppLanguage(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .system
             LanguageSettings.apply(language)
         case AppIconSettings.modeKey:
+            guard isInitializationComplete else { break }
             AppIconSettings.applyIcon(AppIconSettings.resolvedMode())
         default:
             break
@@ -1235,6 +1244,7 @@ final class CmuxSettingsFileStore {
             let language = AppLanguage(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .system
             LanguageSettings.apply(language)
         case AppIconSettings.modeKey:
+            guard isInitializationComplete else { break }
             AppIconSettings.applyIcon(AppIconSettings.resolvedMode())
         default:
             break

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -844,6 +844,73 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(dockTileNotificationCount, 0)
     }
 
+    func testSettingsFileStoreDoesNotApplyAppIconDuringInitEvenIfLaunchIsAlreadyFinished() throws {
+        // Regression test for macOS 26 (build 25D771280a+) where applicationDidFinishLaunching
+        // fires before cmuxApp.init() body completes, causing isApplicationFinishedLaunching()
+        // to return true while CmuxSettingsFileStore.init() is still running. Without the
+        // isInitializationComplete guard, applyIcon(.automatic) would crash by calling
+        // NSApplication APIs that are unsafe during App.init() re-entrancy.
+        let defaults = UserDefaults.standard
+        let previousMode = defaults.object(forKey: AppIconSettings.modeKey)
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            if let previousMode {
+                defaults.set(previousMode, forKey: AppIconSettings.modeKey)
+            } else {
+                defaults.removeObject(forKey: AppIconSettings.modeKey)
+            }
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+            AppIconSettings.resetLiveEnvironmentProviderForTesting()
+        }
+
+        defaults.removeObject(forKey: AppIconSettings.modeKey)
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("settings.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "app": {
+                "appIcon": "automatic"
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        var startObservationCallCount = 0
+        var stopObservationCallCount = 0
+        var runtimeIconSetCount = 0
+        AppIconSettings.setLiveEnvironmentProviderForTesting {
+            AppIconSettings.Environment(
+                // Simulate macOS 26: launch is already "finished" before store init runs.
+                isApplicationFinishedLaunching: { true },
+                imageForMode: { _ in nil },
+                setApplicationIconImage: { _ in runtimeIconSetCount += 1 },
+                startAppearanceObservation: { startObservationCallCount += 1 },
+                stopAppearanceObservation: { stopObservationCallCount += 1 },
+                notifyDockTilePlugin: {}
+            )
+        }
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        XCTAssertEqual(startObservationCallCount, 0, "startAppearanceObservation must not be called during store init")
+        XCTAssertEqual(stopObservationCallCount, 0)
+        XCTAssertEqual(runtimeIconSetCount, 0)
+    }
+
     func testSettingsFileStoreRejectsModifierFreeFirstStroke() throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }


### PR DESCRIPTION
## Summary

Fixes #3099 — deterministic crash on launch on macOS 26.3.1 (build 25D771280a+).

**Root cause:** On this build, `applicationDidFinishLaunching` fires before `cmuxApp.init()` body completes. `@NSApplicationDelegateAdaptor` stored properties are initialized before the `init()` body, which causes SwiftUI to wire up the delegate (and fire `applicationDidFinishLaunching`) before `_ = KeyboardShortcutSettings.settingsFileStore` runs. As a result, `isApplicationFinishedLaunching()` returns `true` while `CmuxSettingsFileStore.init()` is still executing, bypassing the existing guard in `AppIconSettings.applyIcon` and crashing at:

```
AppIconAppearanceObserver.applyIconForCurrentAppearance() + 648  ← brk #1
closure #3 in static AppIconSettings.Environment.live()
CmuxSettingsFileStore.applyManagedUserDefaultsValue(_:for:)
CmuxSettingsFileStore.init(primaryPath:fallbackPath:...)
cmuxApp.init()
```

**Fix:** Add `isInitializationComplete` flag to `CmuxSettingsFileStore`. Both `applyManagedUserDefaultsValue` and `restoreUserDefaultsBackup` now skip `AppIconSettings.applyIcon` while `isInitializationComplete == false` (i.e. during `init()`). `AppDelegate.ensureApplicationIcon()` handles the initial icon apply in `applicationDidFinishLaunching`, which is already the correct path.

**Two-commit structure:**
1. Failing regression test (`testSettingsFileStoreDoesNotApplyAppIconDuringInitEvenIfLaunchIsAlreadyFinished`) — simulates macOS 26 by setting `isApplicationFinishedLaunching: { true }` and asserting no `startAppearanceObservation` calls during store init.
2. Fix — `isInitializationComplete` flag.

## Workaround (for users on macOS 26.3.1 until a fix ships)

Create `~/.config/cmux/settings.json` with any non-automatic `appIconMode`:
```json
{
  "$schema": "https://raw.githubusercontent.com/manaflow-ai/cmux/main/web/data/cmux-settings.schema.json",
  "appIconMode": "light"
}
```

## Test plan

- [ ] Unit test `testSettingsFileStoreDoesNotApplyAppIconDuringInitEvenIfLaunchIsAlreadyFinished` passes after the fix commit
- [ ] Existing tests `testSettingsFileStoreDoesNotApplyAutomaticAppIconDuringStartupReplay` and `testSettingsFileStoreCanReplayAutomaticAppIconSettingTwiceWithoutTouchingAppKit` still pass
- [ ] App icon still applies correctly after `applicationDidFinishLaunching` (via `ensureApplicationIcon()`)
- [ ] Runtime `appIconMode` changes in settings.json still take effect after app is running

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where app icon settings were being applied prematurely during startup, which could cause unintended appearance changes.

* **Tests**
  * Added regression test to prevent recurrence of app icon initialization issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a deterministic crash on launch in macOS 26.3.1 by deferring app icon application during `CmuxSettingsFileStore` initialization; the initial icon now applies after `applicationDidFinishLaunching`.

- **Bug Fixes**
  - Added `isInitializationComplete` flag set after the first `reload()`; `applyManagedUserDefaultsValue` and `restoreUserDefaultsBackup` skip `AppIconSettings.applyIcon` until initialization completes. `AppDelegate.ensureApplicationIcon()` applies the icon after launch.
  - Added regression test `testSettingsFileStoreDoesNotApplyAppIconDuringInitEvenIfLaunchIsAlreadyFinished`.

<sup>Written for commit 7ecb658a2ecdc13590976ccaffb8a6e769ee742f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

