### PR TITLE
fix(zsh): guard Ghostty sudo bootstrap against aliases

### DIFF
--- a/Resources/shell-integration/.zshenv
+++ b/Resources/shell-integration/.zshenv
@@ -56,7 +56,21 @@ fi
             if [[ ! -r "${_cmux_ghostty:-}" && -n "${GHOSTTY_RESOURCES_DIR:-}" ]]; then
                 builtin typeset _cmux_ghostty="$GHOSTTY_RESOURCES_DIR/shell-integration/zsh/ghostty-integration"
             fi
-            [[ -r "$_cmux_ghostty" ]] && builtin source -- "$_cmux_ghostty"
+            if [[ -r "$_cmux_ghostty" ]]; then
+                builtin typeset -g _cmux_restore_aliases=0
+                {
+                    if [[ -o aliases ]]; then
+                        _cmux_restore_aliases=1
+                        builtin unsetopt aliases
+                    fi
+                    builtin source -- "$_cmux_ghostty"
+                } always {
+                    if (( _cmux_restore_aliases )); then
+                        builtin setopt aliases
+                    fi
+                    builtin unset _cmux_restore_aliases
+                }
+            fi
         fi
 
         # Load cmux integration (unless disabled)

--- a/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
+++ b/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
@@ -43,8 +43,10 @@ def main() -> int:
         for filename in (".zprofile", ".zshrc"):
             (orig / filename).write_text("", encoding="utf-8")
 
+        # Use the real Ghostty-style `sudo()` definition here: with
+        # `alias sudo='sudo '`, zsh can choke while parsing this exact form.
         (bundled / "ghostty-integration.zsh").write_text(
-            "function sudo() { :; }\n"
+            "sudo() { :; }\n"
             'print -r -- "loaded" >> "$CMUX_TEST_OUT"\n',
             encoding="utf-8",
         )

--- a/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
+++ b/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""
+Regression for issue #3134:
+cmux's zsh bootstrap should load Ghostty's integration without letting a user
+alias like `alias sudo='sudo '` break Ghostty's `sudo()` wrapper definition.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER_DIR = ROOT / "Resources" / "shell-integration"
+
+
+def main() -> int:
+    if not (WRAPPER_DIR / ".zshenv").exists():
+        print(f"SKIP: missing wrapper .zshenv at {WRAPPER_DIR}")
+        return 0
+    if shutil.which("zsh") is None:
+        print("SKIP: zsh is not installed")
+        return 0
+
+    base = Path("/tmp") / f"cmux_issue_3134_{os.getpid()}"
+    try:
+        shutil.rmtree(base, ignore_errors=True)
+        base.mkdir(parents=True, exist_ok=True)
+
+        home = base / "home"
+        orig = base / "orig-zdotdir"
+        bundled = base / "bundled-shell-integration"
+        marker = base / "marker.txt"
+
+        home.mkdir(parents=True, exist_ok=True)
+        orig.mkdir(parents=True, exist_ok=True)
+        bundled.mkdir(parents=True, exist_ok=True)
+
+        (orig / ".zshenv").write_text("alias sudo='sudo '\n", encoding="utf-8")
+        for filename in (".zprofile", ".zshrc"):
+            (orig / filename).write_text("", encoding="utf-8")
+
+        (bundled / "ghostty-integration.zsh").write_text(
+            "function sudo() { :; }\n"
+            'print -r -- "loaded" >> "$CMUX_TEST_OUT"\n',
+            encoding="utf-8",
+        )
+
+        env = dict(os.environ)
+        env["HOME"] = str(home)
+        env["ZDOTDIR"] = str(WRAPPER_DIR)
+        env["GHOSTTY_ZSH_ZDOTDIR"] = str(orig)
+        env["CMUX_SHELL_INTEGRATION_DIR"] = str(bundled)
+        env["CMUX_LOAD_GHOSTTY_ZSH_INTEGRATION"] = "1"
+        env["CMUX_SHELL_INTEGRATION"] = "0"
+        env["CMUX_TEST_OUT"] = str(marker)
+
+        result = subprocess.run(
+            ["zsh", "-d", "-i", "-c", "true"],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=8,
+            check=False,
+        )
+
+        combined = ((result.stdout or "") + (result.stderr or "")).strip()
+        if result.returncode != 0:
+            print(f"FAIL: zsh exited non-zero rc={result.returncode}")
+            if combined:
+                print(combined)
+            return 1
+
+        if not marker.exists():
+            print("FAIL: Ghostty integration was not loaded")
+            if combined:
+                print(combined)
+            return 1
+
+        entries = [
+            line.strip()
+            for line in marker.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        if entries != ["loaded"]:
+            print(f"FAIL: unexpected marker entries {entries!r}")
+            return 1
+
+        print("PASS: cmux zsh bootstrap loads Ghostty integration even when sudo is aliased")
+        return 0
+    finally:
+        shutil.rmtree(base, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
+++ b/tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py
@@ -7,9 +7,9 @@ alias like `alias sudo='sudo '` break Ghostty's `sudo()` wrapper definition.
 
 from __future__ import annotations
 
-import os
 import shutil
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -25,10 +25,8 @@ def main() -> int:
         print("SKIP: zsh is not installed")
         return 0
 
-    base = Path("/tmp") / f"cmux_issue_3134_{os.getpid()}"
+    base = Path(tempfile.mkdtemp(prefix="cmux_issue_3134_"))
     try:
-        shutil.rmtree(base, ignore_errors=True)
-        base.mkdir(parents=True, exist_ok=True)
 
         home = base / "home"
         orig = base / "orig-zdotdir"


### PR DESCRIPTION
A user-defined `alias sudo='sudo '` causes Ghostty's zsh integration to fail while cmux is bootstrapping it, because the sourced file defines `sudo()` directly.

This temporarily disables alias expansion only while sourcing the Ghostty zsh integration from the cmux wrapper, so the existing Ghostty script loads cleanly and user aliases are restored immediately afterward. It also adds a focused regression test for the stacked `.zshenv`/Ghostty bootstrap path.

Verification in this environment:
- `python3 tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py` → skipped because `zsh` is unavailable here
- `python3 -m py_compile tests/test_issue_3134_ghostty_sudo_alias_zsh_bootstrap.py`

Fixes #3134

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Ghostty’s zsh integration from failing during cmux bootstrap when users alias sudo. Temporarily disables alias expansion only while sourcing the integration, then restores it. Fixes #3134.

- **Bug Fixes**
  - Wrap sourcing of the Ghostty zsh integration with an aliases-off/restore guard using zsh’s always block to preserve user aliases.
  - Add a regression test that simulates `alias sudo='sudo '`, uses Ghostty’s exact `sudo()` wrapper, and runs in an isolated temp dir.

<sup>Written for commit dc47f131524789386c23e03a111f05da340e76bd. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3144?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ghostty shell integration now preserves user aliases during initialization, temporarily disables alias handling as needed, restores the original alias state afterward, and avoids leaving temporary state behind.

* **Tests**
  * Added a regression test that verifies Ghostty's alias handling and bootstrap behavior in interactive zsh sessions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->