### PR TITLE
Add setting to hide sidebar by default on new windows

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -8,7 +8,7 @@
 13702	Sources/Workspace.swift
 13208	Sources/GhosttyTerminalView.swift
 10549	Sources/Panels/BrowserPanel.swift
-8419	Sources/cmuxApp.swift
+8461	Sources/cmuxApp.swift
 7490	Sources/TabManager.swift
 6811	Sources/Panels/BrowserPanelView.swift
 5139	cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -32,8 +32,8 @@
 1879	Sources/SessionIndexStore.swift
 1735	Sources/SessionIndexView.swift
 1692	cmuxTests/CmuxConfigTests.swift
+1680	Sources/KeyboardShortcutSettingsFileStore.swift
 1677	cmuxTests/ShortcutAndCommandPaletteTests.swift
-1676	Sources/KeyboardShortcutSettingsFileStore.swift
 1563	cmuxTests/WindowAndDragTests.swift
 1517	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1502	Sources/Update/UpdateTitlebarAccessory.swift

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -51514,6 +51514,57 @@
         }
       }
     },
+    "settings.app.hideSidebarOnNewWindow": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hide Sidebar on New Window"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいウィンドウでサイドバーを非表示にする"
+          }
+        }
+      }
+    },
+    "settings.app.hideSidebarOnNewWindow.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New windows keep the sidebar visible by default."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいウィンドウはデフォルトでサイドバーを表示したまま開きます。"
+          }
+        }
+      }
+    },
+    "settings.app.hideSidebarOnNewWindow.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New windows start with the sidebar hidden. Toggle Cmd+B to show it."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいウィンドウはサイドバーを非表示で開始します。Cmd+B で表示できます。"
+          }
+        }
+      }
+    },
     "settings.app.paneFirstClickFocus": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6257,7 +6257,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .map(SessionPersistencePolicy.sanitizedSidebarWidth)
             ?? SessionPersistencePolicy.defaultSidebarWidth
         let sidebarState = SidebarState(
-            isVisible: sessionWindowSnapshot?.sidebar.isVisible ?? true,
+            isVisible: sessionWindowSnapshot?.sidebar.isVisible ?? !HideSidebarOnNewWindowSettings.hideSidebarOnNewWindow(),
             persistedWidth: CGFloat(sidebarWidth)
         )
         let sidebarSelectionState = SidebarSelectionState(

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -416,6 +416,9 @@ final class CmuxSettingsFileStore {
         if let value = jsonBool(section["focusPaneOnFirstClick"]) {
             snapshot.managedUserDefaults[PaneFirstClickFocusSettings.enabledKey] = .bool(value)
         }
+        if let value = jsonBool(section["hideSidebarOnNewWindow"]) {
+            snapshot.managedUserDefaults[HideSidebarOnNewWindowSettings.key] = .bool(value)
+        }
         if let value = jsonString(section["preferredEditor"]) {
             snapshot.managedUserDefaults[PreferredEditorSettings.key] = .string(value)
         }
@@ -1223,6 +1226,7 @@ final class CmuxSettingsFileStore {
                     "newWorkspacePlacement": WorkspacePlacementSettings.defaultPlacement.rawValue,
                     "minimalMode": false,
                     "keepWorkspaceOpenWhenClosingLastSurface": !LastSurfaceCloseShortcutSettings.defaultValue,
+                    "hideSidebarOnNewWindow": HideSidebarOnNewWindowSettings.defaultValue,
                     "focusPaneOnFirstClick": PaneFirstClickFocusSettings.defaultEnabled,
                     "preferredEditor": "",
                     "openMarkdownInCmuxViewer": CmdClickMarkdownRouteSettings.defaultValue,

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5060,6 +5060,18 @@ enum CmdClickMarkdownRouteSettings {
     }
 }
 
+enum HideSidebarOnNewWindowSettings {
+    static let key = "hideSidebarOnNewWindow"
+    static let defaultValue = false
+
+    static func hideSidebarOnNewWindow(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: key) == nil {
+            return defaultValue
+        }
+        return defaults.bool(forKey: key)
+    }
+}
+
 enum PreferredEditorSettings {
     static let key = "preferredEditorCommand"
 
@@ -5333,6 +5345,8 @@ struct SettingsView: View {
     private var closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
     @AppStorage(PaneFirstClickFocusSettings.enabledKey)
     private var paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+    @AppStorage(HideSidebarOnNewWindowSettings.key)
+    private var hideSidebarOnNewWindow = HideSidebarOnNewWindowSettings.defaultValue
     @AppStorage(TerminalScrollBarSettings.showScrollBarKey)
     private var showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
@@ -5631,6 +5645,18 @@ struct SettingsView: View {
         default:
             return String(localized: "settings.browser.history.subtitleMany", defaultValue: "\(browserHistoryEntryCount) saved pages appear in omnibar suggestions.")
         }
+    }
+
+    private var hideSidebarOnNewWindowSubtitle: String {
+        hideSidebarOnNewWindow
+            ? String(
+                localized: "settings.app.hideSidebarOnNewWindow.subtitleOn",
+                defaultValue: "New windows start with the sidebar hidden. Toggle Cmd+B to show it."
+            )
+            : String(
+                localized: "settings.app.hideSidebarOnNewWindow.subtitleOff",
+                defaultValue: "New windows keep the sidebar visible by default."
+            )
     }
 
     private var browserImportSubtitle: String {
@@ -6003,6 +6029,21 @@ struct SettingsView: View {
                                 .controlSize(.small)
                                 .accessibilityLabel(
                                     String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click")
+                                )
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardRow(
+                            configurationReview: .json("app.hideSidebarOnNewWindow"),
+                            String(localized: "settings.app.hideSidebarOnNewWindow", defaultValue: "Hide Sidebar On New Window"),
+                            subtitle: hideSidebarOnNewWindowSubtitle
+                        ) {
+                            Toggle("", isOn: $hideSidebarOnNewWindow)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityLabel(
+                                    String(localized: "settings.app.hideSidebarOnNewWindow", defaultValue: "Hide Sidebar On New Window")
                                 )
                         }
 
@@ -7498,6 +7539,7 @@ struct SettingsView: View {
         defaults.removeObject(forKey: WorkspaceButtonFadeSettings.legacyPaneTabBarControlsVisibilityModeKey)
         closeWorkspaceOnLastSurfaceShortcut = LastSurfaceCloseShortcutSettings.defaultValue
         paneFirstClickFocusEnabled = PaneFirstClickFocusSettings.defaultEnabled
+        hideSidebarOnNewWindow = HideSidebarOnNewWindowSettings.defaultValue
         let previousShowTerminalScrollBar = showTerminalScrollBar
         showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
         if previousShowTerminalScrollBar != showTerminalScrollBar {

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -88,6 +88,11 @@
           "default": true,
           "description": "When cmux is inactive, the first click can activate and focus the clicked pane."
         },
+        "hideSidebarOnNewWindow": {
+          "type": "boolean",
+          "default": false,
+          "description": "Hide the sidebar when creating a new window unless a session snapshot restores it."
+        },
         "preferredEditor": {
           "type": "string",
           "default": "",


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/2982

Generated by cmux-loader.

Codex final message:

Implemented on branch `loader/issue-2982-add-setting-to-hide-sidebar-by-default-on-new-windows`.

- Defaulted new windows to read a setting when no session snapshot exists:
  - [Sources/AppDelegate.swift]( /Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/AppDelegate.swift): `createMainWindow(...)` now uses `HideSidebarOnNewWindowSettings` to set `SidebarState.isVisible`.
- Added the new app setting key to schema and file-backed defaults/mapping:
  - [web/data/cmux-settings.schema.json](/Users/runner/work/cmux-loader/cmux-loader/cmux/web/data/cmux-settings.schema.json): added `app.hideSidebarOnNewWindow` (boolean, default `false`).
  - [Sources/KeyboardShortcutSettingsFileStore.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/KeyboardShortcutSettingsFileStore.swift): wired `app.hideSidebarOnNewWindow` into managed settings parsing and commented template defaults.
- Added app settings integration (UI, storage, reset, defaults helper):
  - [Sources/cmuxApp.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/cmuxApp.swift): added `HideSidebarOnNewWindowSettings`, `@AppStorage` binding, localized subtitle, Settings row, and reset handling.
- Added localized strings:
  - [Resources/Localizable.xcstrings](/Users/runner/work/cmux-loader/cmux-loader/cmux/Resources/Localizable.xcstrings): added `settings.app.hideSidebarOnNewWindow` and on/off subtitles.

Issue reference: [https://github.com/manaflow-ai/cmux/issues/2982](https://github.com/manaflow-ai/cmux/issues/2982)

Verification performed:
- Ran required build command:
  - `./scripts/reload.sh --tag loader`
  - Result: failed immediately because `zig` is not installed.
  - Error: `Error: zig is not installed. Install via: brew install zig`

PR status:
- I could not open/update a PR from this environment because `gh` requires `GH_TOKEN` authentication and it is not configured here.

Next step:
1. Set up `GH_TOKEN` (or run with your authenticated env), then I can create/update the PR on your behalf and post the PR URL.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a setting to hide the sidebar by default when opening new windows that aren’t restored from a session. Supports #2982.

- **New Features**
  - Added `app.hideSidebarOnNewWindow` (default `false`) with a Settings toggle and localized labels.
  - New windows use `HideSidebarOnNewWindowSettings` to set `SidebarState.isVisible` in `createMainWindow(...)`; session snapshots still override.
  - Updated `cmux-settings.schema.json` and `CmuxSettingsFileStore` to parse/store this key and include it in reset defaults.

- **Refactors**
  - Updated `.github/swift-file-length-budget.tsv` for the new lines.

<sup>Written for commit 32bb7e9e15740720e877307ff0ca2e89cfc8ad3b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3232?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

