### PR TITLE
Improve settings search aliases

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -33,6 +33,8 @@
 		8C4BBF2DEF6DF93F395A9EE7 /* TerminalControllerSocketSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491751CE2321474474F27DCF /* TerminalControllerSocketSecurityTests.swift */; };
 		A5001001 /* cmuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001011 /* cmuxApp.swift */; };
 		A50019A0 /* SettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019A1 /* SettingsNavigation.swift */; };
+		A50019B0 /* SettingsSearchAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B1 /* SettingsSearchAliases.swift */; };
+		A50019B2 /* SettingsSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B3 /* SettingsSearchIndexTests.swift */; };
 		A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
 		C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
@@ -291,6 +293,8 @@
 		A5001000 /* cmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001011 /* cmuxApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmuxApp.swift; sourceTree = "<group>"; };
 		A50019A1 /* SettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigation.swift; sourceTree = "<group>"; };
+		A50019B1 /* SettingsSearchAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchAliases.swift; sourceTree = "<group>"; };
+		A50019B3 /* SettingsSearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchIndexTests.swift; sourceTree = "<group>"; };
 		A5001012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentViewIdentifierCopyCommands.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
@@ -589,6 +593,7 @@
 				3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
 				A5001011 /* cmuxApp.swift */,
 				A50019A1 /* SettingsNavigation.swift */,
+				A50019B1 /* SettingsSearchAliases.swift */,
 				A5001012 /* ContentView.swift */,
 				C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */,
 				9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */,
@@ -724,6 +729,7 @@
 				FA000001A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift */,
 				A5008380 /* BrowserFindJavaScriptTests.swift */,
 				A5008382 /* CommandPaletteSearchEngineTests.swift */,
+				A50019B3 /* SettingsSearchIndexTests.swift */,
 				970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */,
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
 				02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
@@ -984,6 +990,7 @@
 				3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */,
 				A5001001 /* cmuxApp.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,
+				A50019B0 /* SettingsSearchAliases.swift in Sources */,
 				A5001002 /* ContentView.swift in Sources */,
 				C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
@@ -1150,6 +1157,7 @@
 				FA000000A1B2C3D4E5F60718 /* WorkspaceStressProfileTests.swift in Sources */,
 				A5008381 /* BrowserFindJavaScriptTests.swift in Sources */,
 				A5008383 /* CommandPaletteSearchEngineTests.swift in Sources */,
+				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
 				E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */,
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -68990,6 +68990,1485 @@
         }
       }
     },
