### PR TITLE
Add copy ID actions to context menus

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -33551,6 +33551,52 @@
         }
       }
     },
+    "contextMenu.copyWorkspaceID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace ID"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースIDをコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 ID 복사"
+          }
+        }
+      }
+    },
+    "contextMenu.copyWorkspaceIDs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace IDs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースIDをコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 ID 복사"
+          }
+        }
+      }
+    },
     "contextMenu.moveDown": {
       "extractionState": "manual",
       "localizations": {
@@ -90126,6 +90172,29 @@
           "stringUnit": {
             "state": "translated",
             "value": "복사"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.copyWorkspaceAndSurfaceIDs": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Workspace and Surface IDs"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースIDとサーフェスIDをコピー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "워크스페이스 및 표면 ID 복사"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -90194,7 +90194,7 @@
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "워크스페이스 및 표면 ID 복사"
+            "value": "워크스페이스 및 서피스 ID 복사"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -90539,19 +90539,19 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Copy Workspace and Surface IDs"
+            "value": "Copy IDs"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ワークスペースIDとサーフェスIDをコピー"
+            "value": "IDをコピー"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "워크스페이스 및 서피스 ID 복사"
+            "value": "ID 복사"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -90533,7 +90533,7 @@
         }
       }
     },
-    "terminalContextMenu.copyWorkspaceAndSurfaceIDs": {
+    "terminalContextMenu.copyIdentifiers": {
       "extractionState": "manual",
       "localizations": {
         "en": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12894,11 +12894,6 @@ private struct TabItemView: View, Equatable {
             }
         }
 
-        Button(copyWorkspaceIDLabel) {
-            copyWorkspaceIdsToPasteboard(targetIds)
-        }
-        .disabled(targetIds.isEmpty)
-
         if !remoteContextMenuWorkspaceIds.isEmpty {
             Divider()
 
@@ -13057,6 +13052,13 @@ private struct TabItemView: View, Equatable {
             clearLatestNotifications(targetIds)
         }
         .disabled(!hasLatestNotifications(in: targetIds))
+
+        Divider()
+
+        Button(copyWorkspaceIDLabel) {
+            copyWorkspaceIdsToPasteboard(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
     }
 
     private var backgroundColor: Color {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12333,7 +12333,11 @@ private struct TabItemView: View, Equatable {
     }
 
     private func copyWorkspaceIdsToPasteboard(_ ids: [UUID]) {
-        copyTextToPasteboard(WorkspaceSurfaceIdentifierClipboardText.make(workspaceIds: ids))
+        let refs = TerminalController.shared.v2WorkspaceRefs(for: ids)
+        let workspaces = ids.map { id in
+            (id: id, ref: refs[id])
+        }
+        copyTextToPasteboard(WorkspaceSurfaceIdentifierClipboardText.make(workspaces: workspaces))
     }
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12332,6 +12332,10 @@ private struct TabItemView: View, Equatable {
         pasteboard.setString(text, forType: .string)
     }
 
+    private func copyWorkspaceIdsToPasteboard(_ ids: [UUID]) {
+        copyTextToPasteboard(ids.map(\.uuidString).joined(separator: "\n"))
+    }
+
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {
         settings.visibleAuxiliaryDetails
     }
@@ -12838,6 +12842,10 @@ private struct TabItemView: View, Equatable {
             multi: String(localized: "contextMenu.clearLatestNotifications", defaultValue: "Clear Latest Notifications"),
             single: String(localized: "contextMenu.clearLatestNotification", defaultValue: "Clear Latest Notification"),
             isMulti: isMulti)
+        let copyWorkspaceIDLabel = contextMenuLabel(
+            multi: String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs"),
+            single: String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
+            isMulti: isMulti)
         let renameWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .renameWorkspace)
         let editWorkspaceDescriptionShortcut = KeyboardShortcutSettings.shortcut(for: .editWorkspaceDescription)
         let closeWorkspaceShortcut = KeyboardShortcutSettings.shortcut(for: .closeWorkspace)
@@ -12885,6 +12893,11 @@ private struct TabItemView: View, Equatable {
                 }
             }
         }
+
+        Button(copyWorkspaceIDLabel) {
+            copyWorkspaceIdsToPasteboard(targetIds)
+        }
+        .disabled(targetIds.isEmpty)
 
         if !remoteContextMenuWorkspaceIds.isEmpty {
             Divider()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12333,7 +12333,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private func copyWorkspaceIdsToPasteboard(_ ids: [UUID]) {
-        copyTextToPasteboard(ids.map(\.uuidString).joined(separator: "\n"))
+        copyTextToPasteboard(WorkspaceSurfaceIdentifierClipboardText.make(workspaceIds: ids))
     }
 
     private var visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8626,14 +8626,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEquivalent: ""
         )
         pasteItem.target = self
-        if terminalSurface != nil {
-            let identifiersItem = menu.addItem(
-                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy Workspace and Surface IDs"),
-                action: #selector(copyWorkspaceAndSurfaceIdentifiers(_:)),
-                keyEquivalent: ""
-            )
-            identifiersItem.target = self
-        }
         menu.addItem(.separator())
         let splitHorizontallyItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally"),
@@ -8669,6 +8661,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             systemSymbolName: "arrow.trianglehead.2.clockwise",
             accessibilityDescription: nil
         )
+        if terminalSurface != nil {
+            menu.addItem(.separator())
+            let identifiersItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy Workspace and Surface IDs"),
+                action: #selector(copyWorkspaceAndSurfaceIdentifiers(_:)),
+                keyEquivalent: ""
+            )
+            identifiersItem.target = self
+        }
         return menu
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6611,8 +6611,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
         guard let terminalSurface else { return }
