### PR TITLE
Release build fails without CMUX_SKIP_ZIG_BUILD=1 on macOS 26.4.1

### DIFF
--- a/scripts/build-ghostty-cli-helper.sh
+++ b/scripts/build-ghostty-cli-helper.sh
@@ -16,6 +16,31 @@ EOF
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 GHOSTTY_DIR="$REPO_ROOT/ghostty"
+AUTO_SKIP_ZIG_BUILD_REASON=""
+
+should_skip_zig_build() {
+  if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
+    AUTO_SKIP_ZIG_BUILD_REASON="CMUX_SKIP_ZIG_BUILD=1"
+    return 0
+  fi
+
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    return 1
+  fi
+
+  local product_version zig_version major_version
+  product_version="$(sw_vers -productVersion 2>/dev/null || true)"
+  zig_version="$(zig version 2>/dev/null || true)"
+  major_version="${product_version%%.*}"
+
+  if [[ "$zig_version" == "0.15.2" ]] && [[ "$major_version" =~ ^[0-9]+$ ]] && (( major_version >= 26 )); then
+    AUTO_SKIP_ZIG_BUILD_REASON="macOS ${product_version} + zig ${zig_version}"
+    return 0
+  fi
+
+  AUTO_SKIP_ZIG_BUILD_REASON=""
+  return 1
+}
 
 OUTPUT_PATH=""
 TARGET_TRIPLE=""
@@ -55,8 +80,8 @@ fi
 
 # Allow CI to skip the zig build (e.g., macOS 26 where zig 0.15.2 can't link).
 # Creates a stub binary so the Xcode Run Script file-existence check passes.
-if [[ "${CMUX_SKIP_ZIG_BUILD:-}" == "1" ]]; then
-  echo "Skipping zig CLI helper build (CMUX_SKIP_ZIG_BUILD=1)"
+if should_skip_zig_build; then
+  echo "Skipping zig CLI helper build (${AUTO_SKIP_ZIG_BUILD_REASON})"
   mkdir -p "$(dirname "$OUTPUT_PATH")"
   printf '#!/bin/sh\necho "ghostty CLI helper stub (zig build skipped)" >&2\nexit 1\n' > "$OUTPUT_PATH"
   chmod +x "$OUTPUT_PATH"


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3047

Generated by cmux-loader.

Codex final message:

Implemented.

### Summary
- Updated [`scripts/build-ghostty-cli-helper.sh`](/Users/runner/work/cmux-loader/cmux-loader/cmux/scripts/build-ghostty-cli-helper.sh) to auto-skip Zig CLI helper compilation in the same problematic environment that `reload.sh` already detects:
  - Honors explicit `CMUX_SKIP_ZIG_BUILD=1`.
  - Auto-detects macOS + `zig 0.15.2` on macOS 26+ and skips with a stub, preventing the undefined-symbol linker failure path in direct `xcodebuild` runs.
- The existing `CMUX_SKIP_ZIG_BUILD=1` behavior is unchanged; this just makes it self-contained in the helper script so direct `xcodebuild` paths also benefit without caller-side env setup.

### Verification
- Ran required tagged build command:
  - `./scripts/reload.sh --tag loader`
  - Result: failed quickly due environment limitation (`Error: zig is not installed.`), so full reload compile could not be completed here.
- Ran helper fallback path check (works without Zig):
  - `CMUX_SKIP_ZIG_BUILD=1 ./scripts/build-ghostty-cli-helper.sh --output /tmp/ghostty-helper-stub-test`
  - Output confirmed skip path and produced executable stub successfully.

### PR URL
- Not opened in this environment. If you want, I can create/update the PR and provide the GitHub URL next.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-skip the Ghostty CLI helper Zig build on macOS 26+ with zig 0.15.2 and emit a stub so `xcodebuild` release builds no longer fail when `CMUX_SKIP_ZIG_BUILD=1` isn’t set. Logic is now in `scripts/build-ghostty-cli-helper.sh` to cover direct `xcodebuild` paths.

- **Bug Fixes**
  - Detects macOS 26+ with `zig 0.15.2` and skips the helper build with a stub, printing the reason.
  - Continues to honor `CMUX_SKIP_ZIG_BUILD=1` explicitly.

<sup>Written for commit 0949a5a55316ce16aa00ce49ffd495b135e1f9ed. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3229?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

