### PR TITLE
fix: resolve event window's tabManager for numeric workspace/surface shortcuts

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10477,7 +10477,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Always consume the event when the digit matches to prevent Ghostty's
         // goto_tab fallback from creating a new window when the index is out of bounds.
         if let digit = numberedConfiguredShortcutDigit(event: event, action: .selectWorkspaceByNumber) {
-            if let manager = tabManager,
+            let manager = contextForMainWindow(mainWindowForShortcutEvent(event))?.tabManager ?? tabManager
+            if let manager,
                let targetIndex = WorkspaceShortcutMapper.workspaceIndex(forDigit: digit, workspaceCount: manager.tabs.count) {
 #if DEBUG
                 cmuxDebugLog(
@@ -10491,10 +10492,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Numeric shortcuts for surfaces within the focused pane (9 = last)
         if let digit = numberedConfiguredShortcutDigit(event: event, action: .selectSurfaceByNumber) {
+            let manager = contextForMainWindow(mainWindowForShortcutEvent(event))?.tabManager ?? tabManager
             if digit == 9 {
-                tabManager?.selectLastSurface()
+                manager?.selectLastSurface()
             } else {
-                tabManager?.selectSurface(at: digit - 1)
+                manager?.selectSurface(at: digit - 1)
             }
             return true
         }


### PR DESCRIPTION
## Summary

When two or more windows are open, `Cmd+number` (select workspace) and `Ctrl+number` (select surface) could activate a tab in the **wrong window**.

The shortcuts used `AppDelegate.tabManager` — a cached weak reference that tracks the last-active window — instead of the window the key event actually came from. If the cached pointer drifted to window B while the user was working in window A, only shortcuts whose index existed in window B would fire there; higher-indexed shortcuts silently fell through (`selectTab(at:)` has an out-of-range guard), making the bug appear to affect only specific numbers.

This is the keyboard-shortcut analogue of #770 (split-pane click activates wrong window).

## What changed

`selectWorkspaceByNumber` and `selectSurfaceByNumber` now resolve the `TabManager` from the key event's window via the existing `contextForMainWindow(mainWindowForShortcutEvent(event))` pattern — the same approach already used by sidebar and other shortcut handlers in `AppDelegate`. Falls back to the cached `tabManager` only when no window context can be resolved from the event.

## Verification

- [x] `xcodebuild -scheme cmux -configuration Debug` passes with no new errors or warnings
- [ ] Open two windows, each with multiple workspaces → `Cmd+1`…`Cmd+N` stays within the focused window
- [ ] Surface shortcuts (`Ctrl+1`…`Ctrl+N`) likewise stay within the focused window
- [ ] Single-window behaviour unchanged

## Test note

A unit test for this path requires AppKit multi-window infrastructure (two real `NSWindow` instances with live `TabManager` objects wired to `AppDelegate.mainWindowContexts`). No existing test harness covers this scenario, and a structural test would violate the project's test quality policy. Manual verification with two windows is the practical check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cmd+number (workspace) and Ctrl+number (surface) shortcuts so they act on the focused window. Prevents switching tabs/surfaces in the wrong window when multiple windows are open.

- **Bug Fixes**
  - Resolve the `TabManager` from the shortcut event’s window via `contextForMainWindow(mainWindowForShortcutEvent(event))`, falling back to the cached `tabManager` only if no window is found.

<sup>Written for commit 3bad792fcb31ac54c691808e90a72b454a0e1a83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed numeric shortcuts to correctly respond to the current window context, ensuring workspace and surface selections work reliably across multiple windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->