### PR TITLE
Add activation latency debug logging

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -837,6 +837,55 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
 #if DEBUG
+    private func debugActivationNow() -> TimeInterval {
+        ProcessInfo.processInfo.systemUptime
+    }
+
+    private func debugActivationElapsedMs(_ startedAt: TimeInterval) -> String {
+        String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0))
+    }
+
+    private func debugActivationState() -> String {
+        let windows = NSApp.windows
+        let keyWindow = NSApp.keyWindow
+        let mainWindow = NSApp.mainWindow
+        let active = NSApp.isActive ? 1 : 0
+        let key = keyWindow.map { debugWindowToken($0) } ?? "nil"
+        let main = mainWindow.map { debugWindowToken($0) } ?? "nil"
+        let visibleCount = windows.filter { $0.isVisible }.count
+        let miniCount = windows.filter { $0.isMiniaturized }.count
+        let contextCount = mainWindowContexts.count
+        let activeManager = debugManagerToken(tabManager)
+        let selected = tabManager?.selectedTabId.map { String($0.uuidString.prefix(8)) } ?? "nil"
+        return "appActive=\(active) windows=\(windows.count) visible=\(visibleCount) mini=\(miniCount) contexts=\(contextCount) key={\(key)} main={\(main)} activeMgr=\(activeManager) selected=\(selected)"
+    }
+
+    private func debugSessionSnapshotSummary(_ snapshot: AppSessionSnapshot?) -> String {
+        guard let snapshot else { return "snapshot=nil" }
+        let workspaces = snapshot.windows.reduce(0) { $0 + $1.tabManager.workspaces.count }
+        let panels = snapshot.windows.reduce(0) { total, window in
+            total + window.tabManager.workspaces.reduce(0) { $0 + $1.panels.count }
+        }
+        let terminals = snapshot.windows.reduce(0) { total, window in
+            total + window.tabManager.workspaces.reduce(0) { workspaceTotal, workspace in
+                workspaceTotal + workspace.panels.filter { $0.type == .terminal }.count
+            }
+        }
+        let browsers = snapshot.windows.reduce(0) { total, window in
+            total + window.tabManager.workspaces.reduce(0) { workspaceTotal, workspace in
+                workspaceTotal + workspace.panels.filter { $0.type == .browser }.count
+            }
+        }
+        let scrollbackChars = snapshot.windows.reduce(0) { total, window in
+            total + window.tabManager.workspaces.reduce(0) { workspaceTotal, workspace in
+                workspaceTotal + workspace.panels.reduce(0) { panelTotal, panel in
+                    panelTotal + (panel.terminal?.scrollback?.count ?? 0)
+                }
+            }
+        }
+        return "snapshotWindows=\(snapshot.windows.count) snapshotWorkspaces=\(workspaces) snapshotPanels=\(panels) snapshotTerminals=\(terminals) snapshotBrowsers=\(browsers) scrollbackChars=\(scrollbackChars)"
+    }
+
     private func pointerString(_ object: AnyObject?) -> String {
         guard let object else { return "nil" }
         return String(describing: Unmanaged.passUnretained(object).toOpaque())
@@ -889,6 +938,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func application(_ application: NSApplication, open urls: [URL]) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.openURLs.begin urlCount=\(urls.count) \(debugActivationState())"
+        )
+#endif
         let authCallbacks = urls.filter(AuthCallbackRouter.isAuthCallbackURL)
         for url in authCallbacks {
             Task { @MainActor in
@@ -901,7 +956,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let directories = externalOpenDirectories(from: urls)
-        guard !directories.isEmpty else { return }
+        guard !directories.isEmpty else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.openURLs.end reason=noDirectories authCount=\(authCallbacks.count) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
 
         prepareForExplicitOpenIntentAtStartup()
         for directory in directories {
@@ -910,18 +972,43 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 debugSource: "application.openURLs"
             )
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.openURLs.end authCount=\(authCallbacks.count) directoryCount=\(directories.count) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.reopen.begin hasVisibleWindows=\(flag ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         if hasVisibleMainTerminalWindow() {
             _ = synchronizeActiveMainWindowContext(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.reopen.end route=visibleMainWindow elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
             return true
         }
         ensureInitialMainWindowIfNeeded()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.reopen.end route=ensureInitialWindow elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
         return true
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.launch.begin \(debugActivationState())")
+#endif
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
         let telemetryEnabled = TelemetrySettings.enabledForCurrentLaunch
@@ -929,6 +1016,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         syncActivationPolicy()
 
         claimAuthCallbackURLSchemes()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.launch.phase stage=basicSetup elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) telemetry=\(telemetryEnabled ? 1 : 0) xctest=\(isRunningUnderXCTest ? 1 : 0) \(debugActivationState())"
+        )
+#endif
 
         // Install the Feed (workstream) store. Separate from the transport
         // wiring: the store is a plain singleton here, and the socket
@@ -943,6 +1035,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         Task { @MainActor in
             await FeedCoordinator.shared.store?.start()
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.launch.phase stage=feedInstalled elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
 
         DistributedNotificationCenter.default().addObserver(
             self,
@@ -969,6 +1066,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             name: .feedRequestSendText,
             object: nil
         )
+#if DEBUG
+        cmuxDebugLog(
+            "activation.launch.phase stage=observersInstalled elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
 
 #if DEBUG
         // UI tests run on a shared VM user profile, so persisted shortcuts can drift and make
@@ -1020,6 +1122,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 options.enableCaptureFailedRequests = false
             }
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.launch.phase stage=telemetryStarted elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
 
         if telemetryEnabled && !isRunningUnderXCTest {
             PostHogAnalytics.shared.startIfNeeded()
@@ -1068,6 +1175,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         NSApp.servicesProvider = self
 
         scheduleInitialMainWindowBootstrap(debugSource: "didFinishLaunching")
+#if DEBUG
+        cmuxDebugLog(
+            "activation.launch.end elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
 #if DEBUG
         UpdateTestSupport.applyIfNeeded(to: updateController.viewModel)
         if env["CMUX_UI_TEST_MODE"] == "1" {
@@ -1346,6 +1458,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     func applicationDidBecomeActive(_ notification: Notification) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.didBecomeActive.begin \(debugActivationState())")
+#endif
         sentryBreadcrumb("app.didBecomeActive", category: "lifecycle", data: [
             "tabCount": tabManager?.tabs.count ?? 0
         ])
@@ -1353,18 +1469,51 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             PostHogAnalytics.shared.trackActive(reason: "didBecomeActive")
         }
 
-        guard let notificationStore else { return }
+        guard let notificationStore else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.didBecomeActive.end reason=noNotificationStore elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
         notificationStore.handleApplicationDidBecomeActive()
-        guard let tabManager else { return }
-        guard let tabId = tabManager.selectedTabId else { return }
+        guard let tabManager else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.didBecomeActive.end reason=noTabManager elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
+        guard let tabId = tabManager.selectedTabId else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.didBecomeActive.end reason=noSelectedWorkspace elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
         let surfaceId = tabManager.focusedSurfaceId(for: tabId)
-        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) else { return }
+        guard notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId) else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.didBecomeActive.end unread=0 surface=\(surfaceId.map { String($0.uuidString.prefix(8)) } ?? "nil") elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
 
         if let surfaceId,
            let tab = tabManager.tabs.first(where: { $0.id == tabId }) {
             tab.triggerNotificationFocusFlash(panelId: surfaceId, requiresSplit: false, shouldFocus: false)
         }
         notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.didBecomeActive.end unread=1 surface=\(surfaceId.map { String($0.uuidString.prefix(8)) } ?? "nil") elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
@@ -1432,9 +1581,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationWillResignActive(_ notification: Notification) {
-        guard !isTerminatingApp else { return }
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.willResignActive.begin \(debugActivationState())")
+#endif
+        guard !isTerminatingApp else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.willResignActive.end reason=terminating elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return
+        }
         clearConfiguredShortcutChordState()
         _ = saveSessionSnapshot(includeScrollback: false)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.willResignActive.end elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     func persistSessionForUpdateRelaunch() {
@@ -2180,12 +2345,35 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #endif
 
     private func prepareStartupSessionSnapshotIfNeeded() {
-        guard !didPrepareStartupSessionSnapshot else { return }
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.session.prepare.begin didPrepare=\(didPrepareStartupSessionSnapshot ? 1 : 0)")
+#endif
+        guard !didPrepareStartupSessionSnapshot else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.prepare.end reason=alreadyPrepared elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
+            return
+        }
         didPrepareStartupSessionSnapshot = true
         Self.removeLegacyPersistedWindowGeometry()
         SessionPersistenceStore.syncManualRestoreSnapshotCache()
-        guard SessionRestorePolicy.shouldAttemptRestore() else { return }
+        guard SessionRestorePolicy.shouldAttemptRestore() else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.prepare.end restore=0 elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
+            return
+        }
         startupSessionSnapshot = SessionPersistenceStore.load()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.prepare.end restore=1 elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugSessionSnapshotSummary(startupSessionSnapshot))"
+        )
+#endif
     }
 
     private func persistedWindowGeometry(
@@ -2271,10 +2459,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func attemptStartupSessionRestoreIfNeeded(primaryWindow: NSWindow) {
-        guard !didAttemptStartupSessionRestore else { return }
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.session.restoreAttempt.begin didAttempt=\(didAttemptStartupSessionRestore ? 1 : 0) explicitOpen=\(didHandleExplicitOpenIntentAtStartup ? 1 : 0) primary={\(debugWindowToken(primaryWindow))} \(debugSessionSnapshotSummary(startupSessionSnapshot))"
+        )
+#endif
+        guard !didAttemptStartupSessionRestore else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restoreAttempt.end reason=alreadyAttempted elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
+            return
+        }
         didAttemptStartupSessionRestore = true
