### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9811,6 +9811,8 @@ struct VerticalTabsSidebar: View {
                 }
                 .background(
                     SidebarScrollViewResolver { scrollView in
+                        scrollView?.autohidesScrollers = true
+                        scrollView?.scrollerStyle = .overlay
                         dragAutoScrollController.attach(scrollView: scrollView)
                     }
                     .frame(width: 0, height: 0)


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Recorded videos:

- repro-before: .runner/videos/repro-before.mov (ok)
- fixed-after: .runner/videos/fixed-after.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25088980518

Codex final message:

Implemented a narrow fix for [https://github.com/manaflow-ai/cmux/issues/3241](https://github.com/manaflow-ai/cmux/issues/3241): workspace sidebar scrollbars are now configured to behave like overflow-only/overlay macOS scrollers.

### Summary
- Updated [`Sources/ContentView.swift`](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift) in `workspaceScrollArea`:
  - Added `scrollView?.autohidesScrollers = true`
  - Added `scrollView?.scrollerStyle = .overlay`
- Change is scoped only to the sidebar `ScrollView` via `SidebarScrollViewResolver`, so it won’t affect other scroll areas.

### Verification performed
- Built tagged debug app after edits:
  - `./scripts/reload.sh --tag loader`
- Recorded required GUI evidence:
  - `repro-before` (baseline): `status=ok`
  - `fixed-after` (post-fix): `status=ok`
- App path from tagged build:
=======================================================
[loader: file:///Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux%20DEV%20loader.app](file:///Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux%20DEV%20loader.app)
=======================================================

### Recorded videos
- `repro-before` (`.runner/videos/repro-before.mov`)
- `fixed-after` (`.runner/videos/fixed-after.mov`)

I did not create or push a PR myself.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the workspace sidebar scrollbar auto-hide and show as an overlay so it only appears when content overflows. This removes the always-visible scrollbar and stops it from taking layout space. Fixes #3241.

- **Bug Fixes**
  - In `Sources/ContentView.swift` (sidebar `ScrollView`), set `autohidesScrollers = true` and `scrollerStyle = .overlay`.
  - Scoped via `SidebarScrollViewResolver` to affect only the sidebar; other scroll areas are unchanged.

<sup>Written for commit 0dd9a58cdc6a925811973164982a287df1ed36ec. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3276?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar scrollbars now use overlay-style indicators and automatically hide when not in use for a cleaner interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->