### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9768,6 +9768,7 @@ struct VerticalTabsSidebar: View {
                         minHeight: geometryProxy.size.height
                     )
                 }
+                .scrollIndicators(.automatic)
                 .background(
                     SidebarScrollViewResolver { scrollView in
                         dragAutoScrollController.attach(scrollView: scrollView)


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Recorded videos:

- repro-before: .runner/videos/repro-before.mov (ok)
- fixed-after: .runner/videos/fixed-after.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25087560184

Codex final message:

Implemented a narrow fix for **https://github.com/manaflow-ai/cmux/issues/3241** on branch `loader/issue-3241-sidebar-scrollbar-video13`.

### What changed
- Updated the workspace sidebar scroll container in [`Sources/ContentView.swift`](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift) to use `.scrollIndicators(.automatic)` in `workspaceScrollArea(...)`.
- This changes scrollbar behavior to only surface when content overflows / as macOS decides (instead of always rendering a track).

### Validation performed
1. Built tagged app (required) after change:
- `./scripts/reload.sh --tag loader`
2. Recorded required GUI evidence (as requested by loader workflow):
- `repro-before` → `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro-before.mov` (`status=ok`)
- `fixed-after` → `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/fixed-after.mov` (`status=ok`)
3. Approved and inspected the tagged app state via `computer-use` (app path and accessibility state confirmed for tagged build).

### Notes
- I did not open a PR.
- I did not run tests (per repo policy to avoid local test runs).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3241 by switching the workspace sidebar to automatic scroll indicators so the scrollbar only shows when content overflows.

<sup>Written for commit 38fb01d95b7842761ac9225c36a2896d0a8af196. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3267?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enabled automatic scroll indicators on the sidebar to improve visual feedback when scrolling through content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->