### PR TITLE
Fix minimal-mode top-bar drag pass-through

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -10,6 +10,100 @@ private var cmuxBrowserSearchOverlayPanelIdAssociationKey: UInt8 = 0
 private var cmuxBrowserPortalNeedsRenderingStateReattachKey: UInt8 = 0
 private var cmuxWindowInteractiveSplitDividerDragKey: UInt8 = 0
 
+/// Shared helpers for portal hosts that must defer to the minimal-mode
+/// Bonsplit tab strip rendered underneath them.
+enum BonsplitTabBarPassThrough {
+    static func isPassThroughPointerEvent(_ eventType: NSEvent.EventType?) -> Bool {
+        switch eventType {
+        case .leftMouseDown, .leftMouseUp,
+             .rightMouseDown, .rightMouseUp,
+             .otherMouseDown, .otherMouseUp,
+             .mouseMoved, .mouseEntered,
+             .mouseExited, .cursorUpdate:
+            return true
+        default:
+            return false
+        }
+    }
+
+    static func titlebarInteractionBandMinY(in window: NSWindow) -> CGFloat {
+        let nativeTitlebarHeight = window.frame.height - window.contentLayoutRect.height
+        let customTitlebarBandHeight = max(28, min(72, nativeTitlebarHeight))
+        return window.contentLayoutRect.maxY - customTitlebarBandHeight - 0.5
+    }
+
+    static func shouldPassThroughToPaneTabBar(
+        windowPoint: NSPoint,
+        below portalHost: NSView
+    ) -> (result: Bool, registryHit: Bool) {
+        let registryHit = portalHost.window.map {
+            BonsplitTabBarHitRegionRegistry.containsWindowPoint(windowPoint, in: $0)
+        } ?? false
+        if registryHit {
+            return (true, true)
+        }
+        let fallbackHit = hasUnderlyingBonsplitTabBarBackground(
+            at: windowPoint,
+            below: portalHost
+        )
+        return (fallbackHit, false)
+    }
+
+    static func passThroughDecision(
+        at point: NSPoint,
+        in portalHost: NSView,
+        eventType: NSEvent.EventType?
+    ) -> (windowPoint: NSPoint, result: Bool, registryHit: Bool)? {
+        guard isPassThroughPointerEvent(eventType) else { return nil }
+        let windowPoint = portalHost.convert(point, to: nil)
+        let decision = shouldPassThroughToPaneTabBar(windowPoint: windowPoint, below: portalHost)
+        return (windowPoint, decision.result, decision.registryHit)
+    }
+
+    static func hasBonsplitTabBarBackground(at windowPoint: NSPoint, in view: NSView) -> Bool {
+        guard !view.isHidden, view.alphaValue > 0 else { return false }
+
+        // NSView subviews are not clipped to parent bounds by default, and the
+        // minimal tab strip can render outside its immediate container.
+        let className = NSStringFromClass(type(of: view))
+        if className.contains("TabBarBackgroundNSView") {
+            let pointInView = view.convert(windowPoint, from: nil)
+            if view.bounds.contains(pointInView) {
+                return true
+            }
+        }
+
+        for subview in view.subviews.reversed() {
+            if hasBonsplitTabBarBackground(at: windowPoint, in: subview) {
+                return true
+            }
+        }
+        return false
+    }
+
+    static func hasUnderlyingBonsplitTabBarBackground(
+        at windowPoint: NSPoint,
+        below portalHost: NSView
+    ) -> Bool {
+        if let container = portalHost.superview,
+           let hostIndex = container.subviews.firstIndex(of: portalHost) {
+            for sibling in container.subviews[..<hostIndex].reversed() {
+                guard !sibling.isHidden, sibling.alphaValue > 0 else { continue }
+                if hasBonsplitTabBarBackground(at: windowPoint, in: sibling) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        guard let window = portalHost.window,
+              let rootView = window.contentView else {
+            return false
+        }
+        return hasBonsplitTabBarBackground(at: windowPoint, in: rootView)
+    }
+}
+
 #if DEBUG
 private func browserPortalDebugToken(_ view: NSView?) -> String {
     guard let view else { return "nil" }
@@ -493,6 +587,9 @@ final class WindowBrowserHostView: NSView {
 #endif
             return nil
         }
+        if shouldPassThroughToPaneTabBar(at: point, eventType: NSApp.currentEvent?.type) {
+            return nil
+        }
         if sidebarPassThrough {
 #if DEBUG
             debugLogPointerRouting(
@@ -689,10 +786,27 @@ final class WindowBrowserHostView: NSView {
         // hits that land in native titlebar space or the custom titlebar strip
         // we reserve directly under it for window drag/double-click behaviors.
         let windowPoint = convert(point, to: nil)
-        let nativeTitlebarHeight = window.frame.height - window.contentLayoutRect.height
-        let customTitlebarBandHeight = max(28, min(72, nativeTitlebarHeight))
-        let interactionBandMinY = window.contentLayoutRect.maxY - customTitlebarBandHeight - 0.5
-        return windowPoint.y >= interactionBandMinY
+        return windowPoint.y >= BonsplitTabBarPassThrough.titlebarInteractionBandMinY(in: window)
+    }
+
+    private func shouldPassThroughToPaneTabBar(
+        at point: NSPoint,
+        eventType: NSEvent.EventType?
+    ) -> Bool {
+        guard let decision = BonsplitTabBarPassThrough.passThroughDecision(
+            at: point,
+            in: self,
+            eventType: eventType
+        ) else { return false }
+#if DEBUG
+        if eventType == .leftMouseDown {
+            dlog(
+                "portal.brwsr.passThroughTabBar wp=\(Int(decision.windowPoint.x)),\(Int(decision.windowPoint.y)) " +
+                    "registry=\(decision.registryHit ? 1 : 0) result=\(decision.result ? 1 : 0)"
+            )
+        }
+#endif
+        return decision.result
     }
 
     private func shouldPassThroughToSidebarResizer(at point: NSPoint) -> Bool {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -146,6 +146,16 @@ final class WindowTerminalHostView: NSView {
         }
 
         if isPointerEvent {
+            if shouldPassThroughToTitlebar(at: point) {
+                clearActiveDividerCursor(restoreArrow: false)
+                return nil
+            }
+
+            if shouldPassThroughToPaneTabBar(at: point, eventType: currentEvent?.type) {
+                clearActiveDividerCursor(restoreArrow: false)
+                return nil
+            }
+
             if shouldPassThroughToSidebarResizer(at: point) {
                 clearActiveDividerCursor(restoreArrow: false)
                 return nil
@@ -197,6 +207,32 @@ final class WindowTerminalHostView: NSView {
         // Non-pointer event: skip divider/drag routing, just do standard hit testing.
         let hitView = super.hitTest(point)
         return hitView === self ? nil : hitView
+    }
+
+    private func shouldPassThroughToTitlebar(at point: NSPoint) -> Bool {
+        guard let window else { return false }
+        let windowPoint = convert(point, to: nil)
+        return windowPoint.y >= BonsplitTabBarPassThrough.titlebarInteractionBandMinY(in: window)
+    }
+
+    private func shouldPassThroughToPaneTabBar(
+        at point: NSPoint,
+        eventType: NSEvent.EventType?
+    ) -> Bool {
+        guard let decision = BonsplitTabBarPassThrough.passThroughDecision(
+            at: point,
+            in: self,
+            eventType: eventType
+        ) else { return false }
+#if DEBUG
+        if eventType == .leftMouseDown {
+            dlog(
+                "portal.term.passThroughTabBar wp=\(Int(decision.windowPoint.x)),\(Int(decision.windowPoint.y)) " +
+                    "registry=\(decision.registryHit ? 1 : 0) result=\(decision.result ? 1 : 0)"
+            )
+        }
+#endif
+        return decision.result
     }
 
     private func shouldPassThroughToSidebarResizer(at point: NSPoint) -> Bool {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -399,6 +399,12 @@ final class WindowBrowserHostViewTests: XCTestCase {
         }
     }
 
+    private final class FakeTabBarBackgroundNSView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
     private final class PrimaryPageProbeView: NSView {
         override func hitTest(_ point: NSPoint) -> NSView? {
             bounds.contains(point) ? self : nil
@@ -455,6 +461,57 @@ final class WindowBrowserHostViewTests: XCTestCase {
             return true
         }
         return inspectorView.isDescendant(of: hit) && !(pageView === hit || pageView.isDescendant(of: hit))
+    }
+
+    func testHostViewPassesThroughUnderlyingTabStripBelowTitlebarBand() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        guard let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        let tabStripHeight: CGFloat = 44
+        let tabStrip = FakeTabBarBackgroundNSView(
+            frame: NSRect(
+                x: 0,
+                y: contentView.bounds.maxY - tabStripHeight,
+                width: contentView.bounds.width,
+                height: tabStripHeight
+            )
+        )
+        tabStrip.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(tabStrip)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowBrowserHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        let child = CapturingView(frame: host.bounds)
+        child.autoresizingMask = [.width, .height]
+        host.addSubview(child)
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let titlebarBandHeight = max(28, min(72, window.frame.height - window.contentLayoutRect.height))
+        let pointInContent = NSPoint(
+            x: contentView.bounds.midX,
+            y: contentView.bounds.maxY - titlebarBandHeight - 8
+        )
+        let pointInWindow = contentView.convert(pointInContent, to: nil)
+        let pointInHost = host.convert(pointInWindow, from: nil)
+
+        XCTAssertNil(
+            host.hitTest(pointInHost),
+            "Browser portal should defer to the minimal tab strip even just below the native titlebar interaction band"
+        )
     }
 
     func testHostViewPassesThroughDividerWhenAdjacentPaneIsCollapsed() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2075,6 +2075,12 @@ final class WindowTerminalHostViewTests: XCTestCase {
         }
     }
 
+    private final class FakeTabBarBackgroundNSView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
     private final class BonsplitMockSplitDelegate: NSObject, NSSplitViewDelegate {}
 
     private func makeHostedTerminalView(frame: NSRect) -> GhosttySurfaceScrollView {
@@ -2102,6 +2108,57 @@ final class WindowTerminalHostViewTests: XCTestCase {
             message,
             file: file,
             line: line
+        )
+    }
+
+    func testHostViewPassesThroughUnderlyingTabStripBelowTitlebarBand() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+        guard let container = contentView.superview else {
+            XCTFail("Expected content container")
+            return
+        }
+
+        let tabStripHeight: CGFloat = 44
+        let tabStrip = FakeTabBarBackgroundNSView(
+            frame: NSRect(
+                x: 0,
+                y: contentView.bounds.maxY - tabStripHeight,
+                width: contentView.bounds.width,
+                height: tabStripHeight
+            )
+        )
+        tabStrip.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(tabStrip)
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowTerminalHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+        let child = CapturingView(frame: host.bounds)
+        child.autoresizingMask = [.width, .height]
+        host.addSubview(child)
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let titlebarBandHeight = max(28, min(72, window.frame.height - window.contentLayoutRect.height))
+        let pointInContent = NSPoint(
+            x: contentView.bounds.midX,
+            y: contentView.bounds.maxY - titlebarBandHeight - 8
+        )
+        let pointInWindow = contentView.convert(pointInContent, to: nil)
+        let pointInHost = host.convert(pointInWindow, from: nil)
+
+        XCTAssertNil(
+            host.hitTest(pointInHost),
+            "Terminal portal should defer to the minimal tab strip even just below the native titlebar interaction band"
         )
     }
 


### PR DESCRIPTION
## Summary
- add regression tests that assert portal hosts yield the minimal tab-strip drag region
- route browser and terminal portal hit-testing through the underlying Bonsplit tab strip below the titlebar band
- keep the native titlebar interaction band and empty minimal top strip available for window dragging again

## Root Cause
In minimal mode, the browser and terminal portal hosts sat above the Bonsplit tab strip and continued to claim pointer hits just below the native titlebar interaction band. That prevented empty top-bar drags from reaching the minimal-mode window-drag handlers behind the portals.

## Testing
- built with `./scripts/reload.sh --tag issue-3119-minimal-drag-sidebar --launch`
- local tests not run per repo policy

Closes #3119

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts AppKit hit-testing in window-level browser/terminal portal hosts; mistakes could regress click/drag routing around the titlebar/tab strip and split dividers, but scope is limited to pointer-event routing.
> 
> **Overview**
> Restores minimal-mode top-bar drag/click behavior by teaching the browser and terminal portal host views to **yield pointer hit-testing** not only to the native/custom titlebar band, but also to the *underlying* Bonsplit minimal tab strip.
> 
> This introduces shared `BonsplitTabBarPassThrough` helpers (including a registry-based hit check with a view-tree fallback) and adds regression tests asserting the portal hosts return `nil` for hits in the tab strip area just below the titlebar interaction band.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd54dad85dc7af1be380e0f868544c01dfdfb9fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes minimal-mode top-bar dragging by letting browser and terminal portal hosts pass pointer events through to the native titlebar band and the underlying Bonsplit minimal tab strip. Restores window drag behavior just below the titlebar. Closes #3119.

- **Bug Fixes**
  - Route portal hit-testing via shared `BonsplitTabBarPassThrough` helpers (registry check with view-tree fallback).
  - Respect the native/custom titlebar interaction band for window drags.
  - Add regression tests asserting portal hosts return nil hits in the minimal tab strip area for both browser and terminal.

<sup>Written for commit bd54dad85dc7af1be380e0f868544c01dfdfb9fe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved pointer event handling in minimal-mode pane tab bar regions to correctly pass through events to underlying UI elements.
  * Enhanced detection of tab bar interaction areas to prevent unintended event interception.

* **Tests**
  * Added regression tests for pointer hit-testing behavior in tab bar areas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->