-        guard !didHandleExplicitOpenIntentAtStartup else { return }
-        guard let primaryContext = contextForMainTerminalWindow(primaryWindow) else { return }
+        guard !didHandleExplicitOpenIntentAtStartup else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restoreAttempt.end reason=explicitOpen elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
+            return
+        }
+        guard let primaryContext = contextForMainTerminalWindow(primaryWindow) else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restoreAttempt.end reason=noPrimaryContext elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
+            return
+        }
 
         let startupSnapshot = startupSessionSnapshot
         let primaryWindowSnapshot = startupSnapshot?.windows.first
@@ -2292,6 +2507,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 to: primaryContext,
                 window: primaryWindow
             )
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restoreAttempt.phase stage=primaryApplied elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
         } else {
             let displays = currentDisplayGeometries()
             let fallbackGeometry = persistedWindowGeometry()
@@ -2323,23 +2543,48 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if !additionalWindows.isEmpty {
                 DispatchQueue.main.async { [weak self] in
                     guard let self else { return }
+#if DEBUG
+                    let additionalStartedAt = self.debugActivationNow()
+                    cmuxDebugLog(
+                        "activation.session.restoreAdditional.begin count=\(additionalWindows.count) \(self.debugActivationState())"
+                    )
+#endif
                     for windowSnapshot in additionalWindows {
                         _ = self.createMainWindow(sessionWindowSnapshot: windowSnapshot)
                     }
                     self.completeSessionRestoreOperation(isManualReopen: false)
+#if DEBUG
+                    cmuxDebugLog(
+                        "activation.session.restoreAdditional.end count=\(additionalWindows.count) elapsedMs=\(self.debugActivationElapsedMs(additionalStartedAt)) \(self.debugActivationState())"
+                    )
+#endif
                 }
             } else {
                 completeSessionRestoreOperation(isManualReopen: false)
             }
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.restoreAttempt.end elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     private func completeSessionRestoreOperation(isManualReopen: Bool) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.session.restoreComplete.begin manual=\(isManualReopen ? 1 : 0)")
+#endif
         startupSessionSnapshot = nil
         isApplyingSessionRestore = false
         if Self.shouldSaveSessionSnapshotOnRestoreCompletion(isManualReopen: isManualReopen) {
             _ = saveSessionSnapshot(includeScrollback: false)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.restoreComplete.end manual=\(isManualReopen ? 1 : 0) elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+        )
+#endif
     }
 
     nonisolated static func shouldSaveSessionSnapshotOnRestoreCompletion(
@@ -2418,6 +2663,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window: NSWindow?
     ) {
 #if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.session.apply.begin window=\(String(context.windowId.uuidString.prefix(8))) workspaceCount=\(snapshot.tabManager.workspaces.count) panelCount=\(snapshot.tabManager.workspaces.reduce(0) { $0 + $1.panels.count }) liveWin={\(debugWindowToken(window))}"
+        )
+#endif
+#if DEBUG
         cmuxDebugLog(
             "session.restore.apply window=\(context.windowId.uuidString.prefix(8)) " +
                 "liveWin=\(window?.windowNumber ?? -1) " +
@@ -2441,6 +2692,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
 #endif
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.apply.end window=\(String(context.windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     private func resolvedWindowFrame(from snapshot: SessionWindowSnapshot?) -> NSRect? {
@@ -2958,12 +3214,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         removeWhenEmpty: Bool = false,
         restorableAgentIndex: RestorableAgentSessionIndex? = nil
     ) -> Bool {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.session.save.begin includeScrollback=\(includeScrollback ? 1 : 0) removeWhenEmpty=\(removeWhenEmpty ? 1 : 0) contextCount=\(mainWindowContexts.count) \(debugActivationState())"
+        )
+#endif
         if Self.shouldSkipSessionSaveDuringRestore(
             isApplyingSessionRestore: isApplyingSessionRestore,
             includeScrollback: includeScrollback
         ) {
 #if DEBUG
             cmuxDebugLog("session.save.skipped reason=session_restore_in_progress includeScrollback=0")
+            cmuxDebugLog(
+                "activation.session.save.end saved=0 reason=restoreInProgress elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
 #endif
             return false
         }
@@ -2987,14 +3252,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             includeScrollback: includeScrollback,
             restorableAgentIndex: restorableAgentIndex
         ) else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.save.phase stage=buildNil elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
             persistSessionSnapshot(
                 nil,
                 removeWhenEmpty: removeWhenEmpty,
                 persistedGeometryData: nil,
                 synchronously: writeSynchronously
             )
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.save.end saved=0 reason=noSnapshot elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
             return false
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.save.phase stage=built elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugSessionSnapshotSummary(snapshot))"
+        )
+#endif
 
         let persistedGeometryData = snapshot.windows.first.flatMap { primaryWindow in
             Self.encodedPersistedWindowGeometryData(
@@ -3012,6 +3292,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             persistedGeometryData: persistedGeometryData,
             synchronously: writeSynchronously
         )
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.save.end saved=1 sync=\(writeSynchronously ? 1 : 0) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugSessionSnapshotSummary(snapshot))"
+        )
+#endif
         return true
     }
 
