### PR TITLE
cmux.json: named color strings silently reject entire config file

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -9,7 +9,7 @@
 13208	Sources/GhosttyTerminalView.swift
 10549	Sources/Panels/BrowserPanel.swift
 8419	Sources/cmuxApp.swift
-7490	Sources/TabManager.swift
+7508	Sources/TabManager.swift
 6811	Sources/Panels/BrowserPanelView.swift
 5139	cmuxTests/AppDelegateShortcutRoutingTests.swift
 4641	cmuxTests/WorkspaceUnitTests.swift

--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -1606,14 +1606,14 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
         layout = try container.decodeIfPresent(CmuxLayoutNode.self, forKey: .layout)
 
         if let rawColor = try container.decodeIfPresent(String.self, forKey: .color) {
-            guard let normalized = WorkspaceTabColorSettings.normalizedHex(rawColor) else {
+            guard let resolved = WorkspaceTabColorSettings.resolvedWorkspaceColorHex(rawColor) else {
                 throw DecodingError.dataCorruptedError(
                     forKey: .color,
                     in: container,
-                    debugDescription: "Invalid color \"\(rawColor)\". Expected 6-digit hex format: #RRGGBB"
+                    debugDescription: "Invalid color \"\(rawColor)\". Expected #RRGGBB or a known workspace color name."
                 )
             }
-            color = normalized
+            color = resolved
         } else {
             color = nil
         }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -365,6 +365,24 @@ enum WorkspaceTabColorSettings {
         return "#" + body.uppercased()
     }
 
+    static func resolvedWorkspaceColorHex(_ raw: String, defaults: UserDefaults = .standard) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        if let normalizedHex = normalizedHex(trimmed) {
+            return normalizedHex
+        }
+
+        let palette = effectivePaletteMap(defaults: defaults)
+        if let exactMatch = palette[trimmed] {
+            return exactMatch
+        }
+
+        return palette.first {
+            $0.key.caseInsensitiveCompare(trimmed) == .orderedSame
+        }?.value
+    }
+
     static func displayColor(
         hex: String,
         colorScheme: ColorScheme,


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3075

Generated by cmux-loader.

Codex final message:

Implemented a narrow config-parser fix for issue #3075.

### What changed

1. Added palette-aware color resolution for workspace `color` fields in `cmux.json`:
   - New helper resolves:
     - `#RRGGBB` (or `RRGGBB`) hex colors.
     - Named colors from the effective workspace palette (including user-defined custom colors), case-insensitive.
   - File: [Sources/TabManager.swift](file:///Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/TabManager.swift)

2. Updated command workspace decoding to use that resolver instead of strict hex-only parsing:
   - `cmux.json` workspace `color` now accepts named colors like `"Indigo"`/`"Navy"` and still rejects unknown values with a clearer message.
   - File: [Sources/CmuxConfig.swift](file:///Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/CmuxConfig.swift)

### Verification performed

- Ran required tagged build command:
  - `./scripts/reload.sh --tag loader`
- Result: failed immediately due environment dependency:
  - `Error: zig is not installed. Install via: brew install zig`

No tests were run (per instruction to avoid local tests unless explicitly requested).

### PR status

- No pull request was opened in this session (environment-limited).  
- PR URL: not opened.

If you want, I can next:
1. Open a PR with these changes once you confirm branch/remote access.
2. Add a tiny regression check to ensure named colors in `cmux.json` decode successfully.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3075 where named color strings in `cmux.json` caused the workspace to reject the entire config. The parser now accepts `#RRGGBB` hex and palette color names (case-insensitive), and returns a clear error for unknown colors.

- **Bug Fixes**
  - Added a palette-aware resolver for workspace `color` that supports hex and named colors, including user-defined palette entries.
  - Updated workspace decoding to use the resolver and improved the error message to specify allowed formats.

<sup>Written for commit dfd3d457b12eb696b0373db158c0f2a5c4ef1f4e. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3230?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workspace tab colors now accept both hex color codes (#RRGGBB format) and predefined workspace color names, providing more flexible customization options when configuring workspaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->