### PR TITLE
fix: keep systemDefined events out of shortcut monitor

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8900,10 +8900,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func installShortcutMonitor() {
         // Local monitor only receives events when app is active (not global)
         shortcutMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: [.keyDown, .keyUp, .flagsChanged, .systemDefined]
+            matching: [.keyDown, .keyUp, .flagsChanged]
         ) { [weak self] event in
             guard let self else { return event }
-            if event.type == .keyDown || event.type == .systemDefined {
+            if event.type == .keyDown {
 #if DEBUG
                 let phaseTotalStart = ProcessInfo.processInfo.systemUptime
                 let preludeStart = ProcessInfo.processInfo.systemUptime


### PR DESCRIPTION
Hi, me again.
while testing my other PR #3131 i noticed some strange behavior of the closing dialog when pressing cmd+q as well as when closing a tab while running xclock, when there's only one tab.
So i thought i might as well look into this.

## Summary

- What changed?
  - Removed `.systemDefined` from the app-level shortcut monitor in `AppDelegate.installShortcutMonitor()`, and 
 stopped routing `.systemDefined` events through `handleCustomShortcut(...)`.
- Why?
  - I found a regression where close confirmation dialogs could get into a broken state in current `main`.
  - I bisected it to `1a95cbba`.
  - The regression went away when I removed `.systemDefined` from the global app shortcut monitor.
  - The shortcut recorder’s own `.systemDefined` handling is left unchanged.

## Testing

- How did you test this change?
  - I reproduced the issue locally in a tagged debug build, then bisected current `main` to find the first bad  
 commit, and rebuilt with this fix.
- What did you verify manually?
  - Cmd+Q confirmation dialog buttons work again                                     
  - Close workspace/tab confirmation dialogs work again
  - The app no longer gets stuck in the broken post-dialog state

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced keyboard event handling to improve keyboard shortcut reliability. The app now correctly filters out system-defined keyboard events and processes user-initiated shortcuts exclusively on key-down events. Other critical keyboard functionality remains fully functional, including browser omnibar interaction handling and Escape key suppression to ensure consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes `.systemDefined` events from the app’s shortcut monitor to stop intercepting OS-level keys and fix broken close confirmation dialogs. Restores expected behavior for Cmd+Q and closing a workspace/tab.

- **Bug Fixes**
  - Removed `.systemDefined` from `NSEvent.addLocalMonitorForEvents` and from routing to the custom shortcut handler; only `.keyDown` is handled.
  - Fixes: Cmd+Q confirmation dialog buttons work, close workspace/tab dialogs behave correctly, and no post-dialog stuck state.
  - The shortcut recorder’s own `.systemDefined` handling is unchanged.

<sup>Written for commit 77260a9a9ab6a4d30adeefa58f346e76a56032c1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