@@ -3340,6 +3625,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         fileExplorerState: FileExplorerState? = nil,
         cmuxConfigStore: CmuxConfigStore? = nil
     ) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.mainWindow.register.begin windowId=\(String(windowId.uuidString.prefix(8))) window={\(debugWindowToken(window))} existingByWindow=\(mainWindowContexts[ObjectIdentifier(window)] == nil ? 0 : 1) \(debugActivationState())"
+        )
+#endif
         let key = ObjectIdentifier(window)
         #if DEBUG
         let priorManagerToken = debugManagerToken(self.tabManager)
@@ -3377,6 +3668,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 )
                 window.orderOut(nil)
                 window.close()
+#if DEBUG
+                cmuxDebugLog(
+                    "activation.mainWindow.register.end reason=duplicateIgnored windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+                )
+#endif
                 return
             }
             tabManager.window = window
@@ -3432,6 +3728,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if !isTerminatingApp {
             _ = saveSessionSnapshot(includeScrollback: false)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.mainWindow.register.end windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     struct MainWindowSummary {
@@ -5473,10 +5774,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     @objc func openNewMainWindow(_ sender: Any?) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog("activation.openNewMainWindow.begin \(debugActivationState())")
+#endif
         _ = createMainWindow()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.openNewMainWindow.end elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
     }
 
     func scheduleInitialMainWindowBootstrap(debugSource: String) {
+#if DEBUG
+        cmuxDebugLog(
+            "activation.bootstrap.schedule source=\(debugSource) already=\(didScheduleInitialMainWindowBootstrap ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         guard !didScheduleInitialMainWindowBootstrap else { return }
         didScheduleInitialMainWindowBootstrap = true
         DispatchQueue.main.async { [weak self] in
@@ -5486,24 +5801,56 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func bootstrapInitialMainWindowIfNeeded(debugSource: String, shouldActivate: Bool = true) -> UUID {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.bootstrap.begin source=\(debugSource) shouldActivate=\(shouldActivate ? 1 : 0) didBootstrap=\(didBootstrapInitialMainWindow ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         let windowId = ensureInitialMainWindowIfNeeded(shouldActivate: shouldActivate)
+#if DEBUG
+        let socketStartedAt = debugActivationNow()
+#endif
         if let manager = tabManagerFor(windowId: windowId) {
             startSocketListenerIfEnabled(
                 tabManager: manager,
                 source: "bootstrapInitialMainWindow.\(debugSource)"
             )
         }
-        guard !didBootstrapInitialMainWindow else { return windowId }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.bootstrap.phase stage=socketStart elapsedMs=\(debugActivationElapsedMs(socketStartedAt)) windowId=\(String(windowId.uuidString.prefix(8)))"
+        )
+#endif
+        guard !didBootstrapInitialMainWindow else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.bootstrap.end reason=alreadyBootstrapped windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
+            return windowId
+        }
 
         didBootstrapInitialMainWindow = true
         if ProcessInfo.processInfo.environment["CMUX_UI_TEST_SHOW_SETTINGS"] == "1" {
             openPreferencesWindow(debugSource: "uiTestShowSettings.\(debugSource)")
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.bootstrap.end windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
         return windowId
     }
 
     @discardableResult
     func ensureInitialMainWindowIfNeeded(shouldActivate: Bool = true) -> UUID {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.ensureInitialWindow.begin shouldActivate=\(shouldActivate ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         for context in sortedMainWindowContextsForSessionSnapshot() {
             guard let window = resolvedWindow(for: context) else { continue }
             if shouldActivate {
@@ -5513,10 +5860,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 window.makeKeyAndOrderFront(nil)
                 setActiveMainWindow(window)
             }
+#if DEBUG
+            cmuxDebugLog(
+                "activation.ensureInitialWindow.end route=existing windowId=\(String(context.windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+            )
+#endif
             return context.windowId
         }
 
-        return createMainWindow(shouldActivate: shouldActivate)
+        let windowId = createMainWindow(shouldActivate: shouldActivate)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.ensureInitialWindow.end route=create windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
+        return windowId
     }
 
     private func hasVisibleMainTerminalWindow() -> Bool {
@@ -6183,11 +6541,25 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sessionWindowSnapshot: SessionWindowSnapshot? = nil,
         shouldActivate: Bool = true
     ) -> UUID {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.createMainWindow.begin hasInitialDirectory=\((initialWorkingDirectory?.isEmpty == false) ? 1 : 0) hasSessionSnapshot=\(sessionWindowSnapshot == nil ? 0 : 1) shouldActivate=\(shouldActivate ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         let windowId = UUID()
+#if DEBUG
+        let tabManagerStartedAt = debugActivationNow()
+#endif
         let tabManager = TabManager(initialWorkingDirectory: initialWorkingDirectory)
         if let tabManagerSnapshot = sessionWindowSnapshot?.tabManager {
             tabManager.restoreSessionSnapshot(tabManagerSnapshot)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=tabManager elapsedMs=\(debugActivationElapsedMs(tabManagerStartedAt)) windowId=\(String(windowId.uuidString.prefix(8))) workspaceCount=\(tabManager.tabs.count)"
+        )
+#endif
 
         let sidebarWidth = sessionWindowSnapshot?.sidebar.width
             .map(SessionPersistencePolicy.sanitizedSidebarWidth)
@@ -6215,12 +6587,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         tabManager.syncWorkspaceTabBarLeadingInset(initialTabBarLeadingInset)
         let notificationStore = TerminalNotificationStore.shared
 
+#if DEBUG
+        let configStartedAt = debugActivationNow()
+#endif
         let cmuxConfigStore = CmuxConfigStore()
         cmuxConfigStore.wireDirectoryTracking(tabManager: tabManager)
         cmuxConfigStore.loadAll()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=configStore elapsedMs=\(debugActivationElapsedMs(configStartedAt)) windowId=\(String(windowId.uuidString.prefix(8)))"
+        )
+#endif
 
         let fileExplorerState = FileExplorerState()
 
+#if DEBUG
+        let rootStartedAt = debugActivationNow()
+#endif
         let root = ContentView(updateViewModel: updateViewModel, windowId: windowId)
             .environmentObject(tabManager)
             .environmentObject(notificationStore)
@@ -6228,10 +6611,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
             .environmentObject(fileExplorerState)
             .environmentObject(cmuxConfigStore)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=rootView elapsedMs=\(debugActivationElapsedMs(rootStartedAt)) windowId=\(String(windowId.uuidString.prefix(8)))"
+        )
+#endif
 
         // Use the current key window's size for new windows so Cmd+Shift+N
         // creates a window matching the previous one's dimensions.
         let styleMask: NSWindow.StyleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
+#if DEBUG
+        let windowStartedAt = debugActivationNow()
+#endif
         let sourceContext = preferredMainWindowContextForWorkspaceCreation(
             debugSource: "createMainWindow.initialGeometry"
         )
@@ -6291,10 +6682,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
         window.contentView = MainWindowHostingView(rootView: root)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=windowConstructed elapsedMs=\(debugActivationElapsedMs(windowStartedAt)) windowId=\(String(windowId.uuidString.prefix(8))) restoredFrame=\(restoredFrame == nil ? 0 : 1)"
+        )
+#endif
 
         // Apply shared window styling.
+#if DEBUG
+        let decorateStartedAt = debugActivationNow()
+#endif
         attachUpdateAccessory(to: window)
         applyWindowDecorations(to: window)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=decorated elapsedMs=\(debugActivationElapsedMs(decorateStartedAt)) windowId=\(String(windowId.uuidString.prefix(8)))"
+        )
+#endif
 
         // Keep a strong reference so the window isn't deallocated.
         let controller = MainWindowController(window: window)
@@ -6305,6 +6709,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.delegate = controller
         mainWindowControllers.append(controller)
 
+#if DEBUG
+        let registerStartedAt = debugActivationNow()
+#endif
         registerMainWindow(
             window,
             windowId: windowId,
@@ -6314,7 +6721,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             fileExplorerState: fileExplorerState,
             cmuxConfigStore: cmuxConfigStore
         )
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=registered elapsedMs=\(debugActivationElapsedMs(registerStartedAt)) windowId=\(String(windowId.uuidString.prefix(8)))"
+        )
+#endif
         installFileDropOverlay(on: window, tabManager: tabManager)
+#if DEBUG
+        let orderStartedAt = debugActivationNow()
+#endif
         if !shouldActivate || TerminalController.shouldSuppressSocketCommandActivation() {
             window.orderFront(nil)
             if shouldActivate, TerminalController.socketCommandAllowsInAppFocusMutations() {
@@ -6325,6 +6740,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             setActiveMainWindow(window)
             NSApp.activate(ignoringOtherApps: true)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.phase stage=ordered elapsedMs=\(debugActivationElapsedMs(orderStartedAt)) windowId=\(String(windowId.uuidString.prefix(8))) shouldActivate=\(shouldActivate ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         if shouldTemporarilyDisallowFullScreenTiling {
             DispatchQueue.main.async { [weak window] in
                 window?.collectionBehavior.remove(.fullScreenDisallowsTiling)
@@ -6339,6 +6759,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
 #endif
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.createMainWindow.end windowId=\(String(windowId.uuidString.prefix(8))) elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) \(debugActivationState())"
+        )
+#endif
         return windowId
     }
 
@@ -12250,8 +12675,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         ) { [weak self] note in
             guard let self, let window = note.object as? NSWindow else { return }
             MainActor.assumeIsolated {
+#if DEBUG
+                let activationStartedAt = self.debugActivationNow()
+                cmuxDebugLog(
+                    "activation.window.didBecomeKey.begin window={\(self.debugWindowToken(window))} \(self.debugActivationState())"
+                )
+#endif
                 self.setActiveMainWindow(window)
-                _ = self.contextForMainTerminalWindow(window)?.keyboardFocusCoordinator.restoreTargetAfterWindowBecameKey()
+                let didRestore = self.contextForMainTerminalWindow(window)?.keyboardFocusCoordinator.restoreTargetAfterWindowBecameKey() ?? false
+#if DEBUG
+                cmuxDebugLog(
+                    "activation.window.didBecomeKey.end restored=\(didRestore ? 1 : 0) elapsedMs=\(self.debugActivationElapsedMs(activationStartedAt)) window={\(self.debugWindowToken(window))} \(self.debugActivationState())"
+                )
+#endif
             }
         }
     }
@@ -12400,6 +12836,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func setActiveMainWindow(_ window: NSWindow) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+#endif
         guard let context = contextForMainTerminalWindow(window) else { return }
 #if DEBUG
         let beforeManagerToken = debugManagerToken(tabManager)
@@ -12412,6 +12851,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         cmuxDebugLog(
             "mainWindow.active window={\(debugWindowToken(window))} context={\(debugContextToken(context))} beforeMgr=\(beforeManagerToken) afterMgr=\(debugManagerToken(tabManager)) \(debugShortcutRouteSnapshot())"
+        )
+        cmuxDebugLog(
+            "activation.mainWindow.active elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) window={\(debugWindowToken(window))} context={\(debugContextToken(context))} \(debugActivationState())"
         )
 #endif
     }
@@ -12771,8 +13213,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func bringToFront(_ window: NSWindow) {
+#if DEBUG
+        let activationStartedAt = debugActivationNow()
+        cmuxDebugLog(
+            "activation.bringToFront.begin window={\(debugWindowToken(window))} suppress=\(TerminalController.shouldSuppressSocketCommandActivation() ? 1 : 0) \(debugActivationState())"
+        )
+#endif
         if TerminalController.shouldSuppressSocketCommandActivation(),
            !TerminalController.socketCommandAllowsInAppFocusMutations() {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.bringToFront.end reason=suppressed elapsedMs=\(debugActivationElapsedMs(activationStartedAt))"
+            )
+#endif
             return
         }
         setActiveMainWindow(window)
@@ -12782,6 +13235,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         window.makeKeyAndOrderFront(nil)
         // Improve reliability across Spaces / when other helper panels are key.
         NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+#if DEBUG
+        cmuxDebugLog(
+            "activation.bringToFront.end elapsedMs=\(debugActivationElapsedMs(activationStartedAt)) window={\(debugWindowToken(window))} \(debugActivationState())"
+        )
+#endif
     }
 
     private func markReadIfFocused(

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -3031,6 +3031,12 @@ struct ContentView: View {
         )
 
         view = AnyView(view.onAppear {
+#if DEBUG
+            let activationStartedAt = ProcessInfo.processInfo.systemUptime
+            cmuxDebugLog(
+                "activation.content.onAppear.begin windowId=\(windowId.uuidString.prefix(8)) tabs=\(tabManager.tabs.count) selected=\(debugShortWorkspaceId(tabManager.selectedTabId)) mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds))"
+            )
+#endif
             selectedWorkspaceDirectoryObserver.wire(tabManager: tabManager)
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()
@@ -3051,6 +3057,11 @@ struct ContentView: View {
             applyUITestSidebarSelectionIfNeeded(tabs: tabManager.tabs)
             updateTitlebarText()
             syncTrafficLightInset()
+#if DEBUG
+            cmuxDebugLog(
+                "activation.content.onAppear.phase stage=initialSetup elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) windowId=\(windowId.uuidString.prefix(8)) tabs=\(tabManager.tabs.count) selected=\(debugShortWorkspaceId(tabManager.selectedTabId)) mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds))"
+            )
+#endif
 
             // Startup recovery (#399): if session restore or a race condition leaves the
             // view in a broken state (empty tabs, no selection, unmounted workspaces),
@@ -3098,6 +3109,11 @@ struct ContentView: View {
                     ])
                 }
             }
+#if DEBUG
+            cmuxDebugLog(
+                "activation.content.onAppear.end elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) windowId=\(windowId.uuidString.prefix(8)) tabs=\(tabManager.tabs.count) selected=\(debugShortWorkspaceId(tabManager.selectedTabId)) mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds))"
+            )
+#endif
         })
 
         view = AnyView(view.onChange(of: tabManager.selectedTabId) { newValue in
@@ -3594,6 +3610,12 @@ struct ContentView: View {
         })
 
         view = AnyView(view.background(WindowAccessor { [appearance] window in
+#if DEBUG
+            let activationStartedAt = ProcessInfo.processInfo.systemUptime
+            cmuxDebugLog(
+                "activation.content.windowAccessor.begin windowId=\(windowId.uuidString.prefix(8)) win=\(window.windowNumber) visible=\(window.isVisible ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) tabs=\(tabManager.tabs.count)"
+            )
+#endif
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.isRestorable = false
             window.titlebarAppearsTransparent = true
@@ -3680,12 +3702,20 @@ struct ContentView: View {
                 cmuxConfigStore: cmuxConfigStore
             )
             installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.content.windowAccessor.end elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) windowId=\(windowId.uuidString.prefix(8)) win=\(window.windowNumber) visible=\(window.isVisible ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) tabs=\(tabManager.tabs.count)"
+            )
+#endif
         }))
 
         return view
     }
 
     private func reconcileMountedWorkspaceIds(tabs: [Workspace]? = nil, selectedId: UUID? = nil) {
+#if DEBUG
+        let activationStartedAt = ProcessInfo.processInfo.systemUptime
+#endif
         let currentTabs = tabs ?? tabManager.tabs
         let orderedTabIds = currentTabs.map { $0.id }
         let effectiveSelectedId = selectedId ?? tabManager.selectedTabId
@@ -3732,6 +3762,12 @@ struct ContentView: View {
                     "mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds))"
                 )
             }
