### PR TITLE
Harden Cloud VM create limits

### DIFF
--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -131,6 +131,15 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
             }
 
             await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${input.billingTeamId}, 0))`);
+            if (idempotencyKey) {
+              const [existing] = await tx
+                .select()
+                .from(cloudVms)
+                .where(and(eq(cloudVms.userId, input.userId), eq(cloudVms.idempotencyKey, idempotencyKey)))
+                .limit(1);
+              if (existing) return { inserted: false as const, vm: existing };
+            }
+
             const [active] = await tx
               .select({ total: count() })
               .from(cloudVms)

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -18,6 +18,9 @@ const VM_ENV_KEYS = [
   "CMUX_VM_ALLOW_UNMANIFESTED_IMAGES",
   "E2B_CMUXD_WS_TEMPLATE",
   "FREESTYLE_SANDBOX_SNAPSHOT",
+  "CMUX_VM_FREE_MAX_ACTIVE_VMS",
+  "CMUX_VM_PAID_MAX_ACTIVE_VMS",
+  "CMUX_VM_PLAN_PRO_MAX_ACTIVE_VMS",
   "VERCEL",
   "VERCEL_ENV",
 ] as const;
@@ -156,6 +159,33 @@ describe("VM REST auth", () => {
       idempotencyKey: "idem-1",
     });
     expect(runVmWorkflow).toHaveBeenCalled();
+  });
+
+  test("passes configured plan active VM limits into the create workflow", async () => {
+    process.env.CMUX_VM_PLAN_PRO_MAX_ACTIVE_VMS = "25";
+    getUser.mockResolvedValue(authedStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-plan-limit",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      billingTeamId: "team-1",
+      billingPlanId: "pro",
+      maxActiveVms: 25,
+    }));
   });
 
   test("blocks authenticated cookie mutations from cross-site origins before workflow", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -12,6 +12,7 @@ import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/
 import { VmRepositoryLive } from "../services/vms/repository";
 import {
   VmCreateCreditsInsufficientError,
+  VmCreateInProgressError,
   VmLimitExceededError,
   VmNotFoundError,
 } from "../services/vms/errors";
@@ -224,6 +225,88 @@ describe("VM Effect workflows", () => {
 
     expect(error).toBeInstanceOf(VmLimitExceededError);
     expect(createCalls).toBe(0);
+  });
+
+  dbTest("returns in-progress for concurrent same-key creates before active limit checks", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+
+    let createCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () =>
+        Effect.sync(() => {
+          createCalls += 1;
+          return {
+            provider: "e2b" as const,
+            providerVmId: "provider-vm-concurrent-idem",
+            status: "running" as const,
+            image: "cmuxd-ws:test",
+            createdAt: Date.now(),
+          };
+        }),
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+    const layer = providerLayer(provider);
+    const input = {
+      userId: "user-workflow-concurrent-idem",
+      billingCustomerType: "team" as const,
+      billingTeamId: "team-workflow-concurrent-idem",
+      billingPlanId: "free",
+      maxActiveVms: 1,
+      provider: "e2b" as const,
+      image: "cmuxd-ws:test",
+      idempotencyKey: "concurrent-idem-1",
+    };
+    const locker = postgres(databaseURL(), { max: 1 });
+    let retry: Promise<unknown> | null = null;
+    try {
+      await locker.begin(async (tx) => {
+        await tx`select pg_advisory_xact_lock(hashtextextended(${input.billingTeamId}, 0))`;
+        await tx`
+          insert into cloud_vms (
+            user_id,
+            billing_team_id,
+            billing_plan_id,
+            provider,
+            image_id,
+            status,
+            idempotency_key
+          )
+          values (
+            ${input.userId},
+            ${input.billingTeamId},
+            ${input.billingPlanId},
+            ${input.provider},
+            ${input.image},
+            'provisioning',
+            ${input.idempotencyKey}
+          )
+        `;
+        retry = Effect.runPromise(
+          createVm(input).pipe(
+            Effect.flip,
+            Effect.provide(layer),
+          ),
+        );
+        await waitForBlockedAdvisoryLock(sql);
+      });
+    } finally {
+      await locker.end();
+    }
+    const secondError = await retry;
+
+    expect(secondError).toBeInstanceOf(VmCreateInProgressError);
+    expect(createCalls).toBe(0);
+
+    const [{ vmCount }] = await sql<{ vmCount: string }[]>`
+      select count(*)::text as "vmCount" from cloud_vms
+      where user_id = 'user-workflow-concurrent-idem'
+    `;
+    expect(vmCount).toBe("1");
   });
 
   dbTest("reserves Stack Auth credits only once per new idempotency key", async () => {
@@ -554,3 +637,16 @@ describe("VM Effect workflows", () => {
     ]);
   });
 });
+
+async function waitForBlockedAdvisoryLock(sql: Sql): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    const [{ blocked }] = await sql<{ blocked: string }[]>`
+      select count(*)::text as "blocked"
+      from pg_locks
+      where locktype = 'advisory' and not granted
+    `;
+    if (Number(blocked) > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("timed out waiting for blocked advisory lock");
+}

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -229,6 +229,7 @@ describe("VM Effect workflows", () => {
 
   dbTest("returns in-progress for concurrent same-key creates before active limit checks", async () => {
     if (!sql) throw new Error("test database not initialized");
+    const testSql = sql;
     await sql`truncate cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
 
     let createCalls = 0;
