### PR TITLE
Add environments to cmux.json

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -20063,6 +20063,125 @@
         }
       }
     },
+    "command.cmuxConfig.environmentTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment: %@"
+          }
+        }
+      }
+    },
     "command.equalizeSplits.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -13,6 +13,7 @@ struct CmuxConfigFile: Codable, Sendable {
     var newWorkspaceCommand: String?
     var surfaceTabBarButtons: [CmuxSurfaceTabBarButton]?
     var commands: [CmuxCommandDefinition]
+    var environments: [CmuxEnvironmentDefinition]?
 
     private enum CodingKeys: String, CodingKey {
         case actions
@@ -20,6 +21,7 @@ struct CmuxConfigFile: Codable, Sendable {
         case newWorkspaceCommand
         case surfaceTabBarButtons
         case commands
+        case environments
     }
 
     init(
@@ -27,13 +29,15 @@ struct CmuxConfigFile: Codable, Sendable {
         ui: CmuxConfigUIDefinition? = nil,
         newWorkspaceCommand: String? = nil,
         surfaceTabBarButtons: [CmuxSurfaceTabBarButton]? = nil,
-        commands: [CmuxCommandDefinition] = []
+        commands: [CmuxCommandDefinition] = [],
+        environments: [CmuxEnvironmentDefinition]? = nil
     ) {
         self.actions = actions
         self.ui = ui
         self.newWorkspaceCommand = newWorkspaceCommand
         self.surfaceTabBarButtons = surfaceTabBarButtons
         self.commands = commands
+        self.environments = environments
     }
 
     init(from decoder: Decoder) throws {
@@ -79,6 +83,7 @@ struct CmuxConfigFile: Codable, Sendable {
             surfaceTabBarButtons = nil
         }
         commands = try container.decodeIfPresent([CmuxCommandDefinition].self, forKey: .commands) ?? []
+        environments = try container.decodeIfPresent([CmuxEnvironmentDefinition].self, forKey: .environments)
     }
 
     private static func normalizedActions(
@@ -1423,6 +1428,63 @@ struct CmuxResolvedConfigAction: Identifiable, Sendable, Hashable {
     }
 }
 
+struct CmuxEnvironmentDefinition: Codable, Sendable, Identifiable {
+    var name: String
+    var description: String?
+    var keywords: [String]?
+    var workspaces: [String]
+
+    var id: String {
+        "cmux.config.environment." + (name.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? name)
+    }
+
+    init(
+        name: String,
+        description: String? = nil,
+        keywords: [String]? = nil,
+        workspaces: [String]
+    ) {
+        self.name = name
+        self.description = description
+        self.keywords = keywords
+        self.workspaces = workspaces
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        keywords = try container.decodeIfPresent([String].self, forKey: .keywords)
+        workspaces = try container.decode([String].self, forKey: .workspaces)
+
+        if name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Environment name must not be blank"
+                )
+            )
+        }
+        if workspaces.isEmpty {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Environment '\(name)' must have at least one workspace"
+                )
+            )
+        }
+        let unique = Set(workspaces)
+        if unique.count != workspaces.count {
+            throw DecodingError.dataCorrupted(
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "Environment '\(name)' contains duplicate workspace references"
+                )
+            )
+        }
+    }
+}
+
 struct CmuxCommandDefinition: Codable, Sendable, Identifiable {
     var name: String
     var description: String?
@@ -1698,6 +1760,7 @@ final class CmuxConfigStore: ObservableObject {
     ]
 
     @Published private(set) var loadedCommands: [CmuxCommandDefinition] = []
+    @Published private(set) var loadedEnvironments: [CmuxEnvironmentDefinition] = []
     @Published private(set) var loadedActions: [CmuxResolvedConfigAction] = []
     @Published private(set) var newWorkspaceCommandName: String?
     @Published private(set) var newWorkspaceActionID: String?
@@ -1908,6 +1971,8 @@ final class CmuxConfigStore: ObservableObject {
         var commands: [CmuxCommandDefinition] = []
         var seenNames = Set<String>()
         var sourcePaths: [String: String] = [:]
+        var rawEnvironments: [CmuxEnvironmentDefinition] = []
+        var seenEnvNames = Set<String>()
         var configuredNewWorkspaceCommandName: String?
         var configuredNewWorkspaceCommandSourcePath: String?
         var configuredNewWorkspaceActionID: String?
@@ -1959,6 +2024,12 @@ final class CmuxConfigStore: ObservableObject {
                     }
                 }
             }