+        }
+        let elapsedMs = max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0)
+        if elapsedMs >= 1.0 || mountedWorkspaceIds != previousMountedIds {
+            cmuxDebugLog(
+                "activation.content.reconcileMounted elapsedMs=\(String(format: "%.2f", elapsedMs)) tabs=\(currentTabs.count) selected=\(debugShortWorkspaceId(effectiveSelectedId)) mounted=\(debugShortWorkspaceIds(mountedWorkspaceIds)) changed=\(mountedWorkspaceIds == previousMountedIds ? 0 : 1)"
+            )
         }
 #endif
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4678,17 +4678,24 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return
         }
         #if DEBUG
+        let activationStartedAt = ProcessInfo.processInfo.systemUptime
         let resourcesDir = getenv("GHOSTTY_RESOURCES_DIR").flatMap { String(cString: $0) } ?? "(unset)"
         let terminfo = getenv("TERMINFO").flatMap { String(cString: $0) } ?? "(unset)"
         let xdg = getenv("XDG_DATA_DIRS").flatMap { String(cString: $0) } ?? "(unset)"
         let manpath = getenv("MANPATH").flatMap { String(cString: $0) } ?? "(unset)"
         Self.surfaceLog("createSurface start surface=\(id.uuidString) tab=\(tabId.uuidString) bounds=\(view.bounds) inWindow=\(view.window != nil) resources=\(resourcesDir) terminfo=\(terminfo) xdg=\(xdg) manpath=\(manpath)")
