### PR TITLE
Add CLI contract help checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,7 +288,7 @@ jobs:
           CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
             ./tests/test_bundled_ghostty_theme_picker_helper.sh
 
-      - name: Run CLI version memory guard regression
+      - name: Run CLI no-socket regressions
         run: |
           set -euo pipefail
 
@@ -304,6 +304,7 @@ jobs:
           fi
 
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_version_memory_guard.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_contract_help.py
 
   tests-build-and-lag:
     # Build the full cmux scheme and run the lag regression on WarpBuild.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -38,8 +38,8 @@ Global options:
 | `--socket <path>` | Override the socket path for this invocation. |
 | `--password <value>` | Use an explicit socket password. Takes precedence over `CMUX_SOCKET_PASSWORD`. |
 | `--json` | Prefer machine-readable JSON output for commands that support it. |
-| `--id-format <refs|uuids|both>` | Select handle format in JSON and supported text output. |
-| `--window <id|ref|index>` | Route the command through a specific window when supported. |
+| `--id-format <refs\|uuids\|both>` | Select handle format in JSON and supported text output. |
+| `--window <id\|ref\|index>` | Route the command through a specific window when supported. |
 
 Environment:
 
@@ -399,6 +399,15 @@ the expected text without connecting to a cmux socket.
 - `cmux is-webview-focused --help` -> `Legacy alias for 'cmux browser is-webview-focused'`
 - `cmux markdown --help` -> `Usage: cmux markdown open <path>`
 <!-- cli-contract-help-probes:end -->