+    "settings.search.alias.section.account": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "auth authentication login logout sign in sign out email user profile team"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "auth authentication login logout sign in sign out email user profile team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.app": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 一般 環境設定 設定 動作 外観 ドック メニューバー 通知 サイドバー テレメトリ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.terminal": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "shell scrollback scrollbar scroll bar ghostty tty pty"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "shell scrollback scrollbar scroll bar ghostty tty pty シェル スクロールバック スクロールバー ターミナル ghostty tty pty"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.sidebarAppearance": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "left rail navigation tint transparency opacity material color"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "left rail navigation tint transparency opacity material color 左サイドバー ナビゲーション 色 透明度 不透明度 マテリアル"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.automation": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "api cli control socket mcp agents hooks ports"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "api cli control socket mcp agents hooks ports api cli 制御 ソケット mcp エージェント フック ポート 自動化"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.browser": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "web webview address bar omnibar links urls embedded default browser"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "web webview address bar omnibar links urls embedded default browser ウェブ webview アドレスバー オムニバー リンク url 内蔵ブラウザ デフォルトブラウザ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.browserImport": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル インポート"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.globalHotkey": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "system shortcut global keyboard show hide bring forward"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "system shortcut global keyboard show hide bring forward システム ショートカット グローバル ホットキー キーボード 表示 非表示 前面"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.keyboardShortcuts": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "keybinds key bindings hotkeys chords accelerators commands"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "keybinds key bindings hotkeys chords accelerators commands キーバインド キー割り当て ホットキー コード コマンド ショートカット"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.workspaceColors": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "tab colors palette accent badge selected highlight"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "tab colors palette accent badge selected highlight タブ 色 パレット アクセント バッジ 選択 ハイライト ワークスペース"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.settingsJSON": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "configuration config file json jsonc dotfile ~/.config schema docs"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "configuration config file json jsonc dotfile ~/.config schema docs 設定 構成 ファイル json jsonc ドットファイル スキーマ ドキュメント"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.section.reset": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "factory defaults restore clear preferences"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "factory defaults restore clear preferences 初期化 デフォルト 復元 リセット 設定を消去"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.account.account": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.language": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.language locale l10n localization translation japanese english ja en nihongo restart"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 言語 地域 ロケール ローカライズ 翻訳 日本語 英語 再起動"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.appearance": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.appearance theme color scheme light mode dark mode system mode"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.appearance theme color scheme light mode dark mode system mode 外観 テーマ 配色 ライトモード ダークモード システムモード"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.app-icon": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.appIcon dock icon application icon app switcher alternate icon"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.appIcon dock icon application icon app switcher alternate icon アプリアイコン ドック アイコン アプリ切り替え 代替アイコン"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.new-workspace-placement": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.newWorkspacePlacement new tab insert position order top bottom end"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.newWorkspacePlacement new tab insert position order top bottom end 新規ワークスペース 新しいタブ 挿入位置 並び順 上 下 末尾"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.minimal-mode": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.minimalMode minimal layout simple chrome compact titlebar controls"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.minimalMode minimal layout simple chrome compact titlebar controls ミニマル 省スペース コンパクト タイトルバー 表示モード"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.keep-workspace-open": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 閉じる 最後のペイン サーフェス ワークスペースを残す コマンドw"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.focus-pane-first-click": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation クリック フォーカス マウス 最初のクリック ペインを選択"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.preferred-editor": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor エディタ ファイルを開く vscode visual studio code zed sublime cursor"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.terminal-config": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "ghostty config configuration terminal settings preview merged file reload"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "ghostty config configuration terminal settings preview merged file reload ghostty 設定 構成 ターミナル プレビュー マージ ファイル 再読み込み"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.markdown-viewer": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme md markdown mdx ビューア プレビュー readme 表示"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.reorder-notification": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.reorderOnNotification notification reorder move workspace top unread sort"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.reorderOnNotification notification reorder move workspace top unread sort 通知 並べ替え ワークスペースを上へ 未読 ソート"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.dock-badge": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.dockBadge badge dock unread count icon notifications red bubble"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.dockBadge badge dock unread count icon notifications red bubble ドック バッジ 未読 件数 アイコン 通知 赤丸"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.menu-bar-only": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab メニューバーのみ ドックなし ドック非表示 アプリ切り替え cmd-tab command-tab"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-menu-bar": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.showInMenuBar menubar menu bar status item tray extra"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.showInMenuBar menubar menu bar status item tray extra メニューバー ステータス項目 トレイ メニューエクストラ 表示"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.unread-pane-ring": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.unreadPaneRing blue border unread ring notification pane outline"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 未読 青い枠 リング 通知 ペイン アウトライン"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.pane-flash": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.paneFlash flash blink highlight pane notification pulse"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.paneFlash flash blink highlight pane notification pulse フラッシュ 点滅 ハイライト ペイン 通知"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.desktop-notifications": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "macos desktop notifications system settings permission alerts notify test"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "macos desktop notifications system settings permission alerts notify test macos デスクトップ通知 システム設定 権限 アラート テスト"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.notification-sound": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 通知音 サウンド 音 アラート チャイム ビープ カスタムファイル"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.notification-command": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.command shell command hook script env environment variable done agent"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "notifications.command shell command hook script env environment variable done agent 通知コマンド シェル コマンド フック スクリプト 環境変数 完了 エージェント"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.telemetry": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy テレメトリ 分析 クラッシュレポート 使用状況 匿名 プライバシー"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.warn-before-quit": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 終了 確認 command-q cmd-q アプリを閉じる 警告"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.rename-selects-name": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 名前変更 既存名を選択 タイトル コマンドパレット ワークスペース名"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.palette-search-all": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown コマンドパレット すべて検索 サーフェス ターミナル ブラウザ markdown"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.hide-sidebar-details": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail サイドバー コンパクト 詳細を隠す タイトルのみ 左レール"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.sidebar-branch-layout": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.branchLayout git branch layout vertical inline cwd directory"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.branchLayout git branch layout vertical inline cwd directory git ブランチ レイアウト 縦 インライン cwd ディレクトリ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-notification-message": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showNotificationMessage latest message unread notification text sidebar"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 最新メッセージ 未読 通知 テキスト サイドバー"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-branch-directory": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar git ブランチ cwd パス ディレクトリ フォルダ リポジトリ サイドバー"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-pull-requests": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request pr mr レビュー github gitlab bitbucket プルリクエスト マージリクエスト"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.open-pr-links": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded pr リンク github ブラウザ デフォルト 外部 内蔵"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.open-port-links": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded ポート localhost リンク ブラウザ デフォルト 外部 内蔵"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-ssh": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showSSH remote host target ssh server"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showSSH remote host target ssh server ssh リモート ホスト 接続先 サーバー"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-ports": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showPorts localhost port listener dev server url"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showPorts localhost port listener dev server url localhost ポート リスナー 開発サーバー url"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-log": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showLog log status latest message imperative"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showLog log status latest message imperative ログ ステータス 最新メッセージ imperative"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-progress": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showProgress progress bar percent status set_progress"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showProgress progress bar percent status set_progress 進捗 プログレスバー パーセント ステータス set_progress"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.app.show-metadata": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block メタデータ meta report_meta ステータス カスタム ブロック"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.terminal.scrollbar": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui ターミナル スクロールバック スクロールバー 右端 代替画面 tui"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.sidebarAppearance.match-terminal": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync 透明 背景 マテリアル ターミナル背景 同期"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.sidebarAppearance.light-tint": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime ライトモード 色 サイドバー tint hex 昼"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.sidebarAppearance.dark-tint": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime ダークモード 色 サイドバー tint hex 夜"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.sidebarAppearance.tint-opacity": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 透明度 不透明度 alpha 強さ ブレンド"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.sidebarAppearance.reset-tint": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "restore default clear tint colors opacity"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "restore default clear tint colors opacity デフォルトに戻す 色を消す tint 透明度"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.socket-mode": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled api ソケット unix domain 制御 サーバー 認証 許可 パスワード 無効"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.socket-password": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.socketPassword auth token credential secret password access key"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.socketPassword auth token credential secret password access key ソケット パスワード 認証 トークン 資格情報 シークレット アクセスキー"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.claude-code": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications claude code フック エージェント 連携 通知"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.claude-path": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.claudeBinaryPath claude binary executable path cli command custom"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.claudeBinaryPath claude binary executable path cli command custom claude バイナリ 実行ファイル パス cli コマンド カスタム"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.cursor": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.cursorIntegration cursor ide agent hooks notifications"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.cursorIntegration cursor ide agent hooks notifications cursor ide エージェント フック 通知 連携"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.gemini": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.geminiIntegration gemini cli google agent hooks notifications"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.geminiIntegration gemini cli google agent hooks notifications gemini cli google エージェント フック 通知 連携"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.port-base": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.portBase cmux_port start first base env environment variable"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.portBase cmux_port start first base env environment variable cmux_port 開始 最初 ベース 環境変数 ポート"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.automation.port-range": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.portRange cmux_port_end range size count env ports"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "automation.portRange cmux_port_end range size count env ports cmux_port_end 範囲 サイズ 個数 環境変数 ポート"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.enable-browser": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.enabled enable disable webview embedded browser tabs links"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.enabled enable disable webview embedded browser tabs links ブラウザ 有効 無効 webview 内蔵ブラウザ タブ リンク"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.search-engine": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider オムニバー アドレスバー google duckduckgo bing 検索エンジン 検索プロバイダ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.search-suggestions": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions サジェスト 補完 アドレスバー 検索候補"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.theme": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.theme web page theme color scheme light dark system"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.theme web page theme color scheme light dark system ウェブページ テーマ 配色 ライト ダーク システム"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.terminal-links": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href クリック url ターミナルリンク ブラウザで開く href"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.intercept-open": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept open コマンド http https url ターミナル インターセプト"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.host-whitelist": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 許可リスト ホワイトリスト ホスト ワイルドカード ドメイン 内蔵ブラウザ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.external-patterns": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 拒否リスト ブロックリスト regex ルール 外部 デフォルトブラウザ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.http-allowlist": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 安全でない http 許可リスト localhost localtest 非https 警告"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browserImport.import-data": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル 移行"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browserImport.import-hint": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 空のタブ オンボーディング ヒント インポート プロンプト 非表示"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.react-grab": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component react grab npm バージョン ツールバー inspect コンポーネント"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.browser.history": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "clear browser history visited pages suggestions omnibar"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "clear browser history visited pages suggestions omnibar ブラウザ履歴 閲覧履歴 訪問ページ サジェスト オムニバー 消去"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.globalHotkey.enable-hotkey": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "global hotkey enable system wide show hide all windows"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "global hotkey enable system wide show hide all windows グローバルホットキー 有効 システム全体 表示 非表示 全ウィンドウ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.globalHotkey.shortcut": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "global hotkey shortcut recorder key command option control"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "global hotkey shortcut recorder key command option control グローバルホットキー ショートカット レコーダー command option control"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.keyboardShortcuts.shortcut-chords": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tmux prefix プレフィックス ctrl-b control-b 複数キー シーケンス コード settings json"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.keyboardShortcuts.show-hints": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills コマンド長押し ctrl 長押し キーヒント 修飾キー オーバーレイ ピル"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.keyboardShortcuts.shortcuts": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json ホットキー キーバインド キー割り当て コマンド キーボード ショートカット settings json"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.workspaceColors.indicator": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot ワークスペース タブ インジケータ アクティブ 色 ストライプ ドット"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.workspaceColors.selection": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.selectionColor selected workspace color highlight background active tab"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 選択中 ワークスペース 色 ハイライト 背景 アクティブタブ"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.workspaceColors.badge": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 未読 通知 バッジ 色 ドット 件数"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.workspaceColors.palette": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.colors workspace palette named colors custom color reset built-in"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "workspaceColors.colors workspace palette named colors custom color reset built-in ワークスペース パレット 名前付き色 カスタム色 リセット 組み込み"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.settingsJSON.open-file": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "open settings file json jsonc config editor ~/.config cmux preferences"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "open settings file json jsonc config editor ~/.config cmux preferences settings.json を開く json jsonc 設定ファイル エディタ ドットファイル 環境設定"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.settingsJSON.documentation": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "docs documentation schema reference settings json keys configuration"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "docs documentation schema reference settings json keys configuration ドキュメント スキーマ リファレンス settings json キー 構成"
+                      }
+                }
+          }
+    },
+    "settings.search.alias.setting.reset.reset-all": {
+          "extractionState": "manual",
+          "localizations": {
+                "en": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "factory reset restore defaults clear preferences"
+                      }
+                },
+                "ja": {
+                      "stringUnit": {
+                            "state": "translated",
+                            "value": "factory reset restore defaults clear preferences 初期化 リセット デフォルト 復元 設定を消去"
+                      }
+                }
+          }
+    },
     "settings.search.prompt": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -276,7 +276,7 @@ enum SettingsSearchIndex {
             title: target.title,
             subtitle: nil,
             symbolName: target.symbolName,
-            searchText: target.searchText
+            searchText: "\(target.rawValue) \(target.searchText) \(SettingsSearchAliasIndex.sectionAliases(for: target))"
         )
     }
 