-        let refs = TerminalController.shared.v2WorkspaceAndSurfaceRefs(
+        let paneId = terminalSurface.owningWorkspace()?.paneId(forPanelId: terminalSurface.id)?.id
+        let refs = TerminalController.shared.v2WorkspacePaneAndSurfaceRefs(
             workspaceId: terminalSurface.tabId,
+            paneId: paneId,
             surfaceId: terminalSurface.id
         )
         let pasteboard = NSPasteboard.general
@@ -6620,8 +6622,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         pasteboard.setString(
             WorkspaceSurfaceIdentifierClipboardText.make(
                 workspaceId: terminalSurface.tabId,
+                paneId: paneId,
                 surfaceId: terminalSurface.id,
                 workspaceRef: refs.workspaceRef,
+                paneRef: refs.paneRef,
                 surfaceRef: refs.surfaceRef
             ),
             forType: .string

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6611,12 +6611,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
         guard let terminalSurface else { return }
+        let refs = TerminalController.shared.v2WorkspaceAndSurfaceRefs(
+            workspaceId: terminalSurface.tabId,
+            surfaceId: terminalSurface.id
+        )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(
             WorkspaceSurfaceIdentifierClipboardText.make(
                 workspaceId: terminalSurface.tabId,
-                surfaceId: terminalSurface.id
+                surfaceId: terminalSurface.id,
+                workspaceRef: refs.workspaceRef,
+                surfaceRef: refs.surfaceRef
             ),
             forType: .string
         )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6609,6 +6609,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = performBindingAction("copy_to_clipboard")
     }
 
+    @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
+        guard let terminalSurface else { return }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(
+            """
+            workspace_id=\(terminalSurface.tabId.uuidString)
+            surface_id=\(terminalSurface.id.uuidString)
+            """,
+            forType: .string
+        )
+    }
+
     // MARK: - Clipboard paste
 
     @IBAction func paste(_ sender: Any?) {
@@ -6634,6 +6647,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return GhosttyPasteboardHelper.hasString(for: GHOSTTY_CLIPBOARD_STANDARD)
         case #selector(splitHorizontally(_:)), #selector(splitVertically(_:)):
             return canSplitCurrentSurface()
+        case #selector(copyWorkspaceAndSurfaceIdentifiers(_:)):
+            return terminalSurface != nil
         default:
             return true
         }
@@ -8611,6 +8626,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyEquivalent: ""
         )
         pasteItem.target = self
+        if terminalSurface != nil {
+            let identifiersItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy Workspace and Surface IDs"),
+                action: #selector(copyWorkspaceAndSurfaceIdentifiers(_:)),
+                keyEquivalent: ""
+            )
+            identifiersItem.target = self
+        }
         menu.addItem(.separator())
         let splitHorizontallyItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.splitHorizontally", defaultValue: "Split Horizontally"),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6614,10 +6614,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(
