### PR TITLE
Fix terminal Cmd+= zoom on command-aware layouts (#1456)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12,6 +12,39 @@ import Bonsplit
 import IOSurface
 import UniformTypeIdentifiers
 
+func ghosttyUnshiftedCodepoint(
+    keyCode: UInt16,
+    modifierFlags: NSEvent.ModifierFlags,
+    charactersIgnoringModifiers: String?,
+    characters: String?,
+    layoutCharacterProvider: (UInt16, NSEvent.ModifierFlags) -> String? = KeyboardLayout.character(forKeyCode:modifierFlags:)
+) -> UInt32 {
+    let normalizedFlags = modifierFlags
+        .intersection(.deviceIndependentFlagsMask)
+        .intersection([.command])
+
+    if let layoutChars = layoutCharacterProvider(keyCode, normalizedFlags),
+       layoutChars.count == 1,
+       let layoutScalar = layoutChars.unicodeScalars.first,
+       layoutScalar.value >= 0x20,
+       !(layoutScalar.value >= 0xF700 && layoutScalar.value <= 0xF8FF) {
+        return layoutScalar.value
+    }
+
+    if normalizedFlags.contains(.command),
+       let layoutChars = layoutCharacterProvider(keyCode, []),
+       layoutChars.count == 1,
+       let layoutScalar = layoutChars.unicodeScalars.first,
+       layoutScalar.value >= 0x20,
+       !(layoutScalar.value >= 0xF700 && layoutScalar.value <= 0xF8FF) {
+        return layoutScalar.value
+    }
+
+    guard let chars = charactersIgnoringModifiers ?? characters,
+          let scalar = chars.unicodeScalars.first else { return 0 }
+    return scalar.value
+}
+
 @_silgen_name("ghostty_surface_clear_selection")
 private func ghostty_surface_clear_selection_compat(_ surface: ghostty_surface_t) -> Bool
 
@@ -7379,17 +7412,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     /// Get the unshifted codepoint for the key event
     private func unshiftedCodepointFromEvent(_ event: NSEvent) -> UInt32 {
-        if let layoutChars = KeyboardLayout.character(forKeyCode: event.keyCode),
-           layoutChars.count == 1,
-           let layoutScalar = layoutChars.unicodeScalars.first,
-           layoutScalar.value >= 0x20,
-           !(layoutScalar.value >= 0xF700 && layoutScalar.value <= 0xF8FF) {
-            return layoutScalar.value
-        }
-
-        guard let chars = (event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers ?? event.characters),
-              let scalar = chars.unicodeScalars.first else { return 0 }
-        return scalar.value
+        ghosttyUnshiftedCodepoint(
+            keyCode: event.keyCode,
+            modifierFlags: event.modifierFlags,
+            charactersIgnoringModifiers: event.characters(byApplyingModifiers: []) ?? event.charactersIgnoringModifiers,
+            characters: event.characters
+        )
     }
 
     private func isControlCharacterScalar(_ scalar: UnicodeScalar) -> Bool {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1456,6 +1456,27 @@ final class GhosttyBackgroundThemeTests: XCTestCase {
 }
 
 
+final class GhosttyUnshiftedCodepointTests: XCTestCase {
+    func testCommandAwareLayoutTranslationWinsForCommandShortcutKeys() {
+        let codepoint = ghosttyUnshiftedCodepoint(
+            keyCode: 24,
+            modifierFlags: [.command],
+            charactersIgnoringModifiers: "=",
+            characters: "=",
+            layoutCharacterProvider: { keyCode, modifierFlags in
+                guard keyCode == 24 else { return nil }
+                return modifierFlags.contains(.command) ? "=" : ";"
+            }
+        )
+
+        XCTAssertEqual(
+            codepoint,
+            "=".unicodeScalars.first?.value,
+            "Command-aware keyboard layouts should preserve the command shortcut character Ghostty binds against"
+        )
+    }
+}
+
 final class GhosttyResponderResolutionTests: XCTestCase {
     private final class FocusProbeView: NSView {
         override var acceptsFirstResponder: Bool { true }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1458,11 +1458,15 @@ final class GhosttyBackgroundThemeTests: XCTestCase {
 
 final class GhosttyUnshiftedCodepointTests: XCTestCase {
     func testCommandAwareLayoutTranslationWinsForCommandShortcutKeys() {
+        // Fixtures deliberately differ from the expected "=" so the test only
+        // passes via the command-aware layout branch. Without that precedence,
+        // every fallback path (no-command layout lookup, charactersIgnoringModifiers,
+        // characters) returns ";" and the assertion fails.
         let codepoint = ghosttyUnshiftedCodepoint(
             keyCode: 24,
             modifierFlags: [.command],
-            charactersIgnoringModifiers: "=",
-            characters: "=",
+            charactersIgnoringModifiers: ";",
+            characters: ";",
             layoutCharacterProvider: { keyCode, modifierFlags in
                 guard keyCode == 24 else { return nil }
                 return modifierFlags.contains(.command) ? "=" : ";"


### PR DESCRIPTION
## Summary

Preserve command-aware keyboard layout translation when deriving the unshifted codepoint Ghostty uses to match its `cmd+=` / `cmd+-` / `cmd+0` font-size bindings. On layouts that remap keys under Command (JIS, Dvorak, etc.), the current code ignores the Command modifier and returns the unmodified layout character (e.g. `;`), so Ghostty's `cmd+=` binding never matches and Zoom In silently no-ops.

## Background

This reapplies the fix originally proposed in #1548, which was closed on 2026-03-18 with:

> Closing this because the reported bug is not reproduced on current `main`, and the original fix is not justified on current evidence. … If we get a concrete repro on `6c203b514` or a current build, we can reopen with verified failing behavior first.

Issue #1456 is that concrete repro. The reporter is on `v0.62.2 / build 77 / commit 6c203b514` — **the exact commit the original author requested** — and reproduces both symptoms:

- ⌘; (Zoom In) does nothing — menu flashes but font size does not change
- ⌘- (Zoom Out) works

The asymmetry is consistent with the bug: `⌘-` happens to produce `-` on the layouts where `⌘=` produces `;`, so only the `=` branch breaks.

## Changes

- `Sources/GhosttyTerminalView.swift` — introduce `ghosttyUnshiftedCodepoint(...)` helper that first consults the layout **with the Command modifier applied**, then falls back to the unmodified layout, then to `charactersIgnoringModifiers`. `GhosttyNSView.unshiftedCodepointFromEvent(_:)` now delegates to the helper.
- `cmuxTests/TerminalAndGhosttyTests.swift` — add `GhosttyUnshiftedCodepointTests.testCommandAwareLayoutTranslationWinsForCommandShortcutKeys`, ported from #1548 to the post-split test file layout.

The code change itself is byte-identical to `bef85712` from #1548 (diff verified).

## Commit structure

Per CLAUDE.md regression-test policy:

1. `Add regression test for terminal Cmd+= zoom` — test alone; fails to compile without the helper, keeping CI red.
2. `Fix terminal Cmd+= zoom on command-aware layouts` — adds the helper; CI green.

## Test plan

- [ ] CI passes on the fix commit (compiles + new unit test passes)
- [ ] CI fails on the test-only commit (helper missing → compile error)
- [ ] Manual: on a command-aware layout (JIS / Dvorak-Qwerty-Cmd / etc.), pressing the key that Ghostty's menu shows as `⌘=` in the terminal increases font size
- [ ] Manual: `⌘-` and `⌘0` continue to work

Closes #1456. Refs #1548.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Zoom In so `cmd+=` works on command-aware keyboard layouts (e.g., JIS, Dvorak-Qwerty-Cmd) by preserving layout translation under Command. `cmd+-` and `cmd+0` continue to work as before. Closes #1456.

- **Bug Fixes**
  - Add `ghosttyUnshiftedCodepoint(...)` to resolve the unshifted codepoint with Command-aware layout translation, falling back to the unmodified layout and event characters.
  - Update `GhosttyNSView.unshiftedCodepointFromEvent(_:)` to use the helper; strengthen the unit test so fixtures force fallbacks to return `";"`, ensuring the test only passes via the Command-aware branch.

<sup>Written for commit b2851b6bf0bc061b1267c0a0207ea2903b0f8e55. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling: layout-aware translation now prefers Command-modified mappings for shortcut keys and falls back reliably to unmodified characters when needed.

* **Tests**
  * Added a unit test validating Command-aware layout translation to ensure the correct codepoint is chosen for shortcut keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->