### PR TITLE
Refactor agent resume specs

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14070,7 +14070,7 @@ struct CMUXCLI {
                 tail,
                 valueOptions: Self.codexLaunchValueOptions,
                 optionalValueOptions: [],
-                variadicOptions: ["--image", "-i", "--add-dir"],
+                variadicOptions: ["--image", "-i"],
                 nonRestorableCommands: Self.codexLaunchNonRestorableCommands,
                 droppedOptions: ["--last", "--all"],
                 droppedOptionPrefixes: [],

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -54,16 +54,22 @@ fileprivate func shellSingleQuoted(_ value: String) -> String {
     "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
 }
 
-fileprivate func isOpenCodeInternalWorkerArgument(_ value: String) -> Bool {
-    let normalized = value.replacingOccurrences(of: "\\", with: "/")
-    return normalized.contains("/$bunfs/") &&
-        normalized.contains("/src/cli/cmd/tui/worker.js")
+private enum OpenCodeResumeArgumentFilter {
+    static func stripInternalWorkerArguments(from args: [String]) -> [String] {
+        args.filter { !isInternalWorkerArgument($0) }
+    }
+
+    private static func isInternalWorkerArgument(_ value: String) -> Bool {
+        let normalized = value.replacingOccurrences(of: "\\", with: "/")
+        return normalized.contains("/$bunfs/") &&
+            normalized.contains("/src/cli/cmd/tui/worker.js")
+    }
 }
 
 private struct AgentResumeOptionPolicy {
     let valueOptions: Set<String>
     let optionalValueOptions: Set<String>
-    let variadicOptions: Set<String>
+    let greedyValueOptions: Set<String>
     let nonRestorableCommands: Set<String>
     let droppedOptions: Set<String>
     let droppedOptionPrefixes: [String]
@@ -76,7 +82,7 @@ private struct AgentResumeOptionPolicy {
     init(
         valueOptions: Set<String>,
         optionalValueOptions: Set<String> = [],
-        variadicOptions: Set<String> = [],
+        greedyValueOptions: Set<String> = [],
         nonRestorableCommands: Set<String>,
         droppedOptions: Set<String> = [],
         droppedOptionPrefixes: [String] = [],
@@ -88,7 +94,7 @@ private struct AgentResumeOptionPolicy {
     ) {
         self.valueOptions = valueOptions
         self.optionalValueOptions = optionalValueOptions
-        self.variadicOptions = variadicOptions
+        self.greedyValueOptions = greedyValueOptions
         self.nonRestorableCommands = nonRestorableCommands
         self.droppedOptions = droppedOptions
         self.droppedOptionPrefixes = droppedOptionPrefixes
@@ -101,8 +107,10 @@ private struct AgentResumeOptionPolicy {
 }
 
 private enum AgentResumeSessionPlacement {
-    case afterPrefix([String])
-    case afterPreserved([String])
+    /// Emit fixed prefix tokens before the session id, then append preserved launch options.
+    case afterPrefix(prefixBeforeSessionId: [String])
+    /// Emit fixed prefix tokens before preserved launch options, then append the session id.
+    case afterPreserved(prefixBeforePreserved: [String])
 
     func build(executable: String, leadingSubcommand: String?, sessionId: String, preserved: [String]) -> [String] {
         var result = [executable]
@@ -111,12 +119,12 @@ private enum AgentResumeSessionPlacement {
         }
 
         switch self {
-        case .afterPrefix(let prefix):
-            result.append(contentsOf: prefix)
+        case .afterPrefix(let prefixBeforeSessionId):
+            result.append(contentsOf: prefixBeforeSessionId)
             result.append(sessionId)
             result.append(contentsOf: preserved)
-        case .afterPreserved(let prefix):
-            result.append(contentsOf: prefix)
+        case .afterPreserved(let prefixBeforePreserved):
+            result.append(contentsOf: prefixBeforePreserved)
             result.append(contentsOf: preserved)
             result.append(sessionId)
         }
@@ -188,7 +196,7 @@ private extension RestorableAgentKind {
                         "-w"
                     ],
                     optionalValueOptions: ["--debug"],
-                    variadicOptions: [
+                    greedyValueOptions: [
                         "--add-dir",
                         "--allowedTools",
                         "--allowed-tools",
@@ -246,14 +254,14 @@ private extension RestorableAgentKind {
                 defaultInvocation: AgentResumeInvocationSpec(
                     fallbackExecutable: "claude",
                     leadingSubcommand: nil,
-                    sessionPlacement: .afterPrefix(["--resume"])
+                    sessionPlacement: .afterPrefix(prefixBeforeSessionId: ["--resume"])
                 ),
                 launcherOverrides: [
                     "claudeTeams": .use(
                         AgentResumeInvocationSpec(
                             fallbackExecutable: "cmux",
                             leadingSubcommand: "claude-teams",
-                            sessionPlacement: .afterPrefix(["--resume"])
+                            sessionPlacement: .afterPrefix(prefixBeforeSessionId: ["--resume"])
                         )
                     ),
                     "omx": .unsupported,
@@ -291,7 +299,7 @@ private extension RestorableAgentKind {
                         "--enable",
                         "--disable"
                     ],
-                    variadicOptions: ["--image", "-i", "--add-dir"],
+                    greedyValueOptions: ["--image", "-i"],
                     nonRestorableCommands: [
                         "exec",
                         "e",
@@ -322,7 +330,7 @@ private extension RestorableAgentKind {
                 defaultInvocation: AgentResumeInvocationSpec(
                     fallbackExecutable: "codex",
                     leadingSubcommand: nil,
-                    sessionPlacement: .afterPreserved(["resume"])
+                    sessionPlacement: .afterPreserved(prefixBeforePreserved: ["resume"])
                 ),
                 launcherOverrides: [
                     "omx": .unsupported,
@@ -346,7 +354,7 @@ private extension RestorableAgentKind {
                         "--prompt",
                         "--agent"
                     ],
-                    variadicOptions: ["--cors"],
+                    greedyValueOptions: ["--cors"],
                     nonRestorableCommands: [
                         "completion",
                         "acp",
@@ -385,21 +393,19 @@ private extension RestorableAgentKind {
                         "--prompt="
                     ],
                     preserveFirstPositional: true,
-                    sanitizeArguments: { args in
-                        args.filter { !isOpenCodeInternalWorkerArgument($0) }
-                    }
+                    sanitizeArguments: OpenCodeResumeArgumentFilter.stripInternalWorkerArguments(from:)
                 ),
                 defaultInvocation: AgentResumeInvocationSpec(
                     fallbackExecutable: "opencode",
                     leadingSubcommand: nil,
-                    sessionPlacement: .afterPrefix(["--session"])
+                    sessionPlacement: .afterPrefix(prefixBeforeSessionId: ["--session"])
                 ),
                 launcherOverrides: [
                     "omo": .use(
                         AgentResumeInvocationSpec(
                             fallbackExecutable: "cmux",
                             leadingSubcommand: "omo",
-                            sessionPlacement: .afterPrefix(["--session"])
+                            sessionPlacement: .afterPrefix(prefixBeforeSessionId: ["--session"])
                         )
                     ),
                     "omx": .unsupported,
@@ -454,6 +460,8 @@ private enum AgentResumeCommandBuilder {
         launchCommand: AgentLaunchCommandSnapshot?
     ) -> [String]? {
         let spec = kind.resumeProviderSpec
+        // Unknown launchers intentionally inherit the provider default until a new launcher
+        // is modeled explicitly as an override or marked unsupported.
         let launcherBehavior = launchCommand?.launcher.flatMap { spec.launcherOverrides[$0] } ?? .use(spec.defaultInvocation)
         guard case .use(let invocation) = launcherBehavior else {
             return nil
@@ -538,7 +546,7 @@ private enum AgentResumeCommandBuilder {
                     index: index,
                     valueOptions: policy.valueOptions,
                     optionalValueOptions: policy.optionalValueOptions,
-                    variadicOptions: policy.variadicOptions
+                    greedyValueOptions: policy.greedyValueOptions
                 )
                 continue
             }
@@ -549,7 +557,7 @@ private enum AgentResumeCommandBuilder {
                     index: index,
                     valueOptions: policy.valueOptions,
                     optionalValueOptions: policy.optionalValueOptions,
-                    variadicOptions: policy.variadicOptions
+                    greedyValueOptions: policy.greedyValueOptions
                 )
                 continue
             }
@@ -559,7 +567,7 @@ private enum AgentResumeCommandBuilder {
                 index: index,
                 valueOptions: policy.valueOptions,
                 optionalValueOptions: policy.optionalValueOptions,
-                variadicOptions: policy.variadicOptions
+                greedyValueOptions: policy.greedyValueOptions
             )
             result.append(contentsOf: args[index..<min(args.count, index + width)])
             index += width
@@ -579,7 +587,7 @@ private enum AgentResumeCommandBuilder {
         index: Int,
         valueOptions: Set<String>,
         optionalValueOptions: Set<String>,
-        variadicOptions: Set<String>
+        greedyValueOptions: Set<String>
     ) -> Int {
         let arg = args[index]
         if arg.contains("=") {
@@ -598,7 +606,7 @@ private enum AgentResumeCommandBuilder {
         guard valueOptions.contains(arg), index + 1 < args.count else {
             return 1
         }
-        if variadicOptions.contains(arg) {
+        if greedyValueOptions.contains(arg) {
             var end = index + 1
             while end < args.count, !args[end].hasPrefix("-") {
                 end += 1

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -54,166 +54,364 @@ fileprivate func shellSingleQuoted(_ value: String) -> String {
     "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
 }
 
+fileprivate func isOpenCodeInternalWorkerArgument(_ value: String) -> Bool {
+    let normalized = value.replacingOccurrences(of: "\\", with: "/")
+    return normalized.contains("/$bunfs/") &&
+        normalized.contains("/src/cli/cmd/tui/worker.js")
+}
+
+private struct AgentResumeOptionPolicy {
+    let valueOptions: Set<String>
+    let optionalValueOptions: Set<String>
+    let variadicOptions: Set<String>
+    let nonRestorableCommands: Set<String>
+    let droppedOptions: Set<String>
+    let droppedOptionPrefixes: [String]
+    let rejectOptions: Set<String>
+    let skipsHookSettings: Bool
+    let resumeSubcommand: String?
+    let preserveFirstPositional: Bool
+    let sanitizeArguments: ([String]) -> [String]
+
+    init(
+        valueOptions: Set<String>,
+        optionalValueOptions: Set<String> = [],
+        variadicOptions: Set<String> = [],
+        nonRestorableCommands: Set<String>,
+        droppedOptions: Set<String> = [],
+        droppedOptionPrefixes: [String] = [],
+        rejectOptions: Set<String> = [],
+        skipsHookSettings: Bool = false,
+        resumeSubcommand: String? = nil,
+        preserveFirstPositional: Bool = false,
+        sanitizeArguments: @escaping ([String]) -> [String] = { $0 }
+    ) {
+        self.valueOptions = valueOptions
+        self.optionalValueOptions = optionalValueOptions
+        self.variadicOptions = variadicOptions
+        self.nonRestorableCommands = nonRestorableCommands
+        self.droppedOptions = droppedOptions
+        self.droppedOptionPrefixes = droppedOptionPrefixes
+        self.rejectOptions = rejectOptions
+        self.skipsHookSettings = skipsHookSettings
+        self.resumeSubcommand = resumeSubcommand
+        self.preserveFirstPositional = preserveFirstPositional
+        self.sanitizeArguments = sanitizeArguments
+    }
+}
+
+private enum AgentResumeSessionPlacement {
+    case afterPrefix([String])
+    case afterPreserved([String])
+
+    func build(executable: String, leadingSubcommand: String?, sessionId: String, preserved: [String]) -> [String] {
+        var result = [executable]
+        if let leadingSubcommand {
+            result.append(leadingSubcommand)
+        }
+
+        switch self {
+        case .afterPrefix(let prefix):
+            result.append(contentsOf: prefix)
+            result.append(sessionId)
+            result.append(contentsOf: preserved)
+        case .afterPreserved(let prefix):
+            result.append(contentsOf: prefix)
+            result.append(contentsOf: preserved)
+            result.append(sessionId)
+        }
+        return result
+    }
+}
+
+private struct AgentResumeInvocationSpec {
+    let fallbackExecutable: String
+    let leadingSubcommand: String?
+    let sessionPlacement: AgentResumeSessionPlacement
+}
+
+private enum AgentResumeLauncherBehavior {
+    case use(AgentResumeInvocationSpec)
+    case unsupported
+}
+
+private struct AgentResumeProviderSpec {
+    let optionPolicy: AgentResumeOptionPolicy
+    let defaultInvocation: AgentResumeInvocationSpec
+    let launcherOverrides: [String: AgentResumeLauncherBehavior]
+    let safeEnvironmentKeys: Set<String>
+}
+
+private extension RestorableAgentKind {
+    var resumeProviderSpec: AgentResumeProviderSpec {
+        switch self {
+        case .claude:
+            return AgentResumeProviderSpec(
+                optionPolicy: AgentResumeOptionPolicy(
+                    valueOptions: [
+                        "--add-dir",
+                        "--agent",
+                        "--agents",
+                        "--allowedTools",
+                        "--allowed-tools",
+                        "--append-system-prompt",
+                        "--betas",
+                        "--debug-file",
+                        "--disallowedTools",
+                        "--disallowed-tools",
+                        "--effort",
+                        "--fallback-model",
+                        "--file",
+                        "--fork-session",
+                        "--from-pr",
+                        "--input-format",
+                        "--json-schema",
+                        "--max-budget-usd",
+                        "--mcp-config",
+                        "--model",
+                        "--name",
+                        "-n",
+                        "--output-format",
+                        "--permission-mode",
+                        "--plugin-dir",
+                        "--remote-control-session-name-prefix",
+                        "--resume",
+                        "-r",
+                        "--session-id",
+                        "--setting-sources",
+                        "--settings",
+                        "--system-prompt",
+                        "--teammate-mode",
+                        "--tmux",
+                        "--tools",
+                        "--worktree",
+                        "-w"
+                    ],
+                    optionalValueOptions: ["--debug"],
+                    variadicOptions: [
+                        "--add-dir",
+                        "--allowedTools",
+                        "--allowed-tools",
+                        "--betas",
+                        "--disallowedTools",
+                        "--disallowed-tools",
+                        "--file",
+                        "--mcp-config",
+                        "--tools"
+                    ],
+                    nonRestorableCommands: [
+                        "agents",
+                        "auth",
+                        "auto-mode",
+                        "api-key",
+                        "config",
+                        "doctor",
+                        "install",
+                        "mcp",
+                        "plugin",
+                        "plugins",
+                        "rc",
+                        "remote-control",
+                        "setup-token",
+                        "update",
+                        "upgrade"
+                    ],
+                    droppedOptions: [
+                        "--continue",
+                        "-c",
+                        "--fork-session",
+                        "--from-pr",
+                        "--resume",
+                        "-r",
+                        "--session-id",
+                        "--tmux",
+                        "--worktree",
+                        "-w"
+                    ],
+                    droppedOptionPrefixes: [
+                        "--fork-session=",
+                        "--from-pr=",
+                        "--resume=",
+                        "--session-id=",
+                        "--tmux=",
+                        "--worktree="
+                    ],
+                    rejectOptions: [
+                        "--print",
+                        "-p",
+                        "--no-session-persistence"
+                    ],
+                    skipsHookSettings: true
+                ),
+                defaultInvocation: AgentResumeInvocationSpec(
+                    fallbackExecutable: "claude",
+                    leadingSubcommand: nil,
+                    sessionPlacement: .afterPrefix(["--resume"])
+                ),
+                launcherOverrides: [
+                    "claudeTeams": .use(
+                        AgentResumeInvocationSpec(
+                            fallbackExecutable: "cmux",
+                            leadingSubcommand: "claude-teams",
+                            sessionPlacement: .afterPrefix(["--resume"])
+                        )
+                    ),
+                    "omx": .unsupported,
+                    "omc": .unsupported
+                ],
+                safeEnvironmentKeys: [
+                    "ANTHROPIC_MODEL",
+                    "CLAUDE_CONFIG_DIR",
+                    "CMUX_CUSTOM_CLAUDE_PATH",
+                    "NODE_OPTIONS"
+                ]
+            )
+        case .codex:
+            return AgentResumeProviderSpec(
+                optionPolicy: AgentResumeOptionPolicy(
+                    valueOptions: [
+                        "--config",
+                        "-c",
+                        "--remote",
+                        "--remote-auth-token-env",
+                        "--image",
+                        "-i",
+                        "--model",
+                        "-m",
+                        "--local-provider",
+                        "--profile",
+                        "-p",
+                        "--sandbox",
+                        "-s",
+                        "--ask-for-approval",
+                        "-a",
+                        "--cd",
+                        "-C",
+                        "--add-dir",
+                        "--enable",
+                        "--disable"
+                    ],
+                    variadicOptions: ["--image", "-i", "--add-dir"],
+                    nonRestorableCommands: [
+                        "exec",
+                        "e",
+                        "review",
+                        "login",
+                        "logout",
+                        "mcp",
+                        "mcp-server",
+                        "app-server",
+                        "app",
+                        "completion",
+                        "sandbox",
+                        "debug",
+                        "apply",
+                        "a",
+                        "fork",
+                        "cloud",
+                        "exec-server",
+                        "features",
+                        "help"
+                    ],
+                    droppedOptions: [
+                        "--last",
+                        "--all"
+                    ],
+                    resumeSubcommand: "resume"
+                ),
+                defaultInvocation: AgentResumeInvocationSpec(
+                    fallbackExecutable: "codex",
+                    leadingSubcommand: nil,
+                    sessionPlacement: .afterPreserved(["resume"])
+                ),
+                launcherOverrides: [
+                    "omx": .unsupported,
+                    "omc": .unsupported
+                ],
+                safeEnvironmentKeys: ["CODEX_HOME"]
+            )
+        case .opencode:
+            return AgentResumeProviderSpec(
+                optionPolicy: AgentResumeOptionPolicy(
+                    valueOptions: [
+                        "--log-level",
+                        "--port",
+                        "--hostname",
+                        "--mdns-domain",
+                        "--cors",
+                        "--model",
+                        "-m",
+                        "--session",
+                        "-s",
+                        "--prompt",
+                        "--agent"
+                    ],
+                    variadicOptions: ["--cors"],
+                    nonRestorableCommands: [
+                        "completion",
+                        "acp",
+                        "mcp",
+                        "attach",
+                        "run",
+                        "debug",
+                        "providers",
+                        "auth",
+                        "agent",
+                        "upgrade",
+                        "uninstall",
+                        "serve",
+                        "web",
+                        "models",
+                        "stats",
+                        "export",
+                        "import",
+                        "pr",
+                        "github",
+                        "session",
+                        "plugin",
+                        "plug",
+                        "db"
+                    ],
+                    droppedOptions: [
+                        "--continue",
+                        "-c",
+                        "--fork",
+                        "--session",
+                        "-s",
+                        "--prompt"
+                    ],
+                    droppedOptionPrefixes: [
+                        "--session=",
+                        "--prompt="
+                    ],
+                    preserveFirstPositional: true,
+                    sanitizeArguments: { args in
+                        args.filter { !isOpenCodeInternalWorkerArgument($0) }
+                    }
+                ),
+                defaultInvocation: AgentResumeInvocationSpec(
+                    fallbackExecutable: "opencode",
+                    leadingSubcommand: nil,
+                    sessionPlacement: .afterPrefix(["--session"])
+                ),
+                launcherOverrides: [
+                    "omo": .use(
+                        AgentResumeInvocationSpec(
+                            fallbackExecutable: "cmux",
+                            leadingSubcommand: "omo",
+                            sessionPlacement: .afterPrefix(["--session"])
+                        )
+                    ),
+                    "omx": .unsupported,
+                    "omc": .unsupported
+                ],
+                safeEnvironmentKeys: ["OPENCODE_CONFIG_DIR"]
+            )
+        }
+    }
+}
+
 private enum AgentResumeCommandBuilder {
-    private static let claudeValueOptions: Set<String> = [
-        "--add-dir",
-        "--agent",
-        "--agents",
-        "--allowedTools",
-        "--allowed-tools",
-        "--append-system-prompt",
-        "--betas",
-        "--debug-file",
-        "--disallowedTools",
-        "--disallowed-tools",
-        "--effort",
-        "--fallback-model",
-        "--file",
-        "--fork-session",
-        "--from-pr",
-        "--input-format",
-        "--json-schema",
-        "--max-budget-usd",
-        "--mcp-config",
-        "--model",
-        "--name",
-        "-n",
-        "--output-format",
-        "--permission-mode",
-        "--plugin-dir",
-        "--remote-control-session-name-prefix",
-        "--resume",
-        "-r",
-        "--session-id",
-        "--setting-sources",
-        "--settings",
-        "--system-prompt",
-        "--teammate-mode",
-        "--tmux",
-        "--tools",
-        "--worktree",
-        "-w"
-    ]
-
-    private static let claudeOptionalValueOptions: Set<String> = [
-        "--debug"
-    ]
-
-    private static let claudeVariadicOptions: Set<String> = [
-        "--add-dir",
-        "--allowedTools",
-        "--allowed-tools",
-        "--betas",
-        "--disallowedTools",
-        "--disallowed-tools",
-        "--file",
-        "--mcp-config",
-        "--tools"
-    ]
-
-    private static let claudeNonRestorableCommands: Set<String> = [
-        "agents",
-        "auth",
-        "auto-mode",
-        "api-key",
-        "config",
-        "doctor",
-        "install",
-        "mcp",
-        "plugin",
-        "plugins",
-        "rc",
-        "remote-control",
-        "setup-token",
-        "update",
-        "upgrade"
-    ]
-
-    private static let codexValueOptions: Set<String> = [
-        "--config",
-        "-c",
-        "--remote",
-        "--remote-auth-token-env",
-        "--image",
-        "-i",
-        "--model",
-        "-m",
-        "--local-provider",
-        "--profile",
-        "-p",
-        "--sandbox",
-        "-s",
-        "--ask-for-approval",
-        "-a",
-        "--cd",
-        "-C",
-        "--add-dir",
-        "--enable",
-        "--disable"
-    ]
-
-    private static let codexNonRestorableCommands: Set<String> = [
-        "exec",
-        "e",
-        "review",
-        "login",
-        "logout",
-        "mcp",
-        "mcp-server",
-        "app-server",
-        "app",
-        "completion",
-        "sandbox",
-        "debug",
-        "apply",
-        "a",
-        "fork",
-        "cloud",
-        "exec-server",
-        "features",
-        "help"
-    ]
-
-    private static let opencodeValueOptions: Set<String> = [
-        "--log-level",
-        "--port",
-        "--hostname",
-        "--mdns-domain",
-        "--cors",
-        "--model",
-        "-m",
-        "--session",
-        "-s",
-        "--prompt",
-        "--agent"
-    ]
-
-    private static let opencodeNonRestorableCommands: Set<String> = [
-        "completion",
-        "acp",
-        "mcp",
-        "attach",
-        "run",
-        "debug",
-        "providers",
-        "auth",
-        "agent",
-        "upgrade",
-        "uninstall",
-        "serve",
-        "web",
-        "models",
-        "stats",
-        "export",
-        "import",
-        "pr",
-        "github",
-        "session",
-        "plugin",
-        "plug",
-        "db"
-    ]
-
     static func resumeShellCommand(
         kind: RestorableAgentKind,
         sessionId: String,
@@ -227,10 +425,11 @@ private enum AgentResumeCommandBuilder {
         }
 
         var commandParts: [String] = []
+        let spec = kind.resumeProviderSpec
         if let env = launchCommand?.environment, !env.isEmpty {
             var environmentParts: [String] = []
             for key in env.keys.sorted() {
-                guard isSafeEnvironmentKey(key),
+                guard spec.safeEnvironmentKeys.contains(key),
                       let value = sanitizedEnvironmentValue(key: key, value: env[key]) else { continue }
                 environmentParts.append("\(key)=\(value)")
             }
@@ -254,49 +453,26 @@ private enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?
     ) -> [String]? {
-        switch launchCommand?.launcher {
-        case "claudeTeams":
-            let original = commandParts(
-                launchCommand: launchCommand,
-                fallbackExecutable: "cmux"
-            )
-            var args = original.tail
-            if args.first == "claude-teams" {
-                args.removeFirst()
-            }
-            guard let preserved = preservedClaudeArguments(args) else { return nil }
-            return [original.executable, "claude-teams", "--resume", sessionId] + preserved
-        case "omo":
-            let original = commandParts(
-                launchCommand: launchCommand,
-                fallbackExecutable: "cmux"
-            )
-            var args = original.tail
-            if args.first == "omo" {
-                args.removeFirst()
-            }
-            guard let preserved = preservedOpenCodeArguments(args) else { return nil }
-            return [original.executable, "omo", "--session", sessionId] + preserved
-        case "omx", "omc":
+        let spec = kind.resumeProviderSpec
+        let launcherBehavior = launchCommand?.launcher.flatMap { spec.launcherOverrides[$0] } ?? .use(spec.defaultInvocation)
+        guard case .use(let invocation) = launcherBehavior else {
             return nil
-        default:
-            break
         }
 
-        switch kind {
-        case .claude:
-            let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "claude")
-            guard let preserved = preservedClaudeArguments(original.tail) else { return nil }
-            return [original.executable, "--resume", sessionId] + preserved
-        case .codex:
-            let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "codex")
-            guard let preserved = preservedCodexArguments(original.tail) else { return nil }
-            return [original.executable, "resume"] + preserved + [sessionId]
-        case .opencode:
-            let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "opencode")
-            guard let preserved = preservedOpenCodeArguments(original.tail) else { return nil }
-            return [original.executable, "--session", sessionId] + preserved
+        let original = commandParts(launchCommand: launchCommand, fallbackExecutable: invocation.fallbackExecutable)
+        var args = original.tail
+        if let leadingSubcommand = invocation.leadingSubcommand, args.first == leadingSubcommand {
+            args.removeFirst()
         }
+
+        let sanitizedArgs = spec.optionPolicy.sanitizeArguments(args)
+        guard let preserved = preserveOptions(sanitizedArgs, policy: spec.optionPolicy) else { return nil }
+        return invocation.sessionPlacement.build(
+            executable: original.executable,
+            leadingSubcommand: invocation.leadingSubcommand,
+            sessionId: sessionId,
+            preserved: preserved
+        )
     }
 
     private static func commandParts(
@@ -311,106 +487,9 @@ private enum AgentResumeCommandBuilder {
         return (executable, tail)
     }
 
-    private static func preservedClaudeArguments(_ args: [String]) -> [String]? {
-        preserveOptions(
-            args,
-            valueOptions: claudeValueOptions,
-            optionalValueOptions: claudeOptionalValueOptions,
-            variadicOptions: claudeVariadicOptions,
-            nonRestorableCommands: claudeNonRestorableCommands,
-            droppedOptions: [
-                "--continue",
-                "-c",
-                "--fork-session",
-                "--from-pr",
-                "--resume",
-                "-r",
-                "--session-id",
-                "--tmux",
-                "--worktree",
-                "-w"
-            ],
-            droppedOptionPrefixes: [
-                "--fork-session=",
-                "--from-pr=",
-                "--resume=",
-                "--session-id=",
-                "--tmux=",
-                "--worktree="
-            ],
-            rejectOptions: [
-                "--print",
-                "-p",
-                "--no-session-persistence"
-            ],
-            skipHookSettings: true,
-            resumeSubcommand: nil
-        )
-    }
-
-    private static func preservedCodexArguments(_ args: [String]) -> [String]? {
-        preserveOptions(
-            args,
-            valueOptions: codexValueOptions,
-            optionalValueOptions: [],
-            variadicOptions: ["--image", "-i", "--add-dir"],
-            nonRestorableCommands: codexNonRestorableCommands,
-            droppedOptions: [
-                "--last",
-                "--all"
-            ],
-            droppedOptionPrefixes: [],
-            rejectOptions: [],
-            skipHookSettings: false,
-            resumeSubcommand: "resume"
-        )
-    }
-
-    private static func preservedOpenCodeArguments(_ args: [String]) -> [String]? {
-        let sanitizedArgs = args.filter { !isOpenCodeInternalWorkerArgument($0) }
-        return preserveOptions(
-            sanitizedArgs,
-            valueOptions: opencodeValueOptions,
-            optionalValueOptions: [],
-            variadicOptions: ["--cors"],
-            nonRestorableCommands: opencodeNonRestorableCommands,
-            droppedOptions: [
-                "--continue",
-                "-c",
-                "--fork",
-                "--session",
-                "-s",
-                "--prompt"
-            ],
-            droppedOptionPrefixes: [
-                "--session=",
-                "--prompt="
-            ],
-            rejectOptions: [],
-            skipHookSettings: false,
-            resumeSubcommand: nil,
-            preserveFirstPositional: true
-        )
-    }
-
-    private static func isOpenCodeInternalWorkerArgument(_ value: String) -> Bool {
-        let normalized = value.replacingOccurrences(of: "\\", with: "/")
-        return normalized.contains("/$bunfs/") &&
-            normalized.contains("/src/cli/cmd/tui/worker.js")
-    }
-
     private static func preserveOptions(
         _ args: [String],
-        valueOptions: Set<String>,
-        optionalValueOptions: Set<String>,
-        variadicOptions: Set<String>,
-        nonRestorableCommands: Set<String>,
-        droppedOptions: Set<String>,
-        droppedOptionPrefixes: [String],
-        rejectOptions: Set<String>,
-        skipHookSettings: Bool,
-        resumeSubcommand: String?,
-        preserveFirstPositional: Bool = false
+        policy: AgentResumeOptionPolicy
     ) -> [String]? {
         var result: [String] = []
         var index = 0
@@ -424,7 +503,7 @@ private enum AgentResumeCommandBuilder {
             }
 
             if !arg.hasPrefix("-") || arg == "-" {
-                if let resumeSubcommand, arg == resumeSubcommand {
+                if let resumeSubcommand = policy.resumeSubcommand, arg == resumeSubcommand {
                     skippingResumePositionals = true
                     index += 1
                     continue
@@ -432,10 +511,10 @@ private enum AgentResumeCommandBuilder {
                 if skippingResumePositionals {
                     break
                 }
-                if nonRestorableCommands.contains(arg) {
+                if policy.nonRestorableCommands.contains(arg) {
                     return nil
                 }
-                if preserveFirstPositional && !consumedFirstPositional {
+                if policy.preserveFirstPositional && !consumedFirstPositional {
                     result.append(arg)
                     consumedFirstPositional = true
                     index += 1
@@ -444,33 +523,33 @@ private enum AgentResumeCommandBuilder {
                 break
             }
 
-            if shouldDropOption(arg, droppedOptions: rejectOptions) {
+            if shouldDropOption(arg, droppedOptions: policy.rejectOptions) {
                 return nil
             }
 
-            if droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) }) {
+            if policy.droppedOptionPrefixes.contains(where: { arg.hasPrefix($0) }) {
                 index += 1
                 continue
             }
 
-            if shouldDropOption(arg, droppedOptions: droppedOptions) {
+            if shouldDropOption(arg, droppedOptions: policy.droppedOptions) {
                 index += optionWidth(
                     args,
                     index: index,
-                    valueOptions: valueOptions,
-                    optionalValueOptions: optionalValueOptions,
-                    variadicOptions: variadicOptions
+                    valueOptions: policy.valueOptions,
+                    optionalValueOptions: policy.optionalValueOptions,
+                    variadicOptions: policy.variadicOptions
                 )
                 continue
             }
 
-            if skipHookSettings, isHookSettingsOption(args, index: index) {
+            if policy.skipsHookSettings, isHookSettingsOption(args, index: index) {
                 index += optionWidth(
                     args,
                     index: index,
-                    valueOptions: valueOptions,
-                    optionalValueOptions: optionalValueOptions,
-                    variadicOptions: variadicOptions
+                    valueOptions: policy.valueOptions,
+                    optionalValueOptions: policy.optionalValueOptions,
+                    variadicOptions: policy.variadicOptions
                 )
                 continue
             }
@@ -478,9 +557,9 @@ private enum AgentResumeCommandBuilder {
             let width = optionWidth(
                 args,
                 index: index,
-                valueOptions: valueOptions,
-                optionalValueOptions: optionalValueOptions,
-                variadicOptions: variadicOptions
+                valueOptions: policy.valueOptions,
+                optionalValueOptions: policy.optionalValueOptions,
+                variadicOptions: policy.variadicOptions
             )
             result.append(contentsOf: args[index..<min(args.count, index + width)])
             index += width
@@ -547,20 +626,6 @@ private enum AgentResumeCommandBuilder {
             return false
         }
         return args[index + 1].contains("claude-hook")
-    }
-
-    private static func isSafeEnvironmentKey(_ key: String) -> Bool {
-        switch key {
-        case "ANTHROPIC_MODEL",
-             "CLAUDE_CONFIG_DIR",
-             "CMUX_CUSTOM_CLAUDE_PATH",
-             "CODEX_HOME",
-             "NODE_OPTIONS",
-             "OPENCODE_CONFIG_DIR":
-            return true
-        default:
-            return false
-        }
     }
 
     private static func sanitizedEnvironmentValue(key: String, value: String?) -> String? {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1820,6 +1820,54 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    func testResumeCommandUsesProviderSpecificEnvironmentAllowlists() {
+        let codex = SessionRestorableAgentSnapshot(
+            kind: .codex,
+            sessionId: "codex-session-env",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "codex",
+                executablePath: "codex",
+                arguments: ["codex"],
+                workingDirectory: nil,
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/tmp/claude",
+                    "CODEX_HOME": "/tmp/codex",
+                    "OPENCODE_CONFIG_DIR": "/tmp/opencode"
+                ],
+                capturedAt: nil,
+                source: nil
+            )
+        )
+        let opencode = SessionRestorableAgentSnapshot(
+            kind: .opencode,
+            sessionId: "opencode-session-env",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "opencode",
+                executablePath: "opencode",
+                arguments: ["opencode"],
+                workingDirectory: nil,
+                environment: [
+                    "CODEX_HOME": "/tmp/codex",
+                    "NODE_OPTIONS": "--trace-warnings",
+                    "OPENCODE_CONFIG_DIR": "/tmp/opencode"
+                ],
+                capturedAt: nil,
+                source: nil
+            )
+        )
+
+        XCTAssertEqual(
+            codex.resumeCommand,
+            "'env' 'CODEX_HOME=/tmp/codex' 'codex' 'resume' 'codex-session-env'"
+        )
+        XCTAssertEqual(
+            opencode.resumeCommand,
+            "'env' 'OPENCODE_CONFIG_DIR=/tmp/opencode' 'opencode' '--session' 'opencode-session-env'"
+        )
+    }
+
     func testClaudeResumeCommandStripsStaleCmuxNodeOptionsRestoreModule() {
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1618,6 +1618,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         let scriptPath = String(trimmedInput.dropFirst(prefix.count).dropLast())
         let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
         XCTAssertTrue(scriptContents.contains(longPath))
+        XCTAssertFalse(scriptContents.contains("initial prompt should not replay"))
         XCTAssertTrue(scriptContents.contains("'resume'"))
         XCTAssertTrue(scriptContents.contains("'019dad34-d218-7943-b81a-eddac5c87951'"))
 
@@ -1708,6 +1709,10 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
                     "--search",
                     "--cd",
                     "/Users/example/repo",
+                    "--add-dir",
+                    "/Users/example/repo-a",
+                    "--add-dir",
+                    "/Users/example/repo-b",
                     "initial prompt should not replay"
                 ],
                 workingDirectory: "/Users/example/repo",
@@ -1719,7 +1724,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search' '--cd' '/Users/example/repo' '019dad34-d218-7943-b81a-eddac5c87951'"
+            "cd '/Users/example/repo' && 'env' 'CODEX_HOME=/tmp/codex home' '/Users/example/.bun/bin/codex' 'resume' '--model' 'gpt-5.4' '--sandbox' 'danger-full-access' '--ask-for-approval' 'never' '--search' '--cd' '/Users/example/repo' '--add-dir' '/Users/example/repo-a' '--add-dir' '/Users/example/repo-b' '019dad34-d218-7943-b81a-eddac5c87951'"
         )
     }
 


### PR DESCRIPTION
## Summary
- refactor Claude, Codex, and OpenCode resume handling into declarative provider specs instead of hard-coded builder branches
- keep provider-specific launcher, flag, and environment policies explicit while making new CLI support easier to add in one place
- add unit coverage for provider-specific environment allowlists on resumed commands

## Testing
- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-task-dry-resume-spec-tests -only-testing:cmuxTests/SessionPersistenceTests
- ./scripts/reload.sh --tag dry-resume-spec

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/2978

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Session resume logic moved to a policy-driven pipeline for consistent option preservation and launcher-specific invocation behavior.

* **Bug Fixes**
  * Resume command generation now sanitizes and normalizes forwarded arguments; only --image/-i is preserved for Codex, while --add-dir is no longer forwarded.

* **Tests**
  * Added/updated tests validating provider-specific environment allowlists (e.g., CODEX_HOME, OPENCODE_CONFIG_DIR) and resume-script content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored agent resume logic to use declarative provider specs and tightened option handling. Codex now preserves repeatable `--add-dir` while only `--image`/`-i` consume multiple values; tests cover this and per‑provider environment allowlists.

- **Refactors**
  - Introduced `AgentResumeProviderSpec` and `AgentResumeOptionPolicy` with declarative flag handling, dropped/reject lists, and session placement; unified resume command building and moved safe env keys to per‑provider allowlists (with tests).
  - Provider-specific arg handling: strips internal OpenCode TUI worker paths, preserves first positional for `opencode`, skips Claude hook settings, respects Codex `resume` positional rules.
  - Codex: narrowed greediness to `--image`/`-i`; `--add-dir` is preserved as repeatable (not greedy). Updated CLI to stop treating `--add-dir` as variadic.
  - Launcher overrides: `claudeTeams` runs as `cmux claude-teams`, `omo` as `cmux omo`; `omx` and `omc` resume is not supported.

<sup>Written for commit 3998818a4f293e556dcb8815debd04625130b5c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

