### PR TITLE
Pin Cloud VM smoke workflow checkout

### DIFF
--- a/.github/workflows/cloud-vm-smoke.yml
+++ b/.github/workflows/cloud-vm-smoke.yml
@@ -53,6 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
+          # Smoke secrets must only run trusted main code.
           ref: refs/heads/main
 
       - name: Setup Bun

--- a/.github/workflows/cloud-vm-smoke.yml
+++ b/.github/workflows/cloud-vm-smoke.yml
@@ -3,10 +3,6 @@ name: Cloud VM smoke
 on:
   workflow_dispatch:
     inputs:
-      ref:
-        description: Branch or SHA containing smoke script
-        required: false
-        default: ""
       target:
         description: Smoke target
         required: true
@@ -57,7 +53,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
-          ref: ${{ inputs.ref || github.ref }}
+          ref: refs/heads/main
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3 # v2


### PR DESCRIPTION
## Summary
- remove the manual ref input from the Cloud VM smoke workflow
- pin the privileged smoke checkout to refs/heads/main so Stack smoke secrets only run trusted main code

## Verification
- ruby YAML parse for .github/workflows/cloud-vm-smoke.yml
- git diff --check
- workflow guard scripts except GhosttyKit archive verification, which fails locally on macOS due an unrelated AppleDouble archive entry while main CI already passes it on Ubuntu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized the smoke testing workflow to always run against the main branch, removing the manual branch/commit selection input.
  * Simplified checkout behavior in automation so smoke runs consistently target main, reducing configuration options and potential selection errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->