### PR TITLE
Fix keyboard shortcut recorder for Page Up/Down/Home/End (#3270)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -70486,6 +70486,74 @@
         }
       }
     },
+    "shortcut.key.pageUp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page Up"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページアップ"
+          }
+        }
+      }
+    },
+    "shortcut.key.pageDown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Page Down"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ページダウン"
+          }
+        }
+      }
+    },
+    "shortcut.key.home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        }
+      }
+    },
+    "shortcut.key.end": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End"
+          }
+        }
+      }
+    },
     "shortcut.previousSurface.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -1187,6 +1187,14 @@ struct ShortcutStroke: Equatable, Hashable {
             return String(localized: "shortcut.key.mediaVolumeDown", defaultValue: "Volume Down")
         case "media.volumeUp":
             return String(localized: "shortcut.key.mediaVolumeUp", defaultValue: "Volume Up")
+        case "pageUp":
+            return String(localized: "shortcut.key.pageUp", defaultValue: "Page Up")
+        case "pageDown":
+            return String(localized: "shortcut.key.pageDown", defaultValue: "Page Down")
+        case "home":
+            return String(localized: "shortcut.key.home", defaultValue: "Home")
+        case "end":
+            return String(localized: "shortcut.key.end", defaultValue: "End")
         default:
             if let functionKeyDisplayString = Self.functionKeyDisplayString(for: key) {
                 return functionKeyDisplayString
@@ -1475,6 +1483,10 @@ struct ShortcutStroke: Equatable, Hashable {
         case 124: return "→" // right arrow
         case 125: return "↓" // down arrow
         case 126: return "↑" // up arrow
+        case 115: return "home"     // kVK_Home
+        case 116: return "pageUp"   // kVK_PageUp
+        case 119: return "end"      // kVK_End
+        case 121: return "pageDown" // kVK_PageDown
         case 48: return "\t" // tab
         case 36, 76: return "\r" // return, keypad enter
         case 33: return "["  // kVK_ANSI_LeftBracket
@@ -1614,6 +1626,13 @@ struct ShortcutStroke: Equatable, Hashable {
     }
 
     private static func keyCodeForShortcutKey(_ key: String) -> UInt16? {
+        switch key.lowercased() {
+        case "pageup": return 116
+        case "pagedown": return 121
+        case "home": return 115
+        case "end": return 119
+        default: break
+        }
         switch key {
         case "f1": return 122
         case "f2": return 120
@@ -1702,7 +1721,14 @@ struct ShortcutStroke: Equatable, Hashable {
     }
 
     private static func usesDirectKeyCodeMatching(_ key: String) -> Bool {
-        functionKeyDisplayString(for: key) != nil || key.hasPrefix("media.")
+        if functionKeyDisplayString(for: key) != nil { return true }
+        if key.hasPrefix("media.") { return true }
+        switch key.lowercased() {
+        case "home", "pageup", "end", "pagedown":
+            return true
+        default:
+            return false
+        }
     }
 
     private static func functionKeyDisplayString(for key: String) -> String? {
@@ -2055,6 +2081,14 @@ extension ShortcutStroke {
             return "↑"
         case "down", "arrowdown", "downarrow", "↓":
             return "↓"
+        case "pageup", "page_up", "pgup":
+            return "pageUp"
+        case "pagedown", "page_down", "pgdn":
+            return "pageDown"
+        case "home":
+            return "home"
+        case "end":
+            return "end"
         case "tab":
             return "\t"
         case "return", "enter", "↩":

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1715,12 +1715,14 @@ final class KeyboardShortcutPageNavParseTests: XCTestCase {
         let parsed = StoredShortcut.parseConfig("cmd+home")
         XCTAssertNotNil(parsed, "cmd+home should parse from config")
         XCTAssertEqual(parsed?.key, "home")
+        XCTAssertTrue(parsed?.command ?? false)
     }
 
     func testParseConfigAcceptsEnd() {
         let parsed = StoredShortcut.parseConfig("cmd+end")
         XCTAssertNotNil(parsed, "cmd+end should parse from config")
         XCTAssertEqual(parsed?.key, "end")
+        XCTAssertTrue(parsed?.command ?? false)
     }
 
     func testParseConfigAcceptsCommonPageNavAliases() {

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1690,3 +1690,43 @@ final class CmuxLayoutEncodingTests: XCTestCase {
         }
     }
 }
+
+// Regression coverage for #3270: the keyboard shortcut recorder and config
+// parser silently dropped Page Up, Page Down, Home, and End. These are
+// common navigation keys (used by iTerm2, browsers, etc.) and must be
+// bindable through both the in-app recorder and the JSON config file.
+final class KeyboardShortcutPageNavParseTests: XCTestCase {
+
+    func testParseConfigAcceptsPageDown() {
+        let parsed = StoredShortcut.parseConfig("cmd+pageDown")
+        XCTAssertNotNil(parsed, "cmd+pageDown should parse from config")
+        XCTAssertEqual(parsed?.key, "pageDown")
+        XCTAssertTrue(parsed?.command ?? false)
+    }
+
+    func testParseConfigAcceptsPageUp() {
+        let parsed = StoredShortcut.parseConfig("cmd+pageUp")
+        XCTAssertNotNil(parsed, "cmd+pageUp should parse from config")
+        XCTAssertEqual(parsed?.key, "pageUp")
+        XCTAssertTrue(parsed?.command ?? false)
+    }
+
+    func testParseConfigAcceptsHome() {
+        let parsed = StoredShortcut.parseConfig("cmd+home")
+        XCTAssertNotNil(parsed, "cmd+home should parse from config")
+        XCTAssertEqual(parsed?.key, "home")
+    }
+
+    func testParseConfigAcceptsEnd() {
+        let parsed = StoredShortcut.parseConfig("cmd+end")
+        XCTAssertNotNil(parsed, "cmd+end should parse from config")
+        XCTAssertEqual(parsed?.key, "end")
+    }
+
+    func testParseConfigAcceptsCommonPageNavAliases() {
+        XCTAssertEqual(StoredShortcut.parseConfig("ctrl+page_up")?.key, "pageUp")
+        XCTAssertEqual(StoredShortcut.parseConfig("ctrl+page_down")?.key, "pageDown")
+        XCTAssertEqual(StoredShortcut.parseConfig("ctrl+pgup")?.key, "pageUp")
+        XCTAssertEqual(StoredShortcut.parseConfig("ctrl+pgdn")?.key, "pageDown")
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3270. The keyboard shortcut recorder (Settings → Keyboard Shortcuts) silently dropped Page Up, Page Down, Home, and End keystrokes — the field stayed empty and no binding was saved. The same gap meant config-file entries like `"cmd+pageDown"` parsed to nothing.

The fix adds these four keys to the four lookup tables in `Sources/KeyboardShortcutSettings.swift` (recorder, display, runtime matcher, config parser), plus localization strings.

## Demo
Using `Page Down` and `Page Up` in keybinding settings:
<img width="531" height="87" alt="Screenshot 2026-04-28 at 11 17 28 PM" src="https://github.com/user-attachments/assets/7fb01997-77d8-48d6-9456-c90b165fddc2" />

Swapping workspaces with the keybinds:

https://github.com/user-attachments/assets/158b3b11-2bcb-4add-8e36-97c7344e9125


## Two-commit structure (per CLAUDE.md regression-test policy)

1. **Commit 1 — failing tests only.** CI should go red here, proving the regression coverage actually catches the bug.
2. **Commit 2 — the fix.** CI should go green.

## Test plan

- [x] Manual: bind `Ctrl+PageDown` to "Next Workspace" via Settings → Keyboard Shortcuts; verify the chord switches workspace (instead of leaking `5~` to the terminal).
- [x] Manual: same for `Ctrl+PageUp`, `Cmd+Home`, `Cmd+End`.
- [x] Unit: `cmd+pageDown`, `cmd+pageUp`, `cmd+home`, `cmd+end`, plus aliases (`page_up`, `page_down`, `pgup`, `pgdn`) round-trip through `StoredShortcut.parseConfig`.

## Notes for reviewers

- Stored canonical form is `pageUp`/`pageDown`/`home`/`end` (camelCase), matching the existing `media.volumeUp` precedent.
- The runtime matcher lowercases keys before comparing (`shortcutKey = key.lowercased()` at the dispatch site), so `usesDirectKeyCodeMatching` and `keyCodeForShortcutKey` accept the lowercase form. Both helpers also re-lowercase defensively in case other call sites pass the raw stored form.
- Localization: added `shortcut.key.{pageUp,pageDown,home,end}` to `Localizable.xcstrings` with English + Japanese, per the localization policy in CLAUDE.md.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3270 by adding full support for Page Up, Page Down, Home, and End in the keyboard shortcut system. These keys now record correctly, parse from config (with aliases), display localized labels, and match at runtime.

- **Bug Fixes**
  - Added mappings for Page Up/Down/Home/End in the recorder, display, runtime matcher, and config parser.
  - Accepted config tokens: `pageup`, `pagedown`, `page_up`, `page_down`, `pgup`, `pgdn`.
  - Added localized labels: `shortcut.key.pageUp`, `shortcut.key.pageDown`, `shortcut.key.home`, `shortcut.key.end` (English + Japanese).
  - Added regression tests for parsing and alias round‑trip.

<sup>Written for commit d559fef2a1dde34fbb830925dfd6bd8707e0aee4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3281?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Page Up, Page Down, Home, and End as configurable keyboard shortcuts with localized labels (English and Japanese).
* **Tests**
  * Added unit tests covering parsing and normalization of Page Up/Down/Home/End shortcut variants and modifier behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->