### PR TITLE
feat: add Agents panel with workspace rooms in right sidebar

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -167,6 +167,7 @@
 		FE003101 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003001 /* SessionIndexStore.swift */; };
 		FE003102 /* SessionIndexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003002 /* SessionIndexView.swift */; };
 		FE003103 /* RightSidebarPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003003 /* RightSidebarPanelView.swift */; };
+		FE003104 /* AgentsPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003004 /* AgentsPanelView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -395,6 +396,7 @@
 		FE003001 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
 		FE003002 /* SessionIndexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexView.swift; sourceTree = "<group>"; };
 		FE003003 /* RightSidebarPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarPanelView.swift; sourceTree = "<group>"; };
+		FE003004 /* AgentsPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentsPanelView.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -600,6 +602,7 @@
 				FE003001 /* SessionIndexStore.swift */,
 				FE003002 /* SessionIndexView.swift */,
 				FE003003 /* RightSidebarPanelView.swift */,
+				FE003004 /* AgentsPanelView.swift */,
 				105D8421DF4E2E09D255D785 /* Auth */,
 			);
 			path = Sources;
@@ -977,6 +980,7 @@
 				FE003101 /* SessionIndexStore.swift in Sources */,
 				FE003102 /* SessionIndexView.swift in Sources */,
 				FE003103 /* RightSidebarPanelView.swift in Sources */,
+				FE003104 /* AgentsPanelView.swift in Sources */,
 				36CE99ED050785B5E96B72BB /* AuthCallbackRouter.swift in Sources */,
 				D9FEC58D5BACCF76459F1BBE /* AuthEnvironment.swift in Sources */,
 				350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -91686,6 +91686,91 @@
           }
         }
       }
+    },
+    "rightSidebar.mode.agents": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント"
+          }
+        }
+      }
+    },
+    "titlebar.agents.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Agents"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントを表示"
+          }
+        }
+      }
+    },
+    "titlebar.agents.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show agents panel"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェントパネルを表示"
+          }
+        }
+      }
+    },
+    "agentsPanel.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No workspaces"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースがありません"
+          }
+        }
+      }
+    },
+    "agentsPanel.room.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No terminals"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルがありません"
+          }
+        }
+      }
     }
   }
 }

