### PR TITLE
Fix nightly Release build debug feed guards

### DIFF
--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -819,7 +819,9 @@ final class FeedKeyboardFocusView: NSView {
 
     func focusHostFromCoordinator() -> Bool {
         guard let window else { return false }
+#if DEBUG
         let before = feedDebugResponderSummary(window.firstResponder)
+#endif
         let result = window.makeFirstResponder(self)
 #if DEBUG
         dlog(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1042,6 +1042,7 @@ struct cmuxApp: App {
         AppDelegate.shared?.toggleNotificationsPopover(animated: false)
     }
 
+#if DEBUG
     private func openAllDebugWindows() {
         BrowserImportHintDebugWindowController.shared.show()
         BrowserProfilePopoverDebugWindowController.shared.show()
@@ -1054,6 +1055,7 @@ struct cmuxApp: App {
         FeedTextEditorDebugWindowController.shared.show()
         FeedButtonStyleDebugWindowController.shared.show()
     }
+#endif
 }
 
 private struct MainWindowBootstrapView: View {
@@ -1622,6 +1624,7 @@ private enum DebugWindowConfigSnapshot {
     }
 }
 
+#if DEBUG
 private final class DebugWindowControlsWindowController: NSWindowController, NSWindowDelegate {
     static let shared = DebugWindowControlsWindowController()
 
@@ -1943,6 +1946,7 @@ private struct DebugWindowControlsView: View {
         pasteboard.setString(payload, forType: .string)
     }
 }
+#endif
 
 private final class BrowserImportHintDebugWindowController: NSWindowController, NSWindowDelegate {
     static let shared = BrowserImportHintDebugWindowController()


### PR DESCRIPTION
Fixes nightly Release compile failure from https://github.com/manaflow-ai/cmux/actions/runs/24952090403.

Release was compiling references to DEBUG-only feed debug windows. This gates those debug surfaces and the log-only responder summary.

Verified with a local nightly-shaped Release build and ./scripts/reload.sh --tag nfeed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nightly Release compile failures by guarding debug-only feed logging and debug window helpers with `#if DEBUG`. Release builds no longer reference debug-only code.

- **Bug Fixes**
  - Guard `feedDebugResponderSummary` call in `FeedPanelView` with `#if DEBUG`.
  - Wrap `openAllDebugWindows` and `DebugWindowControls*` in `cmuxApp` with `#if DEBUG`.

<sup>Written for commit c8d04841e43df8fc252c91be242855a3daf60460. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

