### PR TITLE
Add find in directory shortcut

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -9357,6 +9357,23 @@
         }
       }
     },
+    "command.findInDirectory.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Right Sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバー"
+          }
+        }
+      }
+    },
     "browser.import.warning.additionalDataUnavailable": {
       "extractionState": "manual",
       "localizations": {
@@ -41821,6 +41838,23 @@
         }
       }
     },
+    "menu.find.findInDirectory": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find in Directory…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディレクトリ内を検索…"
+          }
+        }
+      }
+    },
     "menu.find.findPrevious": {
       "extractionState": "manual",
       "localizations": {
@@ -73646,6 +73680,91 @@
         }
       }
     },
+    "fileExplorer.contextMenu.copyPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "パスをコピー"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.copyRelativePath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Relative Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "相対パスをコピー"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.openDefault": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in Default Editor"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デフォルトのエディタで開く"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.openInCmux": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open in cmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmuxで開く"
+          }
+        }
+      }
+    },
+    "fileExplorer.contextMenu.revealInFinder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reveal in Finder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Finderで表示"
+          }
+        }
+      }
+    },
     "fileExplorer.error.unavailable": {
       "extractionState": "manual",
       "localizations": {
@@ -73784,6 +73903,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "rg がステータス %d で終了しました"
+          }
+        }
+      }
+    },
+    "fileExplorer.search.rgNotInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ripgrep (rg) is not installed or is not on PATH."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ripgrep (rg) がインストールされていないか、PATH にありません。"
           }
         }
       }