--- a/Sources/AgentsPanelView.swift
+++ b/Sources/AgentsPanelView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+/// Right-sidebar panel that renders every workspace as a "room" containing
+/// each terminal panel as a clickable "agent" box. Tapping an agent selects
+/// the workspace and focuses that terminal.
+///
+/// Snapshot-boundary rule (`CLAUDE.md`): the row subtree (`AgentsRoomBox`,
+/// `AgentBox`) only sees value-type snapshots and closures — never an
+/// `ObservableObject` reference. This prevents unrelated `@Published`
+/// changes from invalidating every row.
+struct AgentsPanelView: View {
+    @ObservedObject var tabManager: TabManager
+    let onFocusTerminal: (UUID, UUID) -> Void
+
+    var body: some View {
+        let rooms = makeRoomSnapshots()
+        ScrollView {
+            VStack(alignment: .leading, spacing: 8) {
+                if rooms.isEmpty {
+                    Text(String(localized: "agentsPanel.empty", defaultValue: "No workspaces"))
+                        .font(.system(size: 11))
+                        .foregroundColor(.secondary)
+                        .padding(.horizontal, 8)
+                        .padding(.top, 12)
+                } else {
+                    ForEach(rooms) { room in
+                        AgentsRoomBox(snapshot: room, onTapAgent: onFocusTerminal)
+                    }
+                }
+            }
+            .padding(8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .accessibilityIdentifier("AgentsPanel")
+    }
+
+    private func makeRoomSnapshots() -> [AgentsRoomSnapshot] {
+        tabManager.tabs.map { workspace in
+            let agents: [AgentsAgentSnapshot] = workspace.panels.values
+                .compactMap { $0 as? TerminalPanel }
+                .map { panel in
+                    AgentsAgentSnapshot(
+                        id: panel.id,
+                        workspaceId: workspace.id,
+                        title: panel.displayTitle
+                    )
+                }
+                .sorted { $0.title.localizedCaseInsensitiveCompare($1.title) == .orderedAscending }
+            return AgentsRoomSnapshot(
+                id: workspace.id,
+                title: workspace.title,
+                agents: agents
+            )
+        }
+    }
+}
+
+private struct AgentsRoomSnapshot: Identifiable, Equatable {
+    let id: UUID
+    let title: String
+    let agents: [AgentsAgentSnapshot]
+}
+
+private struct AgentsAgentSnapshot: Identifiable, Equatable {
+    let id: UUID
+    let workspaceId: UUID
+    let title: String
+}
+
+private struct AgentsRoomBox: View, Equatable {
+    let snapshot: AgentsRoomSnapshot
+    let onTapAgent: (UUID, UUID) -> Void
+
+    static func == (lhs: AgentsRoomBox, rhs: AgentsRoomBox) -> Bool {
+        lhs.snapshot == rhs.snapshot
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(snapshot.title)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .padding(.horizontal, 8)
+                .padding(.top, 6)
+            if snapshot.agents.isEmpty {
+                Text(String(localized: "agentsPanel.room.empty", defaultValue: "No terminals"))
+                    .font(.system(size: 10))
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 8)
+            } else {
+                AgentsFlow(items: snapshot.agents) { agent in
+                    AgentBox(snapshot: agent, onTap: onTapAgent)
+                }
+                .padding(.horizontal, 6)
+                .padding(.bottom, 6)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .stroke(Color.secondary.opacity(0.35), lineWidth: 1)
+        )
+    }
+}
+
+private struct AgentBox: View, Equatable {
+    let snapshot: AgentsAgentSnapshot
+    let onTap: (UUID, UUID) -> Void
+
+    static func == (lhs: AgentBox, rhs: AgentBox) -> Bool {
+        lhs.snapshot == rhs.snapshot
+    }
+
+    var body: some View {
+        Button {
+            onTap(snapshot.workspaceId, snapshot.id)
+        } label: {
+            Text(snapshot.title)
+                .font(.system(size: 10))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 3)
+                .frame(maxWidth: 140, alignment: .leading)
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .stroke(Color.secondary.opacity(0.45), lineWidth: 1)
+                )
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(snapshot.title)
+    }
+}
+
+/// Simple wrapping flow layout for the agent boxes inside a room.
+private struct AgentsFlow<Item: Identifiable & Equatable, ItemView: View>: View {
+    let items: [Item]
+    let content: (Item) -> ItemView
+
+    var body: some View {
+        FlowLayout(spacing: 4) {
+            ForEach(items) { item in
+                content(item)
+            }
+        }
+    }
+}
+
+private struct FlowLayout: Layout {
+    let spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.width ?? .infinity
+        let arrangement = arrange(subviews: subviews, maxWidth: maxWidth)
+        return CGSize(width: arrangement.totalSize.width, height: arrangement.totalSize.height)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let arrangement = arrange(subviews: subviews, maxWidth: bounds.width)
+        for (index, position) in arrangement.positions.enumerated() {
+            let subview = subviews[index]
+            let size = subview.sizeThatFits(.unspecified)
+            subview.place(
+                at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                proposal: ProposedViewSize(size)
+            )
+        }
+    }
+
+    private func arrange(subviews: Subviews, maxWidth: CGFloat) -> (positions: [CGPoint], totalSize: CGSize) {
+        var positions: [CGPoint] = []
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var maxLineWidth: CGFloat = 0
+
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x > 0, x + size.width > maxWidth {
+                x = 0
+                y += lineHeight + spacing
+                lineHeight = 0
+            }
+            positions.append(CGPoint(x: x, y: y))
+            x += size.width + spacing
+            lineHeight = max(lineHeight, size.height)
+            maxLineWidth = max(maxLineWidth, x - spacing)
+        }
+        let totalHeight = y + lineHeight
+        return (positions, CGSize(width: maxLineWidth, height: totalHeight))
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2539,8 +2539,14 @@ struct ContentView: View {
             fileExplorerStore: fileExplorerStore,
             fileExplorerState: fileExplorerState,
             sessionIndexStore: sessionIndexStore,
+            tabManager: tabManager,
             onResumeSession: { entry in
                 resumeSession(entry: entry)
+            },
+            onFocusTerminal: { [tabManager] workspaceId, terminalId in
+                guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+                tabManager.selectWorkspace(workspace)
+                workspace.focusPanel(terminalId)
             }
         )
         .frame(width: rightSidebarWidth)
@@ -2605,6 +2611,9 @@ struct ContentView: View {
                     tabManager: tabManager,
                     debugSource: "titlebar.fullscreenNewWorkspace"
                 )
+            },
+            onToggleAgentsPanel: {
+                toggleAgentsPanel(fileExplorerState: fileExplorerState)
             },
             visibilityMode: .alwaysVisible
         )

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -5,11 +5,13 @@ import SwiftUI
 enum RightSidebarMode: String, CaseIterable {
     case files
     case sessions
+    case agents
 
     var label: String {
         switch self {
         case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
         case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Sessions")
+        case .agents: return String(localized: "rightSidebar.mode.agents", defaultValue: "Agents")
         }
     }
 
@@ -17,6 +19,7 @@ enum RightSidebarMode: String, CaseIterable {
         switch self {
         case .files: return "folder"
         case .sessions: return "bubble.left.and.text.bubble.right"
+        case .agents: return "person.2"
         }
     }
 }
