### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9762,6 +9762,8 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(
                     SidebarScrollViewResolver { scrollView in
+                        scrollView?.autohidesScrollers = true
+                        scrollView?.scrollerStyle = .overlay
                         dragAutoScrollController.attach(scrollView: scrollView)
                     }
                     .frame(width: 0, height: 0)


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Codex final message:

Implemented the narrow fix in:

- [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift)

What changed:
- In `workspaceScrollArea`’s `.background(SidebarScrollViewResolver { ... })` callback, added:
  - `scrollView?.autohidesScrollers = true`
  - `scrollView?.scrollerStyle = .overlay`
- This applies the native auto-hide/overlay behavior to the workspace sidebar scroll view so the scrollbar track is not permanently visible when content does not overflow.

Verification performed:
1. `./scripts/reload.sh --tag loader-issue-3241-sidebar-scrollbar-video5`
2. Result: failed before app build completion
   - `xcodebuild: error: Could not resolve package dependencies: sandbox-exec: sandbox_apply: Operation not permitted`
   - The failure occurred in dependency resolution, so I could not launch the tagged app or run GUI validation/video capture.

Recorded videos:
- `repro-before`: not recorded
- `fixed-after`: not recorded

Issue context:
- https://github.com/manaflow-ai/cmux/issues/3241

I did not open a PR myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the workspace sidebar scrollbar auto-hide and use the overlay style so it only appears when content overflows. Sets autohidesScrollers = true and scrollerStyle = .overlay on the sidebar scroll view.

<sup>Written for commit ffac780676f5efe46abc6a906c300b907047cb37. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3253?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

