### PR TITLE
Use Ghostty's queued text path for deferred terminal sends

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1976,7 +1976,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
             if terminalReady && terminalVisible && !seeded {
                 seeded = true
-                sendTextWhenReady(shellCommand, to: workspace) {
+                Self.sendTextToTerminalSurface(shellCommand, in: workspace) {
                     workspace.updatePanelDirectory(panelId: terminalPanel.id, directory: fixtureDirectoryURL.path)
                 }
             }
@@ -5749,7 +5749,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func sendWelcomeCommandWhenReady(to workspace: Workspace, markShownOnSend: Bool = false) {
-        sendTextWhenReady("cmux welcome\n", to: workspace) {
+        Self.sendTextToTerminalSurface("cmux welcome\n", in: workspace) {
             if markShownOnSend {
                 UserDefaults.standard.set(true, forKey: WelcomeSettings.shownKey)
             }
@@ -6082,7 +6082,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             "focusedAfterRequest=\(Self.debugShortId(workspace.focusedPanelId))"
         )
 #endif
-        sendTextWhenReady(content, to: workspace, preferredPanelId: returnPanelId)
+        Self.sendTextToTerminalSurface(content, in: workspace, preferredPanelId: returnPanelId)
     }
 
     nonisolated private static func debugShortId(_ id: UUID?) -> String {
@@ -6096,211 +6096,49 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return tab.focusedTerminalPanel
     }
 
-    private func sendTextWhenReady(
+    /// Route bulk text through `TerminalSurface.sendText`, which uses
+    /// `ghostty_surface_text` immediately when the runtime surface is live and
+    /// otherwise queues the payload until the surface attaches.
+    @discardableResult
+    static func sendTextToTerminalSurface(
         _ text: String,
-        to tab: Tab,
+        in tab: Tab,
         preferredPanelId: UUID? = nil,
         beforeSend: (() -> Void)? = nil
-    ) {
+    ) -> Bool {
         let isReactGrabPasteback = preferredPanelId != nil
-#if DEBUG
-        let initialTargetPanel = Self.resolveTerminalPanelForTextSend(
+        guard let terminalPanel = resolveTerminalPanelForTextSend(
             in: tab,
             preferredPanelId: preferredPanelId
-        )
+        ) else {
+            return false
+        }
+#if DEBUG
         if isReactGrabPasteback {
             dlog(
-                "reactGrab.pasteback h2.send.start " +
+                "reactGrab.pasteback h2.send.route " +
                 "workspace=\(Self.debugShortId(tab.id)) " +
                 "preferred=\(Self.debugShortId(preferredPanelId)) " +
                 "focused=\(Self.debugShortId(tab.focusedPanelId)) " +
                 "focusedTerminal=\(Self.debugShortId(tab.focusedTerminalPanel?.id)) " +
-                "resolved=\(Self.debugShortId(initialTargetPanel?.id)) " +
-                "surfaceReady=\(initialTargetPanel?.surface.surface != nil ? 1 : 0) len=\(text.count)"
+                "target=\(Self.debugShortId(terminalPanel.id)) " +
+                "surfaceReady=\(terminalPanel.surface.surface != nil ? 1 : 0) len=\(text.count)"
             )
         }
 #endif
-        if let terminalPanel = Self.resolveTerminalPanelForTextSend(
-            in: tab,
-            preferredPanelId: preferredPanelId
-        ),
-           terminalPanel.surface.surface != nil {
+        beforeSend?()
+        terminalPanel.sendText(text)
 #if DEBUG
-            if isReactGrabPasteback {
-                dlog(
-                    "reactGrab.pasteback h2.send.immediate " +
-                    "workspace=\(Self.debugShortId(tab.id)) " +
-                    "target=\(Self.debugShortId(terminalPanel.id)) len=\(text.count)"
-                )
-            }
-#endif
-            beforeSend?()
-            terminalPanel.sendText(text)
-#if DEBUG
-            if isReactGrabPasteback {
-                dlog(
-                    "reactGrab.pasteback h2.send.sent " +
-                    "workspace=\(Self.debugShortId(tab.id)) " +
-                    "target=\(Self.debugShortId(terminalPanel.id)) mode=immediate len=\(text.count)"
-                )
-            }
-#endif
-            return
-        }
-
-        var resolved = false
-        var readyObserver: NSObjectProtocol?
-        var focusObserver: NSObjectProtocol?
-        var firstResponderObserver: NSObjectProtocol?
-        var panelsCancellable: AnyCancellable?
-
-        func cleanupObservers() {
-            if let readyObserver {
-                NotificationCenter.default.removeObserver(readyObserver)
-            }
-            if let focusObserver {
-                NotificationCenter.default.removeObserver(focusObserver)
-            }
-            if let firstResponderObserver {
-                NotificationCenter.default.removeObserver(firstResponderObserver)
-            }
-            panelsCancellable?.cancel()
-        }
-
-        func finishIfReady() {
-            let terminalPanel = Self.resolveTerminalPanelForTextSend(
-                in: tab,
-                preferredPanelId: preferredPanelId
-            )
-#if DEBUG
-            if isReactGrabPasteback {
-                dlog(
-                    "reactGrab.pasteback h2.finishIfReady " +
-                    "workspace=\(Self.debugShortId(tab.id)) " +
-                    "preferred=\(Self.debugShortId(preferredPanelId)) " +
-                    "focused=\(Self.debugShortId(tab.focusedPanelId)) " +
-                    "resolved=\(Self.debugShortId(terminalPanel?.id)) " +
-                    "surfaceReady=\(terminalPanel?.surface.surface != nil ? 1 : 0) alreadyResolved=\(resolved ? 1 : 0)"
-                )
-            }
-#endif
-            guard !resolved,
-                  let terminalPanel,
-                  terminalPanel.surface.surface != nil else { return }
-            resolved = true
-            cleanupObservers()
-            beforeSend?()
-            terminalPanel.sendText(text)
-#if DEBUG
-            if isReactGrabPasteback {
-                dlog(
-                    "reactGrab.pasteback h2.send.sent " +
-                    "workspace=\(Self.debugShortId(tab.id)) " +
-                    "target=\(Self.debugShortId(terminalPanel.id)) mode=delayed len=\(text.count)"
-                )
-            }
-#endif
-        }
-
-        panelsCancellable = tab.$panels
-            .map { _ in () }
-            .sink { _ in
-#if DEBUG
-                if isReactGrabPasteback {
-                    dlog(
-                        "reactGrab.pasteback h2.panelsChanged " +
-                        "workspace=\(Self.debugShortId(tab.id)) " +
-                        "focused=\(Self.debugShortId(tab.focusedPanelId))"
-                    )
-                }
-#endif
-                finishIfReady()
-            }
         if isReactGrabPasteback {
-            focusObserver = NotificationCenter.default.addObserver(
-                forName: .ghosttyDidFocusSurface,
-                object: nil,
-                queue: .main
-            ) { note in
-                guard let candidateTabId = note.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
-                      candidateTabId == tab.id,
-                      let candidateSurfaceId = note.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else {
-                    return
-                }
-#if DEBUG
-                dlog(
-                    "reactGrab.pasteback h1.focusEvent " +
-                    "workspace=\(Self.debugShortId(candidateTabId)) " +
-                    "surface=\(Self.debugShortId(candidateSurfaceId)) " +
-                    "target=\(Self.debugShortId(preferredPanelId)) " +
-                    "match=\(candidateSurfaceId == preferredPanelId ? 1 : 0)"
-                )
-#endif
-            }
-            firstResponderObserver = NotificationCenter.default.addObserver(
-                forName: .ghosttyDidBecomeFirstResponderSurface,
-                object: nil,
-                queue: .main
-            ) { note in
-                guard let candidateTabId = note.userInfo?[GhosttyNotificationKey.tabId] as? UUID,
-                      candidateTabId == tab.id,
-                      let candidateSurfaceId = note.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else {
-                    return
-                }
-#if DEBUG
-                dlog(
-                    "reactGrab.pasteback h1.firstResponderEvent " +
-                    "workspace=\(Self.debugShortId(candidateTabId)) " +
-                    "surface=\(Self.debugShortId(candidateSurfaceId)) " +
-                    "target=\(Self.debugShortId(preferredPanelId)) " +
-                    "match=\(candidateSurfaceId == preferredPanelId ? 1 : 0)"
-                )
-#endif
-            }
+            dlog(
+                "reactGrab.pasteback h2.send.sent " +
+                "workspace=\(Self.debugShortId(tab.id)) " +
+                "target=\(Self.debugShortId(terminalPanel.id)) " +
+                "surfaceReady=\(terminalPanel.surface.surface != nil ? 1 : 0) len=\(text.count)"
+            )
         }
-        readyObserver = NotificationCenter.default.addObserver(
-            forName: .terminalSurfaceDidBecomeReady,
-            object: nil,
-            queue: .main
-        ) { note in
-            guard let workspaceId = note.userInfo?["workspaceId"] as? UUID,
-                  workspaceId == tab.id else { return }
-            let surfaceId = note.userInfo?["surfaceId"] as? UUID
-#if DEBUG
-            if isReactGrabPasteback {
-                dlog(
-                    "reactGrab.pasteback h2.surfaceReadyEvent " +
-                    "workspace=\(Self.debugShortId(workspaceId)) " +
-                    "surface=\(Self.debugShortId(surfaceId)) " +
-                    "target=\(Self.debugShortId(preferredPanelId)) " +
-                    "match=\(surfaceId == preferredPanelId ? 1 : 0)"
-                )
-            }
 #endif
-            if let preferredPanelId,
-               let surfaceId,
-               surfaceId != preferredPanelId {
-                return
-            }
-            finishIfReady()
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) {
-            if !resolved {
-#if DEBUG
-                if isReactGrabPasteback {
-                    dlog(
-                        "reactGrab.pasteback h2.send.timeout " +
-                        "workspace=\(Self.debugShortId(tab.id)) " +
-                        "preferred=\(Self.debugShortId(preferredPanelId)) " +
-                        "focused=\(Self.debugShortId(tab.focusedPanelId)) " +
-                        "focusedTerminal=\(Self.debugShortId(tab.focusedTerminalPanel?.id))"
-                    )
-                }
-#endif
-                cleanupObservers()
-                NSLog("Command send: surface not ready after 3.0s")
-            }
-        }
+        return true
     }
 
 #if DEBUG
@@ -6331,7 +6169,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let lineCount = max((targetBytes + baseBytesPerLine - 1) / baseBytesPerLine, minimumLineCount)
 
         let command = #"awk 'BEGIN { for (i = 1; i <= \#(lineCount); ++i) printf "scrollback %06d\n", i }'"# + "\n"
-        sendTextWhenReady(command, to: tab)
+        Self.sendTextToTerminalSurface(command, in: tab)
     }
 
     @objc func openDebugLoremTab(_ sender: Any?) {
@@ -6345,7 +6183,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             lines.append(String(format: "%04d %@", index, base))
         }
         let payload = lines.joined(separator: "\n") + "\n"
-        sendTextWhenReady(payload, to: tab)
+        Self.sendTextToTerminalSurface(payload, in: tab)
     }
 
     @objc func openDebugColorComparisonWorkspaces(_ sender: Any?) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6126,8 +6126,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
 #endif
-        beforeSend?()
-        terminalPanel.sendText(text)
+        terminalPanel.sendText(text, onDispatch: beforeSend)
 #if DEBUG
         if isReactGrabPasteback {
             dlog(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5203,6 +5203,16 @@ final class TerminalSurface: Identifiable, ObservableObject {
         needsConfirmCloseOverrideForTesting = value
     }
 
+    @MainActor
+    func debugPendingSocketInputSnapshot() -> (items: Int, keys: Int, bytes: Int) {
+        let pendingKeys = pendingSocketInputQueue.reduce(into: 0) { count, item in
+            if case .key = item {
+                count += 1
+            }
+        }
+        return (items: pendingSocketInputQueue.count, keys: pendingKeys, bytes: pendingSocketInputBytes)
+    }
+
     /// Test-only helper to deterministically simulate a released runtime surface.
     @MainActor
     func releaseSurfaceForTesting() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3644,12 +3644,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     private enum PendingSocketInput {
-        case text(Data)
+        case text(Data, onDispatch: (() -> Void)?)
         case key(PendingKeyEvent)
 
         var estimatedBytes: Int {
             switch self {
-            case .text(let data):
+            case .text(let data, _):
                 return data.count
             case .key(let event):
                 return max(event.label.utf8.count, 1)
@@ -4843,14 +4843,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return ghostty_surface_needs_confirm_quit(surface)
     }
 
-    func sendText(_ text: String) {
+    func sendText(_ text: String, onDispatch: (() -> Void)? = nil) {
         guard let data = text.data(using: .utf8), !data.isEmpty else { return }
         guard let surface = surface else {
-            enqueuePendingSocketInput(.text(data))
+            enqueuePendingSocketInput(.text(data, onDispatch: onDispatch))
             requestBackgroundSurfaceStartIfNeeded()
             return
         }
         writeTextData(data, to: surface)
+        onDispatch?()
     }
 
     @discardableResult
@@ -5147,8 +5148,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         var queuedKeys = 0
         for item in queued {
             switch item {
-            case .text(let chunk):
+            case .text(let chunk, let onDispatch):
                 writeTextData(chunk, to: surface)
+                onDispatch?()
             case .key(let event):
                 queuedKeys += 1
                 sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)

--- a/Sources/Panels/ReactGrab.swift
+++ b/Sources/Panels/ReactGrab.swift
@@ -79,8 +79,23 @@ private enum ReactGrabPastebackContentFilter {
         "\u{FEFF}",
     ]
 
+    private static func isAllowedPastebackScalar(_ scalar: Unicode.Scalar) -> Bool {
+        if dangerousScalars.contains(scalar) {
+            return false
+        }
+
+        switch scalar.value {
+        case 0x09, 0x0A:
+            return true
+        case 0x00 ... 0x1F, 0x7F ... 0x9F:
+            return false
+        default:
+            return true
+        }
+    }
+
     static func filtered(_ text: String) -> String {
-        String(text.unicodeScalars.filter { !dangerousScalars.contains($0) })
+        String(String.UnicodeScalarView(text.unicodeScalars.filter(isAllowedPastebackScalar)))
     }
 }
 
@@ -115,6 +130,13 @@ enum ReactGrabPastebackContentExtractor {
 
         var normalizeBlockText = function(text) {
             return normalizeWhitespace(text).replace(/\\n{3,}/g, '\\n\\n').trim();
+        };
+
+        var normalizePreformattedText = function(text) {
+            return String(text || '')
+                .replace(/\\r\\n?/g, '\\n')
+                .replace(/\\u00A0/g, ' ')
+                .replace(/^\\n+|\\n+$/g, '');
         };
 
         var isHidden = function(element) {
@@ -178,7 +200,6 @@ enum ReactGrabPastebackContentExtractor {
         var pushBlock = function(blocks, value) {
             var text = normalizeBlockText(value);
             if (!text) return;
-            if (blocks.length > 0 && blocks[blocks.length - 1] === text) return;
             blocks.push(text);
         };
 
@@ -194,10 +215,9 @@ enum ReactGrabPastebackContentExtractor {
             if (isHidden(element) || skipTags[element.tagName]) return;
 
             if (element.tagName === 'PRE' || element.tagName === 'CODE') {
-                var codeText = element.innerText || element.textContent || '';
-                codeText = String(codeText).replace(/^\\n+|\\n+$/g, '');
+                var codeText = normalizePreformattedText(element.innerText || element.textContent || '');
                 if (codeText) {
-                    pushBlock(blocks, '```\\n' + codeText + '\\n```');
+                    blocks.push('```\\n' + codeText + '\\n```');
                 }
                 return;
             }

--- a/Sources/Panels/ReactGrab.swift
+++ b/Sources/Panels/ReactGrab.swift
@@ -84,6 +84,188 @@ private enum ReactGrabPastebackContentFilter {
     }
 }
 
+enum ReactGrabPastebackContentExtractor {
+    static let functionName = "__cmuxReactGrabExtractPastebackContent"
+
+    static let installerSource = """
+    (function() {
+        var functionName = '\(functionName)';
+        if (typeof window[functionName] === 'function') {
+            return;
+        }
+
+        var blockTags = {
+            ARTICLE: true, ASIDE: true, BLOCKQUOTE: true, BUTTON: true, DD: true,
+            DETAILS: true, DIALOG: true, DIV: true, DL: true, DT: true,
+            FIELDSET: true, FIGCAPTION: true, FIGURE: true, FOOTER: true,
+            FORM: true, H1: true, H2: true, H3: true, H4: true, H5: true,
+            H6: true, HEADER: true, HR: true, LI: true, MAIN: true, NAV: true,
+            OL: true, P: true, PRE: true, SECTION: true, TABLE: true, TD: true,
+            TH: true, UL: true
+        };
+        var skipTags = { NOSCRIPT: true, SCRIPT: true, STYLE: true, SVG: true, TEMPLATE: true };
+
+        var normalizeWhitespace = function(text) {
+            return String(text || '')
+                .replace(/\\u00A0/g, ' ')
+                .replace(/[ \\t\\f\\v\\r]+/g, ' ')
+                .replace(/ *\\n+ */g, '\\n')
+                .trim();
+        };
+
+        var normalizeBlockText = function(text) {
+            return normalizeWhitespace(text).replace(/\\n{3,}/g, '\\n\\n').trim();
+        };
+
+        var isHidden = function(element) {
+            if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+            if (element.hasAttribute('hidden')) return true;
+            if (element.getAttribute('aria-hidden') === 'true') return true;
+            var style = window.getComputedStyle ? window.getComputedStyle(element) : null;
+            return !!style && (style.display === 'none' || style.visibility === 'hidden');
+        };
+
+        var hasBlockChild = function(element) {
+            for (var child = element.firstElementChild; child; child = child.nextElementSibling) {
+                if (isHidden(child) || skipTags[child.tagName]) continue;
+                if (blockTags[child.tagName] && child.tagName !== 'BUTTON') {
+                    return true;
+                }
+            }
+            return false;
+        };
+
+        var joinInlineParts = function(parts) {
+            return normalizeWhitespace(parts.filter(Boolean).join(' '));
+        };
+
+        var textFromNode = function(node) {
+            return normalizeWhitespace(node && node.textContent ? node.textContent : '');
+        };
+
+        var renderInline = function(node) {
+            if (!node) return '';
+            if (node.nodeType === Node.TEXT_NODE) {
+                return normalizeWhitespace(node.textContent || '');
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) return '';
+
+            var element = node;
+            if (isHidden(element) || skipTags[element.tagName]) return '';
+
+            if (element.tagName === 'BR') return '\\n';
+            if (element.tagName === 'IMG') {
+                return normalizeWhitespace(element.getAttribute('alt') || '');
+            }
+            if (element.tagName === 'INPUT') {
+                var type = (element.getAttribute('type') || '').toLowerCase();
+                if (type === 'button' || type === 'submit' || type === 'reset') {
+                    return normalizeWhitespace(element.value || element.getAttribute('value') || '');
+                }
+            }
+            if (element.tagName === 'A' && !hasBlockChild(element)) {
+                var href = element.getAttribute('href') || element.href || '';
+                var linkText = joinInlineParts(Array.prototype.map.call(element.childNodes, renderInline)) || textFromNode(element);
+                if (!href) return linkText;
+                return '[' + (linkText || href) + '](' + href + ')';
+            }
+            if (blockTags[element.tagName] && element.tagName !== 'BUTTON') {
+                return textFromNode(element);
+            }
+            return joinInlineParts(Array.prototype.map.call(element.childNodes, renderInline));
+        };
+
+        var pushBlock = function(blocks, value) {
+            var text = normalizeBlockText(value);
+            if (!text) return;
+            if (blocks.length > 0 && blocks[blocks.length - 1] === text) return;
+            blocks.push(text);
+        };
+
+        var renderBlocks = function(node, blocks) {
+            if (!node) return;
+            if (node.nodeType === Node.TEXT_NODE) {
+                pushBlock(blocks, node.textContent || '');
+                return;
+            }
+            if (node.nodeType !== Node.ELEMENT_NODE) return;
+
+            var element = node;
+            if (isHidden(element) || skipTags[element.tagName]) return;
+
+            if (element.tagName === 'PRE' || element.tagName === 'CODE') {
+                var codeText = element.innerText || element.textContent || '';
+                codeText = String(codeText).replace(/^\\n+|\\n+$/g, '');
+                if (codeText) {
+                    pushBlock(blocks, '```\\n' + codeText + '\\n```');
+                }
+                return;
+            }
+
+            if (/^H[1-6]$/.test(element.tagName)) {
+                var headingText = textFromNode(element);
+                if (!headingText) return;
+                if (element.tagName === 'H1' || element.tagName === 'H2') {
+                    var underline = (element.tagName === 'H1' ? '=' : '-').repeat(Math.min(Math.max(headingText.length, 3), 80));
+                    pushBlock(blocks, headingText + '\\n' + underline);
+                } else {
+                    var level = Number(element.tagName.slice(1)) || 3;
+                    pushBlock(blocks, '#'.repeat(level) + ' ' + headingText);
+                }
+                return;
+            }
+
+            if (element.tagName === 'LI') {
+                pushBlock(blocks, '- ' + textFromNode(element));
+                return;
+            }
+
+            if (!hasBlockChild(element)) {
+                if (element.tagName === 'BUTTON') {
+                    var buttonText = joinInlineParts(Array.prototype.map.call(element.childNodes, renderInline)) ||
+                        normalizeWhitespace(element.getAttribute('aria-label') || element.value || '');
+                    pushBlock(blocks, buttonText);
+                    return;
+                }
+                pushBlock(blocks, joinInlineParts(Array.prototype.map.call(element.childNodes, renderInline)) || textFromNode(element));
+                return;
+            }
+
+            for (var child = element.firstChild; child; child = child.nextSibling) {
+                renderBlocks(child, blocks);
+            }
+        };
+
+        window[functionName] = function(elements, fallbackContent) {
+            try {
+                var roots = Array.isArray(elements) ? elements.filter(Boolean) : [];
+                if (roots.length > 0) {
+                    var blocks = [];
+                    for (var i = 0; i < roots.length; i += 1) {
+                        renderBlocks(roots[i], blocks);
+                    }
+                    var result = blocks.join('\\n\\n').replace(/\\n{3,}/g, '\\n\\n').trim();
+                    if (result) return result;
+                }
+            } catch (_) {}
+            return typeof fallbackContent === 'string' ? fallbackContent : String(fallbackContent || '');
+        };
+    })();
+    """
+
+    static func invocationScript(
+        elementsExpression: String,
+        fallbackContentLiteral: String
+    ) -> String {
+        """
+        (function() {
+            \(installerSource)
+            return window['\(functionName)'](\(elementsExpression), \(fallbackContentLiteral));
+        })();
+        """
+    }
+}
+
 // MARK: - Script Loader
 
 /// Fetches, integrity-checks, and caches the react-grab script.
@@ -337,6 +519,8 @@ extension BrowserPanel {
         (function() {
             var handler = window.webkit && window.webkit.messageHandlers && window.webkit.messageHandlers.\(handlerName);
             var updaterName = '\(reactGrabBridgeSessionUpdaterName)';
+            \(ReactGrabPastebackContentExtractor.installerSource)
+            var extractPastebackContent = window['\(ReactGrabPastebackContentExtractor.functionName)'];
             var refreshSessionToken = function() {
                 var syncToken = window[updaterName];
                 if (typeof syncToken !== 'function') return false;
@@ -373,7 +557,13 @@ extension BrowserPanel {
                         onCopySuccess: function(elements, content) {
                             var token = activeToken;
                             activeToken = null;
-                            if (handler) handler.postMessage({ type: 'copySuccess', content: String(content || ''), token: token });
+                            var pastebackContent = content;
+                            try {
+                                if (typeof extractPastebackContent === 'function') {
+                                    pastebackContent = extractPastebackContent(elements, content);
+                                }
+                            } catch (_) {}
+                            if (handler) handler.postMessage({ type: 'copySuccess', content: String(pastebackContent || ''), token: token });
                         }
                     }
                 });

--- a/Sources/Panels/ReactGrab.swift
+++ b/Sources/Panels/ReactGrab.swift
@@ -186,7 +186,9 @@ enum ReactGrabPastebackContentExtractor {
                 }
             }
             if (element.tagName === 'A' && !hasBlockChild(element)) {
-                var href = element.getAttribute('href') || element.href || '';
+                var href = element.hasAttribute('href')
+                    ? (element.getAttribute('href') || '')
+                    : (element.href || '');
                 var linkText = joinInlineParts(Array.prototype.map.call(element.childNodes, renderInline)) || textFromNode(element);
                 if (!href) return linkText;
                 return '[' + (linkText || href) + '](' + href + ')';

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -189,8 +189,8 @@ final class TerminalPanel: Panel, ObservableObject {
 
     // MARK: - Terminal-specific methods
 
-    func sendText(_ text: String) {
-        surface.sendText(text)
+    func sendText(_ text: String, onDispatch: (() -> Void)? = nil) {
+        surface.sendText(text, onDispatch: onDispatch)
     }
 
     func sendInput(_ text: String) {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -346,14 +346,14 @@ final class BrowserPanelReactGrabBridgeTests: XCTestCase {
         let terminalId = UUID()
         let panel = BrowserPanel(workspaceId: workspaceId)
         let expectation = expectation(description: "react grab pasteback notification")
-        let rawContent = "<button>Sa\u{202E}v\u{200B}e</button>\u{2069}\n"
+        let rawContent = "<button>\u{0007}Sa\u{202E}v\u{200B}e</button>\u{2069}\n\t"
 
         let observer = NotificationCenter.default.addObserver(
             forName: .reactGrabDidCopySelection,
             object: nil,
             queue: .main
         ) { notification in
-            XCTAssertEqual(notification.userInfo?[ReactGrabPastebackNotificationKey.content] as? String, "<button>Save</button>\n")
+            XCTAssertEqual(notification.userInfo?[ReactGrabPastebackNotificationKey.content] as? String, "<button>Save</button>\n\t")
             expectation.fulfill()
         }
         defer { NotificationCenter.default.removeObserver(observer) }
@@ -426,6 +426,46 @@ final class BrowserPanelReactGrabBridgeTests: XCTestCase {
             "\(heading)\n\(String(repeating: "=", count: heading.count))\n\n" +
                 "Vercel provides the developer tools and cloud infrastructure to build, scale, and secure a faster, more personalized web.\n\n" +
                 "[Deploy](/new) [Get a Demo](/contact/sales/demo)"
+        )
+    }
+
+    func testPastebackExtractorPreservesRepeatedBlocksAndCodeIndentation() async throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let html = """
+        <div id="target">
+          <p>echo ready</p>
+          <p>echo ready</p>
+          <pre><code id="snippet"></code></pre>
+        </div>
+        """
+        let htmlLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral(html))
+        let codeLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral("if true:\n    print(\"a\")\n\tprint(\"b\")"))
+        let fallbackLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral("fallback"))
+
+        let result = try await panel.evaluateJavaScript(
+            """
+            document.body.innerHTML = \(htmlLiteral);
+            document.getElementById('snippet').textContent = \(codeLiteral);
+            \(ReactGrabPastebackContentExtractor.invocationScript(
+                elementsExpression: "[document.getElementById('target')]",
+                fallbackContentLiteral: fallbackLiteral
+            ))
+            """
+        ) as? String
+
+        XCTAssertEqual(
+            result,
+            """
+            echo ready
+
+            echo ready
+
+            ```
+            if true:
+                print("a")
+            \tprint("b")
+            ```
+            """
         )
     }
 }

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -388,6 +388,46 @@ final class BrowserPanelReactGrabBridgeTests: XCTestCase {
         let refreshedToken = try await panel.evaluateJavaScript("window.__cmuxTestRoundTripToken") as? String
         XCTAssertEqual(refreshedToken, token)
     }
+
+    func testPastebackExtractorFormatsReadableContentFromSelectedElements() async throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let html = """
+        <div id="target" class="hero-module__heroCell">
+          <h1>Build and deploy on the AI Cloud.</h1>
+          <p>Vercel provides the developer tools and cloud infrastructure to build, scale, and secure a faster, more personalized web.</p>
+          <div class="actions">
+            <a href="/new">Deploy</a>
+            <a href="/contact/sales/demo">Get a Demo</a>
+          </div>
+        </div>
+        """
+        let fallback = """
+        <div class="hero-module__heroCell">
+          Build and deploy on the AI Cloud.
+          Vercel provides the developer tools and cloud infrastructure to bu...
+        </div>
+        """
+        let htmlLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral(html))
+        let fallbackLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral(fallback))
+        let heading = "Build and deploy on the AI Cloud."
+
+        let result = try await panel.evaluateJavaScript(
+            """
+            document.body.innerHTML = \(htmlLiteral);
+            \(ReactGrabPastebackContentExtractor.invocationScript(
+                elementsExpression: "[document.getElementById('target')]",
+                fallbackContentLiteral: fallbackLiteral
+            ))
+            """
+        ) as? String
+
+        XCTAssertEqual(
+            result,
+            "\(heading)\n\(String(repeating: "=", count: heading.count))\n\n" +
+                "Vercel provides the developer tools and cloud infrastructure to build, scale, and secure a faster, more personalized web.\n\n" +
+                "[Deploy](/new) [Get a Demo](/contact/sales/demo)"
+        )
+    }
 }
 
 

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -468,6 +468,37 @@ final class BrowserPanelReactGrabBridgeTests: XCTestCase {
             """
         )
     }
+
+    func testPastebackExtractorTreatsEmptyAnchorHrefAsPlainText() async throws {
+        let panel = BrowserPanel(workspaceId: UUID())
+        let html = """
+        <div id="target">
+          <p><a href="">Start Deploying</a></p>
+          <p><a>Plain Anchor</a></p>
+        </div>
+        """
+        let htmlLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral(html))
+        let fallbackLiteral = try XCTUnwrap(cmuxJavaScriptStringLiteral("fallback"))
+
+        let result = try await panel.evaluateJavaScript(
+            """
+            document.body.innerHTML = \(htmlLiteral);
+            \(ReactGrabPastebackContentExtractor.invocationScript(
+                elementsExpression: "[document.getElementById('target')]",
+                fallbackContentLiteral: fallbackLiteral
+            ))
+            """
+        ) as? String
+
+        XCTAssertEqual(
+            result,
+            """
+            Start Deploying
+
+            Plain Anchor
+            """
+        )
+    }
 }
 
 

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -219,7 +219,7 @@ final class ReactGrabPastebackTargetTests: XCTestCase {
         )
     }
 
-    func testSendTextToTerminalSurfaceQueuesImmediateTextOnPreferredTerminalWhenSurfaceIsMissing() {
+    func testSendTextToTerminalSurfaceDoesNotInvokeBeforeSendWhileTextIsOnlyQueued() {
         let workspace = Workspace(title: "Tests")
         guard let terminalId = workspace.focusedPanelId,
               let terminalPanel = workspace.terminalPanel(for: terminalId),
@@ -246,7 +246,7 @@ final class ReactGrabPastebackTargetTests: XCTestCase {
             }
         )
 
-        XCTAssertTrue(beforeSendCalled)
+        XCTAssertFalse(beforeSendCalled)
         let snapshot = terminalPanel.surface.debugPendingSocketInputSnapshot()
         XCTAssertEqual(snapshot.items, 1)
         XCTAssertEqual(snapshot.keys, 0)

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -219,6 +219,40 @@ final class ReactGrabPastebackTargetTests: XCTestCase {
         )
     }
 
+    func testSendTextToTerminalSurfaceQueuesImmediateTextOnPreferredTerminalWhenSurfaceIsMissing() {
+        let workspace = Workspace(title: "Tests")
+        guard let terminalId = workspace.focusedPanelId,
+              let terminalPanel = workspace.terminalPanel(for: terminalId),
+              let browserPanel = workspace.newBrowserSplit(
+                from: terminalId,
+                orientation: .horizontal
+              ) else {
+            XCTFail("Expected initial workspace split")
+            return
+        }
+
+        workspace.focusPanel(browserPanel.id)
+        XCTAssertNil(terminalPanel.surface.surface)
+
+        var beforeSendCalled = false
+        let payload = "<button>Save</button>"
+        XCTAssertTrue(
+            AppDelegate.sendTextToTerminalSurface(
+                payload,
+                in: workspace,
+                preferredPanelId: terminalId
+            ) {
+                beforeSendCalled = true
+            }
+        )
+
+        XCTAssertTrue(beforeSendCalled)
+        let snapshot = terminalPanel.surface.debugPendingSocketInputSnapshot()
+        XCTAssertEqual(snapshot.items, 1)
+        XCTAssertEqual(snapshot.keys, 0)
+        XCTAssertEqual(snapshot.bytes, payload.utf8.count)
+    }
+
     func testShortcutStillRoutesTerminalPastebackWhenWebViewFocusIsDeferred() {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,


### PR DESCRIPTION
## Summary
- replace `AppDelegate.sendTextWhenReady` with direct `TerminalSurface.sendText` routing
- use Ghostty's built-in `ghostty_surface_text` path and deferred queue instead of app-level observers and a 3 second timeout
- add regression coverage that proves the preferred terminal target queues text immediately when the runtime surface is still missing

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag txtapi`
- local unit tests not run, repo policy prefers CI for tests

## Issues
- Related: task "Figure out the right Ghostty API to insert a lot of text and remove the sendTextWhenReady code smell"

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route all terminal text inserts through Ghostty’s queued text API to remove app-level deferral logic and avoid 3s timeouts. Adds a more robust ReactGrab pasteback extractor, defers `beforeSend` until text dispatch, and treats empty links as plain text. Addresses the Linear task to use the right Ghostty API for large text inserts and remove the `sendTextWhenReady` code smell.

- **New Features**
  - ReactGrab pasteback extracts readable content from selected elements (headings, paragraphs, links, code) with markdown-style formatting and a safe fallback.
  - Preserves tabs/newlines and filters control characters during pasteback.

- **Bug Fixes**
  - `beforeSend` runs only when text is sent to a live surface; queued sends defer the callback. Added tests for extractor formatting (headings/links/code, indentation) and queued-callback behavior.
  - Empty anchor `href` values are ignored during pasteback and rendered as plain text.

<sup>Written for commit 004a2c559f8722cc1dabe3dc8cecf39eeca93c38. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Injected pasteback extractor that converts copied HTML into normalized, readable plain-text/markdown-like output and tightens scalar filtering (preserves tabs/newlines).

* **Bug Fixes**
  * Terminal text routing now resolves target panels immediately, delegates queuing to the terminal surface, and consolidates routing/debug logging. Dispatch completion callbacks are invoked on actual send.

* **Tests**
  * Added tests for pasteback extraction formatting and terminal send/queue behavior.

* **Chores**
  * Added a debug helper to inspect pending terminal input state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->