+        cmuxDebugLog(
+            "activation.surface.create.begin surface=\(id.uuidString.prefix(8)) workspace=\(tabId.uuidString.prefix(8)) context=\(cmuxSurfaceContextName(surfaceContext)) inWindow=\(view.window != nil ? 1 : 0) bounds=\(String(format: "%.1fx%.1f", view.bounds.width, view.bounds.height))"
+        )
         #endif
 
         guard let app = GhosttyApp.shared.app else {
             print("Ghostty app not initialized")
             #if DEBUG
             Self.surfaceLog("createSurface FAILED surface=\(id.uuidString): ghostty app not initialized")
+            cmuxDebugLog(
+                "activation.surface.create.end result=0 reason=noGhosttyApp elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) surface=\(id.uuidString.prefix(8))"
+            )
             #endif
             return
         }
@@ -4862,8 +4869,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
                 envVars.append(ghostty_env_var_s(key: keyPtr, value: valuePtr))
             }
         }
-
         let createSurface = { [self] in
+#if DEBUG
+            let ghosttyNewStartedAt = ProcessInfo.processInfo.systemUptime
+#endif
             if !envVars.isEmpty {
                 let envVarsCount = envVars.count
                 envVars.withUnsafeMutableBufferPointer { buffer in
@@ -4874,6 +4883,11 @@ final class TerminalSurface: Identifiable, ObservableObject {
             } else {
                 self.surface = ghostty_surface_new(app, &surfaceConfig)
             }
+#if DEBUG
+            cmuxDebugLog(
+                "activation.surface.create.phase stage=ghosttyNew elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - ghosttyNewStartedAt) * 1000.0))) surface=\(id.uuidString.prefix(8)) ready=\(self.surface != nil ? 1 : 0)"
+            )
+#endif
         }
 
         let resolvedWorkingDirectory: String? = {
@@ -4894,6 +4908,11 @@ final class TerminalSurface: Identifiable, ObservableObject {
             }
             return baseConfig.initialInput
         }()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.surface.create.phase stage=envBuilt elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) surface=\(id.uuidString.prefix(8)) envCount=\(envVars.count) hasCommand=\((resolvedCommand?.isEmpty == false) ? 1 : 0) hasInitialInput=\((resolvedInitialInput?.isEmpty == false) ? 1 : 0)"
+        )
+#endif
         func withOptionalCString<T>(_ value: String?, _ body: (UnsafePointer<CChar>?) -> T) -> T {
             guard let value else {
                 return body(nil)
@@ -4922,6 +4941,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
             print("Failed to create ghostty surface")
             #if DEBUG
             Self.surfaceLog("createSurface FAILED surface=\(id.uuidString): ghostty_surface_new returned nil")
+            cmuxDebugLog(
+                "activation.surface.create.end result=0 reason=ghosttyNewNil elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) surface=\(id.uuidString.prefix(8))"
+            )
             if let cfg = GhosttyApp.shared.config {
                 let count = Int(ghostty_config_diagnostics_count(cfg))
                 Self.surfaceLog("createSurface diagnostics count=\(count)")
@@ -5015,6 +5037,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
         cmuxDebugLog(
             "zoom.create.done surface=\(id.uuidString.prefix(5)) context=\(cmuxSurfaceContextName(surfaceContext)) " +
             "runtimeFont=\(runtimeFontText)"
+        )
+        cmuxDebugLog(
+            "activation.surface.create.end result=1 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - activationStartedAt) * 1000.0))) surface=\(id.uuidString.prefix(8)) focus=\(desiredFocusState ? 1 : 0) pixels=\(lastPixelWidth)x\(lastPixelHeight)"
         )
 #endif
     }

--- a/Sources/MainWindowFocusController.swift
+++ b/Sources/MainWindowFocusController.swift
@@ -59,6 +59,44 @@ final class MainWindowFocusController {
     private var feedSelectedItemId: UUID?
     private var lastPublishedFeedFocusSnapshot = FeedFocusSnapshot()
 
+#if DEBUG
+    private func debugFocusNow() -> TimeInterval {
+        ProcessInfo.processInfo.systemUptime
+    }
+
+    private func debugFocusElapsedMs(_ startedAt: TimeInterval) -> String {
+        String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - startedAt) * 1000.0))
+    }
+
+    private func debugResponderLabel(_ responder: NSResponder?) -> String {
+        guard let responder else { return "nil" }
+        return String(describing: type(of: responder))
+    }
+
+    private func debugIntentLabel(_ intent: MainWindowKeyboardFocusIntent?) -> String {
+        switch intent {
+        case .mainPanel(let workspaceId, let panelId):
+            return "mainPanel:\(workspaceId.uuidString.prefix(5)):\(panelId.uuidString.prefix(5))"
+        case .rightSidebar(let mode):
+            return "rightSidebar:\(mode.rawValue)"
+        case nil:
+            return "nil"
+        }
+    }
+
+    private func debugFocusState() -> String {
+        let windowNumber = window?.windowNumber ?? -1
+        let key = window?.isKeyWindow == true ? 1 : 0
+        let visible = window?.isVisible == true ? 1 : 0
+        let firstResponder = debugResponderLabel(window?.firstResponder)
+        let selected = tabManager?.selectedTabId.map { String($0.uuidString.prefix(8)) } ?? "nil"
+        let workspaceCount = tabManager?.tabs.count ?? 0
+        let mode = fileExplorerState?.mode.rawValue ?? "nil"
+        let sidebarVisible = fileExplorerState?.isVisible == true ? 1 : 0
+        return "windowId=\(windowId.uuidString.prefix(8)) win=\(windowNumber) key=\(key) visible=\(visible) selected=\(selected) workspaces=\(workspaceCount) intent=\(debugIntentLabel(intent)) sidebarVisible=\(sidebarVisible) mode=\(mode) pendingFirst=\(pendingRightSidebarFirstItemFocusMode?.rawValue ?? "nil") pendingFind=\(pendingFileSearchFocus ? 1 : 0) fr=\(firstResponder)"
+    }
+#endif
+
     init(
         windowId: UUID,
         window: NSWindow?,
@@ -235,21 +273,47 @@ final class MainWindowFocusController {
 
     @discardableResult
     func restoreTargetAfterWindowBecameKey() -> Bool {
+#if DEBUG
+        let focusStartedAt = debugFocusNow()
+        cmuxDebugLog("activation.focus.restoreAfterKey.begin \(debugFocusState())")
+#endif
         guard case .rightSidebar(let mode) = intent else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.restoreAfterKey.end result=0 reason=notRightSidebar elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return false
         }
         if let responder = window?.firstResponder,
            ownsRightSidebarFocus(responder) {
             publishFeedFocusSnapshot()
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.restoreAfterKey.end result=1 reason=alreadySidebarResponder elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return true
         }
         if pendingFileSearchFocus, mode == .find {
-            return focusFileSearch()
+            let result = focusFileSearch()
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.restoreAfterKey.end result=\(result ? 1 : 0) route=fileSearch elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
+            return result
         }
-        return focusRightSidebar(
+        let result = focusRightSidebar(
             mode: mode,
             focusFirstItem: pendingRightSidebarFirstItemFocusMode == mode
         )
+#if DEBUG
+        cmuxDebugLog(
+            "activation.focus.restoreAfterKey.end result=\(result ? 1 : 0) route=rightSidebar elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+        )
+#endif
+        return result
     }
 
     @discardableResult
@@ -278,12 +342,27 @@ final class MainWindowFocusController {
     }
 
     func syncAfterResponderChange() {
+#if DEBUG
+        let focusStartedAt = debugFocusNow()
+        let beforeIntent = debugIntentLabel(intent)
+        let beforeResponder = debugResponderLabel(window?.firstResponder)
+#endif
         guard let responder = window?.firstResponder else {
             publishFeedFocusSnapshot()
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.syncAfterResponder.end route=noResponder beforeIntent=\(beforeIntent) beforeFr=\(beforeResponder) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return
         }
         if let terminal = terminalFocusRequest(for: responder) {
             noteTerminalInteraction(workspaceId: terminal.workspaceId, panelId: terminal.panelId)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.syncAfterResponder.end route=terminal beforeIntent=\(beforeIntent) beforeFr=\(beforeResponder) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return
         }
         if let mode = rightSidebarModeOwning(responder) {
@@ -300,18 +379,46 @@ final class MainWindowFocusController {
                 feedSelectedItemId = nil
             }
             publishFeedFocusSnapshot()
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.syncAfterResponder.end route=rightSidebar mode=\(mode.rawValue) beforeIntent=\(beforeIntent) beforeFr=\(beforeResponder) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return
         }
         if let mainPanel = selectedFocusedBrowserPanelRequest() {
             noteMainPanelInteraction(workspaceId: mainPanel.workspaceId, panelId: mainPanel.panelId)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.syncAfterResponder.end route=browser beforeIntent=\(beforeIntent) beforeFr=\(beforeResponder) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return
         }
         publishFeedFocusSnapshot()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.focus.syncAfterResponder.end route=unknown beforeIntent=\(beforeIntent) beforeFr=\(beforeResponder) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+        )
+#endif
     }
 
     @discardableResult
     func focusRightSidebar(mode requestedMode: RightSidebarMode? = nil, focusFirstItem: Bool = true) -> Bool {
-        guard let state = fileExplorerState else { return false }
+#if DEBUG
+        let focusStartedAt = debugFocusNow()
+        cmuxDebugLog(
+            "activation.focus.rightSidebar.begin requested=\(requestedMode?.rawValue ?? "nil") focusFirst=\(focusFirstItem ? 1 : 0) \(debugFocusState())"
+        )
+#endif
+        guard let state = fileExplorerState else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.rightSidebar.end result=0 reason=noState elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
+            return false
+        }
         let mode = requestedMode ?? lastRightSidebarMode ?? state.mode
         lastRightSidebarMode = mode
         pendingRightSidebarFirstItemFocusMode = focusFirstItem ? mode : nil
@@ -350,12 +457,28 @@ final class MainWindowFocusController {
         let fallbackResult = modeResult ? false : focusFallbackRightSidebarHost()
         let result = modeResult || fallbackResult || pendingRightSidebarFirstItemFocusMode == mode
         publishFeedFocusSnapshot()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.focus.rightSidebar.end result=\(result ? 1 : 0) modeResult=\(modeResult ? 1 : 0) fallback=\(fallbackResult ? 1 : 0) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+        )
+#endif
         return result
     }
 
     @discardableResult
     func focusFileSearch() -> Bool {
-        guard let state = fileExplorerState else { return false }
+#if DEBUG
+        let focusStartedAt = debugFocusNow()
+        cmuxDebugLog("activation.focus.fileSearch.begin \(debugFocusState())")
+#endif
+        guard let state = fileExplorerState else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.fileSearch.end result=0 reason=noState elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
+            return false
+        }
         lastRightSidebarMode = .find
         pendingRightSidebarFirstItemFocusMode = nil
         pendingFileSearchFocus = true
@@ -375,6 +498,11 @@ final class MainWindowFocusController {
         let fallbackResult = modeResult ? false : focusFallbackRightSidebarHost()
         let result = modeResult || fallbackResult || pendingFileSearchFocus
         publishFeedFocusSnapshot()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.focus.fileSearch.end result=\(result ? 1 : 0) modeResult=\(modeResult ? 1 : 0) fallback=\(fallbackResult ? 1 : 0) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+        )
+#endif
         return result
     }
 
