### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9762,6 +9762,8 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(
                     SidebarScrollViewResolver { scrollView in
+                        scrollView?.autohidesScrollers = true
+                        scrollView?.scrollerStyle = .overlay
                         dragAutoScrollController.attach(scrollView: scrollView)
                     }
                     .frame(width: 0, height: 0)


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Codex final message:

Implemented a narrow fix for issue 3241 in:

- [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift)

What changed:
- In `workspaceScrollArea` → `SidebarScrollViewResolver` callback, added:
  - `scrollView?.autohidesScrollers = true`
  - `scrollView?.scrollerStyle = .overlay`
- This makes the workspace sidebar use native overlay/auto-hide scroller behavior instead of reserving a permanent scrollbar track.

Verification performed:
1. `./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar-video3`  
   Result: failed (exit `74`) while resolving package dependencies.
2. `HOME=/tmp/cmux-home ./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar-video3`  
   Result: same failure (exit `74`) with SwiftPM cache write permission error:
   `Could not resolve package dependencies ... You don’t have permission to save the file “ManifestLoading” in the folder “manifests”.`

Recorded videos:
- None (tagged reload did not complete, so no GUI/app instance was available for `computer-use` capture).

I did not open or update a PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the workspace sidebar to overlay, auto-hiding scrollbars so the bar only appears when content overflows. Addresses #3241.

- **Bug Fixes**
  - Set `autohidesScrollers = true` and `scrollerStyle = .overlay` in `SidebarScrollViewResolver` for the sidebar scroll view.

<sup>Written for commit 613039decba5e12e74b991531e86a2b35b59b37d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3250?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

