### PR TITLE
Move pane tab close (×) button to leading edge to match macOS convention

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,12 +4,12 @@
 18705	CLI/cmux.swift
 16364	Sources/TerminalController.swift
 15762	Sources/ContentView.swift
-13748	Sources/AppDelegate.swift
-13702	Sources/Workspace.swift
+13804	Sources/AppDelegate.swift
+13733	Sources/Workspace.swift
 13208	Sources/GhosttyTerminalView.swift
 10549	Sources/Panels/BrowserPanel.swift
-8419	Sources/cmuxApp.swift
-7490	Sources/TabManager.swift
+8463	Sources/cmuxApp.swift
+7496	Sources/TabManager.swift
 6811	Sources/Panels/BrowserPanelView.swift
 5139	cmuxTests/AppDelegateShortcutRoutingTests.swift
 4641	cmuxTests/WorkspaceUnitTests.swift
@@ -32,8 +32,8 @@
 1879	Sources/SessionIndexStore.swift
 1735	Sources/SessionIndexView.swift
 1692	cmuxTests/CmuxConfigTests.swift
+1684	Sources/KeyboardShortcutSettingsFileStore.swift
 1677	cmuxTests/ShortcutAndCommandPaletteTests.swift
-1676	Sources/KeyboardShortcutSettingsFileStore.swift
 1563	cmuxTests/WindowAndDragTests.swift
 1517	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1502	Sources/Update/UpdateTitlebarAccessory.swift

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -50858,6 +50858,121 @@
         }
       }
     },
+    "settings.app.tabCloseButtonPosition": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tab Close Button Position"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブの閉じるボタンの位置"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 닫기 버튼 위치"
+          }
+        }
+      }
+    },
+    "settings.app.tabCloseButtonPosition.leading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Leading"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "先頭"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "왼쪽"
+          }
+        }
+      }
+    },
+    "settings.app.tabCloseButtonPosition.subtitleLeading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close buttons appear on the leading side of pane tabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブを閉じるボタンは各ペインタブの先頭側に表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 닫기 버튼이 각 패널 탭의 왼쪽에 표시됩니다."
+          }
+        }
+      }
+    },
+    "settings.app.tabCloseButtonPosition.trailing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trailing"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "末尾"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오른쪽"
+          }
+        }
+      }
+    },
+    "settings.app.tabCloseButtonPosition.subtitleTrailing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close buttons appear on the trailing side of pane tabs."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タブを閉じるボタンは各ペインタブの末尾側に表示されます。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "탭 닫기 버튼이 각 패널 탭의 오른쪽에 표시됩니다."
+          }
+        }
+      }
+    },
     "settings.app.newWorkspacePlacement": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -92,6 +92,25 @@ enum PaneFirstClickFocusSettings {
     }
 }
 
+enum TabCloseButtonPositionSettings {
+    enum Position: String, CaseIterable {
+        case leading
+        case trailing
+        var id: String { rawValue }
+    }
+
+    static let storageKey = "tabCloseButtonPosition"
+    static let defaultPosition: Position = .leading
+
+    static func position(for rawValue: String?) -> Position {
+        Position(rawValue: rawValue ?? "") ?? defaultPosition
+    }
+
+    static func position(defaults: UserDefaults = .standard) -> Position {
+        position(for: defaults.string(forKey: storageKey))
+    }
+}
+
 enum TerminalScrollBarSettings {
     static let showScrollBarKey = "terminal.showScrollBar"
     static let defaultShowScrollBar = true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6588,7 +6588,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.scheduleTabCloseButtonPositionRefreshAcrossWorkspaces()
+            Task { @MainActor [weak self] in
+                self?.scheduleTabCloseButtonPositionRefreshAcrossWorkspaces()
+            }
         }
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -641,7 +641,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var shortcutMonitor: Any?
     private var shortcutDefaultsObserver: NSObjectProtocol?
     private var menuBarVisibilityObserver: NSObjectProtocol?
+    private var tabCloseButtonPositionObserver: NSObjectProtocol?
     private var splitButtonTooltipRefreshScheduled = false