+
+## No-Socket Negative Help Probes
+
+The following probes must not print help. They protect argument forwarding after
+`--`, where a forwarded `--help` token belongs to the command payload.
+
+<!-- cli-contract-negative-help-probes:start -->
+- `cmux vm exec demo -- --help` !> `Usage: cmux vm`
+<!-- cli-contract-negative-help-probes:end -->
 
 ## Current Help Caveats
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -1,0 +1,430 @@
+# cmux CLI Contract
+
+This document is the compatibility contract for migrating `CLI/cmux.swift` to
+Swift ArgumentParser. The migration should preserve command names, aliases,
+global flags, exit behavior, socket routing, and no-socket help behavior unless
+a PR explicitly calls out an intentional contract change.
+
+The current implementation is a hand-rolled parser. This spec is deliberately
+written around user-visible behavior so the implementation can change behind it.
+
+## Migration Rules
+
+- Keep `cmux --help`, `cmux -h`, `cmux --version`, and `cmux -v` working without
+  connecting to the cmux socket.
+- Keep documented `cmux <command> --help` probes working without a socket where
+  they already do.
+- Keep `--socket`, `--password`, `--json`, `--id-format`, and `--window` as
+  global options before the command.
+- Keep UUIDs, refs such as `workspace:2`, and indexes accepted wherever the
+  command accepts a window, workspace, pane, surface, or tab handle.
+- Keep text output stable for scripting commands unless a command already
+  documents JSON as the scripting interface.
+- Keep hidden/internal commands available until their callers have migrated.
+
+## Global Invocation
+
+| Form | Contract |
+| --- | --- |
+| `cmux <path>` | Open a directory or file path in cmux. Relative paths resolve from the current working directory. |
+| `cmux [global-options] <command> [options]` | Run a named command. |
+| `cmux --help`, `cmux -h` | Print top-level usage without a socket. |
+| `cmux --version`, `cmux -v`, `cmux version` | Print version summary without a socket. |
+
+Global options:
+
+| Option | Contract |
+| --- | --- |
+| `--socket <path>` | Override the socket path for this invocation. |
+| `--password <value>` | Use an explicit socket password. Takes precedence over `CMUX_SOCKET_PASSWORD`. |
+| `--json` | Prefer machine-readable JSON output for commands that support it. |
+| `--id-format <refs|uuids|both>` | Select handle format in JSON and supported text output. |
+| `--window <id|ref|index>` | Route the command through a specific window when supported. |
+
+Environment:
+
+| Variable | Contract |
+| --- | --- |
+| `CMUX_SOCKET_PATH` | Primary socket path override. |
+| `CMUX_SOCKET` | Compatibility socket path override. |
+| `CMUX_SOCKET_PASSWORD` | Socket password fallback when `--password` is absent. |
+| `CMUX_WORKSPACE_ID` | Default workspace context inside cmux terminals. |
+| `CMUX_SURFACE_ID` | Default surface context inside cmux terminals. |
+| `CMUX_TAB_ID` | Default tab context for tab commands. |
+
+## Top-Level Commands
+
+| Command | Contract |
+| --- | --- |
+| `welcome` | Print the welcome screen. |
+| `shortcuts` | Open Settings to Keyboard Shortcuts. |
+| `restore-session` | Restore the previously saved cmux session. |
+| `feedback` | Open feedback UI or submit feedback with `--email`, `--body`, and repeated `--image`. |
+| `feed` | Manage persisted Feed workstream history. Current public subcommand: `clear`. |
+| `themes` | List, set, clear, or interactively pick Ghostty themes. |
+| `claude-teams` | Launch Claude Code with cmux/tmux-style agent team integration. |
+| `omo` | Launch OpenCode with oh-my-openagent integration. |
+| `omx` | Launch Oh My Codex with cmux pane integration. |
+| `omc` | Launch Oh My Claude Code with cmux pane integration. |
+| `codex` | Install or uninstall Codex hooks. |
+| `opencode` | Install or uninstall OpenCode integration hooks. |
+| `cursor` | Install or uninstall Cursor hooks. |
+| `gemini` | Install or uninstall Gemini hooks. |
+| `copilot` | Install or uninstall Copilot hooks. |
+| `codebuddy` | Install or uninstall CodeBuddy hooks. |
+| `factory` | Install or uninstall Factory hooks. |
+| `qoder` | Install or uninstall Qoder hooks. |
+| `setup-hooks` | Install hooks for all supported agents. |
+| `uninstall-hooks` | Remove hooks for all supported agents. |
+| `ping` | Check socket connectivity. |
+| `capabilities` | Print server capabilities as JSON. |
+| `auth` | Manage auth status, login, and logout through the app. |
+| `vm`, `cloud` | Manage cloud VMs. `cloud` is an alias for `vm`. |
+| `rpc` | Call a raw v2 socket method with optional JSON params. |
+| `identify` | Print server identity and caller context. |
+| `list-windows` | List windows. |
+| `current-window` | Print the selected window ID. |
+| `new-window` | Create a new window. |
+| `focus-window` | Focus a window by handle. |
+| `close-window` | Close a window by handle. |
+| `move-workspace-to-window` | Move a workspace into a target window. |
+| `reorder-workspace` | Reorder a workspace inside a window. |
+| `workspace-action` | Run workspace context-menu actions from the CLI. |
+| `list-workspaces` | List workspaces. |
+| `new-workspace` | Create a workspace, optionally with cwd, command, description, and layout. |
+| `ssh` | Open an SSH-backed workspace. |
+| `remote-daemon-status` | Print bundled remote daemon version, asset, checksum, and cache status. |
+| `new-split` | Split from a surface in a direction. |
+| `list-panes` | List panes in a workspace. |
+| `list-pane-surfaces` | List surfaces in a pane. |
+| `tree` | Print a window, workspace, pane, and surface tree. |
+| `focus-pane` | Focus a pane. |
+| `new-pane` | Create a pane with terminal or browser content. |
+| `new-surface` | Create a surface inside a pane. |
+| `close-surface` | Close a surface. |
+| `move-surface` | Move a surface to another pane, workspace, window, or index. |
+| `reorder-surface` | Reorder a surface within its pane. |
+| `tab-action` | Run horizontal tab context-menu actions. |
+| `rename-tab` | Rename a tab. Compatibility wrapper for `tab-action rename`. |
+| `drag-surface-to-split` | Move a surface into a split direction. |
+| `refresh-surfaces` | Ask the app to refresh terminal surfaces. |
+| `reload-config` | Ask cmux to reload configuration. |
+| `surface-health` | Print terminal surface health information. |
+| `debug-terminals` | Print debug terminal state. |
+| `trigger-flash` | Trigger a visual flash on a workspace or surface. |
+| `list-panels` | List panels. Compatibility alias over pane/surface data. |
+| `focus-panel` | Focus a panel. Compatibility alias over surface focus. |
+| `close-workspace` | Close a workspace. |
+| `select-workspace` | Select a workspace. |
+| `rename-workspace`, `rename-window` | Rename a workspace. `rename-window` is a compatibility alias. |
+| `current-workspace` | Print current workspace information. |
+| `read-screen` | Read terminal text from a surface. |
+| `send` | Send text to a terminal surface. |
+| `send-key` | Send one key to a terminal surface. |
+| `send-panel` | Send text to a panel/surface. |
+| `send-key-panel` | Send one key to a panel/surface. |
+| `notify` | Send a notification to a workspace/surface. |
+| `list-notifications` | List queued notifications. |
+| `clear-notifications` | Clear queued notifications. |
+| `set-status` | Set a sidebar status pill. |
+| `clear-status` | Remove a sidebar status pill. |
+| `list-status` | List sidebar status pills. |
+| `set-progress` | Set sidebar progress. |
+| `clear-progress` | Clear sidebar progress. |
+| `log` | Append a sidebar log entry. |
+| `clear-log` | Clear sidebar log entries. |
+| `list-log` | List sidebar log entries. |
+| `sidebar-state` | Dump sidebar metadata state. |
+| `claude-hook` | Handle Claude Code hook events from stdin JSON. |
+| `feed-hook` | Handle Feed hook events from stdin JSON. |
+| `codex-hook` | Handle Codex hook events from stdin JSON. |
+| `opencode-hook` | Handle OpenCode hook events from stdin JSON. |
+| `cursor-hook` | Handle Cursor hook events from stdin JSON. |
+| `gemini-hook` | Handle Gemini hook events from stdin JSON. |
+| `copilot-hook` | Handle Copilot hook events from stdin JSON. |
+| `codebuddy-hook` | Handle CodeBuddy hook events from stdin JSON. |
+| `factory-hook` | Handle Factory hook events from stdin JSON. |
+| `qoder-hook` | Handle Qoder hook events from stdin JSON. |
+| `set-app-focus` | Override app focus state for tests. |
+| `simulate-app-active` | Trigger app-active handling for tests. |
+| `browser` | Run browser automation commands. |
+| `open-browser` | Legacy alias for `browser open`. |
+| `navigate` | Legacy alias for `browser navigate`. |
+| `browser-back` | Legacy alias for `browser back`. |
+| `browser-forward` | Legacy alias for `browser forward`. |
+| `browser-reload` | Legacy alias for `browser reload`. |
+| `get-url` | Legacy alias for `browser get-url`. |
+| `focus-webview` | Legacy alias for `browser focus-webview`. |
+| `is-webview-focused` | Legacy alias for `browser is-webview-focused`. |
+| `markdown` | Open a markdown file in a formatted viewer panel with live reload. |
+| `vm-pty-attach` | Internal VM PTY attach command. |
+| `vm-ssh-attach` | Hidden compatibility alias for older VM workspaces. |
+| `vm-pty-connect` | Internal helper that connects to a VM PTY from a config file. |
+| `ssh-session-end` | Internal helper that clears remote SSH session state. |
+| `__tmux-compat` | Internal tmux compatibility dispatcher. |
+
+## Command Families
+
+Auth subcommands:
+
+| Command | Contract |
+| --- | --- |
+| `auth status` | Print signed-in state. Supports `--json`. |
+| `auth login` | Begin sign-in through the app and wait for completion. |
+| `auth logout` | Clear the current session. |
+
+VM subcommands:
+
+| Command | Contract |
+| --- | --- |
+| `vm ls`, `vm list` | List VMs. |
+| `vm new`, `vm create` | Create a VM. Supports `--image`, `--provider`, `--detach`, and `-d`. |
+| `vm shell`, `vm attach` | Open an interactive shell for an existing VM. |
+| `vm rm`, `vm destroy`, `vm delete` | Destroy a VM. |
+| `vm ssh`, `vm ssh-info` | Print SSH connection info. |
+| `vm ssh-attach` | Internal attach helper. |
+| `vm exec` | Run a shell command inside a VM. |
+
+Theme subcommands:
+
+| Command | Contract |
+| --- | --- |
+| `themes` | In a TTY, open the interactive picker. Outside a TTY, list themes. |
+| `themes list` | List available themes and current light/dark defaults. |
+| `themes set <theme>` | Set the same theme for light and dark appearance. |
+| `themes set --light <theme>` | Set the light appearance theme. |
+| `themes set --dark <theme>` | Set the dark appearance theme. |
+| `themes clear` | Remove the cmux theme override. |
+
+Workspace and tab action names:
+
+| Command | Actions |
+| --- | --- |
+| `workspace-action` | `pin`, `unpin`, `rename`, `clear-name`, `set-description`, `clear-description`, `move-up`, `move-down`, `move-top`, `close-others`, `close-above`, `close-below`, `mark-read`, `mark-unread`, `set-color`, `clear-color` |
+| `tab-action` | `rename`, `clear-name`, `close-left`, `close-right`, `close-others`, `new-terminal-right`, `new-browser-right`, `reload`, `duplicate`, `pin`, `unpin`, `mark-unread` |
+
+tmux compatibility commands:
+
+| Command | Contract |
+| --- | --- |
+| `capture-pane` | Read pane text. |
+| `resize-pane` | Resize a pane with direction flags. |
+| `pipe-pane` | Pipe pane text to a shell command. |
+| `wait-for` | Signal or wait on a named synchronization point. |
+| `swap-pane` | Swap two panes. |
+| `break-pane` | Move a pane into a new workspace. |
+| `join-pane` | Join a pane into another pane. |
+| `next-window`, `previous-window`, `last-window` | Move workspace selection. |
+| `last-pane` | Focus the last pane. |
+| `find-window` | Find a workspace by title or content. |
+| `clear-history` | Clear terminal scrollback. |
+| `set-hook` | Manage tmux-compat hook definitions. |
+| `popup` | Placeholder, currently unsupported. |
+| `bind-key`, `unbind-key`, `copy-mode` | Placeholders, currently unsupported. |
+| `set-buffer` | Set a tmux-compat buffer. |
+| `paste-buffer` | Paste a tmux-compat buffer. |
+| `list-buffers` | List tmux-compat buffers. |
+| `respawn-pane` | Send a restart command to a surface. |
+| `display-message` | Print or display a message. |
+
+Browser subcommands:
+
+| Command | Contract |
+| --- | --- |
+| `browser open`, `browser open-split`, `browser new` | Create or open a browser surface. |
+| `browser goto`, `browser navigate` | Navigate to a URL. |
+| `browser back`, `browser forward`, `browser reload` | Navigate browser history or reload. |
+| `browser url`, `browser get-url` | Print current URL. |
+| `browser focus-webview`, `browser is-webview-focused` | Focus or query webview focus. |
+| `browser snapshot` | Print a DOM snapshot. |
+| `browser eval` | Evaluate JavaScript. |
+| `browser wait` | Wait for selector, text, URL, load state, or JS predicate. |
+| `browser click`, `browser dblclick`, `browser hover`, `browser focus`, `browser check`, `browser uncheck`, `browser scroll-into-view` | Run element interaction. |
+| `browser type`, `browser fill` | Type into or set an input. |
+| `browser press`, `browser key`, `browser keydown`, `browser keyup` | Send keyboard input. |
+| `browser select` | Select an option. |
+| `browser scroll` | Scroll page or element. |
+| `browser screenshot` | Save a screenshot. |
+| `browser get` | Read URL, title, text, HTML, value, attr, count, box, or styles. |
+| `browser is` | Check visible, enabled, or checked state. |
+| `browser find` | Find by role, text, label, placeholder, alt, title, testid, first, last, or nth. |
+| `browser frame` | Select frame context. |
+| `browser dialog` | Accept or dismiss dialogs. |
+| `browser download` | Wait for or save downloads. |
+| `browser cookies` | Get, set, or clear cookies. |
+| `browser storage` | Get, set, or clear local/session storage. |
+| `browser tab` | Create, list, switch, or close browser tabs. |
+| `browser console`, `browser errors` | List or clear console messages and errors. |
+| `browser highlight` | Highlight an element. |
+| `browser state` | Save or load browser state. |
+| `browser addinitscript`, `browser addscript`, `browser addstyle` | Inject scripts or CSS. |
+| `browser viewport` | Set viewport size. |
+| `browser geolocation`, `browser geo` | Set geolocation. |
+| `browser offline` | Toggle offline state. |
+| `browser trace` | Start or stop trace capture. |
+| `browser network` | Route, unroute, or list requests. |
+| `browser screencast` | Start or stop screencast. |
+| `browser input`, `browser input_mouse`, `browser input_keyboard`, `browser input_touch` | Send low-level input. |
+| `browser identify` | Identify browser surface context. |
+
+Agent hook subcommands:
+
+| Command | Contract |
+| --- | --- |
+| `claude-hook session-start`, `claude-hook active` | Mark a Claude session active. |
+| `claude-hook stop`, `claude-hook idle` | Mark a Claude session stopped or idle. |
+| `claude-hook notification`, `claude-hook notify` | Forward a Claude notification. |
+| `claude-hook prompt-submit` | Clear notification and set running status. |
+| `claude-hook session-end` | Mark Claude session ended. |
+| `claude-hook pre-tool-use` | Record Claude tool-use context. |
+| `codex-hook session-start` | Register a Codex session. |
+| `codex-hook prompt-submit` | Set Codex running status. |
+| `codex-hook stop` | Send completion notification and set idle. |
+| `feed-hook` | Convert agent hook events into Feed context. |
+| `<agent>-hook` | Generic hook surface for `opencode`, `cursor`, `gemini`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
+
+## No-Socket Help Probes
+
+The following probes are executable contract checks. They must exit 0 and print
+the expected text without connecting to a cmux socket.
+
+<!-- cli-contract-help-probes:start -->
+- `cmux --help` -> `cmux - control cmux via Unix socket`
+- `cmux ping --help` -> `Usage: cmux ping`
+- `cmux capabilities --help` -> `Usage: cmux capabilities`
+- `cmux auth --help` -> `Usage: cmux auth <status|login|logout>`
+- `cmux vm --help` -> `Usage: cmux vm <new|ls|rm|exec|shell|attach|ssh> [args...]`
+- `cmux cloud --help` -> `Usage: cmux cloud <new|ls|rm|exec|shell|attach|ssh> [args...]`
+- `cmux rpc --help` -> `Usage: cmux rpc <method> [json-params]`
+- `cmux help --help` -> `Usage: cmux help`
+- `cmux welcome --help` -> `Usage: cmux welcome`
+- `cmux shortcuts --help` -> `Usage: cmux shortcuts`
+- `cmux restore-session --help` -> `Usage: cmux restore-session`
+- `cmux feedback --help` -> `Usage: cmux feedback`
+- `cmux feed --help` -> `Usage: cmux feed clear [--yes|-y]`
+- `cmux opencode --help` -> `Usage: cmux opencode <install-hooks|uninstall-hooks>`
+- `cmux themes --help` -> `Usage: cmux themes`
+- `cmux omo --help` -> `Usage: cmux omo [opencode-args...]`
+- `cmux omx --help` -> `Usage: cmux omx [omx-args...]`
+- `cmux omc --help` -> `Usage: cmux omc [omc-args...]`
+- `cmux identify --help` -> `Usage: cmux identify`
+- `cmux list-windows --help` -> `Usage: cmux list-windows`
+- `cmux current-window --help` -> `Usage: cmux current-window`
+- `cmux new-window --help` -> `Usage: cmux new-window`
+- `cmux focus-window --help` -> `Usage: cmux focus-window --window <id|ref|index>`
+- `cmux close-window --help` -> `Usage: cmux close-window --window <id|ref|index>`
+- `cmux move-workspace-to-window --help` -> `Usage: cmux move-workspace-to-window`
+- `cmux move-surface --help` -> `Usage: cmux move-surface`
+- `cmux reorder-surface --help` -> `Usage: cmux reorder-surface`
+- `cmux reorder-workspace --help` -> `Usage: cmux reorder-workspace`
+- `cmux workspace-action --help` -> `Usage: cmux workspace-action --action <name>`
+- `cmux tab-action --help` -> `Usage: cmux tab-action --action <name>`
+- `cmux rename-tab --help` -> `Usage: cmux rename-tab`
+- `cmux new-workspace --help` -> `Usage: cmux new-workspace`
+- `cmux list-workspaces --help` -> `Usage: cmux list-workspaces`
+- `cmux ssh --help` -> `Usage: cmux ssh <destination>`
+- `cmux new-split --help` -> `Usage: cmux new-split`
+- `cmux list-panes --help` -> `Usage: cmux list-panes`
+- `cmux list-pane-surfaces --help` -> `Usage: cmux list-pane-surfaces`
+- `cmux tree --help` -> `Usage: cmux tree`
+- `cmux focus-pane --help` -> `Usage: cmux focus-pane`
+- `cmux new-pane --help` -> `Usage: cmux new-pane`
+- `cmux new-surface --help` -> `Usage: cmux new-surface`
+- `cmux close-surface --help` -> `Usage: cmux close-surface`
+- `cmux drag-surface-to-split --help` -> `Usage: cmux drag-surface-to-split`
+- `cmux refresh-surfaces --help` -> `Usage: cmux refresh-surfaces`
+- `cmux reload-config --help` -> `Usage: cmux reload-config`
+- `cmux surface-health --help` -> `Usage: cmux surface-health`
+- `cmux debug-terminals --help` -> `Usage: cmux debug-terminals`
+- `cmux trigger-flash --help` -> `Usage: cmux trigger-flash`
+- `cmux list-panels --help` -> `Usage: cmux list-panels`
+- `cmux focus-panel --help` -> `Usage: cmux focus-panel`
+- `cmux close-workspace --help` -> `Usage: cmux close-workspace`
+- `cmux select-workspace --help` -> `Usage: cmux select-workspace`
+- `cmux rename-workspace --help` -> `Usage: cmux rename-workspace`
+- `cmux rename-window --help` -> `Usage: cmux rename-workspace`
+- `cmux current-workspace --help` -> `Usage: cmux current-workspace`
+- `cmux capture-pane --help` -> `Usage: cmux capture-pane`
+- `cmux resize-pane --help` -> `Usage: cmux resize-pane`
+- `cmux pipe-pane --help` -> `Usage: cmux pipe-pane`
+- `cmux wait-for --help` -> `Usage: cmux wait-for`
+- `cmux swap-pane --help` -> `Usage: cmux swap-pane`
+- `cmux break-pane --help` -> `Usage: cmux break-pane`
+- `cmux join-pane --help` -> `Usage: cmux join-pane`
+- `cmux next-window --help` -> `Usage: cmux next-window`
+- `cmux previous-window --help` -> `Usage: cmux previous-window`
+- `cmux last-window --help` -> `Usage: cmux last-window`
+- `cmux last-pane --help` -> `Usage: cmux last-pane`
+- `cmux find-window --help` -> `Usage: cmux find-window`
+- `cmux clear-history --help` -> `Usage: cmux clear-history`
+- `cmux set-hook --help` -> `Usage: cmux set-hook`
+- `cmux popup --help` -> `Usage: cmux popup`
+- `cmux bind-key --help` -> `Usage: cmux bind-key`
+- `cmux unbind-key --help` -> `Usage: cmux unbind-key`
+- `cmux copy-mode --help` -> `Usage: cmux copy-mode`
+- `cmux set-buffer --help` -> `Usage: cmux set-buffer`
+- `cmux paste-buffer --help` -> `Usage: cmux paste-buffer`
+- `cmux list-buffers --help` -> `Usage: cmux list-buffers`
+- `cmux respawn-pane --help` -> `Usage: cmux respawn-pane`
+- `cmux display-message --help` -> `Usage: cmux display-message`
+- `cmux read-screen --help` -> `Usage: cmux read-screen`
+- `cmux send --help` -> `Usage: cmux send`
+- `cmux send-key --help` -> `Usage: cmux send-key`
+- `cmux send-panel --help` -> `Usage: cmux send-panel`
+- `cmux send-key-panel --help` -> `Usage: cmux send-key-panel`
+- `cmux notify --help` -> `Usage: cmux notify`
+- `cmux list-notifications --help` -> `Usage: cmux list-notifications`
+- `cmux clear-notifications --help` -> `Usage: cmux clear-notifications`
+- `cmux set-status --help` -> `Usage: cmux set-status`
+- `cmux clear-status --help` -> `Usage: cmux clear-status`
+- `cmux list-status --help` -> `Usage: cmux list-status`
+- `cmux set-progress --help` -> `Usage: cmux set-progress`
+- `cmux clear-progress --help` -> `Usage: cmux clear-progress`
+- `cmux log --help` -> `Usage: cmux log`
+- `cmux clear-log --help` -> `Usage: cmux clear-log`
+- `cmux list-log --help` -> `Usage: cmux list-log`
+- `cmux sidebar-state --help` -> `Usage: cmux sidebar-state`
+- `cmux set-app-focus --help` -> `Usage: cmux set-app-focus`
+- `cmux simulate-app-active --help` -> `Usage: cmux simulate-app-active`
+- `cmux claude-hook --help` -> `Usage: cmux claude-hook`
+- `cmux codex-hook --help` -> `Usage: cmux codex-hook`
+- `cmux browser --help` -> `Usage: cmux browser`
+- `cmux open-browser --help` -> `Legacy alias for 'cmux browser open'`
+- `cmux navigate --help` -> `Legacy alias for 'cmux browser navigate'`
+- `cmux browser-back --help` -> `Legacy alias for 'cmux browser back'`
+- `cmux browser-forward --help` -> `Legacy alias for 'cmux browser forward'`
+- `cmux browser-reload --help` -> `Legacy alias for 'cmux browser reload'`
+- `cmux get-url --help` -> `Legacy alias for 'cmux browser get-url'`
+- `cmux focus-webview --help` -> `Legacy alias for 'cmux browser focus-webview'`
+- `cmux is-webview-focused --help` -> `Legacy alias for 'cmux browser is-webview-focused'`
+- `cmux markdown --help` -> `Usage: cmux markdown open <path>`
+<!-- cli-contract-help-probes:end -->
+
+## Current Help Caveats
+
+These are current contracts to preserve until a follow-up PR intentionally
+changes them:
+
+- `cmux help` currently routes through the socket dispatch path. Use
+  `cmux --help` or `cmux help --help` for no-socket help.
+- `cmux version --help` currently prints the version summary because `version`
+  is handled before subcommand help dispatch.
+- `cmux codex --help` currently is not a no-socket help probe.
+- `cmux claude-teams --help` is handled by the command launcher, not by the
+  pre-socket help dispatcher.
+- `cmux remote-daemon-status --help` currently prints status because the command
+  runs before subcommand help dispatch.
+
+## ArgumentParser Migration Sequence
+
+1. Keep this contract file and `tests/test_cli_contract_help.py` green.
+2. Add Swift ArgumentParser as a dependency without changing behavior.
+3. Introduce a parse-only facade that maps ArgumentParser command structs onto
+   existing `CMUXCLI` runner methods.
+4. Move one command family at a time into small files, starting with no-socket
+   commands (`version`, `themes`, hook installers), then socket commands, then
+   browser and tmux compatibility.
+5. After each family moves, run the contract probes plus targeted socket tests in
+   GitHub Actions.
+6. When all command families are migrated, remove the manual global parser and
+   legacy helper code that no longer owns behavior.

