### PR TITLE
Fix SSH agent propagation for cmux ssh startup wrappers

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5141,11 +5141,16 @@ struct CMUXCLI {
         isShellSnippet: Bool = false
     ) throws -> String {
         let trimmedFeatures = shellFeatures.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sshAuthSockBootstrap = Self.normalizedEnvValue(ProcessInfo.processInfo.environment["SSH_AUTH_SOCK"])
+            .map { "export SSH_AUTH_SOCK=\(shellQuote($0))" } ?? ""
         let shellFeaturesBootstrap: String = trimmedFeatures.isEmpty
             ? ""
             : "export GHOSTTY_SHELL_FEATURES=\(shellQuote(trimmedFeatures))"
         let lifecycleCleanup = buildSSHSessionEndShellCommand(remoteRelayPort: remoteRelayPort)
         var scriptLines: [String] = []
+        if !sshAuthSockBootstrap.isEmpty {
+            scriptLines.append(sshAuthSockBootstrap)
+        }
         if !shellFeaturesBootstrap.isEmpty {
             scriptLines.append(shellFeaturesBootstrap)
         }

--- a/tests_v2/test_ssh_remote_cli_metadata.py
+++ b/tests_v2/test_ssh_remote_cli_metadata.py
@@ -129,6 +129,7 @@ def main() -> int:
     help_text = _run_cli(cli, ["ssh", "--help"], json_output=False)
     _must("cmux ssh" in help_text, "ssh --help output should include command header")
     _must("Create a new workspace" in help_text, "ssh --help output should describe workspace creation")
+    ssh_auth_sock = "/tmp/cmux-test-ssh-agent.sock"
 
     workspace_id = ""
     workspace_id_without_name = ""
@@ -142,6 +143,7 @@ def main() -> int:
             payload = _run_cli_json(
                 cli,
                 ["ssh", "127.0.0.1", "--port", "1", "--name", ssh_workspace_name],
+                extra_env={"SSH_AUTH_SOCK": ssh_auth_sock},
             )
             payload_workspace_id = _resolve_workspace_id_from_payload(client, payload)
             selected_workspace_id = ""
@@ -220,6 +222,11 @@ def main() -> int:
             _must(
                 "export CMUX_BOOTSTRAP_TTY=\"$cmux_bootstrap_tty\"" in ssh_startup_script,
                 f"cmux ssh startup script should preserve the bootstrap tty for relay warmup: {ssh_startup_command!r}",
+            )
+            _must(
+                re.search(rf"^export SSH_AUTH_SOCK=(?:{re.escape(ssh_auth_sock)}|'{re.escape(ssh_auth_sock)}')$", ssh_startup_script, re.MULTILINE)
+                is not None,
+                f"cmux ssh startup script should preserve SSH_AUTH_SOCK from the CLI environment: {ssh_startup_command!r}",
             )
             bootstrap_b64_match = re.search(r"^cmux_remote_bootstrap_b64=([A-Za-z0-9+/=]+)$", ssh_startup_script, re.MULTILINE)
             _must(


### PR DESCRIPTION
## Summary
- add a regression that seeds `SSH_AUTH_SOCK` into the `cmux ssh` CLI environment and inspects the generated startup script artifact
- export `SSH_AUTH_SOCK` from `buildSSHStartupCommand` so the local `ssh` client spawned by the app-side wrapper sees the user shell's agent socket
- keep the propagation local to the startup wrapper instead of the remote bootstrap shell

## Testing
- not run locally per repo policy
- `python3 -m py_compile tests_v2/test_ssh_remote_cli_metadata.py`

Fixes #3162

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the generated `cmux ssh` startup script and environment propagation for SSH sessions; could impact agent forwarding behavior or startup script correctness across shells.
> 
> **Overview**
> `cmux ssh` now captures `SSH_AUTH_SOCK` from the CLI environment and injects an `export SSH_AUTH_SOCK=...` line into the generated startup script before running the `ssh` command, ensuring the wrapper-launched ssh process can use the user’s SSH agent.
> 
> Adds a regression assertion in `tests_v2/test_ssh_remote_cli_metadata.py` that seeds `SSH_AUTH_SOCK` in the CLI environment and verifies the startup script artifact contains the expected export line.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f084748c2137c32afd675a63e72e83f723a23483. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix SSH agent propagation in cmux ssh by exporting SSH_AUTH_SOCK in the generated startup script so the local ssh client uses the user’s agent. Fixes #3162.

- **Bug Fixes**
  - Read SSH_AUTH_SOCK from the CLI environment and export it at the top of the startup wrapper to preserve agent-based auth.
  - Keep propagation local to the startup wrapper; do not export in the remote bootstrap shell.
  - Add a regression test that seeds SSH_AUTH_SOCK and asserts the startup script contains the expected export.

<sup>Written for commit f084748c2137c32afd675a63e72e83f723a23483. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH agent authentication now properly propagates to remote shell sessions, enabling SSH-based operations to work seamlessly in remote environments without additional manual configuration.

* **Tests**
  * Added regression test to verify SSH agent forwarding behavior is correctly implemented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->