### PR TITLE
Harden cloud VM production controls

### DIFF
--- a/docs/cloud-vm-backend-rollout-todo.md
+++ b/docs/cloud-vm-backend-rollout-todo.md
@@ -11,15 +11,14 @@ This is the scoped todo list for making the Cloud VM backend production-ready wi
   `staging` git branch.
 - VM application logic already runs in the Vercel Next app:
   - `web/app/api/vm/**`
-  - `web/app/api/rivet/**`
   - `web/services/vms/**`
-- Current durable VM control-plane state is in RivetKit actors:
-  - `userVmsActor`
-  - `vmActor`
+- Current durable VM control-plane state is in Postgres:
+  - `cloud_vms`
+  - `cloud_vm_leases`
+  - `cloud_vm_usage_events`
 - WebSocket PTY/browser proxy data paths talk to provider VM endpoints after the REST handshake.
 - No separate AWS app server is required for the current version.
-- No separate staging Vercel project is documented yet. Current Vercel environments are development,
-  preview, and production.
+- A separate `manaflow/cmux-staging` Vercel project exists for staging.
 
 ## Existing Vercel Env Vars
 
@@ -34,27 +33,21 @@ These are already configured in Vercel for development, preview, and production:
 
 ## Phase 1: Finish Current Vercel Backend Setup
 
-- [ ] Decide whether staging is:
-  - a dedicated Vercel project, or
-  - the existing Vercel preview environment with a stable branch alias.
-- [ ] Add a global VM create kill switch, for example `CMUX_VM_CREATE_ENABLED`.
-- [ ] Add per-provider kill switches, for example:
+- [x] Use a dedicated Vercel staging project instead of sharing preview secrets.
+- [x] Add a global VM create kill switch, `CMUX_VM_CREATE_ENABLED`.
+- [x] Add per-provider kill switches:
   - `CMUX_VM_E2B_ENABLED`
   - `CMUX_VM_FREESTYLE_ENABLED`
+- [x] Set kill switches to enabled values in `manaflow/cmux` production and
+  `manaflow/cmux-staging` production.
 - [ ] Add a preview allowlist before paid provider calls if preview uses real provider keys:
   - Stack user ids
   - Stack org ids later, if org billing exists
-- [ ] Set `CMUX_RIVET_INTERNAL_SECRET` in Vercel development, preview, and production.
 - [ ] Set `CMUX_VM_DEFAULT_PROVIDER` in Vercel development, preview, and production.
 - [ ] Set `E2B_API_KEY` in Vercel preview and production.
 - [ ] Set `FREESTYLE_API_KEY` in Vercel preview and production.
 - [ ] Set `E2B_CMUXD_WS_TEMPLATE` in Vercel preview and production.
 - [ ] Set `FREESTYLE_SANDBOX_SNAPSHOT` in Vercel preview and production.
-- [ ] Set Rivet deployment env in Vercel preview and production:
-  - `RIVET_ENDPOINT`, or
-  - `RIVET_TOKEN` plus `RIVET_NAMESPACE`
-- [ ] Set `RIVET_PUBLIC_ENDPOINT` if the selected Rivet deployment flow requires public metadata.
-- [ ] Set `RIVET_RUNNER_VERSION` and document the monotonic bump rule.
 - [ ] Set Axiom/OpenTelemetry env in Vercel preview and production:
   - `OTEL_SERVICE_NAME`
   - `OTEL_EXPORTER_OTLP_ENDPOINT`
@@ -62,8 +55,6 @@ These are already configured in Vercel for development, preview, and production:
 - [ ] Confirm Vercel function max duration for VM routes. `POST /api/vm` can wait on real provider
   provisioning, so the route either needs a sufficient `maxDuration` or must become an async
   create-status flow before production.
-- [ ] Confirm `/api/rivet/start` works with Vercel Deployment Protection. If previews are protected,
-  configure the correct bypass for trusted Rivet engine requests without exposing raw actor actions.
 - [ ] Confirm Stack Auth callback and trusted domains include:
   - `https://cmux.com`
   - the Vercel preview domain pattern used by this project
@@ -79,16 +70,19 @@ These are already configured in Vercel for development, preview, and production:
 
 ## Phase 2: Local Secret Parity
 
-- [ ] Keep Stack/web runtime secrets in `~/.secret/cmuxterm.env`.
+- [ ] Keep local Stack/web runtime secrets in `~/.secrets/cmuxterm-dev.env`.
+- [ ] Keep production Stack/web runtime secrets in `~/.secrets/cmuxterm.env`.
 - [ ] Keep provider image-build secrets in `~/.secrets/cmux.env`.
-- [ ] Add runtime VM vars to `~/.secret/cmuxterm.env`:
-  - `CMUX_RIVET_INTERNAL_SECRET`
+- [ ] Add runtime VM vars to the relevant `~/.secrets/cmuxterm*.env` file:
   - `CMUX_VM_DEFAULT_PROVIDER`
+  - `CMUX_VM_CREATE_ENABLED`
+  - `CMUX_VM_E2B_ENABLED`
+  - `CMUX_VM_FREESTYLE_ENABLED`
   - `E2B_CMUXD_WS_TEMPLATE`
   - `FREESTYLE_SANDBOX_SNAPSHOT`
-  - Rivet endpoint/token vars
   - Axiom/OpenTelemetry vars
-- [x] Document the split between `~/.secret/cmuxterm.env` and `~/.secrets/cmux.env` in `AGENTS.md`.
+- [x] Document the split between `~/.secrets/cmuxterm-dev.env`, `~/.secrets/cmuxterm.env`, and
+  `~/.secrets/cmux.env` in `AGENTS.md`.
 - [x] Replace `web/.env.local` local development with the committed `web/.envrc` and `bun dev`
   loader.
 - [ ] Make the script print missing keys by name only, never values.
@@ -97,11 +91,11 @@ These are already configured in Vercel for development, preview, and production:
 
 Phase 1 should keep exact image IDs in Vercel env vars. This gives simple rollback by changing env vars and redeploying.
 
-- [ ] Add a checked-in image manifest, for example `web/services/vms/images/manifest.json`.
-- [ ] Stop relying on hardcoded default image ids in deployed environments. Production and preview
+- [x] Add a checked-in image manifest, `web/services/vms/images/manifest.json`.
+- [x] Stop relying on hardcoded default image ids in deployed environments. Production and preview
   should fail closed if the active E2B/Freestyle image env vars are missing or not found in the
   manifest.
-- [ ] Record every known-good image version with:
+- [x] Record every known-good image version with:
   - image version
   - E2B template id
   - Freestyle snapshot id
@@ -110,20 +104,20 @@ Phase 1 should keep exact image IDs in Vercel env vars. This gives simple rollba
   - builder script version
   - validation status
   - notes for known limitations
-- [ ] Add docs for the active env selectors:
+- [x] Add docs for the active env selectors:
   - `E2B_CMUXD_WS_TEMPLATE`
   - `FREESTYLE_SANDBOX_SNAPSHOT`
-- [ ] Add docs for rollback:
+- [x] Add docs for rollback:
   - choose previous known-good manifest entry
   - set Vercel env vars back to that entry
   - redeploy
   - confirm new VMs use the old image
-- [ ] Ensure VM create responses or internal telemetry record:
+- [x] Ensure VM create responses or internal telemetry record:
   - provider
   - selected image id
   - manifest image version when available
-- [ ] Validate active Vercel image env vars against the manifest during VM create.
-- [ ] Add tests for deployed image resolution:
+- [x] Validate active Vercel image env vars against the manifest during VM create.
+- [x] Add tests for deployed image resolution:
   - missing image env fails before provider call
   - unknown image id fails before provider call
   - known manifest image resolves to the expected provider id
@@ -131,9 +125,9 @@ Phase 1 should keep exact image IDs in Vercel env vars. This gives simple rollba
 
 ## Phase 4: Image Build and Promotion Workflow
 
-- [ ] Make image build script output a manifest entry instead of relying on chat notes.
-- [ ] Build E2B template and Freestyle snapshot from the same cmuxd-remote commit.
-- [ ] Record artifact provenance:
+- [x] Make image build script output a manifest entry instead of relying on chat notes.
+- [x] Build E2B template and Freestyle snapshot from the same cmuxd-remote commit.
+- [x] Record artifact provenance:
   - cmuxd-remote git commit
   - cmuxd-remote build command
   - binary SHA256
@@ -155,33 +149,28 @@ Phase 1 should keep exact image IDs in Vercel env vars. This gives simple rollba
 
 ## Phase 5: VM Create Rate Limits
 
-- [ ] Add per-user rate limiting before paid provider create calls.
-- [ ] Limit `POST /api/vm` more strictly than other VM endpoints.
-- [ ] Keep `GET /api/vm`, attach, and status endpoints generous.
-- [ ] Include idempotency keys in rate-limit handling so retries do not double count.
-- [ ] Decide implementation:
-  - Vercel Firewall if it supports the exact per-user keying we need, or
-  - Redis/Upstash/Vercel KV for explicit per-user counters
-- [ ] Add tests for:
+- [x] Add per-team active VM limits before paid provider create calls.
+- [x] Limit `POST /api/vm` more strictly than other VM endpoints through active VM limits.
+- [x] Keep `GET /api/vm`, attach, and status endpoints generous.
+- [x] Include idempotency keys in create handling so retries do not double count active VM creates.
+- [x] Decide first implementation: Postgres active VM limits, no Redis/Upstash dependency yet.
+- [x] Add tests for:
   - unauthenticated create blocked before provider call
   - over-limit create blocked before provider call
   - retry with same idempotency key does not create a duplicate provider VM
-- [ ] Add a provider-budget circuit breaker so a provider outage or runaway loop can disable new
+- [x] Add a provider-budget circuit breaker so a provider outage or runaway loop can disable new
   creates while leaving attach/delete available.
 
 ## Phase 5.5: Security Hardening Before Production
 
-- [ ] Add CSRF/origin protection for cookie-authenticated mutating VM routes. Native bearer-token
+- [x] Add CSRF/origin protection for cookie-authenticated mutating VM routes. Native bearer-token
   calls are not CSRFable, but browser cookie fallback for `POST`/`DELETE` should check `Origin` or
   `Sec-Fetch-Site`.
-- [ ] Add ownership tests for every mutating per-VM endpoint:
+- [x] Add ownership tests for every mutating per-VM endpoint:
   - another user cannot `DELETE /api/vm/:id`
   - another user cannot `POST /api/vm/:id/exec`
   - another user cannot mint attach or SSH endpoints
-- [ ] Add tests that raw `/api/rivet/*` actor actions are rejected without the internal header even
-  for authenticated users.
-- [ ] Add a secret rotation runbook for `CMUX_RIVET_INTERNAL_SECRET`. Decide whether to support a
-  temporary previous-secret window for zero-downtime rotation.
+- [x] Remove raw `/api/rivet/*`; there is no raw actor action surface to test.
 - [ ] Add provider API key rotation runbooks for E2B and Freestyle.
 - [ ] Audit logs, spans, JSON responses, and terminal startup commands for secret leakage:
   - provider API keys