--- a/tests/test_cli_contract_help.py
+++ b/tests/test_cli_contract_help.py
@@ -14,6 +14,7 @@ import os
 import re
 import shlex
 import subprocess
+import tempfile
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -116,20 +117,23 @@ def run_probe(cli_path: str, probe: HelpProbe) -> ProbeResult:
         "CMUX_TAB_ID",
     ]:
         env.pop(key, None)
-    no_socket = f"/tmp/cmux-no-socket-{uuid.uuid4().hex}.sock"
-    env["CMUX_SOCKET_PATH"] = no_socket
-    env["CMUX_SOCKET"] = no_socket
     env["CMUX_CLI_SENTRY_DISABLED"] = "1"
     env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
 
-    proc = subprocess.run(
-        [cli_path, *tokens[1:]],
-        text=True,
-        capture_output=True,
-        check=False,
-        timeout=5.0,
-        env=env,
-    )
+    with tempfile.TemporaryDirectory(prefix="cmux-no-socket-") as tmpdir:
+        no_socket = os.path.join(tmpdir, f"socket-{uuid.uuid4().hex}.sock")
+        env["CMUX_SOCKET_PATH"] = no_socket
+        env["CMUX_SOCKET"] = no_socket
+
+        proc = subprocess.run(  # noqa: S603
+            [cli_path, *tokens[1:]],
+            text=True,
+            capture_output=True,
+            check=False,
+            timeout=5.0,
+            env=env,
+        )
+
     return ProbeResult(
         returncode=proc.returncode,
         stdout=proc.stdout.strip(),
@@ -143,7 +147,7 @@ def main() -> int:
         cli_path = resolve_cmux_cli()
         probes = load_help_probes()
         negative_probes = load_negative_help_probes()
-    except Exception as exc:
+    except (RuntimeError, OSError, ValueError) as exc:
         print(f"FAIL: {exc}")
         return 1
 
@@ -154,7 +158,7 @@ def main() -> int:
         except subprocess.TimeoutExpired:
             failures.append(f"{probe.command}: timed out")
             continue
-        except Exception as exc:
+        except (RuntimeError, OSError, ValueError) as exc:
             failures.append(f"{probe.command}: {exc}")
             continue
 
@@ -162,6 +166,12 @@ def main() -> int:
         if result.returncode != 0:
             failures.append(
                 f"{probe.command}: expected exit 0, got {result.returncode}\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+            )
+            continue
+        if result.socket_path in merged:
+            failures.append(
+                f"{probe.command}: unexpected socket usage with forced socket {result.socket_path!r}\n"
                 f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
             )
             continue
@@ -177,7 +187,7 @@ def main() -> int:
         except subprocess.TimeoutExpired:
             failures.append(f"{probe.command}: timed out")
             continue
-        except Exception as exc:
+        except (RuntimeError, OSError, ValueError) as exc:
             failures.append(f"{probe.command}: {exc}")
             continue
 

--- a/tests/test_cli_contract_help.py
+++ b/tests/test_cli_contract_help.py
@@ -13,7 +13,6 @@ import glob
 import os
 import re
 import shlex
-import shutil
 import subprocess
 import uuid
 from dataclasses import dataclass
@@ -34,6 +33,14 @@ class HelpProbe:
     needle: str
 
 
+@dataclass(frozen=True)
+class ProbeResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    socket_path: str
+
+
 def repo_root() -> Path:
     return Path(__file__).resolve().parent.parent
 
@@ -45,15 +52,10 @@ def resolve_cmux_cli() -> str:
 
     candidates: list[str] = []
     candidates.extend(glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/*/Build/Products/Debug/cmux")))
-    candidates.extend(glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux"))
     candidates = [path for path in candidates if os.path.exists(path) and os.access(path, os.X_OK)]
     if candidates:
         candidates.sort(key=os.path.getmtime, reverse=True)
         return candidates[0]
-
-    in_path = shutil.which("cmux")
-    if in_path:
-        return in_path
 
     raise RuntimeError("Unable to find cmux CLI binary. Set CMUX_CLI_BIN.")
 
@@ -101,7 +103,7 @@ def load_probes(start_marker: str, end_marker: str, pattern: re.Pattern[str]) ->
     return probes
 
 
-def run_probe(cli_path: str, probe: HelpProbe) -> tuple[int, str, str]:
+def run_probe(cli_path: str, probe: HelpProbe) -> ProbeResult:
     tokens = shlex.split(probe.command)
     if not tokens or tokens[0] != "cmux":
         raise RuntimeError(f"Probe must start with cmux: {probe.command}")
@@ -128,7 +130,12 @@ def run_probe(cli_path: str, probe: HelpProbe) -> tuple[int, str, str]:
         timeout=5.0,
         env=env,
     )
-    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+    return ProbeResult(
+        returncode=proc.returncode,
+        stdout=proc.stdout.strip(),
+        stderr=proc.stderr.strip(),
+        socket_path=no_socket,
+    )
 
 
 def main() -> int:
@@ -143,7 +150,7 @@ def main() -> int:
     failures: list[str] = []
     for probe in probes:
         try:
-            code, stdout, stderr = run_probe(cli_path, probe)
+            result = run_probe(cli_path, probe)
         except subprocess.TimeoutExpired:
             failures.append(f"{probe.command}: timed out")
             continue
@@ -151,20 +158,22 @@ def main() -> int:
             failures.append(f"{probe.command}: {exc}")
             continue
 
-        merged = f"{stdout}\n{stderr}".strip()
-        if code != 0:
+        merged = f"{result.stdout}\n{result.stderr}".strip()
+        if result.returncode != 0:
             failures.append(
-                f"{probe.command}: expected exit 0, got {code}\nstdout={stdout!r}\nstderr={stderr!r}"
+                f"{probe.command}: expected exit 0, got {result.returncode}\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
             )
             continue
         if probe.needle not in merged:
             failures.append(
-                f"{probe.command}: missing expected text {probe.needle!r}\nstdout={stdout!r}\nstderr={stderr!r}"
+                f"{probe.command}: missing expected text {probe.needle!r}\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
             )
 
     for probe in negative_probes:
         try:
-            _code, stdout, stderr = run_probe(cli_path, probe)
+            result = run_probe(cli_path, probe)
         except subprocess.TimeoutExpired:
             failures.append(f"{probe.command}: timed out")
             continue
@@ -172,10 +181,21 @@ def main() -> int:
             failures.append(f"{probe.command}: {exc}")
             continue
 
-        merged = f"{stdout}\n{stderr}".strip()
+        merged = f"{result.stdout}\n{result.stderr}".strip()
         if probe.needle in merged:
             failures.append(
-                f"{probe.command}: unexpected help text {probe.needle!r}\nstdout={stdout!r}\nstderr={stderr!r}"
+                f"{probe.command}: unexpected help text {probe.needle!r}\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+            )
+        if result.returncode == 0:
+            failures.append(
+                f"{probe.command}: expected nonzero exit after forwarding --help, got 0\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
+            )
+        if result.socket_path not in merged:
+            failures.append(
+                f"{probe.command}: expected forwarded command to reach forced socket {result.socket_path!r}\n"
+                f"stdout={result.stdout!r}\nstderr={result.stderr!r}"
             )
 
     if failures:

--- a/tests/test_cli_contract_help.py
+++ b/tests/test_cli_contract_help.py
@@ -1,0 +1,158 @@
+#!/usr/bin/env python3
+"""
+Executable contract check for no-socket cmux CLI help behavior.
+
+The command list lives in docs/cli-contract.md so the human migration spec and
+CI check stay tied together. This test invokes the built CLI binary; it does not
+inspect Swift source.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+START_MARKER = "<!-- cli-contract-help-probes:start -->"
+END_MARKER = "<!-- cli-contract-help-probes:end -->"
+PROBE_RE = re.compile(r"^- `(?P<command>cmux(?: [^`]+)?)` -> `(?P<needle>[^`]+)`$")
+
+
+@dataclass(frozen=True)
+class HelpProbe:
+    command: str
+    needle: str
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def resolve_cmux_cli() -> str:
+    explicit = os.environ.get("CMUX_CLI_BIN") or os.environ.get("CMUX_CLI")
+    if explicit and os.path.exists(explicit) and os.access(explicit, os.X_OK):
+        return explicit
+
+    candidates: list[str] = []
+    candidates.extend(glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/*/Build/Products/Debug/cmux")))
+    candidates.extend(glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux"))
+    candidates = [path for path in candidates if os.path.exists(path) and os.access(path, os.X_OK)]
+    if candidates:
+        candidates.sort(key=os.path.getmtime, reverse=True)
+        return candidates[0]
+
+    in_path = shutil.which("cmux")
+    if in_path:
+        return in_path
+
+    raise RuntimeError("Unable to find cmux CLI binary. Set CMUX_CLI_BIN.")
+
+
+def load_help_probes() -> list[HelpProbe]:
+    contract_path = repo_root() / "docs" / "cli-contract.md"
+    lines = contract_path.read_text(encoding="utf-8").splitlines()
+
+    in_block = False
+    probes: list[HelpProbe] = []
+    for line in lines:
+        if line.strip() == START_MARKER:
+            in_block = True
+            continue
+        if line.strip() == END_MARKER:
+            in_block = False
+            break
+        if not in_block:
+            continue
+
+        stripped = line.strip()
+        if not stripped:
+            continue
+        match = PROBE_RE.match(stripped)
+        if match is None:
+            raise RuntimeError(f"Malformed help probe line: {line}")
+        probes.append(HelpProbe(command=match.group("command"), needle=match.group("needle")))
+
+    if in_block:
+        raise RuntimeError(f"Missing end marker: {END_MARKER}")
+    if not probes:
+        raise RuntimeError("No CLI help probes found in docs/cli-contract.md")
+    return probes
+
+
+def run_probe(cli_path: str, probe: HelpProbe) -> tuple[int, str, str]:
+    tokens = shlex.split(probe.command)
+    if not tokens or tokens[0] != "cmux":
+        raise RuntimeError(f"Probe must start with cmux: {probe.command}")
+
+    env = dict(os.environ)
+    for key in [
+        "CMUX_SOCKET_PATH",
+        "CMUX_SOCKET",
+        "CMUX_WORKSPACE_ID",
+        "CMUX_SURFACE_ID",
+        "CMUX_TAB_ID",
+    ]:
+        env.pop(key, None)
+    env["CMUX_CLI_SENTRY_DISABLED"] = "1"
+    env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+    proc = subprocess.run(
+        [cli_path, *tokens[1:]],
+        text=True,
+        capture_output=True,
+        check=False,
+        timeout=5.0,
+        env=env,
+    )
+    return proc.returncode, proc.stdout.strip(), proc.stderr.strip()
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+        probes = load_help_probes()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    failures: list[str] = []
+    for probe in probes:
+        try:
+            code, stdout, stderr = run_probe(cli_path, probe)
+        except subprocess.TimeoutExpired:
+            failures.append(f"{probe.command}: timed out")
+            continue
+        except Exception as exc:
+            failures.append(f"{probe.command}: {exc}")
+            continue
+
+        merged = f"{stdout}\n{stderr}".strip()
+        if code != 0:
+            failures.append(
+                f"{probe.command}: expected exit 0, got {code}\nstdout={stdout!r}\nstderr={stderr!r}"
+            )
+            continue
+        if probe.needle not in merged:
+            failures.append(
+                f"{probe.command}: missing expected text {probe.needle!r}\nstdout={stdout!r}\nstderr={stderr!r}"
+            )
+
+    if failures:
+        print("FAIL: CLI help contract probes failed")
+        for failure in failures:
+            print("")
+            print(failure)
+        return 1
+
+    print(f"PASS: {len(probes)} CLI help contract probes passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cli_contract_help.py
+++ b/tests/test_cli_contract_help.py
@@ -15,13 +15,17 @@ import re
 import shlex
 import shutil
 import subprocess
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 
 
 START_MARKER = "<!-- cli-contract-help-probes:start -->"
 END_MARKER = "<!-- cli-contract-help-probes:end -->"
+NEGATIVE_START_MARKER = "<!-- cli-contract-negative-help-probes:start -->"
+NEGATIVE_END_MARKER = "<!-- cli-contract-negative-help-probes:end -->"
 PROBE_RE = re.compile(r"^- `(?P<command>cmux(?: [^`]+)?)` -> `(?P<needle>[^`]+)`$")
+NEGATIVE_PROBE_RE = re.compile(r"^- `(?P<command>cmux(?: [^`]+)?)` !> `(?P<needle>[^`]+)`$")
 
 
 @dataclass(frozen=True)
@@ -55,16 +59,30 @@ def resolve_cmux_cli() -> str:
 
 
 def load_help_probes() -> list[HelpProbe]:
+    probes = load_probes(START_MARKER, END_MARKER, PROBE_RE)
+    if not probes:
+        raise RuntimeError("No CLI help probes found in docs/cli-contract.md")
+    return probes
+
+
+def load_negative_help_probes() -> list[HelpProbe]:
+    probes = load_probes(NEGATIVE_START_MARKER, NEGATIVE_END_MARKER, NEGATIVE_PROBE_RE)
+    if not probes:
+        raise RuntimeError("No negative CLI help probes found in docs/cli-contract.md")
+    return probes
+
+
+def load_probes(start_marker: str, end_marker: str, pattern: re.Pattern[str]) -> list[HelpProbe]:
     contract_path = repo_root() / "docs" / "cli-contract.md"
     lines = contract_path.read_text(encoding="utf-8").splitlines()
 
     in_block = False
     probes: list[HelpProbe] = []
     for line in lines:
-        if line.strip() == START_MARKER:
+        if line.strip() == start_marker:
             in_block = True
             continue
-        if line.strip() == END_MARKER:
+        if line.strip() == end_marker:
             in_block = False
             break
         if not in_block:
@@ -73,15 +91,13 @@ def load_help_probes() -> list[HelpProbe]:
         stripped = line.strip()
         if not stripped:
             continue
-        match = PROBE_RE.match(stripped)
+        match = pattern.match(stripped)
         if match is None:
-            raise RuntimeError(f"Malformed help probe line: {line}")
+            raise RuntimeError(f"Malformed probe line: {line}")
         probes.append(HelpProbe(command=match.group("command"), needle=match.group("needle")))
 
     if in_block:
-        raise RuntimeError(f"Missing end marker: {END_MARKER}")
-    if not probes:
-        raise RuntimeError("No CLI help probes found in docs/cli-contract.md")
+        raise RuntimeError(f"Missing end marker: {end_marker}")
     return probes
 
 
@@ -92,13 +108,15 @@ def run_probe(cli_path: str, probe: HelpProbe) -> tuple[int, str, str]:
 
     env = dict(os.environ)
     for key in [
-        "CMUX_SOCKET_PATH",
-        "CMUX_SOCKET",
+        "CMUX_SOCKET_PASSWORD",
         "CMUX_WORKSPACE_ID",
         "CMUX_SURFACE_ID",
         "CMUX_TAB_ID",
     ]:
         env.pop(key, None)
+    no_socket = f"/tmp/cmux-no-socket-{uuid.uuid4().hex}.sock"
+    env["CMUX_SOCKET_PATH"] = no_socket
+    env["CMUX_SOCKET"] = no_socket
     env["CMUX_CLI_SENTRY_DISABLED"] = "1"
     env["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
 
@@ -117,6 +135,7 @@ def main() -> int:
     try:
         cli_path = resolve_cmux_cli()
         probes = load_help_probes()
+        negative_probes = load_negative_help_probes()
     except Exception as exc:
         print(f"FAIL: {exc}")
         return 1
@@ -143,6 +162,22 @@ def main() -> int:
                 f"{probe.command}: missing expected text {probe.needle!r}\nstdout={stdout!r}\nstderr={stderr!r}"
             )
 
+    for probe in negative_probes:
+        try:
+            _code, stdout, stderr = run_probe(cli_path, probe)
+        except subprocess.TimeoutExpired:
+            failures.append(f"{probe.command}: timed out")
+            continue
+        except Exception as exc:
+            failures.append(f"{probe.command}: {exc}")
+            continue
+
+        merged = f"{stdout}\n{stderr}".strip()
+        if probe.needle in merged:
+            failures.append(
+                f"{probe.command}: unexpected help text {probe.needle!r}\nstdout={stdout!r}\nstderr={stderr!r}"
+            )
+
     if failures:
         print("FAIL: CLI help contract probes failed")
         for failure in failures:
@@ -150,7 +185,7 @@ def main() -> int:
             print(failure)
         return 1
 
-    print(f"PASS: {len(probes)} CLI help contract probes passed")
+    print(f"PASS: {len(probes)} CLI help contract probes and {len(negative_probes)} negative probes passed")
     return 0
 
 


### PR DESCRIPTION
## Summary
- Add docs/cli-contract.md as the migration contract for Swift ArgumentParser.
- Add a no-socket help probe test that reads the contract doc and invokes the built CLI.
- Wire the check into CI next to the existing CLI version guard.

## Tests
- python3 -m py_compile tests/test_cli_contract_help.py
- GitHub Actions will run tests/test_cli_contract_help.py against the built CLI.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CLI contract with executable no-socket help probes and stricter negative probes to lock help behavior during the Swift ArgumentParser migration. CI now enforces stable help output without a socket and safe argument forwarding after `--`.

- **New Features**
  - Added `docs/cli-contract.md` with the CLI migration contract, no-socket help probes, and negative help probes.
  - Added `tests/test_cli_contract_help.py` to read probes from the doc; positive probes exit 0 with expected help; negative probes must not print help, must exit non‑zero, and must show the forced socket path; includes robust binary discovery, env isolation, and timeouts.
  - Updated CI to run the new contract test alongside the existing CLI version guard.

- **Refactors**
  - Cleaned up lints in `tests/test_cli_contract_help.py` (no behavior change).

<sup>Written for commit 52be20b7d9174c809d21a18c576e17c5d2901e5a. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3246?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive CLI compatibility contract describing expected commands, flags, env behavior, and help output.

* **Tests**
  * Added executable CLI contract tests that run "no-socket" help probes to verify positive and negative help behavior.

* **Chores**
  * Updated CI to run the new no-socket help regression in place of the previous version-memory guard regression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->