+    private var tabCloseButtonPositionRefreshScheduled = false
     private struct PendingConfiguredShortcutChord {
         let firstStroke: ShortcutStroke
         let windowNumber: Int?
@@ -1052,6 +1054,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         if !isRunningUnderXCTest {
             configureUserNotifications()
             installMenuBarVisibilityObserver()
+            installTabCloseButtonPositionObserver()
             syncApplicationPresentationPreferences()
             updateController.startUpdaterIfNeeded()
         }
@@ -6578,6 +6581,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
+    private func installTabCloseButtonPositionObserver() {
+        guard tabCloseButtonPositionObserver == nil else { return }
+        tabCloseButtonPositionObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.scheduleTabCloseButtonPositionRefreshAcrossWorkspaces()
+        }
+    }
+
     private func syncApplicationPresentationPreferences(defaults: UserDefaults = .standard) {
         syncActivationPolicy(defaults: defaults)
         syncMenuBarExtraVisibility(defaults: defaults)
@@ -9664,6 +9678,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let self else { return }
             self.splitButtonTooltipRefreshScheduled = false
             self.refreshSplitButtonTooltipsAcrossWorkspaces()
+        }
+    }
+
+    /// Coalesce close-button-position changes and refresh every workspace's Bonsplit
+    /// configuration on the next runloop tick.
+    private func scheduleTabCloseButtonPositionRefreshAcrossWorkspaces() {
+        guard !tabCloseButtonPositionRefreshScheduled else { return }
+        tabCloseButtonPositionRefreshScheduled = true
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            self.tabCloseButtonPositionRefreshScheduled = false
+            self.refreshTabCloseButtonPositionAcrossWorkspaces()
+        }
+    }
+
+    private func refreshTabCloseButtonPositionAcrossWorkspaces() {
+        let closeButtonPosition = resolvedTabCloseButtonPosition()
+        var refreshedManagers: Set<ObjectIdentifier> = []
+
+        if let manager = tabManager {
+            manager.applyTabCloseButtonPosition(closeButtonPosition)
+            refreshedManagers.insert(ObjectIdentifier(manager))
+        }
+
+        for context in mainWindowContexts.values {
+            let manager = context.tabManager
+            let identifier = ObjectIdentifier(manager)
+            guard refreshedManagers.insert(identifier).inserted else { continue }
+            manager.applyTabCloseButtonPosition(closeButtonPosition)
+        }
+    }
+
+    private func resolvedTabCloseButtonPosition(
+        defaults: UserDefaults = .standard
+    ) -> BonsplitConfiguration.Appearance.CloseButtonPosition {
+        switch TabCloseButtonPositionSettings.position(defaults: defaults) {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
         }
     }
 

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -32,6 +32,7 @@ final class CmuxSettingsFileStore {
         "app.newWorkspacePlacement",
         "app.minimalMode",
         "app.keepWorkspaceOpenWhenClosingLastSurface",
+        "app.tabCloseButtonPosition",
         "app.focusPaneOnFirstClick",
         "app.preferredEditor",
         "app.openMarkdownInCmuxViewer",
@@ -415,6 +416,13 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonBool(section["focusPaneOnFirstClick"]) {
             snapshot.managedUserDefaults[PaneFirstClickFocusSettings.enabledKey] = .bool(value)
+        }
+        if let raw = jsonString(section["tabCloseButtonPosition"]) {
+            guard TabCloseButtonPositionSettings.Position(rawValue: raw) != nil else {
+                logInvalid("app.tabCloseButtonPosition", sourcePath: sourcePath)
+                return
+            }
+            snapshot.managedUserDefaults[TabCloseButtonPositionSettings.storageKey] = .string(raw)
         }
         if let value = jsonString(section["preferredEditor"]) {
             snapshot.managedUserDefaults[PreferredEditorSettings.key] = .string(value)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5355,6 +5355,12 @@ class TabManager: ObservableObject {
         }
     }
 
+    func applyTabCloseButtonPosition(_ position: BonsplitConfiguration.Appearance.CloseButtonPosition) {
+        for workspace in tabs {
+            workspace.applyTabCloseButtonPosition(position)
+        }
+    }
+
     func applySurfaceTabBarButtons(
         _ buttons: [CmuxSurfaceTabBarButton],
         sourcePath: String?,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7662,6 +7662,7 @@ final class Workspace: Identifiable, ObservableObject {
     private static func bonsplitAppearance(
         from backgroundColor: NSColor,
         backgroundOpacity: Double,
+        closeButtonPosition: BonsplitConfiguration.Appearance.CloseButtonPosition,
         tabTitleFontSize: CGFloat = 11
     ) -> BonsplitConfiguration.Appearance {
         let sharesWindowBackdrop = usesWindowRootTerminalBackdrop()
@@ -7678,6 +7679,7 @@ final class Workspace: Identifiable, ObservableObject {
             tabTitleFontSize: tabTitleFontSize,
             splitButtonBackdropEffect: Self.bonsplitSplitButtonBackdropEffect(),
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
+            closeButtonPosition: closeButtonPosition,
             enableAnimations: false,
             chromeColors: chromeColors,
             usesSharedBackdrop: sharesWindowBackdrop
@@ -7740,6 +7742,13 @@ final class Workspace: Identifiable, ObservableObject {
                 "resultingTabFont=\(String(format: "%.3f", bonsplitController.configuration.appearance.tabTitleFontSize))"
             )
         }
+    }
+
+    func applyTabCloseButtonPosition(_ position: BonsplitConfiguration.Appearance.CloseButtonPosition) {
+        guard bonsplitController.configuration.appearance.closeButtonPosition != position else {
+            return
+        }
+        bonsplitController.configuration.appearance.closeButtonPosition = position
     }
 
     func applyGhosttyChrome(backgroundColor: NSColor, backgroundOpacity: Double, reason: String = "unspecified") {
@@ -7820,9 +7829,11 @@ final class Workspace: Identifiable, ObservableObject {
         // Use the cached Ghostty config so new workspaces inherit tab-strip sizing
         // without paying repeated parse costs on the workspace-creation hot path.
         let initialSurfaceTabBarFontSize = GhosttyConfig.load().surfaceTabBarFontSize
+        let tabCloseButtonPosition = Self.resolvedTabCloseButtonPosition()
         let appearance = Self.bonsplitAppearance(
             from: GhosttyApp.shared.defaultBackgroundColor,
             backgroundOpacity: GhosttyApp.shared.defaultBackgroundOpacity,
+            closeButtonPosition: tabCloseButtonPosition,
             tabTitleFontSize: initialSurfaceTabBarFontSize
         )
         let config = BonsplitConfiguration(
@@ -7918,6 +7929,17 @@ final class Workspace: Identifiable, ObservableObject {
             bonsplitController.selectTab(initialTabId)
         }
         tmuxLayoutSnapshot = bonsplitController.layoutSnapshot()
+    }
+
+    private static func resolvedTabCloseButtonPosition(
+        defaults: UserDefaults = .standard
+    ) -> BonsplitConfiguration.Appearance.CloseButtonPosition {
+        switch TabCloseButtonPositionSettings.position(defaults: defaults) {
+        case .leading:
+            return .leading
+        case .trailing:
+            return .trailing
+        }
     }
 
     deinit {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7510,6 +7510,7 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitAppearance(
             from: config.backgroundColor,
             backgroundOpacity: config.backgroundOpacity,
+            closeButtonPosition: resolvedTabCloseButtonPosition(),
             tabTitleFontSize: config.surfaceTabBarFontSize
         )
     }
@@ -13684,6 +13685,14 @@ extension Workspace: BonsplitDelegate {
             closeTabs(tabIdsToCloseOthers(of: tab.id, inPane: pane))
         case .move:
             promptMovePanel(tabId: tab.id)
+        case .moveToLeftPane:
+            guard let panelId = panelIdFromSurfaceId(tab.id),
+                  let targetPane = bonsplitController.adjacentPane(to: pane, direction: .left) else { return }
+            moveSurface(panelId: panelId, toPane: targetPane)
+        case .moveToRightPane:
+            guard let panelId = panelIdFromSurfaceId(tab.id),
+                  let targetPane = bonsplitController.adjacentPane(to: pane, direction: .right) else { return }
+            moveSurface(panelId: panelId, toPane: targetPane)
         case .newTerminalToRight:
             createTerminalToRight(of: tab.id, inPane: pane)
         case .newBrowserToRight:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5336,6 +5336,8 @@ struct SettingsView: View {
     @AppStorage(TerminalScrollBarSettings.showScrollBarKey)
     private var showTerminalScrollBar = TerminalScrollBarSettings.defaultShowScrollBar
     @AppStorage(WorkspaceAutoReorderSettings.key) private var workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+    @AppStorage(TabCloseButtonPositionSettings.storageKey)
+    private var tabCloseButtonPosition = TabCloseButtonPositionSettings.defaultPosition.rawValue
     @AppStorage(SidebarWorkspaceDetailSettings.hideAllDetailsKey)
     private var sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
     @AppStorage(SidebarWorkspaceDetailSettings.showNotificationMessageKey)
@@ -5414,6 +5416,32 @@ struct SettingsView: View {
 
     private var keepWorkspaceOpenOnLastSurfaceShortcut: Bool {
         !closeWorkspaceOnLastSurfaceShortcut
+    }
+
+    private var selectedTabCloseButtonPosition: TabCloseButtonPositionSettings.Position {
+        TabCloseButtonPositionSettings.position(for: tabCloseButtonPosition)
+    }
+
+    private var tabCloseButtonPositionBinding: Binding<TabCloseButtonPositionSettings.Position> {
+        Binding(
+            get: { selectedTabCloseButtonPosition },
+            set: { tabCloseButtonPosition = $0.rawValue }
+        )
+    }
+
+    private var tabCloseButtonPositionSubtitle: String {
+        switch selectedTabCloseButtonPosition {
+        case .leading:
+            return String(
+                localized: "settings.app.tabCloseButtonPosition.subtitleLeading",
+                defaultValue: "Close buttons appear on the leading side of pane tabs."
+            )
+        case .trailing:
+            return String(
+                localized: "settings.app.tabCloseButtonPosition.subtitleTrailing",
+                defaultValue: "Close buttons appear on the trailing side of pane tabs."
+            )
+        }
     }
 
     private var keepWorkspaceOpenOnLastSurfaceShortcutBinding: Binding<Bool> {
@@ -6004,6 +6032,21 @@ struct SettingsView: View {
                                 .accessibilityLabel(
                                     String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click")
                                 )
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsPickerRow(
+                            configurationReview: .json("app.tabCloseButtonPosition"),
+                            String(localized: "settings.app.tabCloseButtonPosition", defaultValue: "Tab Close Button Position"),
+                            subtitle: tabCloseButtonPositionSubtitle,
+                            controlWidth: pickerColumnWidth,
+                            selection: tabCloseButtonPositionBinding
+                        ) {
+                            Text(String(localized: "settings.app.tabCloseButtonPosition.leading", defaultValue: "Leading"))
+                                .tag(TabCloseButtonPositionSettings.Position.leading)
+                            Text(String(localized: "settings.app.tabCloseButtonPosition.trailing", defaultValue: "Trailing"))
+                                .tag(TabCloseButtonPositionSettings.Position.trailing)
                         }
 
                         SettingsCardDivider()
@@ -7504,6 +7547,7 @@ struct SettingsView: View {
             TerminalScrollBarSettings.notifyDidChange()
         }
         workspaceAutoReorder = WorkspaceAutoReorderSettings.defaultValue
+        tabCloseButtonPosition = TabCloseButtonPositionSettings.defaultPosition.rawValue
         sidebarHideAllDetails = SidebarWorkspaceDetailSettings.defaultHideAllDetails
         sidebarShowNotificationMessage = SidebarWorkspaceDetailSettings.defaultShowNotificationMessage
         sidebarBranchVerticalLayout = SidebarBranchLayoutSettings.defaultVerticalLayout

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -83,6 +83,12 @@
           "default": false,
           "description": "When true, closing the last surface keeps the workspace open."
         },
+        "tabCloseButtonPosition": {
+          "type": "string",
+          "enum": ["leading", "trailing"],
+          "default": "leading",
+          "description": "Preferred placement for pane tab close buttons."
+        },
         "focusPaneOnFirstClick": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3060

Generated by cmux-loader.

Codex final message:

Implemented the tab-close-position setting flow for issue #3060 in the cmux checkout.

### What I changed

- App runtime propagation added:
  - `Sources/AppDelegate.swift`
    - Added a new `UserDefaults` observer for `tabCloseButtonPosition` changes.
    - Added coalesced refresh methods:
      - `scheduleTabCloseButtonPositionRefreshAcrossWorkspaces()`
      - `refreshTabCloseButtonPositionAcrossWorkspaces()`
      - local mapping from `TabCloseButtonPositionSettings` → `BonsplitConfiguration.Appearance.CloseButtonPosition`.
    - Hooked observer in launch path so live updates apply to all active `Workspace` tab managers.

- Settings persistence/parsing:
  - `Sources/KeyboardShortcutSettingsFileStore.swift`
    - Added `app.tabCloseButtonPosition` to `supportedSettingsJSONPaths`.
    - Added parsing in `parseAppSection(_:)` with enum validation and managed defaults write.

- Settings UI + defaults:
  - `Sources/cmuxApp.swift`
    - Added `@AppStorage` for `TabCloseButtonPositionSettings.storageKey`.
    - Added computed helpers for sanitized selection + subtitle.
    - Added Appearance/App picker row:
      - `settings.app.tabCloseButtonPosition` (`leading` / `trailing`).
    - Included reset default in `resetAllSettings()`.

- Settings schema sync:
  - `web/data/cmux-settings.schema.json`
    - Added `app.tabCloseButtonPosition` with enum `["leading","trailing"]` and default `leading`.

- Localized strings (EN/JA/KO):
  - `Resources/Localizable.xcstrings`
    - Added:
      - `settings.app.tabCloseButtonPosition`
      - `settings.app.tabCloseButtonPosition.subtitleLeading`
      - `settings.app.tabCloseButtonPosition.subtitleTrailing`
      - `settings.app.tabCloseButtonPosition.leading`
      - `settings.app.tabCloseButtonPosition.trailing`

### Verification performed

- Ran required tagged build command:
  - `./scripts/reload.sh --tag loader`
- Result: failed in this environment because `zig` is not installed.
  - Script output included:
    - `Error: zig is not installed.`
- No other verification commands were run.

### PR / branch status

- I did not open or update a GitHub PR in this session (so no PR URL to provide yet).
- If you want, I can create the PR next with this exact branch and include the same summary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the pane tab close button to the leading edge by default to match macOS, and adds a setting to choose leading or trailing. Changes apply instantly across all open workspaces.

- New Features
  - Added `app.tabCloseButtonPosition` setting (`leading` | `trailing`), default `leading`; appears in Settings with localized labels and subtitles.
  - Live updates: observes `UserDefaults` and refreshes all workspace tab managers when the setting changes.
  - Workspaces now honor the close button position for both new and existing tabs.
  - Schema and parsing support added in `web/data/cmux-settings.schema.json` and `KeyboardShortcutSettingsFileStore`.

- Dependencies
  - Updated `vendor/bonsplit` and implemented new delegate actions for moving tabs to left/right panes to match API changes, fixing CI.

<sup>Written for commit 5146b83f243b9c21f2249a5b5b68f58267fb969d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3235?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control where tab close buttons appear on pane tabs, with options for leading (left) or trailing (right) positions.
  * Setting is accessible through app preferences and managed configurations, with full localization support for English, Japanese, and Korean.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->