### PR TITLE
Fix silent app exit when closing the last surface (#3142)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -50073,13 +50073,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut also closes the workspace."
+            "value": "When the focused surface is the last one in its workspace, closing that surface also closes the workspace."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つなら、サーフェスを閉じるショートカットはワークスペースも閉じます。"
+            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つなら、そのサーフェスを閉じるとワークスペースも閉じます。"
           }
         },
         "uk": {
@@ -50102,13 +50102,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When the focused surface is the last one in its workspace, the close-surface shortcut closes only the surface and keeps the workspace open. Use the close-workspace shortcut to close the workspace explicitly."
+            "value": "When the focused surface is the last one in its workspace, closing that surface keeps the workspace open. Use Close Workspace to close the workspace explicitly."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つでも、サーフェスを閉じるショートカットはサーフェスだけを閉じ、ワークスペースは残します。ワークスペースを閉じるショートカットを使うと明示的に閉じられます。"
+            "value": "フォーカス中のサーフェスがそのワークスペースの最後の1つでも、そのサーフェスを閉じてもワークスペースは残ります。ワークスペースを閉じるには「ワークスペースを閉じる」を使ってください。"
           }
         },
         "uk": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -586,6 +586,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private final class MainWindowController: NSWindowController, NSWindowDelegate {
         var onClose: (() -> Void)?
+        var shouldClose: ((NSWindow) -> Bool)?
+
+        func windowShouldClose(_ sender: NSWindow) -> Bool {
+            shouldClose?(sender) ?? true
+        }
 
         func windowWillClose(_ notification: Notification) {
             onClose?()
@@ -805,6 +810,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // Set to true when the user has already confirmed quit via the warning dialog,
     // so applicationShouldTerminate does not show a second alert.
     private var isQuitWarningConfirmed = false
+    private struct PendingTerminationRequest {
+        let source: String
+        let details: [String: String]
+    }
+    private var pendingTerminationRequest: PendingTerminationRequest?
     private var didInstallLifecycleSnapshotObservers = false
     private var didDisableSuddenTermination = false
     private var commandPaletteVisibilityByWindowId: [UUID: Bool] = [:]
@@ -1315,51 +1325,227 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
     }
 
+    private func lifecycleLogData(
+        source: String,
+        details: [String: String] = [:],
+        extra: [String: Any] = [:]
+    ) -> [String: Any] {
+        var data = extra
+        data["source"] = source
+        for (key, value) in details {
+            data[key] = value
+        }
+        return data
+    }
+
+    private func logLifecycleEvent(
+        _ message: String,
+        source: String,
+        details: [String: String] = [:],
+        extra: [String: Any] = [:]
+    ) {
+        let data = lifecycleLogData(source: source, details: details, extra: extra)
+#if DEBUG
+        let fields = data.keys.sorted().compactMap { key -> String? in
+            guard let value = data[key] else { return nil }
+            return "\(key)=\(String(describing: value))"
+        }.joined(separator: " ")
+        if fields.isEmpty {
+            cmuxDebugLog(message)
+        } else {
+            cmuxDebugLog("\(message) \(fields)")
+        }
+#endif
+        sentryBreadcrumb(message, category: "lifecycle", data: data.isEmpty ? nil : data)
+    }
+
+    private func presentQuitWarningAlert() -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(localized: "dialog.quitCmux.title", defaultValue: "Quit cmux?")
+        alert.informativeText = String(localized: "dialog.quitCmux.message", defaultValue: "This will close all windows and workspaces.")
+        alert.addButton(withTitle: String(localized: "dialog.quitCmux.quit", defaultValue: "Quit"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = String(localized: "dialog.dontWarnCmdQ", defaultValue: "Don't warn again for Cmd+Q")
+
+        let response = alert.runModal()
+        if alert.suppressionButton?.state == .on {
+            QuitWarningSettings.setEnabled(false)
+        }
+        return response == .alertFirstButtonReturn
+    }
+
+    func requestApplicationTermination(
+        source: String,
+        sender: Any? = nil,
+        details: [String: String] = [:]
+    ) {
+        pendingTerminationRequest = PendingTerminationRequest(source: source, details: details)
+        logLifecycleEvent(
+            "app.terminate.request",
+            source: source,
+            details: details,
+            extra: [
+                "taggedDevBuild": SocketControlSettings.isTaggedDevBuild() ? 1 : 0
+            ]
+        )
+        NSApp.terminate(sender)
+    }
+
+    private func shouldEscalateMainWindowCloseToAppTermination(_ window: NSWindow) -> Bool {
+        guard isMainTerminalWindow(window),
+              mainWindowContexts.count <= 1,
+              !isTerminatingApp,
+              !isQuitWarningConfirmed,
+              !SocketControlSettings.isTaggedDevBuild(),
+              QuitWarningSettings.isEnabled() else {
+            return false
+        }
+
+        let hasOtherVisibleMainCapableWindows = NSApp.windows.contains { candidate in
+            candidate !== window &&
+            candidate.isVisible &&
+            !candidate.isMiniaturized &&
+            candidate.canBecomeMain
+        }
+        return !hasOtherVisibleMainCapableWindows
+    }
+
+    private func requestMainWindowCloseTermination(_ window: NSWindow, source: String, details: [String: String]) {
+        var terminationDetails = details
+        terminationDetails["windowSource"] = source
+        terminationDetails["windowNumber"] = String(window.windowNumber)
+        terminationDetails["windowIdentifier"] = window.identifier?.rawValue ?? "nil"
+        logLifecycleEvent(
+            "window.close.escalate_to_quit",
+            source: source,
+            details: details,
+            extra: [
+                "windowNumber": window.windowNumber,
+                "windowIdentifier": window.identifier?.rawValue ?? "nil"
+            ]
+        )
+        requestApplicationTermination(
+            source: "window.close.last_main_window",
+            details: terminationDetails
+        )
+    }
+
+    func requestMainWindowClose(
+        _ window: NSWindow,
+        source: String,
+        details: [String: String] = [:]
+    ) {
+        let escalatesToQuit = shouldEscalateMainWindowCloseToAppTermination(window)
+        logLifecycleEvent(
+            "window.close.request",
+            source: source,
+            details: details,
+            extra: [
+                "windowNumber": window.windowNumber,
+                "windowIdentifier": window.identifier?.rawValue ?? "nil",
+                "mainWindowCount": mainWindowContexts.count,
+                "escalatesToQuit": escalatesToQuit ? 1 : 0
+            ]
+        )
+        if escalatesToQuit {
+            requestMainWindowCloseTermination(window, source: source, details: details)
+            return
+        }
+        window.performClose(nil)
+    }
+
+    private func shouldCloseMainWindow(_ window: NSWindow) -> Bool {
+        guard isMainTerminalWindow(window) else { return true }
+        let escalatesToQuit = shouldEscalateMainWindowCloseToAppTermination(window)
+        logLifecycleEvent(
+            "window.close.shouldClose",
+            source: "window.shouldClose",
+            extra: [
+                "windowNumber": window.windowNumber,
+                "windowIdentifier": window.identifier?.rawValue ?? "nil",
+                "mainWindowCount": mainWindowContexts.count,
+                "escalatesToQuit": escalatesToQuit ? 1 : 0
+            ]
+        )
+        guard escalatesToQuit else { return true }
+        requestMainWindowCloseTermination(window, source: "window.shouldClose", details: [:])
+        return false
+    }
+
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
         isTerminatingApp = true
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
+        let request = pendingTerminationRequest
+        let requestSource = request?.source ?? "system.terminate"
+        let requestDetails = request?.details ?? [:]
+        logLifecycleEvent(
+            "app.terminate.shouldTerminate",
+            source: requestSource,
+            details: requestDetails,
+            extra: [
+                "taggedDevBuild": SocketControlSettings.isTaggedDevBuild() ? 1 : 0,
+                "warnBeforeQuit": QuitWarningSettings.isEnabled() ? 1 : 0,
+                "quitWarningConfirmed": isQuitWarningConfirmed ? 1 : 0
+            ]
+        )
 
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
         if SocketControlSettings.isTaggedDevBuild() {
+            logLifecycleEvent(
+                "app.terminate.decision",
+                source: requestSource,
+                details: requestDetails,
+                extra: ["reply": "terminateNow", "reason": "taggedDevBuild"]
+            )
             return .terminateNow
         }
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog
         // (handleQuitShortcutWarning), skip the check to avoid a second alert.
         if isQuitWarningConfirmed {
+            logLifecycleEvent(
+                "app.terminate.decision",
+                source: requestSource,
+                details: requestDetails,
+                extra: ["reply": "terminateNow", "reason": "warningAlreadyConfirmed"]
+            )
             return .terminateNow
         }
 
         // Respect the "Warn Before Quit" setting even when Cmd+Q arrives via
         // the Cmd+Tab app switcher, bypassing handleCustomShortcut.
         guard QuitWarningSettings.isEnabled() else {
+            logLifecycleEvent(
+                "app.terminate.decision",
+                source: requestSource,
+                details: requestDetails,
+                extra: ["reply": "terminateNow", "reason": "warningDisabled"]
+            )
             return .terminateNow
         }
 
         // Show the same confirmation dialog used by the Cmd+Q shortcut path,
         // then reply asynchronously so we can return .terminateLater now.
         DispatchQueue.main.async {
-            let alert = NSAlert()
-            alert.alertStyle = .warning
-            alert.messageText = String(localized: "dialog.quitCmux.title", defaultValue: "Quit cmux?")
-            alert.informativeText = String(localized: "dialog.quitCmux.message", defaultValue: "This will close all windows and workspaces.")
-            alert.addButton(withTitle: String(localized: "dialog.quitCmux.quit", defaultValue: "Quit"))
-            alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
-            alert.showsSuppressionButton = true
-            alert.suppressionButton?.title = String(localized: "dialog.dontWarnCmdQ", defaultValue: "Don't warn again for Cmd+Q")
-
-            let response = alert.runModal()
-            if alert.suppressionButton?.state == .on {
-                QuitWarningSettings.setEnabled(false)
-            }
-
-            let shouldQuit = response == .alertFirstButtonReturn
+            let shouldQuit = self.presentQuitWarningAlert()
             if shouldQuit {
                 self.isQuitWarningConfirmed = true
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
+                self.pendingTerminationRequest = nil
             }
+            self.logLifecycleEvent(
+                "app.terminate.warning.result",
+                source: requestSource,
+                details: requestDetails,
+                extra: [
+                    "confirmed": shouldQuit ? 1 : 0,
+                    "warnBeforeQuit": QuitWarningSettings.isEnabled() ? 1 : 0
+                ]
+            )
             NSApp.reply(toApplicationShouldTerminate: shouldQuit)
         }
         return .terminateLater
@@ -1367,6 +1553,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         isTerminatingApp = true
+        let request = pendingTerminationRequest
+        logLifecycleEvent(
+            "app.terminate.willTerminate",
+            source: request?.source ?? "system.terminate",
+            details: request?.details ?? [:],
+            extra: [
+                "mainWindowCount": mainWindowContexts.count,
+                "tabCount": tabManager?.tabs.count ?? 0
+            ]
+        )
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
         TerminalController.shared.stop()
@@ -4405,7 +4601,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func closeMainWindow(windowId: UUID) -> Bool {
         guard let window = windowForMainWindowId(windowId) else { return false }
-        window.performClose(nil)
+        requestMainWindowClose(
+            window,
+            source: "window.close.api",
+            details: ["windowId": windowId.uuidString]
+        )
         return true
     }
 
@@ -4445,7 +4645,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
         guard confirmCloseMainWindow(window) else { return true }
-        window.performClose(nil)
+        requestMainWindowClose(window, source: "window.close.confirmed")
         return true
     }
 
@@ -5822,6 +6022,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self, let controller else { return }
             self.mainWindowControllers.removeAll(where: { $0 === controller })
         }