@@ -426,8 +554,17 @@ final class MainWindowFocusController {
 
     @discardableResult
     func focusTerminal() -> Bool {
+#if DEBUG
+        let focusStartedAt = debugFocusNow()
+        cmuxDebugLog("activation.focus.terminal.begin \(debugFocusState())")
+#endif
         guard let tabManager,
               let workspace = tabManager.selectedWorkspace else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.terminal.end result=0 reason=noWorkspace elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
             return false
         }
         let terminalPanel: TerminalPanel? = {
@@ -437,7 +574,14 @@ final class MainWindowFocusController {
             }
             return workspace.focusedTerminalPanel
         }()
-        guard let terminalPanel else { return false }
+        guard let terminalPanel else {
+#if DEBUG
+            cmuxDebugLog(
+                "activation.focus.terminal.end result=0 reason=noTerminalPanel elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+            )
+#endif
+            return false
+        }
         pendingRightSidebarFirstItemFocusMode = nil
         pendingFileSearchFocus = false
         intent = .mainPanel(workspaceId: workspace.id, panelId: terminalPanel.id)
@@ -448,7 +592,13 @@ final class MainWindowFocusController {
             surfaceId: terminalPanel.id,
             respectForeignFirstResponder: false
         )
-        return terminalPanel.hostedView.isSurfaceViewFirstResponder()
+        let result = terminalPanel.hostedView.isSurfaceViewFirstResponder()
+#if DEBUG
+        cmuxDebugLog(
+            "activation.focus.terminal.end result=\(result ? 1 : 0) surface=\(terminalPanel.id.uuidString.prefix(8)) elapsedMs=\(debugFocusElapsedMs(focusStartedAt)) \(debugFocusState())"
+        )
+#endif
+        return result
     }
 
     private func findShortcutTarget(forRightSidebarMode mode: RightSidebarMode) -> MainWindowFindShortcutTarget {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7317,6 +7317,20 @@ extension TabManager {
     }
 
     func restoreSessionSnapshot(_ snapshot: SessionTabManagerSnapshot) {
+#if DEBUG
+        let restoreStartedAt = ProcessInfo.processInfo.systemUptime
+        let snapshotPanels = snapshot.workspaces.reduce(0) { total, workspace in
+            total + workspace.panels.count
+        }
+        let snapshotScrollbackChars = snapshot.workspaces.reduce(0) { total, workspace in
+            total + workspace.panels.reduce(0) { panelTotal, panel in
+                panelTotal + (panel.terminal?.scrollback?.count ?? 0)
+            }
+        }
+        cmuxDebugLog(
+            "activation.session.tabManagerRestore.begin oldWorkspaces=\(tabs.count) snapshotWorkspaces=\(snapshot.workspaces.count) snapshotPanels=\(snapshotPanels) scrollbackChars=\(snapshotScrollbackChars)"
+        )
+#endif
         let previousTabs = tabs
         for tab in previousTabs {
             unwireClosedBrowserTracking(for: tab)
@@ -7341,6 +7355,11 @@ extension TabManager {
         isWorkspaceCycleHot = false
         selectionSideEffectsGeneration &+= 1
         recentlyClosedBrowsers = RecentlyClosedBrowserStack(capacity: 20)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.tabManagerRestore.phase stage=cleared elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0)))"
+        )
+#endif
 
         // Build the new workspace list locally to avoid intermediate @Published
         // emissions (empty tabs, nil selectedTabId) that can leave SwiftUI's
@@ -7361,6 +7380,11 @@ extension TabManager {
             wireClosedBrowserTracking(for: workspace)
             newTabs.append(workspace)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.tabManagerRestore.phase stage=workspacesBuilt elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0))) newWorkspaces=\(newTabs.count)"
