### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9762,6 +9762,8 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(
                     SidebarScrollViewResolver { scrollView in
+                        scrollView?.autohidesScrollers = true
+                        scrollView?.scrollerStyle = .overlay
                         dragAutoScrollController.attach(scrollView: scrollView)
                     }
                     .frame(width: 0, height: 0)


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Codex final message:

Implemented the sidebar scrollbar fix with a narrow change in the workspace sidebar scroll setup:

- Updated [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift) in `workspaceScrollArea`’s `SidebarScrollViewResolver` callback:
  - `scrollView?.autohidesScrollers = true`
  - `scrollView?.scrollerStyle = .overlay`

Summary:
- This should make the workspace sidebar scrollbar adopt native behavior (hidden until needed/interaction), removing the permanent track when content fits.

Verification performed:
- `./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar` (failed: `mkdir: /Users/runner/.cache/cmux: Operation not permitted`)
- `HOME=/tmp/cmux-home ./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar` (failed: cannot resolve `github.com` while fetching prebuilt `GhosttyKit`)
- `HOME=/tmp/cmux-home CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar` (failed same network/DNS issue resolving `github.com`)

Issue context:
- https://github.com/manaflow-ai/cmux/issues/3241

Recorded videos:
- None. Build/runtime environment could not complete a tagged launch/reload with network and cache access, so GUI capture wasn’t performed here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3241 by enabling native auto‑hiding, overlay scrollbars in the workspace sidebar. The scrollbar now stays hidden when content fits and appears on interaction or overflow.

<sup>Written for commit aafc1cbb243bf27e4b6e5b969d59b61c56d1e544. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3249?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar scrollbar behavior to use overlay scrollers that automatically hide when not actively in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->