+            for env in localConfig.environments ?? [] {
+                if !seenEnvNames.contains(env.name) {
+                    rawEnvironments.append(env)
+                    seenEnvNames.insert(env.name)
+                }
+            }
         }
 
         // Global config fills in the rest
@@ -1991,6 +2062,33 @@ final class CmuxConfigStore: ObservableObject {
                     seenNames.insert(command.name)
                     sourcePaths[command.id] = globalConfigPath
                 }
+            }
+            for env in globalConfig.environments ?? [] {
+                if !seenEnvNames.contains(env.name) {
+                    rawEnvironments.append(env)
+                    seenEnvNames.insert(env.name)
+                }
+            }
+        }
+
+        let commandsByName = Dictionary(commands.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        var validEnvironments: [CmuxEnvironmentDefinition] = []
+        for env in rawEnvironments {
+            var valid = true
+            for wsName in env.workspaces {
+                guard let cmd = commandsByName[wsName] else {
+                    NSLog("[CmuxConfig] environment '%@' references unknown command '%@'; dropping", env.name, wsName)
+                    valid = false
+                    break
+                }
+                if cmd.workspace == nil {
+                    NSLog("[CmuxConfig] environment '%@' references '%@', which is a shell command, not a workspace; dropping", env.name, wsName)
+                    valid = false
+                    break
+                }
+            }
+            if valid {
+                validEnvironments.append(env)
             }
         }
 
@@ -2042,6 +2140,7 @@ final class CmuxConfigStore: ObservableObject {
         )
 
         loadedCommands = commands
+        loadedEnvironments = validEnvironments
         loadedActions = resolvedActions
         commandSourcePaths = sourcePaths
         actionLookup = resolvedActionLookup

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -421,6 +421,31 @@ struct CmuxConfigExecutor {
         return filtered.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
+    static func executeEnvironment(
+        environment: CmuxEnvironmentDefinition,
+        commands: [CmuxCommandDefinition],
+        tabManager: TabManager,
+        baseCwd: String,
+        configSourcePaths: [String: String],
+        globalConfigPath: String
+    ) {
+        let commandsByName = Dictionary(commands.map { ($0.name, $0) }, uniquingKeysWith: { first, _ in first })
+        Task { @MainActor in
+            for wsName in environment.workspaces {
+                guard let command = commandsByName[wsName] else { continue }
+                let proceeded = execute(
+                    command: command,
+                    tabManager: tabManager,
+                    baseCwd: baseCwd,
+                    configSourcePath: configSourcePaths[command.id],
+                    globalConfigPath: globalConfigPath
+                )
+                if !proceeded { break }
+                try? await Task.sleep(nanoseconds: 500_000_000)
+            }
+        }
+    }
+
     private static func executeWorkspaceCommand(
         command: CmuxCommandDefinition,
         workspace wsDef: CmuxWorkspaceDefinition,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7681,6 +7681,22 @@ struct ContentView: View {
             )
         }
 
+        for environment in cmuxConfigStore.loadedEnvironments {
+            let envName = sanitizeCmuxConfigPaletteText(environment.name)
+            let subtitleText = environment.description
+                .map { sanitizeCmuxConfigPaletteText($0) }
+                .flatMap { $0.isEmpty ? nil : $0 }
+                ?? cmuxConfigDefaultSubtitle
+            contributions.append(
+                CommandPaletteCommandContribution(
+                    commandId: environment.id,
+                    title: constant(String(localized: "command.cmuxConfig.environmentTitle", defaultValue: "Environment: \(envName)")),
+                    subtitle: constant(subtitleText),
+                    keywords: environment.keywords ?? []
+                )
+            )
+        }
+
         return contributions
     }
 
@@ -8196,6 +8212,24 @@ struct ContentView: View {
             let captured = action
             registry.register(commandId: action.id) {
                 executeConfiguredAction(captured)
+            }
+        }
+
+        for environment in cmuxConfigStore.loadedEnvironments {
+            let captured = environment
+            let allCommands = cmuxConfigStore.loadedCommands
+            let sourcePaths = cmuxConfigStore.commandSourcePaths
+            let globalPath = cmuxConfigStore.globalConfigPath
+            registry.register(commandId: environment.id) {
+                let baseCwd = configuredActionBaseCwd()
+                CmuxConfigExecutor.executeEnvironment(
+                    environment: captured,
+                    commands: allCommands,
+                    tabManager: tabManager,
+                    baseCwd: baseCwd,
+                    configSourcePaths: sourcePaths,
+                    globalConfigPath: globalPath
+                )
             }
         }
     }

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1857,6 +1857,113 @@ final class CmuxConfigCwdResolutionTests: XCTestCase {
     }
 }
 
