### PR TITLE
`__tmux-compat`: short tmux format codes (#S, #I, #W, ...) are not substituted, breaking `cmux omc`

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,7 +1,7 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-18705	CLI/cmux.swift
+18716	CLI/cmux.swift
 16364	Sources/TerminalController.swift
 15762	Sources/ContentView.swift
 13748	Sources/AppDelegate.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11560,6 +11560,17 @@ struct CMUXCLI {
         for (key, value) in context {
             rendered = rendered.replacingOccurrences(of: "#{\(key)}", with: value)
         }
+        let shortAliases: [String: String] = [
+            "S": "session_name",
+            "I": "window_index",
+            "W": "window_name",
+            "P": "pane_index",
+            "T": "pane_title",
+            "D": "pane_id",
+        ]
+        for (shortAlias, key) in shortAliases where context.keys.contains(key) {
+            rendered = rendered.replacingOccurrences(of: "#\(shortAlias)", with: context[key] ?? "")
+        }
         rendered = rendered.replacingOccurrences(
             of: "#\\{[^}]+\\}",
             with: "",

--- a/tests_v2/test_tmux_compat_geometry.py
+++ b/tests_v2/test_tmux_compat_geometry.py
@@ -158,6 +158,27 @@ def test_display_geometry_format(cli: str) -> None:
     print("PASS")
 
 
+def test_display_short_format_aliases(cli: str) -> None:
+    """Short tmux format aliases match long-form output."""
+    print("  test_display_short_format_aliases ... ", end="", flush=True)
+    long_form = _run_tmux_compat(cli, ["display", "-p", "#{session_name}:#{window_index}:#{window_name}"])
+    _must(long_form.returncode == 0, f"display with long-form failed: {long_form.stderr}")
+    long_output = long_form.stdout.strip()
+    _must(long_output, f"Expected long-form output, got empty: {long_form.stdout!r}")
+
+    short_form = _run_tmux_compat(cli, ["display", "-p", "#S:#I:#W"])
+    _must(short_form.returncode == 0, f"display with short-form failed: {short_form.stderr}")
+    short_output = short_form.stdout.strip()
+    _must(short_output == long_output, f"Short-form output mismatch: short={short_output!r} long={long_output!r}")
+
+    paneid_form = _run_tmux_compat(cli, ["display", "-p", "#S:#I %<paneid>"])
+    _must(paneid_form.returncode == 0, f"display with paneid token failed: {paneid_form.stderr}")
+    paneid_output = paneid_form.stdout.strip()
+    _must(long_output.split(":")[0] in paneid_output and long_output.split(":")[1] in paneid_output, f"paneid form should include expanded short fields: {paneid_output!r}")
+    _must("%<paneid>" in paneid_output, f"Expected literal %<paneid> to remain: {paneid_output!r}")
+    print("PASS")
+
+
 def test_multi_pane_geometry(cli: str, c: cmux) -> None:
     """After splitting, two panes have different pane_left values and halved widths."""
     print("  test_multi_pane_geometry ... ", end="", flush=True)
@@ -222,6 +243,7 @@ def main() -> int:
             ("test_list_panes_geometry_format", lambda: test_list_panes_geometry_format(cli)),
             ("test_list_panes_pane_target", lambda: test_list_panes_pane_target(cli, c)),
             ("test_display_geometry_format", lambda: test_display_geometry_format(cli)),
+            ("test_display_short_format_aliases", lambda: test_display_short_format_aliases(cli)),
             ("test_multi_pane_geometry", lambda: test_multi_pane_geometry(cli, c)),
         ]
 


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3190

Generated by cmux-loader.

Codex final message:

Done.

### Summary
1. Implemented minimal `__tmux-compat` format substitution support for short tmux aliases in `tmuxRenderFormat` by mapping short codes to existing long-form context keys before fallback cleanup:
   - `#S -> session_name`
   - `#I -> window_index`
   - `#W -> window_name`
   - `#P -> pane_index`
   - `#T -> pane_title`
   - `#D -> pane_id`
   - File: [CLI/cmux.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/CLI/cmux.swift)

2. Added a behavior-level regression test that validates short-form rendering:
   - compares `#S:#I:#W` against `#{session_name}:#{window_index}:#{window_name}` output
   - ensures `%<paneid>` remains literal in mixed format usage
   - File: [tests_v2/test_tmux_compat_geometry.py](/Users/runner/work/cmux-loader/cmux-loader/cmux/tests_v2/test_tmux_compat_geometry.py)

### Verification performed
- Required tagged reload attempted: `./scripts/reload --tag loader`
- Result: failed immediately in this environment with:
  - `Error: zig is not installed. Install via: brew install zig`
- No runtime tests were executed in this session due the environment limitation and the local policy of not running test suites unless explicitly requested.

### PR URL
No PR was opened from this environment because GitHub CLI access requires authentication (`GH_TOKEN`) and it is not set here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable short tmux format aliases in `__tmux-compat` so `#S`, `#I`, `#W`, and others render correctly, fixing broken `cmux omc` output. Fixes #3190 and refreshes the Swift file length budget.

- **Bug Fixes**
  - Map short aliases in `tmuxRenderFormat`: `#S→session_name`, `#I→window_index`, `#W→window_name`, `#P→pane_index`, `#T→pane_title`, `#D→pane_id`.
  - Add regression test comparing `#S:#I:#W` to long-form and keeping `%<paneid>` literal.

<sup>Written for commit 7c793c9b46240f4ca6a9029f952fec771ab724d4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3228?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for shorthand format string placeholders for enhanced tmux compatibility.

* **Tests**
  * Added comprehensive tests for format string rendering and placeholder handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->