### PR TITLE
Add `cmux hermes` launcher command

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1837,6 +1837,15 @@ struct CMUXCLI {
             return
         }
 
+        if command == "hermes" {
+            try runHermes(
+                commandArgs: commandArgs,
+                socketPath: resolvedSocketPath,
+                explicitPassword: socketPasswordArg
+            )
+            return
+        }
+
         // Codex hooks management (no socket needed)
         if command == "codex" {
             let sub = commandArgs.first?.lowercased() ?? "help"
@@ -7182,6 +7191,28 @@ struct CMUXCLI {
               cmux omc
               cmux omc team 3:claude "implement feature"
               cmux omc --watch
+            """)
+        case "hermes":
+            return String(localized: "cli.hermes.usage", defaultValue: """
+            Usage: cmux hermes [hermes-args...]
+
+            Launch Hermes Agent with native cmux pane integration.
+
+            Hermes is an open-source AI coding agent with TUI mode, multi-model
+            support, and a skill/delegation system. This command sets up a tmux
+            shim so Hermes delegation creates native cmux splits.
+
+            This command:
+              - sets a tmux-like environment so Hermes uses cmux splits
+              - prepends a private tmux shim to PATH
+              - forwards all remaining arguments to hermes
+
+            Install: pip install hermes-agent  (or uv pip install hermes-agent)
+
+            Examples:
+              cmux hermes
+              cmux hermes --tui
+              cmux hermes --tui --yolo
             """)
         case "identify":
             return """
@@ -13698,6 +13729,115 @@ struct CMUXCLI {
         return normalized.joined(separator: " ")
     }
 
+    // MARK: - cmux hermes (Hermes Agent)
+
+    private func resolveHermesExecutable(searchPath: String?) -> String? {
+        resolveExecutableInSearchPath("hermes", searchPath: searchPath)
+    }
+
+    private func createHermesShimDirectory() throws -> URL {
+        let tmuxScript = """
+        #!/usr/bin/env bash
+        set -euo pipefail
+        case "${1:-}" in
+          -V|-v) echo "tmux 3.4"; exit 0 ;;
+        esac
+        exec "${CMUX_HERMES_CMUX_BIN:-cmux}" __tmux-compat "$@"
+        """
+        return try createTmuxCompatShimDirectory(
+            directoryName: "hermes-bin",
+            tmuxShimScript: tmuxScript
+        )
+    }
+
+    private func configureHermesEnvironment(
+        processEnvironment: [String: String],
+        shimDirectory: URL,
+        executablePath: String,
+        socketPath: String,
+        explicitPassword: String?,
+        focusedContext: TmuxCompatFocusedContext?
+    ) {
+        configureTmuxCompatEnvironment(
+            processEnvironment: processEnvironment,
+            shimDirectory: shimDirectory,
+            executablePath: executablePath,
+            socketPath: socketPath,
+            explicitPassword: explicitPassword,
+            focusedContext: focusedContext,
+            tmuxPathPrefix: "cmux-hermes",
+            cmuxBinEnvVar: "CMUX_HERMES_CMUX_BIN",
+            termOverrideEnvVar: "CMUX_HERMES_TERM"
+        )
+    }
+
+    private func runHermes(
+        commandArgs: [String],
+        socketPath: String,
+        explicitPassword: String?
+    ) throws {
+        let processEnvironment = ProcessInfo.processInfo.environment
+        var launcherEnvironment = processEnvironment
+        launcherEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        launcherEnvironment["CMUX_SOCKET"] = socketPath
+        if let explicitPassword,
+           !explicitPassword.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            launcherEnvironment["CMUX_SOCKET_PASSWORD"] = explicitPassword
+        }
+
+        let hermesExecutablePath = resolveHermesExecutable(searchPath: launcherEnvironment["PATH"])
+        if hermesExecutablePath == nil {
+            let checkProcess = Process()
+            checkProcess.executableURL = URL(fileURLWithPath: "/usr/bin/which")
+            checkProcess.arguments = ["hermes"]
+            checkProcess.standardOutput = Pipe()
+            checkProcess.standardError = Pipe()
+            try? checkProcess.run()
+            checkProcess.waitUntilExit()
+            if checkProcess.terminationStatus != 0 {
+                throw CLIError(message: "hermes is not installed. Install it first:\n  pip install hermes-agent\n\nThen run: cmux hermes")
+            }
+        }
+
+        let shimDirectory = try createHermesShimDirectory()
+        let executablePath = resolvedExecutableURL()?.path ?? (args.first ?? "cmux")
+        let focusedContext = tmuxCompatFocusedContext(
+            processEnvironment: launcherEnvironment,
+            explicitPassword: explicitPassword
+        )
+        configureHermesEnvironment(
+            processEnvironment: launcherEnvironment,
+            shimDirectory: shimDirectory,
+            executablePath: executablePath,
+            socketPath: socketPath,
+            explicitPassword: explicitPassword,
+            focusedContext: focusedContext
+        )
+
+        let launchPath = hermesExecutablePath ?? "hermes"
+        exportAgentLaunchCommandEnvironment(
+            launcher: "hermes",
+            executablePath: executablePath,
+            arguments: [executablePath, "hermes"] + commandArgs,
+            workingDirectory: launcherEnvironment["PWD"]
+        )
+        var argv = ([launchPath] + commandArgs).map { strdup($0) }
+        defer {
+            for item in argv {
+                free(item)
+            }
+        }
+        argv.append(nil)
+
+        if hermesExecutablePath != nil {
+            execv(launchPath, &argv)
+        } else {
+            execvp("hermes", &argv)
+        }
+        let code = errno
+        throw CLIError(message: "Failed to launch hermes: \(String(cString: strerror(code)))\n\nIs hermes-agent installed? Install with:\n  pip install hermes-agent")
+    }
+
     // MARK: - Codex hooks
 
     /// The hooks.json content that cmux installs into ~/.codex/.
@@ -15675,6 +15815,7 @@ export default CMUXSessionRestore;
           omo [opencode-args...]
           omx [omx-args...]
           omc [omc-args...]
+          hermes [hermes-args...]
           codex <install-hooks|uninstall-hooks>
           opencode <install-hooks|uninstall-hooks>
           ping


### PR DESCRIPTION
Closes #3140

## Summary
- Add `cmux hermes [hermes-args...]` launcher command following the same pattern as `cmux omx`, `cmux omo`, and `cmux omc`
- Sets up the tmux shim so Hermes Agent delegation creates native cmux splits
- Resolves hermes executable, configures environment, and execs into it
- Adds help text and command listing entry

## Implementation
Follows the established agent launcher pattern:
- `resolveHermesExecutable()` - find the hermes binary on PATH
- `createHermesShimDirectory()` - create tmux shim that routes to `cmux __tmux-compat`
- `configureHermesEnvironment()` - set up `CMUX_SOCKET_PATH`, tmux shim PATH prefix
- `runHermes()` - orchestrate setup and exec into hermes

## Test plan
- [ ] `cmux hermes --help` shows usage text
- [ ] `cmux hermes --tui` launches Hermes in TUI mode with cmux tmux shim active
- [ ] Hermes delegation creates native cmux splits instead of tmux panes
- [ ] `cmux help` lists `hermes` in command listing

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `cmux hermes` launcher to run Hermes Agent with native cmux pane integration, so delegation opens cmux splits instead of tmux panes. Also adds usage text and lists the command in `cmux help`.

- **New Features**
  - `cmux hermes [hermes-args...]` launches `hermes` with cmux-aware tmux shim.
  - Shim routes tmux calls to `cmux __tmux-compat` and is prepended to PATH.
  - Sets env vars (`CMUX_SOCKET_PATH`, `CMUX_SOCKET_PASSWORD`, `CMUX_HERMES_CMUX_BIN`, `CMUX_HERMES_TERM`) and resolves the `hermes` binary.
  - Forwards all args to `hermes`; `cmux help` includes `hermes`.

<sup>Written for commit 5f2f294dce3a11cd1d48aaa15b479bc1e5e25652. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new `cmux hermes` command to launch the Hermes Agent with native cmux pane integration
  * Automatically configures environment variables for seamless Hermes integration within cmux panes
  * Improved error handling and messaging for missing installations and launch failures
  * Updated CLI help and usage documentation to include the new command

<!-- end of auto-generated comment: release notes by coderabbit.ai -->