### PR TITLE
Disable right sidebar horizontal scroll

### DIFF
--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -271,7 +271,7 @@ private struct FeedListView: View {
         snapshots: [FeedItemSnapshot],
         actions: FeedRowActions
     ) -> some View {
-        ScrollView {
+        ScrollView(.vertical) {
             LazyVStack(spacing: 0) {
                 ForEach(Array(snapshots.enumerated()), id: \.element.id) { idx, snapshot in
                     rowSurface(

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -936,6 +936,7 @@ final class FileExplorerContainerView: NSView {
         scrollView.translatesAutoresizingMaskIntoConstraints = false
         scrollView.hasVerticalScroller = true
         scrollView.hasHorizontalScroller = false
+        scrollView.horizontalScrollElasticity = .none
         scrollView.autohidesScrollers = true
         scrollView.borderType = .noBorder
         scrollView.drawsBackground = false
@@ -975,6 +976,7 @@ final class FileExplorerContainerView: NSView {
         searchScrollView.translatesAutoresizingMaskIntoConstraints = false
         searchScrollView.hasVerticalScroller = true
         searchScrollView.hasHorizontalScroller = false
+        searchScrollView.horizontalScrollElasticity = .none
         searchScrollView.autohidesScrollers = true
         searchScrollView.borderType = .noBorder
         searchScrollView.drawsBackground = false

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1581,6 +1581,8 @@ final class FileExplorerCellView: NSTableCellView {
     private let loadingIndicator = NSProgressIndicator()
     private var trackingArea: NSTrackingArea?
     var onHover: ((Bool) -> Void)?
+    private var nameLabelTrailingToLoadingConstraint: NSLayoutConstraint!
+    private var nameLabelTrailingToContainerConstraint: NSLayoutConstraint!
 
     init(identifier: NSUserInterfaceItemIdentifier) {
         super.init(frame: .zero)
@@ -1609,6 +1611,7 @@ final class FileExplorerCellView: NSTableCellView {
         loadingIndicator.style = .spinning
         loadingIndicator.controlSize = .small
         loadingIndicator.isHidden = true
+        loadingIndicator.setAccessibilityIdentifier("FileExplorerLoadingIndicator")
 
         addSubview(iconView)
         addSubview(nameLabel)
@@ -1626,13 +1629,26 @@ final class FileExplorerCellView: NSTableCellView {
 
             iconToTextConstraint,
             nameLabel.centerYAnchor.constraint(equalTo: centerYAnchor),
-            nameLabel.trailingAnchor.constraint(lessThanOrEqualTo: loadingIndicator.leadingAnchor, constant: -4),
 
             loadingIndicator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
             loadingIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
             loadingIndicator.widthAnchor.constraint(equalToConstant: 12),
             loadingIndicator.heightAnchor.constraint(equalToConstant: 12),
         ])
+
+        nameLabelTrailingToLoadingConstraint = nameLabel.trailingAnchor.constraint(
+            lessThanOrEqualTo: loadingIndicator.leadingAnchor,
+            constant: -2
+        )
+        nameLabelTrailingToContainerConstraint = nameLabel.trailingAnchor.constraint(
+            lessThanOrEqualTo: trailingAnchor,
+            constant: -2
+        )
+        NSLayoutConstraint.activate([
+            nameLabelTrailingToLoadingConstraint,
+            nameLabelTrailingToContainerConstraint
+        ])
+        nameLabelTrailingToLoadingConstraint.isActive = false
     }
 
     func configure(with node: FileExplorerNode, gitStatus: GitFileStatus? = nil) {
@@ -1673,9 +1689,13 @@ final class FileExplorerCellView: NSTableCellView {
         if node.isLoading {
             loadingIndicator.isHidden = false
             loadingIndicator.startAnimation(nil)
+            nameLabelTrailingToLoadingConstraint.isActive = true
+            nameLabelTrailingToContainerConstraint.isActive = false
         } else {
             loadingIndicator.isHidden = true
             loadingIndicator.stopAnimation(nil)
+            nameLabelTrailingToLoadingConstraint.isActive = false
+            nameLabelTrailingToContainerConstraint.isActive = true
         }
 
         if let error = node.error {

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -180,7 +180,7 @@ struct SessionIndexView: View {
         }
 
         return ScrollViewReader { proxy in
-            ScrollView {
+            ScrollView(.vertical) {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     ForEach(Array(sections.enumerated()), id: \.element.key) { index, section in
                         // Drop above this row → insert dragged section BEFORE this section's key.
@@ -1020,7 +1020,7 @@ private struct SectionPopoverView: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color.orange.opacity(0.10))
             }
-            ScrollView {
+            ScrollView(.vertical) {
                 LazyVStack(alignment: .leading, spacing: 0) {
                     if isLoading && loaded.isEmpty {
                         loadingRow


### PR DESCRIPTION
## Summary
- Prevent horizontal scrolling in right-sidebar file explorer by disabling horizontal elasticity on its AppKit scroll views.
- Make right-sidebar vertical lists explicitly vertical in session and feed panels.

## Testing
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag task-right-sidebar-no-horizontal-scroll`
- Result: build succeeded; app generated at tagged DerivedData path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable horizontal scrolling and bounce in the right sidebar. File explorer rows now adjust trailing constraints with the loading spinner, and SessionIndex/Feed lists are vertical only.

- **Bug Fixes**
  - Disabled horizontal scroll elasticity on right sidebar `NSScrollView`s in the file explorer.
  - Switched list `ScrollView`s to `ScrollView(.vertical)` in SessionIndex and Feed panels.
  - Relaxed file explorer row trailing constraints when the loading indicator is hidden to prevent clipping and layout shifts.

<sup>Written for commit a0f1a1ea835bcba4db5d6f097f50cad38abc6bcb. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3202?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Made scrolling behavior explicit and consistent, reducing unexpected bounce and improving stability in feed, file explorer, and session lists.
* **UI**
  * Improved item layout so labels position correctly during loading states for clearer, more stable presentation.
* **Accessibility**
  * Added an accessibility identifier for the loading indicator to aid assistive tools and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->