### PR TITLE
Quiet reload.sh: log to file, summary on success, dump on failure

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -281,15 +281,6 @@ if [[ -z "$TAG" ]]; then
   exit 1
 fi
 
-"$PWD/scripts/ensure-ghosttykit.sh"
-
-if should_skip_ghostty_cli_helper_zig_build; then
-  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" != "1" ]]; then
-    echo "Auto-enabling CMUX_SKIP_ZIG_BUILD=1 for Ghostty CLI helper (${AUTO_SKIP_ZIG_BUILD_REASON})"
-  fi
-  export CMUX_SKIP_ZIG_BUILD=1
-fi
-
 if [[ -n "$TAG" ]]; then
   TAG_ID="$(sanitize_bundle "$TAG")"
   TAG_SLUG="$(sanitize_path "$TAG")"
@@ -302,6 +293,63 @@ if [[ -n "$TAG" ]]; then
   if [[ "$DERIVED_SET" -eq 0 ]]; then
     DERIVED_DATA="$(tagged_derived_data_path "$TAG_SLUG")"
   fi
+fi
+
+# Quiet logging: capture all noisy build output (xcodebuild, zig, codesign,
+# plistbuddy, etc.) to a single log file. On success we print only a one-line
+# summary plus the App/CLI paths. On failure we dump the log.
+RELOAD_LOG="/tmp/cmux-reload-${TAG_SLUG}.log"
+RELOAD_START_TIME="$(date +%s)"
+: > "$RELOAD_LOG"
+
+# Save the original stdout/stderr so the EXIT trap can write the user-facing
+# summary after the body redirect, then redirect bulk output into the log.
+exec 3>&1 4>&2
+exec >>"$RELOAD_LOG" 2>&1
+
+reload_finalize() {
+  local rc=$?
+  trap - EXIT
+  exec 1>&3 2>&4
+  local elapsed=$(( $(date +%s) - RELOAD_START_TIME ))
+  if [[ "$rc" -ne 0 ]]; then
+    if [[ -s "$RELOAD_LOG" ]]; then
+      cat "$RELOAD_LOG" >&2
+    fi
+    echo "" >&2
+    echo "==> reload FAILED (exit $rc) after ${elapsed}s" >&2
+    echo "==> log: $RELOAD_LOG" >&2
+    exit "$rc"
+  fi
+  echo "==> reload succeeded in ${elapsed}s"
+  echo "==> log: $RELOAD_LOG"
+  if [[ -n "${APP_PATH:-}" ]]; then
+    echo
+    echo "App path:"
+    echo "  $APP_PATH"
+  fi
+  if [[ -x "${CLI_PATH:-}" ]]; then
+    echo
+    echo "CLI path:"
+    echo "  $CLI_PATH"
+  fi
+  if [[ "$LAUNCH" -eq 0 ]]; then
+    echo
+    echo "Build complete. Pass --launch to open the app, or cmd-click the path above."
+  fi
+}
+trap reload_finalize EXIT
+
+# Tell the user we're starting (visible even though body output is redirected).
+echo "==> reload starting (tag: ${TAG}, log: ${RELOAD_LOG})" >&3
+
+"$PWD/scripts/ensure-ghosttykit.sh"
+
+if should_skip_ghostty_cli_helper_zig_build; then
+  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" != "1" ]]; then
+    echo "Auto-enabling CMUX_SKIP_ZIG_BUILD=1 for Ghostty CLI helper (${AUTO_SKIP_ZIG_BUILD_REASON})"
+  fi
+  export CMUX_SKIP_ZIG_BUILD=1
 fi
 
 XCODEBUILD_ARGS=(
@@ -327,13 +375,11 @@ if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
 fi
 XCODEBUILD_ARGS+=(build)
 
-XCODE_LOG="/tmp/cmux-xcodebuild-${TAG_SLUG}.log"
 XCODEBUILD_LOCK="${TMPDIR:-/tmp}/cmux-xcodebuild-$(id -u).lock"
 # Xcode 26's SWBBuildService is a per-user singleton. Concurrent xcodebuild
 # invocations (even with separate -derivedDataPath) share that daemon and can
 # crash it, SIGTERMing in-flight builds. Serialize via a per-user lock so
 # parallel reload.sh runs queue instead of trampling each other.
-set +e
 python3 -c '
 import fcntl
 import os
@@ -368,15 +414,7 @@ try:
     os.execvp(command[0], command)
 except OSError as exc:
     raise SystemExit(f"error: exec: {exc}")
-' "$XCODEBUILD_LOCK" xcodebuild "${XCODEBUILD_ARGS[@]}" 2>&1 | tee "$XCODE_LOG" | grep -E '(warning:|error:|fatal:|BUILD FAILED|BUILD SUCCEEDED|\*\* BUILD|^==> )'
-XCODE_PIPESTATUS=("${PIPESTATUS[@]}")
-set -e
-XCODE_EXIT="${XCODE_PIPESTATUS[0]}"
-echo "Full build log: $XCODE_LOG"
-if [[ "$XCODE_EXIT" -ne 0 ]]; then
-  echo "error: xcodebuild failed with exit code $XCODE_EXIT" >&2
-  exit "$XCODE_EXIT"
-fi
+' "$XCODEBUILD_LOCK" xcodebuild "${XCODEBUILD_ARGS[@]}"
 sleep 0.2
 
 FALLBACK_APP_NAME="$BASE_APP_NAME"
@@ -606,14 +644,17 @@ if [[ "$LAUNCH" -eq 1 ]]; then
   fi
 fi
 
-echo
-echo "App path:"
-echo "  $APP_PATH"
-
+# The user-facing summary (success line, App path, CLI path, "pass --launch")
+# is printed by the reload_finalize EXIT trap. The tag-cleanup reminder still
+# runs here, but its output goes to $RELOAD_LOG (visible by tail -f or by
+# inspecting the log path printed in the summary).
 if [[ -n "${TAG_SLUG:-}" ]]; then
   print_tag_cleanup_reminder "$TAG_SLUG"
 fi
 
+echo
+echo "App path:"
+echo "  $APP_PATH"
 if [[ -x "${CLI_PATH:-}" ]]; then
   echo
   echo "CLI path:"
@@ -625,9 +666,4 @@ if [[ -x "${CLI_PATH:-}" ]]; then
     echo "  $CMUX_SHIM_TARGET ..."
   fi
   echo "If your shell still resolves the old cmux, run: rehash"
-fi
-
-if [[ "$LAUNCH" -eq 0 ]]; then
-  echo
-  echo "Build complete. Pass --launch to open the app, or cmd-click the path above."
 fi

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -332,6 +332,13 @@ reload_finalize() {
     echo
     echo "CLI path:"
     echo "  $CLI_PATH"
+    echo "CLI helpers:"
+    echo "  /tmp/cmux-cli ..."
+    echo "  $HOME/.local/bin/cmux-dev ..."
+    if [[ -n "${CMUX_SHIM_TARGET:-}" ]]; then
+      echo "  $CMUX_SHIM_TARGET ..."
+    fi
+    echo "If your shell still resolves the old cmux, run: rehash"
   fi
   if [[ "$LAUNCH" -eq 0 ]]; then
     echo
@@ -402,7 +409,16 @@ except OSError as exc:
 try:
     fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
 except BlockingIOError:
-    print(f"==> Another xcodebuild is running; waiting for {lock_path}...", file=sys.stderr, flush=True)
+    msg = f"==> Another xcodebuild is running; waiting for {lock_path}...\n"
+    # reload.sh saves the original stderr on fd 4 before redirecting to the
+    # log file. Surface the wait notice to the terminal so the user knows
+    # they are queued, not hung. Fall back to stderr (the log) if fd 4 is
+    # unavailable (e.g. when this script is run standalone).
+    try:
+        os.write(4, msg.encode())
+    except OSError:
+        sys.stderr.write(msg)
+        sys.stderr.flush()
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
     except OSError as exc:
@@ -644,26 +660,10 @@ if [[ "$LAUNCH" -eq 1 ]]; then
   fi
 fi
 
-# The user-facing summary (success line, App path, CLI path, "pass --launch")
-# is printed by the reload_finalize EXIT trap. The tag-cleanup reminder still
-# runs here, but its output goes to $RELOAD_LOG (visible by tail -f or by
-# inspecting the log path printed in the summary).
+# The user-facing summary (success line, App path, CLI path/helpers, rehash
+# hint, "pass --launch") is printed by the reload_finalize EXIT trap. The
+# tag-cleanup reminder still runs here, but its output goes to $RELOAD_LOG
+# (visible by tail -f or by inspecting the log path printed in the summary).
 if [[ -n "${TAG_SLUG:-}" ]]; then
   print_tag_cleanup_reminder "$TAG_SLUG"
-fi
-
-echo
-echo "App path:"
-echo "  $APP_PATH"
-if [[ -x "${CLI_PATH:-}" ]]; then
-  echo
-  echo "CLI path:"
-  echo "  $CLI_PATH"
-  echo "CLI helpers:"
-  echo "  /tmp/cmux-cli ..."
-  echo "  $HOME/.local/bin/cmux-dev ..."
-  if [[ -n "${CMUX_SHIM_TARGET:-}" ]]; then
-    echo "  $CMUX_SHIM_TARGET ..."
-  fi
-  echo "If your shell still resolves the old cmux, run: rehash"
 fi


### PR DESCRIPTION
## Summary

`reload.sh` currently streams ~2,159 lines of xcodebuild/zig/codesign noise per build. Most of it is repeated header-not-found warnings from GhosttyKit and Swift unused-variable warnings. For a human at a terminal that's annoying; for an LLM agent invoking reload it eats most of the context window.

This PR captures the body output to `/tmp/cmux-reload-<tag>.log` and prints only a short summary on success. On failure the full log is dumped to stderr.

### Before vs after

Same clean build, output to stdout+stderr:

```
$ ./scripts/reload.sh --tag foo 2>&1 | wc -l
# before: 2159
# after:    11
```

After:

```
==> reload starting (tag: foo, log: /tmp/cmux-reload-foo.log)
==> reload succeeded in 47s
==> log: /tmp/cmux-reload-foo.log

App path:
  /Users/.../cmux DEV foo.app

CLI path:
  /Users/.../cmux DEV foo.app/Contents/Resources/bin/cmux

Build complete. Pass --launch to open the app, or cmd-click the path above.
```

The full unfiltered log is preserved at `/tmp/cmux-reload-<tag>.log` for tail-f / grep / agent inspection. On failure the trap dumps the entire log to stderr and surfaces the log path so a follow-up agent can re-read it without re-running.

### Implementation

- After tag-derived vars are computed, save original stdout/stderr to fd 3/4 and redirect bulk output to `$RELOAD_LOG`.
- An EXIT trap (`reload_finalize`) restores fd 1/2 and writes the user-facing summary: success line, elapsed seconds, log path, App path, CLI path. On non-zero exit it `cat`s the log to stderr first.
- Drop the old `tee \"$XCODE_LOG\" | grep ...` filter that used to thin xcodebuild output. The body redirect supersedes it, and `set -e` already propagates xcodebuild failures to the trap.
- The tag-cleanup reminder still runs but its output now lives in the log.

The `App path:` line still appears on stdout exactly like before, so existing agents/scripts that grep for it keep working.

## Test plan

- [x] `./scripts/reload.sh --tag <new>` succeeds; stdout = 11 lines; full log at `/tmp/cmux-reload-<new>.log` (~10.7k lines)
- [x] Standalone harness exercising the same fd-redirect + EXIT-trap pattern dumps the full log on failure and prints just the summary on success
- [ ] Manual: trigger a real xcodebuild failure (e.g. introduce a syntax error temporarily) and confirm the trap dumps the build log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Build/reload output now consolidates into per-tag log files and reduces console noise.
  * Success shows a concise timing line with log path; failures print the captured log and a failure summary.
  * Live queue/waiting status remains visible during contention.
  * Helper checks and setup now run after logging is initialized; redundant end-of-script UI blocks removed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiet `reload.sh` by logging build output to a file and showing a short success summary; dump the log on failure. Reduces clean-build output from ~2,159 lines to ~11, keeps App/CLI paths visible, surfaces the lock-wait notice, and includes CLI helper paths with a rehash hint.

- **Refactors**
  - Redirect build output to `/tmp/cmux-reload-<tag>.log` and print a start banner with the log path; remove the `tee | grep` xcodebuild filter.
  - EXIT trap prints status, elapsed time, log path, App path, CLI path, CLI helpers, and a “rehash” hint; on failure, dump the full log to stderr.
  - Show the “Another xcodebuild is running; waiting...” message on the terminal via the saved stderr (fd 4), with a stderr fallback if fd 4 is unavailable.

<sup>Written for commit 36d4169611baf4dfd85f30f069964b82570332d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

