### PR TITLE
Refactor sidebar layout support

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -32,6 +32,7 @@
 		BA3A38809AB34D66AD1FFECD /* SidebarShortcutHintSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7373D91A9F29413DA4C01D08 /* SidebarShortcutHintSupport.swift */; };
 		261EB5012A2742419A7414B6 /* SidebarHelpSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B14C35571C46EF97934B4E /* SidebarHelpSupport.swift */; };
 		211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */; };
+		D367B5E5B41D4C7486297763 /* SidebarLayoutSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07C188A9970C44C197F4200C /* SidebarLayoutSupport.swift */; };
 		4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */; };
 		125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */; };
 		807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */; };
@@ -268,6 +269,7 @@
 		7373D91A9F29413DA4C01D08 /* SidebarShortcutHintSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarShortcutHintSupport.swift; sourceTree = "<group>"; };
 		F2B14C35571C46EF97934B4E /* SidebarHelpSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarHelpSupport.swift; sourceTree = "<group>"; };
 		243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAppearanceSupport.swift; sourceTree = "<group>"; };
+		07C188A9970C44C197F4200C /* SidebarLayoutSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarLayoutSupport.swift; sourceTree = "<group>"; };
 		610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/InternalTabDragConfiguration.swift; sourceTree = "<group>"; };
 		A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintPill.swift; sourceTree = "<group>"; };
 		0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowGlassEffect.swift; sourceTree = "<group>"; };
@@ -528,6 +530,7 @@
 				7373D91A9F29413DA4C01D08 /* SidebarShortcutHintSupport.swift */,
 				F2B14C35571C46EF97934B4E /* SidebarHelpSupport.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
+				07C188A9970C44C197F4200C /* SidebarLayoutSupport.swift */,
 				610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */,
 				A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */,
 				0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */,
@@ -908,6 +911,7 @@
 				BA3A38809AB34D66AD1FFECD /* SidebarShortcutHintSupport.swift in Sources */,
 				261EB5012A2742419A7414B6 /* SidebarHelpSupport.swift in Sources */,
 				211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */,
+				D367B5E5B41D4C7486297763 /* SidebarLayoutSupport.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
 				125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */,
 				807E058A23061EFB70A1B7F8 /* WindowGlassEffect.swift in Sources */,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7208,19 +7208,6 @@ struct ContentView: View {
 #endif
 }
 
-private struct SidebarResizerAccessibilityModifier: ViewModifier {
-    let accessibilityIdentifier: String?
-
-    @ViewBuilder
-    func body(content: Content) -> some View {
-        if let accessibilityIdentifier {
-            content.accessibilityIdentifier(accessibilityIdentifier)
-        } else {
-            content
-        }
-    }
-}
-
 private struct SidebarTabItemSettingsSnapshot: Equatable {
     let sidebarShortcutHintXOffset: Double
     let sidebarShortcutHintYOffset: Double
@@ -7868,76 +7855,6 @@ private struct SidebarExternalDropDelegate: DropDelegate {
     }
 }
 
