### PR TITLE
Fix multi-workspace close confirmation modality

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */; };
 		B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */; };
+		B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900001CA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift */; };
 		B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */; };
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
 		B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
@@ -352,6 +353,7 @@
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
 		B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowDragHandleView.swift; sourceTree = "<group>"; };
 		B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceConfirmDialogUITests.swift; sourceTree = "<group>"; };
+		B900001CA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspacesConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWorkspaceCmdDUITests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
 		BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarOrderingTests.swift; sourceTree = "<group>"; };
@@ -475,6 +477,7 @@
 				B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 				B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
 				B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */,
+				B900001CA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift */,
 				B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */,
 				B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */,
 				818DBCD4AB69EB72573E8138 /* SidebarResizeUITests.swift */,
@@ -1005,6 +1008,7 @@
 				B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
 				B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 				B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
+				B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */,
 				B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */,
 				B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */,
 				B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8709,6 +8709,13 @@ struct ContentView: View {
         lastSidebarSelectionIndex = lastIndex
         tabManager.selectWorkspace(tabs[lastIndex])
         sidebarSelectionState.selection = .tabs
+#if DEBUG
+        UITestRecorder.record([
+            "sidebarSelectedWorkspaceCount": String(selectedIds.count),
+            "sidebarSelectedWorkspaceLastIndex": String(lastIndex),
+            "sidebarWorkspaceCount": String(tabs.count),
+        ])
+#endif
         didApplyUITestSidebarSelection = true
 #endif
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4339,18 +4339,53 @@ class TabManager: ObservableObject {
         ])
         #endif
 
