### PR TITLE
fix(tmux): expand short format aliases in tmux compat

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11550,13 +11550,66 @@ struct CMUXCLI {
         return nil
     }
 
+    private let tmuxShortFormatAliases: [Character: String] = [
+        "D": "pane_id",
+        "F": "window_flags",
+        "I": "window_index",
+        "P": "pane_index",
+        "S": "session_name",
+        "W": "window_name"
+    ]
+
+    private func tmuxExpandShortFormatAliases(
+        _ format: String,
+        context: [String: String]
+    ) -> String {
+        guard format.contains("#") else { return format }
+
+        var rendered = ""
+        rendered.reserveCapacity(format.count)
+        var index = format.startIndex
+        while index < format.endIndex {
+            let character = format[index]
+            guard character == "#" else {
+                rendered.append(character)
+                index = format.index(after: index)
+                continue
+            }
+
+            let nextIndex = format.index(after: index)
+            guard nextIndex < format.endIndex else {
+                rendered.append(character)
+                break
+            }
+
+            let nextCharacter = format[nextIndex]
+            if nextCharacter == "#" {
+                rendered.append("##")
+                index = format.index(after: nextIndex)
+                continue
+            }
+
+            if let key = tmuxShortFormatAliases[nextCharacter],
+               let value = context[key] {
+                rendered.append(value)
+                index = format.index(after: nextIndex)
+                continue
+            }
+
+            rendered.append(character)
+            index = nextIndex
+        }
+
+        return rendered
+    }
+
     private func tmuxRenderFormat(
         _ format: String?,
         context: [String: String],
         fallback: String
     ) -> String {
         guard let format, !format.isEmpty else { return fallback }
-        var rendered = format
+        var rendered = tmuxExpandShortFormatAliases(format, context: context)
         for (key, value) in context {
             rendered = rendered.replacingOccurrences(of: "#{\(key)}", with: value)
         }
@@ -11578,6 +11631,7 @@ struct CMUXCLI {
         let canonicalWorkspaceId = try resolveWorkspaceId(workspaceId, client: client)
         var context: [String: String] = [
             "session_name": "cmux",
+            "window_flags": "*",
             "window_id": "@\(canonicalWorkspaceId)",
             "window_uuid": canonicalWorkspaceId
         ]

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -168,11 +168,54 @@ func parseTmuxArgs(args []string, valueFlags, boolFlags []string) *tmuxParsed {
 
 var tmuxFormatVarRe = regexp.MustCompile(`#\{[^}]+\}`)
 
+var tmuxShortFormatAliases = map[byte]string{
+	'D': "pane_id",
+	'F': "window_flags",
+	'I': "window_index",
+	'P': "pane_index",
+	'S': "session_name",
+	'W': "window_name",
+}
+
+func tmuxExpandShortFormatAliases(format string, context map[string]string) string {
+	if format == "" {
+		return format
+	}
+
+	var builder strings.Builder
+	builder.Grow(len(format))
+	for i := 0; i < len(format); i++ {
+		ch := format[i]
+		if ch != '#' || i+1 >= len(format) {
+			builder.WriteByte(ch)
+			continue
+		}
+
+		next := format[i+1]
+		if next == '#' {
+			builder.WriteString("##")
+			i++
+			continue
+		}
+		if key, ok := tmuxShortFormatAliases[next]; ok {
+			if value, exists := context[key]; exists {
+				builder.WriteString(value)
+				i++
+				continue
+			}
+		}
+
+		builder.WriteByte(ch)
+	}
+
+	return builder.String()
+}
+
 func tmuxRenderFormat(format string, context map[string]string, fallback string) string {
 	if format == "" {
 		return fallback
 	}
-	rendered := format
+	rendered := tmuxExpandShortFormatAliases(format, context)
 	for key, value := range context {
 		rendered = strings.ReplaceAll(rendered, "#{"+key+"}", value)
 	}

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -68,9 +68,14 @@ func TestParseTmuxArgsClusteredValueFlag(t *testing.T) {
 
 func TestTmuxRenderFormat(t *testing.T) {
 	ctx := map[string]string{
-		"pane_id":    "%abc123",
-		"pane_width": "80",
-		"window_id":  "@ws1",
+		"session_name": "cmux",
+		"pane_id":      "%abc123",
+		"pane_index":   "2",
+		"pane_width":   "80",
+		"window_flags": "*",
+		"window_id":    "@ws1",
+		"window_index": "4",
+		"window_name":  "editor",
 	}
 
 	tests := []struct {
@@ -80,6 +85,9 @@ func TestTmuxRenderFormat(t *testing.T) {
 	}{
 		{"#{pane_id}", "fallback", "%abc123"},
 		{"#{pane_id}:#{pane_width}", "", "%abc123:80"},
+		{"#S:#I.#P #W", "", "cmux:4.2 editor"},
+		{"#F #D", "", "* %abc123"},
+		{"##S #S", "", "##S cmux"},
 		{"#{unknown_var}", "fallback", "fallback"},
 		{"", "fallback", "fallback"},
 		{"#{pane_id} #{pane_width} #{window_id}", "", "%abc123 80 @ws1"},

--- a/tests_v2/test_tmux_compat_matrix.py
+++ b/tests_v2/test_tmux_compat_matrix.py
@@ -269,6 +269,10 @@ def main() -> int:
         shown = _run_cli(cli, ["display-message", "-p", msg])
         _must(msg in shown.stdout, f"display-message -p should print message: {shown.stdout!r}")
 
+        short_aliases = _run_cli(cli, ["display-message", "-p", "#S:#I.#P #W"])
+        _must(short_aliases.stdout.strip() == f"cmux:0.0 {ws}",
+              f"display-message short aliases should expand: {short_aliases.stdout!r}")
+
     print("PASS: tmux compatibility matrix commands are wired and tested")
     return 0
 


### PR DESCRIPTION
`tmuxRenderFormat` only substituted `#{...}` placeholders, so short tmux aliases like `#S`, `#I`, and `#W` came back literally from `cmux __tmux-compat display-message -p`.

This teaches both tmux-compat renderers to expand the existing short aliases before the long-form pass, and adds regression coverage in the Go unit tests plus the tmux-compat matrix test.

Tested with `go test ./...` in `daemon/remote/cmd/cmuxd-remote`; the macOS app-side matrix test was updated but not runnable in this Linux workspace.

Fixes #3190

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand short tmux format aliases (`#S`, `#I`, `#W`, `#P`, `#D`, `#F`) in tmux-compat so `display-message -p` returns real values instead of literal aliases. Fixes #3190.

- **Bug Fixes**
  - Expand short aliases before long-form `#{...}` substitution in `CLI/cmux.swift` and `daemon/remote/cmd/cmuxd-remote/tmux_compat.go`.
  - Handle escaped `##` correctly; map aliases to context keys; set `window_flags` default to `*` in the CLI context.
  - Add regression tests in Go and update the tmux-compat matrix test to cover short aliases.

<sup>Written for commit 06a560da84ddcc177a8f5d0bb829401568f7cc1e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3206?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced tmux format string compatibility by adding support for proper expansion of short format aliases (#S, #I, #P, #W, #F, #D) within format strings, with correct handling of escaped characters.

* **Tests**
  * Added comprehensive test coverage for tmux format string alias expansion across CLI and daemon components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->