### PR TITLE
Fix terminal rendering lag during key repeat

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6727,7 +6727,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var interpretMs: Double = 0
         var syncPreeditMs: Double = 0
         var ghosttySendMs: Double = 0
-        var refreshMs: Double = 0
         defer {
             let totalMs = (ProcessInfo.processInfo.systemUptime - phaseTotalStart) * 1000.0
             CmuxTypingTiming.logBreakdown(
@@ -6742,7 +6741,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                     ("interpretMs", interpretMs),
                     ("syncPreeditMs", syncPreeditMs),
                     ("ghosttySendMs", ghosttySendMs),
-                    ("refreshMs", refreshMs),
                 ],
                 extra: "marked=\(hasMarkedText() ? 1 : 0)"
             )
@@ -6992,7 +6990,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Use accumulated text from insertText (for IME), or compute text for key
         let accumulatedText = keyTextAccumulator ?? []
-        var shouldRefreshAfterTextInput = false
         if !accumulatedText.isEmpty {
             // Accumulated text comes from insertText (IME composition result).
             // These never have "composing" set to true because these are the
@@ -7000,7 +6997,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEvent.composing = false
             for text in accumulatedText {
                 if shouldSendText(text) {
-                    shouldRefreshAfterTextInput = true
 #if DEBUG
                     let sendTimingStart = CmuxTypingTiming.start()
                     let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -7079,7 +7075,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 if shouldSendText(text),
                    !suppressShiftSpaceFallbackText,
                    !suppressComposingFallbackText {
-                    shouldRefreshAfterTextInput = true
 #if DEBUG
                     let sendTimingStart = CmuxTypingTiming.start()
                     let ghosttySendStart = ProcessInfo.processInfo.systemUptime
@@ -7141,17 +7136,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
         }
 
-        if shouldRefreshAfterTextInput {
-#if DEBUG
-            let refreshStart = ProcessInfo.processInfo.systemUptime
-#endif
-            terminalSurface?.forceRefresh(reason: "keyDown.textInput")
-#if DEBUG
-            refreshMs = (ProcessInfo.processInfo.systemUptime - refreshStart) * 1000.0
-#endif
-        }
-
         // Rendering is driven by Ghostty's wakeups/renderer.
+        // Avoid synchronous forceRefresh in the text-input hot path: during key
+        // repeat it runs on the main thread and can starve the coalesced Ghostty
+        // tick/wakeup work, which makes the terminal appear to freeze and then
+        // catch up in bursts. Geometry/focus recovery paths trigger explicit
+        // refreshes when needed.
     }
 
     @discardableResult


### PR DESCRIPTION
## Summary
Hi! I'm really enjoying using cmux — thanks for building it.
I ran into the key-repeat lag described in #1829 and dug into it a bit.

- What changed?
    - Removed the synchronous `terminalSurface?.forceRefresh(reason: "keyDown.textInput")` call from `GhosttyNSView.keyDown(with:)`.
- Why?
     - Holding down keys could make terminal rendering freeze briefly and then catch up in bursts.
     - My understanding is that this extra force-refresh was adding synchronous main-thread work in the text-input hot path and interfering with Ghostty’s normal wakeup/tick-driven rendering.

## Testing

- How did you test this change?
    - Built a tagged debug app locally and tested terminal input behavior manually.
- What did you verify manually?
    - Held printable keys in terminal panes
    - Held backspace
    - Checked Neovim `hjkl`
    - Checked arrow keys
    - Verified that rendering stayed smooth instead of freezing and catching up in bursts

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved keyboard input responsiveness by streamlining the rendering pipeline and removing unnecessary refresh operations during text input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes render lag during key repeat by removing a synchronous `terminalSurface?.forceRefresh` in the text-input path. Rendering now stays smooth under sustained input and relies on Ghostty’s normal wakeup/tick cycle.

- **Bug Fixes**
  - Removed `forceRefresh(reason: "keyDown.textInput")` from `GhosttyNSView.keyDown(with:)` to avoid main-thread stalls during key repeat.
  - Dropped `refreshMs` from debug timing logs.
  - Added comment clarifying why synchronous refresh is avoided; explicit refresh remains in geometry/focus paths.

<sup>Written for commit 7b9b7486e19fad273d198e7961214c1ef1456c98. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