+        return runCloseConfirmationAlert(alert) == .alertFirstButtonReturn
+    }
+
+    private func runCloseConfirmationAlert(_ alert: NSAlert) -> NSApplication.ModalResponse {
         if NSApp.activationPolicy() == .regular {
             NSApp.activate(ignoringOtherApps: true)
         }
 
-        #if DEBUG
-        UITestRecorder.record([
-            "closeConfirmationPresentation": "appModal",
-            "closeConfirmationAttachedSheet": "0",
-        ])
-        #endif
+        guard let presentingWindow = closeConfirmationPresentingWindow(),
+              presentingWindow.attachedSheet == nil else {
+            #if DEBUG
+            UITestRecorder.record([
+                "closeConfirmationPresentation": "appModal",
+                "closeConfirmationAttachedSheet": "0",
+            ])
+            #endif
 
-        return alert.runModal() == .alertFirstButtonReturn
+            return alert.runModal()
+        }
+
+        alert.beginSheetModal(for: presentingWindow) { result in
+            NSApp.stopModal(withCode: result)
+        }
+        #if DEBUG
+        DispatchQueue.main.async {
+            UITestRecorder.record([
+                "closeConfirmationPresentation": "sheet",
+                "closeConfirmationAttachedSheet": presentingWindow.attachedSheet == nil ? "0" : "1",
+            ])
+        }
+        #endif
+        return NSApp.runModal(for: alert.window)
+    }
+
+    private func closeConfirmationPresentingWindow() -> NSWindow? {
+        if let window, window.isVisible {
+            return window
+        }
+        if let keyWindow = NSApp.keyWindow, keyWindow.isVisible {
+            return keyWindow
+        }
+        if let mainWindow = NSApp.mainWindow, mainWindow.isVisible {
+            return mainWindow
+        }
+        return NSApp.windows.first { candidate in
+            candidate.isVisible && candidate.identifier?.rawValue.hasPrefix("cmux.main.") == true
+        }
     }
 
     private struct CloseOtherTabsInFocusedPanePlan {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4347,12 +4347,13 @@ class TabManager: ObservableObject {
             NSApp.activate(ignoringOtherApps: true)
         }
 
-        guard let presentingWindow = closeConfirmationPresentingWindow(),
-              presentingWindow.attachedSheet == nil else {
+        let presentingWindow = closeConfirmationPresentingWindow()
+        let hasAttachedSheet = presentingWindow?.attachedSheet != nil
+        guard let presentingWindow, !hasAttachedSheet else {
             #if DEBUG
             UITestRecorder.record([
                 "closeConfirmationPresentation": "appModal",
-                "closeConfirmationAttachedSheet": "0",
+                "closeConfirmationAttachedSheet": hasAttachedSheet ? "1" : "0",
             ])
             #endif
 
@@ -4374,18 +4375,23 @@ class TabManager: ObservableObject {
     }
 
     private func closeConfirmationPresentingWindow() -> NSWindow? {
-        if let window, window.isVisible {
+        if let window, window.isVisible, isCloseConfirmationMainWindow(window) {
             return window
         }
-        if let keyWindow = NSApp.keyWindow, keyWindow.isVisible {
+        if let keyWindow = NSApp.keyWindow, keyWindow.isVisible, isCloseConfirmationMainWindow(keyWindow) {
             return keyWindow
         }
-        if let mainWindow = NSApp.mainWindow, mainWindow.isVisible {
+        if let mainWindow = NSApp.mainWindow, mainWindow.isVisible, isCloseConfirmationMainWindow(mainWindow) {
             return mainWindow
         }
         return NSApp.windows.first { candidate in
-            candidate.isVisible && candidate.identifier?.rawValue.hasPrefix("cmux.main.") == true
+            candidate.isVisible && isCloseConfirmationMainWindow(candidate)
         }
+    }
+
+    private func isCloseConfirmationMainWindow(_ candidate: NSWindow) -> Bool {
+        guard let raw = candidate.identifier?.rawValue else { return false }
+        return raw == "cmux.main" || raw.hasPrefix("cmux.main.")
     }
 
     private struct CloseOtherTabsInFocusedPanePlan {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4332,9 +4332,23 @@ class TabManager: ObservableObject {
             cancelButton.keyEquivalent = "\u{1b}"
         }
 
+        #if DEBUG
+        UITestRecorder.record([
+            "closeConfirmationTitle": title,
+            "closeConfirmationMessage": message,
+        ])
+        #endif
+
         if NSApp.activationPolicy() == .regular {
             NSApp.activate(ignoringOtherApps: true)
         }
+
+        #if DEBUG
+        UITestRecorder.record([
+            "closeConfirmationPresentation": "appModal",
+            "closeConfirmationAttachedSheet": "0",
+        ])
+        #endif
 
         return alert.runModal() == .alertFirstButtonReturn
     }

--- a/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
+++ b/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
@@ -316,9 +316,6 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
 
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
-        if let first = outStr.split(separator: "\n", maxSplits: 1).first {
-            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
-        }
         let trimmed = outStr.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
     }
@@ -456,6 +453,7 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
                 return true
             }
             guard wrote else { return nil }
+            _ = shutdown(fd, SHUT_WR)
 
             var buf = [UInt8](repeating: 0, count: 4096)
             var accum = ""
@@ -471,12 +469,10 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
                 if n <= 0 { break }
                 if let chunk = String(bytes: buf[0..<n], encoding: .utf8) {
                     accum.append(chunk)
-                    if let idx = accum.firstIndex(of: "\n") {
-                        return String(accum[..<idx])
-                    }
                 }
             }
-            return accum.isEmpty ? nil : accum.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmed = accum.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
         }
     }
 }

--- a/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
+++ b/cmuxUITests/CloseWorkspacesConfirmDialogUITests.swift
@@ -3,24 +3,40 @@ import Foundation
 
 final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
     private var socketPath = ""
