### PR TITLE
Make claude-hook commands silently exit 0 when workspace is closed

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3290,6 +3290,10 @@ struct CMUXCLI {
                 try runClaudeHook(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
                 cliTelemetry.breadcrumb("claude-hook.completed")
             } catch {
+                if shouldSilentlyExitClaudeHookWorkspaceUnavailableError(error) {
+                    cliTelemetry.breadcrumb("claude-hook.workspace-unavailable")
+                    return
+                }
                 cliTelemetry.breadcrumb("claude-hook.failure")
                 cliTelemetry.captureError(stage: "claude_hook_dispatch", error: error)
                 throw error
@@ -13816,6 +13820,17 @@ struct CMUXCLI {
             "not connected"
         ]
         return benignFragments.contains { message.contains($0) }
+    }
+
+    private func shouldSilentlyExitClaudeHookWorkspaceUnavailableError(_ error: Error) -> Bool {
+        let message = String(describing: error).lowercased()
+        let closedWorkspaceFragments = [
+            "tabmanager not available",
+            "workspace not found",
+            "workspace ref not found",
+            "workspace index not found"
+        ]
+        return closedWorkspaceFragments.contains { message.contains($0) }
     }
 
     private func describeAskUserQuestion(_ object: [String: Any]?) -> String? {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1757,6 +1757,59 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         XCTAssertEqual(persistedEnvironment, ["CODEX_HOME": "/tmp/codex home"])
     }
 
+    func testClaudeHookPromptSubmitSilentlySucceedsWhenWorkspaceTabManagerIsUnavailable() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("hook")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            if let data = line.data(using: .utf8),
+               let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+               let id = payload["id"] as? String {
+                return self.v2Response(id: id, ok: true, result: [:])
+            }
+
+            if line == "clear_notifications --tab=\(workspaceId)" {
+                return "ERROR: TabManager not available"
+            }
+
+            return "ERROR: Unexpected command \(line)"
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["claude-hook", "prompt-submit"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertTrue(result.stdout.isEmpty, result.stdout)
+        XCTAssertFalse(result.stderr.localizedCaseInsensitiveContains("TabManager"), result.stderr)
+        XCTAssertFalse(result.stderr.localizedCaseInsensitiveContains("error"), result.stderr)
+        XCTAssertTrue(
+            state.commands.contains("clear_notifications --tab=\(workspaceId)"),
+            "Expected claude-hook prompt-submit to target the stale workspace, saw \(state.commands)"
+        )
+    }
+
     private func base64NULSeparated(_ values: [String]) -> String {
         var data = Data()
         for value in values {


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/3286

## Summary
- add a CLI regression test for claude-hook closed-workspace TabManager failures
- make claude-hook treat workspace-unavailable/TabManager-unavailable errors as silent success
- keep non-hook CLI/RPC TabManager errors visible

## Testing
- ./scripts/ensure-ghosttykit.sh
- attempted ./scripts/test-unit.sh -only-testing:cmuxTests/CLINotifyProcessIntegrationTests/testClaudeHookPromptSubmitSilentlySucceedsWhenWorkspaceTabManagerIsUnavailable (local Xcode build/test was blocked by concurrent build contention)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit bbf5174d325f579fdf05bb34e34ad9c3ec051ae6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `claude-hook` commands exit 0 with no stderr when the workspace is closed or the TabManager is unavailable, fixing #3286. Normal CLI/RPC commands still surface TabManager errors.

- **Bug Fixes**
  - Treat workspace-unavailable errors ("tabmanager not available", "workspace not found", "workspace ref/index not found") as a no-op in `claude-hook` and add a `claude-hook.workspace-unavailable` breadcrumb.
  - Add a regression test for `claude-hook prompt-submit` that asserts silent success when the TabManager is unavailable.

<sup>Written for commit bbf5174d325f579fdf05bb34e34ad9c3ec051ae6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3289?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for workspace unavailability in the CLI. The `claude-hook` dispatcher now gracefully handles workspace-related errors by logging diagnostics and exiting cleanly, rather than propagating failures, resulting in more stable behavior when workspace services are temporarily unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->