### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9762,6 +9762,7 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(
                     SidebarScrollViewResolver { scrollView in
+                        configureSidebarScrollView(scrollView)
                         dragAutoScrollController.attach(scrollView: scrollView)
                     }
                     .frame(width: 0, height: 0)
@@ -9809,6 +9810,19 @@ struct VerticalTabsSidebar: View {
                     flushPendingSelectedWorkspaceScroll(scrollProxy, laidOutWorkspaceRowIds: rowIds)
                 }
             }
+        }
+    }
+
+    private func configureSidebarScrollView(_ scrollView: NSScrollView?) {
+        guard let scrollView else {
+            return
+        }
+
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        if #available(macOS 13.0, *) {
+            scrollView.scrollerStyle = .overlay
         }
     }
 


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Recorded videos:

- repro-before: .runner/videos/repro-before.mov (ok)
- fixed-after: .runner/videos/fixed-after.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25086049294

Codex final message:

Implemented a narrow fix for issue #3241 on branch `loader/issue-3241-sidebar-scrollbar-video8` by changing the sidebar scroll-view setup in:

- [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift:9816)

What changed:
- Updated the sidebar scroll view resolver helper to accept `NSScrollView?` and no-op if nil (resolver passes optional).
- Kept the sidebar scroll behavior configured to hide scrollbar UI unless needed:
  - `autohidesScrollers = true`
  - `hasVerticalScroller = true`
  - `hasHorizontalScroller = false`
  - `scrollerStyle = .overlay` on macOS 13+

Verification performed:
- Ran required tagged reload:
  - `./scripts/reload.sh --tag loader`
  - Build succeeded.
  - App path: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux DEV loader.app`
- Approved tagged app for computer-use:
  - `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux DEV loader.app"`
- Launched and controlled the tagged app to capture visual evidence.
- No additional tests were run beyond the required reload build and video capture.

Recorded videos:
- `repro-before` — `status=ok`
- `fixed-after` — `status=ok` (`/.runner/videos/fixed-after.mov`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar scrollbars always showing by configuring the sidebar scroll view to autohide and use overlay style so the bar appears only when content overflows. Also handles a nil scroll view from the resolver safely.

- **Bug Fixes**
  - Configure sidebar scroll view: autohidesScrollers=true, hasVerticalScroller=true, hasHorizontalScroller=false, overlay scroller style on macOS 13+.
  - Make the resolver accept `NSScrollView?` and no-op when nil.

<sup>Written for commit 72b7f176e33ebba9ba63864bcaa1f28c860e40e7. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3258?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