-private struct SidebarTopScrim: View {
-    let height: CGFloat
-
-    var body: some View {
-        SidebarTopBlurEffect()
-            .frame(height: height)
-            .mask(
-                LinearGradient(
-                    colors: [
-                        Color.black.opacity(0.95),
-                        Color.black.opacity(0.75),
-                        Color.black.opacity(0.35),
-                        Color.clear
-                    ],
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-    }
-}
-
-private struct SidebarTopBlurEffect: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.blendingMode = .withinWindow
-        view.material = .underWindowBackground
-        view.state = .active
-        view.isEmphasized = false
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
-}
-
-private struct SidebarScrollViewResolver: NSViewRepresentable {
-    let onResolve: (NSScrollView?) -> Void
-
-    func makeNSView(context: Context) -> SidebarScrollViewResolverView {
-        let view = SidebarScrollViewResolverView()
-        view.onResolve = onResolve
-        return view
-    }
-
-    func updateNSView(_ nsView: SidebarScrollViewResolverView, context: Context) {
-        nsView.onResolve = onResolve
-        nsView.resolveScrollView()
-    }
-}
-
-private final class SidebarScrollViewResolverView: NSView {
-    var onResolve: ((NSScrollView?) -> Void)?
-
-    override func viewDidMoveToSuperview() {
-        super.viewDidMoveToSuperview()
-        resolveScrollView()
-    }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        resolveScrollView()
-    }
-
-    func resolveScrollView() {
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            onResolve?(self.enclosingScrollView)
-        }
-    }
-}
-
 private struct SidebarEmptyArea: View {
     @EnvironmentObject var tabManager: TabManager
     let rowSpacing: CGFloat
@@ -7988,35 +7905,6 @@ private struct SidebarEmptyArea: View {
         }
         guard indicator.edge == .bottom, let lastTabId = tabManager.tabs.last?.id else { return false }
         return indicator.tabId == lastTabId
-    }
-}
-
-enum SidebarPathFormatter {
-    static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
-
-    static func shortenedPath(
-        _ path: String,
-        homeDirectoryPath: String = Self.homeDirectoryPath
-    ) -> String {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return path }
-        if trimmed == homeDirectoryPath {
-            return "~"
-        }
-        if trimmed.hasPrefix(homeDirectoryPath + "/") {
-            return "~" + trimmed.dropFirst(homeDirectoryPath.count)
-        }
-        return trimmed
-    }
-}
-
-enum SidebarTrailingAccessoryWidthPolicy {
-    static let closeButtonWidth: CGFloat = 16
-
-    static func width(
-        canCloseWorkspace: Bool
-    ) -> CGFloat {
-        return canCloseWorkspace ? closeButtonWidth : 0
     }
 }
 
