### PR TITLE
sidebar scrollbar always visible — should only appear when content overflows

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9809,9 +9809,14 @@ struct VerticalTabsSidebar: View {
                         minHeight: geometryProxy.size.height
                     )
                 }
+                .scrollIndicators(.automatic)
                 .background(
                     SidebarScrollViewResolver { scrollView in
-                        dragAutoScrollController.attach(scrollView: scrollView)
+                        if let scrollView {
+                            scrollView.autohidesScrollers = true
+                            scrollView.scrollerStyle = .overlay
+                            dragAutoScrollController.attach(scrollView: scrollView)
+                        }
                     }
                     .frame(width: 0, height: 0)
                 )
@@ -12171,6 +12176,13 @@ private final class SidebarScrollViewResolverView: NSView {
     func resolveScrollView() {
         DispatchQueue.main.async { [weak self] in
             guard let self else { return }
+            if let scrollView = enclosingScrollView {
+                let contentHeight = scrollView.documentView?.bounds.height ?? 0
+                let visibleHeight = scrollView.contentView.bounds.height
+                scrollView.hasVerticalScroller = contentHeight > visibleHeight + 1
+                scrollView.autohidesScrollers = true
+                scrollView.scrollerStyle = .overlay
+            }
             onResolve?(self.enclosingScrollView)
         }
     }


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/3241

Generated by cmux-loader.

Recorded videos:

- repro-before: .runner/videos/repro-before.mov (ok)
- fixed-after: .runner/videos/fixed-after.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25089637151

Codex final message:

Implemented in branch `loader/issue-3241-sidebar-scrollbar-video18` for https://github.com/manaflow-ai/cmux/issues/3241.

### Summary
I narrowed the fix to the workspace sidebar scroll container in [Sources/ContentView.swift](/Users/runner/work/cmux-loader/cmux-loader/cmux/Sources/ContentView.swift:9809):

- Added `.scrollIndicators(.automatic)` on the sidebar `ScrollView`.
- Updated the sidebar scroll resolver callback to always set:
  - `autohidesScrollers = true`
  - `scrollerStyle = .overlay`
- Updated `SidebarScrollViewResolverView.resolveScrollView()` to compute content/viewport heights and set:
  - `hasVerticalScroller = contentHeight > visibleHeight + 1`
  This prevents a vertical scroller when sidebar rows fit in the viewport.

### Verification performed
- Built tagged debug app (no test suite run):  
  `./scripts/reload.sh --tag loader`  
  `./scripts/reload.sh --tag loader --launch`
- Approved app for GUI automation:
  `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-loader/Build/Products/Debug/cmux DEV loader.app"`
- Confirmed app was running as `cmux DEV loader` and inspected GUI state via computer-use after rebuild.
- Recorded required videos (both succeeded):
  - `./.cmux-loader/record-video start repro-before 180` → `./.cmux-loader/record-video stop repro-before` (`status=ok`)
  - `./.cmux-loader/record-video start fixed-after 180` → `./.cmux-loader/record-video stop fixed-after` (`status=ok`)

### Recorded videos
- `repro-before.mov`
- `fixed-after.mov`

If you want, I can also keep the change minimal by removing the overflow-height guard and relying only on `.overlay + autohide`, but this may reintroduce the one-item visible-track behavior on some macOS settings.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace sidebar so its scrollbar only shows when content overflows. Uses overlay, autohiding indicators to remove the always-visible track.

- **Bug Fixes**
  - Set `.scrollIndicators(.automatic)` on the sidebar `ScrollView`.
  - Force `autohidesScrollers = true` and `scrollerStyle = .overlay` on the sidebar `NSScrollView`.
  - Toggle `hasVerticalScroller` based on content vs. visible height to prevent a scroller when items fit.

<sup>Written for commit 39313d64f8b8256b08e43b2c0b4b55863404934f. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3277?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar scroll view behavior with automatic scroll indicator visibility and overlay-style auto-hiding scrollers.
  * Enhanced vertical scroller rendering based on content dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->