### PR TITLE
`claude` wrapper mktemp template fails on BSD (macOS) — "File exists" with concurrent tab launches

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -97,7 +97,7 @@ ensure_node_options_restore_module() {
     local guard_path="$guard_dir/restore-node-options.cjs"
     mkdir -p "$guard_dir" || return 1
     local temp_path
-    temp_path="$(mktemp "$guard_dir/restore-node-options.cjs.XXXXXX")" || return 1
+    temp_path="$(mktemp "$guard_dir/restore-node-options.XXXXXX")" || return 1
     cat >"$temp_path" <<'EOF'
 const hadOriginalNodeOptions = process.env.CMUX_ORIGINAL_NODE_OPTIONS_PRESENT === "1";
 if (hadOriginalNodeOptions) {


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3064

Generated by cmux-loader.

Codex final message:

Implemented.

- Updated the `claude` wrapper template in:
  - [Resources/bin/claude](/Users/runner/work/cmux-loader/cmux-loader/cmux/Resources/bin/claude)

Change made:
- In `ensure_node_options_restore_module`, changed mktemp template from:
  - `"$guard_dir/restore-node-options.cjs.XXXXXX"`
  - to `"$guard_dir/restore-node-options.XXXXXX"`
- This keeps the template compliant with BSD `mktemp` (trailing `XXXXXX` requirement) and avoids literal filename collisions under concurrent tab starts.

Verification performed:
- Attempted required build command:
  - `./scripts/reload.sh --tag loader`
  - Result: failed in this environment because `zig` is not installed (`Error: zig is not installed. Install via: brew install zig`).
- Performed direct shell compatibility check for the corrected mktemp form:
  - `mktemp "${TMPDIR:-/tmp}/cmux-claude-node-options/restore-node-options.XXXXXX"` three times in a row produced three unique paths, confirming no collision behavior.

No PR was opened in this session because local environment lacks the required network/auth setup for GitHub operations (and `zig` also prevented the required reload build step from completing). Full issue URL for tracking: https://github.com/manaflow-ai/cmux/issues/3064

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes “File exists” errors on macOS when multiple tabs launch the `claude` wrapper by switching to a BSD‑compatible `mktemp` template, ensuring unique temp files.

- **Bug Fixes**
  - In `Resources/bin/claude`, changed `mktemp "$guard_dir/restore-node-options.cjs.XXXXXX"` to `mktemp "$guard_dir/restore-node-options.XXXXXX"` to satisfy BSD’s trailing `XXXXXX` rule and avoid literal filename collisions.

<sup>Written for commit ef8dc5b1ed1d5e78b618d405f8c87220cfb7fdba. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3227?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized temporary file naming in the wrapper's internal module restoration process for improved compatibility and cleaner file handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->