### PR TITLE
fix: move NODE_OPTIONS restore guard out of $TMPDIR to user cache dir

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11488,7 +11488,20 @@ struct CMUXCLI {
     }
 
     private func createClaudeNodeOptionsRestoreModule() throws -> URL {
-        let root = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+        // Use the user's cache directory rather than NSTemporaryDirectory()
+        // so the guard module survives macOS `periodic` cleanup of
+        // /var/folders/.../T/ (which reaps temp files after ~3 days of no
+        // access and breaks long-running Claude sessions). The path must
+        // not contain whitespace, since Node.js splits NODE_OPTIONS on
+        // whitespace and the --require=<path> flag is not quoted.
+        let cachesURL = try FileManager.default.url(
+            for: .cachesDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        let root = cachesURL
+            .appendingPathComponent("com.cmuxterm.app", isDirectory: true)
             .appendingPathComponent("cmux-claude-node-options", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true, attributes: nil)
         let restoreModuleURL = root.appendingPathComponent("restore-node-options.cjs", isDirectory: false)

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -99,7 +99,11 @@ ensure_node_options_restore_module() {
     # whitespace, since Node.js splits NODE_OPTIONS on whitespace and
     # the --require=<path> flag is not quoted downstream.
     local guard_dir
-    if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+    # Reject XDG_CACHE_HOME values containing whitespace, since the
+    # path is interpolated unquoted into NODE_OPTIONS=--require=<path>
+    # below and node would split on the space (the same failure mode
+    # that sank #2983). Fall back to the OS default in that case.
+    if [[ -n "${XDG_CACHE_HOME:-}" && "$XDG_CACHE_HOME" != *[[:space:]]* ]]; then
         guard_dir="${XDG_CACHE_HOME}/cmux/cmux-claude-node-options"
     elif [[ "$(uname)" == "Darwin" ]]; then
         guard_dir="${HOME}/Library/Caches/com.cmuxterm.app/cmux-claude-node-options"

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -92,8 +92,20 @@ fi
 REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
 
 ensure_node_options_restore_module() {
-    local guard_dir="${TMPDIR:-/tmp}"
-    guard_dir="${guard_dir%/}/cmux-claude-node-options"
+    # Use a persistent cache directory rather than $TMPDIR so the guard
+    # module survives macOS `periodic` cleanup of /var/folders/.../T/
+    # (which reaps temp files after ~3 days of no access and breaks
+    # long-running Claude sessions). The directory must not contain
+    # whitespace, since Node.js splits NODE_OPTIONS on whitespace and
+    # the --require=<path> flag is not quoted downstream.
+    local guard_dir
+    if [[ -n "${XDG_CACHE_HOME:-}" ]]; then
+        guard_dir="${XDG_CACHE_HOME}/cmux/cmux-claude-node-options"
+    elif [[ "$(uname)" == "Darwin" ]]; then
+        guard_dir="${HOME}/Library/Caches/com.cmuxterm.app/cmux-claude-node-options"
+    else
+        guard_dir="${HOME}/.cache/cmux/cmux-claude-node-options"
+    fi
     local guard_path="$guard_dir/restore-node-options.cjs"
     mkdir -p "$guard_dir" || return 1
     local temp_path

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -326,7 +327,14 @@ func ensureClaudeNodeOptionsRestoreModule() (string, error) {
 		// cache directory; the bug only reproduces on macOS today.
 		cacheRoot = os.TempDir()
 	}
-	dir := filepath.Join(cacheRoot, "cmux", "cmux-claude-node-options")
+	// On macOS, align the subdirectory with the bash wrapper and Swift
+	// launcher (~/Library/Caches/com.cmuxterm.app/...) so all three
+	// launchers share a single cache tree instead of writing duplicates.
+	subdir := "cmux"
+	if runtime.GOOS == "darwin" {
+		subdir = "com.cmuxterm.app"
+	}
+	dir := filepath.Join(cacheRoot, subdir, "cmux-claude-node-options")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}

--- a/daemon/remote/cmd/cmuxd-remote/agent_launch.go
+++ b/daemon/remote/cmd/cmuxd-remote/agent_launch.go
@@ -314,7 +314,19 @@ func writeShimIfChanged(path string, content string) error {
 }
 
 func ensureClaudeNodeOptionsRestoreModule() (string, error) {
-	dir := filepath.Join(os.TempDir(), "cmux-claude-node-options")
+	// Use the user's cache directory rather than os.TempDir() so the guard
+	// module survives macOS `periodic` cleanup of /var/folders/.../T/
+	// (which reaps temp files after ~3 days of no access and breaks
+	// long-running Claude sessions). The path must not contain whitespace,
+	// since Node.js splits NODE_OPTIONS on whitespace and the
+	// --require=<path> flag is not quoted downstream.
+	cacheRoot, err := os.UserCacheDir()
+	if err != nil {
+		// Fall back to TempDir on systems without a discoverable user
+		// cache directory; the bug only reproduces on macOS today.
+		cacheRoot = os.TempDir()
+	}
+	dir := filepath.Join(cacheRoot, "cmux", "cmux-claude-node-options")
 	if err := os.MkdirAll(dir, 0755); err != nil {
 		return "", err
 	}

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -169,8 +169,10 @@ exit 0
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
-        if xdg_cache_home is not None:
-            env["XDG_CACHE_HOME"] = xdg_cache_home
+        # Always pin XDG_CACHE_HOME to a deterministic per-test path so
+        # tests don't leak into the host's real ~/.cache or
+        # ~/Library/Caches when an explicit override isn't provided.
+        env["XDG_CACHE_HOME"] = xdg_cache_home if xdg_cache_home is not None else str(tmp / "xdg-cache")
         if node_options is not None:
             env["NODE_OPTIONS"] = node_options
 

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -45,6 +45,7 @@ def run_wrapper(
     argv: list[str],
     node_options: str | None = None,
     tmpdir: str | None = None,
+    xdg_cache_home: str | None = None,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -168,6 +169,8 @@ exit 0
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
+        if xdg_cache_home is not None:
+            env["XDG_CACHE_HOME"] = xdg_cache_home
         if node_options is not None:
             env["NODE_OPTIONS"] = node_options
 
@@ -367,13 +370,15 @@ def test_live_socket_does_not_duplicate_bypass_availability_flag(failures: list[
 def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> None:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-tmp-") as td:
         tmpdir = Path(td)
-        guard_dir = tmpdir / "cmux-claude-node-options"
+        # Mirror the wrapper's XDG_CACHE_HOME override layout:
+        # ${XDG_CACHE_HOME}/cmux/cmux-claude-node-options/.
+        guard_dir = tmpdir / "cmux" / "cmux-claude-node-options"
         guard_dir.mkdir(parents=True, exist_ok=True)
         (guard_dir / "restore-node-options.XXXXXX.cjs").write_text("stale", encoding="utf-8")
         code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
             argv=["hello"],
-            tmpdir=str(tmpdir),
+            xdg_cache_home=str(tmpdir),
         )
     expect(code == 0, f"stale mktemp literal: wrapper exited {code}: {stderr}", failures)
     expect("mktemp:" not in stderr, f"stale mktemp literal: unexpected mktemp warning: {stderr!r}", failures)


### PR DESCRIPTION
## Summary

Move the `restore-node-options.cjs` guard out of `$TMPDIR` to a persistent **no-whitespace** cache path so it survives macOS `periodic` cleanup of `/var/folders/.../T/`, while avoiding the `Application Support` space breakage that sank #2983.

Fixes the recurring `Cannot find module '/var/folders/.../T/cmux-claude-node-options/restore-node-options.cjs'` failure originally reported in #2983 and contributes to the broader NODE_OPTIONS-injection issues tracked in #3059.

## The bug

`Resources/bin/claude`, `CLI/cmux.swift` and `daemon/remote/cmd/cmuxd-remote/agent_launch.go` all write the same restore shim under `${TMPDIR}/cmux-claude-node-options/` (or `os.TempDir()` / `NSTemporaryDirectory()` equivalents), then inject `NODE_OPTIONS=--require=<that path>` for the lifetime of the Claude session. macOS `com.apple.periodic-daily` reaps that path after ~3 days of no access, so every node child process from a long-running session crashes on module resolution.

## Why not `Application Support` (#2983)

Greptile flagged the previous attempt: `~/Library/Application Support` contains a space, and node splits `NODE_OPTIONS` on whitespace, so `--require=.../Application Support/...` is truncated at the first space and `MODULE_NOT_FOUND`s on **every** launch — replacing a 3-day-latent bug with an immediate one.

## New path layout (no whitespace)

| Source | New location |
|---|---|
| `XDG_CACHE_HOME` set | `\$XDG_CACHE_HOME/cmux/cmux-claude-node-options/` |
| macOS (default) | `~/Library/Caches/com.cmuxterm.app/cmux-claude-node-options/` |
| Linux (default) | `~/.cache/cmux/cmux-claude-node-options/` |

`Library/Caches` is the Apple-recommended location for regenerable runtime data and is **not** swept by `com.apple.periodic-daily` like `\$TMPDIR` is. The Go daemon uses `os.UserCacheDir()`, which resolves to the same destinations per platform.

## Files

- `Resources/bin/claude` — `ensure_node_options_restore_module()` now selects an XDG/macOS/Linux-specific cache dir.
- `CLI/cmux.swift` — `createClaudeNodeOptionsRestoreModule()` now uses `FileManager.url(for: .cachesDirectory, ...)` + bundle ID.
- `daemon/remote/cmd/cmuxd-remote/agent_launch.go` — `ensureClaudeNodeOptionsRestoreModule()` now uses `os.UserCacheDir()` with a `os.TempDir()` fallback.
- `tests/test_claude_wrapper_hooks.py` — `run_wrapper(...)` accepts `xdg_cache_home`; the stale-mktemp test now asserts the new layout.

## Testing

- `bash -n Resources/bin/claude` ✓
- `go build ./...` and `go test ./cmd/cmuxd-remote/...` in `daemon/remote/` ✓
- `test_live_socket_stale_mktemp_literal_does_not_warn` (run in isolation) ✓

## Notes

- Existing snapshot-resume tests in `cmuxTests/SessionPersistenceTests.swift` still hardcode `/tmp/...` paths; that's intentional — they verify that legacy on-disk session snapshots get their stale `--require=/tmp/...` flags stripped on resume, which remains correct.
- `~/Library/Caches/<bundle-id>/` may be cleared by macOS under disk pressure, but not periodically. Combined with `writeShimIfChanged` regenerating on every cmux launch, this gives a much wider safety window than the 3-day `\$TMPDIR` reap.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move the `restore-node-options.cjs` shim from `$TMPDIR` to a persistent, no-whitespace user cache path to prevent macOS temp cleanup from breaking long-running sessions and to avoid `NODE_OPTIONS=--require=<path>` whitespace issues. Paths are now aligned across the bash wrapper, Swift app, and Go agent.

- **Bug Fixes**
  - Cache path selection:
    - `$XDG_CACHE_HOME/cmux/cmux-claude-node-options` (if set and no whitespace)
    - `~/Library/Caches/com.cmuxterm.app/cmux-claude-node-options` (macOS)
    - `~/.cache/cmux/cmux-claude-node-options` (Linux)
  - All launchers use the same macOS path; Go uses `os.UserCacheDir()` with `os.TempDir()` fallback; Swift writes under the user caches dir with the bundle ID.
  - Bash wrapper rejects `XDG_CACHE_HOME` values containing whitespace and falls back to the OS default.
  - Tests pin `XDG_CACHE_HOME` to a per-test path for hermetic runs and assert the new layout.

<sup>Written for commit a667bf3890cd93fae04b1547942020977ad715d4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3278?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability for long-running Claude sessions by storing required runtime guard files in a persistent per-user cache instead of ephemeral temp locations, preventing system cleanup from interrupting sessions.
* **Tests**
  * Updated tests to align with the new cache-based paths and ensure the restore-guard behavior is validated under the new layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->