### PR TITLE
Hide portals for unmounted workspaces

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3558,17 +3558,22 @@ struct ContentView: View {
             isCycleHot: isCycleHot,
             maxMounted: maxMounted
         )
+        let removedIds = previousMountedIds.filter { !mountedWorkspaceIds.contains($0) }
+        hidePortalViewsForUnmountedWorkspaces(
+            removedIds,
+            tabs: currentTabs,
+            selectedId: effectiveSelectedId
+        )
 #if DEBUG
         if mountedWorkspaceIds != previousMountedIds {
             let added = mountedWorkspaceIds.filter { !previousMountedIds.contains($0) }
-            let removed = previousMountedIds.filter { !mountedWorkspaceIds.contains($0) }
             if let snapshot = tabManager.debugCurrentWorkspaceSwitchSnapshot() {
                 let dtMs = (CACurrentMediaTime() - snapshot.startedAt) * 1000
                 cmuxDebugLog(
                     "ws.mount.reconcile id=\(snapshot.id) dt=\(debugMsText(dtMs)) hot=\(isCycleHot ? 1 : 0) " +
                     "selected=\(debugShortWorkspaceId(effectiveSelectedId)) " +
                     "mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds)) " +
-                    "added=\(debugShortWorkspaceIds(added)) removed=\(debugShortWorkspaceIds(removed))"
+                    "added=\(debugShortWorkspaceIds(added)) removed=\(debugShortWorkspaceIds(removedIds))"
                 )
             } else {
                 cmuxDebugLog(
@@ -3578,6 +3583,19 @@ struct ContentView: View {
             }
         }
 #endif
+    }
+
+    private func hidePortalViewsForUnmountedWorkspaces(
+        _ workspaceIds: [UUID],
+        tabs: [Workspace],
+        selectedId: UUID?
+    ) {
+        guard !workspaceIds.isEmpty else { return }
+        let unmountedIds = Set(workspaceIds)
+        for workspace in tabs where unmountedIds.contains(workspace.id) && workspace.id != selectedId {
+            workspace.hideAllTerminalPortalViews()
+            workspace.hideAllBrowserPortalViews()
+        }
     }
 
     private enum BackgroundWorkspacePrimeState {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1022,7 +1022,6 @@ final class WindowTerminalPortal: NSObject {
     /// Used when a workspace is permanently unmounted (vs. transient bonsplit dismantles).
     func hideEntry(forHostedId hostedId: ObjectIdentifier) {
         guard var entry = entriesByHostedId[hostedId] else { return }
-        guard entry.visibleInUI else { return }
         entry.visibleInUI = false
         entry.transientRecoveryRetriesRemaining = 0
         entriesByHostedId[hostedId] = entry


### PR DESCRIPTION
## Summary
- Hide terminal and browser portal views whenever workspace mount reconciliation evicts a workspace from the SwiftUI tree.
- Make terminal portal hiding idempotent so an already non-visible portal entry still gets its hosted view hidden.

## Audit
- Release app `/Applications/cmux.app` is `0.63.2` at commit `179b16ce6`; while the bug was active it was around 180% CPU.
- `vmmap` showed roughly 20G physical footprint dominated by IOSurface and IOAccelerator graphics memory.
- CoreGraphics reported 88 `cmux` windows for PID 680, while the cmux socket reported one logical app window with 21 workspaces.
- `surface-health` showed hidden workspaces still had terminal/browser surfaces marked `in_window=true`.
- Installed nightly is `0.63.2-nightly.2492757099701` at commit `631a9af`, matching latest nightly run https://github.com/manaflow-ai/cmux/actions/runs/24927570997 and current `origin/main`, so this portal leak was still present in latest nightly before this PR.

## Testing
- `./scripts/reload.sh --tag wpaudit` succeeded

## Task
- User-reported CPU/RAM spike, duplicate cmux windows with identical workspace state, and missing terminal rendering in one duplicate window.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide terminal and browser portal views when a workspace is unmounted to stop leaked portal surfaces. Prevents duplicate windows, high CPU, and GPU/IOSurface memory spikes seen by users.

- **Bug Fixes**
  - Hide portals for workspaces removed during mount reconciliation.
  - Make terminal portal hiding idempotent by always hiding the hosted view.
  - Skip the currently selected workspace to avoid flicker.
  - Updates debug logs to include removed IDs.

<sup>Written for commit c8896d7b13bff1dd24c870ccf46e08c1a4fdc446. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where terminal and browser views for unmounted workspaces were not properly hidden and could persist in the interface. The cleanup process now consistently removes these views when workspaces are deselected or removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->