@@ -292,7 +293,7 @@ describe("VM Effect workflows", () => {
             Effect.provide(layer),
           ),
         );
-        await waitForBlockedAdvisoryLock(sql);
+        await waitForBlockedAdvisoryLock(testSql, input.billingTeamId);
       });
     } finally {
       await locker.end();
@@ -307,6 +308,69 @@ describe("VM Effect workflows", () => {
       where user_id = 'user-workflow-concurrent-idem'
     `;
     expect(vmCount).toBe("1");
+  });
+
+  dbTest("allows a new create after destroy releases the active team slot", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    await sql`
+      insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, provider_vm_id, image_id, status)
+      values ('user-workflow-reuse-slot', 'team-workflow-reuse-slot', 'free', 'e2b', 'provider-vm-reuse-old', 'cmuxd-ws:test', 'running')
+    `;
+
+    let createCalls = 0;
+    let destroyCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () =>
+        Effect.sync(() => {
+          createCalls += 1;
+          return {
+            provider: "e2b" as const,
+            providerVmId: "provider-vm-reuse-new",
+            status: "running" as const,
+            image: "cmuxd-ws:test",
+            createdAt: Date.now(),
+          };
+        }),
+      destroy: () =>
+        Effect.sync(() => {
+          destroyCalls += 1;
+        }),
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+    const layer = providerLayer(provider);
+
+    await Effect.runPromise(
+      destroyVm({ userId: "user-workflow-reuse-slot", providerVmId: "provider-vm-reuse-old" }).pipe(
+        Effect.provide(layer),
+      ),
+    );
+    const created = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-reuse-slot",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-reuse-slot",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "e2b",
+        image: "cmuxd-ws:test",
+        idempotencyKey: "reuse-slot-new",
+      }).pipe(Effect.provide(layer)),
+    );
+
+    expect(created.providerVmId).toBe("provider-vm-reuse-new");
+    expect(destroyCalls).toBe(1);
+    expect(createCalls).toBe(1);
+
+    const [{ runningCount }] = await sql<{ runningCount: string }[]>`
+      select count(*)::text as "runningCount"
+      from cloud_vms
+      where billing_team_id = 'team-workflow-reuse-slot' and status = 'running'
+    `;
+    expect(runningCount).toBe("1");
   });
 
   dbTest("reserves Stack Auth credits only once per new idempotency key", async () => {
@@ -638,12 +702,20 @@ describe("VM Effect workflows", () => {
   });
 });
 
-async function waitForBlockedAdvisoryLock(sql: Sql): Promise<void> {
+async function waitForBlockedAdvisoryLock(sql: Sql, billingTeamId: string): Promise<void> {
   for (let attempt = 0; attempt < 100; attempt += 1) {
     const [{ blocked }] = await sql<{ blocked: string }[]>`
+      with target as (
+        select
+          (((hashtextextended(${billingTeamId}, 0) >> 32) & 4294967295)::bigint)::oid as classid,
+          ((hashtextextended(${billingTeamId}, 0) & 4294967295)::bigint)::oid as objid
+      )
       select count(*)::text as "blocked"
-      from pg_locks
-      where locktype = 'advisory' and not granted
+      from pg_locks l
+      join target t on l.classid = t.classid and l.objid = t.objid
+      where l.locktype = 'advisory'
+        and l.objsubid = 1
+        and not l.granted
     `;
     if (Number(blocked) > 0) return;
     await new Promise((resolve) => setTimeout(resolve, 10));


### PR DESCRIPTION
## Summary
- preserve idempotent VM create retries when a concurrent request is blocked behind the billing-team active-limit lock
- add DB-backed provider mock coverage for the race and for destroy releasing an active VM slot
- add route coverage proving configured plan limits reach the create workflow

## Verification
- First commit intentionally fails `bun run db:test` with `VmLimitExceededError` for the concurrent same-key retry case
- `bun run cloud-vm:preflight -- .`
- `bun test tests/vm-route-auth.test.ts`

## Notes
- No schema migration required
- No app reload required, backend web-only change


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * VM active limits enforced per billing plan (Pro: 25 max)

* **Bug Fixes**
  * Stronger idempotency guard during VM creation to avoid duplicate VMs on concurrent retries
  * Prevented duplicate provider calls and ensured single persisted VM under concurrent creates
  * Restored VM slot availability after deletion for subsequent creates

* **Tests**
  * Added tests for idempotency, concurrency, slot reuse, and env-var parsing for limits
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves idempotent VM create retries under team active-VM locks by checking the `idempotencyKey` inside the advisory-locked transaction and returning the existing VM, or `VmCreateInProgressError` if still provisioning, before provider calls and limit checks. Adds DB-backed tests for the concurrent same-key race, verifies destroy frees a team slot for a new create, and confirms plan-based max active VM limits from env reach the create workflow.

<sup>Written for commit f50b6b7851bd2f8763198b461a4258c1bb2a5a67. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3219?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