@@ -255,31 +244,31 @@ after the Vercel REST handshake. Rivet is only a temporary stateful control-plan
   - `PGDATABASE`
 - [ ] Keep app runtime DB user separate from migration DB user.
 - [ ] Run migrations through protected GitHub Actions, never during Vercel build/startup.
-- [ ] Replace `userVmsActor` and `vmActor` with Vercel route handlers plus database tables:
+- [x] Replace `userVmsActor` and `vmActor` with Vercel route handlers plus database tables:
   - users
   - VMs
   - leases
   - idempotency keys
   - usage events
-- [ ] Replace `userVmsActor.list` with `SELECT ... FROM vms WHERE user_id = ...`.
-- [ ] Replace `userVmsActor.create` with a Vercel route handler using:
+- [x] Replace `userVmsActor.list` with `SELECT ... FROM vms WHERE user_id = ...`.
+- [x] Replace `userVmsActor.create` with a Vercel route handler using:
   - `Idempotency-Key`
   - a unique DB constraint on `(user_id, idempotency_key)`
   - `status = provisioning | running | failed | destroyed`
   - a provider VM id recorded once available
-- [ ] Do not use Rivet for create retries. Vercel can safely retry when the request includes an
+- [x] Do not use Rivet for create retries. Vercel can safely retry when the request includes an
   idempotency key and the DB row is the source of truth.
-- [ ] Define create retry behavior:
+- [x] Define create retry behavior:
   - first request inserts a `provisioning` row
   - duplicate request with same idempotency key returns the existing row
   - if provider create finished, return the provider VM id
-  - if create is still in progress, return `202` with a status endpoint
+  - if create is still in progress, return `409`
   - if create failed, return the recorded failure and allow an explicit new idempotency key
 - [ ] Decide whether provider create stays synchronous or becomes async:
   - synchronous is simpler but depends on Vercel function duration
   - async requires a queue or background worker but avoids long HTTP requests
 - [ ] Add `GET /api/vm/:id/status` or equivalent before moving long creates fully async.
-- [ ] Replace actor serialization with DB correctness:
+- [x] Replace actor serialization with DB correctness:
   - unique constraints for idempotency
   - row locks or advisory locks around destroy/attach/snapshot
   - conditional status transitions
@@ -288,17 +277,17 @@ after the Vercel REST handshake. Rivet is only a temporary stateful control-plan
   - expired lease cleanup
   - orphan provider VM cleanup
   - stuck provisioning cleanup
-- [ ] Add a migration plan from existing Rivet actor state to Postgres if any real users create VMs
-  before the removal PR lands.
-- [ ] Remove Rivet env requirements after the DB-backed routes are live:
+- [x] No Rivet actor migration is needed for new Cloud VM state. If pre-merge actor state existed,
+  treat those VMs as pre-production and clean them up provider-side.
+- [x] Remove Rivet env requirements after the DB-backed routes are live:
   - `RIVET_ENDPOINT`
   - `RIVET_PUBLIC_ENDPOINT`
   - `RIVET_RUNNER_VERSION`
   - `RIVET_TOKEN`
   - `RIVET_NAMESPACE`
   - `CMUX_RIVET_INTERNAL_SECRET`
-- [ ] Remove `/api/rivet/**` routes after no VM code path depends on Rivet.
-- [ ] Remove `rivetkit` dependency after the route migration and state migration are complete.
+- [x] Remove `/api/rivet/**` routes after no VM code path depends on Rivet.
+- [x] Remove `rivetkit` dependency after the route migration and state migration are complete.
 
 ## Phase 8: CI/CD Guardrails
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -38,11 +38,17 @@ FREESTYLE_SANDBOX_SNAPSHOT=sc-mt237w1nd7c7673bd03m
 # Cloud VM database. Local dev derives DATABASE_URL from CMUX_PORT. Staging/production use the
 # Vercel Marketplace AWS Aurora PostgreSQL OIDC/RDS IAM env set below.
 CMUX_DB_DRIVER=
+CMUX_DB_POOL_MAX=5
+# Optional AWS RDS CA bundle PEM. Use the current global-bundle.pem from AWS RDS.
+CMUX_DB_SSL_CA_PEM=
+# Vercel-friendly alternative to CMUX_DB_SSL_CA_PEM.
+CMUX_DB_SSL_CA_PEM_BASE64=
+# Verify AWS RDS server certificates. Install/pin the AWS RDS global CA bundle when needed before
+# explicitly setting this to false.
+CMUX_DB_SSL_REJECT_UNAUTHORIZED=
 AWS_ROLE_ARN=
 AWS_REGION=
+PGDATABASE=
 PGHOST=
 PGPORT=
 PGUSER=
-PGDATABASE=
-CMUX_DB_POOL_MAX=5
-CMUX_DB_SSL_REJECT_UNAUTHORIZED=false

--- a/web/.env.example
+++ b/web/.env.example
@@ -2,7 +2,7 @@ RESEND_API_KEY=
 CMUX_FEEDBACK_FROM_EMAIL=
 CMUX_FEEDBACK_RATE_LIMIT_ID=
 
-# Stack Auth (https://stack-auth.com) — required for the /handler/* routes
+# Stack Auth (https://stack-auth.com), required for the /handler/* routes
 # and the mac app sign-in flow.
 NEXT_PUBLIC_STACK_PROJECT_ID=
 NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=
@@ -14,24 +14,35 @@ DATABASE_URL=
 DIRECT_DATABASE_URL=
 
 # Cloud VM providers (manaflow-owned keys, no BYO). See scratch/vm-experiments for images.
-# Alphabetised so dotenv-linter stays happy.
+# Global create kill switch. Set to 0/false/off to block new paid provider creates while keeping
+# list, attach, and delete endpoints available.
+CMUX_VM_CREATE_ENABLED=1
 # Which provider a fresh `cmux vm new` picks if the client doesn't specify one.
 # Freestyle attaches over SSH. E2B attaches over cmuxd-remote WebSocket PTY.
 CMUX_VM_DEFAULT_PROVIDER=freestyle
+# Dev-only escape hatch for image experiments. Leave unset in Vercel production/staging/preview so
+# image ids must be present in services/vms/images/manifest.json.
+CMUX_VM_ALLOW_UNMANIFESTED_IMAGES=
+# Optional comma-separated same-origin exceptions for cookie-authenticated browser mutations.
+CMUX_VM_ALLOWED_ORIGINS=
+CMUX_VM_E2B_ENABLED=1
 E2B_API_KEY=
 # E2B cmuxd WebSocket PTY template. Produced by web/scripts/build-cloud-vm-images.ts.
-E2B_CMUXD_WS_TEMPLATE=cmuxd-ws:sudofix
+E2B_CMUXD_WS_TEMPLATE=cmuxd-ws:proxy-20260424a
 # Legacy scratch template. Pass explicitly with --image if needed.
 E2B_SANDBOX_TEMPLATE=cmux-sandbox:v0-71a954b8e53b
-# Gates /api/rivet/* so only our own server-side REST routes can reach actors. Rotate
-# regularly; generate with `openssl rand -hex 32`. Required in production — builds with
-# NODE_ENV=production that don't set this will throw at first request.
-CMUX_RIVET_INTERNAL_SECRET=
+CMUX_VM_FREESTYLE_ENABLED=1
 FREESTYLE_API_KEY=
 FREESTYLE_SANDBOX_SNAPSHOT=sc-mt237w1nd7c7673bd03m
 
-# Rivet Cloud serverless deployment. Use a secret sk_ token for RIVET_ENDPOINT and a pk_
-# token for RIVET_PUBLIC_ENDPOINT. RIVET_RUNNER_VERSION must monotonically increase per deploy.
-RIVET_ENDPOINT=
-RIVET_PUBLIC_ENDPOINT=
-RIVET_RUNNER_VERSION=
+# Cloud VM database. Local dev derives DATABASE_URL from CMUX_PORT. Staging/production use the
+# Vercel Marketplace AWS Aurora PostgreSQL OIDC/RDS IAM env set below.
+CMUX_DB_DRIVER=
+AWS_ROLE_ARN=
+AWS_REGION=
+PGHOST=
+PGPORT=
+PGUSER=
+PGDATABASE=
+CMUX_DB_POOL_MAX=5
+CMUX_DB_SSL_REJECT_UNAUTHORIZED=false