@@ -10671,60 +10559,6 @@ private final class MiddleClickCaptureView: NSView {
 enum SidebarSelection {
     case tabs
     case notifications
-}
-
-private struct ClearScrollBackground: ViewModifier {
-    func body(content: Content) -> some View {
-        if #available(macOS 13.0, *) {
-            content
-                .scrollContentBackground(.hidden)
-                .background(ScrollBackgroundClearer())
-        } else {
-            content
-                .background(ScrollBackgroundClearer())
-        }
-    }
-}
-
-private struct ScrollBackgroundClearer: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSView {
-        NSView()
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        DispatchQueue.main.async {
-            guard let scrollView = findScrollView(startingAt: nsView) else { return }
-            // Clear all backgrounds and mark as non-opaque for transparency
-            scrollView.drawsBackground = false
-            scrollView.backgroundColor = .clear
-            scrollView.wantsLayer = true
-            scrollView.layer?.backgroundColor = NSColor.clear.cgColor
-            scrollView.layer?.isOpaque = false
-
-            scrollView.contentView.drawsBackground = false
-            scrollView.contentView.backgroundColor = .clear
-            scrollView.contentView.wantsLayer = true
-            scrollView.contentView.layer?.backgroundColor = NSColor.clear.cgColor
-            scrollView.contentView.layer?.isOpaque = false
-
-            if let docView = scrollView.documentView {
-                docView.wantsLayer = true
-                docView.layer?.backgroundColor = NSColor.clear.cgColor
-                docView.layer?.isOpaque = false
-            }
-        }
-    }
-
-    private func findScrollView(startingAt view: NSView) -> NSScrollView? {
-        var current: NSView? = view
-        while let candidate = current {
-            if let scrollView = candidate as? NSScrollView {
-                return scrollView
-            }
-            current = candidate.superview
-        }
-        return nil
-    }
 }
 
 private struct DraggableFolderIcon: View {

--- a/Sources/Sidebar/SidebarLayoutSupport.swift
+++ b/Sources/Sidebar/SidebarLayoutSupport.swift
@@ -1,0 +1,168 @@
+import AppKit
+import SwiftUI
+
+struct SidebarResizerAccessibilityModifier: ViewModifier {
+    let accessibilityIdentifier: String?
+
+    @ViewBuilder
+    func body(content: Content) -> some View {
+        if let accessibilityIdentifier {
+            content.accessibilityIdentifier(accessibilityIdentifier)
+        } else {
+            content
+        }
+    }
+}
+
+struct SidebarTopScrim: View {
+    let height: CGFloat
+
+    var body: some View {
+        SidebarTopBlurEffect()
+            .frame(height: height)
+            .mask(
+                LinearGradient(
+                    colors: [
+                        Color.black.opacity(0.95),
+                        Color.black.opacity(0.75),
+                        Color.black.opacity(0.35),
+                        Color.clear
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+    }
+}
+
+private struct SidebarTopBlurEffect: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.blendingMode = .withinWindow
+        view.material = .underWindowBackground
+        view.state = .active
+        view.isEmphasized = false
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}
+
+struct SidebarScrollViewResolver: NSViewRepresentable {
+    let onResolve: (NSScrollView?) -> Void
+
+    func makeNSView(context: Context) -> SidebarScrollViewResolverView {
+        let view = SidebarScrollViewResolverView()
+        view.onResolve = onResolve
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarScrollViewResolverView, context: Context) {
+        nsView.onResolve = onResolve
+        nsView.resolveScrollView()
+    }
+}
+
+final class SidebarScrollViewResolverView: NSView {
+    var onResolve: ((NSScrollView?) -> Void)?
+
+    override func viewDidMoveToSuperview() {
+        super.viewDidMoveToSuperview()
+        resolveScrollView()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        resolveScrollView()
+    }
+
+    func resolveScrollView() {
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            onResolve?(self.enclosingScrollView)
+        }
+    }
+}
+
+enum SidebarPathFormatter {
+    static let homeDirectoryPath: String = FileManager.default.homeDirectoryForCurrentUser.path
+
+    static func shortenedPath(
+        _ path: String,
+        homeDirectoryPath: String = Self.homeDirectoryPath
+    ) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return path }
+        if trimmed == homeDirectoryPath {
+            return "~"
+        }
+        if trimmed.hasPrefix(homeDirectoryPath + "/") {
+            return "~" + trimmed.dropFirst(homeDirectoryPath.count)
+        }
+        return trimmed
+    }
+}
+
+enum SidebarTrailingAccessoryWidthPolicy {
+    static let closeButtonWidth: CGFloat = 16
+
+    static func width(
+        canCloseWorkspace: Bool
+    ) -> CGFloat {
+        return canCloseWorkspace ? closeButtonWidth : 0
+    }
+}
+
+struct ClearScrollBackground: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(macOS 13.0, *) {
+            content
+                .scrollContentBackground(.hidden)
+                .background(ScrollBackgroundClearer())
+        } else {
+            content
+                .background(ScrollBackgroundClearer())
+        }
+    }
+}
+
+private struct ScrollBackgroundClearer: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSView {
+        NSView()
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        DispatchQueue.main.async {
+            guard let scrollView = findScrollView(startingAt: nsView) else { return }
+            // Clear all backgrounds and mark as non-opaque for transparency.
+            scrollView.drawsBackground = false
+            scrollView.backgroundColor = .clear
+            scrollView.wantsLayer = true
+            scrollView.layer?.backgroundColor = NSColor.clear.cgColor
+            scrollView.layer?.isOpaque = false
+
+            scrollView.contentView.drawsBackground = false
+            scrollView.contentView.backgroundColor = .clear
+            scrollView.contentView.wantsLayer = true
+            scrollView.contentView.layer?.backgroundColor = NSColor.clear.cgColor
+            scrollView.contentView.layer?.isOpaque = false
+
+            if let docView = scrollView.documentView {
+                docView.wantsLayer = true
+                docView.layer?.backgroundColor = NSColor.clear.cgColor
+                docView.layer?.isOpaque = false
+            }
+        }
+    }
+
+    private func findScrollView(startingAt view: NSView) -> NSScrollView? {
+        var current: NSView? = view
+        while let candidate = current {
+            if let scrollView = candidate as? NSScrollView {
+                return scrollView
+            }
+            current = candidate.superview
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary\n- move sidebar layout and scroll background helpers out of ContentView\n- keep sidebar path/accessory sizing policies in Sources/Sidebar\n\n## Testing\n- ./scripts/reload.sh --tag sblay

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moved sidebar layout and scroll background helpers out of `ContentView` into `Sources/Sidebar/SidebarLayoutSupport.swift` to simplify `ContentView` and centralize sidebar behavior. No UI or behavior changes.

- **Refactors**
  - Extracted `SidebarResizerAccessibilityModifier`, `SidebarTopScrim` (and blur view), `SidebarScrollViewResolver`, and `ClearScrollBackground` into `SidebarLayoutSupport.swift`.
  - Co-located `SidebarPathFormatter` and `SidebarTrailingAccessoryWidthPolicy` under `Sources/Sidebar`.
  - Updated the Xcode project to include the new source file.

<sup>Written for commit 07178403de2cb2dc71ec4c37ad21b1047f90b6c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

