### PR TITLE
fix: add AppleEvents usage description

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -49,6 +49,8 @@
 	<string>A program running within cmux would like to use your camera.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>
 	<string>A program running within cmux would like to use Bluetooth to discover passkeys and security keys.</string>
+	<key>NSAppleEventsUsageDescription</key>
+	<string>A program running within cmux would like to use AppleScript.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## Summary
- Add NSAppleEventsUsageDescription to the macOS app Info.plist
- Allows macOS TCC to show an AppleEvents consent prompt for tools running under cmux, including Computer Use MCP

## Verification
- plutil -lint Resources/Info.plist
- ./scripts/reload.sh --tag appleevents
- Verified the built tagged app contains NSAppleEventsUsageDescription in Contents/Info.plist

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NSAppleEventsUsageDescription to the macOS app Info.plist so macOS TCC shows the AppleEvents consent prompt. This enables AppleScript access for tools running under cmux, including Computer Use MCP.

<sup>Written for commit c5747af59e03b5a5db218a9815137322b3253d40. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apple Events/AppleScript support with appropriate privacy declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->