### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9763,6 +9763,7 @@ struct VerticalTabsSidebar: View {
                 .background(
                     SidebarScrollViewResolver { scrollView in
                         dragAutoScrollController.attach(scrollView: scrollView)
+                        configureSidebarScrollView(scrollView)
                     }
                     .frame(width: 0, height: 0)
                 )
@@ -9928,6 +9929,13 @@ struct VerticalTabsSidebar: View {
     private func debugShortSidebarTabId(_ id: UUID?) -> String {
         guard let id else { return "nil" }
         return String(id.uuidString.prefix(5))
+    }
+
+    private func configureSidebarScrollView(_ scrollView: NSScrollView?) {
+        guard let scrollView else { return }
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Recorded videos:

- repro-before: .runner/videos/repro-before.mov (ok)
- fixed-after: .runner/videos/fixed-after.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25086398926

Codex final message:

Implemented a narrow sidebar-only fix in `VerticalTabsSidebar` so the sidebar’s `ScrollView` uses overlay + auto-hiding scrollbars.

- [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift:9763)
  - In `workspaceScrollArea`, pass the resolved `NSScrollView` into a new helper.
  - Added `configureSidebarScrollView(_:)` and set:
    - `hasVerticalScroller = true`
    - `autohidesScrollers = true`
    - `scrollerStyle = .overlay`

=======================================================
[loader: file:///Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux%20DEV%20loader.app](file:///Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux%20DEV%20loader.app)
=======================================================

Issue reference: https://github.com/manaflow-ai/cmux/issues/3241

Verification performed:
- Reloaded tagged app build as required:
  - `./scripts/reload.sh --tag loader`
- Baseline and fixed UI capture workflow (required by workflow instructions) completed with `computer-use` approval flow:
  - `./.cmux-loader/record-video start repro-before 180`
  - `./.cmux-loader/record-video stop repro-before` → `status=ok`
  - `./.cmux-loader/record-video start fixed-after 180`
  - `./.cmux-loader/record-video stop fixed-after` → `status=ok`
- Recorded video names:
  - `repro-before`
  - `fixed-after`

Note:
- I did not run unit/UI/test suites locally per repo policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the sidebar scrollbar auto-hide and use overlay style so it only appears when content overflows. Fixes https://github.com/manaflow-ai/cmux/issues/3241.

- **Bug Fixes**
  - In `VerticalTabsSidebar`, configured the sidebar `NSScrollView` via `configureSidebarScrollView` to set `hasVerticalScroller = true`, `autohidesScrollers = true`, and `scrollerStyle = .overlay`.
  - Scoped to the sidebar only; verified with before/after recordings.

<sup>Written for commit 81ac9b88febf2bcdd3c551aec411d7b82b2e3c89. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3260?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

