### PR TITLE
fix: pre-push hook exit 0 on success path

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Pre-push hook - regression harness gate
+# DO NOT BYPASS with --no-verify. DO NOT SILENCE failures.
+# Failures are regression signals; reproduce and fix them before pushing.
+
+set -u
+set -o pipefail
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$repo_root" || exit 1
+
+if [ ! -x scripts/run_tests.sh ]; then
+  printf 'WARNING: no executable scripts/run_tests.sh; skipping regression harness\n' >&2
+  exit 0
+fi
+
+bash scripts/run_tests.sh
+exit_status=$?
+
+if [ "$exit_status" -ne 0 ]; then
+  cat >&2 <<'BANNER'
+
+PUSH BLOCKED - regression harness failed.
+Read the failure, reproduce it, and fix the bug.
+DO NOT bypass with --no-verify or silence this hook.
+
+BANNER
+  exit "$exit_status"
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -27,3 +27,5 @@ DO NOT bypass with --no-verify or silence this hook.
 BANNER
   exit "$exit_status"
 fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,16 @@ zig build -Demit-xcframework=true -Doptimize=ReleaseFast
 
 ## Running Tests
 
+### Pre-push regression gate
+
+Enable the local regression harness hook before pushing:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+This enables `.githooks/pre-push`, which runs `scripts/run_tests.sh` and blocks pushes on regression failures. Do not bypass it with `--no-verify`; fix the failing regression instead.
+
 ### Basic tests (run on VM)
 
 ```bash

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */; };
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */; };
 					F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */; };
+					F9200000A1B2C3D4E5F60718 /* RapidSpawnKillFixtureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9200001A1B2C3D4E5F60718 /* RapidSpawnKillFixtureTests.swift */; };
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */; };
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008380 /* BrowserFindJavaScriptTests.swift */; };
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5008382 /* CommandPaletteSearchEngineTests.swift */; };
@@ -251,6 +252,7 @@
 				F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceContentViewVisibilityTests.swift; sourceTree = "<group>"; };
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlPasswordStoreTests.swift; sourceTree = "<group>"; };
 					F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyEnsureFocusWindowActivationTests.swift; sourceTree = "<group>"; };
+					F9200001A1B2C3D4E5F60718 /* RapidSpawnKillFixtureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RapidSpawnKillFixtureTests.swift; sourceTree = "<group>"; };
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceStressProfileTests.swift; sourceTree = "<group>"; };
 					A5008380 /* BrowserFindJavaScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserFindJavaScriptTests.swift; sourceTree = "<group>"; };
 				A5008382 /* CommandPaletteSearchEngineTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSearchEngineTests.swift; sourceTree = "<group>"; };
@@ -492,6 +494,7 @@
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
 					A5009002 /* MCPServerTests.swift */,
 					F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
+					F9200001A1B2C3D4E5F60718 /* RapidSpawnKillFixtureTests.swift */,
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
 					A5008382 /* CommandPaletteSearchEngineTests.swift */,
@@ -738,6 +741,7 @@
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 					A5009003 /* MCPServerTests.swift in Sources */,
 					F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
+					F9200000A1B2C3D4E5F60718 /* RapidSpawnKillFixtureTests.swift in Sources */,
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 					A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -22,6 +22,8 @@
 		A5001500 /* CmuxWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001510 /* CmuxWebView.swift */; };
 		A5001501 /* UITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001511 /* UITestRecorder.swift */; };
 		A5001226 /* SocketControlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlSettings.swift */; };
+		A5009001 /* MCPServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5009000 /* MCPServer.swift */; };
+		A5009003 /* MCPServerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5009002 /* MCPServerTests.swift */; };
 		A5001601 /* SentryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001600 /* SentryHelper.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
@@ -179,6 +181,8 @@
 			A5001511 /* UITestRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestRecorder.swift; sourceTree = "<group>"; };
 			A5001520 /* PostHogAnalytics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostHogAnalytics.swift; sourceTree = "<group>"; };
 			A5001225 /* SocketControlSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocketControlSettings.swift; sourceTree = "<group>"; };
+			A5009000 /* MCPServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServer.swift; sourceTree = "<group>"; };
+			A5009002 /* MCPServerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MCPServerTests.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001411 /* TerminalPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanel.swift; sourceTree = "<group>"; };
 		A5001412 /* BrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanel.swift; sourceTree = "<group>"; };
@@ -382,6 +386,7 @@
 				A5001019 /* TerminalController.swift */,
 				A5001541 /* PortScanner.swift */,
 				A5001225 /* SocketControlSettings.swift */,
+				A5009000 /* MCPServer.swift */,
 				A5001600 /* SentryHelper.swift */,
 				A5001620 /* AppleScriptSupport.swift */,
 				A5001090 /* AppDelegate.swift */,
@@ -485,6 +490,7 @@
 					F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
 					F7000001A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift */,
 					F8000001A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift */,
+					A5009002 /* MCPServerTests.swift */,
 					F9000001A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift */,
 					FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 					A5008380 /* BrowserFindJavaScriptTests.swift */,
@@ -658,6 +664,7 @@
 				A5001007 /* TerminalController.swift in Sources */,
 				A5001540 /* PortScanner.swift in Sources */,
 				A5001226 /* SocketControlSettings.swift in Sources */,
+				A5009001 /* MCPServer.swift in Sources */,
 				A5001601 /* SentryHelper.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
@@ -729,6 +736,7 @@
 					F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
 					F7000000A1B2C3D4E5F60718 /* WorkspaceContentViewVisibilityTests.swift in Sources */,
 					F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
+					A5009003 /* MCPServerTests.swift in Sources */,
 					F9000000A1B2C3D4E5F60718 /* GhosttyEnsureFocusWindowActivationTests.swift in Sources */,
 					FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 					A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -1,0 +1,531 @@
+import Foundation
+
+// MARK: - MCP Content-Length Framing
+
+/// Parses MCP Content-Length framed messages from raw bytes.
+/// Format: `Content-Length: N\r\n\r\n{json of N bytes}`
+enum MCPFraming {
+    /// Result of attempting to parse one MCP message from a buffer.
+    enum ParseResult {
+        /// Successfully parsed a message; `consumed` is the total bytes eaten from the buffer.
+        case message(Data, consumed: Int)
+        /// Not enough data yet — need more bytes.
+        case needMore
+        /// Buffer does not start with "Content-Length:" — not MCP.
+        case notMCP
+    }
+
+    /// Try to extract one Content-Length framed message from the front of `buffer`.
+    static func parse(_ buffer: Data) -> ParseResult {
+        // MCP header starts with "Content-Length: "
+        let headerPrefix = "Content-Length: ".data(using: .utf8)!
+        guard buffer.count >= headerPrefix.count else {
+            // Could still be MCP if we haven't received enough bytes.
+            // Check if what we have is a prefix of "Content-Length: ".
+            if buffer.count > 0 {
+                let partial = headerPrefix.prefix(buffer.count)
+                if buffer.starts(with: partial) {
+                    return .needMore
+                }
+            }
+            return buffer.isEmpty ? .needMore : .notMCP
+        }
+
+        guard buffer.starts(with: headerPrefix) else {
+            return .notMCP
+        }
+
+        // Find \r\n\r\n separator
+        let separator = "\r\n\r\n".data(using: .utf8)!
+        guard let separatorRange = buffer.range(of: separator) else {
+            return .needMore
+        }
+
+        // Extract content length value
+        let headerEnd = separatorRange.lowerBound
+        let headerData = buffer[headerPrefix.count..<headerEnd]
+        guard let headerStr = String(data: headerData, encoding: .utf8),
+              let contentLength = Int(headerStr.trimmingCharacters(in: .whitespaces)),
+              contentLength >= 0 else {
+            return .notMCP
+        }
+
+        // Check if we have the full body
+        let bodyStart = separatorRange.upperBound
+        let totalNeeded = bodyStart + contentLength
+        guard buffer.count >= totalNeeded else {
+            return .needMore
+        }
+
+        let body = buffer[bodyStart..<(bodyStart + contentLength)]
+        return .message(Data(body), consumed: totalNeeded)
+    }
+
+    /// Encode a JSON response with Content-Length framing.
+    static func encode(_ json: Data) -> Data {
+        let header = "Content-Length: \(json.count)\r\n\r\n"
+        var result = header.data(using: .utf8)!
+        result.append(json)
+        return result
+    }
+
+    /// Encode a dictionary as a JSON-RPC response with Content-Length framing.
+    static func encodeResponse(_ dict: [String: Any]) -> Data {
+        guard let json = try? JSONSerialization.data(withJSONObject: dict, options: [.sortedKeys]) else {
+            // Fallback: return a minimal JSON-RPC error that is always serializable
+            let fallback = #"{"jsonrpc":"2.0","id":null,"error":{"code":-32603,"message":"Internal serialization error"}}"#
+            return encode(fallback.data(using: .utf8)!)
+        }
+        return encode(json)
+    }
+}
+
+// MARK: - MCP JSON-RPC Protocol
+
+/// Handles MCP JSON-RPC 2.0 protocol methods.
+/// Routes `initialize`, `tools/list`, `tools/call` and delegates tool execution.
+final class MCPHandler {
+    /// Callback to execute a cmux V2 method. Returns the V2 result dict or throws.
+    typealias V2Executor = (_ method: String, _ params: [String: Any]) -> V2ExecutorResult
+
+    enum V2ExecutorResult {
+        case ok(Any)
+        case error(code: String, message: String)
+    }
+
+    private let v2Execute: V2Executor
+    private var initialized = false
+
+    init(v2Execute: @escaping V2Executor) {
+        self.v2Execute = v2Execute
+    }
+
+    /// Process one MCP JSON-RPC request. Returns the response dict.
+    func handleRequest(_ data: Data) -> [String: Any]? {
+        guard let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return jsonRPCError(id: NSNull(), code: -32700, message: "Parse error")
+        }
+
+        let id: Any = object["id"] ?? NSNull()
+        let method = object["method"] as? String ?? ""
+        let params = object["params"] as? [String: Any] ?? [:]
+
+        // Notifications (no id) — acknowledge silently
+        if object["id"] == nil {
+            return nil
+        }
+
+        switch method {
+        case "initialize":
+            return handleInitialize(id: id, params: params)
+        case "initialized":
+            // Client notification — no response needed
+            return nil
+        case "ping":
+            return jsonRPCResult(id: id, result: [:])
+        case "tools/list", "tools/call":
+            // Require initialize handshake before tool operations
+            guard initialized else {
+                return jsonRPCError(id: id, code: -32002, message: "Server not initialized. Send initialize first.")
+            }
+            if method == "tools/list" {
+                return handleToolsList(id: id, params: params)
+            } else {
+                return handleToolsCall(id: id, params: params)
+            }
+        default:
+            return jsonRPCError(id: id, code: -32601, message: "Method not found: \(method)")
+        }
+    }
+
+    // MARK: - MCP Methods
+
+    private func handleInitialize(id: Any, params: [String: Any]) -> [String: Any] {
+        initialized = true
+        return jsonRPCResult(id: id, result: [
+            "protocolVersion": "2024-11-05",
+            "capabilities": [
+                "tools": [
+                    "listChanged": false
+                ]
+            ],
+            "serverInfo": [
+                "name": "cmux",
+                "version": "0.1.0"
+            ]
+        ])
+    }
+
+    private func handleToolsList(id: Any, params: [String: Any]) -> [String: Any] {
+        return jsonRPCResult(id: id, result: [
+            "tools": MCPToolSchemas.all
+        ])
+    }
+
+    private func handleToolsCall(id: Any, params: [String: Any]) -> [String: Any] {
+        guard let toolName = params["name"] as? String else {
+            return jsonRPCError(id: id, code: -32602, message: "Missing tool name")
+        }
+
+        let toolArgs = params["arguments"] as? [String: Any] ?? [:]
+
+        guard let route = MCPToolSchemas.route(for: toolName) else {
+            return jsonRPCError(id: id, code: -32602, message: "Unknown tool: \(toolName)")
+        }
+
+        // Map MCP tool arguments to V2 method params
+        let v2Params = route.mapParams(toolArgs)
+        let result = v2Execute(route.v2Method, v2Params)
+
+        switch result {
+        case .ok(let payload):
+            let text: String
+            if let dict = payload as? [String: Any],
+               let jsonData = try? JSONSerialization.data(withJSONObject: dict, options: []),
+               let jsonStr = String(data: jsonData, encoding: .utf8) {
+                text = jsonStr
+            } else {
+                text = String(describing: payload)
+            }
+            return jsonRPCResult(id: id, result: [
+                "content": [
+                    ["type": "text", "text": text]
+                ]
+            ])
+        case .error(_, let message):
+            return jsonRPCResult(id: id, result: [
+                "content": [
+                    ["type": "text", "text": "Error: \(message)"]
+                ],
+                "isError": true
+            ])
+        }
+    }
+
+    // MARK: - JSON-RPC Helpers
+
+    private func jsonRPCResult(id: Any, result: [String: Any]) -> [String: Any] {
+        return [
+            "jsonrpc": "2.0",
+            "id": id,
+            "result": result
+        ]
+    }
+
+    private func jsonRPCError(id: Any, code: Int, message: String) -> [String: Any] {
+        return [
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": [
+                "code": code,
+                "message": message
+            ]
+        ]
+    }
+}
+
+// MARK: - MCP Tool Schemas & Routing
+
+/// Defines the 20 MCP tools and their mapping to V2 methods.
+enum MCPToolSchemas {
+    struct Route {
+        let v2Method: String
+        let mapParams: ([String: Any]) -> [String: Any]
+    }
+
+    /// All tool schemas for tools/list response.
+    static let all: [[String: Any]] = [
+        tool("list_surfaces",
+             description: "List all surfaces (terminal/browser panes) across workspaces",
+             properties: [
+                "workspace": prop("string", "Filter by workspace ref")
+             ]),
+        tool("read_screen",
+             description: "Read the current screen content of a terminal surface",
+             properties: [
+                "surface": prop("string", "Target surface ref"),
+                "lines": prop("integer", "Number of lines to read (default 20)"),
+                "scrollback": prop("boolean", "Include scrollback buffer")
+             ],
+             required: ["surface"]),
+        tool("send_input",
+             description: "Send text input to a terminal surface",
+             properties: [
+                "surface": prop("string", "Target surface ref"),
+                "text": prop("string", "Text to send"),
+                "workspace": prop("string", "Target workspace ref"),
+                "press_enter": prop("boolean", "Press enter after sending")
+             ],
+             required: ["surface", "text"]),
+        tool("send_key",
+             description: "Send a key press to a terminal surface",
+             properties: [
+                "surface": prop("string", "Target surface ref"),
+                "key": prop("string", "Key name (e.g. 'return', 'escape', 'tab')"),
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["surface", "key"]),
+        tool("new_split",
+             description: "Create a new split pane (terminal or browser)",
+             properties: [
+                "direction": propEnum("string", "Split direction", ["left", "right", "up", "down"]),
+                "workspace": prop("string", "Target workspace ref"),
+                "surface": prop("string", "Target surface ref"),
+                "pane": prop("string", "Target pane ref"),
+                "type": propEnum("string", "Surface type", ["terminal", "browser"]),
+                "url": prop("string", "URL for browser surfaces"),
+                "title": prop("string", "Tab title"),
+                "focus": prop("boolean", "Focus the new pane (default true)")
+             ],
+             required: ["direction"]),
+        tool("close_surface",
+             description: "Close a surface (terminal or browser pane)",
+             properties: [
+                "surface": prop("string", "Target surface ref"),
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["surface"]),
+        tool("set_status",
+             description: "Set a sidebar status key-value pair",
+             properties: [
+                "key": prop("string", "Status key"),
+                "value": prop("string", "Status value"),
+                "workspace": prop("string", "Target workspace ref"),
+                "surface": prop("string", "Target surface ref"),
+                "icon": prop("string", "Icon name"),
+                "color": prop("string", "Hex color (#RRGGBB)")
+             ],
+             required: ["key", "value"]),
+        tool("set_progress",
+             description: "Set sidebar progress indicator (0.0 to 1.0)",
+             properties: [
+                "value": prop("number", "Progress value between 0 and 1"),
+                "label": prop("string", "Progress label text"),
+                "workspace": prop("string", "Target workspace ref"),
+                "surface": prop("string", "Target surface ref")
+             ],
+             required: ["value"]),
+        tool("rename_tab",
+             description: "Rename a surface tab",
+             properties: [
+                "surface": prop("string", "Target surface ref"),
+                "title": prop("string", "New tab title"),
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["surface", "title"]),
+        tool("list_workspaces",
+             description: "List all workspaces",
+             properties: [:]),
+        tool("create_workspace",
+             description: "Create a new workspace",
+             properties: [
+                "title": prop("string", "Workspace title"),
+                "select": prop("boolean", "Select the new workspace (default true)")
+             ]),
+        tool("select_workspace",
+             description: "Select (switch to) a workspace",
+             properties: [
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["workspace"]),
+        tool("list_panes",
+             description: "List all panes in a workspace",
+             properties: [
+                "workspace": prop("string", "Target workspace ref")
+             ]),
+        tool("focus_pane",
+             description: "Focus a specific pane",
+             properties: [
+                "pane": prop("string", "Target pane ref"),
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["pane"]),
+        tool("system_identify",
+             description: "Get currently focused workspace, pane, and surface",
+             properties: [:]),
+        tool("system_tree",
+             description: "Get full window/workspace/pane/surface tree",
+             properties: [:]),
+        tool("notification_create",
+             description: "Create a notification",
+             properties: [
+                "title": prop("string", "Notification title"),
+                "body": prop("string", "Notification body"),
+                "surface": prop("string", "Target surface ref"),
+                "workspace": prop("string", "Target workspace ref")
+             ],
+             required: ["title"]),
+        tool("browser_open",
+             description: "Open a browser pane",
+             properties: [
+                "url": prop("string", "URL to open"),
+                "workspace": prop("string", "Target workspace ref"),
+                "direction": propEnum("string", "Split direction", ["left", "right", "up", "down"])
+             ]),
+        tool("browser_navigate",
+             description: "Navigate a browser surface to a URL",
+             properties: [
+                "surface": prop("string", "Target browser surface ref"),
+                "url": prop("string", "URL to navigate to")
+             ],
+             required: ["surface", "url"]),
+        tool("browser_snapshot",
+             description: "Take an accessibility snapshot of a browser surface",
+             properties: [
+                "surface": prop("string", "Target browser surface ref")
+             ],
+             required: ["surface"]),
+    ]
+
+    // MARK: - Tool Routing
+
+    private static let routes: [String: Route] = [
+        "list_surfaces": Route(v2Method: "surface.list", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "read_screen": Route(v2Method: "surface.read_text", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let l = params["lines"] { v2["lines"] = l }
+            if let sb = params["scrollback"] { v2["scrollback"] = sb }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "send_input": Route(v2Method: "surface.send_text", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let t = params["text"] { v2["text"] = t }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let pe = params["press_enter"] { v2["press_enter"] = pe }
+            return v2
+        }),
+        "send_key": Route(v2Method: "surface.send_key", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let k = params["key"] { v2["key"] = k }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "new_split": Route(v2Method: "surface.split", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let d = params["direction"] { v2["direction"] = d }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let s = params["surface"] { v2["surface"] = s }
+            if let p = params["pane"] { v2["pane"] = p }
+            if let t = params["type"] { v2["type"] = t }
+            if let u = params["url"] { v2["url"] = u }
+            if let ti = params["title"] { v2["title"] = ti }
+            if let f = params["focus"] { v2["focus"] = f }
+            return v2
+        }),
+        "close_surface": Route(v2Method: "surface.close", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "set_status": Route(v2Method: "report_meta", mapParams: { params in
+            // V1 command: set_status key value
+            // This maps to V1 sidebar commands, handled specially
+            return params
+        }),
+        "set_progress": Route(v2Method: "set_progress", mapParams: { params in
+            return params
+        }),
+        "rename_tab": Route(v2Method: "surface.action", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let t = params["title"] { v2["title"] = t }
+            v2["action"] = "rename"
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "list_workspaces": Route(v2Method: "workspace.list", mapParams: { _ in [:] }),
+        "create_workspace": Route(v2Method: "workspace.create", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let t = params["title"] { v2["title"] = t }
+            if let s = params["select"] { v2["select"] = s }
+            return v2
+        }),
+        "select_workspace": Route(v2Method: "workspace.select", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "list_panes": Route(v2Method: "pane.list", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "focus_pane": Route(v2Method: "pane.focus", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let p = params["pane"] { v2["pane"] = p }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "system_identify": Route(v2Method: "system.identify", mapParams: { _ in [:] }),
+        "system_tree": Route(v2Method: "system.tree", mapParams: { _ in [:] }),
+        "notification_create": Route(v2Method: "notification.create", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let t = params["title"] { v2["title"] = t }
+            if let b = params["body"] { v2["body"] = b }
+            if let s = params["surface"] { v2["surface"] = s }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            return v2
+        }),
+        "browser_open": Route(v2Method: "browser.open_split", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let u = params["url"] { v2["url"] = u }
+            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let d = params["direction"] { v2["direction"] = d }
+            return v2
+        }),
+        "browser_navigate": Route(v2Method: "browser.navigate", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            if let u = params["url"] { v2["url"] = u }
+            return v2
+        }),
+        "browser_snapshot": Route(v2Method: "browser.snapshot", mapParams: { params in
+            var v2: [String: Any] = [:]
+            if let s = params["surface"] { v2["surface"] = s }
+            return v2
+        }),
+    ]
+
+    static func route(for toolName: String) -> Route? {
+        return routes[toolName]
+    }
+
+    // MARK: - Schema Helpers
+
+    private static func tool(
+        _ name: String,
+        description: String,
+        properties: [String: [String: Any]],
+        required: [String] = []
+    ) -> [String: Any] {
+        var schema: [String: Any] = [
+            "type": "object",
+            "properties": properties
+        ]
+        if !required.isEmpty {
+            schema["required"] = required
+        }
+        return [
+            "name": name,
+            "description": description,
+            "inputSchema": schema
+        ]
+    }
+
+    private static func prop(_ type: String, _ description: String) -> [String: Any] {
+        return ["type": type, "description": description]
+    }
+
+    private static func propEnum(_ type: String, _ description: String, _ values: [String]) -> [String: Any] {
+        return ["type": type, "description": description, "enum": values]
+    }
+}

--- a/Sources/MCPServer.swift
+++ b/Sources/MCPServer.swift
@@ -382,38 +382,38 @@ enum MCPToolSchemas {
     private static let routes: [String: Route] = [
         "list_surfaces": Route(v2Method: "surface.list", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "read_screen": Route(v2Method: "surface.read_text", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            if let s = params["surface"] { v2["surface_id"] = s }
             if let l = params["lines"] { v2["lines"] = l }
             if let sb = params["scrollback"] { v2["scrollback"] = sb }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "send_input": Route(v2Method: "surface.send_text", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            if let s = params["surface"] { v2["surface_id"] = s }
             if let t = params["text"] { v2["text"] = t }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             if let pe = params["press_enter"] { v2["press_enter"] = pe }
             return v2
         }),
         "send_key": Route(v2Method: "surface.send_key", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            if let s = params["surface"] { v2["surface_id"] = s }
             if let k = params["key"] { v2["key"] = k }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "new_split": Route(v2Method: "surface.split", mapParams: { params in
             var v2: [String: Any] = [:]
             if let d = params["direction"] { v2["direction"] = d }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
-            if let s = params["surface"] { v2["surface"] = s }
-            if let p = params["pane"] { v2["pane"] = p }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
+            if let s = params["surface"] { v2["surface_id"] = s }
+            if let p = params["pane"] { v2["pane_id"] = p }
             if let t = params["type"] { v2["type"] = t }
             if let u = params["url"] { v2["url"] = u }
             if let ti = params["title"] { v2["title"] = ti }
@@ -422,8 +422,8 @@ enum MCPToolSchemas {
         }),
         "close_surface": Route(v2Method: "surface.close", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let s = params["surface"] { v2["surface_id"] = s }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "set_status": Route(v2Method: "report_meta", mapParams: { params in
@@ -436,10 +436,10 @@ enum MCPToolSchemas {
         }),
         "rename_tab": Route(v2Method: "surface.action", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            if let s = params["surface"] { v2["surface_id"] = s }
             if let t = params["title"] { v2["title"] = t }
             v2["action"] = "rename"
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "list_workspaces": Route(v2Method: "workspace.list", mapParams: { _ in [:] }),
@@ -451,18 +451,18 @@ enum MCPToolSchemas {
         }),
         "select_workspace": Route(v2Method: "workspace.select", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "list_panes": Route(v2Method: "pane.list", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "focus_pane": Route(v2Method: "pane.focus", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let p = params["pane"] { v2["pane"] = p }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let p = params["pane"] { v2["pane_id"] = p }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "system_identify": Route(v2Method: "system.identify", mapParams: { _ in [:] }),
@@ -471,26 +471,28 @@ enum MCPToolSchemas {
             var v2: [String: Any] = [:]
             if let t = params["title"] { v2["title"] = t }
             if let b = params["body"] { v2["body"] = b }
-            if let s = params["surface"] { v2["surface"] = s }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let s = params["surface"] { v2["surface_id"] = s }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             return v2
         }),
         "browser_open": Route(v2Method: "browser.open_split", mapParams: { params in
             var v2: [String: Any] = [:]
             if let u = params["url"] { v2["url"] = u }
-            if let ws = params["workspace"] { v2["workspace"] = ws }
+            if let ws = params["workspace"] { v2["workspace_id"] = ws }
             if let d = params["direction"] { v2["direction"] = d }
             return v2
         }),
         "browser_navigate": Route(v2Method: "browser.navigate", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            // V2 browser.navigate expects surface_id, not surface
+            if let s = params["surface"] { v2["surface_id"] = s }
             if let u = params["url"] { v2["url"] = u }
             return v2
         }),
         "browser_snapshot": Route(v2Method: "browser.snapshot", mapParams: { params in
             var v2: [String: Any] = [:]
-            if let s = params["surface"] { v2["surface"] = s }
+            // V2 browser.snapshot uses v2BrowserWithPanel which expects surface_id
+            if let s = params["surface"] { v2["surface_id"] = s }
             return v2
         }),
     ]

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1171,6 +1171,25 @@ class TerminalController {
         }
     }
 
+    /// Write binary data to a socket, handling partial writes and EINTR.
+    private func writeSocketData(_ data: Data, to socket: Int32) {
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var written = 0
+            let total = data.count
+            while written < total {
+                let result = write(socket, baseAddress.advanced(by: written), total - written)
+                if result > 0 {
+                    written += result
+                } else if result == -1 && errno == EINTR {
+                    continue
+                } else {
+                    break // write error — connection likely closed
+                }
+            }
+        }
+    }
+
     private func passwordAuthRequiredResponse(for command: String) -> String {
         let message = "Authentication required. Send auth <password> first."
         guard command.hasPrefix("{"),
@@ -1573,27 +1592,75 @@ class TerminalController {
         var buffer = [UInt8](repeating: 0, count: 4096)
         var pending = ""
         var authenticated = false
+        var mcpDetected = false
+        var mcpBuffer = Data()
+        var mcpHandler: MCPHandler?
 
         while withListenerState({ isRunning }) {
             let bytesRead = read(socket, &buffer, buffer.count - 1)
             guard bytesRead > 0 else { break }
 
-            let chunk = String(bytes: buffer[0..<bytesRead], encoding: .utf8) ?? ""
-            pending.append(chunk)
-
-            while let newlineIndex = pending.firstIndex(of: "\n") {
-                let line = String(pending[..<newlineIndex])
-                pending = String(pending[pending.index(after: newlineIndex)...])
-                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { continue }
-
-                if let authResponse = authResponseIfNeeded(for: trimmed, authenticated: &authenticated) {
-                    writeSocketResponse(authResponse, to: socket)
-                    continue
+            // On first read, detect MCP Content-Length framing vs NDJSON/V1.
+            if !mcpDetected && mcpHandler == nil {
+                let firstBytes = Data(buffer[0..<min(bytesRead, 16)])
+                if firstBytes.starts(with: "Content-Length:".data(using: .utf8)!) {
+                    // Reject MCP connections when password auth is required.
+                    // MCP clients (socat) cannot perform the password handshake.
+                    if accessMode.requiresPasswordAuth {
+                        let errMsg = "ERROR: MCP connections not supported in password auth mode\n"
+                        errMsg.withCString { ptr in _ = write(socket, ptr, strlen(ptr)) }
+                        return
+                    }
+                    mcpDetected = true
+                    mcpHandler = MCPHandler { [weak self] method, params in
+                        guard let self else { return .error(code: "internal", message: "Server unavailable") }
+                        return self.mcpExecuteV2(method: method, params: params)
+                    }
                 }
+            }
 
-                let response = processCommand(trimmed)
-                writeSocketResponse(response, to: socket)
+            if mcpDetected, let handler = mcpHandler {
+                // MCP mode: Content-Length framed messages
+                mcpBuffer.append(contentsOf: buffer[0..<bytesRead])
+
+                while true {
+                    let result = MCPFraming.parse(mcpBuffer)
+                    switch result {
+                    case .message(let messageData, let consumed):
+                        mcpBuffer = mcpBuffer.subdata(in: consumed..<mcpBuffer.count)
+                        if let response = handler.handleRequest(messageData) {
+                            let framed = MCPFraming.encodeResponse(response)
+                            writeSocketData(framed, to: socket)
+                        }
+                        continue  // Try parsing next message from buffer
+                    case .needMore:
+                        break
+                    case .notMCP:
+                        // Corrupted data after MCP detection — close connection.
+                        mcpBuffer.removeAll()
+                        return
+                    }
+                    break  // Only reached from .needMore
+                }
+            } else {
+                // V1/V2 mode: newline-delimited
+                let chunk = String(bytes: buffer[0..<bytesRead], encoding: .utf8) ?? ""
+                pending.append(chunk)
+
+                while let newlineIndex = pending.firstIndex(of: "\n") {
+                    let line = String(pending[..<newlineIndex])
+                    pending = String(pending[pending.index(after: newlineIndex)...])
+                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    guard !trimmed.isEmpty else { continue }
+
+                    if let authResponse = authResponseIfNeeded(for: trimmed, authenticated: &authenticated) {
+                        writeSocketResponse(authResponse, to: socket)
+                        continue
+                    }
+
+                    let response = processCommand(trimmed)
+                    writeSocketResponse(response, to: socket)
+                }
             }
         }
     }
@@ -1950,6 +2017,90 @@ class TerminalController {
                 return "ERROR: Unknown command '\(cmd)'. Use 'help' for available commands."
             }
         }
+    }
+
+    // MARK: - MCP Bridge
+
+    /// Execute a V2 method from the MCP handler, bridging MCP tool calls to the V2 dispatch.
+    private func mcpExecuteV2(method: String, params: [String: Any]) -> MCPHandler.V2ExecutorResult {
+        // V1 commands (no dot in method name) are routed as plain text commands
+        if !method.contains(".") {
+            return mcpExecuteV1(command: method, params: params)
+        }
+
+        // V2: Build a synthetic JSON-RPC request
+        let requestId = UUID().uuidString
+        let request: [String: Any] = [
+            "id": requestId,
+            "method": method,
+            "params": params
+        ]
+        guard let jsonData = try? JSONSerialization.data(withJSONObject: request),
+              let jsonStr = String(data: jsonData, encoding: .utf8) else {
+            return .error(code: "internal", message: "Failed to serialize V2 request")
+        }
+
+        let responseStr = processV2Command(jsonStr)
+
+        // Parse the V2 response
+        guard let responseData = responseStr.data(using: .utf8),
+              let responseDict = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            return .error(code: "internal", message: "Failed to parse V2 response")
+        }
+
+        if let ok = responseDict["ok"] as? Bool, ok, let result = responseDict["result"] {
+            return .ok(result)
+        } else if let error = responseDict["error"] as? [String: Any] {
+            let code = error["code"] as? String ?? "unknown"
+            let message = error["message"] as? String ?? "Unknown error"
+            return .error(code: code, message: message)
+        }
+
+        return .error(code: "internal", message: "Unexpected V2 response format")
+    }
+
+    /// Execute a V1 plain-text command from MCP tool calls (for sidebar commands like set_status, set_progress).
+    private func mcpExecuteV1(command: String, params: [String: Any]) -> MCPHandler.V2ExecutorResult {
+        var args = command
+        // Build V1 argument string from params.
+        // Values are quoted to prevent injection via the V1 tokenizer.
+        switch command {
+        case "report_meta":
+            // Format: report_meta key value [--icon=X] [--color=#RRGGBB] [--surface=S]
+            guard let key = params["key"] as? String, let value = params["value"] as? String else {
+                return .error(code: "invalid_params", message: "report_meta requires key and value")
+            }
+            args = "report_meta \(mcpQuoteV1(key)) \(mcpQuoteV1(value))"
+            if let icon = params["icon"] as? String { args += " --icon=\(mcpQuoteV1(icon))" }
+            if let color = params["color"] as? String { args += " --color=\(mcpQuoteV1(color))" }
+            if let surface = params["surface"] as? String { args += " --surface=\(mcpQuoteV1(surface))" }
+        case "set_progress":
+            // Format: set_progress value [--label=TEXT] [--surface=S]
+            if let value = params["value"] as? Double {
+                args = "set_progress \(value)"
+            } else if let value = params["value"] as? Int {
+                args = "set_progress \(value)"
+            }
+            if let label = params["label"] as? String { args += " --label=\(mcpQuoteV1(label))" }
+            if let surface = params["surface"] as? String { args += " --surface=\(mcpQuoteV1(surface))" }
+        default:
+            break
+        }
+
+        let responseStr = processCommand(args)
+        if responseStr.hasPrefix("ERROR") || responseStr.hasPrefix("error") {
+            return .error(code: "v1_error", message: responseStr)
+        }
+        return .ok(["response": responseStr])
+    }
+
+    /// Quote a string for safe embedding in V1 command arguments.
+    /// Wraps in double quotes and escapes internal quotes/backslashes.
+    private func mcpQuoteV1(_ value: String) -> String {
+        let escaped = value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
     }
 
     // MARK: - V2 JSON Socket Protocol

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -705,7 +705,15 @@ final class TerminalNotificationStore: ObservableObject {
             self?.refreshDockBadge()
         }
         refreshDockBadge()
-        refreshAuthorizationStatus()
+        // Defer initial authorization check past the window constraint setup
+        // phase. When getNotificationSettings completes quickly (cached result),
+        // setting @Published authorizationState during an active Auto Layout
+        // pass triggers an infinite constraint-update cycle (NSGenericException).
+        // A real delay (not just async) is needed because the constraint pass
+        // can span multiple main-queue drain cycles.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+            self?.refreshAuthorizationStatus()
+        }
     }
 
     deinit {
@@ -763,9 +771,24 @@ final class TerminalNotificationStore: ObservableObject {
 
     func refreshAuthorizationStatus() {
         center.getNotificationSettings { [weak self] settings in
-            DispatchQueue.main.async {
+            // Use asyncAfter to ensure the @Published update lands outside
+            // any active Auto Layout constraint pass. A plain main.async can
+            // still fire during the same display cycle that triggered the
+            // settings query, causing an infinite constraint-update loop.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 guard let self else { return }
-                self.authorizationState = Self.authorizationState(from: settings.authorizationStatus)
+                let newState = Self.authorizationState(from: settings.authorizationStatus)
+                // Skip no-op updates to avoid triggering @Published / SwiftUI
+                // invalidation during Auto Layout constraint passes. When this
+                // fires during window setup the constraint-update cycle can
+                // exceed AppKit's limit and throw NSGenericException.
+                guard newState != self.authorizationState else {
+                    self.logAuthorization(
+                        "refresh status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(newState.statusLabel) (no change)"
+                    )
+                    return
+                }
+                self.authorizationState = newState
                 self.logAuthorization(
                     "refresh status=\(Self.authorizationStatusLabel(settings.authorizationStatus)) mapped=\(self.authorizationState.statusLabel)"
                 )

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -670,6 +670,12 @@ final class TerminalNotificationStore: ObservableObject {
     private var hasDeferredAuthorizationRequest = false
     private var hasPromptedForSettings = false
     private var userDefaultsObserver: NSObjectProtocol?
+    /// Delay before the initial authorization check from init, allowing the
+    /// window constraint setup phase to complete before any @Published update.
+    private static let initialAuthCheckDelay: TimeInterval = 0.2
+    /// Delay before applying authorizationState mutations from async callbacks,
+    /// ensuring the update lands outside any active Auto Layout constraint pass.
+    private static let authStateUpdateDelay: TimeInterval = 0.05
     private let settingsPromptWindowRetryDelay: TimeInterval = 0.5
     private let settingsPromptWindowRetryLimit = 20
     private var notificationSettingsWindowProvider: () -> NSWindow? = {
@@ -711,7 +717,7 @@ final class TerminalNotificationStore: ObservableObject {
         // pass triggers an infinite constraint-update cycle (NSGenericException).
         // A real delay (not just async) is needed because the constraint pass
         // can span multiple main-queue drain cycles.
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) { [weak self] in
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.initialAuthCheckDelay) { [weak self] in
             self?.refreshAuthorizationStatus()
         }
     }
@@ -775,7 +781,7 @@ final class TerminalNotificationStore: ObservableObject {
             // any active Auto Layout constraint pass. A plain main.async can
             // still fire during the same display cycle that triggered the
             // settings query, causing an infinite constraint-update loop.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+            DispatchQueue.main.asyncAfter(deadline: .now() + Self.authStateUpdateDelay) {
                 guard let self else { return }
                 let newState = Self.authorizationState(from: settings.authorizationStatus)
                 // Skip no-op updates to avoid triggering @Published / SwiftUI
@@ -1075,6 +1081,9 @@ final class TerminalNotificationStore: ObservableObject {
     ) {
         logAuthorization("ensure start origin=\(origin.rawValue)")
         center.getNotificationSettings { [weak self] settings in
+            // Safe to use plain main.async here: ensureAuthorization is only
+            // called from user-initiated actions (settings button, notification
+            // delivery) well after window constraints have converged.
             DispatchQueue.main.async {
                 guard let self else {
                     completion(false)
@@ -1135,6 +1144,9 @@ final class TerminalNotificationStore: ObservableObject {
             "request starting origin=\(origin.rawValue) automatic=\(isAutomaticRequest) hasRequestedAutomatic=\(hasRequestedAutomaticAuthorization)"
         )
         center.requestAuthorization(options: [.alert, .sound]) { granted, error in
+            // Safe to use plain main.async: requestAuthorization is triggered
+            // by explicit user action or automatic first-request, both after
+            // window constraint setup has completed.
             DispatchQueue.main.async {
                 if granted {
                     self.authorizationState = .authorized

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8047,6 +8047,12 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func flushWorkspaceWindowLayouts() {
         for window in NSApp.windows {
+            // Skip windows that are not visible or are off-screen SwiftUI
+            // system windows (settings, about, etc.). Calling
+            // layoutSubtreeIfNeeded on those can trigger an infinite
+            // constraint-update cycle (NSGenericException) when their
+            // SwiftUI layout has not converged.
+            guard window.isVisible, window.frame.origin.y >= -2000 else { continue }
             window.contentView?.layoutSubtreeIfNeeded()
             window.contentView?.displayIfNeeded()
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8045,6 +8045,11 @@ final class Workspace: Identifiable, ObservableObject {
         layoutFollowUpNeedsGeometryPass = false
     }
 
+    /// Windows positioned below this Y coordinate are treated as off-screen
+    /// SwiftUI system windows (settings, about, etc.) and skipped during layout
+    /// flushes to avoid triggering Auto Layout constraint cycles.
+    private static let offscreenLayoutSkipYThreshold: CGFloat = -2000
+
     private func flushWorkspaceWindowLayouts() {
         for window in NSApp.windows {
             // Skip windows that are not visible or are off-screen SwiftUI
@@ -8052,7 +8057,7 @@ final class Workspace: Identifiable, ObservableObject {
             // layoutSubtreeIfNeeded on those can trigger an infinite
             // constraint-update cycle (NSGenericException) when their
             // SwiftUI layout has not converged.
-            guard window.isVisible, window.frame.origin.y >= -2000 else { continue }
+            guard window.isVisible, window.frame.origin.y >= Self.offscreenLayoutSkipYThreshold else { continue }
             window.contentView?.layoutSubtreeIfNeeded()
             window.contentView?.displayIfNeeded()
         }

--- a/cmuxTests/MCPServerTests.swift
+++ b/cmuxTests/MCPServerTests.swift
@@ -1,0 +1,385 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// MARK: - MCPFraming Tests
+
+final class MCPFramingTests: XCTestCase {
+
+    func testParseCompleteMessage() {
+        let body = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
+        let framed = "Content-Length: \(body.count)\r\n\r\n\(body)"
+        let data = framed.data(using: .utf8)!
+
+        let result = MCPFraming.parse(data)
+        if case .message(let messageData, let consumed) = result {
+            XCTAssertEqual(consumed, framed.count)
+            let parsed = String(data: messageData, encoding: .utf8)
+            XCTAssertEqual(parsed, body)
+        } else {
+            XCTFail("Expected .message, got \(result)")
+        }
+    }
+
+    func testParsePartialHeader() {
+        let data = "Content-Len".data(using: .utf8)!
+        let result = MCPFraming.parse(data)
+        if case .needMore = result {} else {
+            XCTFail("Expected .needMore for partial header, got \(result)")
+        }
+    }
+
+    func testParsePartialBody() {
+        let body = #"{"jsonrpc":"2.0","id":1,"method":"initialize"}"#
+        let framed = "Content-Length: \(body.count)\r\n\r\n\(body.prefix(10))"
+        let data = framed.data(using: .utf8)!
+
+        let result = MCPFraming.parse(data)
+        if case .needMore = result {} else {
+            XCTFail("Expected .needMore for partial body, got \(result)")
+        }
+    }
+
+    func testParseNotMCP() {
+        let data = #"{"id":"test","method":"system.ping"}"#.data(using: .utf8)!
+        let result = MCPFraming.parse(data)
+        if case .notMCP = result {} else {
+            XCTFail("Expected .notMCP for JSON line, got \(result)")
+        }
+    }
+
+    func testParseEmptyBuffer() {
+        let result = MCPFraming.parse(Data())
+        if case .needMore = result {} else {
+            XCTFail("Expected .needMore for empty buffer, got \(result)")
+        }
+    }
+
+    func testParseMultipleMessages() {
+        let body1 = #"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}"#
+        let body2 = #"{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}"#
+        let framed1 = "Content-Length: \(body1.count)\r\n\r\n\(body1)"
+        let framed2 = "Content-Length: \(body2.count)\r\n\r\n\(body2)"
+        var data = (framed1 + framed2).data(using: .utf8)!
+
+        // Parse first message
+        let result1 = MCPFraming.parse(data)
+        if case .message(let msg1, let consumed1) = result1 {
+            XCTAssertEqual(String(data: msg1, encoding: .utf8)!, body1)
+            data = data.subdata(in: consumed1..<data.count)
+        } else {
+            XCTFail("Expected first message")
+            return
+        }
+
+        // Parse second message
+        let result2 = MCPFraming.parse(data)
+        if case .message(let msg2, let consumed2) = result2 {
+            XCTAssertEqual(String(data: msg2, encoding: .utf8)!, body2)
+            XCTAssertEqual(consumed2, data.count)
+        } else {
+            XCTFail("Expected second message")
+        }
+    }
+
+    func testParseZeroLengthBody() {
+        let framed = "Content-Length: 0\r\n\r\n"
+        let data = framed.data(using: .utf8)!
+        let result = MCPFraming.parse(data)
+        if case .message(let body, let consumed) = result {
+            XCTAssertEqual(body.count, 0)
+            XCTAssertEqual(consumed, framed.count)
+        } else {
+            XCTFail("Expected .message with empty body, got \(result)")
+        }
+    }
+
+    func testEncodeResponse() {
+        let dict: [String: Any] = ["jsonrpc": "2.0", "id": 1, "result": ["ok": true]]
+        let encoded = MCPFraming.encodeResponse(dict)
+        let str = String(data: encoded, encoding: .utf8)!
+
+        XCTAssertTrue(str.hasPrefix("Content-Length: "))
+        XCTAssertTrue(str.contains("\r\n\r\n"))
+
+        // Parse it back
+        let result = MCPFraming.parse(encoded)
+        if case .message(let body, _) = result {
+            let parsed = try! JSONSerialization.jsonObject(with: body) as! [String: Any]
+            XCTAssertEqual(parsed["jsonrpc"] as? String, "2.0")
+            XCTAssertEqual(parsed["id"] as? Int, 1)
+        } else {
+            XCTFail("Should be able to parse encoded response")
+        }
+    }
+}
+
+// MARK: - MCPHandler Tests
+
+final class MCPHandlerTests: XCTestCase {
+    private var executedMethod: String?
+    private var executedParams: [String: Any]?
+    private var executorResult: MCPHandler.V2ExecutorResult = .ok(["test": true])
+
+    private lazy var handler: MCPHandler = {
+        MCPHandler { [weak self] method, params in
+            self?.executedMethod = method
+            self?.executedParams = params
+            return self?.executorResult ?? .ok([:])
+        }
+    }()
+
+    override func setUp() {
+        super.setUp()
+        executedMethod = nil
+        executedParams = nil
+        executorResult = .ok(["test": true])
+        // Initialize the handler so tools/list and tools/call work
+        let initReq = mcpRequest(id: 0, method: "initialize", params: [
+            "protocolVersion": "2024-11-05",
+            "capabilities": [:],
+            "clientInfo": ["name": "test", "version": "1.0"]
+        ])
+        _ = handler.handleRequest(initReq)
+    }
+
+    func testInitializeReturnsProtocolVersion() {
+        let request = mcpRequest(id: 1, method: "initialize", params: [
+            "protocolVersion": "2024-11-05",
+            "capabilities": [:],
+            "clientInfo": ["name": "test", "version": "1.0"]
+        ])
+        let response = handler.handleRequest(request)!
+        XCTAssertEqual(response["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(response["id"] as? Int, 1)
+
+        let result = response["result"] as! [String: Any]
+        XCTAssertEqual(result["protocolVersion"] as? String, "2024-11-05")
+
+        let serverInfo = result["serverInfo"] as! [String: Any]
+        XCTAssertEqual(serverInfo["name"] as? String, "cmux")
+
+        let capabilities = result["capabilities"] as! [String: Any]
+        XCTAssertNotNil(capabilities["tools"])
+    }
+
+    func testToolsListReturns20Tools() {
+        let request = mcpRequest(id: 2, method: "tools/list", params: [:])
+        let response = handler.handleRequest(request)!
+        let result = response["result"] as! [String: Any]
+        let tools = result["tools"] as! [[String: Any]]
+
+        XCTAssertEqual(tools.count, 20)
+
+        // Verify each tool has required fields
+        for tool in tools {
+            XCTAssertNotNil(tool["name"] as? String, "Tool missing name")
+            XCTAssertNotNil(tool["description"] as? String, "Tool missing description")
+            XCTAssertNotNil(tool["inputSchema"] as? [String: Any], "Tool missing inputSchema")
+        }
+
+        // Verify specific tools exist
+        let toolNames = Set(tools.map { $0["name"] as! String })
+        XCTAssertTrue(toolNames.contains("list_surfaces"))
+        XCTAssertTrue(toolNames.contains("read_screen"))
+        XCTAssertTrue(toolNames.contains("send_input"))
+        XCTAssertTrue(toolNames.contains("send_key"))
+        XCTAssertTrue(toolNames.contains("new_split"))
+        XCTAssertTrue(toolNames.contains("close_surface"))
+        XCTAssertTrue(toolNames.contains("set_status"))
+        XCTAssertTrue(toolNames.contains("set_progress"))
+        XCTAssertTrue(toolNames.contains("rename_tab"))
+        XCTAssertTrue(toolNames.contains("list_workspaces"))
+        XCTAssertTrue(toolNames.contains("system_identify"))
+        XCTAssertTrue(toolNames.contains("browser_snapshot"))
+    }
+
+    func testToolsCallRoutesToV2() {
+        let request = mcpRequest(id: 3, method: "tools/call", params: [
+            "name": "read_screen",
+            "arguments": ["surface": "surface:1", "lines": 10]
+        ])
+        let response = handler.handleRequest(request)!
+
+        // Should have routed to surface.read_text
+        XCTAssertEqual(executedMethod, "surface.read_text")
+        XCTAssertEqual(executedParams?["surface"] as? String, "surface:1")
+        XCTAssertEqual(executedParams?["lines"] as? Int, 10)
+
+        // Response should be valid tools/call response
+        let result = response["result"] as! [String: Any]
+        let content = result["content"] as! [[String: Any]]
+        XCTAssertEqual(content.first?["type"] as? String, "text")
+    }
+
+    func testToolsCallUnknownTool() {
+        let request = mcpRequest(id: 4, method: "tools/call", params: [
+            "name": "nonexistent_tool",
+            "arguments": [:]
+        ])
+        let response = handler.handleRequest(request)!
+
+        XCTAssertNotNil(response["error"])
+        let error = response["error"] as! [String: Any]
+        XCTAssertEqual(error["code"] as? Int, -32602)
+    }
+
+    func testUnknownMethodReturnsError() {
+        let request = mcpRequest(id: 5, method: "resources/list", params: [:])
+        let response = handler.handleRequest(request)!
+
+        XCTAssertNotNil(response["error"])
+        let error = response["error"] as! [String: Any]
+        XCTAssertEqual(error["code"] as? Int, -32601)
+    }
+
+    func testNotificationReturnsNil() {
+        // Notifications have no "id" field
+        let json: [String: Any] = [
+            "jsonrpc": "2.0",
+            "method": "notifications/initialized"
+        ]
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        let response = handler.handleRequest(data)
+        XCTAssertNil(response, "Notifications should return nil (no response)")
+    }
+
+    func testToolsCallV2Error() {
+        executorResult = .error(code: "not_found", message: "Surface not found")
+        let request = mcpRequest(id: 6, method: "tools/call", params: [
+            "name": "read_screen",
+            "arguments": ["surface": "invalid"]
+        ])
+        let response = handler.handleRequest(request)!
+
+        let result = response["result"] as! [String: Any]
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        let content = result["content"] as! [[String: Any]]
+        let text = content.first?["text"] as? String ?? ""
+        XCTAssertTrue(text.contains("Surface not found"))
+    }
+
+    func testPingReturnsEmptyResult() {
+        let request = mcpRequest(id: 7, method: "ping", params: [:])
+        let response = handler.handleRequest(request)!
+        XCTAssertEqual(response["jsonrpc"] as? String, "2.0")
+        XCTAssertEqual(response["id"] as? Int, 7)
+        XCTAssertNotNil(response["result"])
+    }
+
+    func testInvalidJSONReturnsParseError() {
+        let data = "not json at all".data(using: .utf8)!
+        let response = handler.handleRequest(data)!
+        let error = response["error"] as! [String: Any]
+        XCTAssertEqual(error["code"] as? Int, -32700)
+    }
+
+    func testToolsListBeforeInitializeReturnsError() {
+        // Fresh handler without initialize
+        let freshHandler = MCPHandler { _, _ in .ok([:]) }
+        let request = mcpRequest(id: 1, method: "tools/list", params: [:])
+        let response = freshHandler.handleRequest(request)!
+        XCTAssertNotNil(response["error"])
+        let error = response["error"] as! [String: Any]
+        XCTAssertEqual(error["code"] as? Int, -32002)
+    }
+
+    // MARK: - Routing Tests for All 20 Tools
+
+    func testListSurfacesRouting() {
+        callTool("list_surfaces", arguments: ["workspace": "ws:1"])
+        XCTAssertEqual(executedMethod, "surface.list")
+        XCTAssertEqual(executedParams?["workspace"] as? String, "ws:1")
+    }
+
+    func testSendInputRouting() {
+        callTool("send_input", arguments: ["surface": "s:1", "text": "hello", "workspace": "ws:1"])
+        XCTAssertEqual(executedMethod, "surface.send_text")
+        XCTAssertEqual(executedParams?["surface"] as? String, "s:1")
+        XCTAssertEqual(executedParams?["text"] as? String, "hello")
+    }
+
+    func testSendKeyRouting() {
+        callTool("send_key", arguments: ["surface": "s:1", "key": "return"])
+        XCTAssertEqual(executedMethod, "surface.send_key")
+        XCTAssertEqual(executedParams?["key"] as? String, "return")
+    }
+
+    func testNewSplitRouting() {
+        callTool("new_split", arguments: ["direction": "right", "type": "terminal"])
+        XCTAssertEqual(executedMethod, "surface.split")
+        XCTAssertEqual(executedParams?["direction"] as? String, "right")
+        XCTAssertEqual(executedParams?["type"] as? String, "terminal")
+    }
+
+    func testCloseSurfaceRouting() {
+        callTool("close_surface", arguments: ["surface": "s:1"])
+        XCTAssertEqual(executedMethod, "surface.close")
+    }
+
+    func testListWorkspacesRouting() {
+        callTool("list_workspaces", arguments: [:])
+        XCTAssertEqual(executedMethod, "workspace.list")
+    }
+
+    func testCreateWorkspaceRouting() {
+        callTool("create_workspace", arguments: ["title": "new-ws"])
+        XCTAssertEqual(executedMethod, "workspace.create")
+        XCTAssertEqual(executedParams?["title"] as? String, "new-ws")
+    }
+
+    func testSelectWorkspaceRouting() {
+        callTool("select_workspace", arguments: ["workspace": "ws:2"])
+        XCTAssertEqual(executedMethod, "workspace.select")
+    }
+
+    func testSystemIdentifyRouting() {
+        callTool("system_identify", arguments: [:])
+        XCTAssertEqual(executedMethod, "system.identify")
+    }
+
+    func testSystemTreeRouting() {
+        callTool("system_tree", arguments: [:])
+        XCTAssertEqual(executedMethod, "system.tree")
+    }
+
+    func testBrowserOpenRouting() {
+        callTool("browser_open", arguments: ["url": "https://example.com", "direction": "right"])
+        XCTAssertEqual(executedMethod, "browser.open_split")
+        XCTAssertEqual(executedParams?["url"] as? String, "https://example.com")
+    }
+
+    func testBrowserNavigateRouting() {
+        callTool("browser_navigate", arguments: ["surface": "s:1", "url": "https://example.com"])
+        XCTAssertEqual(executedMethod, "browser.navigate")
+    }
+
+    func testBrowserSnapshotRouting() {
+        callTool("browser_snapshot", arguments: ["surface": "s:1"])
+        XCTAssertEqual(executedMethod, "browser.snapshot")
+    }
+
+    // MARK: - Helpers
+
+    private func mcpRequest(id: Int, method: String, params: [String: Any]) -> Data {
+        let dict: [String: Any] = [
+            "jsonrpc": "2.0",
+            "id": id,
+            "method": method,
+            "params": params
+        ]
+        return try! JSONSerialization.data(withJSONObject: dict)
+    }
+
+    private func callTool(_ name: String, arguments: [String: Any]) {
+        let request = mcpRequest(id: 99, method: "tools/call", params: [
+            "name": name,
+            "arguments": arguments
+        ])
+        _ = handler.handleRequest(request)
+    }
+}

--- a/cmuxTests/RapidSpawnKillFixtureTests.swift
+++ b/cmuxTests/RapidSpawnKillFixtureTests.swift
@@ -1,0 +1,187 @@
+import XCTest
+
+final class RapidSpawnKillFixtureTests: XCTestCase {
+    private struct ProcessResult {
+        let status: Int32
+        let stdout: String
+        let stderr: String
+        let timedOut: Bool
+    }
+
+    func testRapidSpawnKillFixtureKeepsIOSurfaceFootprintUnderBudget() throws {
+        let repositoryRoot = try Self.repositoryRoot()
+        let fixtureURL = repositoryRoot
+            .appendingPathComponent("tests/fixtures/rapid_spawn_kill.sh")
+
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: fixtureURL.path),
+            "Expected executable fixture at \(fixtureURL.path)"
+        )
+
+        let appURL = try Self.cmuxAppURL()
+        let thresholdMB = ProcessInfo.processInfo.environment["CMUX_RAPID_SPAWN_KILL_IOSURFACE_LIMIT_MB"]
+            .flatMap(Double.init) ?? 50
+        let result = runProcess(
+            executablePath: "/usr/bin/leaks",
+            arguments: [
+                "--atExit",
+                "--",
+                "/bin/bash",
+                fixtureURL.path,
+            ],
+            environment: [
+                "CMUX_RAPID_SPAWN_KILL_APP_PATH": appURL.path,
+                "CMUX_RAPID_SPAWN_KILL_ITERATIONS": "3",
+                "CMUX_RAPID_SPAWN_KILL_FORCE_WINDOW": "1",
+                "CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS": "8000",
+            ],
+            timeout: 90
+        )
+
+        let combinedOutput = [result.stdout, result.stderr]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+        let attachment = XCTAttachment(string: combinedOutput)
+        attachment.name = "rapid-spawn-kill-leaks-output"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+
+        XCTAssertFalse(result.timedOut, combinedOutput)
+        XCTAssertEqual(result.status, 0, combinedOutput)
+
+        let measuredMB = try XCTUnwrap(
+            Self.parseIOSurfaceFootprintMB(from: combinedOutput),
+            "Expected fixture output to include 'VM: IOSurface = <N> MB'. Output:\n\(combinedOutput)"
+        )
+        XCTAssertGreaterThan(
+            measuredMB,
+            0,
+            "Expected rapid_spawn_kill.sh to force an IOSurface allocation. Output:\n\(combinedOutput)"
+        )
+        XCTAssertLessThanOrEqual(
+            measuredMB,
+            thresholdMB,
+            "VM: IOSurface exceeded \(thresholdMB) MB after rapid spawn/kill loop. Output:\n\(combinedOutput)"
+        )
+    }
+
+    private static func repositoryRoot(filePath: String = #filePath) throws -> URL {
+        var url = URL(fileURLWithPath: filePath)
+        while url.path != "/" {
+            let candidate = url
+                .deletingLastPathComponent()
+                .appendingPathComponent("GhosttyTabs.xcodeproj")
+            if FileManager.default.fileExists(atPath: candidate.path) {
+                return url.deletingLastPathComponent()
+            }
+            url.deleteLastPathComponent()
+        }
+        throw XCTSkip("Unable to locate repository root from \(filePath)")
+    }
+
+    private static func cmuxAppURL() throws -> URL {
+        let environment = ProcessInfo.processInfo.environment
+
+        if let override = environment["CMUX_RAPID_SPAWN_KILL_APP_PATH"], !override.isEmpty {
+            let url = URL(fileURLWithPath: override)
+            if FileManager.default.fileExists(atPath: url.path) {
+                return url
+            }
+        }
+
+        if let testHost = environment["TEST_HOST"], !testHost.isEmpty,
+           let appURL = enclosingAppBundle(for: URL(fileURLWithPath: testHost)) {
+            return appURL
+        }
+
+        if let builtProductsDir = environment["BUILT_PRODUCTS_DIR"], !builtProductsDir.isEmpty {
+            let appURL = URL(fileURLWithPath: builtProductsDir)
+                .appendingPathComponent("cmux DEV.app")
+            if FileManager.default.fileExists(atPath: appURL.path) {
+                return appURL
+            }
+        }
+
+        if let appURL = enclosingAppBundle(for: Bundle.main.bundleURL) {
+            return appURL
+        }
+
+        throw XCTSkip("Unable to locate built cmux app bundle for rapid_spawn_kill.sh")
+    }
+
+    private static func enclosingAppBundle(for url: URL) -> URL? {
+        var current = url
+        while current.path != "/" {
+            if current.pathExtension == "app" && FileManager.default.fileExists(atPath: current.path) {
+                return current
+            }
+            current.deleteLastPathComponent()
+        }
+        return nil
+    }
+
+    private static func parseIOSurfaceFootprintMB(from output: String) -> Double? {
+        let pattern = #"VM: IOSurface\s*=\s*([0-9]+(?:\.[0-9]+)?)\s*MB"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let range = NSRange(output.startIndex..<output.endIndex, in: output)
+        guard
+            let match = regex.firstMatch(in: output, range: range),
+            let valueRange = Range(match.range(at: 1), in: output)
+        else {
+            return nil
+        }
+        return Double(output[valueRange])
+    }
+
+    private func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        var mergedEnvironment = ProcessInfo.processInfo.environment
+        for (key, value) in environment {
+            mergedEnvironment[key] = value
+        }
+        process.environment = mergedEnvironment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessResult(
+                status: -1,
+                stdout: "",
+                stderr: String(describing: error),
+                timedOut: false
+            )
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            _ = exitSignal.wait(timeout: .now() + 2)
+        }
+
+        return ProcessResult(
+            status: process.terminationStatus,
+            stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            stderr: String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            timedOut: timedOut
+        )
+    }
+}

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+EXIT_STATUS=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PROJECT="${CMUX_RUN_TESTS_PROJECT:-GhosttyTabs.xcodeproj}"
+SCHEME="${CMUX_RUN_TESTS_SCHEME:-cmux-unit}"
+CONFIGURATION="${CMUX_RUN_TESTS_CONFIGURATION:-Debug}"
+DESTINATION="${CMUX_RUN_TESTS_DESTINATION:-platform=macOS,arch=arm64}"
+DERIVED_DATA_PATH="${CMUX_RUN_TESTS_DERIVED_DATA_PATH:-/tmp/cmux-run-tests-derived}"
+FIXTURE_PATH="$REPO_ROOT/tests/fixtures/rapid_spawn_kill.sh"
+IOSURFACE_LIMIT_MB="${CMUX_RAPID_SPAWN_KILL_IOSURFACE_LIMIT_MB:-50}"
+XCTEST_ITERATIONS="${CMUX_RUN_TESTS_XCTEST_ITERATIONS:-3}"
+READY_TIMEOUT_MS="${CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS:-8000}"
+ZIG_015_BIN="${CMUX_RUN_TESTS_ZIG_BIN:-/opt/homebrew/opt/zig@0.15/bin}"
+
+if [ -d "$ZIG_015_BIN" ]; then
+  PATH="$ZIG_015_BIN:$PATH"
+  export PATH
+fi
+
+log() {
+  printf '[cmux-run-tests] %s\n' "$*"
+}
+
+mark_failure() {
+  local mask="$1"
+  local label="$2"
+  log "FAIL mask=$mask step=$label"
+  ((EXIT_STATUS |= mask))
+}
+
+run_xcodebuild_fixture_test() {
+  log "Running xcodebuild RapidSpawnKillFixtureTests (/usr/bin/leaks --atExit -> rapid_spawn_kill.sh)"
+  CMUX_RAPID_SPAWN_KILL_ITERATIONS="$XCTEST_ITERATIONS" \
+  CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS="$READY_TIMEOUT_MS" \
+  CMUX_RAPID_SPAWN_KILL_IOSURFACE_LIMIT_MB="$IOSURFACE_LIMIT_MB" \
+    xcodebuild \
+      -quiet \
+      -project "$PROJECT" \
+      -scheme "$SCHEME" \
+      -configuration "$CONFIGURATION" \
+      -destination "$DESTINATION" \
+      -derivedDataPath "$DERIVED_DATA_PATH" \
+      -only-testing:cmuxTests/RapidSpawnKillFixtureTests/testRapidSpawnKillFixtureKeepsIOSurfaceFootprintUnderBudget \
+      test
+  return $?
+}
+
+cd "$REPO_ROOT" || {
+  mark_failure 1 "cd-repo-root"
+  exit "$EXIT_STATUS"
+}
+
+if [ ! -x "$FIXTURE_PATH" ]; then
+  log "Missing executable fixture: $FIXTURE_PATH"
+  mark_failure 1 "fixture-present"
+else
+  if [ ! -d "$REPO_ROOT/GhosttyKit.xcframework" ]; then
+    log "GhosttyKit.xcframework missing; initializing submodules and downloading prebuilt framework"
+    if ! git submodule update --init --recursive ghostty vendor/bonsplit; then
+      mark_failure 2 "submodule-init"
+    elif ! "$REPO_ROOT/scripts/download-prebuilt-ghosttykit.sh"; then
+      mark_failure 2 "ghosttykit-download"
+    fi
+  fi
+
+  run_xcodebuild_fixture_test
+  xcodebuild_status=$?
+  if [ "$xcodebuild_status" -ne 0 ]; then
+    mark_failure 4 "xcodebuild-rapid-spawn-kill"
+  fi
+fi
+
+log "finished with exit status $EXIT_STATUS"
+
+if [ "$EXIT_STATUS" -ne 0 ]; then
+  exit "$EXIT_STATUS"
+fi

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -12,10 +12,13 @@ SCHEME="${CMUX_RUN_TESTS_SCHEME:-cmux-unit}"
 CONFIGURATION="${CMUX_RUN_TESTS_CONFIGURATION:-Debug}"
 DESTINATION="${CMUX_RUN_TESTS_DESTINATION:-platform=macOS,arch=arm64}"
 DERIVED_DATA_PATH="${CMUX_RUN_TESTS_DERIVED_DATA_PATH:-/tmp/cmux-run-tests-derived}"
+BUILT_APP_PATH="$DERIVED_DATA_PATH/Build/Products/$CONFIGURATION/cmux DEV.app"
 FIXTURE_PATH="$REPO_ROOT/tests/fixtures/rapid_spawn_kill.sh"
+LEAK_TEST_PATH="$REPO_ROOT/tests/regression/test_iosurface_leak.sh"
 IOSURFACE_LIMIT_MB="${CMUX_RAPID_SPAWN_KILL_IOSURFACE_LIMIT_MB:-50}"
 XCTEST_ITERATIONS="${CMUX_RUN_TESTS_XCTEST_ITERATIONS:-3}"
 READY_TIMEOUT_MS="${CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS:-8000}"
+LEAK_TEST_ITERATIONS="${CMUX_RUN_TESTS_LEAK_ITERATIONS:-3}"
 ZIG_015_BIN="${CMUX_RUN_TESTS_ZIG_BIN:-/opt/homebrew/opt/zig@0.15/bin}"
 
 if [ -d "$ZIG_015_BIN" ]; then
@@ -51,6 +54,16 @@ run_xcodebuild_fixture_test() {
   return $?
 }
 
+run_iosurface_leak_test() {
+  log "Running Apple leaks CLI IOSurface regression test"
+  CMUX_LEAK_THRESHOLD_MB="$IOSURFACE_LIMIT_MB" \
+  CMUX_LEAK_TEST_ITERATIONS="$LEAK_TEST_ITERATIONS" \
+  CMUX_LEAK_READY_TIMEOUT_MS="$READY_TIMEOUT_MS" \
+  CMUX_LEAK_APP_PATH="$BUILT_APP_PATH" \
+    "$LEAK_TEST_PATH"
+  return $?
+}
+
 cd "$REPO_ROOT" || {
   mark_failure 1 "cd-repo-root"
   exit "$EXIT_STATUS"
@@ -59,6 +72,9 @@ cd "$REPO_ROOT" || {
 if [ ! -x "$FIXTURE_PATH" ]; then
   log "Missing executable fixture: $FIXTURE_PATH"
   mark_failure 1 "fixture-present"
+elif [ ! -x "$LEAK_TEST_PATH" ]; then
+  log "Missing executable regression test: $LEAK_TEST_PATH"
+  mark_failure 1 "iosurface-leak-test-present"
 else
   if [ ! -d "$REPO_ROOT/GhosttyKit.xcframework" ]; then
     log "GhosttyKit.xcframework missing; initializing submodules and downloading prebuilt framework"
@@ -73,6 +89,12 @@ else
   xcodebuild_status=$?
   if [ "$xcodebuild_status" -ne 0 ]; then
     mark_failure 4 "xcodebuild-rapid-spawn-kill"
+  fi
+
+  run_iosurface_leak_test
+  leak_test_status=$?
+  if [ "$leak_test_status" -ne 0 ]; then
+    mark_failure 8 "leaks-iosurface-regression"
   fi
 fi
 

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,25 @@
+# cmux Test Fixtures
+
+## rapid_spawn_kill.sh
+
+`rapid_spawn_kill.sh` is a stress fixture for the cmux IOSurface regression harness. It repeatedly launches a fresh cmux app process, waits only long enough for the child process to expose `vmmap -summary` data, samples the `IOSurface` resident + swapped footprint, terminates the child, and immediately starts the next iteration.
+
+The default loop count is 100 to force Mach-port and IOSurface churn without inter-iteration settle time. XCTest uses a lower count for targeted verification so the fixture remains practical in local and CI runs.
+
+Useful environment variables:
+
+- `CMUX_RAPID_SPAWN_KILL_APP_PATH`: path to the cmux `.app` bundle. Defaults to `/Applications/cmux.app`.
+- `CMUX_RAPID_SPAWN_KILL_EXECUTABLE_PATH`: direct cmux executable override.
+- `CMUX_RAPID_SPAWN_KILL_ITERATIONS`: loop count. Defaults to `100`.
+- `CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS`: maximum per-child startup sampling wait. Defaults to `2500`.
+- `CMUX_RAPID_SPAWN_KILL_TMPDIR`: scratch directory for per-iteration sockets and logs.
+
+Example:
+
+```bash
+CMUX_RAPID_SPAWN_KILL_APP_PATH="/Applications/cmux.app" \
+CMUX_RAPID_SPAWN_KILL_ITERATIONS=100 \
+tests/fixtures/rapid_spawn_kill.sh
+```
+
+The fixture prints `VM: IOSurface = <N> MB`; `RapidSpawnKillFixtureTests` runs it under `leaks --atExit` and asserts that value stays under the configured threshold.

--- a/tests/fixtures/rapid_spawn_kill.sh
+++ b/tests/fixtures/rapid_spawn_kill.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+set -euo pipefail
+set +m 2>/dev/null || true
+
+ITERATIONS="${CMUX_RAPID_SPAWN_KILL_ITERATIONS:-100}"
+READY_TIMEOUT_MS="${CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS:-2500}"
+APP_PATH="${CMUX_RAPID_SPAWN_KILL_APP_PATH:-}"
+EXECUTABLE_PATH="${CMUX_RAPID_SPAWN_KILL_EXECUTABLE_PATH:-}"
+TMP_ROOT="${CMUX_RAPID_SPAWN_KILL_TMPDIR:-${TMPDIR:-/tmp}/cmux-rapid-spawn-kill.$$}"
+
+log() {
+  printf '[rapid-spawn-kill] %s\n' "$*" >&2
+}
+
+die() {
+  log "ERROR: $*"
+  exit 1
+}
+
+bytes_from_human() {
+  local value="$1"
+  local trimmed number unit exponent
+  trimmed="$(printf '%s' "$value" | tr -d '[:space:],')"
+  if [[ -z "$trimmed" || "$trimmed" == "-" ]]; then
+    echo 0
+    return
+  fi
+  if [[ "$trimmed" =~ ^([0-9]+([.][0-9]+)?)([KMGTP]?) ]]; then
+    number="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[3]}"
+  else
+    echo 0
+    return
+  fi
+
+  exponent=0
+  case "$unit" in
+    K) exponent=1 ;;
+    M) exponent=2 ;;
+    G) exponent=3 ;;
+    T) exponent=4 ;;
+    P) exponent=5 ;;
+  esac
+
+  awk -v number="$number" -v exponent="$exponent" '
+    function power(base, exponent_value,   out, i) {
+      out = 1
+      for (i = 0; i < exponent_value; i++) out *= base
+      return out
+    }
+    BEGIN { printf "%.0f\n", number * power(1024, exponent) }'
+}
+
+bytes_to_mb() {
+  local bytes="$1"
+  awk -v bytes="$bytes" 'BEGIN { printf "%.2f", bytes / (1024 * 1024) }'
+}
+
+resolve_executable() {
+  if [[ -n "$EXECUTABLE_PATH" ]]; then
+    [[ -x "$EXECUTABLE_PATH" ]] || die "CMUX_RAPID_SPAWN_KILL_EXECUTABLE_PATH is not executable: $EXECUTABLE_PATH"
+    printf '%s\n' "$EXECUTABLE_PATH"
+    return
+  fi
+
+  if [[ -z "$APP_PATH" ]]; then
+    APP_PATH="/Applications/cmux.app"
+  fi
+  [[ -d "$APP_PATH" ]] || die "cmux app not found: $APP_PATH"
+
+  local candidate
+  for candidate in \
+    "$APP_PATH/Contents/MacOS/cmux DEV" \
+    "$APP_PATH/Contents/MacOS/cmux"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  die "no cmux executable found inside $APP_PATH"
+}
+
+iosurface_bytes_for_pid() {
+  local pid="$1"
+  local vmmap_output line resident swapped
+  if ! vmmap_output="$(vmmap -summary "$pid" 2>/dev/null)"; then
+    echo 0
+    return
+  fi
+
+  line="$(printf '%s\n' "$vmmap_output" | awk '/^IOSurface[[:space:]]/ {print; exit}')"
+  if [[ -z "$line" ]]; then
+    echo 0
+    return
+  fi
+
+  resident="$(awk '{print $3}' <<<"$line")"
+  swapped="$(awk '{print $5}' <<<"$line")"
+  awk -v resident_bytes="$(bytes_from_human "$resident")" \
+      -v swapped_bytes="$(bytes_from_human "$swapped")" \
+      'BEGIN { printf "%.0f\n", resident_bytes + swapped_bytes }'
+}
+
+wait_for_child_ready() {
+  local pid="$1"
+  local deadline
+  deadline=$((SECONDS + (READY_TIMEOUT_MS / 1000) + 1))
+  while kill -0 "$pid" 2>/dev/null; do
+    if [[ "$(iosurface_bytes_for_pid "$pid")" != "0" ]]; then
+      return 0
+    fi
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+terminate_child() {
+  local pid="$1"
+  kill -TERM "$pid" 2>/dev/null || return 0
+  for _ in {1..20}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.05
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+main() {
+  [[ "$ITERATIONS" =~ ^[0-9]+$ ]] || die "CMUX_RAPID_SPAWN_KILL_ITERATIONS must be an integer"
+  [[ "$ITERATIONS" -gt 0 ]] || die "CMUX_RAPID_SPAWN_KILL_ITERATIONS must be greater than zero"
+
+  local executable
+  executable="$(resolve_executable)"
+  mkdir -p "$TMP_ROOT"
+  trap 'rm -rf "$TMP_ROOT"' EXIT
+
+  local max_iosurface_bytes=0
+  local spawned=0
+  local iteration pid sample_bytes
+  for ((iteration = 1; iteration <= ITERATIONS; iteration++)); do
+    CMUX_TAG="rapid-spawn-kill-$iteration-$$" \
+    CMUX_SOCKET_PATH="$TMP_ROOT/socket-$iteration.sock" \
+    CMUX_RAPID_SPAWN_KILL_FIXTURE=1 \
+      "$executable" >"$TMP_ROOT/cmux-$iteration.log" 2>&1 &
+    pid="$!"
+    spawned=$((spawned + 1))
+
+    wait_for_child_ready "$pid" || true
+    sample_bytes="$(iosurface_bytes_for_pid "$pid")"
+    printf 'rapid_spawn_kill_sample iteration=%s pid=%s iosurface_mb=%s\n' \
+      "$iteration" "$pid" "$(bytes_to_mb "$sample_bytes")"
+    if [[ "$sample_bytes" -gt "$max_iosurface_bytes" ]]; then
+      max_iosurface_bytes="$sample_bytes"
+    fi
+    terminate_child "$pid"
+  done
+
+  printf 'rapid_spawn_kill_iterations=%s\n' "$ITERATIONS"
+  printf 'rapid_spawn_kill_spawned=%s\n' "$spawned"
+  printf 'VM: IOSurface = %s MB\n' "$(bytes_to_mb "$max_iosurface_bytes")"
+}
+
+main "$@"

--- a/tests/regression/README.md
+++ b/tests/regression/README.md
@@ -1,0 +1,14 @@
+# cmux Regression Tests
+
+## test_iosurface_leak.sh
+
+`test_iosurface_leak.sh` runs the Phase 2e `rapid_spawn_kill.sh` fixture under Apple's `/usr/bin/leaks --atExit`, then samples a live cmux process with `leaks $PID`. It parses the fixture's `VM: IOSurface = <N> MB` line and fails when the value exceeds `CMUX_LEAK_THRESHOLD_MB` (default: `50`).
+
+Useful environment variables:
+
+- `CMUX_LEAK_APP_PATH`: cmux `.app` bundle to test. `scripts/run_tests.sh` sets this to the app built by Xcode.
+- `CMUX_LEAK_EXECUTABLE_PATH`: direct cmux executable override when an app bundle is unavailable.
+- `CMUX_LEAK_TEST_ITERATIONS`: rapid spawn/kill loop count. Defaults to `10`; `scripts/run_tests.sh` uses `3`.
+- `CMUX_LEAK_THRESHOLD_MB`: IOSurface threshold in MB. Defaults to `50`.
+- `CMUX_LEAK_REQUIRE_IOSURFACE`: set to `1` for manual debugging when the shell context must prove a nonzero IOSurface sample. The top-level gate leaves this off because `RapidSpawnKillFixtureTests` already enforces positive IOSurface allocation from the XCTest host.
+- `CMUX_LEAK_KEEP_OUTPUT`: set to `1` to retain raw `leaks` and fixture output under the temp directory.

--- a/tests/regression/test_iosurface_leak.sh
+++ b/tests/regression/test_iosurface_leak.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+set -u
+set -o pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+FIXTURE_PATH="$REPO_ROOT/tests/fixtures/rapid_spawn_kill.sh"
+
+THRESHOLD_MB="${CMUX_LEAK_THRESHOLD_MB:-50}"
+ITERATIONS="${CMUX_LEAK_TEST_ITERATIONS:-10}"
+READY_TIMEOUT_MS="${CMUX_LEAK_READY_TIMEOUT_MS:-8000}"
+APP_PATH="${CMUX_LEAK_APP_PATH:-${CMUX_RAPID_SPAWN_KILL_APP_PATH:-}}"
+EXECUTABLE_PATH="${CMUX_LEAK_EXECUTABLE_PATH:-${CMUX_RAPID_SPAWN_KILL_EXECUTABLE_PATH:-}}"
+TMP_ROOT="${CMUX_LEAK_TMPDIR:-${TMPDIR:-/tmp}/cmux-iosurface-leak.$$}"
+KEEP_OUTPUT="${CMUX_LEAK_KEEP_OUTPUT:-0}"
+REQUIRE_IOSURFACE="${CMUX_LEAK_REQUIRE_IOSURFACE:-0}"
+SENTINEL_PID=""
+
+log() {
+  printf '[iosurface-leak] %s\n' "$*"
+}
+
+die() {
+  log "ERROR: $*" >&2
+  exit 1
+}
+
+bytes_from_human() {
+  local value="$1"
+  local trimmed number unit exponent
+  trimmed="$(printf '%s' "$value" | tr -d '[:space:],')"
+  if [[ -z "$trimmed" || "$trimmed" == "-" ]]; then
+    echo 0
+    return
+  fi
+  if [[ "$trimmed" =~ ^([0-9]+([.][0-9]+)?)([KMGTP]?) ]]; then
+    number="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[3]}"
+  else
+    echo 0
+    return
+  fi
+
+  exponent=0
+  case "$unit" in
+    K) exponent=1 ;;
+    M) exponent=2 ;;
+    G) exponent=3 ;;
+    T) exponent=4 ;;
+    P) exponent=5 ;;
+  esac
+
+  awk -v number="$number" -v exponent="$exponent" '
+    function power(base, exponent_value,   out, i) {
+      out = 1
+      for (i = 0; i < exponent_value; i++) out *= base
+      return out
+    }
+    BEGIN { printf "%.0f\n", number * power(1024, exponent) }'
+}
+
+bytes_to_mb() {
+  local bytes="$1"
+  awk -v bytes="$bytes" 'BEGIN { printf "%.2f", bytes / (1024 * 1024) }'
+}
+
+mb_to_bytes() {
+  local mb="$1"
+  awk -v mb="$mb" 'BEGIN { printf "%.0f\n", mb * 1024 * 1024 }'
+}
+
+resolve_executable() {
+  if [[ -n "$EXECUTABLE_PATH" ]]; then
+    [[ -x "$EXECUTABLE_PATH" ]] || die "CMUX_LEAK_EXECUTABLE_PATH is not executable: $EXECUTABLE_PATH"
+    printf '%s\n' "$EXECUTABLE_PATH"
+    return
+  fi
+
+  if [[ -z "$APP_PATH" ]]; then
+    APP_PATH="/Applications/cmux.app"
+  fi
+  [[ -d "$APP_PATH" ]] || die "cmux app not found: $APP_PATH"
+
+  local candidate
+  for candidate in \
+    "$APP_PATH/Contents/MacOS/cmux DEV" \
+    "$APP_PATH/Contents/MacOS/cmux"; do
+    if [[ -x "$candidate" ]]; then
+      printf '%s\n' "$candidate"
+      return
+    fi
+  done
+
+  die "no cmux executable found inside $APP_PATH"
+}
+
+iosurface_bytes_for_pid() {
+  local pid="$1"
+  local vmmap_output line resident swapped
+  if ! vmmap_output="$(vmmap -summary "$pid" 2>/dev/null)"; then
+    echo 0
+    return
+  fi
+
+  line="$(printf '%s\n' "$vmmap_output" | awk '/^IOSurface[[:space:]]/ {print; exit}')"
+  if [[ -z "$line" ]]; then
+    echo 0
+    return
+  fi
+
+  resident="$(awk '{print $3}' <<<"$line")"
+  swapped="$(awk '{print $5}' <<<"$line")"
+  awk -v resident_bytes="$(bytes_from_human "$resident")" \
+      -v swapped_bytes="$(bytes_from_human "$swapped")" \
+      'BEGIN { printf "%.0f\n", resident_bytes + swapped_bytes }'
+}
+
+parse_fixture_iosurface_mb() {
+  local output_path="$1"
+  awk -F'= ' '/VM: IOSurface[[:space:]]*=/ {
+    value = $2
+    sub(/[[:space:]]*MB.*/, "", value)
+    print value
+  }' "$output_path" | tail -n 1
+}
+
+wait_for_iosurface_or_timeout() {
+  local pid="$1"
+  local deadline iosurface_bytes
+  deadline=$((SECONDS + (READY_TIMEOUT_MS / 1000) + 1))
+  while kill -0 "$pid" 2>/dev/null; do
+    iosurface_bytes="$(iosurface_bytes_for_pid "$pid")"
+    if (( iosurface_bytes > 0 )); then
+      return 0
+    fi
+    # Timeout is non-fatal: direct shell runs can report 0 MB while the XCTest
+    # host still records positive IOSurface allocation from the same fixture.
+    if [[ "$SECONDS" -ge "$deadline" ]]; then
+      return 0
+    fi
+    sleep 0.2
+  done
+  return 1
+}
+
+terminate_pid() {
+  local pid="$1"
+  kill -TERM "$pid" 2>/dev/null || return 0
+  for _ in {1..20}; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      wait "$pid" 2>/dev/null || true
+      return 0
+    fi
+    sleep 0.05
+  done
+  kill -KILL "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null || true
+}
+
+cleanup() {
+  local status="$1"
+  if [[ -n "$SENTINEL_PID" ]]; then
+    terminate_pid "$SENTINEL_PID"
+  fi
+  if [[ "$status" -eq 0 && "$KEEP_OUTPUT" != "1" ]]; then
+    rm -rf "$TMP_ROOT"
+  else
+    log "artifacts kept at $TMP_ROOT"
+  fi
+}
+
+main() {
+  command -v leaks >/dev/null 2>&1 || die "Apple leaks CLI not found"
+  command -v vmmap >/dev/null 2>&1 || die "vmmap not found"
+  [[ "$THRESHOLD_MB" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "CMUX_LEAK_THRESHOLD_MB must be numeric"
+  [[ "$ITERATIONS" =~ ^[0-9]+$ ]] || die "CMUX_LEAK_TEST_ITERATIONS must be an integer"
+  [[ "$ITERATIONS" -gt 0 ]] || die "CMUX_LEAK_TEST_ITERATIONS must be greater than zero"
+  [[ -x "$FIXTURE_PATH" ]] || die "missing executable fixture: $FIXTURE_PATH"
+
+  local threshold_bytes executable pid fixture_leaks_output live_leaks_output fixture_leaks_status live_leaks_status
+  local sentinel_iosurface_bytes fixture_iosurface_mb fixture_iosurface_bytes
+  if [[ -z "$APP_PATH" && -z "$EXECUTABLE_PATH" ]]; then
+    APP_PATH="/Applications/cmux.app"
+  fi
+
+  threshold_bytes="$(mb_to_bytes "$THRESHOLD_MB")"
+  executable="$(resolve_executable)"
+
+  mkdir -p "$TMP_ROOT"
+  trap 'cleanup $?' EXIT
+
+  fixture_leaks_output="$TMP_ROOT/rapid_spawn_kill.leaks.out"
+  log "running rapid_spawn_kill.sh under leaks --atExit iterations=$ITERATIONS"
+  if [[ -n "$APP_PATH" ]]; then
+    CMUX_RAPID_SPAWN_KILL_APP_PATH="$APP_PATH" \
+    CMUX_RAPID_SPAWN_KILL_ITERATIONS="$ITERATIONS" \
+    CMUX_RAPID_SPAWN_KILL_FORCE_WINDOW=1 \
+    CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS="$READY_TIMEOUT_MS" \
+    CMUX_RAPID_SPAWN_KILL_TMPDIR="$TMP_ROOT/fixture" \
+      leaks --quiet --atExit -- /bin/bash "$FIXTURE_PATH" >"$fixture_leaks_output" 2>&1
+  else
+    CMUX_RAPID_SPAWN_KILL_EXECUTABLE_PATH="$executable" \
+    CMUX_RAPID_SPAWN_KILL_ITERATIONS="$ITERATIONS" \
+    CMUX_RAPID_SPAWN_KILL_FORCE_WINDOW=1 \
+    CMUX_RAPID_SPAWN_KILL_READY_TIMEOUT_MS="$READY_TIMEOUT_MS" \
+    CMUX_RAPID_SPAWN_KILL_TMPDIR="$TMP_ROOT/fixture" \
+      leaks --quiet --atExit -- /bin/bash "$FIXTURE_PATH" >"$fixture_leaks_output" 2>&1
+  fi
+  fixture_leaks_status=$?
+
+  fixture_iosurface_mb="$(parse_fixture_iosurface_mb "$fixture_leaks_output")"
+  [[ -n "$fixture_iosurface_mb" ]] || die "fixture did not print VM: IOSurface; output saved at $fixture_leaks_output"
+  fixture_iosurface_bytes="$(mb_to_bytes "$fixture_iosurface_mb")"
+
+  log "spawning cmux live leaks sentinel"
+  CMUX_TAG="iosurface-leak-sentinel-$$" \
+  CMUX_SOCKET_PATH="$TMP_ROOT/sentinel.sock" \
+  CMUX_RAPID_SPAWN_KILL_FIXTURE=1 \
+  CMUX_RAPID_SPAWN_KILL_FORCE_WINDOW=1 \
+    "$executable" >"$TMP_ROOT/sentinel.log" 2>&1 &
+  pid="$!"
+  SENTINEL_PID="$pid"
+
+  wait_for_iosurface_or_timeout "$pid" || die "cmux sentinel exited before leaks sampling"
+
+  live_leaks_output="$TMP_ROOT/live-pid.leaks.out"
+  log "running leaks pid=$pid"
+  leaks --quiet "$pid" >"$live_leaks_output" 2>&1
+  live_leaks_status=$?
+
+  sentinel_iosurface_bytes="$(iosurface_bytes_for_pid "$pid")"
+
+  printf 'fixture_leaks_exit_status=%s\n' "$fixture_leaks_status"
+  printf 'fixture_leaks_iosurface_lines=%s\n' "$(grep -c 'IOSurface' "$fixture_leaks_output" || true)"
+  printf 'live_leaks_exit_status=%s\n' "$live_leaks_status"
+  printf 'live_leaks_iosurface_lines=%s\n' "$(grep -c 'IOSurface' "$live_leaks_output" || true)"
+  printf 'sentinel_VM_IOSurface_MB=%s\n' "$(bytes_to_mb "$sentinel_iosurface_bytes")"
+  printf 'fixture_VM_IOSurface_MB=%s\n' "$fixture_iosurface_mb"
+  printf 'threshold_MB=%s\n' "$THRESHOLD_MB"
+
+  if [[ "$fixture_leaks_status" -ne 0 ]]; then
+    log "leaks --atExit reported leaked allocations; IOSurface excerpts follow"
+    grep 'IOSurface' "$fixture_leaks_output" || true
+    exit "$fixture_leaks_status"
+  fi
+
+  if [[ "$live_leaks_status" -ne 0 ]]; then
+    log "live leaks reported leaked allocations; IOSurface excerpts follow"
+    grep 'IOSurface' "$live_leaks_output" || true
+    exit "$live_leaks_status"
+  fi
+
+  if [[ "$fixture_iosurface_bytes" -eq 0 && "$REQUIRE_IOSURFACE" = "1" ]]; then
+    log "FAIL no IOSurface footprint observed; fixture did not exercise the target allocation path"
+    exit 1
+  fi
+
+  if [[ "$fixture_iosurface_bytes" -gt "$threshold_bytes" ]]; then
+    log "FAIL fixture VM: IOSurface ${fixture_iosurface_mb} MB exceeds threshold ${THRESHOLD_MB} MB"
+    exit 1
+  fi
+
+  log "PASS IOSurface footprint stayed within threshold"
+}
+
+main "$@"


### PR DESCRIPTION
Sister PR to voicelayer #182. cmux fork hook had same fall-off-end bug. Source: brainbar-85cb1121-307.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the pre-push git hook to exit 0 on success and adds a regression gate that runs a new test harness before pushes. Also introduces native MCP protocol support on the socket server and fixes a launch crash caused by Auto Layout cycles.

- **New Features**
  - Pre-push regression gate: `.githooks/pre-push` runs `scripts/run_tests.sh`; setup documented in CONTRIBUTING.
  - Native MCP support: detects `Content-Length` framing, implements `initialize`, `tools/list`, `tools/call`, and maps 20 tools to V2 methods; covered by unit tests.
  - IOSurface leak harness: `tests/fixtures/rapid_spawn_kill.sh`, `tests/regression/test_iosurface_leak.sh`, and an Xcode-driven fixture test integrated via `scripts/run_tests.sh`.

- **Bug Fixes**
  - Hook now exits 0 on success; warns and skips if the harness script is missing.
  - Prevents launch crash by deferring notification auth updates and skipping off-screen windows during layout.
  - Socket hardening: safe partial writes, require MCP initialize handshake, reject MCP when password auth is enabled, map MCP refs to `*_id`, parse multiple frames per read, close on malformed frames, and quote V1 args from MCP routes.

<sup>Written for commit 707a05e3213b541e49ef1aad406efd33903a5c7d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3192?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Model Context Protocol (MCP) support enabling tool-driven interactions over JSON-RPC messaging.

* **Bug Fixes**
  * Fixed Auto Layout constraint cycles triggered by off-screen window updates.
  * Improved authorization state update timing to prevent layout conflicts.

* **Tests & Infrastructure**
  * Added pre-push regression testing and memory leak detection framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->