+// MARK: - Environment definitions
+
+final class CmuxEnvironmentDecodingTests: XCTestCase {
+
+    private func decode(_ json: String) throws -> CmuxConfigFile {
+        let data = json.data(using: .utf8)!
+        return try JSONDecoder().decode(CmuxConfigFile.self, from: data)
+    }
+
+    func testDecodeValidEnvironment() throws {
+        let json = """
+        {
+          "commands": [
+            { "name": "WS A", "workspace": { "name": "A" } },
+            { "name": "WS B", "workspace": { "name": "B" } }
+          ],
+          "environments": [{
+            "name": "Daily",
+            "description": "All workspaces",
+            "keywords": ["daily", "all"],
+            "workspaces": ["WS A", "WS B"]
+          }]
+        }
+        """
+        let config = try decode(json)
+        XCTAssertEqual(config.environments?.count, 1)
+        let env = config.environments![0]
+        XCTAssertEqual(env.name, "Daily")
+        XCTAssertEqual(env.description, "All workspaces")
+        XCTAssertEqual(env.keywords, ["daily", "all"])
+        XCTAssertEqual(env.workspaces, ["WS A", "WS B"])
+    }
+
+    func testDecodeConfigWithoutEnvironments() throws {
+        let json = """
+        {
+          "commands": [{ "name": "Build", "command": "make" }]
+        }
+        """
+        let config = try decode(json)
+        XCTAssertNil(config.environments)
+        XCTAssertEqual(config.commands.count, 1)
+    }
+
+    func testDecodeEmptyEnvironmentsArray() throws {
+        let json = """
+        {
+          "commands": [{ "name": "Build", "command": "make" }],
+          "environments": []
+        }
+        """
+        let config = try decode(json)
+        XCTAssertEqual(config.environments?.count, 0)
+    }
+
+    func testDecodeBlankEnvironmentNameThrows() {
+        let json = """
+        {
+          "commands": [{ "name": "WS", "workspace": { "name": "ws" } }],
+          "environments": [{ "name": "", "workspaces": ["WS"] }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    func testDecodeWhitespaceOnlyEnvironmentNameThrows() {
+        let json = """
+        {
+          "commands": [{ "name": "WS", "workspace": { "name": "ws" } }],
+          "environments": [{ "name": "   ", "workspaces": ["WS"] }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    func testDecodeEmptyWorkspacesArrayThrows() {
+        let json = """
+        {
+          "commands": [{ "name": "WS", "workspace": { "name": "ws" } }],
+          "environments": [{ "name": "Empty", "workspaces": [] }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    func testDecodeDuplicateWorkspaceReferencesThrows() {
+        let json = """
+        {
+          "commands": [{ "name": "WS", "workspace": { "name": "ws" } }],
+          "environments": [{ "name": "Dupes", "workspaces": ["WS", "WS"] }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    func testEnvironmentIdIsDeterministic() {
+        let env = CmuxEnvironmentDefinition(name: "Daily Work", workspaces: ["A"])
+        XCTAssertEqual(env.id, "cmux.config.environment.Daily%20Work")
+    }
+
+    func testEnvironmentIdDoesNotCollideWithCommandId() {
+        let env = CmuxEnvironmentDefinition(name: "build", workspaces: ["A"])
+        let cmd = CmuxCommandDefinition(name: "build", command: "make")
+        XCTAssertNotEqual(env.id, cmd.id)
+    }
+}
+
 // MARK: - Layout encoding round-trip
 
 final class CmuxLayoutEncodingTests: XCTestCase {


### PR DESCRIPTION
## Summary

Closes #2086 · Discussion #681

An environment is a named set of references to existing workspace commands. Opening an environment from the command palette opens each referenced workspace in order, reusing each command's existing `restart` behavior.

### Example config

```json
{
  "commands": [
    { "name": "CC - vault", "workspace": { ... } },
    { "name": "CC - web", "workspace": { ... } }
  ],
  "environments": [{
    "name": "Daily",
    "description": "All daily workspaces",
    "keywords": ["daily"],
    "workspaces": ["CC - vault", "CC - web"]
  }]
}
```

### Validation (at config load time)
- Empty/blank name, empty workspaces, duplicates → rejected during decode
- Unknown reference, shell-command reference → dropped with console log
- Invalid environments never appear in the command palette

### Scope
- Additive only — no close/replace semantics, no startup auto-open, no inline workspace definitions
- Environments appear in the command palette as "Environment: \<name\>"
- Hot reload works via existing configRevision publisher
- Workspaces open with a 500ms stagger to allow terminal setup between spawns

## Test plan

- [x] "Environment: Smoke All" opens 3 workspace tabs (Tab A, B, C)
- [x] "Smoke Bad Ref" and "Smoke Wrong Type" silently dropped at load time (not in palette)
- [x] Re-invoking environment with `restart: ignore` reuses existing workspaces
- [x] Re-invoking environment with `restart: recreate` closes and reopens workspaces
- [x] Existing cmux.json without `environments` works unchanged
- [ ] Unit tests pass (`xcodebuild -scheme cmux-unit`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add environments to `cmux.json` so you can open a named set of workspace commands from the command palette in one go. Each workspace opens in order, reuses its restart behavior, and stops if you cancel.

- **New Features**
  - Add `environments`: `name`, optional `description`/`keywords`, and `workspaces` (by command name); merged from local/global config and de-duped by name.
  - Show in the command palette as "Environment: <name>" (localized); use description as subtitle and keywords for search; hot-reloads on config changes.
  - Opening an environment spawns its workspaces in order with a 500 ms stagger and honors each command’s `restart`. Validate at load (blank names, empty lists, or duplicate refs rejected; unknown or non-workspace refs drop the env and are logged). Backward compatible; unit tests added.

- **Bug Fixes**
  - Ensure UI-safe execution with `@MainActor` on staggered environment launch.
  - Prevent crashes on duplicate command names by using `uniquingKeysWith` when indexing commands.
  - Use a serialized `Task` loop for staggering instead of `DispatchQueue.main.asyncAfter` to avoid queued spawns piling up after confirm dialogs.

<sup>Written for commit ef9e751f21d5db3e80dd5b255a92f2239dc32136. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add environment definitions to group and execute multiple workspaces via the command palette, with dynamic palette entries per environment.
  * Environment executions are staggered (500ms) for orderly startup.

* **Bug Fixes**
  * Environments with invalid or unresolved workspace references are omitted at load time.

* **Localization**
  * Added localized title for environment commands across many languages (English marked translated; others need review).

* **Tests**
  * New tests validating environment decoding, validation rules, and ID determinism.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->