+        controller.shouldClose = { [weak self] closingWindow in
+            self?.shouldCloseMainWindow(closingWindow) ?? true
+        }
         window.delegate = controller
         mainWindowControllers.append(controller)
 
@@ -6008,8 +6211,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             onOpenPreferences: { [weak self] in
                 self?.openPreferencesWindow(debugSource: "menuBarExtra")
             },
-            onQuitApp: {
-                NSApp.terminate(nil)
+            onQuitApp: { [weak self] in
+                self?.requestApplicationTermination(source: "menuBarExtra.quit")
             }
         )
     }
@@ -9151,34 +9354,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func handleQuitShortcutWarning() -> Bool {
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
         if SocketControlSettings.isTaggedDevBuild() {
-            NSApp.terminate(nil)
+            requestApplicationTermination(source: "shortcut.quit.taggedDevBuild")
             return true
         }
 
         if !QuitWarningSettings.isEnabled() {
-            NSApp.terminate(nil)
+            requestApplicationTermination(source: "shortcut.quit.warningDisabled")
             return true
         }
 
-        let alert = NSAlert()
-        alert.alertStyle = .warning
-        alert.messageText = String(localized: "dialog.quitCmux.title", defaultValue: "Quit cmux?")
-        alert.informativeText = String(localized: "dialog.quitCmux.message", defaultValue: "This will close all windows and workspaces.")
-        alert.addButton(withTitle: String(localized: "dialog.quitCmux.quit", defaultValue: "Quit"))
-        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
-        alert.showsSuppressionButton = true
-        alert.suppressionButton?.title = String(localized: "dialog.dontWarnCmdQ", defaultValue: "Don't warn again for Cmd+Q")
-
-        let response = alert.runModal()
-        if alert.suppressionButton?.state == .on {
-            QuitWarningSettings.setEnabled(false)
-        }
-
-        if response == .alertFirstButtonReturn {
+        if presentQuitWarningAlert() {
             // Mark as confirmed so applicationShouldTerminate does not show a
             // second alert when NSApp.terminate re-enters the delegate callback.
             isQuitWarningConfirmed = true
-            NSApp.terminate(nil)
+            requestApplicationTermination(source: "shortcut.quit.warningConfirmed")
         }
         return true
     }
@@ -11768,11 +11957,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         workspaceForMainActor(tabId: tabId)
     }
 