+        )
+#endif
 
         if newTabs.isEmpty {
             let ordinal = Self.nextPortOrdinal
@@ -7407,6 +7431,11 @@ extension TabManager {
                 userInfo: [GhosttyNotificationKey.tabId: selectedTabId]
             )
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.tabManagerRestore.end elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0))) newWorkspaces=\(tabs.count) selected=\(selectedTabId.map { String($0.uuidString.prefix(8)) } ?? "nil")"
+        )
+#endif
     }
 }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -337,6 +337,15 @@ extension Workspace {
     }
 
     func restoreSessionSnapshot(_ snapshot: SessionWorkspaceSnapshot) {
+#if DEBUG
+        let restoreStartedAt = ProcessInfo.processInfo.systemUptime
+        let snapshotScrollbackChars = snapshot.panels.reduce(0) { total, panel in
+            total + (panel.terminal?.scrollback?.count ?? 0)
+        }
+        cmuxDebugLog(
+            "activation.session.workspaceRestore.begin workspace=\(id.uuidString.prefix(8)) panels=\(snapshot.panels.count) scrollbackChars=\(snapshotScrollbackChars) currentDir=\(snapshot.currentDirectory.isEmpty ? "nil" : "set")"
+        )
+#endif
         restoredTerminalScrollbackByPanelId.removeAll(keepingCapacity: false)
         restoredAgentSnapshotsByPanelId.removeAll(keepingCapacity: false)
         restoredAgentAutoResumePendingPanelIds.removeAll(keepingCapacity: false)
@@ -349,6 +358,11 @@ extension Workspace {
 
         let panelSnapshotsById = Dictionary(uniqueKeysWithValues: snapshot.panels.map { ($0.id, $0) })
         let leafEntries = restoreSessionLayout(snapshot.layout)
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.workspaceRestore.phase stage=layout elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0))) workspace=\(id.uuidString.prefix(8)) leaves=\(leafEntries.count) panels=\(snapshot.panels.count)"
+        )
+#endif
         var oldToNewPanelIds: [UUID: UUID] = [:]
 
         for entry in leafEntries {
@@ -359,6 +373,11 @@ extension Workspace {
                 oldToNewPanelIds: &oldToNewPanelIds
             )
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.workspaceRestore.phase stage=panesRestored elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0))) workspace=\(id.uuidString.prefix(8)) mappedPanels=\(oldToNewPanelIds.count)"
+        )
+#endif
 
         pruneSurfaceMetadata(validSurfaceIds: Set(panels.keys))
         applySessionDividerPositions(snapshotNode: snapshot.layout, liveNode: bonsplitController.treeSnapshot())