-            """
-            workspace_id=\(terminalSurface.tabId.uuidString)
-            surface_id=\(terminalSurface.id.uuidString)
-            """,
+            WorkspaceSurfaceIdentifierClipboardText.make(
+                workspaceId: terminalSurface.tabId,
+                surfaceId: terminalSurface.id
+            ),
             forType: .string
         )
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8674,7 +8674,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if terminalSurface != nil {
             menu.addItem(.separator())
             let identifiersItem = menu.addItem(
-                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy IDs"),
+                withTitle: String(localized: "terminalContextMenu.copyIdentifiers", defaultValue: "Copy IDs"),
                 action: #selector(copyWorkspaceAndSurfaceIdentifiers(_:)),
                 keyEquivalent: ""
             )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8674,7 +8674,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if terminalSurface != nil {
             menu.addItem(.separator())
             let identifiersItem = menu.addItem(
-                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy Workspace and Surface IDs"),
+                withTitle: String(localized: "terminalContextMenu.copyWorkspaceAndSurfaceIDs", defaultValue: "Copy IDs"),
                 action: #selector(copyWorkspaceAndSurfaceIdentifiers(_:)),
                 keyEquivalent: ""
             )

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3309,9 +3309,14 @@ class TerminalController {
         return refs
     }
 
-    func v2WorkspaceAndSurfaceRefs(workspaceId: UUID, surfaceId: UUID) -> (workspaceRef: String, surfaceRef: String) {
+    func v2WorkspacePaneAndSurfaceRefs(
+        workspaceId: UUID,
+        paneId: UUID?,
+        surfaceId: UUID
+    ) -> (workspaceRef: String, paneRef: String?, surfaceRef: String) {
         return (
             workspaceRef: v2EnsureHandleRef(kind: .workspace, uuid: workspaceId),
+            paneRef: paneId.map { v2EnsureHandleRef(kind: .pane, uuid: $0) },
             surfaceRef: v2EnsureHandleRef(kind: .surface, uuid: surfaceId)
         )
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3300,6 +3300,22 @@ class TerminalController {
         return v2EnsureHandleRef(kind: kind, uuid: uuid)
     }
 
+    func v2WorkspaceRefs(for ids: [UUID]) -> [UUID: String] {
+        var refs: [UUID: String] = [:]
+        refs.reserveCapacity(ids.count)
+        for id in ids {
+            refs[id] = v2EnsureHandleRef(kind: .workspace, uuid: id)
+        }
+        return refs
+    }
+
+    func v2WorkspaceAndSurfaceRefs(workspaceId: UUID, surfaceId: UUID) -> (workspaceRef: String, surfaceRef: String) {
+        return (
+            workspaceRef: v2EnsureHandleRef(kind: .workspace, uuid: workspaceId),
+            surfaceRef: v2EnsureHandleRef(kind: .surface, uuid: surfaceId)
+        )
+    }
+
     private func v2TabRef(uuid: UUID?) -> Any {
         guard let uuid else { return NSNull() }
         let surfaceRef = v2EnsureHandleRef(kind: .surface, uuid: uuid)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7193,18 +7193,26 @@ enum WorkspaceSurfaceIdentifierClipboardText {
 
     static func make(
         workspaceId: UUID,
+        paneId: UUID? = nil,
         surfaceId: UUID,
         workspaceRef: String? = nil,
+        paneRef: String? = nil,
         surfaceRef: String? = nil
     ) -> String {
         var lines: [String] = []
         if let workspaceRef {
             lines.append("workspace_ref=\(workspaceRef)")
         }
+        lines.append("workspace_id=\(workspaceId.uuidString)")
+        if let paneRef {
+            lines.append("pane_ref=\(paneRef)")
+        }
+        if let paneId {
+            lines.append("pane_id=\(paneId.uuidString)")
+        }
         if let surfaceRef {
             lines.append("surface_ref=\(surfaceRef)")
         }
-        lines.append("workspace_id=\(workspaceId.uuidString)")
         lines.append("surface_id=\(surfaceId.uuidString)")
         return lines.joined(separator: "\n")
     }
@@ -11342,14 +11350,21 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: UUID) {
-        let refs = TerminalController.shared.v2WorkspaceAndSurfaceRefs(workspaceId: id, surfaceId: surfaceId)
+        let paneId = paneId(forPanelId: surfaceId)?.id
+        let refs = TerminalController.shared.v2WorkspacePaneAndSurfaceRefs(
+            workspaceId: id,
+            paneId: paneId,
+            surfaceId: surfaceId
+        )
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(
             WorkspaceSurfaceIdentifierClipboardText.make(
                 workspaceId: id,
+                paneId: paneId,
                 surfaceId: surfaceId,
                 workspaceRef: refs.workspaceRef,
+                paneRef: refs.paneRef,
                 surfaceRef: refs.surfaceRef
             ),
             forType: .string

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11302,6 +11302,22 @@ final class Workspace: Identifiable, ObservableObject {
         return shortcuts
     }
 
+    private static func workspaceAndSurfaceIDsClipboardText(workspaceId: UUID, surfaceId: UUID) -> String {
+        """
+        workspace_id=\(workspaceId.uuidString)
+        surface_id=\(surfaceId.uuidString)
+        """
+    }
+
+    private func copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: UUID) {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(
+            Self.workspaceAndSurfaceIDsClipboardText(workspaceId: id, surfaceId: surfaceId),
+            forType: .string
+        )
+    }
+
     // MARK: - Flash/Notification Support
 
     func triggerFocusFlash(panelId: UUID) {
@@ -13538,6 +13554,9 @@ extension Workspace: BonsplitDelegate {
         case .clearName:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             setPanelCustomTitle(panelId: panelId, title: nil)
+        case .copyIdentifiers:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: panelId)
         case .closeToLeft:
             closeTabs(tabIdsToLeft(of: tab.id, inPane: pane))
         case .closeToRight:

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7172,19 +7172,41 @@ struct ClosedBrowserPanelRestoreSnapshot {
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 enum WorkspaceSurfaceIdentifierClipboardText {
-    static func make(workspaceId: UUID) -> String {
-        "workspace_id=\(workspaceId.uuidString)"
+    static func make(workspaceId: UUID, workspaceRef: String? = nil) -> String {
+        var lines: [String] = []
+        if let workspaceRef {
+            lines.append("workspace_ref=\(workspaceRef)")
+        }
+        lines.append("workspace_id=\(workspaceId.uuidString)")
+        return lines.joined(separator: "\n")
     }
 
     static func make(workspaceIds: [UUID]) -> String {
-        workspaceIds.map { make(workspaceId: $0) }.joined(separator: "\n")
+        workspaceIds.map { make(workspaceId: $0) }.joined(separator: "\n\n")
     }
 
-    static func make(workspaceId: UUID, surfaceId: UUID) -> String {
-        """
-        \(make(workspaceId: workspaceId))
-        surface_id=\(surfaceId.uuidString)
-        """
+    static func make(workspaces: [(id: UUID, ref: String?)]) -> String {
+        workspaces
+            .map { make(workspaceId: $0.id, workspaceRef: $0.ref) }
+            .joined(separator: "\n\n")
+    }
+
+    static func make(
+        workspaceId: UUID,
+        surfaceId: UUID,
+        workspaceRef: String? = nil,
+        surfaceRef: String? = nil
+    ) -> String {
+        var lines: [String] = []
+        if let workspaceRef {
+            lines.append("workspace_ref=\(workspaceRef)")
+        }
+        if let surfaceRef {
+            lines.append("surface_ref=\(surfaceRef)")
+        }
+        lines.append("workspace_id=\(workspaceId.uuidString)")
+        lines.append("surface_id=\(surfaceId.uuidString)")
+        return lines.joined(separator: "\n")
     }
 }
 
@@ -11320,10 +11342,16 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: UUID) {
+        let refs = TerminalController.shared.v2WorkspaceAndSurfaceRefs(workspaceId: id, surfaceId: surfaceId)
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(
-            WorkspaceSurfaceIdentifierClipboardText.make(workspaceId: id, surfaceId: surfaceId),
+            WorkspaceSurfaceIdentifierClipboardText.make(
+                workspaceId: id,
+                surfaceId: surfaceId,
+                workspaceRef: refs.workspaceRef,
+                surfaceRef: refs.surfaceRef
+            ),
             forType: .string
         )
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7171,6 +7171,15 @@ struct ClosedBrowserPanelRestoreSnapshot {
 
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
+enum WorkspaceSurfaceIdentifierClipboardText {
+    static func make(workspaceId: UUID, surfaceId: UUID) -> String {
+        """
+        workspace_id=\(workspaceId.uuidString)
+        surface_id=\(surfaceId.uuidString)
+        """
+    }
+}
+
 @MainActor
 final class Workspace: Identifiable, ObservableObject {
     static let terminalScrollBarHiddenDidChangeNotification = Notification.Name(
@@ -11302,18 +11311,11 @@ final class Workspace: Identifiable, ObservableObject {
         return shortcuts
     }
 
-    private static func workspaceAndSurfaceIDsClipboardText(workspaceId: UUID, surfaceId: UUID) -> String {
-        """
-        workspace_id=\(workspaceId.uuidString)
-        surface_id=\(surfaceId.uuidString)
-        """
-    }
-
     private func copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: UUID) {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(
-            Self.workspaceAndSurfaceIDsClipboardText(workspaceId: id, surfaceId: surfaceId),
+            WorkspaceSurfaceIdentifierClipboardText.make(workspaceId: id, surfaceId: surfaceId),
             forType: .string
         )
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7172,9 +7172,17 @@ struct ClosedBrowserPanelRestoreSnapshot {
 /// Workspace represents a sidebar tab.
 /// Each workspace contains one BonsplitController that manages split panes and nested surfaces.
 enum WorkspaceSurfaceIdentifierClipboardText {
+    static func make(workspaceId: UUID) -> String {
+        "workspace_id=\(workspaceId.uuidString)"
+    }
+
+    static func make(workspaceIds: [UUID]) -> String {
+        workspaceIds.map { make(workspaceId: $0) }.joined(separator: "\n")
+    }
+
     static func make(workspaceId: UUID, surfaceId: UUID) -> String {
         """
-        workspace_id=\(workspaceId.uuidString)
+        \(make(workspaceId: workspaceId))
         surface_id=\(surfaceId.uuidString)
         """
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11349,7 +11349,7 @@ final class Workspace: Identifiable, ObservableObject {
         return shortcuts
     }
 
-    private func copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: UUID) {
+    private func copyIdentifiersToPasteboard(surfaceId: UUID) {
         let paneId = paneId(forPanelId: surfaceId)?.id
         let refs = TerminalController.shared.v2WorkspacePaneAndSurfaceRefs(
             workspaceId: id,
@@ -13609,7 +13609,7 @@ extension Workspace: BonsplitDelegate {
             setPanelCustomTitle(panelId: panelId, title: nil)
         case .copyIdentifiers:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
-            copyWorkspaceAndSurfaceIDsToPasteboard(surfaceId: panelId)
+            copyIdentifiersToPasteboard(surfaceId: panelId)
         case .closeToLeft:
             closeTabs(tabIdsToLeft(of: tab.id, inPane: pane))
         case .closeToRight:


### PR DESCRIPTION
## Summary
- Add workspace ID copying to workspace sidebar context menus.
- Add workspace/surface ID copying to Bonsplit surface tab menus and terminal content context menus.
- Localize the new menu labels and update the Bonsplit submodule pointer.

## Testing
- `jq empty Resources/Localizable.xcstrings`
- `plutil -lint vendor/bonsplit/Sources/Bonsplit/Resources/en.lproj/Localizable.strings vendor/bonsplit/Sources/Bonsplit/Resources/ja.lproj/Localizable.strings`
- `./scripts/reload.sh --tag surfid` passed

## Issues
- Task: right-click a tab, surface, or terminal and copy workspace/surface IDs
- Related: https://github.com/manaflow-ai/bonsplit/pull/107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Copy Workspace ID(s)" to the sidebar (copies one or multiple workspace IDs; disabled when none selected).
  * Added "Copy Workspace and Surface IDs" to the terminal (copies workspace_id and surface_id pairs when available).
  * Added "Copy Identifiers" to tab context menus.

* **Localization**
  * New menu labels localized in English, Japanese, and Korean.

* **Chores**
  * Updated bundled vendor dependency to a newer pinned version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added “Copy Workspace ID” and “Copy IDs” actions to workspace sidebar, surface tab, and terminal context menus. Clipboard output uses keyed lines with stable refs and includes pane refs/IDs; actions appear at the bottom of menus and labels are shortened.

- **New Features**
  - Sidebar: copy one or multiple Workspace IDs; label pluralizes; disabled when none selected. Output: workspace_id (+ optional workspace_ref).
  - Surface tabs and terminal: copy workspace, pane, and surface identifiers with refs:
    - workspace_ref=..., workspace_id=..., pane_ref=..., pane_id=..., surface_ref=..., surface_id=...
  - Localized labels in English, Japanese, and Korean; shortened to “Copy IDs”; fixed Korean surface ID label; renamed terminal context menu key to `terminalContextMenu.copyIdentifiers`.

- **Dependencies**
  - Updated `Bonsplit` submodule to include the tab “Copy Identifiers” action.

<sup>Written for commit 0cb80d997329eaf6cf269cbb56066d2b852887d3. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3183?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

