### PR TITLE
Fix locale separators in sidebar identifiers

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12821,6 +12821,7 @@ private struct TabItemView: View, Equatable {
             if detailVisibility.showsPullRequests, !workspaceSnapshot.pullRequestRows.isEmpty {
                 VStack(alignment: .leading, spacing: 1) {
                     ForEach(workspaceSnapshot.pullRequestRows) { pullRequest in
+                        let pullRequestNumber = String(pullRequest.number)
                         Button(action: {
                             openPullRequestLink(pullRequest.url)
                         }) {
@@ -12829,7 +12830,7 @@ private struct TabItemView: View, Equatable {
                                     status: pullRequest.status,
                                     color: pullRequestForegroundColor
                                 )
-                                Text("\(pullRequest.label) #\(pullRequest.number)")
+                                Text("\(pullRequest.label) #\(pullRequestNumber)")
                                     .underline()
                                     .lineLimit(1)
                                     .truncationMode(.tail)
@@ -12842,7 +12843,7 @@ private struct TabItemView: View, Equatable {
                             .opacity(pullRequest.isStale ? 0.5 : 1)
                         }
                         .buttonStyle(.plain)
-                        .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"))
+                        .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequest.label) #\(pullRequestNumber)"))
                     }
                 }
             }
@@ -12851,14 +12852,15 @@ private struct TabItemView: View, Equatable {
             if detailVisibility.showsPorts, !workspaceSnapshot.listeningPorts.isEmpty {
                 HStack(spacing: 4) {
                     ForEach(workspaceSnapshot.listeningPorts, id: \.self) { port in
+                        let portText = String(port)
                         Button(action: {
                             openPortLink(port)
                         }) {
-                            Text(String(localized: "sidebar.port.label", defaultValue: ":\(port)"))
+                            Text(String(localized: "sidebar.port.label", defaultValue: ":\(portText)"))
                                 .underline()
                         }
                         .buttonStyle(.plain)
-                        .safeHelp(String(localized: "sidebar.port.openTooltip", defaultValue: "Open localhost:\(port)"))
+                        .safeHelp(String(localized: "sidebar.port.openTooltip", defaultValue: "Open localhost:\(portText)"))
                     }
                     Spacer(minLength: 0)
                 }

--- a/cmuxTests/SidebarIdentifierFormattingTests.swift
+++ b/cmuxTests/SidebarIdentifierFormattingTests.swift
@@ -1,0 +1,200 @@
+import AppKit
+import SwiftUI
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class SidebarIdentifierFormattingTests: XCTestCase {
+    func testSidebarLabelsRenderPortAndPullRequestIdentifiersWithoutThousandsSeparators() throws {
+        let harness = try makeHarness()
+        defer { harness.tearDown() }
+
+        let strings = renderedStrings(in: harness.window.contentView)
+
+        XCTAssertTrue(
+            strings.contains(":2014"),
+            "Expected sidebar port label without locale separators. Rendered strings: \(strings)"
+        )
+        XCTAssertTrue(
+            strings.contains("PR #1234"),
+            "Expected sidebar PR label without locale separators. Rendered strings: \(strings)"
+        )
+        XCTAssertFalse(
+            strings.contains(":2,014"),
+            "Sidebar should not locale-format port identifiers. Rendered strings: \(strings)"
+        )
+        XCTAssertFalse(
+            strings.contains("PR #1,234"),
+            "Sidebar should not locale-format pull request identifiers. Rendered strings: \(strings)"
+        )
+    }
+
+    func testSidebarTooltipsRenderPortAndPullRequestIdentifiersWithoutThousandsSeparators() throws {
+        let harness = try makeHarness()
+        defer { harness.tearDown() }
+
+        let tooltips = renderedTooltips(in: harness.window.contentView)
+
+        XCTAssertTrue(
+            tooltips.contains("Open localhost:2014"),
+            "Expected port tooltip without locale separators. Tooltips: \(tooltips)"
+        )
+        XCTAssertTrue(
+            tooltips.contains("Open PR #1234"),
+            "Expected PR tooltip without locale separators. Tooltips: \(tooltips)"
+        )
+        XCTAssertFalse(
+            tooltips.contains("Open localhost:2,014"),
+            "Sidebar should not locale-format port tooltips. Tooltips: \(tooltips)"
+        )
+        XCTAssertFalse(
+            tooltips.contains("Open PR #1,234"),
+            "Sidebar should not locale-format PR tooltips. Tooltips: \(tooltips)"
+        )
+    }
+
+    private func makeHarness() throws -> SidebarHarness {
+        _ = NSApplication.shared
+
+        let defaults = UserDefaults.standard
+        let trackedDefaults = [
+            SidebarWorkspaceDetailSettings.hideAllDetailsKey,
+            "sidebarShowPullRequest",
+            "sidebarShowPorts",
+        ]
+        let originalDefaults = trackedDefaults.reduce(into: [String: Any?]()) { result, key in
+            result[key] = defaults.object(forKey: key)
+        }
+
+        defaults.set(false, forKey: SidebarWorkspaceDetailSettings.hideAllDetailsKey)
+        defaults.set(true, forKey: "sidebarShowPullRequest")
+        defaults.set(true, forKey: "sidebarShowPorts")
+
+        let notificationStore = TerminalNotificationStore.shared
+        notificationStore.replaceNotificationsForTesting([])
+
+        let tabManager = TabManager()
+        guard let workspace = tabManager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            throw HarnessError.missingWorkspace
+        }
+
+        let pullRequestURL = try XCTUnwrap(URL(string: "https://github.com/manaflow-ai/cmux/pull/1234"))
+        let branch = "issue-2530-sidebar-thousands-separator"
+        workspace.panelGitBranches[panelId] = SidebarGitBranchState(branch: branch, isDirty: false)
+        workspace.panelPullRequests[panelId] = SidebarPullRequestState(
+            number: 1234,
+            label: "PR",
+            url: pullRequestURL,
+            status: .open,
+            branch: branch
+        )
+        workspace.listeningPorts = [2014]
+
+        var selection: SidebarSelection = .tabs
+        var selectedTabIds: Set<UUID> = [workspace.id]
+        var lastSidebarSelectionIndex: Int? = 0
+
+        let root = VerticalTabsSidebar(
+            updateViewModel: UpdateViewModel(),
+            fileExplorerState: FileExplorerState(),
+            onSendFeedback: {},
+            titlebarHeight: 0,
+            selection: Binding(
+                get: { selection },
+                set: { selection = $0 }
+            ),
+            selectedTabIds: Binding(
+                get: { selectedTabIds },
+                set: { selectedTabIds = $0 }
+            ),
+            lastSidebarSelectionIndex: Binding(
+                get: { lastSidebarSelectionIndex },
+                set: { lastSidebarSelectionIndex = $0 }
+            )
+        )
+        .environmentObject(tabManager)
+        .environmentObject(notificationStore)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 320),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = MainWindowHostingView(rootView: root)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        window.contentView?.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        window.contentView?.layoutSubtreeIfNeeded()
+
+        return SidebarHarness(
+            window: window,
+            originalDefaults: originalDefaults
+        )
+    }
+
+    private func renderedStrings(in root: NSView?) -> [String] {
+        let strings = flattenedViews(from: root).flatMap { view -> [String] in
+            var values: [String] = []
+            if let textField = view as? NSTextField {
+                let string = textField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !string.isEmpty {
+                    values.append(string)
+                }
+            }
+            if let button = view as? NSButton {
+                let title = button.title.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !title.isEmpty {
+                    values.append(title)
+                }
+            }
+            return values
+        }
+        return Array(Set(strings)).sorted()
+    }
+
+    private func renderedTooltips(in root: NSView?) -> [String] {
+        let tooltips = flattenedViews(from: root).compactMap { view in
+            guard let tooltip = view.toolTip?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !tooltip.isEmpty else { return nil }
+            return tooltip
+        }
+        return Array(Set(tooltips)).sorted()
+    }
+
+    private func flattenedViews(from root: NSView?) -> [NSView] {
+        guard let root else { return [] }
+        return [root] + root.subviews.flatMap(flattenedViews)
+    }
+}
+
+private struct SidebarHarness {
+    let window: NSWindow
+    let originalDefaults: [String: Any?]
+
+    func tearDown() {
+        let defaults = UserDefaults.standard
+        for (key, value) in originalDefaults {
+            if let value {
+                defaults.set(value, forKey: key)
+            } else {
+                defaults.removeObject(forKey: key)
+            }
+        }
+
+        TerminalNotificationStore.shared.replaceNotificationsForTesting([])
+        TerminalNotificationStore.shared.resetNotificationDeliveryHandlerForTesting()
+        window.orderOut(nil)
+    }
+}
+
+private enum HarnessError: Error {
+    case missingWorkspace
+}


### PR DESCRIPTION
## Summary
- add a sidebar rendering regression test that checks PR and port labels/tooltips stay digit-exact
- wrap sidebar PR and port identifier Ints in String(...) before they reach SwiftUI Text or String(localized:)
- keep the fix scoped to the identifier display sites in Sources/ContentView.swift

## Testing
- not run locally per repo policy

Closes #2530

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c9e21d1aa98d7f6637fb772a07f6d6d5bc93cb88. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar labels and tooltips so PR numbers and ports render without locale thousands separators. Converts numeric identifiers to strings before rendering and adds a UI-backed regression test to lock this behavior.

- **Bug Fixes**
  - Wrap `pullRequest.number` and port values in `String(...)` before passing to `Text` and `String(localized:)` in `Sources/ContentView.swift`.
  - Add `SidebarIdentifierFormattingTests` to verify labels and tooltips render digit-exact (e.g., `PR #1234`, `:2014`) with no `1,234` or `2,014`.

<sup>Written for commit c9e21d1aa98d7f6637fb772a07f6d6d5bc93cb88. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3269?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar display of pull request numbers and port identifiers to consistently show unlocalized values without locale-specific thousands separators.

* **Tests**
  * Added test suite to verify pull request and port formatting displays correctly across different locales without unwanted number formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->