-    func closeMainWindowContainingTabId(_ tabId: UUID) {
+    func closeMainWindowContainingTabId(_ tabId: UUID, source: String = "window.close.containing_tab") {
         guard let context = contextContainingTabId(tabId) else { return }
         let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
         let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
-        window?.performClose(nil)
+        guard let window else { return }
+        requestMainWindowClose(
+            window,
+            source: source,
+            details: [
+                "workspaceId": tabId.uuidString,
+                "windowId": context.windowId.uuidString
+            ]
+        )
     }
 
     @discardableResult

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3229,6 +3229,21 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     private func replaceWebViewAfterContentProcessTermination(for terminatedWebView: WKWebView) {
+#if DEBUG
+        cmuxDebugLog(
+            "browser.webcontent.terminated panel=\(id.uuidString.prefix(5)) " +
+            "workspace=\(workspaceId.uuidString.prefix(5)) url=\(currentURL?.absoluteString ?? "nil")"
+        )
+#endif
+        sentryBreadcrumb(
+            "browser.webcontent.terminated",
+            category: "browser",
+            data: [
+                "panelId": id.uuidString,
+                "workspaceId": workspaceId.uuidString,
+                "url": currentURL?.absoluteString ?? ""
+            ]
+        )
         replaceWebViewPreservingState(
             from: terminatedWebView,
             websiteDataStore: websiteDataStore,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4460,9 +4460,20 @@ class TabManager: ObservableObject {
         if tabs.count <= 1 {
             // Last workspace in this window: close the window (Cmd+Shift+W behavior).
             if let window {
-                window.performClose(nil)
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.requestMainWindowClose(
+                        window,
+                        source: "workspace.close.last_workspace",
+                        details: ["workspaceId": workspace.id.uuidString]
+                    )
+                } else {
+                    window.performClose(nil)
+                }
             } else {
-                AppDelegate.shared?.closeMainWindowContainingTabId(workspace.id)
+                AppDelegate.shared?.closeMainWindowContainingTabId(
+                    workspace.id,
+                    source: "workspace.close.last_workspace"
+                )
             }
         } else {
             closeWorkspace(workspace)
@@ -4505,8 +4516,8 @@ class TabManager: ObservableObject {
         )
 #endif
 
-        // The last-surface shortcut preference only affects Cmd+W. The tab close button
-        // continues to use Workspace's explicit-close path when it closes the last surface.
+        // Route last-surface shortcut closes through Workspace's explicit-close path so
+        // the workspace-level keep-open preference is honored consistently.
         if closesWorkspaceOnLastSurfaceShortcut,
            let surfaceId = tab.surfaceIdFromPanelId(panelId) {
             tab.markExplicitClose(surfaceId: surfaceId)
@@ -4601,14 +4612,18 @@ class TabManager: ObservableObject {
     func closePanelAfterChildExited(tabId: UUID, surfaceId: UUID) {
         guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
         guard tab.panels[surfaceId] != nil else { return }
+        let closesWorkspaceOnLastSurface = LastSurfaceCloseShortcutSettings.closesWorkspace()
         let keepsRemoteWorkspaceOpen =
             tab.panels.count <= 1 && tab.shouldDemoteWorkspaceAfterChildExit(surfaceId: surfaceId)
+        let keepsWorkspaceOpenOnLastSurface =
+            tab.panels.count <= 1 && !closesWorkspaceOnLastSurface
 
 #if DEBUG
         cmuxDebugLog(
             "surface.close.childExited tab=\(tabId.uuidString.prefix(5)) " +
             "surface=\(surfaceId.uuidString.prefix(5)) panels=\(tab.panels.count) workspaces=\(tabs.count) " +
-            "remoteWorkspace=\(tab.isRemoteWorkspace ? 1 : 0) keepRemote=\(keepsRemoteWorkspaceOpen ? 1 : 0)"
+            "remoteWorkspace=\(tab.isRemoteWorkspace ? 1 : 0) keepRemote=\(keepsRemoteWorkspaceOpen ? 1 : 0) " +
+            "closeWorkspaceOnLastSurface=\(closesWorkspaceOnLastSurface ? 1 : 0)"
         )
 #endif
 
@@ -4617,18 +4632,18 @@ class TabManager: ObservableObject {
         // logic run before TabManager considers removing the workspace itself, including
         // session-end paths where remote configuration was cleared before Ghostty delivered
         // the child-exit callback.
-        if keepsRemoteWorkspaceOpen {
+        if keepsRemoteWorkspaceOpen || keepsWorkspaceOpenOnLastSurface {
             closeRuntimeSurface(tabId: tabId, surfaceId: surfaceId)
             return
         }
 
-        // Child-exit on the last panel should collapse the workspace, matching explicit close
-        // semantics (and close the window when it was the last workspace).
+        // Child-exit on the last panel collapses the workspace only when the
+        // keep-workspace-open preference is disabled.
         if tab.panels.count <= 1 {
             if tabs.count <= 1 {
                 if let app = AppDelegate.shared {
                     app.notificationStore?.clearNotifications(forTabId: tabId)
-                    app.closeMainWindowContainingTabId(tabId)
+                    app.closeMainWindowContainingTabId(tabId, source: "surface.close.childExited.last_workspace")
                 } else {
                     // Headless/test fallback when no AppDelegate window context exists.
                     closeRuntimeSurface(tabId: tabId, surfaceId: surfaceId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7234,8 +7234,8 @@ final class Workspace: Identifiable, ObservableObject {
     private var pendingCloseConfirmTabIds: Set<TabID> = []
 
     /// Tab IDs whose next close attempt should be treated as an explicit
-    /// workspace-close gesture from the user (the tab-strip X button, or Cmd+W when
-    /// the shortcut preference is set to close the workspace on the last surface),
+    /// user-driven surface close (for example the tab-strip X button, or Cmd+W when
+    /// the last-surface preference is configured to collapse the workspace),
     /// rather than an internal close/move flow.
     private var explicitUserCloseTabIds: Set<TabID> = []
 
@@ -11571,7 +11571,8 @@ extension Workspace: BonsplitDelegate {
     @MainActor
     private func shouldCloseWorkspaceOnLastSurface(for tabId: TabID) -> Bool {
         let manager = owningTabManager ?? AppDelegate.shared?.tabManagerFor(tabId: id) ?? AppDelegate.shared?.tabManager
-        guard panels.count <= 1,
+        guard LastSurfaceCloseShortcutSettings.closesWorkspace(),
+              panels.count <= 1,
               panelIdFromSurfaceId(tabId) != nil,
               let manager,
               manager.tabs.contains(where: { $0.id == id }) else {
@@ -12064,7 +12065,30 @@ extension Workspace: BonsplitDelegate {
             return false
         }
 
-        if explicitUserClose && shouldCloseWorkspaceOnLastSurface(for: tab.id) {
+        let closesWorkspaceOnLastSurface = explicitUserClose && shouldCloseWorkspaceOnLastSurface(for: tab.id)
+#if DEBUG
+        if explicitUserClose && panels.count <= 1 {
+            cmuxDebugLog(
+                "surface.close.explicit tab=\(tab.id.uuidString.prefix(5)) " +
+                "workspace=\(id.uuidString.prefix(5)) closeWorkspace=\(closesWorkspaceOnLastSurface ? 1 : 0) " +
+                "preference=\(LastSurfaceCloseShortcutSettings.closesWorkspace() ? 1 : 0)"
+            )
+        }
+#endif
+        if explicitUserClose && panels.count <= 1 {
+            sentryBreadcrumb(
+                "surface.close.explicit.last_surface",
+                category: "workspace",
+                data: [
+                    "workspaceId": id.uuidString,
+                    "surfaceId": String(describing: tab.id),
+                    "closeWorkspace": closesWorkspaceOnLastSurface ? 1 : 0,
+                    "closeWorkspaceOnLastSurface": LastSurfaceCloseShortcutSettings.closesWorkspace() ? 1 : 0
+                ]
+            )
+        }
+
+        if closesWorkspaceOnLastSurface {
             clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
             owningTabManager?.closeWorkspaceWithConfirmation(self)
             return false

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12069,7 +12069,7 @@ extension Workspace: BonsplitDelegate {
 #if DEBUG
         if explicitUserClose && panels.count <= 1 {
             cmuxDebugLog(
-                "surface.close.explicit tab=\(tab.id.uuidString.prefix(5)) " +
+                "surface.close.explicit tab=\(tab.id.uuid.uuidString.prefix(5)) " +
                 "workspace=\(id.uuidString.prefix(5)) closeWorkspace=\(closesWorkspaceOnLastSurface ? 1 : 0) " +
                 "preference=\(LastSurfaceCloseShortcutSettings.closesWorkspace() ? 1 : 0)"
             )

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -252,7 +252,7 @@ struct cmuxApp: App {
 
             CommandGroup(replacing: .appTermination) {
                 splitCommandButton(title: String(localized: "menu.quitCmux", defaultValue: "Quit cmux"), shortcut: menuShortcut(for: .quit)) {
-                    NSApp.terminate(nil)
+                    appDelegate.requestApplicationTermination(source: "menu.quit")
                 }
             }
 
@@ -4690,12 +4690,12 @@ struct SettingsView: View {
         if keepWorkspaceOpenOnLastSurfaceShortcut {
             return String(
                 localized: "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOn",
-                defaultValue: "When the focused surface is the last one in its workspace, the close-surface shortcut closes only the surface and keeps the workspace open. Use the close-workspace shortcut to close the workspace explicitly."
+                defaultValue: "When the focused surface is the last one in its workspace, closing that surface keeps the workspace open. Use Close Workspace to close the workspace explicitly."
             )
         }
         return String(
             localized: "settings.app.closeWorkspaceOnLastSurfaceShortcut.subtitleOff",
-            defaultValue: "When the focused surface is the last one in its workspace, the close-surface shortcut also closes the workspace."
+            defaultValue: "When the focused surface is the last one in its workspace, closing that surface also closes the workspace."
         )
     }
 
@@ -6664,7 +6664,10 @@ struct SettingsView: View {
         } catch {
             return
         }
-        NSApplication.shared.terminate(nil)
+        appDelegate.requestApplicationTermination(
+            source: "app.relaunch",
+            details: ["reason": "settings_reset"]
+        )
     }
 
     private func resetAllSettings() {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6664,7 +6664,7 @@ struct SettingsView: View {
         } catch {
             return
         }
-        appDelegate.requestApplicationTermination(
+        AppDelegate.shared?.requestApplicationTermination(
             source: "app.relaunch",
             details: ["reason": "settings_reset"]
         )

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -171,6 +171,39 @@ final class TabManagerChildExitCloseTests: XCTestCase {
         )
     }
 
+    func testChildExitOnLastPanelKeepsWorkspaceOpenWhenKeepWorkspaceOpenPreferenceIsEnabled() {
+        let defaults = UserDefaults.standard
+        let originalSetting = defaults.object(forKey: lastSurfaceCloseShortcutDefaultsKey)
+        defaults.set(false, forKey: lastSurfaceCloseShortcutDefaultsKey)
+        defer {
+            if let originalSetting {
+                defaults.set(originalSetting, forKey: lastSurfaceCloseShortcutDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: lastSurfaceCloseShortcutDefaultsKey)
+            }
+        }
+
+        let manager = TabManager()
+        let firstWorkspace = manager.tabs[0]
+        let secondWorkspace = manager.addWorkspace()
+        manager.selectWorkspace(secondWorkspace)
+
+        guard let secondPanelId = secondWorkspace.focusedPanelId else {
+            XCTFail("Expected focused panel in selected workspace")
+            return
+        }
+
+        manager.closePanelAfterChildExited(tabId: secondWorkspace.id, surfaceId: secondPanelId)
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(manager.tabs.map(\.id), [firstWorkspace.id, secondWorkspace.id])
+        XCTAssertEqual(manager.selectedTabId, secondWorkspace.id)
+        XCTAssertNil(secondWorkspace.panels[secondPanelId])
+        XCTAssertEqual(secondWorkspace.panels.count, 1)
+        XCTAssertNotEqual(secondWorkspace.focusedPanelId, secondPanelId)
+    }
+
     func testChildExitOnLastRemotePanelKeepsWorkspaceAndDemotesToLocal() throws {
         let manager = TabManager()
         guard let workspace = manager.selectedWorkspace,

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1203,7 +1203,7 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         XCTAssertTrue(secondWorkspace.panels.isEmpty)
     }
 
-    func testClosePanelButtonStillClosesWorkspaceWhenKeepWorkspaceOpenPreferenceIsEnabled() {
+    func testClosePanelButtonKeepsWorkspaceOpenWhenKeepWorkspaceOpenPreferenceIsEnabled() {
         let defaults = UserDefaults.standard
         let originalSetting = defaults.object(forKey: lastSurfaceCloseShortcutDefaultsKey)
         defaults.set(false, forKey: lastSurfaceCloseShortcutDefaultsKey)
@@ -1235,10 +1235,11 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         drainMainQueue()
         drainMainQueue()
 
-        XCTAssertEqual(manager.tabs.map(\.id), [firstWorkspace.id])
-        XCTAssertEqual(manager.selectedTabId, firstWorkspace.id)
+        XCTAssertEqual(manager.tabs.map(\.id), [firstWorkspace.id, secondWorkspace.id])
+        XCTAssertEqual(manager.selectedTabId, secondWorkspace.id)
         XCTAssertNil(secondWorkspace.panels[secondPanelId])
-        XCTAssertTrue(secondWorkspace.panels.isEmpty)
+        XCTAssertEqual(secondWorkspace.panels.count, 1)
+        XCTAssertNotEqual(secondWorkspace.focusedPanelId, secondPanelId)
     }
 
     func testGenericClosePanelKeepsWorkspaceOpenWithoutExplicitCloseMarker() {


### PR DESCRIPTION
## Summary
- honor the keep-workspace-open preference for explicit last-surface closes and child-exit last-surface closes
- route internal last-main-window close requests through quit-warning + lifecycle logging instead of silently disappearing
- add lifecycle breadcrumbs/debug logging for terminate/window-close paths and browser web content termination

## Testing
- not run locally per repo policy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core window/workspace close and app termination paths, which can affect quitting behavior and data/session persistence; however the changes are localized and add tests plus extra logging for diagnosis.
> 
> **Overview**
> Fixes last-surface close semantics to consistently honor the *Keep workspace open* preference across explicit closes (e.g. tab-strip close / Cmd+W) and child-exit closes; when enabled, the last panel closes without collapsing the workspace/window.
> 
> Centralizes termination/close handling in `AppDelegate` via `requestApplicationTermination`/`requestMainWindowClose`, adds `windowShouldClose` interception to escalate closing the last main window into the standard quit-warning flow (instead of silently exiting), and records lifecycle breadcrumbs/debug logs for terminate/window-close decisions.
> 
> Adds additional diagnostics for browser web content process termination, updates the related settings copy, and extends unit tests to cover the new keep-workspace-open behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89a86f152e50c471649e727b8ed6b8d8b3141af5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed behavior of "keep workspace open when closing last surface" setting to properly retain the workspace when closing the final panel.

* **Documentation**
  * Updated UI text and guidance for closing surfaces and workspaces, clarifying the distinction between closing individual surfaces and explicitly closing the workspace.

* **Chores**
  * Enhanced diagnostic logging when web content processes terminate, improving troubleshooting capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent app exit when closing the last surface and unifies quit behavior. Closing the last main window now routes through the quit-warning flow instead of disappearing.

- **Bug Fixes**
  - Honor “keep workspace open” for Cmd+W, tab close, and child-exit on the last surface; only collapse when the preference is off.
  - Escalate closing the last main window to a quit with the warning dialog (DEV builds skip it) instead of silently exiting.
  - Fix compile error in TabID logging for explicit close breadcrumbs.

- **Refactors**
  - Centralized quit/close handling with `requestApplicationTermination` and `requestMainWindowClose`; `windowShouldClose` decides when to escalate.
  - Added lifecycle breadcrumbs/debug logs for window close/app termination and browser web content termination; routed menu, menu bar, and relaunch quits through the centralized flow (fixed relaunch wiring); updated settings copy and tests.

<sup>Written for commit 89a86f152e50c471649e727b8ed6b8d8b3141af5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

