### PR TITLE
Fix feedback dialog textarea hiding text past visible area (#3271)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11201,6 +11201,8 @@ private enum SidebarHelpMenuAction {
 
 private struct SidebarFeedbackComposerSheet: View {
     private static let formMaxHeight: CGFloat = 560
+    private static let messageEditorMinHeight: CGFloat = 180
+    private static let messageEditorMaxHeight: CGFloat = 320
 
     @AppStorage(FeedbackComposerSettings.storedEmailKey) private var email = ""
     @Environment(\.dismiss) private var dismiss
@@ -11314,7 +11316,10 @@ private struct SidebarFeedbackComposerSheet: View {
                     accessibilityLabel: String(localized: "sidebar.help.feedback.message", defaultValue: "Message"),
                     accessibilityIdentifier: "SidebarFeedbackMessageEditor"
                 )
-                .frame(minHeight: 180)
+                .frame(
+                    minHeight: Self.messageEditorMinHeight,
+                    maxHeight: Self.messageEditorMaxHeight
+                )
             }
 
             VStack(alignment: .leading, spacing: 8) {


### PR DESCRIPTION
## Summary

Fixes #3271. The feedback composer's message editor only had `.frame(minHeight: 180)` with no max. As content grew, the AppKit `NSTextView` inside the `NSViewRepresentable` kept expanding vertically and pushed itself off the parent SwiftUI `ScrollView`'s 560pt viewport, instead of letting its own `NSScrollView` (already configured with `hasVerticalScroller = true`, `scrollerStyle = .overlay`) engage.

End result: anything past ~12 wrapped lines was typed off-screen with no scrollbar to reach it.

## Fix

Cap the editor at `messageEditorMaxHeight = 320`. Once content exceeds that, the inner `NSScrollView` takes over scrolling — cursor stays visible, prior lines are reachable. The outer SwiftUI `ScrollView` still handles overall form overflow, so email/attachments/buttons remain reachable when the dialog is short.

```diff
-                .frame(minHeight: 180)
+                .frame(
+                    minHeight: Self.messageEditorMinHeight,
+                    maxHeight: Self.messageEditorMaxHeight
+                )
```

## Demo

Before

https://github.com/user-attachments/assets/9ab6ee80-4926-4d12-bee1-d5359528184b

After

https://github.com/user-attachments/assets/b3aa27ec-46da-4717-9c4a-ba4e8fffd1e9

## Out of scope

The original issue also asked for the dialog itself to be resizable. That requires either a deployment-target bump (`presentationSizing(.fitted)` is macOS 15+, cmux ships 14.0) or replacing the `.sheet` with a custom `NSWindow` — both larger changes than warranted by the actual blocking complaint, which was "I can't see what I'm typing." Happy to follow up in a separate PR if maintainers want to tackle resizability.

## Test plan

No unit test added: per CLAUDE.md's test-quality policy, source-shape tests are discouraged, and the only meaningful coverage here is runtime behavior (type N lines → scrollbar engages → earlier text remains reachable), which isn't easily expressible as a unit test for an `NSViewRepresentable`-backed editor inside a sheet.

Manual verification on macOS 15.6.1 (M1 Max), Debug build:

- [x] Help → Send Feedback opens the composer.
- [x] Typing/pasting 30+ wrapped lines keeps the cursor visible.
- [x] Scrollbar appears in the textarea on hover; trackpad scroll works inside it.
- [x] Earlier lines are reachable by scrolling up.
- [x] Email field, attachments, character counter, and Send/Cancel buttons remain visible and clickable in all cases.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3271 by capping the feedback message editor at 320pt so the inner scrollbar activates and text stays visible while typing. The outer form still scrolls, keeping email, attachments, and buttons reachable.

<sup>Written for commit c211dfa0ec5bb5d1bd9a27f53983c806f2b8a12d. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3288?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated feedback composer message editor to enforce maximum height constraints, preventing the input field from expanding beyond a reasonable size while maintaining minimum height functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->