--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -415,6 +415,7 @@ func shouldRouteCommandEquivalentDirectlyToMainMenu(_ event: NSEvent) -> Bool {
 
 private enum BrowserFindCommandEquivalent {
     case find
+    case findInDirectory
     case findNext
     case findPrevious
     case hideFind
@@ -424,7 +425,7 @@ private enum BrowserFindCommandEquivalent {
         switch self {
         case .find, .findNext, .findPrevious, .hideFind:
             return true
-        case .useSelection:
+        case .findInDirectory, .useSelection:
             return false
         }
     }
@@ -482,7 +483,7 @@ private func browserFindCommandEquivalent(for event: NSEvent) -> BrowserFindComm
         return nil
     case [.command, .shift]:
         if matches("f", keyCode: 3) { // kVK_ANSI_F
-            return .hideFind
+            return .findInDirectory
         }
         if matches("g", keyCode: 5) { // kVK_ANSI_G
             return .findPrevious
@@ -506,6 +507,10 @@ func shouldRouteBrowserFindCommandEquivalentThroughWebContentFirst(
     }
 
     if case .find = shortcut {
+        return false
+    }
+
+    if case .findInDirectory = shortcut {
         return false
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -900,10 +900,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
-        let directories = externalOpenDirectories(from: urls)
-        guard !directories.isEmpty else { return }
+        let fileURLs = externalOpenFileURLs(from: urls)
+        let directories = externalOpenDirectories(from: urls.filter { externalOpenURLIsDirectory($0) })
+        guard !fileURLs.isEmpty || !directories.isEmpty else { return }
 
         prepareForExplicitOpenIntentAtStartup()
+        for fileURL in fileURLs {
+            _ = openFilePreviewInPreferredMainWindow(
+                filePath: fileURL.path(percentEncoded: false),
+                debugSource: "application.openURLs"
+            )
+        }
         for directory in directories {
             openWorkspaceForExternalDirectory(
                 workingDirectory: directory,
@@ -5867,6 +5874,34 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    private func externalOpenFileURLs(from urls: [URL]) -> [URL] {
+        var seen: Set<String> = []
+        var fileURLs: [URL] = []
+        for url in urls where url.isFileURL && !externalOpenURLIsDirectory(url) {
+            let standardized = url.standardizedFileURL.resolvingSymlinksInPath()
+            guard !externalOpenURLIsDescendantOfCurrentBundle(standardized) else { continue }
+            let path = standardized.path(percentEncoded: false)
+            guard seen.insert(path).inserted else { continue }
+            fileURLs.append(url.standardizedFileURL)
+        }
+        return fileURLs
+    }
+
+    private func externalOpenURLIsDirectory(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        if url.hasDirectoryPath {
+            return true
+        }
+        return (try? url.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true
+    }
+
+    private func externalOpenURLIsDescendantOfCurrentBundle(_ url: URL) -> Bool {
+        let pathComponents = url.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        let bundleComponents = Bundle.main.bundleURL.standardizedFileURL.resolvingSymlinksInPath().pathComponents
+        guard pathComponents.count >= bundleComponents.count else { return false }
+        return Array(pathComponents.prefix(bundleComponents.count)) == bundleComponents
+    }
+
     private func openWorkspaceForExternalDirectory(
         workingDirectory: String,
         debugSource: String
@@ -5879,6 +5914,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
         _ = createMainWindow(initialWorkingDirectory: workingDirectory)
+    }
+
+    @discardableResult
+    func openFilePreviewInPreferredMainWindow(
+        filePath: String,
+        preferredWindow: NSWindow? = nil,
+        debugSource: String = "unspecified"
+    ) -> Bool {
+        let parentDirectory = URL(fileURLWithPath: filePath).deletingLastPathComponent().path
+        let context: MainWindowContext? = {
+            if let existing = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow) {
+                return existing
+            }
+            let windowId = createMainWindow(initialWorkingDirectory: parentDirectory)
+            return mainWindowContexts.values.first { $0.windowId == windowId }
+        }()
+        guard let context else { return false }
+
+        let window = context.window ?? windowForMainWindowId(context.windowId)
+        if let window {
+            bringToFront(window)
+            setActiveMainWindow(window)
+        }
+
+        let workspace = context.tabManager.selectedWorkspace
+            ?? context.tabManager.addWorkspace(workingDirectory: parentDirectory, select: true)
+        guard let paneId = workspace.bonsplitController.focusedPaneId
+            ?? workspace.bonsplitController.allPaneIds.first else {
+            return false
+        }
+
+#if DEBUG
+        cmuxDebugLog("file.preview.externalOpen source=\(debugSource) path=\(filePath)")
+#endif
+        _ = workspace.openOrFocusFilePreviewSurface(inPane: paneId, filePath: filePath)
+        return true
     }
 
     @discardableResult
@@ -10771,6 +10842,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return performFindShortcutInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
         }
 
+        if matchConfiguredShortcut(event: event, action: .findInDirectory) {
+            return focusFileSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
+        }
+
         if matchConfiguredShortcut(event: event, action: .findNext) {
             guard !shouldLetFocusedBrowserOwnFindShortcut(event) else {
                 return false
@@ -11496,6 +11571,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func handleBrowserSurfaceKeyEquivalentBeforeMainMenu(_ event: NSEvent) -> Bool {
         if matchConfiguredShortcut(event: event, action: .find) {
             return performFindShortcutInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
+        }
+        if matchConfiguredShortcut(event: event, action: .findInDirectory) {
+            return focusFileSearchInActiveMainWindow(preferredWindow: resolvedShortcutEventWindow(event))
         }
         return false
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6424,6 +6424,8 @@ struct ContentView: View {
             return .splitRight
         case "palette.terminalSplitDown":
             return .splitDown
+        case "palette.findInDirectory":
+            return .findInDirectory
         case "palette.terminalFind":
             return .find
         case "palette.terminalFindNext":
@@ -6432,6 +6434,8 @@ struct ContentView: View {
             return .findPrevious
         case "palette.terminalHideFind":
             return .hideFind
+        case "palette.terminalUseSelectionForFind":
+            return .useSelectionForFind
         case "palette.toggleSplitZoom":
             return .toggleSplitZoom
         case "palette.triggerFlash":
@@ -6472,7 +6476,7 @@ struct ContentView: View {
         case "palette.terminalFindPrevious":
             return "⌥⌘G"
         case "palette.terminalHideFind":
-            return "⌘⇧F"
+            return "⌥⌘⇧F"
         case "palette.terminalUseSelectionForFind":
             return "⌘E"
         case "palette.toggleFullScreen":
@@ -7212,6 +7216,14 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.findInDirectory",
+                title: constant(String(localized: "menu.find.findInDirectory", defaultValue: "Find in Directory…")),
+                subtitle: constant(String(localized: "command.findInDirectory.subtitle", defaultValue: "Right Sidebar")),
+                keywords: ["files", "directory", "find", "search"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.terminalFind",
                 title: constant(String(localized: "command.terminalFind.title", defaultValue: "Find…")),
                 subtitle: terminalPanelSubtitle,
@@ -7245,7 +7257,7 @@ struct ContentView: View {
                 commandId: "palette.terminalHideFind",
                 title: constant(String(localized: "command.terminalHideFind.title", defaultValue: "Hide Find Bar")),
                 subtitle: terminalPanelSubtitle,
-                shortcutHint: "⌘⇧F",
+                shortcutHint: "⌥⌘⇧F",
                 keywords: ["terminal", "hide", "find", "search"],
                 when: { $0.bool(CommandPaletteContextKeys.panelIsTerminal) }
             )
@@ -7724,6 +7736,11 @@ struct ContentView: View {
         }
         registry.register(commandId: "palette.browserClearHistory") {
             BrowserHistoryStore.shared.clearHistory()
+        }
+        registry.register(commandId: "palette.findInDirectory") {
+            _ = AppDelegate.shared?.focusFileSearchInActiveMainWindow(
+                preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
+            )
         }
         registry.register(commandId: "palette.browserSplitRight") {
             _ = tabManager.createBrowserSplit(direction: .right)

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -84,15 +84,33 @@ private final class FileSearchController {
         let isLocal: Bool
     }
 
+    private struct CacheKey: Hashable {
+        let query: String
+        let rootPath: String
+    }
+
+    private struct CacheEntry {
+        let results: [FileSearchResult]
+        let status: FileSearchSnapshot.Status
+    }
+
+    private struct RipgrepExecutable {
+        let url: URL
+        let prefixArguments: [String]
+    }
+
     var onSnapshotChanged: ((FileSearchSnapshot) -> Void)?
 
     private let maxResults = 500
+    private let maxCacheEntries = 32
     private var process: Process?
     private var stdoutBuffer = Data()
     private var stderrBuffer = Data()
     private var generation = 0
     private var request: Request?
     private var results: [FileSearchResult] = []
+    private var cache: [CacheKey: CacheEntry] = [:]
+    private var cacheOrder: [CacheKey] = []
 
     func search(query rawQuery: String, rootPath: String, isLocal: Bool) {
         let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -117,13 +135,25 @@ private final class FileSearchController {
             emit(status: .noMatches, isSearching: false)
             return
         }
+        let cacheKey = CacheKey(query: query, rootPath: rootPath)
+        if let cached = cache[cacheKey] {
+            results = cached.results
+            emit(status: cached.status, isSearching: false)
+            return
+        }
+        guard let executable = Self.ripgrepExecutable() else {
+            emit(
+                status: .failed(String(localized: "fileExplorer.search.rgNotInstalled", defaultValue: "ripgrep (rg) is not installed or is not on PATH.")),
+                isSearching: false
+            )
+            return
+        }
 
         generation += 1
         let searchGeneration = generation
         emit(status: .searching, isSearching: true)
 
         let process = Process()
-        let executable = Self.ripgrepExecutable()
         process.executableURL = executable.url
         process.arguments = executable.prefixArguments + [
             "--json",
@@ -131,12 +161,6 @@ private final class FileSearchController {
             "--column",
             "--smart-case",
             "--fixed-strings",
-            "--hidden",
-            "--glob", "!.git/**",
-            "--glob", "!node_modules/**",
-            "--glob", "!dist/**",
-            "--glob", "!build/**",
-            "--glob", "!DerivedData/**",
             "--max-columns", "300",
             "--max-columns-preview",
             "--color", "never",
@@ -207,6 +231,7 @@ private final class FileSearchController {
             results.append(result)
             didAppendResult = true
             if results.count >= maxResults {
+                cacheCurrentResults(status: .limited(maxResults))
                 stopAndAdvanceGeneration()
                 emit(status: .limited(maxResults), isSearching: false)
                 return
@@ -230,7 +255,9 @@ private final class FileSearchController {
         stopCurrentProcess()
 
         if status == 0 || status == 1 {
-            emit(status: results.isEmpty ? .noMatches : .matches, isSearching: false)
+            let finalStatus: FileSearchSnapshot.Status = results.isEmpty ? .noMatches : .matches
+            cacheCurrentResults(status: finalStatus)
+            emit(status: finalStatus, isSearching: false)
             return
         }
 
@@ -241,6 +268,20 @@ private final class FileSearchController {
             Int(status)
         )
         emit(status: .failed(errorText?.isEmpty == false ? errorText! : fallback), isSearching: false)
+    }
+
+    private func cacheCurrentResults(status: FileSearchSnapshot.Status) {
+        guard let request, request.isLocal, !request.query.isEmpty, !request.rootPath.isEmpty else {
+            return
+        }
+        let key = CacheKey(query: request.query, rootPath: request.rootPath)
+        cache[key] = CacheEntry(results: results, status: status)
+        cacheOrder.removeAll { $0 == key }
+        cacheOrder.append(key)
+        while cacheOrder.count > maxCacheEntries {
+            let evicted = cacheOrder.removeFirst()
+            cache.removeValue(forKey: evicted)
+        }
     }
 
     private func emit(status: FileSearchSnapshot.Status, isSearching: Bool) {
@@ -268,12 +309,19 @@ private final class FileSearchController {
         }
     }
 
-    private static func ripgrepExecutable() -> (url: URL, prefixArguments: [String]) {
+    private static func ripgrepExecutable() -> RipgrepExecutable? {
         let fileManager = FileManager.default
         for path in ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"] where fileManager.isExecutableFile(atPath: path) {
-            return (URL(fileURLWithPath: path), [])
+            return RipgrepExecutable(url: URL(fileURLWithPath: path), prefixArguments: [])
         }
-        return (URL(fileURLWithPath: "/usr/bin/env"), ["rg"])
+        let pathValue = ProcessInfo.processInfo.environment["PATH"] ?? ""
+        for directory in pathValue.split(separator: ":", omittingEmptySubsequences: true) {
+            let path = URL(fileURLWithPath: String(directory)).appendingPathComponent("rg").path
+            if fileManager.isExecutableFile(atPath: path) {
+                return RipgrepExecutable(url: URL(fileURLWithPath: path), prefixArguments: [])
+            }
+        }
+        return nil
     }
 }
 
@@ -864,6 +912,7 @@ final class FileExplorerContainerView: NSView {
     private var currentProviderIsLocal = false
     private var isSearchVisible = false
     private var presentation: FileExplorerPanelPresentation
+    private let coordinator: FileExplorerPanelView.Coordinator
 
     init(coordinator: FileExplorerPanelView.Coordinator, presentation: FileExplorerPanelPresentation) {
         headerView = FileExplorerHeaderView()
@@ -878,6 +927,7 @@ final class FileExplorerContainerView: NSView {
         loadingIndicator = NSProgressIndicator()
         searchController = FileSearchController()
         self.presentation = presentation
+        self.coordinator = coordinator
 
         super.init(frame: .zero)
 
@@ -1010,6 +1060,10 @@ final class FileExplorerContainerView: NSView {
         searchResultsView.delegate = self
         searchResultsView.target = self
         searchResultsView.doubleAction = #selector(openSelectedSearchResultFromTable(_:))
+        searchResultsView.setDraggingSourceOperationMask(.move, forLocal: true)
+        let searchMenu = NSMenu()
+        searchMenu.delegate = self
+        searchResultsView.menu = searchMenu
 
         searchScrollView.translatesAutoresizingMaskIntoConstraints = false
         searchScrollView.hasVerticalScroller = true
@@ -1333,21 +1387,77 @@ final class FileExplorerContainerView: NSView {
         }
     }
 
+    private func searchResult(forMenuItem sender: NSMenuItem) -> FileSearchResult? {
+        guard let row = (sender.representedObject as? NSNumber)?.intValue,
+              row >= 0,
+              row < searchSnapshot.results.count else {
+            return nil
+        }
+        return searchSnapshot.results[row]
+    }
+
     fileprivate func openSelectedSearchResult() {
         let row = searchResultsView.selectedRow
         guard row >= 0, row < searchSnapshot.results.count else { return }
-        PreferredEditorSettings.open(URL(fileURLWithPath: searchSnapshot.results[row].path))
+        coordinator.onOpenFilePreview(searchSnapshot.results[row].path)
     }
 
     @objc private func openSelectedSearchResultFromTable(_ sender: NSTableView) {
         openSelectedSearchResult()
     }
+
+    @objc private func contextMenuOpenSearchResultInCmux(_ sender: NSMenuItem) {
+        guard let result = searchResult(forMenuItem: sender) else { return }
+        coordinator.onOpenFilePreview(result.path)
+    }
+
+    @objc private func contextMenuOpenSearchResultInDefaultEditor(_ sender: NSMenuItem) {
+        guard let result = searchResult(forMenuItem: sender) else { return }
+        PreferredEditorSettings.open(URL(fileURLWithPath: result.path))
+    }
+
+    @objc private func contextMenuRevealSearchResultInFinder(_ sender: NSMenuItem) {
+        guard let result = searchResult(forMenuItem: sender) else { return }
+        NSWorkspace.shared.selectFile(result.path, inFileViewerRootedAtPath: "")
+    }
+
+    @objc private func contextMenuCopySearchResultPath(_ sender: NSMenuItem) {
+        guard let result = searchResult(forMenuItem: sender) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(result.path, forType: .string)
+    }
+
+    @objc private func contextMenuCopySearchResultRelativePath(_ sender: NSMenuItem) {
+        guard let result = searchResult(forMenuItem: sender) else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(result.relativePath, forType: .string)
+    }
 }
 
-extension FileExplorerContainerView: NSSearchFieldDelegate, NSTableViewDataSource, NSTableViewDelegate {
+extension FileExplorerContainerView: NSSearchFieldDelegate, NSTableViewDataSource, NSTableViewDelegate, NSMenuDelegate {
     func controlTextDidChange(_ notification: Notification) {
         guard notification.object as? NSTextField === searchField else { return }
         refreshSearchIfNeeded()
+    }
+
+    func control(_ control: NSControl, textView: NSTextView, doCommandBy commandSelector: Selector) -> Bool {
+        guard control === searchField else { return false }
+        switch commandSelector {
+        case #selector(NSResponder.insertNewline(_:)):
+            openSelectedSearchResult()
+            return true
+        case #selector(NSResponder.cancelOperation(_:)):
+            closeSearchAndFocusOutline()
+            return true
+        case #selector(NSResponder.moveDown(_:)):
+            moveSearchSelection(by: 1, focusResults: true)
+            return true
+        case #selector(NSResponder.moveUp(_:)):
+            moveSearchSelection(by: -1, focusResults: true)
+            return true
+        default:
+            return false
+        }
     }
 
     func numberOfRows(in tableView: NSTableView) -> Int {
@@ -1369,6 +1479,87 @@ extension FileExplorerContainerView: NSSearchFieldDelegate, NSTableViewDataSourc
         }
         cellView.configure(with: searchSnapshot.results[row])
         return cellView
+    }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> (any NSPasteboardWriting)? {
+        guard tableView === searchResultsView,
+              row >= 0,
+              row < searchSnapshot.results.count else {
+            return nil
+        }
+        let result = searchSnapshot.results[row]
+        return FilePreviewDragPasteboardWriter(
+            filePath: result.path,
+            displayTitle: (result.relativePath as NSString).lastPathComponent
+        )
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        guard tableView === searchResultsView else { return }
+        FilePreviewDragPasteboardWriter.discardRegisteredDrag(from: NSPasteboard(name: .drag))
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        guard let searchMenu = searchResultsView.menu, menu === searchMenu else { return }
+        menu.removeAllItems()
+        let clickedRow = searchResultsView.clickedRow
+        let row = clickedRow >= 0 ? clickedRow : searchResultsView.selectedRow
+        guard row >= 0, row < searchSnapshot.results.count else { return }
+        if clickedRow >= 0 {
+            searchResultsView.selectRowIndexes(IndexSet(integer: clickedRow), byExtendingSelection: false)
+        }
+
+        let openInCmuxItem = NSMenuItem(
+            title: String(localized: "fileExplorer.contextMenu.openInCmux", defaultValue: "Open in cmux"),
+            action: #selector(contextMenuOpenSearchResultInCmux(_:)),
+            keyEquivalent: ""
+        )
+        openInCmuxItem.target = self
+        openInCmuxItem.representedObject = NSNumber(value: row)
+        menu.addItem(openInCmuxItem)
+
+        let openDefaultItem = NSMenuItem(
+            title: String(localized: "fileExplorer.contextMenu.openDefault", defaultValue: "Open in Default Editor"),
+            action: #selector(contextMenuOpenSearchResultInDefaultEditor(_:)),
+            keyEquivalent: ""
+        )
+        openDefaultItem.target = self
+        openDefaultItem.representedObject = NSNumber(value: row)
+        menu.addItem(openDefaultItem)
+
+        let revealItem = NSMenuItem(
+            title: String(localized: "fileExplorer.contextMenu.revealInFinder", defaultValue: "Reveal in Finder"),
+            action: #selector(contextMenuRevealSearchResultInFinder(_:)),
+            keyEquivalent: ""
+        )
+        revealItem.target = self
+        revealItem.representedObject = NSNumber(value: row)
+        menu.addItem(revealItem)
+
+        menu.addItem(.separator())
+
+        let copyPathItem = NSMenuItem(
+            title: String(localized: "fileExplorer.contextMenu.copyPath", defaultValue: "Copy Path"),
+            action: #selector(contextMenuCopySearchResultPath(_:)),
+            keyEquivalent: ""
+        )
+        copyPathItem.target = self
+        copyPathItem.representedObject = NSNumber(value: row)
+        menu.addItem(copyPathItem)
+
+        let copyRelativePathItem = NSMenuItem(
+            title: String(localized: "fileExplorer.contextMenu.copyRelativePath", defaultValue: "Copy Relative Path"),
+            action: #selector(contextMenuCopySearchResultRelativePath(_:)),
+            keyEquivalent: ""
+        )
+        copyRelativePathItem.target = self
+        copyRelativePathItem.representedObject = NSNumber(value: row)
+        menu.addItem(copyRelativePathItem)
     }
 }
 
@@ -1523,8 +1714,8 @@ private final class FileExplorerSearchResultCellView: NSTableCellView {
         addSubview(previewLabel)
 
         NSLayoutConstraint.activate([
-            pathLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 10),
-            pathLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -10),
+            pathLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 6),
+            pathLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
             pathLabel.topAnchor.constraint(equalTo: topAnchor, constant: 5),
 
             previewLabel.leadingAnchor.constraint(equalTo: pathLabel.leadingAnchor),
@@ -1635,6 +1826,7 @@ final class FileExplorerCellView: NSTableCellView {
     private var iconWidthConstraint: NSLayoutConstraint!
     private var iconHeightConstraint: NSLayoutConstraint!
     private var iconToTextConstraint: NSLayoutConstraint!
+    private var loadingWidthConstraint: NSLayoutConstraint!
 
     private func setupViews() {
         iconView.translatesAutoresizingMaskIntoConstraints = false
@@ -1658,6 +1850,7 @@ final class FileExplorerCellView: NSTableCellView {
         iconWidthConstraint = iconView.widthAnchor.constraint(equalToConstant: 16)
         iconHeightConstraint = iconView.heightAnchor.constraint(equalToConstant: 16)
         iconToTextConstraint = nameLabel.leadingAnchor.constraint(equalTo: iconView.trailingAnchor, constant: 4)
+        loadingWidthConstraint = loadingIndicator.widthAnchor.constraint(equalToConstant: 0)
 
         NSLayoutConstraint.activate([
             iconView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 0),
@@ -1670,16 +1863,16 @@ final class FileExplorerCellView: NSTableCellView {
 
             loadingIndicator.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -4),
             loadingIndicator.centerYAnchor.constraint(equalTo: centerYAnchor),
-            loadingIndicator.widthAnchor.constraint(equalToConstant: 12),
+            loadingWidthConstraint,
             loadingIndicator.heightAnchor.constraint(equalToConstant: 12),
         ])
 
         nameLabelTrailingToLoadingConstraint = nameLabel.trailingAnchor.constraint(
-            lessThanOrEqualTo: loadingIndicator.leadingAnchor,
+            equalTo: loadingIndicator.leadingAnchor,
             constant: -2
         )
         nameLabelTrailingToContainerConstraint = nameLabel.trailingAnchor.constraint(
-            lessThanOrEqualTo: trailingAnchor,
+            equalTo: trailingAnchor,
             constant: -2
         )
         NSLayoutConstraint.activate([
@@ -1725,11 +1918,13 @@ final class FileExplorerCellView: NSTableCellView {
         }
 
         if node.isLoading {
+            loadingWidthConstraint.constant = 12
             loadingIndicator.isHidden = false
             loadingIndicator.startAnimation(nil)
             nameLabelTrailingToLoadingConstraint.isActive = true
             nameLabelTrailingToContainerConstraint.isActive = false
         } else {
+            loadingWidthConstraint.constant = 0
             loadingIndicator.isHidden = true
             loadingIndicator.stopAnimation(nil)
             nameLabelTrailingToLoadingConstraint.isActive = false

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -96,6 +96,7 @@ enum KeyboardShortcutSettings {
         case browserZoomOut
         case browserZoomReset
         case find
+        case findInDirectory
         case findNext
         case findPrevious
         case hideFind
@@ -165,6 +166,7 @@ enum KeyboardShortcutSettings {
             case .browserZoomOut: return String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out")
             case .browserZoomReset: return String(localized: "menu.view.actualSize", defaultValue: "Actual Size")
             case .find: return String(localized: "menu.find.find", defaultValue: "Find…")
+            case .findInDirectory: return String(localized: "menu.find.findInDirectory", defaultValue: "Find in Directory…")
             case .findNext: return String(localized: "menu.find.findNext", defaultValue: "Find Next")
             case .findPrevious: return String(localized: "menu.find.findPrevious", defaultValue: "Find Previous")
             case .hideFind: return String(localized: "menu.find.hideFindBar", defaultValue: "Hide Find Bar")
@@ -311,12 +313,14 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "0", command: true, shift: false, option: false, control: false)
             case .find:
                 return StoredShortcut(key: "f", command: true, shift: false, option: false, control: false)
+            case .findInDirectory:
+                return StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
             case .findNext:
                 return StoredShortcut(key: "g", command: true, shift: false, option: false, control: false)
             case .findPrevious:
                 return StoredShortcut(key: "g", command: true, shift: false, option: true, control: false)
             case .hideFind:
-                return StoredShortcut(key: "f", command: true, shift: true, option: false, control: false)
+                return StoredShortcut(key: "f", command: true, shift: true, option: true, control: false)
             case .useSelectionForFind:
                 return StoredShortcut(key: "e", command: true, shift: false, option: false, control: false)
             case .toggleBrowserDeveloperTools:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -551,6 +551,12 @@ struct cmuxApp: App {
                         )
                     }
 
+                    splitCommandButton(title: String(localized: "menu.find.findInDirectory", defaultValue: "Find in Directory…"), shortcut: menuShortcut(for: .findInDirectory)) {
+                        _ = AppDelegate.shared?.focusFileSearchInActiveMainWindow(
+                            preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
+                        )
+                    }
+
                     splitCommandButton(title: String(localized: "menu.find.findNext", defaultValue: "Find Next"), shortcut: menuShortcut(for: .findNext)) {
                         restoreFindTargetFocus()
                         activeTabManager.findNext()

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -569,6 +569,7 @@
               "browserZoomOut",
               "browserZoomReset",
               "find",
+              "findInDirectory",
               "findNext",
               "findPrevious",
               "hideFind",

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -154,9 +154,10 @@ export const shortcutCategories: ShortcutCategory[] = [
     titleKey: "find",
     shortcuts: [
       { id: "find", combos: [["⌘", "F"]], description: { en: "Find", ja: "検索" } },
+      { id: "findInDirectory", combos: [["⌘", "⇧", "F"]], description: { en: "Find in directory", ja: "ディレクトリ内を検索" } },
       { id: "findNext", combos: [["⌘", "G"]], description: { en: "Find next", ja: "次を検索" } },
       { id: "findPrevious", combos: [["⌥", "⌘", "G"]], description: { en: "Find previous", ja: "前を検索" } },
-      { id: "hideFind", combos: [["⌘", "⇧", "F"]], description: { en: "Hide find bar", ja: "検索バーを隠す" } },
+      { id: "hideFind", combos: [["⌥", "⌘", "⇧", "F"]], description: { en: "Hide find bar", ja: "検索バーを隠す" } },
       { id: "useSelectionForFind", combos: [["⌘", "E"]], description: { en: "Use selection for find", ja: "選択範囲で検索" } },
     ],
   },


### PR DESCRIPTION
Adds a configurable Find in Directory shortcut for the right sidebar.

Includes cached rg-backed results per root/query, default rg ignore behavior, an rg-not-installed message, cmux file preview opening from results, contextual result actions, drag support, and wider file explorer rows.

Verification:
- ./scripts/reload.sh --tag fdir
- Dogfooded tagged app via /tmp/cmux-debug-fdir.sock: Cmd+Shift+F from terminal focus opened right-sidebar Find, search returned results, Return opened the selected result in cmux preview.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a configurable “Find in Directory” shortcut (Cmd+Shift+F) that opens right‑sidebar search powered by `ripgrep`, with cached results and richer result actions. External file URLs now open in a cmux preview, and file explorer rows show more content.

- **New Features**
  - Cmd+Shift+F focuses “Find in Directory”; added menu item and command palette entry with “Right Sidebar” subtitle.
  - Search uses `ripgrep` with default ignore behavior, caches results per root/query, and shows an `rg`‑not‑installed message when needed.
  - Results support Return/double‑click to open in cmux preview, context menu actions (open in cmux/default, reveal in Finder, copy path/relative path), keyboard navigation, and drag‑to‑open.
  - Opening a file URL from outside the app now opens a preview in the preferred main window; file explorer layout shows more content.

- **Migration**
  - Ensure `ripgrep` (`rg`) is installed and on PATH to use directory search.
  - “Hide Find Bar” is now Opt+Cmd+Shift+F (was Cmd+Shift+F).

<sup>Written for commit 6ae8ec73f582b611507a97e42fe7534a28b32f3d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3208?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