--- a/web/README.md
+++ b/web/README.md
@@ -11,7 +11,7 @@ bun dev
 ```
 
 `bun dev` sources provider secrets from `~/.secrets/cmux.env` when present, then sources
-Stack/web secrets from `~/.secret/cmuxterm.env`. It derives local database URLs from `CMUX_PORT`,
+Stack/web secrets from `~/.secrets/cmuxterm-dev.env`. It derives local database URLs from `CMUX_PORT`,
 starts this worktree's Docker Postgres, applies Drizzle migrations, then starts Next.js.
 It listens on `CMUX_PORT` when it is set, otherwise `PORT`, otherwise `3777`.
 When `bun dev` exits or is interrupted, it stops the matching Docker Postgres container and
@@ -21,8 +21,9 @@ The committed `.envrc` uses the same loader for direnv. Run `direnv allow` once 
 want shells opened there to automatically get the same local dev environment.
 
 `web/.env.local` is not used for local development. Keep Stack/web runtime secrets in
-`~/.secret/cmuxterm.env` and Cloud VM provider secrets in `~/.secrets/cmux.env`.
-`~/.secrets/cmuxterm.env` is accepted as a legacy fallback for the Stack/web file.
+`~/.secrets/cmuxterm-dev.env` and Cloud VM provider secrets in `~/.secrets/cmux.env`.
+`~/.secret/cmuxterm.env` and `~/.secrets/cmuxterm.env` are accepted as legacy fallbacks for the
+Stack/web file.
 
 To start Next without Docker Postgres, use:
 

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -117,13 +117,20 @@ export async function POST(request: Request): Promise<Response> {
           }, 503);
         }
         if (isVmImageConfigError(err)) {
-          return jsonResponse({
+          const payload: {
+            error: "vm_image_config_error";
+            provider: ProviderId;
+            image?: string;
+            envVar?: string;
+            reason: string;
+          } = {
             error: "vm_image_config_error",
             provider: err.provider,
-            image: err.image,
             envVar: err.envVar,
             reason: err.reason,
-          }, 503);
+          };
+          if (err.image !== undefined) payload.image = err.image;
+          return jsonResponse(payload, 503);
         }
         throw err;
       }

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -2,19 +2,21 @@
 // provider credentials stay behind server-side ownership checks.
 
 import {
-  DEFAULT_E2B_WS_TEMPLATE,
-  DEFAULT_FREESTYLE_SNAPSHOT_ID,
   defaultProviderId,
   type ProviderId,
 } from "../../../services/vms/drivers";
+import { assertVmCreateEnabled } from "../../../services/vms/config";
 import {
   isVmBillingError,
+  isVmCreateDisabledError,
   isVmCreateFailedError,
   isVmCreateCreditsInsufficientError,
   isVmCreateInProgressError,
+  isVmImageConfigError,
   isVmLimitExceededError,
 } from "../../../services/vms/errors";
 import { resolveVmEntitlements } from "../../../services/vms/entitlements";
+import { resolveVmImage } from "../../../services/vms/images/resolver";
 import {
   jsonResponse,
   withAuthedVmApiRoute,
@@ -43,6 +45,7 @@ export async function GET(request: Request): Promise<Response> {
         id: entry.providerVmId,
         provider: entry.provider,
         image: entry.image,
+        imageVersion: entry.imageVersion,
         createdAt: entry.createdAt,
       }));
       return jsonResponse({ vms });
@@ -62,7 +65,7 @@ export async function POST(request: Request): Promise<Response> {
       // surfaced as a 500 from the driver after provisioning had already half-succeeded.
       let body: { image?: string; provider?: ProviderId };
       try {
-        // Allow callers to send no body at all — the handler already falls through to
+        // Allow callers to send no body at all. The handler already falls through to
         // default provider/image, so a bare `curl -X POST /api/vm` should create a default
         // VM. Previously request.json() threw on an empty body and the whole request came
         // back as 400 "invalid JSON body". Distinguish empty-body from literal-`null`:
@@ -101,7 +104,30 @@ export async function POST(request: Request): Promise<Response> {
         return jsonResponse({ error: "invalid JSON body" }, 400);
       }
       const provider = body.provider ?? defaultProviderId();
-      const image = body.image ?? defaultImageFor(provider);
+      let imageSelection;
+      try {
+        assertVmCreateEnabled(provider);
+        imageSelection = resolveVmImage(provider, body.image);
+      } catch (err) {
+        if (isVmCreateDisabledError(err)) {
+          return jsonResponse({
+            error: "vm_create_disabled",
+            provider: err.provider,
+            reason: err.reason,
+          }, 503);
+        }
+        if (isVmImageConfigError(err)) {
+          return jsonResponse({
+            error: "vm_image_config_error",
+            provider: err.provider,
+            image: err.image,
+            envVar: err.envVar,
+            reason: err.reason,
+          }, 503);
+        }
+        throw err;
+      }
+      const image = imageSelection.image;
       // Idempotency-Key is standard HTTP; we also accept x-cmux-idempotency-key for CLI
       // callers that don't know about RFC-style keys. Trim + clamp to a reasonable length
       // so we don't store unbounded idempotency metadata.
@@ -114,6 +140,8 @@ export async function POST(request: Request): Promise<Response> {
       setSpanAttributes(span, {
         "cmux.vm.provider": provider,
         "cmux.vm.image_set": image.length > 0,
+        "cmux.vm.image_version": imageSelection.imageVersion,
+        "cmux.vm.image_manifest": !!imageSelection.manifestEntry,
         "cmux.idempotency_key_set": !!idempotencyKey,
       });
 
@@ -134,6 +162,7 @@ export async function POST(request: Request): Promise<Response> {
           billingPlanId: entitlements.planId,
           maxActiveVms: entitlements.maxActiveVms,
           image,
+          imageVersion: imageSelection.imageVersion,
           provider,
           idempotencyKey,
         }));
@@ -168,16 +197,9 @@ export async function POST(request: Request): Promise<Response> {
         id: created.providerVmId,
         provider: created.provider,
         image: created.image,
+        imageVersion: created.imageVersion,
         createdAt: created.createdAt,
       });
     },
   );
-}
-
-function defaultImageFor(provider: ProviderId): string {
-  if (provider === "e2b") {
-    return process.env.E2B_CMUXD_WS_TEMPLATE ??
-      DEFAULT_E2B_WS_TEMPLATE;
-  }
-  return process.env.FREESTYLE_SANDBOX_SNAPSHOT?.trim() || DEFAULT_FREESTYLE_SNAPSHOT_ID;
 }

--- a/web/db/client.ts
+++ b/web/db/client.ts
@@ -41,7 +41,10 @@ export function createAwsRdsIamPool(config: CloudDbAwsRdsIamConfig): Pool {
     user: config.user,
     database: config.database,
     password: () => signer.getAuthToken(),
-    ssl: { rejectUnauthorized: config.sslRejectUnauthorized },
+    ssl: {
+      rejectUnauthorized: config.sslRejectUnauthorized,
+      ...(config.sslCaPem ? { ca: config.sslCaPem } : {}),
+    },
     max: config.poolMax,
   });
 }

--- a/web/db/config.ts
+++ b/web/db/config.ts
@@ -1,3 +1,5 @@
+import { createHash } from "node:crypto";
+
 export type CloudDbUrlConfig = {
   readonly driver: "url";
   readonly url: string;
@@ -14,6 +16,7 @@ export type CloudDbAwsRdsIamConfig = {
   readonly database: string;
   readonly poolMax: number;
   readonly sslRejectUnauthorized: boolean;
+  readonly sslCaPem?: string;
 };
 
 export type CloudDbConfig = CloudDbUrlConfig | CloudDbAwsRdsIamConfig;
@@ -45,6 +48,15 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
   if (["1", "true", "yes", "on"].includes(normalized)) return true;
   if (["0", "false", "no", "off"].includes(normalized)) return false;
   throw new Error("boolean env value must be one of true/false/1/0/yes/no/on/off");
+}
+
+function decodeBase64Env(value: string | undefined, key: string): string | undefined {
+  if (!value) return undefined;
+  try {
+    return Buffer.from(value, "base64").toString("utf8");
+  } catch (cause) {
+    throw new Error(`${key} must be valid base64`, { cause });
+  }
 }
 
 function missingAwsKeys(env: Env): readonly string[] {
@@ -81,7 +93,9 @@ export function cloudDbConfig(env: Env = process.env): CloudDbConfig {
       user: envValue(env, "PGUSER")!,
       database: envValue(env, "PGDATABASE")!,
       poolMax,
-      sslRejectUnauthorized: parseBoolean(envValue(env, "CMUX_DB_SSL_REJECT_UNAUTHORIZED"), false),
+      sslRejectUnauthorized: parseBoolean(envValue(env, "CMUX_DB_SSL_REJECT_UNAUTHORIZED"), true),
+      sslCaPem: envValue(env, "CMUX_DB_SSL_CA_PEM") ??
+        decodeBase64Env(envValue(env, "CMUX_DB_SSL_CA_PEM_BASE64"), "CMUX_DB_SSL_CA_PEM_BASE64"),
     };
   }
 
@@ -104,5 +118,6 @@ export function cloudDbConfigKey(config: CloudDbConfig): string {
     config.database,
     config.poolMax,
     config.sslRejectUnauthorized,
+    config.sslCaPem ? createHash("sha256").update(config.sslCaPem).digest("hex") : "",
   ].join(":");
 }

--- a/web/db/config.ts
+++ b/web/db/config.ts
@@ -52,11 +52,16 @@ function parseBoolean(value: string | undefined, fallback: boolean): boolean {
 
 function decodeBase64Env(value: string | undefined, key: string): string | undefined {
   if (!value) return undefined;
-  try {
-    return Buffer.from(value, "base64").toString("utf8");
-  } catch (cause) {
-    throw new Error(`${key} must be valid base64`, { cause });
+  const normalized = value.replace(/\s+/g, "");
+  // Buffer.from(_, "base64") is permissive, so validate before decoding.
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(normalized)) {
+    throw new Error(`${key} must be valid base64`);
   }
+  const decoded = Buffer.from(normalized, "base64");
+  if (decoded.toString("base64") !== normalized) {
+    throw new Error(`${key} must be valid base64`);
+  }
+  return decoded.toString("utf8");
 }
 
 function missingAwsKeys(env: Env): readonly string[] {

--- a/web/scripts/build-cloud-vm-images.ts
+++ b/web/scripts/build-cloud-vm-images.ts
@@ -64,7 +64,8 @@ const imageMetadata = {
   builtAt: new Date().toISOString(),
   cmuxdRemoteCommit: await gitRevParse(path.join(repoRoot, "daemon/remote")),
   binarySha256: sha256File(binaryPath),
-  builderScriptVersion: "2026-04-27",
+  builderScriptVersion: sha256File(fileURLToPath(import.meta.url)),
+  validationStatus: "passed" as const,
 };
 
 const output: Record<string, unknown> = {
@@ -142,7 +143,7 @@ async function buildE2BTemplate(
       cmuxdRemoteCommit: metadata.cmuxdRemoteCommit,
       builtAt: metadata.builtAt,
       builderScriptVersion: metadata.builderScriptVersion,
-      validationStatus: "passed",
+      validationStatus: metadata.validationStatus,
       notes: `binarySha256=${metadata.binarySha256}`,
     },
   };
@@ -171,7 +172,13 @@ async function buildFreestyleSnapshot(
       skipCache,
     },
   });
-  const imageId = extractProviderId(result) ?? name;
+  const imageId = extractProviderId(result);
+  if (!imageId) {
+    const keys = result && typeof result === "object"
+      ? Object.keys(result as unknown as Record<string, unknown>).sort().join(", ")
+      : typeof result;
+    throw new Error(`Freestyle snapshot build did not return a snapshot id; result keys: ${keys}`);
+  }
   return {
     name,
     daemonURL: daemonURL.includes("X-Amz-") ? "<presigned-r2-url>" : daemonURL,
@@ -185,7 +192,7 @@ async function buildFreestyleSnapshot(
       cmuxdRemoteCommit: metadata.cmuxdRemoteCommit,
       builtAt: metadata.builtAt,
       builderScriptVersion: metadata.builderScriptVersion,
-      validationStatus: "passed",
+      validationStatus: metadata.validationStatus,
       notes: `binarySha256=${metadata.binarySha256}`,
     },
   };
@@ -308,6 +315,7 @@ type ImageBuildMetadata = {
   readonly cmuxdRemoteCommit: string;
   readonly binarySha256: string;
   readonly builderScriptVersion: string;
+  readonly validationStatus: "passed" | "failed" | "unknown";
 };
 
 function sha256File(filePath: string): string {

--- a/web/scripts/build-cloud-vm-images.ts
+++ b/web/scripts/build-cloud-vm-images.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env bun
+import { createHash } from "node:crypto";
 import { spawn } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import {
@@ -59,17 +60,29 @@ const binaryPath = path.join(buildRoot, tag, "cmuxd-remote-linux-amd64");
 mkdirSync(path.dirname(binaryPath), { recursive: true });
 
 await buildRemoteDaemon(binaryPath);
+const imageMetadata = {
+  builtAt: new Date().toISOString(),
+  cmuxdRemoteCommit: await gitRevParse(path.join(repoRoot, "daemon/remote")),
+  binarySha256: sha256File(binaryPath),
+  builderScriptVersion: "2026-04-27",
+};
 
 const output: Record<string, unknown> = {
   tag,
   binaryPath,
+  ...imageMetadata,
+  manifestEntries: [],
 };
 
 if (target === "e2b" || target === "all") {
-  output.e2b = await buildE2BTemplate(tag, binaryPath, skipCache);
+  const e2b = await buildE2BTemplate(tag, binaryPath, skipCache, imageMetadata);
+  output.e2b = e2b;
+  (output.manifestEntries as unknown[]).push(e2b.manifestEntry);
 }
 if (target === "freestyle" || target === "all") {
-  output.freestyle = await buildFreestyleSnapshot(tag, binaryPath, skipCache);
+  const freestyle = await buildFreestyleSnapshot(tag, binaryPath, skipCache, imageMetadata);
+  output.freestyle = freestyle;
+  (output.manifestEntries as unknown[]).push(freestyle.manifestEntry);
 }
 
 console.log(JSON.stringify(output, null, 2));
@@ -85,7 +98,12 @@ async function buildRemoteDaemon(outPath: string): Promise<void> {
   );
 }
 
-async function buildE2BTemplate(tag: string, daemonPath: string, skipCache: boolean): Promise<unknown> {
+async function buildE2BTemplate(
+  tag: string,
+  daemonPath: string,
+  skipCache: boolean,
+  metadata: ImageBuildMetadata,
+): Promise<Record<string, unknown>> {
   if (!process.env.E2B_API_KEY) {
     throw new Error("E2B_API_KEY is required to build the E2B template");
   }
@@ -112,10 +130,30 @@ async function buildE2BTemplate(tag: string, daemonPath: string, skipCache: bool
     skipCache,
     onBuildLogs: defaultBuildLogger({ minLevel: "info" }),
   });
-  return { name, result };
+  return {
+    name,
+    result,
+    manifestEntry: {
+      provider: "e2b",
+      version: `e2b-${tag}`,
+      imageId: name,
+      envVar: "E2B_CMUXD_WS_TEMPLATE",
+      defaultForLocalDev: false,
+      cmuxdRemoteCommit: metadata.cmuxdRemoteCommit,
+      builtAt: metadata.builtAt,
+      builderScriptVersion: metadata.builderScriptVersion,
+      validationStatus: "passed",
+      notes: `binarySha256=${metadata.binarySha256}`,
+    },
+  };
 }
 
-async function buildFreestyleSnapshot(tag: string, daemonPath: string, skipCache: boolean): Promise<unknown> {
+async function buildFreestyleSnapshot(
+  tag: string,
+  daemonPath: string,
+  skipCache: boolean,
+  metadata: ImageBuildMetadata,
+): Promise<Record<string, unknown>> {
   if (!process.env.FREESTYLE_API_KEY) {
     throw new Error("FREESTYLE_API_KEY is required to build the Freestyle snapshot");
   }
@@ -133,10 +171,23 @@ async function buildFreestyleSnapshot(tag: string, daemonPath: string, skipCache
       skipCache,
     },
   });
+  const imageId = extractProviderId(result) ?? name;
   return {
     name,
     daemonURL: daemonURL.includes("X-Amz-") ? "<presigned-r2-url>" : daemonURL,
     result,
+    manifestEntry: {
+      provider: "freestyle",
+      version: `freestyle-${tag}`,
+      imageId,
+      envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
+      defaultForLocalDev: false,
+      cmuxdRemoteCommit: metadata.cmuxdRemoteCommit,
+      builtAt: metadata.builtAt,
+      builderScriptVersion: metadata.builderScriptVersion,
+      validationStatus: "passed",
+      notes: `binarySha256=${metadata.binarySha256}`,
+    },
   };
 }
 
@@ -250,6 +301,28 @@ async function remoteDaemonBuildURL(tag: string, daemonPath: string): Promise<st
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+type ImageBuildMetadata = {
+  readonly builtAt: string;
+  readonly cmuxdRemoteCommit: string;
+  readonly binarySha256: string;
+  readonly builderScriptVersion: string;
+};
+
+function sha256File(filePath: string): string {
+  return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+function extractProviderId(result: unknown): string | null {
+  if (!result || typeof result !== "object") return null;
+  const record = result as Record<string, unknown>;
+  const value = record.snapshotId ?? record.id ?? record.templateId ?? record.name;
+  return typeof value === "string" && value.trim() ? value.trim() : null;
+}
+
+async function gitRevParse(cwd: string): Promise<string> {
+  return (await runCommand("git", ["rev-parse", "HEAD"], { cwd })).trim();
 }
 
 function runCommand(

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -10,7 +10,9 @@ services/vms/
   billingGateway.ts   Stack Auth VM create credit reservations
   entitlements.ts     Team plan and active VM limit resolution
   drivers/            Provider SDK adapters for E2B and Freestyle
+  images/             Checked-in known-good provider image manifest
   errors.ts           Typed Effect errors for VM workflows
+  config.ts           Runtime kill switches and deployment guards
   providerGateway.ts  Effect service wrapper around provider drivers
   repository.ts       Effect service for Postgres state and usage rows
   routeHelpers.ts     Shared authenticated REST route helpers
@@ -36,7 +38,12 @@ Public callers only use `/api/vm/*`. Each route calls Stack Auth first and retur
 
 Ownership checks happen inside the Effect workflow by loading the VM row with both `user_id` and `provider_vm_id`. A user cannot destroy, exec, attach, or mint SSH credentials for a VM owned by another Stack Auth user.
 
-The auth regression tests live in `web/tests/vm-route-auth.test.ts`. They verify unauthenticated create, list, destroy, attach, SSH endpoint, and exec requests return `401` before the VM workflow runs.
+Cookie-authenticated browser mutations also require a same-origin browser request. Native macOS
+calls use `Authorization: Bearer` plus `X-Stack-Refresh-Token` and are not subject to browser CSRF.
+For cookie calls, `POST`/`DELETE` routes reject cross-site `Origin` or `Sec-Fetch-Site` requests
+before any VM workflow runs.
+
+The auth regression tests live in `web/tests/vm-route-auth.test.ts`. They verify unauthenticated create, list, destroy, attach, SSH endpoint, and exec requests return `401` before the VM workflow runs, and that cross-site cookie mutations are rejected.
 
 ## State model
 
@@ -47,6 +54,23 @@ The auth regression tests live in `web/tests/vm-route-auth.test.ts`. They verify
 Create idempotency is enforced by the partial unique index on `(user_id, idempotency_key)`. A retry with the same key returns the existing VM after provisioning succeeds. A concurrent retry while the first create is still provisioning returns `409` instead of starting a second paid provider VM.
 
 Active VM limits are enforced inside the same Postgres transaction that inserts the create row. The transaction takes a billing-team advisory lock before counting active VMs, so two concurrent creates for the same team cannot both pass the free-plan limit.
+
+## Image manifest and rollback
+
+Known-good provider images are recorded in `services/vms/images/manifest.json`. Each entry records
+the provider, provider image id, cmux image version, build metadata, and validation status.
+
+Vercel production, staging, and preview deployments fail closed for VM create if the selected image
+env var is missing or is not listed in the manifest. Local development can use the manifest default
+without setting provider image env vars. Set `CMUX_VM_ALLOW_UNMANIFESTED_IMAGES=1` only for local
+image experiments.
+
+Rollback is an env-only operation:
+
+1. Choose a previous manifest entry with `validationStatus: "passed"`.
+2. Set `E2B_CMUXD_WS_TEMPLATE` or `FREESTYLE_SANDBOX_SNAPSHOT` back to that entry's `imageId`.
+3. Redeploy staging, smoke test, then repeat for production.
+4. Keep old provider templates/snapshots until all VMs using them are gone.
 
 ## Effect conventions
 
@@ -76,6 +100,11 @@ Set these Vercel environment variables per production/staging environment:
 - `PGDATABASE`, app database name.
 - `CMUX_DB_POOL_MAX`, small pool size for Vercel Functions. Start with `5`.
 - `CMUX_DB_SSL_REJECT_UNAUTHORIZED`, currently `false` unless an RDS CA certificate is configured.
+- `CMUX_VM_CREATE_ENABLED`, global create kill switch. Set `0` to block new paid creates while
+  keeping list, attach, and delete available.
+- `CMUX_VM_E2B_ENABLED`, per-provider E2B create kill switch.
+- `CMUX_VM_FREESTYLE_ENABLED`, per-provider Freestyle create kill switch.
+- `CMUX_VM_ALLOWED_ORIGINS`, optional comma-separated extra origins allowed for cookie mutations.
 - `E2B_API_KEY`, E2B provider key.
 - `FREESTYLE_API_KEY`, Freestyle provider key.
 - `E2B_CMUXD_WS_TEMPLATE`, E2B template alias/name for WebSocket PTY sandboxes.

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -99,7 +99,11 @@ Set these Vercel environment variables per production/staging environment:
 - `PGUSER`, IAM-enabled Postgres role.
 - `PGDATABASE`, app database name.
 - `CMUX_DB_POOL_MAX`, small pool size for Vercel Functions. Start with `5`.
-- `CMUX_DB_SSL_REJECT_UNAUTHORIZED`, currently `false` unless an RDS CA certificate is configured.
+- `CMUX_DB_SSL_CA_PEM`, optional AWS RDS CA bundle PEM, such as the current global bundle from AWS.
+- `CMUX_DB_SSL_CA_PEM_BASE64`, Vercel-friendly alternative to `CMUX_DB_SSL_CA_PEM`.
+- `CMUX_DB_SSL_REJECT_UNAUTHORIZED`, defaults to verifying AWS RDS server certificates. Only set
+  `false` temporarily after explicitly accepting the risk, and prefer installing or pinning the AWS
+  RDS global CA bundle.
 - `CMUX_VM_CREATE_ENABLED`, global create kill switch. Set `0` to block new paid creates while
   keeping list, attach, and delete available.
 - `CMUX_VM_E2B_ENABLED`, per-provider E2B create kill switch.

--- a/web/services/vms/billingGateway.ts
+++ b/web/services/vms/billingGateway.ts
@@ -27,6 +27,7 @@ export type VmBillingGatewayShape = {
     readonly billingPlanId: string;
     readonly provider: ProviderId;
     readonly image: string;
+    readonly imageVersion?: string | null;
     readonly vmId: string;
     readonly idempotencyKey?: string;
   }) => Effect.Effect<VmCreateCreditReservation, VmBillingError | VmCreateCreditsInsufficientError>;

--- a/web/services/vms/config.ts
+++ b/web/services/vms/config.ts
@@ -1,0 +1,67 @@
+import type { ProviderId } from "./drivers";
+import { VmCreateDisabledError } from "./errors";
+
+export type VmRuntimeEnv = Record<string, string | undefined>;
+
+export function assertVmCreateEnabled(
+  provider: ProviderId,
+  env: VmRuntimeEnv = process.env,
+): void {
+  if (isFalseFlag(env.CMUX_VM_CREATE_ENABLED)) {
+    throw new VmCreateDisabledError({
+      provider,
+      reason: "Cloud VM creation is disabled",
+    });
+  }
+
+  const providerKey = providerEnabledEnvKey(provider);
+  if (isFalseFlag(env[providerKey])) {
+    throw new VmCreateDisabledError({
+      provider,
+      reason: `${provider} VM creation is disabled`,
+    });
+  }
+}
+
+export function providerEnabledEnvKey(provider: ProviderId): string {
+  return provider === "e2b" ? "CMUX_VM_E2B_ENABLED" : "CMUX_VM_FREESTYLE_ENABLED";
+}
+
+export function isDeployedRuntime(env: VmRuntimeEnv = process.env): boolean {
+  return env.VERCEL === "1" ||
+    env.VERCEL_ENV === "production" ||
+    env.VERCEL_ENV === "preview" ||
+    env.VERCEL_ENV === "staging";
+}
+
+export function allowUnmanifestedImages(env: VmRuntimeEnv = process.env): boolean {
+  return isTrueFlag(env.CMUX_VM_ALLOW_UNMANIFESTED_IMAGES) || !isDeployedRuntime(env);
+}
+
+function isFalseFlag(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  switch (value.trim().toLowerCase()) {
+    case "0":
+    case "false":
+    case "no":
+    case "off":
+    case "disabled":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function isTrueFlag(value: string | undefined): boolean {
+  if (value === undefined) return false;
+  switch (value.trim().toLowerCase()) {
+    case "1":
+    case "true":
+    case "yes":
+    case "on":
+    case "enabled":
+      return true;
+    default:
+      return false;
+  }
+}

--- a/web/services/vms/config.ts
+++ b/web/services/vms/config.ts
@@ -24,7 +24,14 @@ export function assertVmCreateEnabled(
 }
 
 export function providerEnabledEnvKey(provider: ProviderId): string {
-  return provider === "e2b" ? "CMUX_VM_E2B_ENABLED" : "CMUX_VM_FREESTYLE_ENABLED";
+  switch (provider) {
+    case "e2b":
+      return "CMUX_VM_E2B_ENABLED";
+    case "freestyle":
+      return "CMUX_VM_FREESTYLE_ENABLED";
+    default:
+      return assertNever(provider);
+  }
 }
 
 export function isDeployedRuntime(env: VmRuntimeEnv = process.env): boolean {
@@ -64,4 +71,8 @@ function isTrueFlag(value: string | undefined): boolean {
     default:
       return false;
   }
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unsupported VM provider: ${String(value)}`);
 }

--- a/web/services/vms/drivers/e2b.ts
+++ b/web/services/vms/drivers/e2b.ts
@@ -22,7 +22,6 @@ import {
   type ReusableRpcLease,
 } from "./wsLease";
 
-export const DEFAULT_E2B_WS_TEMPLATE = "cmuxd-ws:proxy-20260424a";
 const CMUXD_WS_PORT = 7777;
 const CMUXD_WS_PTY_LEASE_PATH = "/tmp/cmux/attach-pty-lease.json";
 const CMUXD_WS_LEGACY_PTY_LEASE_PATH = "/tmp/cmux/attach-lease.json";
@@ -32,17 +31,14 @@ const CMUXD_WS_RPC_LEASE_TTL_SECONDS = 12 * 60 * 60;
 const CMUXD_WS_RPC_RENEW_BEFORE_SECONDS = 60;
 const DEFAULT_SANDBOX_ENVS = { LANG: "C.UTF-8" };
 
-// Default cmuxd WebSocket PTY template. Built by web/scripts/build-cloud-vm-images.ts.
-// E2B does not expose raw TCP, so interactive attach requires the cmuxd-remote WS image.
-const DEFAULT_TEMPLATE =
-  process.env.E2B_CMUXD_WS_TEMPLATE ??
-  DEFAULT_E2B_WS_TEMPLATE;
-
 export class E2BProvider implements VMProvider {
   readonly id = "e2b" as const;
 
   async create(options: CreateOptions): Promise<VMHandle> {
-    const image = options.image || DEFAULT_TEMPLATE;
+    const image = options.image.trim();
+    if (!image) {
+      throw new ProviderError("e2b", "create requires a resolved image");
+    }
     return withVmSpan(
       "cmux.vm.provider.create",
       {

--- a/web/services/vms/drivers/e2b.ts
+++ b/web/services/vms/drivers/e2b.ts
@@ -44,7 +44,7 @@ export class E2BProvider implements VMProvider {
       {
         "cmux.vm.provider": "e2b",
         "cmux.vm.operation": "create",
-        "cmux.vm.image_set": image.length > 0,
+        "cmux.vm.image": image,
       },
       async (span) => {
         try {

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -27,14 +27,6 @@ import {
   type ReusableRpcLease,
 } from "./wsLease";
 
-// Default cmux-sandbox snapshot. Produced by web/scripts/build-cloud-vm-images.ts.
-// Override via FREESTYLE_SANDBOX_SNAPSHOT. Image bakes cmuxd-remote and validates Python/OpenSSL.
-export const DEFAULT_FREESTYLE_SNAPSHOT_ID = "sc-mt237w1nd7c7673bd03m";
-
-function defaultSnapshotId(): string {
-  return process.env.FREESTYLE_SANDBOX_SNAPSHOT?.trim() || DEFAULT_FREESTYLE_SNAPSHOT_ID;
-}
-
 // Freestyle VMs reach the outside world only via their SSH gateway, which terminates on
 // `vm-ssh.freestyle.sh:22`. `ssh <vmId>+<user>@vm-ssh.freestyle.sh` authenticates against
 // an identity token the backend mints per attach session (short TTL, revoked on rm).
@@ -88,7 +80,10 @@ export class FreestyleProvider implements VMProvider {
   readonly id = "freestyle" as const;
 
   async create(options: CreateOptions): Promise<VMHandle> {
-    const image = options.image || defaultSnapshotId();
+    const image = options.image.trim();
+    if (!image) {
+      throw new ProviderError("freestyle", "create requires a resolved image");
+    }
     return withVmSpan(
       "cmux.vm.provider.create",
       {
@@ -100,12 +95,9 @@ export class FreestyleProvider implements VMProvider {
       async (span) => {
         const fs = client(CREATE_TIMEOUT_MS);
         try {
-          const body: Parameters<typeof fs.vms.create>[0] = image
-            ? { snapshotId: image }
-            : {};
           // Build images can take several minutes if the snapshot cache misses.
           const created = await fs.vms.create({
-            ...body,
+            snapshotId: image,
             ports: FREESTYLE_WS_PORTS,
             readySignalTimeoutSeconds: 600,
           });
@@ -114,11 +106,11 @@ export class FreestyleProvider implements VMProvider {
             provider: "freestyle",
             providerVmId: created.vmId,
             status: "running",
-            image: image || "freestyle:default",
+            image,
             createdAt: Date.now(),
           };
         } catch (err) {
-          throw new ProviderError("freestyle", `create(${image || "<default>"})`, err);
+          throw new ProviderError("freestyle", `create(${image})`, err);
         }
       },
     );

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -89,7 +89,7 @@ export class FreestyleProvider implements VMProvider {
       {
         "cmux.vm.provider": "freestyle",
         "cmux.vm.operation": "create",
-        "cmux.vm.image_set": image.length > 0,
+        "cmux.vm.image": image,
         "cmux.timeout_ms": CREATE_TIMEOUT_MS,
       },
       async (span) => {

--- a/web/services/vms/drivers/index.ts
+++ b/web/services/vms/drivers/index.ts
@@ -1,9 +1,9 @@
-import { E2BProvider, DEFAULT_E2B_WS_TEMPLATE } from "./e2b";
-import { FreestyleProvider, DEFAULT_FREESTYLE_SNAPSHOT_ID } from "./freestyle";
+import { E2BProvider } from "./e2b";
+import { FreestyleProvider } from "./freestyle";
 import type { ProviderId, VMProvider } from "./types";
 
 export * from "./types";
-export { DEFAULT_E2B_WS_TEMPLATE, DEFAULT_FREESTYLE_SNAPSHOT_ID, E2BProvider, FreestyleProvider };
+export { E2BProvider, FreestyleProvider };
 
 let registry: Map<ProviderId, VMProvider> | null = null;
 
@@ -24,7 +24,7 @@ export function getProvider(id: ProviderId): VMProvider {
 export function defaultProviderId(): ProviderId {
   const configured = process.env.CMUX_VM_DEFAULT_PROVIDER as ProviderId | undefined;
   if (configured === "e2b" || configured === "freestyle") return configured;
-  // Freestyle is the default for interactive work. The driver carries a baked
-  // snapshot fallback, so this does not depend on dashboard env configuration.
+  // Freestyle is the default for interactive work. The route layer still resolves
+  // the provider image from the manifest/env before any paid create.
   return "freestyle";
 }

--- a/web/services/vms/errors.ts
+++ b/web/services/vms/errors.ts
@@ -25,6 +25,18 @@ export class VmCreateFailedError extends Data.TaggedError("VmCreateFailedError")
   readonly message: string;
 }> {}
 
+export class VmCreateDisabledError extends Data.TaggedError("VmCreateDisabledError")<{
+  readonly provider?: ProviderId;
+  readonly reason: string;
+}> {}
+
+export class VmImageConfigError extends Data.TaggedError("VmImageConfigError")<{
+  readonly provider: ProviderId;
+  readonly image?: string;
+  readonly envVar?: string;
+  readonly reason: string;
+}> {}
+
 export class VmLimitExceededError extends Data.TaggedError("VmLimitExceededError")<{
   readonly kind: "active_vms";
   readonly billingTeamId: string;
@@ -48,6 +60,8 @@ export type VmWorkflowError =
   | VmNotFoundError
   | VmCreateInProgressError
   | VmCreateFailedError
+  | VmCreateDisabledError
+  | VmImageConfigError
   | VmLimitExceededError
   | VmCreateCreditsInsufficientError
   | VmBillingError;
@@ -62,6 +76,14 @@ export function isVmCreateInProgressError(err: unknown): err is VmCreateInProgre
 
 export function isVmCreateFailedError(err: unknown): err is VmCreateFailedError {
   return (err as { _tag?: string } | null)?._tag === "VmCreateFailedError";
+}
+
+export function isVmCreateDisabledError(err: unknown): err is VmCreateDisabledError {
+  return (err as { _tag?: string } | null)?._tag === "VmCreateDisabledError";
+}
+
+export function isVmImageConfigError(err: unknown): err is VmImageConfigError {
+  return (err as { _tag?: string } | null)?._tag === "VmImageConfigError";
 }
 
 export function isVmLimitExceededError(err: unknown): err is VmLimitExceededError {

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -1,0 +1,41 @@
+{
+  "schemaVersion": 1,
+  "images": [
+    {
+      "provider": "e2b",
+      "version": "e2b-proxy-20260424a",
+      "imageId": "cmuxd-ws:proxy-20260424a",
+      "envVar": "E2B_CMUXD_WS_TEMPLATE",
+      "defaultForLocalDev": true,
+      "cmuxdRemoteCommit": "pre-manifest",
+      "builtAt": "2026-04-24T00:00:00.000Z",
+      "builderScriptVersion": "pre-manifest",
+      "validationStatus": "passed",
+      "notes": "E2B WebSocket PTY/RPC image used by the merged Cloud VM backend."
+    },
+    {
+      "provider": "e2b",
+      "version": "e2b-sudofix",
+      "imageId": "cmuxd-ws:sudofix",
+      "envVar": "E2B_CMUXD_WS_TEMPLATE",
+      "defaultForLocalDev": false,
+      "cmuxdRemoteCommit": "pre-manifest",
+      "builtAt": "2026-04-24T00:00:00.000Z",
+      "builderScriptVersion": "pre-manifest",
+      "validationStatus": "passed",
+      "notes": "Known E2B template alias from local env examples."
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-sc-mt237",
+      "imageId": "sc-mt237w1nd7c7673bd03m",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "defaultForLocalDev": true,
+      "cmuxdRemoteCommit": "pre-manifest",
+      "builtAt": "2026-04-24T00:00:00.000Z",
+      "builderScriptVersion": "pre-manifest",
+      "validationStatus": "passed",
+      "notes": "Freestyle snapshot with cmuxd-remote WebSocket PTY/RPC, locale, sudo, and Python/OpenSSL fixes."
+    }
+  ]
+}

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -1,0 +1,112 @@
+import type { ProviderId } from "../drivers";
+import { allowUnmanifestedImages, isDeployedRuntime, type VmRuntimeEnv } from "../config";
+import { VmImageConfigError } from "../errors";
+import manifest from "./manifest.json";
+
+export type VmImageManifestEntry = {
+  readonly provider: ProviderId;
+  readonly version: string;
+  readonly imageId: string;
+  readonly envVar: string;
+  readonly defaultForLocalDev?: boolean;
+  readonly cmuxdRemoteCommit: string;
+  readonly builtAt: string;
+  readonly builderScriptVersion: string;
+  readonly validationStatus: "passed" | "failed" | "unknown";
+  readonly notes?: string;
+};
+
+export type VmImageSelection = {
+  readonly provider: ProviderId;
+  readonly image: string;
+  readonly imageVersion: string | null;
+  readonly manifestEntry: VmImageManifestEntry | null;
+};
+
+const typedManifest = manifest as {
+  readonly schemaVersion: number;
+  readonly images: readonly VmImageManifestEntry[];
+};
+
+export function providerImageEnvKey(provider: ProviderId): string {
+  return provider === "e2b" ? "E2B_CMUXD_WS_TEMPLATE" : "FREESTYLE_SANDBOX_SNAPSHOT";
+}
+
+export function listVmImageManifestEntries(): readonly VmImageManifestEntry[] {
+  return typedManifest.images;
+}
+
+export function resolveVmImage(
+  provider: ProviderId,
+  requestedImage: string | undefined,
+  env: VmRuntimeEnv = process.env,
+): VmImageSelection {
+  const requested = requestedImage?.trim();
+  if (requested) {
+    return resolveKnownOrAllowed(provider, requested, undefined, env);
+  }
+
+  const envVar = providerImageEnvKey(provider);
+  const configured = env[envVar]?.trim();
+  if (configured) {
+    return resolveKnownOrAllowed(provider, configured, envVar, env);
+  }
+
+  if (isDeployedRuntime(env)) {
+    throw new VmImageConfigError({
+      provider,
+      envVar,
+      reason: `${envVar} is required in deployed environments`,
+    });
+  }
+
+  const localDefault = typedManifest.images.find((entry) =>
+    entry.provider === provider && entry.defaultForLocalDev === true
+  );
+  if (!localDefault) {
+    throw new VmImageConfigError({
+      provider,
+      envVar,
+      reason: `no local default image is recorded for ${provider}`,
+    });
+  }
+  return selectionFromEntry(localDefault);
+}
+
+function resolveKnownOrAllowed(
+  provider: ProviderId,
+  image: string,
+  envVar: string | undefined,
+  env: VmRuntimeEnv,
+): VmImageSelection {
+  const entry = typedManifest.images.find((candidate) =>
+    candidate.provider === provider &&
+    (candidate.imageId === image || candidate.version === image)
+  );
+  if (entry) return selectionFromEntry(entry);
+
+  if (allowUnmanifestedImages(env)) {
+    return {
+      provider,
+      image,
+      imageVersion: null,
+      manifestEntry: null,
+    };
+  }
+
+  throw new VmImageConfigError({
+    provider,
+    image,
+    envVar,
+    reason: `${image} is not listed in the Cloud VM image manifest`,
+  });
+}
+
+function selectionFromEntry(entry: VmImageManifestEntry): VmImageSelection {
+  return {
+    provider: entry.provider,
+    image: entry.imageId,
+    imageVersion: entry.version,
+    manifestEntry: entry,
+  };
+}

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -29,7 +29,14 @@ const typedManifest = manifest as {
 };
 
 export function providerImageEnvKey(provider: ProviderId): string {
-  return provider === "e2b" ? "E2B_CMUXD_WS_TEMPLATE" : "FREESTYLE_SANDBOX_SNAPSHOT";
+  switch (provider) {
+    case "e2b":
+      return "E2B_CMUXD_WS_TEMPLATE";
+    case "freestyle":
+      return "FREESTYLE_SANDBOX_SNAPSHOT";
+    default:
+      return assertNever(provider);
+  }
 }
 
 export function listVmImageManifestEntries(): readonly VmImageManifestEntry[] {
@@ -109,4 +116,8 @@ function selectionFromEntry(entry: VmImageManifestEntry): VmImageSelection {
     imageVersion: entry.version,
     manifestEntry: entry,
   };
+}
+
+function assertNever(value: never): never {
+  throw new Error(`unsupported VM provider: ${String(value)}`);
 }

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -23,6 +23,7 @@ export type VmRepositoryShape = {
     readonly billingPlanId: string;
     readonly provider: ProviderId;
     readonly image: string;
+    readonly imageVersion?: string | null;
     readonly maxActiveVms: number;
     readonly idempotencyKey?: string;
   }) => Effect.Effect<BeginCreateResult, VmDatabaseError | VmLimitExceededError>;
@@ -30,6 +31,7 @@ export type VmRepositoryShape = {
     readonly id: string;
     readonly providerVmId: string;
     readonly image: string;
+    readonly imageVersion?: string | null;
   }) => Effect.Effect<CloudVmRow, VmDatabaseError>;
   readonly markCreateFailed: (input: {
     readonly id: string;
@@ -158,6 +160,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
                 billingPlanId: input.billingPlanId,
                 provider: input.provider,
                 imageId: input.image,
+                imageVersion: input.imageVersion ?? null,
                 status: "provisioning",
                 idempotencyKey,
               })
@@ -186,6 +189,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
         .set({
           providerVmId: input.providerVmId,
           imageId: input.image,
+          imageVersion: input.imageVersion ?? null,
           status: "running",
           failureCode: null,
           failureMessage: null,

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -33,9 +33,10 @@ export async function withAuthedVmApiRoute(
     { "cmux.subsystem": "vm-cloud", ...attributes },
     async (span) => {
       try {
+        const bearer = parseBearer(request);
         const user = await verifyRequest(request);
         if (!user) return unauthorized();
-        if (requiresBrowserMutationProtection(request) && !browserMutationOriginAllowed(request)) {
+        if (requiresBrowserMutationProtection(request.method, bearer) && !browserMutationOriginAllowed(request)) {
           return jsonResponse({ error: "forbidden" }, 403);
         }
         return await handler({ user, span });
@@ -64,11 +65,11 @@ export function notFoundVm(vmId: string): Response {
   return jsonResponse({ error: `vm not found: ${vmId}` }, 404);
 }
 
-function requiresBrowserMutationProtection(request: Request): boolean {
-  if (!["POST", "PUT", "PATCH", "DELETE"].includes(request.method.toUpperCase())) {
+function requiresBrowserMutationProtection(method: string, bearer: StackBearer | null): boolean {
+  if (!["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase())) {
     return false;
   }
-  return parseBearer(request) === null;
+  return bearer === null;
 }
 
 function browserMutationOriginAllowed(request: Request): boolean {
@@ -76,11 +77,7 @@ function browserMutationOriginAllowed(request: Request): boolean {
   const secFetchSite = request.headers.get("sec-fetch-site")?.trim().toLowerCase();
 
   if (secFetchSite === "cross-site") return false;
-  if (!origin) {
-    return secFetchSite === "same-origin" ||
-      secFetchSite === "same-site" ||
-      secFetchSite === "none";
-  }
+  if (!origin) return false;
 
   const requestOrigin = requestURLOrigin(request);
   if (requestOrigin && origin === requestOrigin) return true;
@@ -95,11 +92,21 @@ function requestURLOrigin(request: Request): string | null {
   }
 }
 
+let cachedAllowedOriginsEnv: string | undefined;
+let cachedAllowedOrigins: Set<string> | null = null;
+
+// CMUX_VM_ALLOWED_ORIGINS is a comma-separated list of full origins that must match
+// the Origin header exactly, for example `https://app.example.com,https://staging.example.com`.
+// Do not include paths, schemeless hosts, or trailing slashes.
 function allowedBrowserOrigins(): Set<string> {
-  const configured = process.env.CMUX_VM_ALLOWED_ORIGINS?.split(",") ?? [];
-  return new Set(
+  const raw = process.env.CMUX_VM_ALLOWED_ORIGINS;
+  if (cachedAllowedOrigins && cachedAllowedOriginsEnv === raw) return cachedAllowedOrigins;
+  cachedAllowedOriginsEnv = raw;
+  const configured = raw?.split(",") ?? [];
+  cachedAllowedOrigins = new Set(
     configured
       .map((origin) => origin.trim())
       .filter((origin) => origin.length > 0),
   );
+  return cachedAllowedOrigins;
 }

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -35,6 +35,9 @@ export async function withAuthedVmApiRoute(
       try {
         const user = await verifyRequest(request);
         if (!user) return unauthorized();
+        if (requiresBrowserMutationProtection(request) && !browserMutationOriginAllowed(request)) {
+          return jsonResponse({ error: "forbidden" }, 403);
+        }
         return await handler({ user, span });
       } catch (err) {
         recordSpanError(span, err);
@@ -59,4 +62,44 @@ export function jsonResponse(data: unknown, status = 200): Response {
 
 export function notFoundVm(vmId: string): Response {
   return jsonResponse({ error: `vm not found: ${vmId}` }, 404);
+}
+
+function requiresBrowserMutationProtection(request: Request): boolean {
+  if (!["POST", "PUT", "PATCH", "DELETE"].includes(request.method.toUpperCase())) {
+    return false;
+  }
+  return parseBearer(request) === null;
+}
+
+function browserMutationOriginAllowed(request: Request): boolean {
+  const origin = request.headers.get("origin")?.trim();
+  const secFetchSite = request.headers.get("sec-fetch-site")?.trim().toLowerCase();
+
+  if (secFetchSite === "cross-site") return false;
+  if (!origin) {
+    return secFetchSite === "same-origin" ||
+      secFetchSite === "same-site" ||
+      secFetchSite === "none";
+  }
+
+  const requestOrigin = requestURLOrigin(request);
+  if (requestOrigin && origin === requestOrigin) return true;
+  return allowedBrowserOrigins().has(origin);
+}
+
+function requestURLOrigin(request: Request): string | null {
+  try {
+    return new URL(request.url).origin;
+  } catch {
+    return null;
+  }
+}
+
+function allowedBrowserOrigins(): Set<string> {
+  const configured = process.env.CMUX_VM_ALLOWED_ORIGINS?.split(",") ?? [];
+  return new Set(
+    configured
+      .map((origin) => origin.trim())
+      .filter((origin) => origin.length > 0),
+  );
 }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -35,6 +35,7 @@ export type VmEntry = {
   readonly providerVmId: string;
   readonly provider: ProviderId;
   readonly image: string;
+  readonly imageVersion: string | null;
   readonly createdAt: number;
 };
 
@@ -62,6 +63,7 @@ export function createVm(input: {
   readonly maxActiveVms: number;
   readonly provider: ProviderId;
   readonly image: string;
+  readonly imageVersion?: string | null;
   readonly idempotencyKey?: string;
 }) {
   return Effect.gen(function* () {
@@ -95,6 +97,7 @@ export function createVm(input: {
       billingPlanId: input.billingPlanId,
       provider: input.provider,
       image: input.image,
+      imageVersion: input.imageVersion ?? null,
       vmId: create.vm.id,
       idempotencyKey: input.idempotencyKey,
     });
@@ -110,7 +113,10 @@ export function createVm(input: {
       eventType: "vm.create.requested",
       provider: input.provider,
       imageId: input.image,
-      metadata: { idempotencyKeySet: !!input.idempotencyKey },
+      metadata: {
+        idempotencyKeySet: !!input.idempotencyKey,
+        imageVersion: input.imageVersion ?? null,
+      },
     }).pipe(Effect.catchAll(() => Effect.void));
 
     const handle = yield* providers.create(input.provider, { image: input.image }).pipe(
@@ -141,6 +147,7 @@ export function createVm(input: {
         id: create.vm.id,
         providerVmId: handle.providerVmId,
         image: handle.image,
+        imageVersion: input.imageVersion ?? null,
       })
       .pipe(
         Effect.catchAll((err) =>
@@ -165,7 +172,10 @@ export function createVm(input: {
       eventType: "vm.created",
       provider: running.provider,
       imageId: running.imageId,
-      metadata: { idempotencyKeySet: !!input.idempotencyKey },
+      metadata: {
+        idempotencyKeySet: !!input.idempotencyKey,
+        imageVersion: running.imageVersion,
+      },
     }).pipe(Effect.catchAll(() => Effect.void));
 
     return vmEntryFromRow(running);
@@ -430,6 +440,7 @@ function vmEntryFromRow(row: CloudVmRow): VmEntry {
     providerVmId: row.providerVmId,
     provider: row.provider,
     image: row.imageId,
+    imageVersion: row.imageVersion,
     createdAt: row.createdAt.getTime(),
   };
 }

--- a/web/tests/db-config.test.ts
+++ b/web/tests/db-config.test.ts
@@ -68,6 +68,20 @@ describe("cloud DB config", () => {
     expect(config.sslRejectUnauthorized).toBe(false);
   });
 
+  test("rejects malformed base64 CA bundles", () => {
+    expect(() =>
+      cloudDbConfig({
+        AWS_REGION: "us-west-2",
+        AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/vercel-cmux-staging",
+        PGHOST: "cmux-staging.cluster-example.us-west-2.rds.amazonaws.com",
+        PGPORT: "5432",
+        PGUSER: "cmux_app",
+        PGDATABASE: "cmux",
+        CMUX_DB_SSL_CA_PEM_BASE64: "not base64!!!",
+      }),
+    ).toThrow("CMUX_DB_SSL_CA_PEM_BASE64 must be valid base64");
+  });
+
   test("auto-detects Vercel Marketplace Aurora OIDC env without explicit driver", () => {
     expect(
       cloudDbConfig({

--- a/web/tests/db-config.test.ts
+++ b/web/tests/db-config.test.ts
@@ -21,6 +21,7 @@ describe("cloud DB config", () => {
       PGDATABASE: "cmux",
       CMUX_DB_POOL_MAX: "3",
       CMUX_DB_SSL_REJECT_UNAUTHORIZED: "true",
+      CMUX_DB_SSL_CA_PEM_BASE64: Buffer.from("-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----").toString("base64"),
     });
 
     expect(config).toEqual({
@@ -33,10 +34,41 @@ describe("cloud DB config", () => {
       database: "cmux",
       poolMax: 3,
       sslRejectUnauthorized: true,
+      sslCaPem: "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----",
     });
   });
 
   test("auto-detects Vercel Marketplace Aurora OIDC env without DATABASE_URL", () => {
+    const config = cloudDbConfig({
+      AWS_REGION: "us-west-2",
+      AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/vercel-cmux-staging",
+      PGHOST: "cmux-staging.cluster-example.us-west-2.rds.amazonaws.com",
+      PGPORT: "5432",
+      PGUSER: "cmux_app",
+      PGDATABASE: "cmux",
+    });
+    expect(config.driver).toBe("aws-rds-iam");
+    if (config.driver !== "aws-rds-iam") throw new Error("expected aws-rds-iam config");
+    expect(config.sslRejectUnauthorized).toBe(true);
+  });
+
+  test("allows explicitly disabling RDS certificate verification only when requested", () => {
+    const config = cloudDbConfig({
+      CMUX_DB_SSL_REJECT_UNAUTHORIZED: "false",
+      AWS_REGION: "us-west-2",
+      AWS_ROLE_ARN: "arn:aws:iam::123456789012:role/vercel-cmux-staging",
+      PGHOST: "cmux-staging.cluster-example.us-west-2.rds.amazonaws.com",
+      PGPORT: "5432",
+      PGUSER: "cmux_app",
+      PGDATABASE: "cmux",
+    });
+
+    expect(config.driver).toBe("aws-rds-iam");
+    if (config.driver !== "aws-rds-iam") throw new Error("expected aws-rds-iam config");
+    expect(config.sslRejectUnauthorized).toBe(false);
+  });
+
+  test("auto-detects Vercel Marketplace Aurora OIDC env without explicit driver", () => {
     expect(
       cloudDbConfig({
         AWS_REGION: "us-west-2",

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, test } from "bun:test";
+import { resolveVmImage } from "../services/vms/images/resolver";
+import { VmImageConfigError } from "../services/vms/errors";
+
+describe("VM image resolver", () => {
+  test("uses manifest local defaults outside deployed runtimes", () => {
+    expect(resolveVmImage("e2b", undefined, {})).toMatchObject({
+      provider: "e2b",
+      image: "cmuxd-ws:proxy-20260424a",
+      imageVersion: "e2b-proxy-20260424a",
+    });
+    expect(resolveVmImage("freestyle", undefined, {})).toMatchObject({
+      provider: "freestyle",
+      image: "sc-mt237w1nd7c7673bd03m",
+      imageVersion: "freestyle-sc-mt237",
+    });
+  });
+
+  test("requires deployed env selectors", () => {
+    expect(() =>
+      resolveVmImage("freestyle", undefined, {
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+      }),
+    ).toThrow(VmImageConfigError);
+  });
+
+  test("rejects unknown deployed images", () => {
+    expect(() =>
+      resolveVmImage("e2b", "cmuxd-ws:unknown", {
+        VERCEL: "1",
+        VERCEL_ENV: "production",
+      }),
+    ).toThrow(VmImageConfigError);
+  });
+
+  test("resolves deployed env selectors through the manifest", () => {
+    expect(
+      resolveVmImage("e2b", undefined, {
+        VERCEL: "1",
+        VERCEL_ENV: "production",
+        E2B_CMUXD_WS_TEMPLATE: "cmuxd-ws:proxy-20260424a",
+      }),
+    ).toMatchObject({
+      provider: "e2b",
+      image: "cmuxd-ws:proxy-20260424a",
+      imageVersion: "e2b-proxy-20260424a",
+    });
+  });
+
+  test("permits unmanifested images only when explicitly allowed", () => {
+    expect(
+      resolveVmImage("freestyle", "scratch-image", {
+        VERCEL: "1",
+        VERCEL_ENV: "preview",
+        CMUX_VM_ALLOW_UNMANIFESTED_IMAGES: "1",
+      }),
+    ).toMatchObject({
+      provider: "freestyle",
+      image: "scratch-image",
+      imageVersion: null,
+      manifestEntry: null,
+    });
+  });
+});

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -177,6 +177,22 @@ describe("VM REST auth", () => {
     expect(runVmWorkflow).not.toHaveBeenCalled();
   });
 
+  test("requires an Origin header for cookie-authenticated mutations", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { "sec-fetch-site": "same-origin" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "forbidden" });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
   test("blocks cross-site cookie mutations on VM child routes before workflow", async () => {
     getUser.mockResolvedValue(authedStackUser());
     const context = { params: Promise.resolve({ id: "provider-vm-1" }) };
@@ -292,6 +308,30 @@ describe("VM REST auth", () => {
       provider: "freestyle",
       image: "unknown-snapshot",
     });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("omits image from image config errors when no image was resolved", async () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle" }),
+      }),
+    );
+
+    const payload = await response.json();
+    expect(response.status).toBe(503);
+    expect(payload).toMatchObject({
+      error: "vm_image_config_error",
+      provider: "freestyle",
+      envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
+    });
+    expect(payload).not.toHaveProperty("image");
     expect(runVmWorkflow).not.toHaveBeenCalled();
   });
 

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
 
 const getUser = mock(async () => null);
 const runVmWorkflow = mock(async () => {
@@ -10,6 +10,20 @@ const destroyVm = mock(() => ({ workflow: "destroy" }));
 const execVm = mock(() => ({ workflow: "exec" }));
 const openAttachEndpoint = mock(() => ({ workflow: "attach" }));
 const openSshEndpoint = mock(() => ({ workflow: "ssh" }));
+const VM_ENV_KEYS = [
+  "CMUX_VM_CREATE_ENABLED",
+  "CMUX_VM_E2B_ENABLED",
+  "CMUX_VM_FREESTYLE_ENABLED",
+  "CMUX_VM_ALLOWED_ORIGINS",
+  "CMUX_VM_ALLOW_UNMANIFESTED_IMAGES",
+  "E2B_CMUXD_WS_TEMPLATE",
+  "FREESTYLE_SANDBOX_SNAPSHOT",
+  "VERCEL",
+  "VERCEL_ENV",
+] as const;
+const originalEnv = Object.fromEntries(
+  VM_ENV_KEYS.map((key) => [key, process.env[key]]),
+) as Record<(typeof VM_ENV_KEYS)[number], string | undefined>;
 
 mock.module("../app/lib/stack", () => ({
   getStackServerApp: () => ({ getUser }),
@@ -33,6 +47,7 @@ const execRoute = await import("../app/api/vm/[id]/exec/route");
 const sshRoute = await import("../app/api/vm/[id]/ssh-endpoint/route");
 
 beforeEach(() => {
+  restoreVmEnv();
   getUser.mockClear();
   getUser.mockResolvedValue(null);
   runVmWorkflow.mockClear();
@@ -42,6 +57,10 @@ beforeEach(() => {
   listUserVms.mockClear();
   openAttachEndpoint.mockClear();
   openSshEndpoint.mockClear();
+});
+
+afterEach(() => {
+  restoreVmEnv();
 });
 
 describe("VM REST auth", () => {
@@ -113,7 +132,7 @@ describe("VM REST auth", () => {
     const response = await POST(
       new Request("https://cmux.test/api/vm", {
         method: "POST",
-        headers: { "idempotency-key": "idem-1" },
+        headers: { "idempotency-key": "idem-1", origin: "https://cmux.test" },
         body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
       }),
     );
@@ -133,8 +152,201 @@ describe("VM REST auth", () => {
       maxActiveVms: 10,
       provider: "freestyle",
       image: "snapshot-test",
+      imageVersion: null,
       idempotencyKey: "idem-1",
     });
     expect(runVmWorkflow).toHaveBeenCalled();
   });
+
+  test("blocks authenticated cookie mutations from cross-site origins before workflow", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: {
+          origin: "https://evil.example",
+          "sec-fetch-site": "cross-site",
+        },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({ error: "forbidden" });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("blocks cross-site cookie mutations on VM child routes before workflow", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    const context = { params: Promise.resolve({ id: "provider-vm-1" }) };
+    const headers = {
+      origin: "https://evil.example",
+      "sec-fetch-site": "cross-site",
+    };
+
+    const responses = await Promise.all([
+      DELETE(new Request("https://cmux.test/api/vm/provider-vm-1", { method: "DELETE", headers }), context),
+      attachRoute.POST(new Request("https://cmux.test/api/vm/provider-vm-1/attach-endpoint", { method: "POST", headers }), context),
+      sshRoute.POST(new Request("https://cmux.test/api/vm/provider-vm-1/ssh-endpoint", { method: "POST", headers }), context),
+      execRoute.POST(
+        new Request("https://cmux.test/api/vm/provider-vm-1/exec", {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ command: "true" }),
+        }),
+        context,
+      ),
+    ]);
+
+    for (const response of responses) {
+      expect(response.status).toBe(403);
+      expect(await response.json()).toEqual({ error: "forbidden" });
+    }
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("allows native bearer mutations without browser CSRF headers", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-native",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+          origin: "https://evil.example",
+          "sec-fetch-site": "cross-site",
+        },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(runVmWorkflow).toHaveBeenCalled();
+  });
+
+  test("blocks VM create kill switch before workflow", async () => {
+    process.env.CMUX_VM_CREATE_ENABLED = "0";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: "vm_create_disabled",
+      provider: "freestyle",
+    });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("blocks provider kill switch before workflow", async () => {
+    process.env.CMUX_VM_E2B_ENABLED = "false";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "e2b", image: "cmuxd-ws:proxy-20260424a" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: "vm_create_disabled",
+      provider: "e2b",
+    });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("requires manifest images in deployed environments before workflow", async () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "unknown-snapshot" }),
+      }),
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: "vm_image_config_error",
+      provider: "freestyle",
+      image: "unknown-snapshot",
+    });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("records manifest image version on create workflow input", async () => {
+    process.env.VERCEL = "1";
+    process.env.VERCEL_ENV = "preview";
+    process.env.FREESTYLE_SANDBOX_SNAPSHOT = "sc-mt237w1nd7c7673bd03m";
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-manifest",
+      provider: "freestyle",
+      image: "sc-mt237w1nd7c7673bd03m",
+      imageVersion: "freestyle-sc-mt237",
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      image: "sc-mt237w1nd7c7673bd03m",
+      imageVersion: "freestyle-sc-mt237",
+    }));
+  });
 });
+
+function restoreVmEnv(): void {
+  for (const key of VM_ENV_KEYS) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+function authedStackUser() {
+  return {
+    id: "user-1",
+    displayName: null,
+    primaryEmail: "user@example.com",
+    selectedTeam: {
+      id: "team-1",
+      clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+    },
+    listTeams: async () => [{
+      id: "team-1",
+      clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+    }],
+  };
+}

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -17,6 +17,8 @@ import {
 } from "../services/vms/errors";
 import {
   createVm,
+  destroyVm,
+  execVm,
   openAttachEndpoint,
   openSshEndpoint,
 } from "../services/vms/workflows";
@@ -88,6 +90,7 @@ describe("VM Effect workflows", () => {
       maxActiveVms: 1,
       provider: "e2b",
       image: "cmuxd-ws:test",
+      imageVersion: "test-version",
       idempotencyKey: "idem-1",
     });
     const layer = providerLayer(provider);
@@ -104,8 +107,12 @@ describe("VM Effect workflows", () => {
       select count(*)::text as "usageCount" from cloud_vm_usage_events
       where user_id = 'user-workflow-idem' and event_type = 'vm.created'
     `;
+    const [{ imageVersion }] = await sql<{ imageVersion: string | null }[]>`
+      select image_version as "imageVersion" from cloud_vms where user_id = 'user-workflow-idem'
+    `;
     expect(vmCount).toBe("1");
     expect(usageCount).toBe("1");
+    expect(imageVersion).toBe("test-version");
   });
 
   dbTest("revokes the previous SSH identity before minting a replacement", async () => {
@@ -417,6 +424,72 @@ describe("VM Effect workflows", () => {
     );
     expect(error).toBeInstanceOf(VmNotFoundError);
     expect(attachCalls).toBe(0);
+  });
+
+  dbTest("does not destroy, exec, or mint SSH for another user's VM", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    await sql`
+      insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, provider_vm_id, image_id, status)
+      values ('user-workflow-owner', 'team-workflow-owner', 'free', 'freestyle', 'provider-vm-private-2', 'snapshot-test', 'running')
+    `;
+
+    let destroyCalls = 0;
+    let execCalls = 0;
+    let sshCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () => Effect.fail(new Error("unused") as never),
+      destroy: () => Effect.sync(() => {
+        destroyCalls += 1;
+      }),
+      exec: () => Effect.sync(() => {
+        execCalls += 1;
+        return { exitCode: 0, stdout: "", stderr: "" };
+      }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.sync(() => {
+        sshCalls += 1;
+        return {
+          transport: "ssh" as const,
+          host: "vm-ssh.freestyle.sh",
+          port: 22,
+          username: "provider-vm-private-2+cmux",
+          publicKeyFingerprint: null,
+          credential: { kind: "password" as const, value: "token" },
+          identityHandle: "identity",
+        };
+      }),
+      revokeSSHIdentity: () => Effect.void,
+    };
+    const layer = providerLayer(provider);
+
+    const destroyError = await Effect.runPromise(
+      destroyVm({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      ),
+    );
+    const execError = await Effect.runPromise(
+      execVm({
+        userId: "user-workflow-attacker",
+        providerVmId: "provider-vm-private-2",
+        command: "true",
+        timeoutMs: 1000,
+      }).pipe(Effect.flip, Effect.provide(layer)),
+    );
+    const sshError = await Effect.runPromise(
+      openSshEndpoint({ userId: "user-workflow-attacker", providerVmId: "provider-vm-private-2" }).pipe(
+        Effect.flip,
+        Effect.provide(layer),
+      ),
+    );
+
+    expect(destroyError).toBeInstanceOf(VmNotFoundError);
+    expect(execError).toBeInstanceOf(VmNotFoundError);
+    expect(sshError).toBeInstanceOf(VmNotFoundError);
+    expect(destroyCalls).toBe(0);
+    expect(execCalls).toBe(0);
+    expect(sshCalls).toBe(0);
   });
 
   dbTest("records repeated attach RPC leases idempotently when provider returns a stable daemon token", async () => {


### PR DESCRIPTION
## Summary

- add Cloud VM create kill switches and deploy-time image manifest validation
- remove hidden provider image fallbacks so deployed creates fail closed when image env is missing or unknown
- add CSRF/origin protection for cookie-authenticated VM mutations while preserving native bearer auth
- record manifest image versions in VM rows, responses, usage metadata, and image build output
- update Cloud VM docs, env examples, and rollout todo for Postgres/Vercel without Rivet

## Verification

- `bun test tests/vm-route-auth.test.ts tests/vm-image-resolver.test.ts`
- `bunx tsc --noEmit --pretty false`
- `bunx eslint app/api/vm/route.ts services/vms/config.ts services/vms/errors.ts services/vms/routeHelpers.ts services/vms/images/resolver.ts services/vms/billingGateway.ts services/vms/repository.ts services/vms/workflows.ts services/vms/drivers/e2b.ts services/vms/drivers/freestyle.ts services/vms/drivers/index.ts tests/vm-route-auth.test.ts tests/vm-image-resolver.test.ts tests/vm-workflows.test.ts scripts/build-cloud-vm-images.ts`
- `/Users/lawrence/fun/cmuxterm-hq/skills/cloud-vm-ops/scripts/verify-migration-preflight.sh web`
- `set -a; source ~/.secrets/cmuxterm.env; source ~/.secrets/cmuxterm-dev.env; set +a; bun run build`
- `./scripts/reload.sh --tag cvmhard`

## Ops

Added these non-secret Vercel production env keys to both `manaflow/cmux` and `manaflow/cmux-staging`:

- `CMUX_VM_CREATE_ENABLED=1`
- `CMUX_VM_E2B_ENABLED=1`
- `CMUX_VM_FREESTYLE_ENABLED=1`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds production hardening for Cloud VMs: global/per‑provider create kill switches, manifest‑based image resolution with explicit 503s on misconfig, same‑origin checks for cookie mutations, and end‑to‑end image version tracking. Also enables AWS RDS SSL verification by default with strict CA bundle handling via `CMUX_DB_SSL_CA_PEM`/`CMUX_DB_SSL_CA_PEM_BASE64`.

- **New Features**
  - Create kill switches via `CMUX_VM_CREATE_ENABLED`, `CMUX_VM_E2B_ENABLED`, `CMUX_VM_FREESTYLE_ENABLED`; disabled creates return 503 with a clear JSON payload.
  - Enforce a checked‑in image manifest (`services/vms/images/manifest.json`); deployed creates require manifest‑listed images via `E2B_CMUXD_WS_TEMPLATE` or `FREESTYLE_SANDBOX_SNAPSHOT`. Local dev uses manifest defaults; `CMUX_VM_ALLOW_UNMANIFESTED_IMAGES` allows experiments. Drivers now require a resolved image (no internal fallbacks).
  - Same‑origin checks for cookie‑authenticated `POST`/`DELETE` VM routes; bearer auth is unaffected. Optional allowlist via `CMUX_VM_ALLOWED_ORIGINS`.
  - Track `imageVersion` in DB rows, API responses, billing usage metadata, and spans. `web/scripts/build-cloud-vm-images.ts` now emits manifest entries with commit, SHA256, and builder script version.
  - RDS IAM/SSL: verify AWS RDS certs by default; load CA from `CMUX_DB_SSL_CA_PEM` or validated `CMUX_DB_SSL_CA_PEM_BASE64` and pass it to the client. `CMUX_DB_SSL_REJECT_UNAUTHORIZED=false` is allowed only when explicitly set.

- **Migration**
  - In Vercel, set `CMUX_VM_CREATE_ENABLED=1`, `CMUX_VM_E2B_ENABLED=1`, `CMUX_VM_FREESTYLE_ENABLED=1`.
  - Set `E2B_CMUXD_WS_TEMPLATE` and/or `FREESTYLE_SANDBOX_SNAPSHOT` to manifest‑listed IDs; creates fail with 503 if missing or unknown.
  - Optionally set `CMUX_VM_ALLOWED_ORIGINS` for cross‑origin browser clients.
  - For AWS RDS, keep verification on by default; install/pin a CA via `CMUX_DB_SSL_CA_PEM` or `CMUX_DB_SSL_CA_PEM_BASE64`, and tune `CMUX_DB_POOL_MAX`.
  - Local dev: use `~/.secrets/cmuxterm-dev.env`; examples/docs updated.

<sup>Written for commit fcadf10e6500ef31339f612e27303180d3a29436. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3185?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-provider and global VM create kill‑switches; image manifest with versioned entries and opt‑in for unmanifested images; API responses now include imageVersion and return clear 503 payloads for disabled/misconfigured images.
  * Origin/CSRF gating for browser cookie VM actions; native bearer flows unaffected.

* **Documentation**
  * Updated env/config docs, local secrets path, staging deployment notes, and image manifest/rollback guidance; DB SSL CA options documented.

* **Tests**
  * Expanded image resolver, auth/CSRF, workflows, and DB/config SSL coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->