### PR TITLE
Cmd+Shift+[ triggers nextSurface instead of prevSurface (regression likely from #2528)

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -21,7 +21,7 @@
 3128	cmuxTests/BrowserPanelTests.swift
 3126	cmuxTests/WorkspaceRemoteConnectionTests.swift
 2850	Sources/CmuxConfig.swift
-2675	Sources/KeyboardShortcutSettings.swift
+2681	Sources/KeyboardShortcutSettings.swift
 2491	Sources/Panels/CmuxWebView.swift
 2292	cmuxTests/TabManagerUnitTests.swift
 2153	cmuxTests/SessionPersistenceTests.swift

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1375,6 +1375,12 @@ struct ShortcutStroke: Equatable, Hashable {
         guard flags == self.modifierFlags else { return false }
 
         let shortcutKey = key.lowercased()
+        if flags.contains(.command) || flags.contains(.control) || flags.contains(.option) {
+            if let expectedKeyCode = self.keyCode ?? Self.keyCodeForShortcutKey(shortcutKey) {
+                return keyCode == expectedKeyCode
+            }
+        }
+
         if Self.usesDirectKeyCodeMatching(shortcutKey) {
             guard let expectedKeyCode = self.keyCode ?? Self.keyCodeForShortcutKey(shortcutKey) else {
                 return false


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3061

Generated by cmux-loader.

Codex final message:

Implemented a narrow fix for #3061.

### What I changed

- Updated `KeyboardShortcutSettings.swift`:
  - In `ShortcutStroke.matches(keyCode:modifierFlags:eventCharacter:)`, added a physical-key precedence for modified shortcuts:
    - For shortcuts with `command`, `control`, or `option` modifiers, matching now requires `event.keyCode` to equal the resolved shortcut keycode (from stored `keyCode` or `keyCodeForShortcutKey`) before falling back to character-based matching.
    - This prevents shifted bracket aliases from resolving both `Cmd+Shift+]` / `Cmd+Shift+[` to the same logical shortcut.
- File changed:
  - [`Sources/KeyboardShortcutSettings.swift`](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/KeyboardShortcutSettings.swift)

### Verification performed

- Ran required tagged reload:
  - `./scripts/reload.sh --tag loader`
- Result:
  - Build script failed before compile due missing Zig:
    - `Error: zig is not installed. Install via: brew install zig`
  - So I could not complete an app build/launch verification in this environment.
  - No local tests were run (per local testing policy).

### PR status

- No PR was opened yet from this environment.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a keyboard shortcut regression so `Cmd+Shift+[` triggers prevSurface and `Cmd+Shift+]` triggers nextSurface as expected. Addresses #3061 by prioritizing physical key matching for modified shortcuts.

- **Bug Fixes**
  - In `ShortcutStroke.matches`, when `command`/`control`/`option` is pressed, require `event.keyCode` to match the shortcut’s key code before any character-based matching. This prevents shifted bracket aliases from mapping to the same action.
  - Updated `Sources/KeyboardShortcutSettings.swift`.

- **Refactors**
  - Refreshed `.github/swift-file-length-budget.tsv` to reflect the updated size of `Sources/KeyboardShortcutSettings.swift`.

<sup>Written for commit e816a5447338f03ff72a70174b5b8d6197092a97. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3231?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut detection reliability for shortcuts that include Command, Control, or Option modifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->