### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9763,6 +9763,10 @@ struct VerticalTabsSidebar: View {
                 .background(
                     SidebarScrollViewResolver { scrollView in
                         dragAutoScrollController.attach(scrollView: scrollView)
+                        if let scrollView {
+                            scrollView.autohidesScrollers = true
+                            scrollView.scrollerStyle = .overlay
+                        }
                     }
                     .frame(width: 0, height: 0)
                 )


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Codex final message:

Implemented a narrow fix for the sidebar scrollbar behavior.

### What I changed
- Updated the workspace sidebar scroll setup in:
  - [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift)

Change is in `workspaceScrollArea`’s `SidebarScrollViewResolver` callback:

- set `scrollView.autohidesScrollers = true`
- set `scrollView.scrollerStyle = .overlay`

This makes the sidebar scrollbar follow overflow/interaction behavior instead of reserving a permanent track.

### Verification performed
- Attempted build command:
  - `./scripts/reload.sh --tag loader`
- Attempted with skip flag:
  - `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag loader`
- Both failed immediately with:
  - `Error: zig is not installed. Install via: brew install zig`

Result: I could not build a tagged app in this runner, so I could not run `computer-use` or capture before/after videos here.

### Environment/build constraints
- Working directory is writable for source edits, but `.git` is not writable in this session:
  - `git commit` failed with `Unable to create .../.git/index.lock`
  - `touch .git/...` also fails with `Operation not permitted`

### Recorded videos
- `repro-before`: **not recorded**
- `fixed-after`: **not recorded**

### PR
- Not opened yet (no commit could be created in this session due read-only `.git`).

If you want, I can finish this by creating the commit/PR locally once run in an environment with `zig` installed and writable `.git`, then I can also capture and include both required videos.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3241 by making the sidebar scrollbar appear only when content overflows or during interaction, instead of always being visible. Sets `scrollView.autohidesScrollers = true` and `scrollView.scrollerStyle = .overlay` in the sidebar scroll resolver to remove the permanent track.

<sup>Written for commit 11a95bb94bd9378b2887cf1978d753e679db55dd. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3248?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