@@ -26,7 +29,9 @@ struct RightSidebarPanelView: View {
     @ObservedObject var fileExplorerStore: FileExplorerStore
     @ObservedObject var fileExplorerState: FileExplorerState
     @ObservedObject var sessionIndexStore: SessionIndexStore
+    @ObservedObject var tabManager: TabManager
     let onResumeSession: ((SessionEntry) -> Void)?
+    let onFocusTerminal: (UUID, UUID) -> Void
 
     var body: some View {
         VStack(spacing: 0) {
@@ -75,6 +80,8 @@ struct RightSidebarPanelView: View {
                 .onAppear {
                     sessionIndexStore.setCurrentDirectoryIfChanged(sessionIndexDirectory)
                 }
+        case .agents:
+            AgentsPanelView(tabManager: tabManager, onFocusTerminal: onFocusTerminal)
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -256,6 +256,7 @@ struct TitlebarControlsView: View {
     let onToggleSidebar: () -> Void
     let onToggleNotifications: () -> Void
     let onNewTab: () -> Void
+    let onToggleAgentsPanel: () -> Void
     let visibilityMode: TitlebarControlsVisibilityMode
     @AppStorage("titlebarControlsStyle") private var styleRawValue = TitlebarControlsStyle.classic.rawValue
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
@@ -407,6 +408,18 @@ struct TitlebarControlsView: View {
             .accessibilityIdentifier("titlebarControl.newTab")
             .accessibilityLabel(String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"))
             .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
+
+            TitlebarControlButton(config: config, action: {
+                #if DEBUG
+                cmuxDebugLog("titlebar.toggleAgents")
+                #endif
+                onToggleAgentsPanel()
+            }) {
+                iconLabel(systemName: "person.2", config: config)
+            }
+            .accessibilityIdentifier("titlebarControl.toggleAgents")
+            .accessibilityLabel(String(localized: "titlebar.agents.accessibilityLabel", defaultValue: "Show Agents"))
+            .safeHelp(String(localized: "titlebar.agents.tooltip", defaultValue: "Show agents panel"))
 
         }
 
@@ -561,9 +574,28 @@ struct HiddenTitlebarSidebarControlsView: View {
             onNewTab: {
                 AppDelegate.shared?.performNewWorkspaceAction(debugSource: "titlebar.hiddenNewWorkspace")
             },
+            onToggleAgentsPanel: {
+                if let state = AppDelegate.shared?.fileExplorerState {
+                    toggleAgentsPanel(fileExplorerState: state)
+                }
+            },
             visibilityMode: .onHover
         )
         .frame(width: hostWidth, height: hostHeight, alignment: .leading)
+    }
+}
+
+/// Toggle the right sidebar to/from the agents mode.
+///
+/// - Hidden, or visible in a different mode → switch to agents mode and show.
+/// - Already visible in agents mode → hide.
+@MainActor
+func toggleAgentsPanel(fileExplorerState: FileExplorerState) {
+    if fileExplorerState.isVisible && fileExplorerState.mode == .agents {
+        fileExplorerState.setVisible(false)
+    } else {
+        fileExplorerState.mode = .agents
+        fileExplorerState.setVisible(true)
     }
 }
 
@@ -794,6 +826,11 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         let toggleSidebar = { _ = AppDelegate.shared?.sidebarState?.toggle() }
         let toggleNotifications: () -> Void = { _ = AppDelegate.shared?.toggleNotificationsPopover(animated: true) }
         let newTab = { _ = AppDelegate.shared?.performNewWorkspaceAction(debugSource: "titlebar.accessoryNewWorkspace") }
+        let toggleAgents: () -> Void = {
+            if let state = AppDelegate.shared?.fileExplorerState {
+                toggleAgentsPanel(fileExplorerState: state)
+            }
+        }
         hostingView = NonDraggableHostingView(
             rootView: TitlebarControlsView(
                 notificationStore: notificationStore,
@@ -801,6 +838,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
                 onToggleSidebar: toggleSidebar,
                 onToggleNotifications: toggleNotifications,
                 onNewTab: newTab,
+                onToggleAgentsPanel: toggleAgents,
                 visibilityMode: .alwaysVisible
             )
         )


### PR DESCRIPTION
Adds a fourth titlebar button that toggles a new "Agents" mode in the existing right sidebar. Each workspace renders as a room box; each TerminalPanel inside renders as a clickable agent box that selects the workspace and focuses that terminal via Workspace.focusPanel.

## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an “Agents” mode to the right sidebar with a new titlebar button. It lists each workspace as a room and each terminal as a clickable agent to quickly focus that terminal.

- **New Features**
  - New titlebar button (person.2) toggles the right sidebar to “Agents”; toggles off if already shown.
  - Agents panel shows rooms per workspace and agent chips per terminal; clicking selects the workspace and focuses that terminal.
  - Added EN/JA strings for mode label, button label/tooltip, and empty states; accessibility IDs for the button and panel.

<sup>Written for commit a57e415ae034656c57e2d4140b0f6d4f4de44113. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Agents sidebar panel displaying workspaces and associated terminals.
  * Added titlebar control to toggle the Agents panel visibility.
  * Clicking a terminal in the Agents panel focuses that workspace and terminal.
  * Localization support added for English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->