### PR TITLE
fix: resolve event window's tabManager for numeric workspace/surface shortcuts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10477,7 +10477,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Always consume the event when the digit matches to prevent Ghostty's
         // goto_tab fallback from creating a new window when the index is out of bounds.
         if let digit = numberedConfiguredShortcutDigit(event: event, action: .selectWorkspaceByNumber) {
-            if let manager = tabManager,
+            let manager = contextForMainWindow(mainWindowForShortcutEvent(event))?.tabManager ?? tabManager
+            if let manager,
                let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
                 cmuxDebugLog(
@@ -10491,10 +10492,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Numeric shortcuts for surfaces within the focused pane (9 = last)
         if let digit = numberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
+            let manager = contextForMainWindow(mainWindowForShortcutEvent(event))?.tabManager ?? tabManager
             if digit == 9 {
-                tabManager?.selectLastSurface()
+                manager?.selectLastSurface()
             } else {
-                tabManager?.selectSurface(at: digit - 1)
+                manager?.selectSurface(at: digit - 1)
             }
             return true
         }


### PR DESCRIPTION
## Summary

When two or more windows are open, pressing `Cmd+number` (select workspace) or `Ctrl+number` (select surface) could activate a tab in the **wrong window**.

The shortcuts used `AppDelegate.tabManager` — a cached weak reference that tracks the last-active window — instead of the window the key event actually came from. If the cached pointer drifted to window B while the user was working in window A, only shortcuts whose index existed in window B would misbehave; higher-indexed shortcuts silently fell through (`selectTab(at:)` has an out-of-range guard), making the bug appear to affect only specific numbers.

This is the keyboard-shortcut analogue of #770 (split-pane click activates wrong window).

## What changed

- `selectWorkspaceByNumber` and `selectSurfaceByNumber` shortcut handlers now resolve the `TabManager` from the key event's window using the existing `contextForMainWindow(mainWindowForShortcutEvent(event))` pattern — the same approach already used by sidebar and other shortcut handlers.
- Falls back to the cached `tabManager` only when no window context can be resolved from the event (preserves existing behaviour for single-window setups).

## Verification

- [x] `xcodebuild -scheme cmux -configuration Debug` passes (no new errors or warnings)
- [ ] Open two windows, each with multiple workspaces → `Cmd+1`…`Cmd+N` stays within the focused window
- [ ] Surface shortcuts (`Ctrl+1`…`Ctrl+N`) likewise stay within the focused window
- [ ] Single-window behaviour unchanged

## Test note

A unit test for this path requires AppKit multi-window infrastructure (two real `NSWindow` instances with live `TabManager` objects wired to `AppDelegate.mainWindowContexts`). No existing test harness covers this, and a fake structural test would violate the project's test quality policy. Manual verification with two windows is the practical check here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Numeric shortcuts for workspace and surface selection now consistently target the correct window context, including the “9 = last” behavior.
  * Improved shortcut routing so numeric selections work reliably across different window situations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+number (workspace) and Ctrl+number (surface) so they act in the focused window when multiple windows are open.

- **Bug Fixes**
  - Resolve the `TabManager` from the shortcut event’s window for `selectWorkspaceByNumber` and `selectSurfaceByNumber`, falling back to the cached manager only when no window context is found.

<sup>Written for commit f1379eba02381e8d6503b92c6a5c9c94e524c512. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

