### PR TITLE
Throttle preexec ports_kick to drop redundant burst-chain kicks

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -413,6 +413,15 @@ _cmux_report_shell_activity_state() {
 # precmd-equivalent paths have their own throttle (`>= 10s elapsed`) and are
 # unaffected.
 _cmux_ports_kick_for_command() {
+    # `_CMUX_PORTS_LAST_RUN == 0` means we haven't kicked in this shell yet.
+    # Always let the first kick through — never throttle into silence. This
+    # also avoids a false-throttle when `_cmux_now` falls back to $SECONDS
+    # (e.g., bash 3.2 on macOS without EPOCHSECONDS) and the shell is younger
+    # than 3s.
+    if (( _CMUX_PORTS_LAST_RUN == 0 )); then
+        _cmux_ports_kick command
+        return
+    fi
     local now
     now="$(_cmux_now)"
     if (( now - _CMUX_PORTS_LAST_RUN >= 3 )); then

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -405,6 +405,21 @@ _cmux_report_shell_activity_state() {
     } >/dev/null 2>&1 & disown
 }
 
+# Preexec wrapper that skips a kick when we've already kicked recently.
+# A previous kick's 10-second burst (running scans at offsets 0.5/1.5/3/5/7.5/10s)
+# already covers any port that opens within a few seconds, so kicks fired in
+# rapid succession are redundant. Skipping them eliminates the burst-chain
+# storm that occurs when a busy panel runs many short commands in a row.
+# precmd-equivalent paths have their own throttle (`>= 10s elapsed`) and are
+# unaffected.
+_cmux_ports_kick_for_command() {
+    local now
+    now="$(_cmux_now)"
+    if (( now - _CMUX_PORTS_LAST_RUN >= 3 )); then
+        _cmux_ports_kick command
+    fi
+}
+
 _cmux_ports_kick() {
     local reason="${1:-command}"
     # Lightweight: just tell the app to run a batched scan for this panel.
@@ -935,7 +950,7 @@ _cmux_preexec_command() {
 
     _cmux_report_shell_activity_state running
     _cmux_report_tty_once
-    _cmux_ports_kick command
+    _cmux_ports_kick_for_command
     _cmux_halt_pr_poll_loop
     if _cmux_command_starts_nested_shell "$cmd"; then
         return 0

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -502,6 +502,21 @@ _cmux_report_shell_activity_state() {
     _cmux_send_bg "report_shell_state $state --tab=$CMUX_TAB_ID --panel=$CMUX_PANEL_ID"
 }
 
+# Preexec wrapper that skips a kick when we've already kicked recently.
+# A previous kick's 10-second burst (running scans at offsets 0.5/1.5/3/5/7.5/10s)
+# already covers any port that opens within a few seconds, so kicks fired in
+# rapid succession are redundant. Skipping them eliminates the burst-chain
+# storm that occurs when a busy panel runs many short commands in a row.
+# precmd has its own throttle (`cmd_dur >= 2 || >= 10s elapsed`) and is
+# unaffected.
+_cmux_ports_kick_for_command() {
+    local now
+    now="$(_cmux_now)"
+    if (( now - _CMUX_PORTS_LAST_RUN >= 3 )); then
+        _cmux_ports_kick command
+    fi
+}
+
 _cmux_ports_kick() {
     local reason="${1:-command}"
     # Lightweight: just tell the app to run a batched scan for this panel.
@@ -1091,7 +1106,7 @@ _cmux_preexec() {
 
     # Register TTY + kick batched port scan for foreground commands (servers).
     _cmux_report_tty_once
-    _cmux_ports_kick command
+    _cmux_ports_kick_for_command
     _cmux_halt_pr_poll_loop
     _cmux_stop_git_head_watch
     if _cmux_command_starts_nested_shell "$cmd"; then

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -510,6 +510,14 @@ _cmux_report_shell_activity_state() {
 # precmd has its own throttle (`cmd_dur >= 2 || >= 10s elapsed`) and is
 # unaffected.
 _cmux_ports_kick_for_command() {
+    # `_CMUX_PORTS_LAST_RUN == 0` means we haven't kicked in this shell yet.
+    # Always let the first kick through — never throttle into silence. This
+    # also avoids a false-throttle when `_cmux_now` falls back to $SECONDS
+    # (e.g., zsh without zsh/datetime) and the shell is younger than 3s.
+    if (( _CMUX_PORTS_LAST_RUN == 0 )); then
+        _cmux_ports_kick command
+        return
+    fi
     local now
     now="$(_cmux_now)"
     if (( now - _CMUX_PORTS_LAST_RUN >= 3 )); then


### PR DESCRIPTION
## Summary

When a busy panel runs many short commands in succession, every shell `preexec` fires `_cmux_ports_kick command` unconditionally. Each kick triggers a 10-second `PortScanner` burst (six `ps`+`lsof` scans at 0.5/1.5/3/5/7.5/10s). Kicks that arrive during a burst cause the next burst to start as soon as the current one ends, producing a continuous chain of overlapping bursts even when ports never change.

This PR adds a 3-second floor between consecutive `command`-reason kicks in both zsh and bash. The first kick's burst already covers any port that opens within ~10s, so kicks fired in rapid succession are redundant and can be dropped without losing detection. `precmd`/refresh paths keep their existing throttle (`>= 10s elapsed`) and are unaffected.

Refs #2540 — addresses the shell-side half of the PortScanner idle-CPU finding (`sghael`'s sample analysis named PortScanner as ~14% of idle CPU). The Swift adaptive-burst-termination follow-up (early-exit when consecutive scans return identical results) is being prepared as a separate PR — splitting because I don't have an Xcode build environment locally.

## Validation

Measured on a 14-panel session under heavy command churn (a `cargo test` loop + general fastlint development) using `fs_usage` capture of all-process FS ops over 5 seconds:

| | Before | After |
|---|---|---|
| `lsof` events | 369,682 | 35,578 |
| effective rate | ~74k ops/sec | ~7k ops/sec |
| reduction | — | **9.6×** |

(Reproducer:
```
sudo sh -c 'fs_usage -w -f filesys 2>/dev/null & P=$!; sleep 5; kill $P 2>/dev/null' \
  | awk '{print $NF}' | sed 's/\.[0-9]*$//' | sort | uniq -c | sort -rn | head -10
```)

Most of the savings come from preventing burst chains, not from skipping individual kicks — which is why a 3-second floor is enough to produce a 9.6× reduction.

The 3s threshold is conservative: a server that binds slightly after a kick is throttled is still detected by either (a) the in-flight burst that's still running scans, or (b) the next non-throttled `precmd` kick on prompt return. Worst-case detection latency for a new listening port is `3s skip + 10s burst tail = ~13s`, which is well under the typical UX window for a sidebar port indicator.

## What changed

- New helper `_cmux_ports_kick_for_command` in both `cmux-zsh-integration.zsh` and `cmux-bash-integration.bash`. Calls `_cmux_ports_kick command` only if `_CMUX_PORTS_LAST_RUN` is more than 3 seconds old.
- `preexec` (zsh) / `_cmux_preexec_command` (bash) now invoke the wrapper instead of `_cmux_ports_kick command` directly.
- `_cmux_ports_kick` itself, the `precmd` paths, and the relay code path are untouched.

## Test plan

- [ ] Existing CI tests (`tests_v2/` + workflow) pass on both bash and zsh
- [ ] Manual: open multiple panels, run a script that loops short commands, confirm `_CMUX_PORTS_LAST_RUN` advances by ≥3s between captured `ports_kick` socket sends
- [ ] Manual: regression check that starting a `bun dev` / `npm run dev` server still surfaces its port in the sidebar within ~10s of `preexec`
- [ ] Optional: add a python integration test that runs a tight `for i in 1 2 3 4 5; do _cmux_preexec_*; done` loop and asserts only one `ports_kick command` is sent — happy to extend `tests/test_issue_1138_sidebar_pr_polling.py` with that scenario if the maintainers want it before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Throttle `preexec`-triggered port-scan kicks with a 3s floor to stop burst chains on busy panels. Reduces `ps`/`lsof` load ~9.6× while keeping port detection within ~10–13s.

- **Performance**
  - Added `_cmux_ports_kick_for_command` in zsh/bash to call `_cmux_ports_kick command` only if `_CMUX_PORTS_LAST_RUN` is older than 3s; `preexec` now uses this wrapper.
  - Left `_cmux_ports_kick`, `precmd`/refresh throttles, and relay logic unchanged.
  - In a 14-panel churn test, `lsof` events over 5s dropped ~370k → ~36k (~9.6×). Addresses #2540 (shell-side PortScanner idle CPU).

<sup>Written for commit 1c7fe19ae4a9863a70171ecb4596f0d4a13ca1dd. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3199?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved shell integration performance by reducing unnecessary port-scan operations when multiple commands execute in quick succession. The first port scan executes immediately, while subsequent scans are throttled to occur no more frequently than every 3 seconds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->