+    private var diagnosticsPath = ""
+    private var launchTag = ""
 
     override func setUp() {
         super.setUp()
         continueAfterFailure = false
         socketPath = "/tmp/cmux-ui-test-close-workspaces-\(UUID().uuidString).sock"
+        diagnosticsPath = "/tmp/cmux-ui-test-close-workspaces-\(UUID().uuidString).json"
+        launchTag = "ui-tests-close-workspaces-\(UUID().uuidString.prefix(8))"
         try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: taggedSocketPath())
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: socketPath)
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        try? FileManager.default.removeItem(atPath: taggedSocketPath())
+        super.tearDown()
     }
 
     func testCommandPaletteCloseOtherWorkspacesShowsSingleSummaryDialog() {
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        configureSocketLaunchEnvironment(app)
         app.launchEnvironment["CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"] = "1"
         app.launch()
         XCTAssertTrue(
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for close-workspaces confirmation test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket to respond at \(socketPath)")
+        XCTAssertTrue(
+            waitForSocketPong(timeout: 12.0),
+            "Expected control socket to respond at \(socketPath). diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
+        )
 
         XCTAssertEqual(socketCommand("new_workspace")?.prefix(2), "OK")
         XCTAssertEqual(socketCommand("new_workspace")?.prefix(2), "OK")
@@ -63,7 +79,7 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
 
     func testCmdShiftWUsesSidebarMultiSelectionSummaryDialog() {
         let app = XCUIApplication()
-        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        configureSocketLaunchEnvironment(app)
         app.launchEnvironment["CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_SIDEBAR_SELECTED_WORKSPACE_INDICES"] = "0,1"
         app.launch()
@@ -71,7 +87,10 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
             ensureForegroundAfterLaunch(app, timeout: 12.0),
             "Expected app to launch for close-workspaces shortcut test. state=\(app.state.rawValue)"
         )
-        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket to respond at \(socketPath)")
+        XCTAssertTrue(
+            waitForSocketPong(timeout: 12.0),
+            "Expected control socket to respond at \(socketPath). diagnostics=\(loadJSON(atPath: diagnosticsPath) ?? [:])"
+        )
 
         XCTAssertEqual(socketCommand("new_workspace")?.prefix(2), "OK")
         XCTAssertTrue(
@@ -98,6 +117,80 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
         )
     }
 
+    func testCmdShiftWCloseWorkspacesPromptIsWindowModalSheet() {
+        let app = XCUIApplication()
+        let recorderPath = "/tmp/cmux-ui-test-close-workspaces-presentation-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: recorderPath)
+        configureSocketLaunchEnvironment(app)
+        app.launchEnvironment["CMUX_UI_TEST_KEYEQUIV_PATH"] = recorderPath
+        app.launchEnvironment["CMUX_UI_TEST_FORCE_CONFIRM_CLOSE_WORKSPACE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SIDEBAR_SELECTED_WORKSPACE_INDICES"] = "0,1"
+        app.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for close-workspaces modal routing test. state=\(app.state.rawValue)"
+        )
+
+        app.typeKey("n", modifierFlags: [.command])
+        app.typeKey("n", modifierFlags: [.command])
+        let sidebarSelection = waitForJSONKey(
+            "tabCount",
+            equals: "3",
+            atPath: recorderPath,
+            timeout: 10.0
+        )
+        XCTAssertEqual(
+            sidebarSelection?["sidebarSelectedWorkspaceCount"],
+            "2",
+            "Expected Cmd+N to create three workspaces and UI-test setup to select two before Cmd+Shift+W. recorder=\(sidebarSelection ?? loadJSON(atPath: recorderPath) ?? [:])"
+        )
+
+        app.typeKey("w", modifierFlags: [.command, .shift])
+        let closePrompt = waitForJSONKey(
+            "closeConfirmationTitle",
+            equals: "Close workspaces?",
+            atPath: recorderPath,
+            timeout: 5.0
+        )
+        XCTAssertEqual(
+            closePrompt?["closeConfirmationTitle"],
+            "Close workspaces?",
+            "Expected Cmd+Shift+W to use the aggregated close-workspaces alert for sidebar multi-selection. recorder=\(closePrompt ?? loadJSON(atPath: recorderPath) ?? [:])"
+        )
+
+        let presentation = waitForJSONKey(
+            "closeConfirmationAttachedSheet",
+            equals: "1",
+            atPath: recorderPath,
+            timeout: 5.0
+        )
+        XCTAssertEqual(
+            presentation?["closeConfirmationPresentation"],
+            "sheet",
+            "Workspace close confirmation should be attached to the cmux window so it cannot get stranded as a separate app-modal alert. recorder=\(presentation ?? loadJSON(atPath: recorderPath) ?? [:])"
+        )
+        XCTAssertEqual(
+            presentation?["closeConfirmationAttachedSheet"],
+            "1",
+            "Expected the close confirmation to report an attached sheet. recorder=\(presentation ?? loadJSON(atPath: recorderPath) ?? [:])"
+        )
+
+        clickCancelOnCloseWorkspacesAlert(app: app)
+    }
+
+    private func configureSocketLaunchEnvironment(_ app: XCUIApplication) {
+        app.launchArguments += ["-socketControlMode", "allowAll"]
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_ENABLE"] = "1"
+        app.launchEnvironment["CMUX_SOCKET_MODE"] = "allowAll"
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_ALLOW_SOCKET_OVERRIDE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_TAG"] = launchTag
+    }
+
     private func ensureForegroundAfterLaunch(_ app: XCUIApplication, timeout: TimeInterval) -> Bool {
         if app.wait(for: .runningForeground, timeout: timeout) {
             return true
@@ -110,13 +203,46 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
     }
 
     private func waitForSocketPong(timeout: TimeInterval) -> Bool {
+        var resolvedPath: String?
         let expectation = XCTNSPredicateExpectation(
             predicate: NSPredicate { _, _ in
-                self.socketCommand("ping") == "PONG"
+                let originalPath = self.socketPath
+                for candidate in self.socketCandidates() {
+                    guard FileManager.default.fileExists(atPath: candidate) else { continue }
+                    self.socketPath = candidate
+                    if self.socketCommand("ping") == "PONG" {
+                        resolvedPath = candidate
+                        return true
+                    }
+                    self.socketPath = originalPath
+                }
+                return false
             },
             object: NSObject()
         )
-        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+        let completed = XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed
+        if let resolvedPath {
+            socketPath = resolvedPath
+        }
+        return completed
+    }
+
+    private func socketCandidates() -> [String] {
+        var candidates = [socketPath, taggedSocketPath()]
+        var seen = Set<String>()
+        candidates.removeAll { !seen.insert($0).inserted }
+        return candidates
+    }
+
+    private func taggedSocketPath() -> String {
+        let slug = launchTag
+            .lowercased()
+            .replacingOccurrences(of: ".", with: "-")
+            .replacingOccurrences(of: "_", with: "-")
+            .components(separatedBy: CharacterSet.alphanumerics.inverted)
+            .filter { !$0.isEmpty }
+            .joined(separator: "-")
+        return "/tmp/cmux-debug-\(slug).sock"
     }
 
     private func waitForWorkspaceCount(_ expectedCount: Int, timeout: TimeInterval) -> Bool {
@@ -140,20 +266,45 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
             .count
     }
 
-    private func socketCommand(_ cmd: String) -> String? {
+    private func waitForJSONKey(_ key: String, equals expected: String, atPath path: String, timeout: TimeInterval) -> [String: String]? {
+        var latest: [String: String]?
+        let expectation = XCTNSPredicateExpectation(
+            predicate: NSPredicate { _, _ in
+                latest = self.loadJSON(atPath: path)
+                return latest?[key] == expected
+            },
+            object: NSObject()
+        )
+        return XCTWaiter().wait(for: [expectation], timeout: timeout) == .completed ? latest : nil
+    }
+
+    private func loadJSON(atPath path: String) -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return json
+    }
+
+    private func socketCommand(_ cmd: String, responseTimeout: TimeInterval = 2.0) -> String? {
+        if let response = ControlSocketClient(path: socketPath, responseTimeout: responseTimeout).sendLine(cmd) {
+            return response
+        }
+        return socketCommandViaNetcat(cmd, responseTimeout: responseTimeout)
+    }
+
+    private func socketCommandViaNetcat(_ cmd: String, responseTimeout: TimeInterval = 2.0) -> String? {
         let nc = "/usr/bin/nc"
         guard FileManager.default.isExecutableFile(atPath: nc) else { return nil }
 
         let proc = Process()
-        proc.executableURL = URL(fileURLWithPath: nc)
-        proc.arguments = ["-U", socketPath, "-w", "2"]
+        proc.executableURL = URL(fileURLWithPath: "/bin/sh")
+        let timeoutSeconds = max(1, Int(ceil(responseTimeout)))
+        let script = "printf '%s\\n' \(shellSingleQuote(cmd)) | \(nc) -U \(shellSingleQuote(socketPath)) -w \(timeoutSeconds) 2>/dev/null"
+        proc.arguments = ["-lc", script]
 
-        let inPipe = Pipe()
         let outPipe = Pipe()
-        let errPipe = Pipe()
-        proc.standardInput = inPipe
         proc.standardOutput = outPipe
-        proc.standardError = errPipe
 
         do {
             try proc.run()
@@ -161,16 +312,20 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
             return nil
         }
 
-        if let data = (cmd + "\n").data(using: .utf8) {
-            inPipe.fileHandleForWriting.write(data)
-        }
-        inPipe.fileHandleForWriting.closeFile()
-
         proc.waitUntilExit()
 
         let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
         guard let outStr = String(data: outData, encoding: .utf8) else { return nil }
-        return outStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let first = outStr.split(separator: "\n", maxSplits: 1).first {
+            return String(first).trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+        let trimmed = outStr.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func shellSingleQuote(_ value: String) -> String {
+        if value.isEmpty { return "''" }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 
     private func isCloseWorkspacesAlertPresent(app: XCUIApplication) -> Bool {
@@ -212,5 +367,116 @@ final class CloseWorkspacesConfirmDialogUITests: XCTestCase {
 
     private func closeWorkspacesAlert(app: XCUIApplication) -> XCUIElement {
         app.alerts.containing(.staticText, identifier: "Close workspaces?").firstMatch
+    }
+
+    private final class ControlSocketClient {
+        private let path: String
+        private let responseTimeout: TimeInterval
+
+        init(path: String, responseTimeout: TimeInterval = 2.0) {
+            self.path = path
+            self.responseTimeout = responseTimeout
+        }
+
+        func sendLine(_ line: String) -> String? {
+            let fd = socket(AF_UNIX, SOCK_STREAM, 0)
+            guard fd >= 0 else { return nil }
+            defer { close(fd) }
+
+            var socketTimeout = timeval(
+                tv_sec: Int(responseTimeout.rounded(.down)),
+                tv_usec: Int32(((responseTimeout - floor(responseTimeout)) * 1_000_000).rounded())
+            )
+
+            var noSigPipe: Int32 = 1
+            _ = withUnsafePointer(to: &noSigPipe) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_NOSIGPIPE,
+                    ptr,
+                    socklen_t(MemoryLayout<Int32>.size)
+                )
+            }
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_RCVTIMEO,
+                    ptr,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            }
+            _ = withUnsafePointer(to: &socketTimeout) { ptr in
+                setsockopt(
+                    fd,
+                    SOL_SOCKET,
+                    SO_SNDTIMEO,
+                    ptr,
+                    socklen_t(MemoryLayout<timeval>.size)
+                )
+            }
+
+            var addr = sockaddr_un()
+            memset(&addr, 0, MemoryLayout<sockaddr_un>.size)
+            addr.sun_family = sa_family_t(AF_UNIX)
+
+            let maxLen = MemoryLayout.size(ofValue: addr.sun_path)
+            let bytes = Array(path.utf8CString)
+            guard bytes.count <= maxLen else { return nil }
+            withUnsafeMutablePointer(to: &addr.sun_path) { p in
+                let raw = UnsafeMutableRawPointer(p).assumingMemoryBound(to: CChar.self)
+                memset(raw, 0, maxLen)
+                for i in 0..<bytes.count {
+                    raw[i] = bytes[i]
+                }
+            }
+
+            let pathOffset = MemoryLayout<sockaddr_un>.offset(of: \.sun_path) ?? 0
+            let addrLen = socklen_t(pathOffset + bytes.count)
+            addr.sun_len = UInt8(min(Int(addrLen), 255))
+
+            let connected = withUnsafePointer(to: &addr) { ptr in
+                ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sa in
+                    connect(fd, sa, addrLen)
+                }
+            }
+            guard connected == 0 else { return nil }
+
+            let payload = line + "\n"
+            let wrote: Bool = payload.withCString { cstr in
+                var remaining = strlen(cstr)
+                var p = UnsafeRawPointer(cstr)
+                while remaining > 0 {
+                    let n = write(fd, p, remaining)
+                    if n <= 0 { return false }
+                    remaining -= n
+                    p = p.advanced(by: n)
+                }
+                return true
+            }
+            guard wrote else { return nil }
+
+            var buf = [UInt8](repeating: 0, count: 4096)
+            var accum = ""
+            while true {
+                let n = read(fd, &buf, buf.count)
+                if n < 0 {
+                    let code = errno
+                    if code == EAGAIN || code == EWOULDBLOCK {
+                        break
+                    }
+                    return nil
+                }
+                if n <= 0 { break }
+                if let chunk = String(bytes: buf[0..<n], encoding: .utf8) {
+                    accum.append(chunk)
+                    if let idx = accum.firstIndex(of: "\n") {
+                        return String(accum[..<idx])
+                    }
+                }
+            }
+            return accum.isEmpty ? nil : accum.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
     }
 }


### PR DESCRIPTION
Summary
- Add a UI regression test for multi-workspace Cmd+Shift+W close confirmation modality.
- Present workspace close confirmations as a window-attached sheet when a cmux window is available.

Testing
- Red run on test-only commit d2ad8d891ea814e1ed50c1262a5a5d6032c5ebe1 failed as expected: https://github.com/manaflow-ai/cmux/actions/runs/24928018156
- Green run on fix commit 5a866ac6d074ae99657a3062f528653a10a8713e passed: https://github.com/manaflow-ai/cmux/actions/runs/24928018157
- Local compile: xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -destination platform=macOS -derivedDataPath /tmp/cmux-mwclose-reg build-for-testing -only-testing:cmuxUITests/CloseWorkspacesConfirmDialogUITests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-workspace close confirmation so Cmd+Shift+W shows a window-attached sheet on the active `cmux` window, falling back only when no eligible window exists or it already has a sheet. Adds a focused UITest and improved diagnostics to prevent modality regressions.

- Bug Fixes
  - Present close prompts as a sheet on a stable window (current, key, main, or first visible `cmux.main*`); fall back to app-modal if none or if that window already has an attached sheet.
  - Emit DEBUG diagnostics for title, message, presentation mode, attached-sheet flag, and sidebar selection counts to support UITest assertions.

- New Features
  - Added `CloseWorkspacesConfirmDialogUITests` that verifies Cmd+Shift+W uses a window-modal sheet with sidebar multi-selection; hardened the UITest harness with centralized env setup, tagged socket fallback and a Unix domain socket client, JSON recorder helpers, and run cleanup.

<sup>Written for commit b2f00745463cdaa8c59e7d161dcb393ddb060104. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved close-confirmation behavior so the dialog appears as a sheet when appropriate.

* **Tests**
  * Added a new UI test for the close-workspaces confirmation flow with stronger diagnostics and more robust socket handling.
  * Added cleanup between test runs to reduce flakiness.

* **Chores**
  * Updated project configuration to include the new UI test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->