@@ -332,6 +332,7 @@ enum SettingsSearchIndex {
         setting(.automation, "port-base", String(localized: "settings.automation.portBase", defaultValue: "Port Base"), "CMUX_PORT start"),
         setting(.automation, "port-range", String(localized: "settings.automation.portRange", defaultValue: "Port Range Size"), "CMUX_PORT_END workspace ports"),
         setting(.browser, "search-engine", String(localized: "settings.browser.searchEngine", defaultValue: "Default Search Engine"), "address bar query google duckduckgo"),
+        setting(.browser, "enable-browser", String(localized: "settings.browser.enabled", defaultValue: "Enable cmux Browser"), "webview tabs links"),
         setting(.browser, "search-suggestions", String(localized: "settings.browser.searchSuggestions", defaultValue: "Show Search Suggestions"), "browser address bar suggestions"),
         setting(.browser, "theme", String(localized: "settings.browser.theme", defaultValue: "Browser Theme"), "web appearance light dark system"),
         setting(.browser, "terminal-links", String(localized: "settings.browser.openTerminalLinks", defaultValue: "Open Terminal Links in cmux Browser"), "click links browser"),
@@ -472,7 +473,7 @@ enum SettingsSearchIndex {
             title: title,
             subtitle: target.title,
             symbolName: target.symbolName,
-            searchText: "\(target.searchText) \(searchText)"
+            searchText: "\(target.rawValue) \(idSuffix) \(target.searchText) \(searchText) \(SettingsSearchAliasIndex.aliases(target: target, idSuffix: idSuffix))"
         )
     }
 

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -415,6 +415,7 @@ enum SettingsSearchIndex {
         "automation.geminiIntegration": settingID(for: .automation, idSuffix: "gemini"),
         "automation.portBase": settingID(for: .automation, idSuffix: "port-base"),
         "automation.portRange": settingID(for: .automation, idSuffix: "port-range"),
+        "browser.enabled": settingID(for: .browser, idSuffix: "enable-browser"),
         "browser.defaultSearchEngine": settingID(for: .browser, idSuffix: "search-engine"),
         "browser.showSearchSuggestions": settingID(for: .browser, idSuffix: "search-suggestions"),
         "browser.theme": settingID(for: .browser, idSuffix: "theme"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -1,0 +1,120 @@
+enum SettingsSearchAliasIndex {
+    static func sectionAliases(for target: SettingsNavigationTarget) -> String {
+        switch target {
+        case .account:
+            return "auth authentication login logout sign in sign out email user profile team"
+        case .app:
+            return "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
+        case .terminal:
+            return "shell scrollback scrollbar scroll bar ghostty tty pty"
+        case .sidebarAppearance:
+            return "left rail navigation tint transparency opacity material color"
+        case .automation:
+            return "api cli control socket mcp agents hooks ports"
+        case .browser:
+            return "web webview address bar omnibar links urls embedded default browser"
+        case .browserImport:
+            return "chrome safari firefox brave edge arc bookmarks history cookies profiles"
+        case .globalHotkey:
+            return "system shortcut global keyboard show hide bring forward"
+        case .keyboardShortcuts:
+            return "keybinds key bindings hotkeys chords accelerators commands"
+        case .workspaceColors:
+            return "tab colors palette accent badge selected highlight"
+        case .settingsJSON:
+            return "configuration config file json jsonc dotfile ~/.config schema docs"
+        case .reset:
+            return "factory defaults restore clear preferences"
+        }
+    }
+
+    static func aliases(target: SettingsNavigationTarget, idSuffix: String) -> String {
+        let aliases = settingAliases["\(target.rawValue):\(idSuffix)"] ?? ""
+        if target == .keyboardShortcuts, idSuffix == "shortcuts" {
+            return "\(aliases) \(keyboardShortcutActionAliases)"
+        }
+        return aliases
+    }
+
+    private static let settingAliases: [String: String] = [
+        "account:account": "auth authentication login logout signin sign-in signout sign-out email user profile stack team",
+        "app:language": "app.language locale l10n localization translation japanese english ja en nihongo restart",
+        "app:appearance": "app.appearance theme color scheme light mode dark mode system mode",
+        "app:app-icon": "app.appIcon dock icon application icon app switcher alternate icon",
+        "app:new-workspace-placement": "app.newWorkspacePlacement new tab insert position order top bottom end",
+        "app:minimal-mode": "app.minimalMode minimal layout simple chrome compact titlebar controls",
+        "app:keep-workspace-open": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace",
+        "app:focus-pane-first-click": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation",
+        "app:preferred-editor": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor",
+        "app:terminal-config": "ghostty config configuration terminal settings preview merged file reload",
+        "app:markdown-viewer": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme",
+        "app:reorder-notification": "app.reorderOnNotification notification reorder move workspace top unread sort",
+        "app:dock-badge": "notifications.dockBadge badge dock unread count icon notifications red bubble",
+        "app:menu-bar-only": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab",
+        "app:show-menu-bar": "notifications.showInMenuBar menubar menu bar status item tray extra",
+        "app:unread-pane-ring": "notifications.unreadPaneRing blue border unread ring notification pane outline",
+        "app:pane-flash": "notifications.paneFlash flash blink highlight pane notification pulse",
+        "app:desktop-notifications": "macos desktop notifications system settings permission alerts notify test",
+        "app:notification-sound": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff",
+        "app:notification-command": "notifications.command shell command hook script env environment variable done agent",
+        "app:telemetry": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy",
+        "app:warn-before-quit": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app",
+        "app:rename-selects-name": "app.renameSelectsExistingName rename select all existing title command palette workspace name",
+        "app:palette-search-all": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown",
+        "app:hide-sidebar-details": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail",
+        "app:sidebar-branch-layout": "sidebar.branchLayout git branch layout vertical inline cwd directory",
+        "app:show-notification-message": "sidebar.showNotificationMessage latest message unread notification text sidebar",
+        "app:show-branch-directory": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar",
+        "app:show-pull-requests": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request",
+        "app:open-pr-links": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded",
+        "app:open-port-links": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded",
+        "app:show-ssh": "sidebar.showSSH remote host target ssh server",
+        "app:show-ports": "sidebar.showPorts localhost port listener dev server url",
+        "app:show-log": "sidebar.showLog log status latest message imperative",
+        "app:show-progress": "sidebar.showProgress progress bar percent status set_progress",
+        "app:show-metadata": "sidebar.showCustomMetadata metadata meta report_meta status custom block",
+        "terminal:scrollbar": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui",
+        "sidebarAppearance:match-terminal": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync",
+        "sidebarAppearance:light-tint": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime",
+        "sidebarAppearance:dark-tint": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime",
+        "sidebarAppearance:tint-opacity": "sidebarAppearance.tintOpacity alpha transparency intensity blend",
+        "sidebarAppearance:reset-tint": "restore default clear tint colors opacity",
+        "automation:socket-mode": "automation.socketControlMode api socket unix domain control server auth allow password disabled",
+        "automation:socket-password": "automation.socketPassword auth token credential secret password access key",
+        "automation:claude-code": "automation.claudeCodeIntegration claude code hooks agent integration status notifications",
+        "automation:claude-path": "automation.claudeBinaryPath claude binary executable path cli command custom",
+        "automation:cursor": "automation.cursorIntegration cursor ide agent hooks notifications",
+        "automation:gemini": "automation.geminiIntegration gemini cli google agent hooks notifications",
+        "automation:port-base": "automation.portBase cmux_port start first base env environment variable",
+        "automation:port-range": "automation.portRange cmux_port_end range size count env ports",
+        "browser:enable-browser": "browser.enabled enable disable webview embedded browser tabs links",
+        "browser:search-engine": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider",
+        "browser:search-suggestions": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions",
+        "browser:theme": "browser.theme web page theme color scheme light dark system",
+        "browser:terminal-links": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href",
+        "browser:intercept-open": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept",
+        "browser:host-whitelist": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser",
+        "browser:external-patterns": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser",
+        "browser:http-allowlist": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning",
+        "browserImport:import-data": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration",
+        "browserImport:import-hint": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss",
+        "browser:react-grab": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component",
+        "browser:history": "clear browser history visited pages suggestions omnibar",
+        "globalHotkey:enable-hotkey": "global hotkey enable system wide show hide all windows",
+        "globalHotkey:shortcut": "global hotkey shortcut recorder key command option control",
+        "keyboardShortcuts:shortcut-chords": "tmux prefix ctrl-b control-b multi key sequence chord settings json",
+        "keyboardShortcuts:show-hints": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills",
+        "keyboardShortcuts:shortcuts": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json",
+        "workspaceColors:indicator": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot",
+        "workspaceColors:selection": "workspaceColors.selectionColor selected workspace color highlight background active tab",
+        "workspaceColors:badge": "workspaceColors.notificationBadgeColor unread notification badge color dot count",
+        "workspaceColors:palette": "workspaceColors.colors workspace palette named colors custom color reset built-in",
+        "settingsJSON:open-file": "open settings file json jsonc config editor ~/.config cmux preferences",
+        "settingsJSON:documentation": "docs documentation schema reference settings json keys configuration",
+        "reset:reset-all": "factory reset restore defaults clear preferences"
+    ]
+
+    private static var keyboardShortcutActionAliases: String {
+        KeyboardShortcutSettings.Action.allCases.map(\.label).joined(separator: " ")
+    }
+}

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -2,29 +2,29 @@ enum SettingsSearchAliasIndex {
     static func sectionAliases(for target: SettingsNavigationTarget) -> String {
         switch target {
         case .account:
-            return "auth authentication login logout sign in sign out email user profile team"
+            return localized("settings.search.alias.section.account", defaultValue: "auth authentication login logout sign in sign out email user profile team")
         case .app:
-            return "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
+            return localized("settings.search.alias.section.app", defaultValue: "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry")
         case .terminal:
-            return "shell scrollback scrollbar scroll bar ghostty tty pty"
+            return localized("settings.search.alias.section.terminal", defaultValue: "shell scrollback scrollbar scroll bar ghostty tty pty")
         case .sidebarAppearance:
-            return "left rail navigation tint transparency opacity material color"
+            return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "left rail navigation tint transparency opacity material color")
         case .automation:
-            return "api cli control socket mcp agents hooks ports"
+            return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports")
         case .browser:
-            return "web webview address bar omnibar links urls embedded default browser"
+            return localized("settings.search.alias.section.browser", defaultValue: "web webview address bar omnibar links urls embedded default browser")
         case .browserImport:
-            return "chrome safari firefox brave edge arc bookmarks history cookies profiles"
+            return localized("settings.search.alias.section.browserImport", defaultValue: "chrome safari firefox brave edge arc bookmarks history cookies profiles")
         case .globalHotkey:
-            return "system shortcut global keyboard show hide bring forward"
+            return localized("settings.search.alias.section.globalHotkey", defaultValue: "system shortcut global keyboard show hide bring forward")
         case .keyboardShortcuts:
-            return "keybinds key bindings hotkeys chords accelerators commands"
+            return localized("settings.search.alias.section.keyboardShortcuts", defaultValue: "keybinds key bindings hotkeys chords accelerators commands")
         case .workspaceColors:
-            return "tab colors palette accent badge selected highlight"
+            return localized("settings.search.alias.section.workspaceColors", defaultValue: "tab colors palette accent badge selected highlight")
         case .settingsJSON:
-            return "configuration config file json jsonc dotfile ~/.config schema docs"
+            return localized("settings.search.alias.section.settingsJSON", defaultValue: "configuration config file json jsonc dotfile ~/.config schema docs")
         case .reset:
-            return "factory defaults restore clear preferences"
+            return localized("settings.search.alias.section.reset", defaultValue: "factory defaults restore clear preferences")
         }
     }
 
@@ -37,84 +37,88 @@ enum SettingsSearchAliasIndex {
     }
 
     private static let settingAliases: [String: String] = [
-        "account:account": "auth authentication login logout signin sign-in signout sign-out email user profile stack team",
-        "app:language": "app.language locale l10n localization translation japanese english ja en nihongo restart",
-        "app:appearance": "app.appearance theme color scheme light mode dark mode system mode",
-        "app:app-icon": "app.appIcon dock icon application icon app switcher alternate icon",
-        "app:new-workspace-placement": "app.newWorkspacePlacement new tab insert position order top bottom end",
-        "app:minimal-mode": "app.minimalMode minimal layout simple chrome compact titlebar controls",
-        "app:keep-workspace-open": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace",
-        "app:focus-pane-first-click": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation",
-        "app:preferred-editor": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor",
-        "app:terminal-config": "ghostty config configuration terminal settings preview merged file reload",
-        "app:markdown-viewer": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme",
-        "app:reorder-notification": "app.reorderOnNotification notification reorder move workspace top unread sort",
-        "app:dock-badge": "notifications.dockBadge badge dock unread count icon notifications red bubble",
-        "app:menu-bar-only": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab",
-        "app:show-menu-bar": "notifications.showInMenuBar menubar menu bar status item tray extra",
-        "app:unread-pane-ring": "notifications.unreadPaneRing blue border unread ring notification pane outline",
-        "app:pane-flash": "notifications.paneFlash flash blink highlight pane notification pulse",
-        "app:desktop-notifications": "macos desktop notifications system settings permission alerts notify test",
-        "app:notification-sound": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff",
-        "app:notification-command": "notifications.command shell command hook script env environment variable done agent",
-        "app:telemetry": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy",
-        "app:warn-before-quit": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app",
-        "app:rename-selects-name": "app.renameSelectsExistingName rename select all existing title command palette workspace name",
-        "app:palette-search-all": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown",
-        "app:hide-sidebar-details": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail",
-        "app:sidebar-branch-layout": "sidebar.branchLayout git branch layout vertical inline cwd directory",
-        "app:show-notification-message": "sidebar.showNotificationMessage latest message unread notification text sidebar",
-        "app:show-branch-directory": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar",
-        "app:show-pull-requests": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request",
-        "app:open-pr-links": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded",
-        "app:open-port-links": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded",
-        "app:show-ssh": "sidebar.showSSH remote host target ssh server",
-        "app:show-ports": "sidebar.showPorts localhost port listener dev server url",
-        "app:show-log": "sidebar.showLog log status latest message imperative",
-        "app:show-progress": "sidebar.showProgress progress bar percent status set_progress",
-        "app:show-metadata": "sidebar.showCustomMetadata metadata meta report_meta status custom block",
-        "terminal:scrollbar": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui",
-        "sidebarAppearance:match-terminal": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync",
-        "sidebarAppearance:light-tint": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime",
-        "sidebarAppearance:dark-tint": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime",
-        "sidebarAppearance:tint-opacity": "sidebarAppearance.tintOpacity alpha transparency intensity blend",
-        "sidebarAppearance:reset-tint": "restore default clear tint colors opacity",
-        "automation:socket-mode": "automation.socketControlMode api socket unix domain control server auth allow password disabled",
-        "automation:socket-password": "automation.socketPassword auth token credential secret password access key",
-        "automation:claude-code": "automation.claudeCodeIntegration claude code hooks agent integration status notifications",
-        "automation:claude-path": "automation.claudeBinaryPath claude binary executable path cli command custom",
-        "automation:cursor": "automation.cursorIntegration cursor ide agent hooks notifications",
-        "automation:gemini": "automation.geminiIntegration gemini cli google agent hooks notifications",
-        "automation:port-base": "automation.portBase cmux_port start first base env environment variable",
-        "automation:port-range": "automation.portRange cmux_port_end range size count env ports",
-        "browser:enable-browser": "browser.enabled enable disable webview embedded browser tabs links",
-        "browser:search-engine": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider",
-        "browser:search-suggestions": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions",
-        "browser:theme": "browser.theme web page theme color scheme light dark system",
-        "browser:terminal-links": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href",
-        "browser:intercept-open": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept",
-        "browser:host-whitelist": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser",
-        "browser:external-patterns": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser",
-        "browser:http-allowlist": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning",
-        "browserImport:import-data": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration",
-        "browserImport:import-hint": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss",
-        "browser:react-grab": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component",
-        "browser:history": "clear browser history visited pages suggestions omnibar",
-        "globalHotkey:enable-hotkey": "global hotkey enable system wide show hide all windows",
-        "globalHotkey:shortcut": "global hotkey shortcut recorder key command option control",
-        "keyboardShortcuts:shortcut-chords": "tmux prefix ctrl-b control-b multi key sequence chord settings json",
-        "keyboardShortcuts:show-hints": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills",
-        "keyboardShortcuts:shortcuts": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json",
-        "workspaceColors:indicator": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot",
-        "workspaceColors:selection": "workspaceColors.selectionColor selected workspace color highlight background active tab",
-        "workspaceColors:badge": "workspaceColors.notificationBadgeColor unread notification badge color dot count",
-        "workspaceColors:palette": "workspaceColors.colors workspace palette named colors custom color reset built-in",
-        "settingsJSON:open-file": "open settings file json jsonc config editor ~/.config cmux preferences",
-        "settingsJSON:documentation": "docs documentation schema reference settings json keys configuration",
-        "reset:reset-all": "factory reset restore defaults clear preferences"
+        "account:account": localized("settings.search.alias.setting.account.account", defaultValue: "auth authentication login logout signin sign-in signout sign-out email user profile stack team"),
+        "app:language": localized("settings.search.alias.setting.app.language", defaultValue: "app.language locale l10n localization translation japanese english ja en nihongo restart"),
+        "app:appearance": localized("settings.search.alias.setting.app.appearance", defaultValue: "app.appearance theme color scheme light mode dark mode system mode"),
+        "app:app-icon": localized("settings.search.alias.setting.app.app-icon", defaultValue: "app.appIcon dock icon application icon app switcher alternate icon"),
+        "app:new-workspace-placement": localized("settings.search.alias.setting.app.new-workspace-placement", defaultValue: "app.newWorkspacePlacement new tab insert position order top bottom end"),
+        "app:minimal-mode": localized("settings.search.alias.setting.app.minimal-mode", defaultValue: "app.minimalMode minimal layout simple chrome compact titlebar controls"),
+        "app:keep-workspace-open": localized("settings.search.alias.setting.app.keep-workspace-open", defaultValue: "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace"),
+        "app:focus-pane-first-click": localized("settings.search.alias.setting.app.focus-pane-first-click", defaultValue: "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"),
+        "app:preferred-editor": localized("settings.search.alias.setting.app.preferred-editor", defaultValue: "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"),
+        "app:terminal-config": localized("settings.search.alias.setting.app.terminal-config", defaultValue: "ghostty config configuration terminal settings preview merged file reload"),
+        "app:markdown-viewer": localized("settings.search.alias.setting.app.markdown-viewer", defaultValue: "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"),
+        "app:reorder-notification": localized("settings.search.alias.setting.app.reorder-notification", defaultValue: "app.reorderOnNotification notification reorder move workspace top unread sort"),
+        "app:dock-badge": localized("settings.search.alias.setting.app.dock-badge", defaultValue: "notifications.dockBadge badge dock unread count icon notifications red bubble"),
+        "app:menu-bar-only": localized("settings.search.alias.setting.app.menu-bar-only", defaultValue: "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab"),
+        "app:show-menu-bar": localized("settings.search.alias.setting.app.show-menu-bar", defaultValue: "notifications.showInMenuBar menubar menu bar status item tray extra"),
+        "app:unread-pane-ring": localized("settings.search.alias.setting.app.unread-pane-ring", defaultValue: "notifications.unreadPaneRing blue border unread ring notification pane outline"),
+        "app:pane-flash": localized("settings.search.alias.setting.app.pane-flash", defaultValue: "notifications.paneFlash flash blink highlight pane notification pulse"),
+        "app:desktop-notifications": localized("settings.search.alias.setting.app.desktop-notifications", defaultValue: "macos desktop notifications system settings permission alerts notify test"),
+        "app:notification-sound": localized("settings.search.alias.setting.app.notification-sound", defaultValue: "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff"),
+        "app:notification-command": localized("settings.search.alias.setting.app.notification-command", defaultValue: "notifications.command shell command hook script env environment variable done agent"),
+        "app:telemetry": localized("settings.search.alias.setting.app.telemetry", defaultValue: "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"),
+        "app:warn-before-quit": localized("settings.search.alias.setting.app.warn-before-quit", defaultValue: "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"),
+        "app:rename-selects-name": localized("settings.search.alias.setting.app.rename-selects-name", defaultValue: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),
+        "app:palette-search-all": localized("settings.search.alias.setting.app.palette-search-all", defaultValue: "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"),
+        "app:hide-sidebar-details": localized("settings.search.alias.setting.app.hide-sidebar-details", defaultValue: "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"),
+        "app:sidebar-branch-layout": localized("settings.search.alias.setting.app.sidebar-branch-layout", defaultValue: "sidebar.branchLayout git branch layout vertical inline cwd directory"),
+        "app:show-notification-message": localized("settings.search.alias.setting.app.show-notification-message", defaultValue: "sidebar.showNotificationMessage latest message unread notification text sidebar"),
+        "app:show-branch-directory": localized("settings.search.alias.setting.app.show-branch-directory", defaultValue: "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"),
+        "app:show-pull-requests": localized("settings.search.alias.setting.app.show-pull-requests", defaultValue: "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"),
+        "app:open-pr-links": localized("settings.search.alias.setting.app.open-pr-links", defaultValue: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
+        "app:open-port-links": localized("settings.search.alias.setting.app.open-port-links", defaultValue: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
+        "app:show-ssh": localized("settings.search.alias.setting.app.show-ssh", defaultValue: "sidebar.showSSH remote host target ssh server"),
+        "app:show-ports": localized("settings.search.alias.setting.app.show-ports", defaultValue: "sidebar.showPorts localhost port listener dev server url"),
+        "app:show-log": localized("settings.search.alias.setting.app.show-log", defaultValue: "sidebar.showLog log status latest message imperative"),
+        "app:show-progress": localized("settings.search.alias.setting.app.show-progress", defaultValue: "sidebar.showProgress progress bar percent status set_progress"),
+        "app:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
+        "terminal:scrollbar": localized("settings.search.alias.setting.terminal.scrollbar", defaultValue: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),
+        "sidebarAppearance:match-terminal": localized("settings.search.alias.setting.sidebarAppearance.match-terminal", defaultValue: "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync"),
+        "sidebarAppearance:light-tint": localized("settings.search.alias.setting.sidebarAppearance.light-tint", defaultValue: "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime"),
+        "sidebarAppearance:dark-tint": localized("settings.search.alias.setting.sidebarAppearance.dark-tint", defaultValue: "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime"),
+        "sidebarAppearance:tint-opacity": localized("settings.search.alias.setting.sidebarAppearance.tint-opacity", defaultValue: "sidebarAppearance.tintOpacity alpha transparency intensity blend"),
+        "sidebarAppearance:reset-tint": localized("settings.search.alias.setting.sidebarAppearance.reset-tint", defaultValue: "restore default clear tint colors opacity"),
+        "automation:socket-mode": localized("settings.search.alias.setting.automation.socket-mode", defaultValue: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),
+        "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),
+        "automation:claude-code": localized("settings.search.alias.setting.automation.claude-code", defaultValue: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),
+        "automation:claude-path": localized("settings.search.alias.setting.automation.claude-path", defaultValue: "automation.claudeBinaryPath claude binary executable path cli command custom"),
+        "automation:cursor": localized("settings.search.alias.setting.automation.cursor", defaultValue: "automation.cursorIntegration cursor ide agent hooks notifications"),
+        "automation:gemini": localized("settings.search.alias.setting.automation.gemini", defaultValue: "automation.geminiIntegration gemini cli google agent hooks notifications"),
+        "automation:port-base": localized("settings.search.alias.setting.automation.port-base", defaultValue: "automation.portBase cmux_port start first base env environment variable"),
+        "automation:port-range": localized("settings.search.alias.setting.automation.port-range", defaultValue: "automation.portRange cmux_port_end range size count env ports"),
+        "browser:enable-browser": localized("settings.search.alias.setting.browser.enable-browser", defaultValue: "browser.enabled enable disable webview embedded browser tabs links"),
+        "browser:search-engine": localized("settings.search.alias.setting.browser.search-engine", defaultValue: "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider"),
+        "browser:search-suggestions": localized("settings.search.alias.setting.browser.search-suggestions", defaultValue: "browser.showSearchSuggestions suggest autocomplete address bar search suggestions"),
+        "browser:theme": localized("settings.search.alias.setting.browser.theme", defaultValue: "browser.theme web page theme color scheme light dark system"),
+        "browser:terminal-links": localized("settings.search.alias.setting.browser.terminal-links", defaultValue: "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href"),
+        "browser:intercept-open": localized("settings.search.alias.setting.browser.intercept-open", defaultValue: "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept"),
+        "browser:host-whitelist": localized("settings.search.alias.setting.browser.host-whitelist", defaultValue: "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser"),
+        "browser:external-patterns": localized("settings.search.alias.setting.browser.external-patterns", defaultValue: "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser"),
+        "browser:http-allowlist": localized("settings.search.alias.setting.browser.http-allowlist", defaultValue: "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning"),
+        "browserImport:import-data": localized("settings.search.alias.setting.browserImport.import-data", defaultValue: "chrome safari firefox brave edge arc bookmarks history cookies profiles migration"),
+        "browserImport:import-hint": localized("settings.search.alias.setting.browserImport.import-hint", defaultValue: "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss"),
+        "browser:react-grab": localized("settings.search.alias.setting.browser.react-grab", defaultValue: "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component"),
+        "browser:history": localized("settings.search.alias.setting.browser.history", defaultValue: "clear browser history visited pages suggestions omnibar"),
+        "globalHotkey:enable-hotkey": localized("settings.search.alias.setting.globalHotkey.enable-hotkey", defaultValue: "global hotkey enable system wide show hide all windows"),
+        "globalHotkey:shortcut": localized("settings.search.alias.setting.globalHotkey.shortcut", defaultValue: "global hotkey shortcut recorder key command option control"),
+        "keyboardShortcuts:shortcut-chords": localized("settings.search.alias.setting.keyboardShortcuts.shortcut-chords", defaultValue: "tmux prefix ctrl-b control-b multi key sequence chord settings json"),
+        "keyboardShortcuts:show-hints": localized("settings.search.alias.setting.keyboardShortcuts.show-hints", defaultValue: "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills"),
+        "keyboardShortcuts:shortcuts": localized("settings.search.alias.setting.keyboardShortcuts.shortcuts", defaultValue: "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json"),
+        "workspaceColors:indicator": localized("settings.search.alias.setting.workspaceColors.indicator", defaultValue: "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot"),
+        "workspaceColors:selection": localized("settings.search.alias.setting.workspaceColors.selection", defaultValue: "workspaceColors.selectionColor selected workspace color highlight background active tab"),
+        "workspaceColors:badge": localized("settings.search.alias.setting.workspaceColors.badge", defaultValue: "workspaceColors.notificationBadgeColor unread notification badge color dot count"),
+        "workspaceColors:palette": localized("settings.search.alias.setting.workspaceColors.palette", defaultValue: "workspaceColors.colors workspace palette named colors custom color reset built-in"),
+        "settingsJSON:open-file": localized("settings.search.alias.setting.settingsJSON.open-file", defaultValue: "open settings file json jsonc config editor ~/.config cmux preferences"),
+        "settingsJSON:documentation": localized("settings.search.alias.setting.settingsJSON.documentation", defaultValue: "docs documentation schema reference settings json keys configuration"),
+        "reset:reset-all": localized("settings.search.alias.setting.reset.reset-all", defaultValue: "factory reset restore defaults clear preferences")
     ]
 
     private static var keyboardShortcutActionAliases: String {
         KeyboardShortcutSettings.Action.allCases.map(\.label).joined(separator: " ")
+    }
+
+    private static func localized(_ key: StaticString, defaultValue: String.LocalizationValue) -> String {
+        String(localized: key, defaultValue: defaultValue)
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5439,7 +5439,8 @@ struct SettingsView: View {
         SettingsCardRow(
             configurationReview: .settingsOnly,
             String(localized: "settings.browser.enabled", defaultValue: "Enable cmux Browser"),
-            subtitle: browserEnabledSubtitle
+            subtitle: browserEnabledSubtitle,
+            searchAnchorID: SettingsSearchIndex.settingID(for: .browser, idSuffix: "enable-browser")
         ) {
             Toggle("", isOn: browserEnabledBinding)
                 .labelsHidden()

--- a/cmuxTests/SettingsSearchIndexTests.swift
+++ b/cmuxTests/SettingsSearchIndexTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class SettingsSearchIndexTests: XCTestCase {
+    func testAlternativeSearchTermsFindSettingsRows() {
+        assertSearch("dockless", contains: SettingsSearchIndex.settingID(for: .app, idSuffix: "menu-bar-only"))
+        assertSearch("menubar", contains: SettingsSearchIndex.settingID(for: .app, idSuffix: "show-menu-bar"))
+        assertSearch("vscode", contains: SettingsSearchIndex.settingID(for: .app, idSuffix: "preferred-editor"))
+        assertSearch("cmd q", contains: SettingsSearchIndex.settingID(for: .app, idSuffix: "warn-before-quit"))
+        assertSearch("sound file", contains: SettingsSearchIndex.settingID(for: .app, idSuffix: "notification-sound"))
+        assertSearch("disable browser", contains: SettingsSearchIndex.settingID(for: .browser, idSuffix: "enable-browser"))
+        assertSearch("http allowlist", contains: SettingsSearchIndex.settingID(for: .browser, idSuffix: "http-allowlist"))
+        assertSearch("claude executable", contains: SettingsSearchIndex.settingID(for: .automation, idSuffix: "claude-path"))
+        assertSearch("ctrl b", contains: SettingsSearchIndex.settingID(for: .keyboardShortcuts, idSuffix: "shortcut-chords"))
+        assertSearch("split right", contains: SettingsSearchIndex.settingID(for: .keyboardShortcuts, idSuffix: "shortcuts"))
+        assertSearch("factory defaults", contains: SettingsSearchIndex.settingID(for: .reset, idSuffix: "reset-all"))
+    }
+
+    private func assertSearch(
+        _ query: String,
+        contains expectedID: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        let resultIDs = Set(SettingsSearchIndex.entries(matching: query).map(\.id))
+        XCTAssertTrue(
+            resultIDs.contains(expectedID),
+            "Expected settings search for '\(query)' to include \(expectedID), got \(resultIDs.sorted())",
+            file: file,
+            line: line
+        )
+    }
+}

--- a/cmuxTests/SettingsSearchIndexTests.swift
+++ b/cmuxTests/SettingsSearchIndexTests.swift
@@ -21,6 +21,13 @@ final class SettingsSearchIndexTests: XCTestCase {
         assertSearch("factory defaults", contains: SettingsSearchIndex.settingID(for: .reset, idSuffix: "reset-all"))
     }
 
+    func testSettingsPathAnchorIncludesBrowserEnabled() {
+        XCTAssertEqual(
+            SettingsSearchIndex.anchorID(forSettingsPath: "browser.enabled"),
+            SettingsSearchIndex.settingID(for: .browser, idSuffix: "enable-browser")
+        )
+    }
+
     private func assertSearch(
         _ query: String,
         contains expectedID: String,


### PR DESCRIPTION
Adds explicit alternate search terms for every settings search row so users can find settings by common synonyms, config keys, shortcut names, browser names, and related product terms.

Also adds the missing Browser enabled row to the settings search index and anchors it to the visible setting.

Verification:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-searchalias-unit -only-testing:cmuxTests/SettingsSearchIndexTests test`\n- `git diff --check`\n- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`\n- `plutil -lint GhosttyTabs.xcodeproj/project.pbxproj`\n- `./scripts/reload.sh --tag searchalias`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves Settings search with rich, localized aliases (en/ja) so users can find options via synonyms, config keys, and shortcut names. Also indexes and anchors the “Enable cmux Browser” toggle.

- **New Features**
  - Added `SettingsSearchAliasIndex` to append section and per-setting aliases to search text.
  - Includes keyboard shortcut action labels to match queries like “ctrl b” or “split right”.
  - Localized all alias strings (English and Japanese) in `Resources/Localizable.xcstrings`.

- **Bug Fixes**
  - Indexed the Browser Enabled setting and mapped the `browser.enabled` settings path to its `searchAnchorID`.

<sup>Written for commit e4d12570a322240d6f267f61e96628b9e366b944. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3294?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Settings search now includes additional keywords and aliases (including keyboard shortcut action labels) for improved discovery across sections and individual settings.
  * A browser-related setting is searchable and will jump/highlight from search results.

* **Tests**
  * Added tests validating settings search matches multiple alternative search terms and anchors.

* **Documentation**
  * Large set of English and Japanese localization entries added to support new search aliases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->