@@ -398,6 +417,11 @@ extension Workspace {
         } else {
             scheduleFocusReconcile()
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.workspaceRestore.end elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restoreStartedAt) * 1000.0))) workspace=\(id.uuidString.prefix(8)) panels=\(panels.count)"
+        )
+#endif
     }
 
     private func sessionLayoutSnapshot(from node: ExternalTreeNode) -> SessionWorkspaceLayoutSnapshot {
@@ -654,6 +678,9 @@ extension Workspace {
         panelSnapshotsById: [UUID: SessionPanelSnapshot],
         oldToNewPanelIds: inout [UUID: UUID]
     ) {
+#if DEBUG
+        let restorePaneStartedAt = ProcessInfo.processInfo.systemUptime
+#endif
         let existingPanelIds = bonsplitController
             .tabs(inPane: paneId)
             .compactMap { panelIdFromSurfaceId($0.id) }
@@ -689,9 +716,21 @@ extension Workspace {
             bonsplitController.focusPane(paneId)
             bonsplitController.selectTab(selectedTabId)
         }
+#if DEBUG
+        cmuxDebugLog(
+            "activation.session.restorePane.end elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - restorePaneStartedAt) * 1000.0))) workspace=\(id.uuidString.prefix(8)) pane=\(String(describing: paneId).prefix(8)) desired=\(desiredOldPanelIds.count) created=\(createdPanelIds.count) existing=\(existingPanelIds.count)"
+        )
+#endif
     }
 
     private func createPanel(from snapshot: SessionPanelSnapshot, inPane paneId: PaneID) -> UUID? {
+#if DEBUG
+        let createPanelStartedAt = ProcessInfo.processInfo.systemUptime
+        let snapshotScrollbackChars = snapshot.terminal?.scrollback?.count ?? 0
+        cmuxDebugLog(
+            "activation.session.restorePanel.begin type=\(snapshot.type.rawValue) oldPanel=\(snapshot.id.uuidString.prefix(8)) workspace=\(id.uuidString.prefix(8)) pane=\(String(describing: paneId).prefix(8)) scrollbackChars=\(snapshotScrollbackChars)"
+        )
+#endif
         switch snapshot.type {
         case .terminal:
             let workingDirectory =
@@ -720,6 +759,11 @@ extension Workspace {
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: shouldReplayScrollback ? snapshot.terminal?.scrollback : nil
             )
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restorePanel.phase stage=replayEnvironment elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) type=terminal oldPanel=\(snapshot.id.uuidString.prefix(8)) env=\(replayEnvironment.isEmpty ? 0 : 1) scrollbackChars=\(snapshotScrollbackChars)"
+            )
+#endif
             guard let terminalPanel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
@@ -751,6 +795,11 @@ extension Workspace {
                 invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: terminalPanel.id)
             }
             applySessionPanelMetadata(snapshot, toPanelId: terminalPanel.id)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restorePanel.end type=terminal result=1 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) oldPanel=\(snapshot.id.uuidString.prefix(8)) newPanel=\(terminalPanel.id.uuidString.prefix(8)) scrollbackChars=\(snapshotScrollbackChars)"
+            )
+#endif
             return terminalPanel.id
         case .browser:
             guard let browserPanel = newBrowserSurface(
@@ -759,20 +808,40 @@ extension Workspace {
                 focus: false,
                 preferredProfileID: snapshot.browser?.profileID
             ) else {
+#if DEBUG
+                cmuxDebugLog(
+                    "activation.session.restorePanel.end type=browser result=0 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) oldPanel=\(snapshot.id.uuidString.prefix(8))"
+                )
+#endif
                 return nil
             }
             applySessionPanelMetadata(snapshot, toPanelId: browserPanel.id)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restorePanel.end type=browser result=1 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) oldPanel=\(snapshot.id.uuidString.prefix(8)) newPanel=\(browserPanel.id.uuidString.prefix(8))"
+            )
+#endif
             return browserPanel.id
         case .markdown:
             guard let filePath = snapshot.markdown?.filePath,
                   let markdownPanel = newMarkdownSurface(
                     inPane: paneId,
                     filePath: filePath,
-                    focus: false
+                      focus: false
                   ) else {
+#if DEBUG
+                cmuxDebugLog(
+                    "activation.session.restorePanel.end type=markdown result=0 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) oldPanel=\(snapshot.id.uuidString.prefix(8))"
+                )
+#endif
                 return nil
             }
             applySessionPanelMetadata(snapshot, toPanelId: markdownPanel.id)
+#if DEBUG
+            cmuxDebugLog(
+                "activation.session.restorePanel.end type=markdown result=1 elapsedMs=\(String(format: "%.2f", max(0, (ProcessInfo.processInfo.systemUptime - createPanelStartedAt) * 1000.0))) oldPanel=\(snapshot.id.uuidString.prefix(8)) newPanel=\(markdownPanel.id.uuidString.prefix(8))"
+            )
+#endif
             return markdownPanel.id
         }
     }


### PR DESCRIPTION
Adds debug-only activation timing logs for investigating reported lag when foregrounding cmux or reopening it from the Dock.

Covers launch, reopen, become-active, resign-active, main window creation and registration, session restore/save, content appear/window accessor, focus restoration, and Ghostty surface creation.

No behavior fix is included. This PR is for gathering targeted timing data from affected machines.

Local checks:
- ./scripts/reload.sh --tag actlag
- clean-profile experiments against /tmp/cmux-debug-actlag.log

Initial clean-profile findings:
- cold launch bootstrap: 433 ms
- createMainWindow: 431 ms
- first Ghostty surface create: 155 ms
- visible-window Dock/open reopen: 0.24 ms
- foreground activation via NSRunningApplication.activate: about 0.2 to 0.3 ms
- resign-active session save, one terminal: about 1.3 to 2.0 ms

Hypotheses to validate on affected machines:
- large session snapshots make resign-active or early restore/save slow
- first Ghostty surface creation dominates cold or no-window Dock opens
- SwiftUI/AppKit window construction or WindowAccessor styling churn dominates first visible window
- right-sidebar or file-search focus restoration is slow only for specific focus states
- users reporting Dock lag may be hitting the no-visible-window path, not the visible-window reopen path
- telemetry, feed setup, or LaunchServices work may overlap with first activation on slower machines

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add DEBUG-only activation latency tracing across the app to investigate lag when foregrounding or reopening from the Dock. No behavior changes; diagnostics only.

- **New Features**
  - Lifecycle logs for launch, open URLs, reopen, didBecomeActive, willResignActive with app/window state and elapsedMs.
  - Session attribution: prepare/attempt/apply/complete/save with snapshot summaries (windows/workspaces/panels/terminals/scrollback), plus TabManager/Workspace/pane/panel restore timings.
  - Window pipeline: ensure/create/register/bootstrap/bringToFront/key-activation with elapsedMs and active window attribution.
  - UI hooks: `ContentView` onAppear/window accessor and mounted reconciliation; Focus Controller logs for right sidebar, file search, and terminal focus paths.
  - Ghostty surface creation phases: env build, `ghostty_surface_new`, completion, with env counts and outcomes.
  - All logs gated by DEBUG and emitted via `cmuxDebugLog`.

<sup>Written for commit 87dbc446ed02cc2746190f5e1d76d9d860993783. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3195?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added extensive debug instrumentation and logging (debug builds only) across app lifecycle, window/focus handling, session restore, view rendering, and terminal surface flows to aid development and troubleshooting.
  * No functional or public-facing changes; normal app behavior and user experience remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->