### PR TITLE
Localize settings search aliases for all locales

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -68991,1483 +68991,10357 @@
       }
     },
     "settings.search.alias.section.account": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "auth authentication login logout sign in sign out email user profile team"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "auth authentication login logout sign in sign out email user profile team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in sign out email user profile team"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in sign out email user profile team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team autentikacija prijava odjava korisnik profil tim račun"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team godkendelse logud bruger profil konto"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team authentifizierung anmeldung abmeldung benutzer profil konto"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team authentification connexion déconnexion e-mail utilisateur profil équipe compte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team autenticazione accesso disconnessione utente profilo account"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정 로그인…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team autentisering innlogging utlogging e-post bruker profil konto"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team uwierzytelnianie logowanie wylogowanie użytkownik profil zespół konto"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team autenticação sair usuário perfil equipe conta"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team аутентификация вход выход пользователь профиль команда аккаунт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team 认证 登录 退出登录 邮件 用户 个人资料 团队 账户"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout sign in out email user profile team автентифікація вхід вихід користувач профіль команда обліковий запис Увійти… Вийти"
+                }
+            }
+        }
     },
     "settings.search.alias.section.app": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 一般 環境設定 設定 動作 外観 ドック メニューバー 通知 サイドバー テレメトリ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 一般 環境設定 設定 動作 外観 ドック メニューバー 通知 サイドバー テレメトリ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية إعدادات تكوين ملف json مخطط وثائق مرجع إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب قياس استخدام تحليلات تعطل تقارير مجهول خصوصية الإشعارات التفضيلات… التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplikacija opće postavke ponašanje traka menija bočna navigacija lijevo detalji sakrij raspored uvoz migracija oznake historija kolačići profili konfiguracija datoteka json šema dokumentacija referenca preferencije obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop telemetrija analitika rušenje izvještaji korištenje anonimno privatnost Obavještenja Postavke… Meni"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generelt indstillinger adfærd menulinje sidepanel navigation venstre detaljer skjul layout import migrering bogmærker historik cookies profiler konfiguration fil json skema dokumentation reference præferencer notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord telemetri analyse nedbrud rapporter brug anonym privatliv Indstillinger… Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app allgemein einstellungen verhalten menüleiste seitenleiste navigation links details ausblenden layout import migration lesezeichen verlauf cookies profile konfiguration datei json schema dokumentation referenz präferenzen benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop telemetrie analyse absturz berichte nutzung anonym datenschutz … Menü"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplicación preferencias comportamiento barra de menú estado lateral navegación izquierda detalles ocultar diseño importar migración marcadores historial cookies perfiles ajustes configuración archivo json esquema documentación referencia notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio telemetría analíticas fallos informes uso anónimo privacidad Preferencias… App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry application général préférences comportement barre de menus état latérale navigation gauche détails masquer disposition importer migration favoris historique cookies profils réglages configuration fichier json schéma documentation référence notification alerte non lu message badge anneau flash son bureau télémétrie analytique plantage rapports utilisation anonyme confidentialité Préférences... App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generale preferenze comportamento barra stato laterale navigazione sinistra dettagli nascondi layout importa migrazione segnalibri cronologia cookie profili impostazioni configurazione file json schema documentazione riferimento notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania telemetria analisi crash rapporti utilizzo anonimo privacy Preferenze…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 설정 구성 파일 json 스키마 문서 참조 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 텔레메트리 분석 충돌 보고서 사용량 익명 개인정보 환경설정…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generelt innstillinger oppførsel menylinje sidepanel navigasjon venstre detaljer skjul oppsett import migrering bokmerker historikk informasjonskapsler profiler konfigurasjon fil json skjema dokumentasjon referanse preferanser varsling varsler ulest melding merke ring blink lyd skrivebord telemetri analyse krasj rapporter bruk anonym personvern … Meny"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplikacja ogólne preferencje zachowanie pasek boczny nawigacja lewy szczegóły ukryj układ import migracja zakładki historia ciasteczka profile ustawienia konfiguracja plik json schemat dokumentacja referencja powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit telemetria analityka awaria raporty użycie anonimowe prywatność Preferencje…"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app geral preferências comportamento barra de lateral navegação esquerda detalhes ocultar layout importar migração favoritos histórico cookies perfis configurações configuração arquivo json esquema documentação referência notificação notificações alerta não lido mensagem selo anel piscar som desktop telemetria análises falhas relatórios uso anônimo privacidade Preferências…"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет импорт миграция закладки история cookies профили конфигурация файл json схема документация справочник предпочтения уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол телеметрия аналитика сбой отчеты использование анонимно приватность Настройки..."
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป เทเลเมทรี วิเคราะห์ ขัดข้อง รายงาน การใช้งาน นิรนาม ความเป็นส่วนตัว การตั้งค่า... เมนู"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry uygulama genel tercihler davranış menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen içe aktar geçiş yer imleri geçmiş çerezler profiller ayarlar yapılandırma dosya json şema belgeler başvuru bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü telemetri analiz çökme raporlar kullanım anonim gizlilik Tercihler…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 导入 迁移 书签 历史记录 Cookie 个人资料 设置 配置 文件 json 架构 文档 参考 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 遥测 分析 崩溃 报告 使用 匿名 隐私 偏好设置... 菜单"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 應用程式 一般 偏好設定 行為 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 設定 設定檔 檔案 json 結構描述 文件 參考 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 遙測 分析 當機 報告 使用 匿名 隱私 偏好設定... 選單 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет імпорт міграція закладки історія cookies профілі налаштування конфігурація файл json схема документація довідник сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл телеметрія аналітика збій звіти використання анонімно приватність Параметри…"
+                }
+            }
+        }
     },
     "settings.search.alias.section.terminal": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "shell scrollback scrollbar scroll bar ghostty tty pty"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "shell scrollback scrollbar scroll bar ghostty tty pty シェル スクロールバック スクロールバー ターミナル ghostty tty pty"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty シェル スクロールバック スクロールバー ターミナル ghostty tty pty"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي طرفية صدفة تمرير سجل شاشة الطرفية • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty aplikacija opće postavke ponašanje dock traka menija status bočna terminal povratni zapis za pomicanje ekran • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty app generelt indstillinger adfærd dock menulinje status sidepanel terminal rullepanel skærm • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty app allgemein einstellungen verhalten dock menüleiste status seitenleiste terminal scrollleiste bildschirm • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty aplicación general preferencias comportamiento dock barra de menú estado lateral terminal historial desplazamiento pantalla • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty application général préférences comportement dock barre de menus état latérale terminal historique défilement écran • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty app generale preferenze comportamento dock barra menu stato laterale terminale cronologia di scorrimento schermo • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 • %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty app generelt innstillinger oppførsel dock menylinje status sidepanel terminal skall tilbakerulling rullefelt skjerm • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty aplikacja ogólne preferencje zachowanie dock pasek menu status boczny terminal powłoka przewijanie przewijania ekran • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty app geral preferências comportamento dock barra de menu status lateral terminal histórico rolagem tela • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty приложение общие настройки поведение док строка меню статус боковая панель терминал оболочка история прокрутки полоса экран • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty uygulama genel tercihler davranış dock menü çubuğu durum kenar terminal kabuk geri kaydırma ekran • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 终端 回滚 滚动条 屏幕 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 終端機 回捲 捲動列 螢幕 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shell scrollback scrollbar scroll bar ghostty tty pty програма загальні параметри поведінка док рядок меню статус бічна панель термінал історія прокручування смуга екран • %@"
+                }
+            }
+        }
     },
     "settings.search.alias.section.sidebarAppearance": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "left rail navigation tint transparency opacity material color"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "left rail navigation tint transparency opacity material color 左サイドバー ナビゲーション 色 透明度 不透明度 マテリアル"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color 左サイドバー ナビゲーション 色 透明度 不透明度 マテリアル"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color شريط جانبي تنقل يسار تفاصيل إخفاء تخطيط مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع أيسر شفافية اللون"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color bočna traka navigacija lijevo detalji sakrij raspored izgled tema boja boje shema svijetlo tamno sistem način Lijeva Prozirnost nijanse"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color sidepanel venstre detaljer skjul layout udseende tema farve farver skema lys mørk system tilstand skinne Farvetone gennemsigtighed"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color seitenleiste links details ausblenden layout darstellung design farbe farben schema hell dunkel system modus Linke Leiste Farbton-Deckkraft"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color barra lateral navegación izquierda detalles ocultar diseño apariencia tema colores esquema claro oscuro sistema modo Opacidad del tinte"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color barre latérale gauche détails masquer disposition apparence thème couleur couleurs schéma clair sombre système mode Opacité de la teinte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color barra laterale navigazione sinistra dettagli nascondi layout aspetto tema colore colori schema chiaro scuro sistema modalità Opacità tinta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 레일 색조 불투명도"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color sidepanel navigasjon venstre detaljer skjul oppsett utseende tema farge farger skjema lys mørk system modus skinne Fargetone-opasitet"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color pasek boczny nawigacja lewy szczegóły ukryj układ wygląd motyw kolor kolory schemat jasny ciemny system tryb Lewa listwa Krycie odcienia"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color barra lateral navegação esquerda detalhes ocultar layout aparência tema cor cores esquema claro escuro sistema modo Trilho Esquerdo Opacidade da Tonalidade"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color боковая панель навигация слева детали скрыть макет внешний вид тема цвет цвета схема светлый темный система режим Левая полоса Непрозрачность оттенка"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด แถบด้านซ้าย ความทึบของโทนสี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color kenar çubuğu gezinme sol ayrıntılar gizle düzen görünüm tema renk renkler şema açık koyu sistem mod Şerit Tonu Opaklığı"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color 侧边栏 导航 左侧 详细信息 隐藏 布局 外观 主题 颜色 配色 浅色 深色 系统 模式 左侧导轨 色调不透明度"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color 側邊欄 導覽 左側 詳細資訊 隱藏 版面 外觀 主題 顏色 配色 淺色 深色 系統 模式 左側軌道 色調不透明度"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "left rail navigation tint transparency opacity material color бічна панель навігація ліворуч деталі приховати макет вигляд тема колір кольори схема світлий темний система режим Лівий рейл Непрозорість відтінку"
+                }
+            }
+        }
     },
     "settings.search.alias.section.automation": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "api cli control socket mcp agents hooks ports"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "api cli control socket mcp agents hooks ports api cli 制御 ソケット mcp エージェント フック ポート 自動化"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports api cli 制御 ソケット mcp エージェント フック ポート 自動化"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة الأوامر الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatizacija kontrola agent kuke portovi okruženje"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatisering kontrol agent porte miljø"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatisierung steuerung agent umgebung"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatización agente puertos entorno"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatisation contrôle agent environnement"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automazione controllo agente hook porte ambiente"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports 자동화 제어 소켓 에이전트 훅 포트 환경"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatisering kontroll agent porter miljø"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automatyzacja sterowanie gniazdo agent haki porty środowisko"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports automação controle agente portas ambiente"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports автоматизация управление сокет агент хуки порты окружение"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports อัตโนมัติ ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports otomasyon kontrol soket ajan kancalar portlar ortam"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports 自动化 控制 套接字 代理 钩子 端口 环境"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports 自動化 控制 代理程式 hook 連接埠 環境"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "api cli control socket mcp agents hooks ports автоматизація керування сокет агент хуки порти середовище"
+                }
+            }
+        }
     },
     "settings.search.alias.section.browser": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "web webview address bar omnibar links urls embedded default browser"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "web webview address bar omnibar links urls embedded default browser ウェブ webview アドレスバー オムニバー リンク url 内蔵ブラウザ デフォルトブラウザ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser ウェブ webview アドレスバー オムニバー リンク url 内蔵ブラウザ デフォルトブラウザ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات إعادة ضبط مصنع افتراضي استعادة مسح المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser aplikacija opće postavke ponašanje dock traka menija status bočna preglednik adresna linkovi url ugrađen stranica kartice reset fabrički zadano vrati očisti • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser app generelt indstillinger adfærd dock menulinje status sidepanel webvisning adresselinje url indlejret side faner nulstil fabrik standard gendan ryd • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser app allgemein einstellungen verhalten dock menüleiste status seitenleiste adressleiste eingebettet seite tabs zurücksetzen werkseinstellungen standard wiederherstellen löschen • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser aplicación general preferencias comportamiento dock barra de menú estado lateral navegador direcciones enlaces integrado página pestañas restablecer fábrica predeterminado restaurar borrar • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser application général préférences comportement dock barre de menus état latérale navigateur adresse liens intégré page onglets réinitialiser usine défaut restaurer effacer • %@ Par"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser app generale preferenze comportamento dock barra menu stato laterale indirizzi link url incorporato pagina schede reimposta fabbrica predefinito ripristina cancella • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 재설정 초기화 기본값 복원 지우기 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser app generelt innstillinger oppførsel dock menylinje status sidepanel nettleser webvisning adresselinje lenker url innebygd side faner tilbakestill fabrikk standard gjenopprett tøm • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser aplikacja ogólne preferencje zachowanie dock pasek menu status boczny przeglądarka adresu linki url osadzony strona karty reset fabryczne domyślne przywróć wyczyść • %@ Domyślny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser app geral preferências comportamento dock barra de menu status lateral navegador endereço incorporado página abas redefinir fábrica padrão restaurar limpar • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser приложение общие настройки поведение док строка меню статус боковая панель браузер веб адресная ссылки url встроенный страница вкладки сброс заводские по умолчанию восстановить очистить • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser uygulama genel tercihler davranış dock menü çubuğu durum kenar tarayıcı adres bağlantılar url gömülü sayfa sekmeler sıfırla fabrika varsayılan geri yükle temizle • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 浏览器 网页 地址栏 链接 URL 内嵌 页面 标签页 重置 出厂 默认 恢复 清除 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 瀏覽器 網頁 位址列 連結 URL 內嵌 頁面 分頁 重置 出廠 預設 還原 清除 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "web webview address bar omnibar links urls embedded default browser програма загальні параметри поведінка док рядок меню статус бічна панель браузер веб адресний посилання url вбудований сторінка вкладки скидання заводські типові відновити очистити Стандартний Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.section.browserImport": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル インポート"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル インポート"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles uvoz migracija oznake historija kolačići profili"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles import migrering bogmærker historik profiler"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles import migration lesezeichen verlauf profile"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles importar migración marcadores historial perfiles"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles importer migration favoris historique profils"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles importa migrazione segnalibri cronologia cookie profili"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 +"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles import migrering bokmerker historikk informasjonskapsler profiler"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles import migracja zakładki historia ciasteczka profile"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles importar migração favoritos histórico perfis"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles импорт миграция закладки история профили"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles içe aktar geçiş yer imleri geçmiş çerezler profiller"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles 导入 迁移 书签 历史记录 Cookie 个人资料"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles імпорт міграція закладки історія профілі +"
+                }
+            }
+        }
     },
     "settings.search.alias.section.globalHotkey": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "system shortcut global keyboard show hide bring forward"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "system shortcut global keyboard show hide bring forward システム ショートカット グローバル ホットキー キーボード 表示 非表示 前面"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward システム ショートカット グローバル ホットキー キーボード 表示 非表示 前面"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع النظام عام تقدم"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward tastatura prečica prečice hotkey komande tipke snimač izgled tema boja boje shema svijetlo tamno sistem način Sistemski Globalno Naprijed"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward tastatur genvej genveje hotkey kommandoer taster optager udseende tema farve farver skema lys mørk tilstand Globalt Frem"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder darstellung design farbe farben schema hell dunkel modus Vor"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward teclado atajo atajos tecla rápida comandos teclas grabador apariencia tema color colores esquema claro oscuro sistema modo Adelante"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward clavier raccourci raccourcis touche globale commandes touches enregistreur apparence thème couleur couleurs schéma clair sombre système mode Général Suivant"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore aspetto tema colore colori schema chiaro scuro sistema modalità Globale Avanti"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward 키보드 단축키 핫키 명령 키 기록기 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 전역 앞으로"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward tastatur snarvei snarveier hurtigtast kommandoer taster opptaker utseende tema farge farger skjema lys mørk modus Globalt Fremover"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward klawiatura skrót skróty klawisz polecenia klawisze rejestrator wygląd motyw kolor kolory schemat jasny ciemny tryb Systemowy Globalne Do przodu"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward teclado atalho atalhos tecla rápida comandos teclas gravador aparência tema cor cores esquema claro escuro sistema modo Avançar"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward клавиатура сочетание клавиш горячая клавиша команды клавиши запись внешний вид тема цвет цвета схема светлый темный система режим Системное Глобальные Вперед Системный Системная"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด ทั่วไป ไปข้างหน้า"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici görünüm tema renk renkler şema açık koyu sistem mod Genel İleri"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward 键盘 快捷键 热键 命令 按键 录制器 外观 主题 颜色 配色 浅色 深色 系统 模式 全局 前进"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 外觀 主題 顏色 配色 淺色 深色 系統 模式 全域 下一頁"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "system shortcut global keyboard show hide bring forward клавіатура скорочення гарячі клавіші команди записувач вигляд тема колір кольори схема світлий темний система режим Системна Глобальна Вперед"
+                }
+            }
+        }
     },
     "settings.search.alias.section.keyboardShortcuts": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "keybinds key bindings hotkeys chords accelerators commands"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "keybinds key bindings hotkeys chords accelerators commands キーバインド キー割り当て ホットキー コード コマンド ショートカット"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands キーバインド キー割り当て ホットキー コード コマンド ショートカット"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands tastatura prečica prečice hotkey komande tipke snimač"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands tastatur genvej genveje hotkey kommandoer taster optager"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands teclado atajo atajos tecla rápida comandos teclas grabador"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands clavier raccourci raccourcis touche globale commandes touches enregistreur"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands 키보드 단축키 핫키 명령 키 기록기"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands tastatur snarvei snarveier hurtigtast kommandoer taster opptaker"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands klawiatura skrót skróty klawisz polecenia klawisze rejestrator"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands teclado atalho atalhos tecla rápida comandos teclas gravador"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands клавиатура сочетание клавиш горячая клавиша команды клавиши запись"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands 键盘 快捷键 热键 命令 按键 录制器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "keybinds key bindings hotkeys chords accelerators commands клавіатура скорочення гарячі клавіші команди записувач"
+                }
+            }
+        }
     },
     "settings.search.alias.section.workspaceColors": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "tab colors palette accent badge selected highlight"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "tab colors palette accent badge selected highlight タブ 色 パレット アクセント バッジ 選択 ハイライト ワークスペース"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight タブ 色 パレット アクセント バッジ 選択 ハイライト ワークスペース"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة مظهر سمة لون مخطط فاتح داكن نظام وضع إشعار إشعارات تنبيه غير مقروء رسالة رنين وميض صوت سطح المكتب لسان • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka izgled tema boja shema svijetlo tamno sistem način obavijest obavijesti upozorenje nepročitano poruka prsten bljesak zvuk desktop • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight arbejdsområde fane farver valgt fremhævning indikator aktiv prik udseende tema farve skema lys mørk system tilstand notifikation notifikationer advarsel ulæst besked ring blink lyd skrivebord • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight arbeitsbereich farben ausgewählt hervorhebung indikator aktiv punkt darstellung design farbe schema hell dunkel system modus benachrichtigung benachrichtigungen alarm ungelesen nachricht ring blinken ton desktop • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight espacio de trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto apariencia tema color esquema claro oscuro sistema modo notificación notificaciones alerta no leído mensaje anillo destello sonido escritorio • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight espace de travail onglet couleurs sélectionné surbrillance indicateur actif point apparence thème couleur schéma clair sombre système mode notification notifications alerte non lu message anneau flash son bureau • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight area di lavoro scheda colori tavolozza selezionato evidenziazione indicatore attivo punto aspetto tema colore schema chiaro scuro sistema modalità notifica notifiche avviso non letto messaggio anello lampeggio suono scrivania • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 • %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk utseende tema farge skjema lys mørk system modus varsling varsler ulest melding ring blink lyd skrivebord • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka wygląd motyw kolor schemat jasny ciemny system tryb powiadomienie powiadomienia alert nieprzeczytane wiadomość pierścień błysk dźwięk pulpit • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight workspace aba cores paleta selo selecionado destaque indicador ativo ponto aparência tema cor esquema claro escuro sistema modo notificação notificações alerta não lido mensagem anel piscar som desktop • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка внешний вид тема цвет схема светлый темный система режим уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ลักษณะ ธีม โครงร่าง สว่าง มืด ระบบ โหมด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ วงแหวน แฟลช เสียง เดสก์ท็อป • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta görünüm tema renk şema açık koyu sistem mod bildirim bildirimler uyarı okunmamış mesaj halka flaş ses masaüstü • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 外观 主题 配色 浅色 深色 系统 模式 通知 未读 消息 圆环 闪烁 声音 桌面 提醒 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 外觀 主題 配色 淺色 深色 系統 模式 通知 未讀 訊息 圓環 閃爍 聲音 桌面 提醒 標籤頁 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tab colors palette accent badge selected highlight робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка вигляд тема колір схема світлий темний система режим сповіщення непрочитане повідомлення кільце спалах звук стіл • %@"
+                }
+            }
+        }
     },
     "settings.search.alias.section.settingsJSON": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "configuration config file json jsonc dotfile ~/.config schema docs"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "configuration config file json jsonc dotfile ~/.config schema docs 設定 構成 ファイル json jsonc ドットファイル スキーマ ドキュメント"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs 設定 構成 ファイル json jsonc ドットファイル スキーマ ドキュメント"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs إعدادات تكوين ملف مخطط وثائق مرجع تفضيلات محرر كود فتح مسار المستندات"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs postavke konfiguracija datoteka šema dokumentacija referenca preferencije editor kod otvori putanja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs indstillinger konfiguration fil skema dokumentation reference præferencer editor kode åbn sti"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs einstellungen konfiguration datei dokumentation referenz präferenzen editor code öffnen pfad"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs ajustes configuración archivo esquema documentación referencia preferencias editor código abrir ruta"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs réglages fichier schéma documentation référence préférences éditeur code ouvrir chemin"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs impostazioni configurazione documentazione riferimento preferenze editor codice apri percorso"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs 설정 구성 파일 스키마 문서 참조 환경설정 편집기 코드 열기 경로"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs innstillinger konfigurasjon fil skjema dokumentasjon referanse preferanser redigerer kode åpne bane"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs ustawienia konfiguracja plik schemat dokumentacja referencja preferencje edytor kod otwórz ścieżka"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs configurações configuração arquivo esquema documentação referência preferências editor código abrir caminho"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs настройки конфигурация файл схема документация справочник предпочтения редактор код открыть путь"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs การตั้งค่า การกำหนดค่า ไฟล์ สคีมา เอกสาร อ้างอิง ค่ากำหนด ตัวแก้ไข โค้ด เปิด เส้นทาง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs ayarlar yapılandırma dosya şema belgeler başvuru tercihler düzenleyici kod aç yol"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs 设置 配置 文件 架构 文档 参考 偏好设置 编辑器 代码 打开 路径"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs 設定 設定檔 檔案 結構描述 文件 參考 偏好設定 編輯器 程式碼 開啟 路徑"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "configuration config file json jsonc dotfile ~/.config schema docs налаштування конфігурація файл схема документація довідник параметри редактор код відкрити шлях"
+                }
+            }
+        }
     },
     "settings.search.alias.section.reset": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "factory defaults restore clear preferences"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "factory defaults restore clear preferences 初期化 デフォルト 復元 リセット 設定を消去"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences 初期化 デフォルト 復元 リセット 設定を消去"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إعدادات تكوين ملف json مخطط وثائق مرجع إعادة ضبط مصنع افتراضي استعادة مسح التفضيلات… التعيين تعيين"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences aplikacija opće postavke ponašanje dock traka menija status bočna konfiguracija datoteka json šema dokumentacija referenca preferencije reset fabrički zadano vrati očisti Postavke… Obriši Resetovanje Resetuj"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences app generelt indstillinger adfærd dock menulinje status sidepanel konfiguration fil json skema dokumentation reference præferencer nulstil fabrik standard gendan ryd Indstillinger…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences app allgemein einstellungen verhalten dock menüleiste status seitenleiste konfiguration datei json schema dokumentation referenz präferenzen zurücksetzen werkseinstellungen standard wiederherstellen löschen …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences aplicación general preferencias comportamiento dock barra de menú estado lateral ajustes configuración archivo json esquema documentación referencia restablecer fábrica predeterminado restaurar borrar Preferencias…"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences application général préférences comportement dock barre de menus état latérale réglages configuration fichier json schéma documentation référence réinitialiser usine défaut restaurer effacer Préférences..."
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences app generale preferenze comportamento dock barra menu stato laterale impostazioni configurazione file json schema documentazione riferimento reimposta fabbrica predefinito ripristina cancella Preferenze…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 설정 구성 파일 json 스키마 문서 참조 재설정 초기화 기본값 복원 지우기 환경설정…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences app generelt innstillinger oppførsel dock menylinje status sidepanel konfigurasjon fil json skjema dokumentasjon referanse preferanser tilbakestill fabrikk standard gjenopprett tøm … Fjern"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences aplikacja ogólne preferencje zachowanie dock pasek menu status boczny ustawienia konfiguracja plik json schemat dokumentacja referencja reset fabryczne domyślne przywróć wyczyść Preferencje… Resetuj"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences app geral preferências comportamento dock barra de menu status lateral configurações configuração arquivo json esquema documentação referência redefinir fábrica padrão restaurar limpar Preferências…"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences приложение общие настройки поведение док строка меню статус боковая панель конфигурация файл json схема документация справочник предпочтения сброс заводские по умолчанию восстановить очистить Настройки... Сбросить"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง การตั้งค่า..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences uygulama genel tercihler davranış dock menü çubuğu durum kenar ayarlar yapılandırma dosya json şema belgeler başvuru sıfırla fabrika varsayılan geri yükle temizle Tercihler…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 设置 配置 文件 json 架构 文档 参考 重置 出厂 默认 恢复 清除 偏好设置..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 設定 設定檔 檔案 json 結構描述 文件 參考 重置 出廠 預設 還原 清除 偏好設定..."
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory defaults restore clear preferences програма загальні параметри поведінка док рядок меню статус бічна панель налаштування конфігурація файл json схема документація довідник скидання заводські типові відновити очистити Скинути Параметри…"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.account.account": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 認証 ログイン ログアウト サインイン サインアウト メール ユーザー プロフィール チーム アカウント"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team autentikacija prijava odjava korisnik profil tim račun"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team godkendelse logud bruger profil konto"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team authentifizierung anmeldung abmeldung benutzer profil konto"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team authentification connexion déconnexion e-mail utilisateur profil équipe compte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team autenticazione accesso disconnessione utente profilo account"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team autentisering innlogging utlogging e-post bruker profil konto"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team uwierzytelnianie logowanie wylogowanie użytkownik profil zespół konto"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team autenticação sair usuário perfil equipe conta"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team аутентификация вход выход пользователь профиль команда аккаунт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 认证 登录 退出登录 邮件 用户 个人资料 团队 账户"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "auth authentication login logout signin sign-in signout sign-out email user profile stack team автентифікація вхід вихід користувач профіль команда обліковий запис"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.language": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.language locale l10n localization translation japanese english ja en nihongo restart"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 言語 地域 ロケール ローカライズ 翻訳 日本語 英語 再起動"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 言語 地域 ロケール ローカライズ 翻訳 日本語 英語 再起動"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي لغة محلية ترجمة تعريب يابانية إنجليزية إعادة تشغيل اللغة التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart aplikacija opće postavke ponašanje dock traka menija status bočna jezik lokalizacija prijevod japanski engleski ponovno pokretanje"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart app generelt indstillinger adfærd dock menulinje status sidepanel sprog lokalitet lokalisering oversættelse japansk engelsk genstart"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart app allgemein einstellungen verhalten dock menüleiste status seitenleiste sprache lokalisierung übersetzung japanisch englisch neustart"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart aplicación general preferencias comportamiento dock barra de menú estado lateral idioma configuración regional localización traducción japonés inglés reiniciar App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart application général préférences comportement dock barre de menus état latérale langue paramètres régionaux localisation traduction japonais anglais redémarrer App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart app generale preferenze comportamento dock barra menu stato laterale lingua localizzazione traduzione giapponese inglese riavvia"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 언어 로케일 현지화 번역 일본어 영어 재시작"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart app generelt innstillinger oppførsel dock menylinje status sidepanel språk lokale lokalisering oversettelse japansk engelsk omstart"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart aplikacja ogólne preferencje zachowanie dock pasek menu status boczny język ustawienia regionalne lokalizacja tłumaczenie japoński angielski"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart app geral preferências comportamento dock barra de menu status lateral idioma localidade localização tradução japonês inglês reiniciar"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart приложение общие настройки поведение док строка меню статус боковая панель язык локаль локализация перевод японский английский перезапуск"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง ภาษา โลแคล การแปล ท้องถิ่น ญี่ปุ่น อังกฤษ รีสตาร์ท"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart uygulama genel tercihler davranış dock menü çubuğu durum kenar dil yerel ayar yerelleştirme çeviri japonca ingilizce yeniden başlat"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 语言 区域设置 本地化 翻译 日语 英语 重新启动"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 語言 地區設定 在地化 翻譯 日文 英文 重新啟動 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.language locale l10n localization translation japanese english ja en nihongo restart програма загальні параметри поведінка док рядок меню статус бічна панель мова локаль локалізація переклад японська англійська перезапуск"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.appearance": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.appearance theme color scheme light mode dark mode system mode"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.appearance theme color scheme light mode dark mode system mode 外観 テーマ 配色 ライトモード ダークモード システムモード"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark mode system mode"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark mode system mode 外観 テーマ 配色 ライトモード ダークモード システムモード"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع النظام المظهر التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system aplikacija opće postavke ponašanje dock traka menija status bočna izgled tema boja boje shema svijetlo tamno sistem način Tamna Svijetla Sistemski"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system app generelt indstillinger adfærd dock menulinje status sidepanel udseende tema farve farver skema lys mørk tilstand"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system app allgemein einstellungen verhalten dock menüleiste status seitenleiste darstellung design farbe farben schema hell dunkel modus"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system aplicación general preferencias comportamiento dock barra de menú estado lateral apariencia tema colores esquema claro oscuro sistema modo App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system application général préférences comportement dock barre de menus état latérale apparence thème couleur couleurs schéma clair sombre système App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system app generale preferenze comportamento dock barra menu stato laterale aspetto tema colore colori schema chiaro scuro sistema modalità Scura Chiara"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 외관 테마 색상 색 구성표 라이트 다크 시스템 모드"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system app generelt innstillinger oppførsel dock menylinje status sidepanel utseende tema farge farger skjema lys mørk modus"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system aplikacja ogólne preferencje zachowanie dock pasek menu status boczny wygląd motyw kolor kolory schemat jasny ciemny tryb Ciemna Jasna Systemowy"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system app geral preferências comportamento dock barra de menu status lateral aparência tema cor cores esquema claro escuro sistema modo"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system приложение общие настройки поведение док строка меню статус боковая панель внешний вид тема цвет цвета схема светлый темный система режим Темная Светлая Темное Светлое Системное Системный Системная"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system uygulama genel tercihler davranış dock menü çubuğu durum kenar görünüm tema renk renkler şema açık koyu sistem mod"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 外观 主题 颜色 配色 浅色 深色 系统 模式"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 外觀 主題 顏色 配色 淺色 深色 系統 模式 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appearance theme color scheme light mode dark system програма загальні параметри поведінка док рядок меню статус бічна панель вигляд тема колір кольори схема світлий темний система режим Темна Світла Системна"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.app-icon": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.appIcon dock icon application icon app switcher alternate icon"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.appIcon dock icon application icon app switcher alternate icon アプリアイコン ドック アイコン アプリ切り替え 代替アイコン"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application icon app switcher alternate icon"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application icon app switcher alternate icon アプリアイコン ドック アイコン アプリ切り替え 代替アイコン"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي أيقونة التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate aplikacija opće postavke ponašanje traka menija status bočna Ikona aplikacije"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate generelt indstillinger adfærd menulinje status sidepanel Appikon"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate allgemein einstellungen verhalten menüleiste status seitenleiste App-Symbol"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate aplicación general preferencias comportamiento barra de menú estado lateral Ícono la"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate général préférences comportement barre de menus état latérale Icône l'app"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate generale preferenze comportamento barra menu stato laterale Icona"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 아이콘"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate generelt innstillinger oppførsel menylinje status sidepanel Appikon"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate aplikacja ogólne preferencje zachowanie pasek menu status boczny Ikona aplikacji"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate geral preferências comportamento barra de menu status lateral Ícone do"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate приложение общие настройки поведение док строка меню статус боковая панель Значок приложения"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง ไอคอนแอป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate uygulama genel tercihler davranış menü çubuğu durum kenar Simgesi"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 应用图标"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate 應用程式 一般 偏好設定 行為 選單列 狀態 側邊欄 圖示"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.appIcon dock icon application app switcher alternate програма загальні параметри поведінка док рядок меню статус бічна панель Іконка програми"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.new-workspace-placement": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.newWorkspacePlacement new tab insert position order top bottom end"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.newWorkspacePlacement new tab insert position order top bottom end 新規ワークスペース 新しいタブ 挿入位置 並び順 上 下 末尾"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 新規ワークスペース 新しいタブ 挿入位置 並び順 上 下 末尾"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة لسان جديد العمل جديدة • %@ موضع الجديدة التطبيق النهاية الأعلى"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end aplikacija opće postavke ponašanje dock traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka novi • %@ Pozicija novog radnog prostora Kraj Vrh"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end app generelt indstillinger adfærd dock menulinje status sidepanel arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik ny Nyt • %@ Placering af Sidst Øverst"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end app allgemein einstellungen verhalten dock menüleiste status seitenleiste arbeitsbereich farben palette badge ausgewählt hervorhebung indikator aktiv punkt Neuer • %@ Platzierung Arbeitsbereiche Ende Oben"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end aplicación general preferencias comportamiento dock barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto nueva Nuevo • %@ Ubicación App Final Inicio"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end application général préférences comportement dock barre de menus état latérale espace travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point nouvel • %@ Emplacement des nouveaux espaces App Fin Début"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end app generale preferenze comportamento dock barra menu stato laterale area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto nuova • %@ Posizionamento Fine Inizio"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 새 작업 공간 • %@ 위치 끝 맨 위"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end app generelt innstillinger oppførsel dock menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk ny Nytt • %@ Plassering av Slutt Topp"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end aplikacja ogólne preferencje zachowanie dock pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka nowa Przestrzeń robocza • %@ Umieszczenie nowej przestrzeni roboczej Na końcu górze"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end app geral preferências comportamento dock barra de menu status lateral workspace aba cores paleta selo selecionado destaque indicador ativo ponto nova Área Trabalho • %@ Posição da Final Topo"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка новая Рабочее пространство Новое • %@ Расположение нового рабочего пространства В конец начало"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด แท็บใหม่ เวิร์กสเปซ เวิร์กสเปซใหม่ • %@ ตำแหน่งเวิร์กสเปซใหม่ ท้ายสุด ด้านบน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end uygulama genel tercihler davranış dock menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta yeni • %@ Konumu Sona En Üste"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 新建标签页 新建工作区 • %@ 新工作区位置 末尾 顶部"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 新增標籤頁 標籤頁 新增工作區 • %@ 新工作區位置 App 底部 最上方"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.newWorkspacePlacement new tab insert position order top bottom end програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка нова Робоча область • %@ Розташування нової робочої області В кінці На початку"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.minimal-mode": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.minimalMode minimal layout simple chrome compact titlebar controls"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.minimalMode minimal layout simple chrome compact titlebar controls ミニマル 省スペース コンパクト タイトルバー 表示モード"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls ミニマル 省スペース コンパクト タイトルバー 表示モード"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع التخطيط التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls aplikacija opće postavke ponašanje dock traka menija status bočna uvoz migracija oznake historija kolačići profili izgled tema boja boje shema svijetlo tamno sistem način Raspored"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls app generelt indstillinger adfærd dock menulinje status sidepanel import migrering bogmærker historik cookies profiler udseende tema farve farver skema lys mørk system tilstand"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls app allgemein einstellungen verhalten dock menüleiste status seitenleiste import migration lesezeichen verlauf cookies profile darstellung design farbe farben schema hell dunkel system modus"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls aplicación general preferencias comportamiento dock barra de menú estado lateral importar migración marcadores historial cookies perfiles apariencia tema color colores esquema claro oscuro sistema modo Disposición App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls application général préférences comportement dock barre de menus état latérale importer migration favoris historique cookies profils apparence thème couleur couleurs schéma clair sombre système mode Disposition App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls app generale preferenze comportamento dock barra menu stato laterale importa migrazione segnalibri cronologia cookie profili aspetto tema colore colori schema chiaro scuro sistema modalità"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 레이아웃 미니멀"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls app generelt innstillinger oppførsel dock menylinje status sidepanel import migrering bokmerker historikk informasjonskapsler profiler utseende tema farge farger skjema lys mørk system modus Oppsett"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls aplikacja ogólne preferencje zachowanie dock pasek menu status boczny import migracja zakładki historia ciasteczka profile wygląd motyw kolor kolory schemat jasny ciemny system tryb Układ"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls app geral preferências comportamento dock barra de menu status lateral importar migração favoritos histórico cookies perfis aparência tema cor cores esquema claro escuro sistema modo"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls приложение общие настройки поведение док строка меню статус боковая панель импорт миграция закладки история cookies профили внешний вид тема цвет цвета схема светлый темный система режим Макет"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด เค้าโครง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls uygulama genel tercihler davranış dock menü çubuğu durum kenar içe aktar geçiş yer imleri geçmiş çerezler profiller görünüm tema renk renkler şema açık koyu sistem mod Düzen"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导入 迁移 书签 历史记录 Cookie 个人资料 外观 主题 颜色 配色 浅色 深色 系统 模式 布局"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 外觀 主題 顏色 配色 淺色 深色 系統 模式 版面 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.minimalMode minimal layout simple chrome compact titlebar controls програма загальні параметри поведінка док рядок меню статус бічна панель імпорт міграція закладки історія cookies профілі вигляд тема колір кольори схема світлий темний система режим Макет Мінімальний"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.keep-workspace-open": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 閉じる 最後のペイン サーフェス ワークスペースを残す コマンドw"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 閉じる 最後のペイン サーフェス ワークスペースを残す コマンドw"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة محرر ملف كود فتح مسار لسان إغلاق اللسان العمل • %@ اللسان؟ العمل؟ التطبيق مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace aplikacija opće postavke ponašanje dock traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka editor datoteka kod otvori putanja Zatvori • %@ Zatvoriti tab? prostor? otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace app generelt indstillinger adfærd dock menulinje status sidepanel arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik editor fil kode åbn sti Luk • %@ fane? arbejdsområde? åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace app allgemein einstellungen verhalten dock menüleiste status seitenleiste arbeitsbereich farben palette badge ausgewählt hervorhebung indikator aktiv punkt editor datei code öffnen pfad schließen • %@ schließen? offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace aplicación general preferencias comportamiento dock barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto editor archivo código abrir ruta Cerrar • %@ ¿Cerrar pestaña? trabajo? App abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace application général préférences comportement dock barre de menus état latérale espace travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point éditeur fichier code ouvrir chemin Fermer l'onglet l'espace • %@ ? App ouverte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace app generale preferenze comportamento dock barra menu stato laterale area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto editor file codice apri percorso Chiudi • %@ Chiudere la scheda? l'area lavoro? aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 편집기 파일 코드 열기 경로 닫기 작업 공간 • %@ 탭을 닫으시겠습니까? 공간을 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace app generelt innstillinger oppførsel dock menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk redigerer fil kode åpne bane Lukk • %@ Lukke fane? arbeidsområde? åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace aplikacja ogólne preferencje zachowanie dock pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka edytor plik kod otwórz ścieżka Zamknij kartę Przestrzeń robocza roboczą • %@ Zamknąć kartę? roboczą? otwarty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace app geral preferências comportamento dock barra de menu status lateral aba cores paleta selo selecionado destaque indicador ativo ponto editor arquivo código abrir caminho Fechar Área Trabalho • %@ aba? trabalho? aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка редактор файл код открыть путь Закрыть вкладку Рабочее пространство • %@ вкладку? пространство? открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง ปิดแท็บ เวิร์กสเปซ ปิดเวิร์กสเปซ • %@ ปิด ปิดแท็บหรือไม่? ปิดเวิร์กสเปซหรือไม่?"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace uygulama genel tercihler davranış dock menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta düzenleyici dosya kod aç yol Sekmeyi Kapat Alanını • %@ kapatılsın mı? açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 编辑器 文件 代码 打开 路径 关闭标签页 关闭工作区 • %@ 关闭 关闭标签页？ 关闭工作区？"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 編輯器 檔案 程式碼 開啟 路徑 標籤頁 關閉標籤頁 關閉工作區 • %@ 關閉 要關閉標籤頁嗎？ 要關閉工作區嗎？ App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.keepWorkspaceOpenWhenClosingLastSurface cmd-w command-w close last pane surface keep tab workspace програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка редактор файл код відкрити шлях Закрити вкладку Робоча область робочу • %@ вкладку? область? відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.focus-pane-first-click": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation クリック フォーカス マウス 最初のクリック ペインを選択"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus focus follows mouse first click mouse activation クリック フォーカス マウス 最初のクリック ペインを選択"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي تركيز نقر ماوس تنشيط يتبع أول التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation aplikacija opće postavke ponašanje dock traka menija status bočna fokus klik miš aktivacija prati prvi"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation app generelt indstillinger adfærd dock menulinje status sidepanel fokus klik mus aktivering følger første"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation app allgemein einstellungen verhalten dock menüleiste status seitenleiste fokus klicken maus aktivierung folgt erster"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation aplicación general preferencias comportamiento dock barra de menú estado lateral foco clic ratón activación sigue primero App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation application général préférences comportement dock barre de menus état latérale clic souris suit premier App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation app generale preferenze comportamento dock barra menu stato laterale clic attivazione segue primo"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 포커스 클릭 마우스 활성화 따름 첫 번째"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation app generelt innstillinger oppførsel dock menylinje status sidepanel fokus klikk mus aktivering følger første"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation aplikacja ogólne preferencje zachowanie dock pasek menu status boczny fokus klik mysz aktywacja podąża pierwszy"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation app geral preferências comportamento dock barra de menu status lateral foco clique ativação segue primeiro"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation приложение общие настройки поведение док строка меню статус боковая панель фокус щелчок мышь активация следует первый"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง โฟกัส คลิก เมาส์ เปิดใช้งาน ตาม ครั้งแรก"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation uygulama genel tercihler davranış dock menü çubuğu durum kenar odak tık fare etkinleştirme izler ilk"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 焦点 点击 鼠标 激活 跟随 首次"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 焦點 點按 滑鼠 啟用 跟隨 首次 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.focusPaneOnFirstClick click to focus follows mouse first activation програма загальні параметри поведінка док рядок меню статус бічна панель фокус клацання миша активація слідує перший"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.preferred-editor": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor エディタ ファイルを開く vscode visual studio code zed sublime cursor"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor エディタ ファイルを開く vscode visual studio code zed sublime cursor"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إعدادات تكوين ملف json مخطط وثائق مرجع محرر كود فتح مسار التطبيق مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor aplikacija opće postavke ponašanje dock traka menija status bočna konfiguracija datoteka json šema dokumentacija referenca preferencije kod otvori putanja otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor app generelt indstillinger adfærd dock menulinje status sidepanel konfiguration fil json skema dokumentation reference præferencer kode åbn sti åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor app allgemein einstellungen verhalten dock menüleiste status seitenleiste konfiguration datei json schema dokumentation referenz präferenzen öffnen pfad offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor aplicación general preferencias comportamiento dock barra de menú estado lateral ajustes configuración archivo json esquema documentación referencia código abrir ruta App abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor application général préférences comportement dock barre de menus état latérale réglages configuration fichier json schéma documentation référence éditeur ouvrir chemin App ouverte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor app generale preferenze comportamento dock barra menu stato laterale impostazioni configurazione json schema documentazione riferimento codice apri percorso aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 설정 구성 파일 json 스키마 문서 참조 편집기 코드 열기 경로 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor app generelt innstillinger oppførsel dock menylinje status sidepanel konfigurasjon fil json skjema dokumentasjon referanse preferanser redigerer kode åpne bane åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor aplikacja ogólne preferencje zachowanie dock pasek menu status boczny ustawienia konfiguracja plik json schemat dokumentacja referencja edytor kod otwórz ścieżka otwarty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor app geral preferências comportamento dock barra de menu status lateral configurações configuração arquivo json esquema documentação referência código abrir caminho aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor приложение общие настройки поведение док строка меню статус боковая панель конфигурация файл json схема документация справочник предпочтения редактор код открыть путь открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง ตัวแก้ไข โค้ด เปิด เส้นทาง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor uygulama genel tercihler davranış dock menü çubuğu durum kenar ayarlar yapılandırma dosya json şema belgeler başvuru düzenleyici kod aç yol açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 设置 配置 文件 json 架构 文档 参考 编辑器 代码 打开 路径"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 設定 設定檔 檔案 json 結構描述 文件 參考 編輯器 程式碼 開啟 路徑 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.preferredEditor editor open file code vscode visual studio zed sublime subl cursor програма загальні параметри поведінка док рядок меню статус бічна панель налаштування конфігурація файл json схема документація довідник редактор код відкрити шлях відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.terminal-config": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "ghostty config configuration terminal settings preview merged file reload"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "ghostty config configuration terminal settings preview merged file reload ghostty 設定 構成 ターミナル プレビュー マージ ファイル 再読み込み"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload ghostty 設定 構成 ターミナル プレビュー マージ ファイル 再読み込み"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي طرفية صدفة تمرير سجل شاشة إعدادات تكوين ملف json مخطط وثائق مرجع محرر كود فتح مسار إعادة تحميل الطرفية • %@ Ghostty… الإعدادات الإعدادات… التطبيق مدمج"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload aplikacija opće postavke ponašanje dock traka menija status bočna shell povratni zapis za pomicanje ekran konfiguracija datoteka json šema dokumentacija referenca preferencije editor kod otvori putanja Ponovo učitaj • %@ postavke… konfiguraciju spojen"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload app generelt indstillinger adfærd dock menulinje status sidepanel shell scrollback rullepanel skærm konfiguration fil json skema dokumentation reference præferencer editor kode åbn sti Genindlæs • %@ Ghostty-indstillinger… Indstillinger… sammenlagt"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload app allgemein einstellungen verhalten dock menüleiste status seitenleiste shell scrollback scrollleiste bildschirm konfiguration datei json schema dokumentation referenz präferenzen editor code öffnen pfad Neu laden • %@ Ghostty-Einstellungen … zusammengeführt"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload aplicación general preferencias comportamiento dock barra de menú estado lateral shell historial desplazamiento pantalla ajustes configuración archivo json esquema documentación referencia editor código abrir ruta Recargar • %@ Ghostty… Ajustes… App fusionado"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload application général préférences comportement dock barre de menus état latérale shell historique défilement écran réglages fichier json schéma documentation référence éditeur code ouvrir chemin Recharger • %@ Ghostty... la Réglages... App fusionnée"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload app generale preferenze comportamento dock barra menu stato laterale terminale shell cronologia di scorrimento schermo impostazioni configurazione json schema documentazione riferimento editor codice apri percorso Ricarica • %@ Ghostty… Impostazioni… unita"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 설정 구성 파일 json 스키마 문서 참조 편집기 코드 열기 경로 미리보기 새로고침 • %@ 설정… 다시 불러오기 병합됨"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload app generelt innstillinger oppførsel dock menylinje status sidepanel skall tilbakerulling rullefelt skjerm konfigurasjon fil json skjema dokumentasjon referanse preferanser redigerer kode åpne bane Last inn på nytt • %@ Ghostty-innstillinger … sammenslått"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload aplikacja ogólne preferencje zachowanie dock pasek menu status boczny powłoka przewijanie przewijania ekran ustawienia konfiguracja plik json schemat dokumentacja referencja edytor kod otwórz ścieżka Odśwież • %@ Ghostty… konfigurację Ustawienia… scalony"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload app geral preferências comportamento dock barra de menu status lateral shell histórico rolagem tela configurações configuração arquivo json esquema documentação referência editor código abrir caminho Recarregar • %@ Ajustes do Ghostty… Ajustes… mesclado"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload приложение общие настройки поведение док строка меню статус боковая панель терминал оболочка история прокрутки полоса экран конфигурация файл json схема документация справочник предпочтения редактор код открыть путь Перезагрузить • %@ Ghostty... конфигурацию Настройки... объединен"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง ตัวแก้ไข โค้ด เปิด เส้นทาง โหลดใหม่ • %@ Ghostty... โหลดการกำหนดค่าใหม่ การตั้งค่า... ผสานแล้ว"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload uygulama genel tercihler davranış dock menü çubuğu durum kenar kabuk geri kaydırma ekran ayarlar yapılandırma dosya json şema belgeler başvuru düzenleyici kod aç yol Yeniden Yükle • %@ Ayarları… Yapılandırmayı Ayarlar… birleştirildi"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 终端 shell 回滚 滚动条 屏幕 设置 配置 文件 json 架构 文档 参考 编辑器 代码 打开 路径 重新加载 • %@ 设置... 重新加载配置 已合并"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 終端機 shell 回捲 捲動列 螢幕 設定 設定檔 檔案 json 結構描述 文件 參考 編輯器 程式碼 開啟 路徑 重新載入 • %@ 設定... 重新載入設定 App 已合併"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "ghostty config configuration terminal settings preview merged file reload програма загальні параметри поведінка док рядок меню статус бічна панель термінал shell історія прокручування смуга екран налаштування конфігурація файл json схема документація довідник редактор код відкрити шлях Перегляд Перезавантажити • %@ Ghostty… конфігурацію Налаштування… злитий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.markdown-viewer": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme md markdown mdx ビューア プレビュー readme 表示"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme md markdown mdx ビューア プレビュー readme 表示"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme aplikacija opće postavke ponašanje dock traka menija status bočna"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme app generelt indstillinger adfærd dock menulinje status sidepanel"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme app allgemein einstellungen verhalten dock menüleiste status seitenleiste"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme aplicación general preferencias comportamiento dock barra de menú estado lateral App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme application général préférences comportement dock barre de menus état latérale App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme app generale preferenze comportamento dock barra menu stato laterale"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 미리보기 마크다운"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme app generelt innstillinger oppførsel dock menylinje status sidepanel"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme aplikacja ogólne preferencje zachowanie dock pasek menu status boczny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme app geral preferências comportamento dock barra de menu status lateral"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme приложение общие настройки поведение док строка меню статус боковая панель"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme uygulama genel tercihler davranış dock menü çubuğu durum kenar"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.openMarkdownInCmuxViewer md markdown mdx viewer preview readme програма загальні параметри поведінка док рядок меню статус бічна панель Перегляд"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.reorder-notification": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.reorderOnNotification notification reorder move workspace top unread sort"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.reorderOnNotification notification reorder move workspace top unread sort 通知 並べ替え ワークスペースを上へ 未読 ソート"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 通知 並べ替え ワークスペースを上へ 未読 ソート"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة إشعار إشعارات تنبيه غير مقروء رسالة رنين وميض صوت سطح المكتب العمل • %@ نقل التطبيق واحد الأعلى"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort aplikacija opće postavke ponašanje dock traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka obavijest obavijesti upozorenje nepročitano poruka prsten bljesak zvuk desktop • %@ Premjesti 1 obavještenje Vrh"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort app generelt indstillinger adfærd dock menulinje status sidepanel arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik notifikation notifikationer advarsel ulæst besked ring blink lyd skrivebord • %@ Flyt 1 Øverst"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort app allgemein einstellungen verhalten dock menüleiste status seitenleiste arbeitsbereich tab farben palette badge ausgewählt hervorhebung indikator aktiv punkt benachrichtigung benachrichtigungen alarm ungelesen nachricht ring blinken ton desktop • %@ Verschieben 1 ungelesene Oben"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort aplicación general preferencias comportamiento dock barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto notificación notificaciones alerta no leído mensaje anillo destello sonido escritorio • %@ Mover App 1 leída Inicio"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort application général préférences comportement dock barre de menus état latérale espace travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point notifications alerte non lu message anneau flash son bureau • %@ Déplacer App 1 lue Début"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort app generale preferenze comportamento dock barra menu stato laterale area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto notifica notifiche avviso non letto messaggio anello lampeggio suono scrivania • %@ Sposta 1 letta Inizio"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 작업 공간 • %@ 이동 않은 1개 맨 위"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort app generelt innstillinger oppførsel dock menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk varsling varsler ulest melding ring blink lyd skrivebord • %@ Flytt 1 varsel Topp"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort aplikacja ogólne preferencje zachowanie dock pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka powiadomienie powiadomienia alert nieprzeczytane wiadomość pierścień błysk dźwięk pulpit Przestrzeń robocza • %@ Przenieś 1 Na górze"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort app geral preferências comportamento dock barra de menu status lateral aba cores paleta selo selecionado destaque indicador ativo ponto notificação notificações alerta não lido mensagem anel piscar som desktop Área Trabalho • %@ Mover 1 lida Topo"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол Рабочее пространство • %@ Переместить 1 В начало"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ วงแหวน แฟลช เสียง เดสก์ท็อป เวิร์กสเปซ • %@ ย้าย 1 การแจ้งเตือนที่ยังไม่อ่าน ด้านบน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort uygulama genel tercihler davranış dock menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta bildirim bildirimler uyarı okunmamış mesaj halka flaş ses masaüstü • %@ Taşı 1 En Üste"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 通知 未读 消息 圆环 闪烁 声音 桌面 提醒 • %@ 移动 1 条未读通知 顶部"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 通知 未讀 訊息 圓環 閃爍 聲音 桌面 提醒 • %@ 移動 App 1 則未讀通知 最上方"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.reorderOnNotification notification reorder move workspace top unread sort програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка сповіщення непрочитане повідомлення кільце спалах звук стіл Робоча область • %@ Перемістити 1 На початку"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.dock-badge": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.dockBadge badge dock unread count icon notifications red bubble"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.dockBadge badge dock unread count icon notifications red bubble ドック バッジ 未読 件数 アイコン 通知 赤丸"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble ドック バッジ 未読 件数 アイコン 通知 赤丸"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة إشعار إشعارات تنبيه غير مقروء رسالة رنين وميض صوت سطح المكتب الإشعارات أيقونة التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble aplikacija opće postavke ponašanje traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka obavijest obavijesti upozorenje nepročitano poruka prsten bljesak zvuk desktop Obavještenja Ikona aplikacije Oznaka na Docku"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble app generelt indstillinger adfærd menulinje status sidepanel arbejdsområde fane farver palette valgt fremhævning indikator aktiv prik notifikation notifikationer advarsel ulæst besked ring blink lyd skrivebord Appikon Dock-badge"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble app allgemein einstellungen verhalten menüleiste status seitenleiste arbeitsbereich tab farben palette ausgewählt hervorhebung indikator aktiv punkt benachrichtigung benachrichtigungen alarm ungelesen nachricht ring blinken ton desktop App-Symbol Dock-Badge"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble aplicación general preferencias comportamiento barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto notificación notificaciones alerta no leído mensaje anillo destello sonido escritorio Ícono la app del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble application général préférences comportement barre de menus état latérale espace travail onglet couleurs palette sélectionné surbrillance indicateur actif point notification alerte non lu message anneau flash son bureau Icône l'app du App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble app generale preferenze comportamento barra menu stato laterale area di lavoro scheda colori tavolozza selezionato evidenziazione indicatore attivo punto notifica notifiche avviso non letto messaggio anello lampeggio suono scrivania Icona del"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 아이콘"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble app generelt innstillinger oppførsel menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk varsling varsler ulest melding ring blink lyd skrivebord Appikon Dock-merke"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble aplikacja ogólne preferencje zachowanie pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka powiadomienie powiadomienia alert nieprzeczytane wiadomość pierścień błysk dźwięk pulpit Ikona aplikacji Plakietka w Docku"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble app geral preferências comportamento barra de menu status lateral workspace aba cores paleta selo selecionado destaque indicador ativo ponto notificação notificações alerta não lido mensagem anel piscar som desktop Ícone do Emblema"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол приложения"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ วงแหวน แฟลช เสียง เดสก์ท็อป ไอคอนแอป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble uygulama genel tercihler davranış menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta bildirim bildirimler uyarı okunmamış mesaj halka flaş ses masaüstü Simgesi Rozeti"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 通知 未读 消息 圆环 闪烁 声音 桌面 提醒 应用图标 程序坞角标"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble 應用程式 一般 偏好設定 行為 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 通知 未讀 訊息 圓環 閃爍 聲音 桌面 提醒 App 圖示 標記"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.dockBadge badge dock unread count icon notifications red bubble програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка сповіщення непрочитане повідомлення кільце спалах звук стіл Іконка програми"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.menu-bar-only": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab メニューバーのみ ドックなし ドック非表示 アプリ切り替え cmd-tab command-tab"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab メニューバーのみ ドックなし ドック非表示 アプリ切り替え cmd-tab command-tab"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي فقط التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab aplikacija opće postavke ponašanje traka menija status bočna Samo Meni"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab generelt indstillinger adfærd menulinje status sidepanel Kun"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab allgemein einstellungen verhalten menüleiste status seitenleiste Nur Menü"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab aplicación general preferencias comportamiento barra de menú estado lateral Solo menús"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab application général préférences comportement barre de menus état latérale des uniquement"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab generale preferenze comportamento barra stato laterale Solo dei"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 전용"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab generelt innstillinger oppførsel menylinje status sidepanel Kun Meny"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab aplikacja ogólne preferencje zachowanie pasek status boczny Tylko"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab geral preferências comportamento barra de status lateral Apenas menus"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab приложение общие настройки поведение док строка меню статус боковая панель Только"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เฉพาะแถบเมนู เมนู"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab uygulama genel tercihler davranış menü çubuğu durum kenar Yalnızca"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 仅菜单栏 菜单"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab 應用程式 一般 偏好設定 行為 選單列 狀態 側邊欄 僅選單列 選單"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.menuBarOnly menubar menu bar dockless hide dock app switcher cmd-tab command-tab програма загальні параметри поведінка док рядок меню статус бічна панель Лише"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-menu-bar": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.showInMenuBar menubar menu bar status item tray extra"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.showInMenuBar menubar menu bar status item tray extra メニューバー ステータス項目 トレイ メニューエクストラ 表示"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra メニューバー ステータス項目 トレイ メニューエクストラ 表示"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب الإشعارات عرض التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra aplikacija opće postavke ponašanje dock traka menija bočna obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Obavještenja Prikaži Meni"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra app generelt indstillinger adfærd dock menulinje sidepanel notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord Vis"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra app allgemein einstellungen verhalten dock menüleiste seitenleiste benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop anzeigen Menü"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra aplicación general preferencias comportamiento dock barra de menú estado lateral notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio Mostrar App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra application général préférences comportement dock barre de menus état latérale notification notifications alerte non lu message badge anneau flash son bureau Afficher les App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra app generale preferenze comportamento dock barra stato laterale notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania Mostra"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 표시"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra app generelt innstillinger oppførsel dock menylinje sidepanel varsling varsler ulest melding merke ring blink lyd skrivebord Vis Meny"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra aplikacja ogólne preferencje zachowanie dock pasek boczny powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit Pokaż"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra app geral preferências comportamento dock barra de lateral notificação notificações alerta não lido mensagem selo anel piscar som desktop Mostrar"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra приложение общие настройки поведение док строка меню статус боковая панель уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол Показать"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป แสดงการแจ้งเตือน เมนู"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra uygulama genel tercihler davranış dock menü çubuğu durum kenar bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü Bildirimleri Göster"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 显示通知 菜单"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 顯示通知 選單 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.showInMenuBar menubar menu bar status item tray extra програма загальні параметри поведінка док рядок меню статус бічна панель сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл Показати"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.unread-pane-ring": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.unreadPaneRing blue border unread ring notification pane outline"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 未読 青い枠 リング 通知 ペイン アウトライン"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 未読 青い枠 リング 通知 ペイン アウトライン"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب الإشعارات التطبيق واحد"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline aplikacija opće postavke ponašanje dock traka menija status bočna obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Obavještenja 1 obavještenje"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline app generelt indstillinger adfærd dock menulinje status sidepanel notifikation notifikationer advarsel ulæst besked badge blink lyd skrivebord 1"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline app allgemein einstellungen verhalten dock menüleiste status seitenleiste benachrichtigung benachrichtigungen alarm ungelesen nachricht badge blinken ton desktop 1 ungelesene"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline aplicación general preferencias comportamiento dock barra de menú estado lateral notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio App 1 leída"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline application général préférences comportement dock barre de menus état latérale notifications alerte non lu message badge anneau flash son bureau App 1 lue"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline app generale preferenze comportamento dock barra menu stato laterale notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania 1 letta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 않은 패인 1개"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline app generelt innstillinger oppførsel dock menylinje status sidepanel varsling varsler ulest melding merke blink lyd skrivebord 1 varsel"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline aplikacja ogólne preferencje zachowanie dock pasek menu status boczny powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit 1"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline app geral preferências comportamento dock barra de menu status lateral notificação notificações alerta não lido mensagem selo anel piscar som desktop 1 lida"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline приложение общие настройки поведение док строка меню статус боковая панель уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол 1"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป 1 การแจ้งเตือนที่ยังไม่อ่าน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline uygulama genel tercihler davranış dock menü çubuğu durum kenar bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü 1"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 1 条未读通知"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 App 1 則未讀通知"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.unreadPaneRing blue border unread ring notification pane outline програма загальні параметри поведінка док рядок меню статус бічна панель сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл непрочитаних панелей 1"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.pane-flash": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.paneFlash flash blink highlight pane notification pulse"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.paneFlash flash blink highlight pane notification pulse フラッシュ 点滅 ハイライト ペイン 通知"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse フラッシュ 点滅 ハイライト ペイン 通知"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة إشعار إشعارات تنبيه غير مقروء رسالة رنين وميض صوت سطح المكتب الإشعارات التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse aplikacija opće postavke ponašanje dock traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka obavijest obavijesti upozorenje nepročitano poruka prsten bljesak zvuk desktop Obavještenja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse app generelt indstillinger adfærd dock menulinje status sidepanel arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik notifikation notifikationer advarsel ulæst besked ring lyd skrivebord"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse app allgemein einstellungen verhalten dock menüleiste status seitenleiste arbeitsbereich tab farben palette badge ausgewählt hervorhebung indikator aktiv punkt benachrichtigung benachrichtigungen alarm ungelesen nachricht ring blinken ton desktop"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse aplicación general preferencias comportamiento dock barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto notificación notificaciones alerta no leído mensaje anillo destello sonido escritorio App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse application général préférences comportement dock barre de menus état latérale espace travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point notifications alerte non lu message anneau son bureau App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse app generale preferenze comportamento dock barra menu stato laterale area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto notifica notifiche avviso non letto messaggio anello lampeggio suono scrivania"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 패인 플래시"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse app generelt innstillinger oppførsel dock menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk varsling varsler ulest melding ring lyd skrivebord"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse aplikacja ogólne preferencje zachowanie dock pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka powiadomienie powiadomienia alert nieprzeczytane wiadomość pierścień błysk dźwięk pulpit"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse app geral preferências comportamento dock barra de menu status lateral workspace aba cores paleta selo selecionado destaque indicador ativo ponto notificação notificações alerta não lido mensagem anel piscar som desktop"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ วงแหวน แฟลช เสียง เดสก์ท็อป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse uygulama genel tercihler davranış dock menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta bildirim bildirimler uyarı okunmamış mesaj halka flaş ses masaüstü"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 通知 未读 消息 圆环 闪烁 声音 桌面 提醒"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 通知 未讀 訊息 圓環 閃爍 聲音 桌面 提醒 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.paneFlash flash blink highlight pane notification pulse програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка сповіщення непрочитане повідомлення кільце спалах звук стіл панелі"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.desktop-notifications": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "macos desktop notifications system settings permission alerts notify test"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "macos desktop notifications system settings permission alerts notify test macos デスクトップ通知 システム設定 権限 アラート テスト"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test macos デスクトップ通知 システム設定 権限 アラート テスト"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن آمن النظام الإشعارات الإعدادات… التطبيق الإعدادات"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test aplikacija opće postavke ponašanje dock traka menija status bočna izgled tema boja boje shema svijetlo tamno sistem način obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk lozinka tajna token vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno Sistemski Obavještenja Postavke…"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test app generelt indstillinger adfærd dock menulinje status sidepanel udseende tema farve farver skema lys mørk tilstand notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord adgangskode hemmelighed token legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker Indstillinger…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test app allgemein einstellungen verhalten dock menüleiste status seitenleiste darstellung design farbe farben schema hell dunkel modus benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton passwort geheimnis token zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test aplicación general preferencias comportamiento dock barra de menú estado lateral apariencia tema color colores esquema claro oscuro sistema modo notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio contraseña secreto token credencial acceso permitir desactivar activar permiso inseguro Ajustes… App Ajustes"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test application général préférences comportement dock barre de menus état latérale apparence thème couleur couleurs schéma clair sombre système mode notification alerte non lu message badge anneau flash son bureau mot passe secret jeton identifiant accès autoriser désactiver activer autorisation sécurisé Réglages... App Réglages"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test app generale preferenze comportamento dock barra menu stato laterale aspetto tema colore colori schema chiaro scuro sistema modalità notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania password segreto token credenziale accesso consenti disabilita abilita autorizzazione sicuro Impostazioni… Impostazioni"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 설정… 설정"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test app generelt innstillinger oppførsel dock menylinje status sidepanel utseende tema farge farger skjema lys mørk modus varsling varsler ulest melding merke ring blink lyd skrivebord passord hemmelighet token legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker …"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test aplikacja ogólne preferencje zachowanie dock pasek menu status boczny wygląd motyw kolor kolory schemat jasny ciemny tryb powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit hasło sekret token poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone Systemowy Ustawienia… Ustawienia"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test app geral preferências comportamento dock barra de menu status lateral aparência tema cor cores esquema claro escuro sistema modo notificação notificações alerta não lido mensagem selo anel piscar som senha segredo token credencial acesso permitir desativar ativar permissão inseguro Ajustes… Ajustes"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test приложение общие настройки поведение док строка меню статус боковая панель внешний вид тема цвет цвета схема светлый темный система режим уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно Системное Системный Настройки... Системная"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย การตั้งค่า... การตั้งค่า"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test uygulama genel tercihler davranış dock menü çubuğu durum kenar görünüm tema renk renkler şema açık koyu sistem mod bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü parola gizli token kimlik bilgisi erişim izin ver devre dışı etkinleştir güvensiz Ayarlar… Ayarlar"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 外观 主题 颜色 配色 浅色 深色 系统 模式 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 设置... 设置"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 外觀 主題 顏色 配色 淺色 深色 系統 模式 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全 設定... App 設定"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "macos desktop notifications system settings permission alerts notify test програма загальні параметри поведінка док рядок меню статус бічна панель вигляд тема колір кольори схема світлий темний система режим сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно Системна Налаштування… Налаштування"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.notification-sound": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 通知音 サウンド 音 アラート チャイム ビープ カスタムファイル"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 通知音 サウンド 音 アラート チャイム ビープ カスタムファイル"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إعدادات تكوين ملف json مخطط وثائق مرجع محرر كود فتح مسار إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب مخصص: %@ الإشعارات التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff aplikacija opće postavke ponašanje dock traka menija status bočna konfiguracija datoteka json šema dokumentacija referenca preferencije editor kod otvori putanja obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Prilagođeno: %@ Obavještenja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff app generelt indstillinger adfærd dock menulinje status sidepanel konfiguration fil json skema dokumentation reference præferencer editor kode åbn sti notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord Brugerdefineret: %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff app allgemein einstellungen verhalten dock menüleiste status seitenleiste konfiguration datei json schema dokumentation referenz präferenzen editor code öffnen pfad benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop Benutzerdefiniert: %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff aplicación general preferencias comportamiento dock barra de menú estado lateral ajustes configuración archivo json esquema documentación referencia editor código abrir ruta notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio Personalizado: %@ App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff application général préférences comportement dock barre de menus état latérale réglages configuration fichier json schéma documentation référence éditeur code ouvrir chemin notification notifications alerte non lu message badge anneau flash son bureau Personnalisé : %@ App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff app generale preferenze comportamento dock barra menu stato laterale impostazioni configurazione json schema documentazione riferimento editor codice apri percorso notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania Personalizzato: %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 설정 구성 파일 json 스키마 문서 참조 편집기 코드 열기 경로 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 사용자 정의: %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff app generelt innstillinger oppførsel dock menylinje status sidepanel konfigurasjon fil json skjema dokumentasjon referanse preferanser redigerer kode åpne bane varsling varsler ulest melding merke ring blink lyd skrivebord Egendefinert: %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff aplikacja ogólne preferencje zachowanie dock pasek menu status boczny ustawienia konfiguracja plik json schemat dokumentacja referencja edytor kod otwórz ścieżka powiadomienie powiadomienia nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit Niestandardowe: %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff app geral preferências comportamento dock barra de menu status lateral configurações configuração arquivo json esquema documentação referência editor código abrir caminho notificação notificações alerta não lido mensagem selo anel piscar som desktop Personalizado: %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff приложение общие настройки поведение док строка меню статус боковая панель конфигурация файл json схема документация справочник предпочтения редактор код открыть путь уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол Пользовательское: %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง ตัวแก้ไข โค้ด เปิด เส้นทาง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป กำหนดเอง: %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff uygulama genel tercihler davranış dock menü çubuğu durum kenar ayarlar yapılandırma dosya json şema belgeler başvuru düzenleyici kod aç yol bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü Özel: %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 设置 配置 文件 json 架构 文档 参考 编辑器 代码 打开 路径 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 自定义: %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 設定 設定檔 檔案 json 結構描述 文件 參考 編輯器 程式碼 開啟 路徑 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 自訂: %@ App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.sound notifications.customSoundFilePath sound audio alert chime beep custom file wav mp3 caf aiff програма загальні параметри поведінка док рядок меню статус бічна панель налаштування конфігурація файл json схема документація довідник редактор код відкрити шлях сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл Власне: %@"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.notification-command": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.command shell command hook script env environment variable done agent"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "notifications.command shell command hook script env environment variable done agent 通知コマンド シェル コマンド フック スクリプト 環境変数 完了 エージェント"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent 通知コマンド シェル コマンド フック スクリプト 環境変数 完了 エージェント"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي طرفية صدفة تمرير سجل شاشة أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب الإشعارات التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent aplikacija opće postavke ponašanje dock traka menija status bočna terminal povratni zapis za pomicanje ekran automatizacija api cli kontrola socket kuke portovi okruženje obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Obavještenja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent app generelt indstillinger adfærd dock menulinje status sidepanel terminal scrollback rullepanel skærm automatisering api cli kontrol socket hooks porte miljø notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent app allgemein einstellungen verhalten dock menüleiste status seitenleiste terminal scrollback scrollleiste bildschirm automatisierung api cli steuerung socket hooks ports umgebung benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent aplicación general preferencias comportamiento dock barra de menú estado lateral terminal historial desplazamiento pantalla automatización api cli control socket agente hooks puertos entorno notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent application général préférences comportement dock barre de menus état latérale terminal historique défilement écran automatisation api cli contrôle socket hooks ports environnement notification notifications alerte non lu message badge anneau flash son bureau App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent app generale preferenze comportamento dock barra menu stato laterale terminale cronologia di scorrimento schermo automazione api cli controllo socket agente porte ambiente notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 완료"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent app generelt innstillinger oppførsel dock menylinje status sidepanel terminal skall tilbakerulling rullefelt skjerm automatisering api cli kontroll socket hooks porter miljø varsling varsler ulest melding merke ring blink lyd skrivebord"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent aplikacja ogólne preferencje zachowanie dock pasek menu status boczny terminal powłoka przewijanie przewijania ekran automatyzacja api cli sterowanie gniazdo haki porty środowisko powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent app geral preferências comportamento dock barra de menu status lateral terminal histórico rolagem tela automação api cli controle socket agente hooks portas ambiente notificação notificações alerta não lido mensagem selo anel piscar som desktop"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent приложение общие настройки поведение док строка меню статус боковая панель терминал оболочка история прокрутки полоса экран автоматизация api cli управление сокет агент хуки порты окружение уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent uygulama genel tercihler davranış dock menü çubuğu durum kenar terminal kabuk geri kaydırma ekran otomasyon api cli kontrol soket ajan kancalar portlar ortam bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 终端 回滚 滚动条 屏幕 自动化 api cli 控制 套接字 代理 钩子 端口 环境 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 終端機 回捲 捲動列 螢幕 自動化 api cli 控制 socket 代理程式 連接埠 環境 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "notifications.command shell command hook script env environment variable done agent програма загальні параметри поведінка док рядок меню статус бічна панель термінал історія прокручування смуга екран автоматизація api cli керування сокет агент хуки порти середовище сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл Готово"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.telemetry": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy テレメトリ 分析 クラッシュレポート 使用状況 匿名 プライバシー"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy テレメトリ 分析 クラッシュレポート 使用状況 匿名 プライバシー"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي قياس استخدام تحليلات تعطل تقارير مجهول خصوصية التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy aplikacija opće postavke ponašanje dock traka menija status bočna telemetrija analitika rušenje izvještaji korištenje anonimno privatnost"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy app generelt indstillinger adfærd dock menulinje status sidepanel telemetri analyse nedbrud rapporter brug anonym privatliv"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy app allgemein einstellungen verhalten dock menüleiste status seitenleiste telemetrie analyse absturz berichte nutzung anonym datenschutz"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy aplicación general preferencias comportamiento dock barra de menú estado lateral telemetría analíticas fallos informes uso anónimo privacidad App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy application général préférences comportement dock barre de menus état latérale télémétrie analytique plantage rapports utilisation anonyme confidentialité App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy app generale preferenze comportamento dock barra menu stato laterale telemetria analisi rapporti utilizzo anonimo"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 텔레메트리 분석 충돌 보고서 사용량 익명 개인정보"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy app generelt innstillinger oppførsel dock menylinje status sidepanel telemetri analyse krasj rapporter bruk anonym personvern"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy aplikacja ogólne preferencje zachowanie dock pasek menu status boczny telemetria analityka awaria raporty użycie anonimowe prywatność"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy app geral preferências comportamento dock barra de menu status lateral telemetria análises falhas relatórios uso anônimo privacidade"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy приложение общие настройки поведение док строка меню статус боковая панель телеметрия аналитика сбой отчеты использование анонимно приватность"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทเลเมทรี วิเคราะห์ ขัดข้อง รายงาน การใช้งาน นิรนาม ความเป็นส่วนตัว"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy uygulama genel tercihler davranış dock menü çubuğu durum kenar telemetri analiz çökme raporlar kullanım anonim gizlilik"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 遥测 分析 崩溃 报告 使用 匿名 隐私"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 遙測 分析 當機 報告 使用 匿名 隱私 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy програма загальні параметри поведінка док рядок меню статус бічна панель телеметрія аналітика збій звіти використання анонімно приватність"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.warn-before-quit": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 終了 確認 command-q cmd-q アプリを閉じる 警告"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 終了 確認 command-q cmd-q アプリを閉じる 警告"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إغلاق إنهاء التحذير قبل الإنهاء التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app aplikacija opće postavke ponašanje dock traka menija status bočna Zatvori Upozori prije zatvaranja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app generelt indstillinger adfærd dock menulinje status sidepanel Luk Afslut Advar før afslutning"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app allgemein einstellungen verhalten dock menüleiste status seitenleiste Schließen Beenden Vor dem warnen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app aplicación general preferencias comportamiento dock barra de menú estado lateral Cerrar Salir Advertir antes"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app application général préférences comportement dock barre de menus état latérale Fermer Quitter Avertir avant"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app generale preferenze comportamento dock barra menu stato laterale Chiudi Esci Avvisa prima di uscire"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 닫기 종료 전 경고"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app generelt innstillinger oppførsel dock menylinje status sidepanel Lukk Avslutt Advar før avslutning"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app aplikacja ogólne preferencje zachowanie dock pasek menu status boczny Zamknij Zakończ Ostrzegaj przed zamknięciem"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app geral preferências comportamento dock barra de menu status lateral Fechar Encerrar Avisar Antes"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app приложение общие настройки поведение док строка меню статус боковая панель Закрыть Завершить Предупреждать перед выходом"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง ปิด ออก เตือนก่อนออก"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app uygulama genel tercihler davranış dock menü çubuğu durum kenar Kapat Çık Çıkmadan Önce Uyar"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 关闭 退出 退出前警告"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 關閉 結束 結束前警告"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app програма загальні параметри поведінка док рядок меню статус бічна панель Закрити Завершити Попереджувати перед виходом"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.rename-selects-name": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 名前変更 既存名を選択 タイトル コマンドパレット ワークスペース名"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 名前変更 既存名を選択 タイトル コマンドパレット ワークスペース名"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة اسم العمل إعادة تسمية العمل… • %@ الأوامر… التسمية تحدد الاسم الحالي التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name aplikacija opće postavke ponašanje dock traka menija status bočna radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka Naziv radnog prostora Preimenuj prostor… • %@ naredbi… Preimenovanje odabere postojeći"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name app generelt indstillinger adfærd dock menulinje status sidepanel arbejdsområde fane farver badge valgt fremhævning indikator aktiv prik Navn på Omdøb arbejdsområde… Arbejdsområdenavn • %@ Kommandopalette… Omdøbning markerer eksisterende"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name app allgemein einstellungen verhalten dock menüleiste status seitenleiste arbeitsbereich tab farben badge ausgewählt hervorhebung indikator aktiv punkt des Arbeitsbereichs Umbenennen … • %@ Befehlspalette wählt vorhandenen Namen aus"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name aplicación general preferencias comportamiento dock barra de menú estado lateral espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto Nombre del Renombrar trabajo… • %@ comandos… selecciona el existente App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name application général préférences comportement dock barre de menus état latérale espace travail onglet couleurs badge sélectionné surbrillance indicateur actif point Nom l'espace Renommer travail... • %@ commandes... Le renommage sélectionne existant App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name app generale preferenze comportamento dock barra menu stato laterale area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto Nome Rinomina lavoro… • %@ comandi… seleziona il esistente"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 작업 공간 이름 변경 변경… • %@ 명령어 팔레트… 시 기존 선택 워크스페이스 1…9"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name app generelt innstillinger oppførsel dock menylinje status sidepanel arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk Navn på Gi nytt arbeidsområdet … Arbeidsområdenavn • %@ Kommandopalett Omdøping velger eksisterende"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name aplikacja ogólne preferencje zachowanie dock pasek menu status boczny obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka Nazwa przestrzeni roboczej Zmień nazwę Przestrzeń robocza roboczej… • %@ poleceń… Zmiana nazwy zaznacza istniejącą"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name app geral preferências comportamento dock barra de menu status lateral aba cores paleta selo selecionado destaque indicador ativo ponto Nome da área trabalho Renomear Trabalho… • %@ Comandos… Seleciona o Existente"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name приложение общие настройки поведение док строка меню статус боковая панель рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка Имя рабочего пространства Переименовать рабочее пространство пространство... • %@ команд... Переименование выделяет"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ชื่อเวิร์กสเปซ เปลี่ยนชื่อ เปลี่ยนชื่อเวิร์กสเปซ เวิร์กสเปซ เปลี่ยนชื่อเวิร์กสเปซ... • %@ แถบคำสั่ง... เลือกชื่อเมื่อเปลี่ยนชื่อ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name uygulama genel tercihler davranış dock menü çubuğu durum kenar çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta adı Yeniden Adlandır Alanını Adlandır… • %@ Komut Paleti… Adlandırma Mevcut Seçer"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 工作区名称 重命名 重命名工作区 重命名工作区... • %@ 命令面板... 重命名时选中现有名称"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 工作區名稱 重新命名 重新命名工作區 重新命名工作區... • %@ 指令面板... 重新命名時選取現有名稱 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.renameSelectsExistingName rename select all existing title command palette workspace name програма загальні параметри поведінка док рядок меню статус бічна панель робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка Назва робочої області Перейменувати робочу область Робоча область… • %@ команд… Виділяти назву при перейменуванні Вибрати 1…9"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.palette-search-all": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown コマンドパレット すべて検索 サーフェス ターミナル ブラウザ markdown"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown コマンドパレット すべて検索 サーフェス ターミナル ブラウザ markdown"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي طرفية صدفة تمرير سجل شاشة متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة بحث اقتراحات إكمال تلقائي مزود محرك المتصفح • %@ الطرفية الأوامر… التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown aplikacija opće postavke ponašanje dock traka menija status bočna shell povratni zapis za pomicanje ekran preglednik web webview adresna linkovi url ugrađen stranica kartice radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka pretraga prijedlozi automatsko dovršavanje pružatelj pretraživač Pretraži • %@ naredbi…"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown app generelt indstillinger adfærd dock menulinje status sidepanel shell scrollback rullepanel skærm web webvisning adresselinje links url indlejret side faner arbejdsområde fane farver badge valgt fremhævning indikator aktiv prik søgning forslag autofuldførelse udbyder søgemaskine Søg • %@ Kommandopalette…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown app allgemein einstellungen verhalten dock menüleiste status seitenleiste shell scrollback scrollleiste bildschirm web webview adressleiste links urls eingebettet seite tabs arbeitsbereich tab farben badge ausgewählt hervorhebung indikator aktiv punkt suche vorschläge autovervollständigung anbieter suchmaschine Suchen • %@ Befehlspalette …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown aplicación general preferencias comportamiento dock barra de menú estado lateral shell historial desplazamiento pantalla navegador web webview direcciones enlaces urls integrado página pestañas espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto búsqueda sugerencias autocompletar proveedor motor Buscar • %@ comandos… App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown application général préférences comportement dock barre de menus état latérale shell historique défilement écran navigateur web webview adresse liens urls intégré page onglets espace travail onglet couleurs badge sélectionné surbrillance indicateur actif point recherche suggestions saisie automatique fournisseur moteur Rechercher • %@ commandes... App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown app generale preferenze comportamento dock barra menu stato laterale terminale shell cronologia di scorrimento schermo web webview indirizzi link url incorporato pagina schede area lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto ricerca suggerimenti completamento automatico provider motore Cerca • %@ comandi…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 검색 제안 자동완성 제공자 엔진 브라우저: %@ 마크다운 • 명령어 팔레트…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown app generelt innstillinger oppførsel dock menylinje status sidepanel skall tilbakerulling rullefelt skjerm nettleser web webvisning adresselinje lenker url innebygd side faner arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk søk forslag autofullføring leverandør søkemotor • %@ Kommandopalett …"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown aplikacja ogólne preferencje zachowanie dock pasek menu status boczny powłoka przewijanie przewijania ekran przeglądarka web webview adresu linki url osadzony strona karty obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka wyszukiwanie sugestie autouzupełnianie dostawca silnik wyszukiwania Szukaj • %@ poleceń…"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown app geral preferências comportamento dock barra de menu status lateral shell histórico rolagem tela navegador web webview endereço links urls incorporado página abas workspace aba cores paleta selo selecionado destaque indicador ativo ponto pesquisa sugestões autocompletar provedor mecanismo busca Pesquisar • %@ Comandos…"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown приложение общие настройки поведение док строка меню статус боковая панель терминал оболочка история прокрутки полоса экран браузер веб webview адресная ссылки url встроенный страница вкладки рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка поиск предложения автозаполнение провайдер поисковая система • %@ команд..."
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ พื้นที่ทำงาน สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ค้นหา คำแนะนำ เติมอัตโนมัติ ผู้ให้บริการ เครื่องมือค้นหา • %@ แถบคำสั่ง..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown uygulama genel tercihler davranış dock menü çubuğu durum kenar kabuk geri kaydırma ekran tarayıcı web webview adres bağlantılar url gömülü sayfa sekmeler çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta arama öneriler otomatik tamamlama sağlayıcı motoru Ara • %@ Komut Paleti…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 终端 shell 回滚 滚动条 屏幕 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 工作区 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 搜索 建议 自动完成 提供商 搜索引擎 • %@ 命令面板..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 終端機 shell 回捲 捲動列 螢幕 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 工作區 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 搜尋 建議 自動完成 提供者 搜尋引擎 • %@ 指令面板... App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown програма загальні параметри поведінка док рядок меню статус бічна панель термінал shell історія прокручування смуга екран браузер веб webview адресний посилання url вбудований сторінка вкладки робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка пошук пропозиції автодоповнення постачальник пошукова система Браузер: %@ • команд…"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.hide-sidebar-details": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail サイドバー コンパクト 詳細を隠す タイトルのみ 左レール"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail サイドバー コンパクト 詳細を隠す タイトルのみ 左レール"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط التطبيق أيسر التفاصيل"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored Lijeva"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout Sidebjælke skinne"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links ausblenden layout Linke Leiste"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 레일 세부 정보"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett skinne"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ Lewa listwa"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout Trilho Esquerdo"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет Левая полоса Подробности"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง แถบด้านซ้าย"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen Şerit"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 左侧导轨"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 App 左側軌道"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет Лівий рейл"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.sidebar-branch-layout": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.branchLayout git branch layout vertical inline cwd directory"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.branchLayout git branch layout vertical inline cwd directory git ブランチ レイアウト 縦 インライン cwd ディレクトリ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory git ブランチ レイアウト 縦 インライン cwd ディレクトリ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط فرع مجلد مستودع github طلب سحب دمج مراجعة التخطيط الفروع في سطري عمودي التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored grana direktorij folder repo github pull request spajanje pregled u bočnoj traci redu Vertikalno"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul gren mappe repo github pull request merge gennemgang Sidebjælkens grenlayout Lodret Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden ordner repo github pull request merge review Seitenleisten-Branch-Layout Einzeilig Vertikal"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño rama directorio carpeta repo github pull request fusionar revisión Disposición ramas en la línea App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition branche dossier dépôt github pull request fusionner revue des branches dans la En ligne App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi cartella repo github pull request merge revisione nella In linea Verticale"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 브랜치 디렉터리 폴더 저장소 github pull request 병합 리뷰 세로 인라인"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett gren mappe repo github pull request merge gjennomgang Grenoppsett i sidepanelet Innebygd Vertikal"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ gałąź katalog folder repo github pull request merge przegląd gałęzi na pasku bocznym W linii Pionowo"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar diretório pasta repo github pull request merge revisão na Em Linha"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет ветка каталог папка репозиторий github pull request merge ревью веток в боковой панели строку Вертикально"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง สาขา ไดเรกทอรี โฟลเดอร์ repo github pull request merge รีวิว เค้าโครงสาขาในแถบด้านข้าง แบบอินไลน์ แนวตั้ง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen dal dizin klasör repo github pull request birleştir inceleme Düzeni Satır İçi Dikey"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 分支 目录 文件夹 仓库 github 拉取请求 合并 审查 侧边栏分支布局 单行 垂直"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 分支 目錄 資料夾 儲存庫 github 拉取請求 合併 審查 側邊欄分支版面 行內 垂直 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.branchLayout git branch layout vertical inline cwd directory програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет гілка каталог папка репозиторій github pull request merge огляд Вертикальний гілок у бічній панелі В Вертикально"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-notification-message": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showNotificationMessage latest message unread notification text sidebar"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 最新メッセージ 未読 通知 テキスト サイドバー"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 最新メッセージ 未読 通知 テキスト サイドバー"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب التطبيق واحد"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop 1 obavještenje"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord Sidebjælke 1"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop 1 ungelesene"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio App 1 leída"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition notifications alerte non lu badge anneau flash son bureau App 1 lue"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania 1 letta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 않은 1개"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett varsling varsler ulest melding merke ring blink lyd skrivebord 1 varsel"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit 1"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout notificação notificações alerta não lido mensagem selo anel piscar som desktop 1 lida"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол 1"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป 1 การแจ้งเตือนที่ยังไม่อ่าน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü 1"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 1 条未读通知"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 App 1 則未讀通知"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showNotificationMessage latest message unread notification text sidebar програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл 1"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-branch-directory": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar git ブランチ cwd パス ディレクトリ フォルダ リポジトリ サイドバー"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar git ブランチ cwd パス ディレクトリ フォルダ リポジトリ サイドバー"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط محرر ملف كود فتح مسار فرع مجلد مستودع github طلب سحب دمج مراجعة التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored editor datoteka kod otvori putanja grana direktorij github pull request spajanje pregled"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout editor fil kode åbn sti gren mappe github pull request merge gennemgang Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout editor datei code öffnen pfad ordner github pull request merge review"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño editor archivo código abrir ruta rama directorio carpeta github pull request fusionar revisión App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition éditeur fichier code ouvrir chemin branche dossier dépôt github pull request fusionner revue App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout editor file codice apri percorso cartella github pull request merge revisione"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 편집기 파일 코드 열기 경로 브랜치 디렉터리 폴더 저장소 github pull request 병합 리뷰"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett redigerer fil kode åpne bane gren mappe github pull request merge gjennomgang"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ edytor plik kod otwórz ścieżka gałąź katalog github pull request merge przegląd"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout editor arquivo código abrir caminho diretório pasta github pull request merge revisão"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет редактор файл код открыть путь ветка каталог папка репозиторий github pull request merge ревью"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง สาขา ไดเรกทอรี โฟลเดอร์ github pull request merge รีวิว"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen düzenleyici dosya kod aç yol dal dizin klasör github pull request birleştir inceleme"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 编辑器 文件 代码 打开 路径 分支 目录 文件夹 仓库 github 拉取请求 合并 审查"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 編輯器 檔案 程式碼 開啟 路徑 分支 目錄 資料夾 儲存庫 github 拉取請求 合併 審查 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет редактор файл код відкрити шлях гілка каталог папка репозиторій github pull request merge огляд"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-pull-requests": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request pr mr レビュー github gitlab bitbucket プルリクエスト マージリクエスト"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request pr mr レビュー github gitlab bitbucket プルリクエスト マージリクエスト"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط git فرع مجلد مستودع طلب سحب دمج مراجعة التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored git grana direktorij folder repo spajanje pregled"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout git gren mappe repo gennemgang Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout git branch ordner repo"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño git rama directorio carpeta repo fusionar revisión App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition git branche dossier dépôt fusionner revue App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout git branch directory cartella repo revisione"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 git 브랜치 디렉터리 폴더 저장소 병합 리뷰"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett git gren mappe repo gjennomgang"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ git gałąź katalog folder repo przegląd"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout git branch diretório pasta repo revisão"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет git ветка каталог папка репозиторий ревью"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง git สาขา ไดเรกทอรี โฟลเดอร์ repo รีวิว"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen git dal dizin klasör repo birleştir inceleme"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 git 分支 目录 文件夹 仓库 拉取请求 合并 审查"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 git 分支 目錄 資料夾 儲存庫 拉取請求 合併 審查 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет git гілка каталог папка репозиторій огляд"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.open-pr-links": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded pr リンク github ブラウザ デフォルト 外部 内蔵"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded pr リンク github ブラウザ デフォルト 外部 内蔵"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات إعادة ضبط مصنع افتراضي استعادة مسح محرر ملف كود فتح مسار git فرع مجلد مستودع طلب سحب دمج مراجعة المتصفح • %@ التطبيق مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored preglednik web webview adresna linkovi url ugrađen stranica kartice reset fabrički zadano vrati očisti editor datoteka kod otvori putanja git grana direktorij folder repo pull request spajanje pregled • %@ otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout web webvisning adresselinje url indlejret side faner nulstil fabrik standard gendan ryd editor fil kode åbn sti git gren mappe repo pull request merge gennemgang • %@ Sidebjælke åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation details ausblenden layout web webview adressleiste urls eingebettet seite tabs zurücksetzen werkseinstellungen standard wiederherstellen löschen editor datei code öffnen pfad git branch ordner repo pull request merge review • %@ offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño navegador web webview direcciones enlaces urls integrado página pestañas restablecer fábrica predeterminado restaurar borrar editor archivo código abrir ruta git rama directorio carpeta repo pull request fusionar revisión • %@ App abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition navigateur web webview adresse liens urls intégré page onglets réinitialiser usine défaut restaurer effacer éditeur fichier code ouvrir chemin git branche dossier dépôt pull request fusionner revue • %@ App le ouverte Par"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout web webview indirizzi link url incorporato pagina schede reimposta fabbrica predefinito ripristina cancella editor file codice apri percorso git branch directory cartella repo pull request merge revisione • %@ aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 재설정 초기화 기본값 복원 지우기 편집기 파일 코드 열기 경로 git 브랜치 디렉터리 폴더 저장소 pull request 병합 리뷰 브라우저: %@ • 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett nettleser web webvisning adresselinje lenker url innebygd side faner tilbakestill fabrikk standard gjenopprett tøm redigerer fil kode åpne bane git gren mappe repo pull request merge gjennomgang • %@ åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ przeglądarka web webview adresu linki url osadzony strona karty reset fabryczne domyślne przywróć wyczyść edytor plik kod otwórz ścieżka git gałąź katalog folder repo pull request merge przegląd • %@ przeglądarkę otwarty Domyślny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout navegador web webview endereço urls incorporado página abas redefinir fábrica padrão restaurar limpar editor arquivo código abrir caminho git branch diretório pasta repo pull request merge revisão • %@ aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет браузер веб webview адресная ссылки url встроенный страница вкладки сброс заводские по умолчанию восстановить очистить редактор файл код открыть путь git ветка каталог папка репозиторий pull request merge ревью • %@ открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง git สาขา ไดเรกทอรี โฟลเดอร์ repo pull request merge รีวิว • %@ เปิดเบราว์เซอร์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen tarayıcı web webview adres bağlantılar url gömülü sayfa sekmeler sıfırla fabrika varsayılan geri yükle temizle düzenleyici dosya kod aç yol git dal dizin klasör repo pull request birleştir inceleme • %@ Tarayıcıyı açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 重置 出厂 默认 恢复 清除 编辑器 文件 代码 打开 路径 git 分支 目录 文件夹 仓库 拉取请求 合并 审查 • %@ 打开浏览器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 重置 出廠 預設 還原 清除 編輯器 檔案 程式碼 開啟 路徑 git 分支 目錄 資料夾 儲存庫 拉取請求 合併 審查 • %@ App 開啟瀏覽器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет браузер веб webview адресний посилання url вбудований сторінка вкладки скидання заводські типові відновити очистити редактор файл код відкрити шлях git гілка каталог папка репозиторій pull request merge огляд Стандартний Браузер: %@ • відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.open-port-links": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded ポート localhost リンク ブラウザ デフォルト 外部 内蔵"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded ポート localhost リンク ブラウザ デフォルト 外部 内蔵"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات إعادة ضبط مصنع افتراضي استعادة مسح محرر ملف كود فتح مسار المتصفح • %@ التطبيق مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored automatizacija api cli kontrola socket agent kuke portovi okruženje preglednik web webview adresna linkovi url ugrađen stranica kartice reset fabrički zadano vrati očisti editor datoteka kod otvori putanja • %@ otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout automatisering api cli kontrol socket agent hooks porte miljø web webvisning adresselinje url indlejret side faner nulstil fabrik standard gendan ryd editor fil kode åbn sti • %@ Sidebjælke åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation details ausblenden layout automatisierung api cli steuerung socket agent hooks umgebung web webview adressleiste urls eingebettet seite tabs zurücksetzen werkseinstellungen standard wiederherstellen löschen editor datei code öffnen pfad • %@ offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño automatización api cli control socket agente hooks puertos entorno navegador web webview direcciones enlaces urls integrado página pestañas restablecer fábrica predeterminado restaurar borrar editor archivo código abrir ruta • %@ App abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition automatisation api cli contrôle socket agent hooks environnement navigateur web webview adresse liens urls intégré page onglets réinitialiser usine défaut restaurer effacer éditeur fichier code ouvrir chemin • %@ App le ouverte Par"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout automazione api cli controllo socket agente hook porte ambiente web webview indirizzi link url incorporato pagina schede reimposta fabbrica predefinito ripristina cancella editor file codice apri percorso • %@ aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 재설정 초기화 기본값 복원 지우기 편집기 파일 코드 열기 경로 브라우저: %@ • 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett automatisering api cli kontroll socket agent hooks porter miljø nettleser web webvisning adresselinje lenker url innebygd side faner tilbakestill fabrikk standard gjenopprett tøm redigerer fil kode åpne bane • %@ åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ automatyzacja api cli sterowanie gniazdo agent haki porty środowisko przeglądarka web webview adresu linki url osadzony strona karty reset fabryczne domyślne przywróć wyczyść edytor plik kod otwórz ścieżka • %@ przeglądarkę otwarty Domyślny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout automação api cli controle socket agente hooks portas ambiente navegador web webview endereço urls incorporado página abas redefinir fábrica padrão restaurar limpar editor arquivo código abrir caminho • %@ aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет автоматизация api cli управление сокет агент хуки порты окружение браузер веб webview адресная ссылки url встроенный страница вкладки сброс заводские по умолчанию восстановить очистить редактор файл код открыть путь • %@ открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง • %@ เปิดเบราว์เซอร์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen otomasyon api cli kontrol soket ajan kancalar portlar ortam tarayıcı web webview adres bağlantılar url gömülü sayfa sekmeler sıfırla fabrika varsayılan geri yükle temizle düzenleyici dosya kod aç yol • %@ Tarayıcıyı açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 自动化 api cli 控制 套接字 代理 钩子 端口 环境 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 重置 出厂 默认 恢复 清除 编辑器 文件 代码 打开 路径 • %@ 打开浏览器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 重置 出廠 預設 還原 清除 編輯器 檔案 程式碼 開啟 路徑 • %@ App 開啟瀏覽器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет автоматизація api cli керування сокет агент хуки порти середовище браузер веб webview адресний посилання url вбудований сторінка вкладки скидання заводські типові відновити очистити редактор файл код відкрити шлях Стандартний Браузер: %@ • відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-ssh": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showSSH remote host target ssh server"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showSSH remote host target ssh server ssh リモート ホスト 接続先 サーバー"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server ssh リモート ホスト 接続先 サーバー"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 • %@ 원격 호스트"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showSSH remote host target ssh server програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет • %@ віддалений хост"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-ports": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showPorts localhost port listener dev server url"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showPorts localhost port listener dev server url localhost ポート リスナー 開発サーバー url"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url localhost ポート リスナー 開発サーバー url"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored automatizacija api cli kontrola socket agent kuke portovi okruženje preglednik web webview adresna linkovi ugrađen stranica kartice"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout automatisering api cli kontrol socket agent hooks porte miljø browser web webvisning adresselinje links indlejret side faner Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout automatisierung api cli steuerung socket agent hooks ports umgebung browser web webview adressleiste urls eingebettet seite tabs"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño automatización api cli control socket agente hooks puertos entorno navegador web webview direcciones enlaces urls integrado página pestañas App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition automatisation api cli contrôle socket agent hooks ports environnement navigateur web webview adresse liens urls intégré page onglets App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout automazione api cli controllo socket agente hook porte ambiente browser web webview indirizzi link incorporato pagina schede"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 브라우저 웹 웹뷰 주소 표시줄 링크 내장 페이지 탭"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett automatisering api cli kontroll socket agent hooks porter miljø nettleser web webvisning adresselinje lenker innebygd side faner"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ automatyzacja api cli sterowanie gniazdo agent haki porty środowisko przeglądarka web webview adresu linki osadzony strona karty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout automação api cli controle socket agente hooks portas ambiente navegador web webview endereço links urls incorporado página abas"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет автоматизация api cli управление сокет агент хуки порты окружение браузер веб webview адресная ссылки встроенный страница вкладки"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ ฝัง หน้า แท็บ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen otomasyon api cli kontrol soket ajan kancalar portlar ortam tarayıcı web webview adres bağlantılar gömülü sayfa sekmeler"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 自动化 api cli 控制 套接字 代理 钩子 端口 环境 浏览器 网页 WebView 地址栏 链接 内嵌 页面 标签页"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 瀏覽器 網頁 WebView 位址列 連結 內嵌 頁面 分頁 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showPorts localhost port listener dev server url програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет автоматизація api cli керування сокет агент хуки порти середовище браузер веб webview адресний посилання вбудований сторінка вкладки"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-log": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showLog log status latest message imperative"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showLog log status latest message imperative ログ ステータス 最新メッセージ imperative"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative ログ ステータス 最新メッセージ imperative"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative aplikacija opće postavke ponašanje dock traka menija bočna navigacija lijevo detalji sakrij raspored obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative app generelt indstillinger adfærd dock menulinje sidepanel navigation venstre detaljer skjul layout notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative app allgemein einstellungen verhalten dock menüleiste seitenleiste navigation links details ausblenden layout benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition notification notifications alerte non lu badge anneau flash son bureau App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative app generelt innstillinger oppførsel dock menylinje sidepanel navigasjon venstre detaljer skjul oppsett varsling varsler ulest melding merke ring blink lyd skrivebord"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative aplikacja ogólne preferencje zachowanie dock pasek menu boczny nawigacja lewy szczegóły ukryj układ powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative app geral preferências comportamento dock barra de menu lateral navegação esquerda detalhes ocultar layout notificação notificações alerta não lido mensagem selo anel piscar som desktop"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showLog log status latest message imperative програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-progress": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showProgress progress bar percent status set_progress"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showProgress progress bar percent status set_progress 進捗 プログレスバー パーセント ステータス set_progress"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress 進捗 プログレスバー パーセント ステータス set_progress"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress aplikacija opće postavke ponašanje dock traka menija bočna navigacija lijevo detalji sakrij raspored"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress app generelt indstillinger adfærd dock menulinje sidepanel navigation venstre detaljer skjul layout Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress app allgemein einstellungen verhalten dock menüleiste seitenleiste navigation links details ausblenden layout"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress app generelt innstillinger oppførsel dock menylinje sidepanel navigasjon venstre detaljer skjul oppsett"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress aplikacja ogólne preferencje zachowanie dock pasek menu boczny nawigacja lewy szczegóły ukryj układ"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress app geral preferências comportamento dock barra de menu lateral navegação esquerda detalhes ocultar layout"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showProgress progress bar percent status set_progress програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.app.show-metadata": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block メタデータ meta report_meta ステータス カスタム ブロック"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block メタデータ meta report_meta ステータス カスタム ブロック"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط مخصص: %@ التطبيق"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block aplikacija opće postavke ponašanje dock traka menija bočna navigacija lijevo detalji sakrij raspored Prilagođeno: %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block app generelt indstillinger adfærd dock menulinje sidepanel navigation venstre detaljer skjul layout Brugerdefineret: %@ Sidebjælke"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block app allgemein einstellungen verhalten dock menüleiste seitenleiste navigation links details ausblenden layout Benutzerdefiniert: %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño Personalizado: %@ App"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition Personnalisé : %@ App"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout Personalizzato: %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 사용자 정의: %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block app generelt innstillinger oppførsel dock menylinje sidepanel navigasjon venstre detaljer skjul oppsett Egendefinert: %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block aplikacja ogólne preferencje zachowanie dock pasek menu boczny nawigacja lewy szczegóły ukryj układ Niestandardowe: %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block app geral preferências comportamento dock barra de menu lateral navegação esquerda detalhes ocultar layout Personalizado: %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет Пользовательское: %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง กำหนดเอง: %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen Özel: %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 自定义: %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 自訂: %@ App"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebar.showCustomMetadata metadata meta report_meta status custom block програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет Власне: %@"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.terminal.scrollbar": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui ターミナル スクロールバック スクロールバー 右端 代替画面 tui"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui ターミナル スクロールバック スクロールバー 右端 代替画面 tui"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي طرفية صدفة تمرير سجل شاشة استيراد ترحيل إشارات مرجعية ملفات تعريف ارتباط شخصية الطرفية • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui aplikacija opće postavke ponašanje dock traka menija status bočna terminal shell povratni zapis za pomicanje ekran uvoz migracija oznake historija kolačići profili • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui app generelt indstillinger adfærd dock menulinje status sidepanel terminal shell rullepanel skærm import migrering bogmærker historik cookies profiler • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui app allgemein einstellungen verhalten dock menüleiste status seitenleiste terminal shell scrollleiste bildschirm import migration lesezeichen verlauf cookies profile • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui aplicación general preferencias comportamiento dock barra de menú estado lateral terminal shell historial desplazamiento pantalla importar migración marcadores cookies perfiles • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui application général préférences comportement dock barre de menus état latérale terminal shell historique défilement écran importer migration favoris cookies profils • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui app generale preferenze comportamento dock barra menu stato laterale terminale shell cronologia di scorrimento schermo importa migrazione segnalibri cookie profili • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 터미널 셸 스크롤백 스크롤바 화면 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 • %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui app generelt innstillinger oppførsel dock menylinje status sidepanel terminal skall tilbakerulling rullefelt skjerm import migrering bokmerker historikk informasjonskapsler profiler • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui aplikacja ogólne preferencje zachowanie dock pasek menu status boczny terminal powłoka przewijanie przewijania ekran import migracja zakładki historia ciasteczka profile • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui app geral preferências comportamento dock barra de menu status lateral terminal shell histórico rolagem tela importar migração favoritos cookies perfis • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui приложение общие настройки поведение док строка меню статус боковая панель терминал оболочка история прокрутки полоса экран импорт миграция закладки cookies профили • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui uygulama genel tercihler davranış dock menü çubuğu durum kenar terminal kabuk geri kaydırma ekran içe aktar geçiş yer imleri geçmiş çerezler profiller • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 终端 shell 回滚 滚动条 屏幕 导入 迁移 书签 历史记录 Cookie 个人资料 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 終端機 shell 回捲 捲動列 螢幕 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui програма загальні параметри поведінка док рядок меню статус бічна панель термінал shell історія прокручування смуга екран імпорт міграція закладки cookies профілі • %@"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.sidebarAppearance.match-terminal": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync 透明 背景 マテリアル ターミナル背景 同期"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync 透明 背景 マテリアル ターミナル背景 同期"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync طرفية صدفة تمرير سجل شريط شاشة الطرفية • %@ Match"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell povratni zapis traka za pomicanje ekran • %@ Match"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell scrollback rullepanel skærm • %@ Match"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell scrollback scrollleiste bildschirm • %@ Match"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell historial barra de desplazamiento pantalla • %@ Match"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell historique barre de défilement écran • %@ Match"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync terminale shell cronologia barra di scorrimento schermo • %@ Match"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync 터미널 셸 스크롤백 스크롤바 화면 • %@ Match"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync skall tilbakerulling rullefelt skjerm • %@ Match"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync powłoka przewijanie pasek przewijania ekran • %@ Match"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync shell histórico barra de rolagem tela • %@ Match"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync терминал оболочка история прокрутки полоса экран • %@ Match"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ • %@ Match"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync kabuk geri kaydırma çubuğu ekran • %@ Match"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync 终端 shell 回滚 滚动条 屏幕 • %@ Match"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync 終端機 shell 回捲 捲動列 螢幕 • %@ Match"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.matchTerminalBackground transparent background material terminal sync термінал shell історія прокручування смуга екран • %@ Match"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.sidebarAppearance.light-tint": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime ライトモード 色 サイドバー tint hex 昼"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime ライトモード 色 サイドバー tint hex 昼"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored izgled tema boja boje shema svijetlo tamno sistem način Svijetla nijansa"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout udseende tema farve farver skema lys mørk system tilstand Sidebjælke farvetone"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout darstellung design farbe farben schema hell dunkel system modus Heller Farbton"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño apariencia tema colores esquema claro oscuro sistema modo Tinte"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition apparence thème couleur couleurs schéma clair sombre système mode Teinte claire"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout aspetto tema colore colori schema chiaro scuro sistema modalità Chiara Tinta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 색조"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett utseende tema farge farger skjema lys mørk system modus fargetone"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ wygląd motyw kolor kolory schemat jasny ciemny system tryb Jasna odcień"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout aparência tema cor cores esquema claro escuro sistema modo Tonalidade clara"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет внешний вид тема цвет цвета схема светлый темный система режим Светлая Светлое оттенок"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด โทนสว่าง"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen görünüm tema renk renkler şema açık koyu sistem mod ton"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 外观 主题 颜色 配色 浅色 深色 系统 模式 浅色色调"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 外觀 主題 顏色 配色 淺色 深色 系統 模式 淺色色調"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет вигляд тема колір кольори схема світлий темний система режим Світла відтінок"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.sidebarAppearance.dark-tint": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime ダークモード 色 サイドバー tint hex 夜"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime ダークモード 色 サイドバー tint hex 夜"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime aplikacija opće postavke ponašanje dock traka menija status bočna navigacija lijevo detalji sakrij raspored izgled tema boja boje shema svijetlo tamno sistem način Tamna nijansa"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime app generelt indstillinger adfærd dock menulinje status sidepanel navigation venstre detaljer skjul layout udseende tema farve farver skema lys mørk system tilstand Sidebjælke farvetone"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime app allgemein einstellungen verhalten dock menüleiste status seitenleiste navigation links details ausblenden layout darstellung design farbe farben schema hell dunkel system modus Dunkler Farbton"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime aplicación general preferencias comportamiento dock barra de menú estado lateral navegación izquierda detalles ocultar diseño apariencia tema colores esquema claro oscuro sistema modo Tinte"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime application général préférences comportement dock barre de menus état latérale navigation gauche détails masquer disposition apparence thème couleur couleurs schéma clair sombre système mode Teinte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime app generale preferenze comportamento dock barra menu stato laterale navigazione sinistra dettagli nascondi layout aspetto tema colore colori schema chiaro scuro sistema modalità Scura Tinta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 색조"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime app generelt innstillinger oppførsel dock menylinje status sidepanel navigasjon venstre detaljer skjul oppsett utseende tema farge farger skjema lys mørk system modus fargetone"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime aplikacja ogólne preferencje zachowanie dock pasek menu status boczny nawigacja lewy szczegóły ukryj układ wygląd motyw kolor kolory schemat jasny ciemny system tryb Ciemna odcień"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime app geral preferências comportamento dock barra de menu status lateral navegação esquerda detalhes ocultar layout aparência tema cor cores esquema claro escuro sistema modo Tonalidade escura"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет внешний вид тема цвет цвета схема светлый темный система режим Темная Темное Тёмный оттенок"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด โทนมืด"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime uygulama genel tercihler davranış dock menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen görünüm tema renk renkler şema açık koyu sistem mod ton"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 外观 主题 颜色 配色 浅色 深色 系统 模式 深色色调"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 外觀 主題 顏色 配色 淺色 深色 系統 模式 深色色調"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет вигляд тема колір кольори схема світлий темний система режим Темна відтінок"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.sidebarAppearance.tint-opacity": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 透明度 不透明度 alpha 強さ ブレンド"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 透明度 不透明度 alpha 強さ ブレンド"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend شفافية اللون"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Prozirnost nijanse"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Farvetone gennemsigtighed"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Farbton-Deckkraft"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Opacidad del tinte"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Opacité de la teinte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Opacità tinta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 색조 불투명도"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Fargetone-opasitet"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Krycie odcienia"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Opacidade da Tonalidade"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Непрозрачность оттенка"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend ความทึบของโทนสี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Renk Tonu Opaklığı"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 色调不透明度"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend 色調不透明度"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "sidebarAppearance.tintOpacity alpha transparency intensity blend Непрозорість відтінку"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.sidebarAppearance.reset-tint": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "restore default clear tint colors opacity"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "restore default clear tint colors opacity デフォルトに戻す 色を消す tint 透明度"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity デフォルトに戻す 色を消す tint 透明度"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity إعادة ضبط مصنع افتراضي استعادة مسح مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع التعيين تعيين شفافية اللون"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity reset fabrički zadano vrati očisti izgled tema boja boje shema svijetlo tamno sistem način Obriši Resetovanje Resetuj Prozirnost nijanse"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity nulstil fabrik standard gendan ryd udseende tema farve farver skema lys mørk system tilstand Farvetone gennemsigtighed"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity zurücksetzen werkseinstellungen standard wiederherstellen löschen darstellung design farbe farben schema hell dunkel system modus Farbton-Deckkraft"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity restablecer fábrica predeterminado restaurar borrar apariencia tema color colores esquema claro oscuro sistema modo Opacidad del tinte"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity réinitialiser usine défaut restaurer effacer apparence thème couleur couleurs schéma clair sombre système mode Opacité de la teinte Par"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity reimposta fabbrica predefinito ripristina cancella aspetto tema colore colori schema chiaro scuro sistema modalità Opacità tinta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity 재설정 초기화 기본값 복원 지우기 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 색조 불투명도"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity tilbakestill fabrikk standard gjenopprett tøm utseende tema farge farger skjema lys mørk system modus Fjern Fargetone-opasitet"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity reset fabryczne domyślne przywróć wyczyść wygląd motyw kolor kolory schemat jasny ciemny system tryb Resetuj Krycie odcienia Domyślny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity redefinir fábrica padrão restaurar limpar aparência tema cor cores esquema claro escuro sistema modo Opacidade da Tonalidade"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity сброс заводские по умолчанию восстановить очистить внешний вид тема цвет цвета схема светлый темный система режим Сбросить Непрозрачность оттенка"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด ความทึบของโทนสี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity sıfırla fabrika varsayılan geri yükle temizle görünüm tema renk renkler şema açık koyu sistem mod Tonu Opaklığı"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity 重置 出厂 默认 恢复 清除 外观 主题 颜色 配色 浅色 深色 系统 模式 色调不透明度"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity 重置 出廠 預設 還原 清除 外觀 主題 顏色 配色 淺色 深色 系統 模式 色調不透明度"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "restore default clear tint colors opacity скидання заводські типові відновити очистити вигляд тема колір кольори схема світлий темний система режим Скинути Стандартний Непрозорість відтінку"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.socket-mode": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled api ソケット unix domain 制御 サーバー 認証 許可 パスワード 無効"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled api ソケット unix domain 制御 サーバー 認証 許可 パスワード 無効"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن غير آمن التحكم بالمقبس المقبس المرور الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled autentikacija prijava odjava email korisnik profil tim račun automatizacija cli kontrola agent kuke portovi okruženje izgled tema boja boje shema svijetlo tamno sistem način lozinka tajna token vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno Režim kontrolne utičnice automatizacije lozinke"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled godkendelse login logud email bruger profil team konto automatisering cli kontrol agent hooks porte miljø udseende tema farve farver skema lys mørk system tilstand adgangskode hemmelighed token legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker Socket-kontroltilstand Socket-adgangskode Automatiseringstilstand Adgangskodetilstand"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled authentifizierung anmeldung abmeldung email benutzer profil team konto automatisierung cli steuerung agent hooks ports umgebung darstellung design farbe farben schema hell dunkel system modus passwort geheimnis token zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher Socket-Steuerungsmodus Socket-Passwort Automatisierungsmodus Passwortmodus"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta automatización cli agente hooks puertos entorno apariencia tema color colores esquema claro oscuro sistema modo contraseña secreto token credencial acceso permitir desactivar activar permiso inseguro de del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled authentification connexion déconnexion e-mail utilisateur profil équipe compte automatisation cli contrôle agent hooks ports environnement apparence thème couleur couleurs schéma clair sombre système mode mot de passe secret jeton identifiant accès autoriser désactiver activer autorisation non sécurisé du"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled autenticazione accesso disconnessione email utente profilo team account automazione cli controllo agente hook porte ambiente aspetto tema colore colori schema chiaro scuro sistema modalità segreto token credenziale consenti disabilita abilita autorizzazione non sicuro"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정 자동화 cli 제어 소켓 에이전트 훅 포트 환경 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled autentisering innlogging utlogging e-post bruker profil team konto automatisering cli kontroll agent hooks porter miljø utseende tema farge farger skjema lys mørk system modus passord hemmelighet token legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker Socket-kontrollmodus Socket-passord Automatiseringsmodus Passordmodus"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled uwierzytelnianie logowanie wylogowanie email użytkownik profil zespół konto automatyzacja cli sterowanie gniazdo agent haki porty środowisko wygląd motyw kolor kolory schemat jasny ciemny system tryb hasło sekret token poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone sterowania gniazdem gniazda automatyzacji hasła"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled autenticação login sair email usuário perfil equipe conta automação cli controle agente hooks portas ambiente aparência tema cor cores esquema claro escuro sistema modo senha segredo token credencial acesso permitir desativar ativar permissão inseguro de do"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled аутентификация вход выход email пользователь профиль команда аккаунт автоматизация cli управление сокет агент хуки порты окружение внешний вид тема цвет цвета схема светлый темный система режим пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно управления сокетом сокета автоматизации пароля"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี อัตโนมัติ cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย โหมดควบคุมซ็อกเก็ต รหัสผ่านซ็อกเก็ต ระบบอัตโนมัติ โหมดระบบอัตโนมัติ โหมดรหัสผ่าน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap otomasyon cli kontrol soket ajan kancalar portlar ortam görünüm tema renk renkler şema açık koyu sistem mod parola gizli token bilgisi erişim izin ver devre dışı etkinleştir güvensiz İzin Modu Parolası"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled 认证 登录 退出登录 邮件 用户 个人资料 团队 账户 自动化 cli 控制 套接字 代理 钩子 端口 环境 外观 主题 颜色 配色 浅色 深色 系统 模式 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 套接字控制模式 套接字密码 自动化模式 密码模式"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶 自動化 cli 控制 代理程式 hook 連接埠 環境 外觀 主題 顏色 配色 淺色 深色 系統 模式 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全 控制模式 自動化模式 密碼模式"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketControlMode api socket unix domain control server auth allow password disabled автентифікація вхід вихід email користувач профіль команда обліковий запис автоматизація cli керування сокет агент хуки порти середовище вигляд тема колір кольори схема світлий темний система режим пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно керуючого сокета автоматизації пароля"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.socket-password": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.socketPassword auth token credential secret password access key"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.socketPassword auth token credential secret password access key ソケット パスワード 認証 トークン 資格情報 シークレット アクセスキー"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key ソケット パスワード 認証 トークン 資格情報 シークレット アクセスキー"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة لوحة مفاتيح اختصار اختصارات مفتاح سريع كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن غير آمن المقبس المرور الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key autentikacija prijava odjava email korisnik profil tim račun automatizacija api cli kontrola socket agent kuke portovi okruženje tastatura prečica prečice hotkey komande tipke snimač lozinka tajna vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno utičnice"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key godkendelse login logud email bruger profil team konto automatisering api cli kontrol socket agent hooks porte miljø tastatur genvej genveje hotkey kommandoer taster optager adgangskode hemmelighed legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker Socket-adgangskode"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key authentifizierung anmeldung abmeldung email benutzer profil team konto automatisierung api cli steuerung socket agent hooks ports umgebung tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder passwort geheimnis zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher Socket-Passwort"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta automatización api cli control socket agente hooks puertos entorno teclado atajo atajos tecla rápida comandos teclas grabador contraseña secreto credencial acceso permitir desactivar activar permiso inseguro del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key authentification connexion déconnexion e-mail utilisateur profil équipe compte automatisation api cli contrôle socket agent hooks ports environnement clavier raccourci raccourcis touche globale commandes touches enregistreur mot de passe jeton identifiant accès autoriser désactiver activer autorisation non sécurisé du"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key autenticazione accesso disconnessione email utente profilo team account automazione api cli controllo socket agente hook porte ambiente tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore segreto credenziale consenti disabilita abilita autorizzazione non sicuro"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 키보드 단축키 핫키 명령 키 기록기 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key autentisering innlogging utlogging e-post bruker profil team konto automatisering api cli kontroll socket agent hooks porter miljø tastatur snarvei snarveier hurtigtast kommandoer taster opptaker passord hemmelighet legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker Socket-passord"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key uwierzytelnianie logowanie wylogowanie email użytkownik profil zespół konto automatyzacja api cli sterowanie gniazdo agent haki porty środowisko klawiatura skrót skróty klawisz polecenia klawisze rejestrator hasło sekret poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone gniazda"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key autenticação login sair email usuário perfil equipe conta automação api cli controle socket agente hooks portas ambiente teclado atalho atalhos tecla rápida comandos teclas gravador senha segredo credencial acesso permitir desativar ativar permissão inseguro do"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key аутентификация вход выход email пользователь профиль команда аккаунт автоматизация api cli управление сокет агент хуки порты окружение клавиатура сочетание клавиш горячая клавиша команды клавиши запись пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно сокета"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย รหัสผ่านซ็อกเก็ต ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap otomasyon api cli kontrol soket ajan kancalar portlar ortam klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici parola gizli bilgisi erişim izin ver devre dışı etkinleştir güvensiz Parolası"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key 认证 登录 退出登录 邮件 用户 个人资料 团队 账户 自动化 api cli 控制 套接字 代理 钩子 端口 环境 键盘 快捷键 热键 命令 按键 录制器 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 套接字密码"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.socketPassword auth token credential secret password access key автентифікація вхід вихід email користувач профіль команда обліковий запис автоматизація api cli керування сокет агент хуки порти середовище клавіатура скорочення гарячі клавіші команди записувач пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно сокета"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.claude-code": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications claude code フック エージェント 連携 通知"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications claude code フック エージェント 連携 通知"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة محرر ملف كود فتح مسار إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب الإشعارات تكامل الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications aplikacija opće postavke ponašanje dock traka menija bočna automatizacija api cli kontrola socket kuke portovi okruženje editor datoteka kod otvori putanja obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Obavještenja integracija"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications app generelt indstillinger adfærd dock menulinje sidepanel automatisering api cli kontrol socket porte miljø editor fil kode åbn sti notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord Code-integration"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications app allgemein einstellungen verhalten dock menüleiste seitenleiste automatisierung api cli steuerung socket ports umgebung editor datei öffnen pfad benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop Code-Integration"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications aplicación general preferencias comportamiento dock barra de menú estado lateral automatización api cli control socket agente puertos entorno editor archivo código abrir ruta notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio Integración con"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications application général préférences comportement dock barre de menus état latérale automatisation api cli contrôle socket ports environnement éditeur fichier ouvrir chemin notification alerte non lu message badge anneau flash son bureau Intégration"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications app generale preferenze comportamento dock barra menu stato laterale automazione api cli controllo socket agente hook porte ambiente editor file codice apri percorso notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania Integrazione"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 편집기 파일 코드 열기 경로 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 연동"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications app generelt innstillinger oppførsel dock menylinje sidepanel automatisering api cli kontroll socket porter miljø redigerer fil kode åpne bane varsling varsler ulest melding merke ring blink lyd skrivebord Code-integrering"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications aplikacja ogólne preferencje zachowanie dock pasek menu boczny automatyzacja api cli sterowanie gniazdo haki porty środowisko edytor plik kod otwórz ścieżka powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit Integracja z"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications app geral preferências comportamento dock barra de menu lateral automação api cli controle socket agente portas ambiente editor arquivo código abrir caminho notificação notificações alerta não lido mensagem selo anel piscar som desktop Integração com"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications приложение общие настройки поведение док строка меню статус боковая панель автоматизация api cli управление сокет агент хуки порты окружение редактор файл код открыть путь уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол Интеграция с"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป การผสานรวม ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications uygulama genel tercihler davranış dock menü çubuğu durum kenar otomasyon api cli kontrol soket ajan kancalar portlar ortam düzenleyici dosya kod aç yol bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü Entegrasyonu"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 自动化 api cli 控制 套接字 代理 钩子 端口 环境 编辑器 文件 代码 打开 路径 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 集成"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 編輯器 檔案 程式碼 開啟 路徑 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 整合"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeCodeIntegration claude code hooks agent integration status notifications програма загальні параметри поведінка док рядок меню статус бічна панель автоматизація api cli керування сокет агент хуки порти середовище редактор файл код відкрити шлях сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл Інтеграція з"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.claude-path": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.claudeBinaryPath claude binary executable path cli command custom"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.claudeBinaryPath claude binary executable path cli command custom claude バイナリ 実行ファイル パス cli コマンド カスタム"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom claude バイナリ 実行ファイル パス cli コマンド カスタム"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة محرر ملف كود فتح مسار مخصص: %@ الأوامر الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatizacija api kontrola socket agent kuke portovi okruženje editor datoteka kod otvori putanja Prilagođeno: %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatisering api kontrol socket agent hooks porte miljø editor fil kode åbn sti Brugerdefineret: %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatisierung api steuerung socket agent hooks ports umgebung editor datei code öffnen pfad Benutzerdefiniert: %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatización api control socket agente hooks puertos entorno editor archivo código abrir ruta Personalizado: %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatisation api contrôle socket agent hooks ports environnement éditeur fichier code ouvrir chemin Personnalisé : %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automazione api controllo socket agente hook porte ambiente editor file codice apri percorso Personalizzato: %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom 자동화 api 제어 소켓 에이전트 훅 포트 환경 편집기 파일 코드 열기 경로 사용자 정의: %@ 바이너리"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatisering api kontroll socket agent hooks porter miljø redigerer fil kode åpne bane Egendefinert: %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automatyzacja api sterowanie gniazdo agent haki porty środowisko edytor plik kod otwórz ścieżka Niestandardowe: %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom automação api controle socket agente hooks portas ambiente editor arquivo código abrir caminho Personalizado: %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom автоматизация api управление сокет агент хуки порты окружение редактор файл код открыть путь Пользовательское: %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom อัตโนมัติ api ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง กำหนดเอง: %@ ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom otomasyon api kontrol soket ajan kancalar portlar ortam düzenleyici dosya kod aç yol Özel: %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom 自动化 api 控制 套接字 代理 钩子 端口 环境 编辑器 文件 代码 打开 路径 自定义: %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom 自動化 api 控制 socket 代理程式 hook 連接埠 環境 編輯器 檔案 程式碼 開啟 路徑 自訂: %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.claudeBinaryPath claude binary executable path cli command custom автоматизація api керування сокет агент хуки порти середовище редактор файл код відкрити шлях Власне: %@"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.cursor": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.cursorIntegration cursor ide agent hooks notifications"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.cursorIntegration cursor ide agent hooks notifications cursor ide エージェント フック 通知 連携"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications cursor ide エージェント フック 通知 連携"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة محرر ملف كود فتح مسار إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب الإشعارات الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatizacija api cli kontrola socket kuke portovi okruženje editor datoteka kod otvori putanja obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop Obavještenja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatisering api cli kontrol socket porte miljø editor fil kode åbn sti notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatisierung api cli steuerung socket ports umgebung editor datei code öffnen pfad benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatización api cli control socket agente puertos entorno editor archivo código abrir ruta notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatisation api cli contrôle socket ports environnement éditeur fichier code ouvrir chemin notification alerte non lu message badge anneau flash son bureau"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automazione api cli controllo socket agente hook porte ambiente editor file codice apri percorso notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 편집기 파일 코드 열기 경로 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatisering api cli kontroll socket porter miljø redigerer fil kode åpne bane varsling varsler ulest melding merke ring blink lyd skrivebord"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automatyzacja api cli sterowanie gniazdo haki porty środowisko edytor plik kod otwórz ścieżka powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications automação api cli controle socket agente portas ambiente editor arquivo código abrir caminho notificação notificações alerta não lido mensagem selo anel piscar som desktop"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications автоматизация api cli управление сокет агент хуки порты окружение редактор файл код открыть путь уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications otomasyon api cli kontrol soket ajan kancalar portlar ortam düzenleyici dosya kod aç yol bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications 自动化 api cli 控制 套接字 代理 钩子 端口 环境 编辑器 文件 代码 打开 路径 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 編輯器 檔案 程式碼 開啟 路徑 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.cursorIntegration cursor ide agent hooks notifications автоматизація api cli керування сокет агент хуки порти середовище редактор файл код відкрити шлях сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.gemini": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.geminiIntegration gemini cli google agent hooks notifications"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.geminiIntegration gemini cli google agent hooks notifications gemini cli google エージェント フック 通知 連携"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications gemini cli google エージェント フック 通知 連携"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب بحث اقتراحات إكمال تلقائي مزود محرك الأوامر الإشعارات الأتمتة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatizacija api kontrola socket kuke portovi okruženje obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop pretraga prijedlozi automatsko dovršavanje pružatelj pretraživač Obavještenja"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatisering api kontrol socket porte miljø notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord søgning forslag autofuldførelse udbyder søgemaskine"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatisierung api steuerung socket ports umgebung benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop suche vorschläge autovervollständigung anbieter suchmaschine"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatización api control socket agente puertos entorno notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio búsqueda sugerencias autocompletar proveedor motor de"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatisation api contrôle socket ports environnement notification alerte non lu message badge anneau flash son bureau recherche suggestions saisie automatique fournisseur moteur de"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automazione api controllo socket agente hook porte ambiente notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania ricerca suggerimenti completamento automatico provider motore di"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications 자동화 api 제어 소켓 에이전트 훅 포트 환경 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 검색 제안 자동완성 제공자 엔진"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatisering api kontroll socket porter miljø varsling varsler ulest melding merke ring blink lyd skrivebord søk forslag autofullføring leverandør søkemotor"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automatyzacja api sterowanie gniazdo haki porty środowisko powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit wyszukiwanie sugestie autouzupełnianie dostawca silnik wyszukiwania"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications automação api controle socket agente portas ambiente notificação notificações alerta não lido mensagem selo anel piscar som desktop pesquisa sugestões autocompletar provedor mecanismo de busca"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications автоматизация api управление сокет агент хуки порты окружение уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол поиск предложения автозаполнение провайдер поисковая система"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications อัตโนมัติ api ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป ค้นหา คำแนะนำ เติมอัตโนมัติ ผู้ให้บริการ เครื่องมือค้นหา ระบบอัตโนมัติ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications otomasyon api kontrol soket ajan kancalar portlar ortam bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü arama öneriler otomatik tamamlama sağlayıcı motoru"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications 自动化 api 控制 套接字 代理 钩子 端口 环境 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 搜索 建议 自动完成 提供商 搜索引擎"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications 自動化 api 控制 socket 代理程式 hook 連接埠 環境 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 搜尋 建議 自動完成 提供者 搜尋引擎"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.geminiIntegration gemini cli google agent hooks notifications автоматизація api керування сокет агент хуки порти середовище сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл пошук пропозиції автодоповнення постачальник пошукова система"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.port-base": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.portBase cmux_port start first base env environment variable"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.portBase cmux_port start first base env environment variable cmux_port 開始 最初 ベース 環境変数 ポート"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable cmux_port 開始 最初 ベース 環境変数 ポート"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة تركيز نقر ماوس تنشيط يتبع أول المنفذ الأساسي الأتمتة الأساس: %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatizacija api cli kontrola socket agent kuke portovi okruženje fokus klik miš aktivacija prati prvi Početni port Osnovna: %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatisering api cli kontrol socket agent hooks porte miljø fokus klik mus aktivering følger første Portbase Base: %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatisierung api cli steuerung socket agent hooks ports umgebung fokus klicken maus aktivierung folgt erster Port-Basis Basis: %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatización api cli control socket agente hooks puertos entorno foco clic ratón activación sigue primero Puerto Base: %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatisation api cli contrôle socket agent hooks ports environnement focus clic souris activation suit premier Port de : %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automazione api cli controllo socket agente hook porte ambiente focus clic mouse attivazione segue primo Porta Base: %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 포커스 클릭 마우스 활성화 따름 첫 번째 기준값 기본: %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatisering api cli kontroll socket agent hooks porter miljø fokus klikk mus aktivering følger første Portbase Basis: %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automatyzacja api cli sterowanie gniazdo agent haki porty środowisko fokus klik mysz aktywacja podąża pierwszy Port bazowy Bazowy: %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable automação api cli controle socket agente hooks portas ambiente foco clique mouse ativação segue primeiro Porta Base: %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable автоматизация api cli управление сокет агент хуки порты окружение фокус щелчок мышь активация следует первый Базовый порт Базовый: %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม โฟกัส คลิก เมาส์ เปิดใช้งาน ตาม ครั้งแรก พอร์ตเริ่มต้น ระบบอัตโนมัติ ฐาน: %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable otomasyon api cli kontrol soket ajan kancalar portlar ortam odak tık fare etkinleştirme izler ilk Port Tabanı Temel: %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable 自动化 api cli 控制 套接字 代理 钩子 端口 环境 焦点 点击 鼠标 激活 跟随 首次 起始端口 基础色：%@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 焦點 點按 滑鼠 啟用 跟隨 首次 連接埠起始值 基底：%@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portBase cmux_port start first base env environment variable автоматизація api cli керування сокет агент хуки порти середовище фокус клацання миша активація слідує перший Базовий порт Базовий: %@"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.automation.port-range": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.portRange cmux_port_end range size count env ports"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "automation.portRange cmux_port_end range size count env ports cmux_port_end 範囲 サイズ 個数 環境変数 ポート"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports cmux_port_end 範囲 サイズ 個数 環境変数 ポート"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة حجم نطاق المنافذ الأتمتة الحجم:"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatizacija api cli kontrola socket agent kuke portovi okruženje Veličina raspona portova Veličina:"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatisering api cli kontrol socket agent hooks porte miljø Portområdestørrelse Størrelse:"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatisierung api cli steuerung socket agent hooks umgebung Portbereichsgröße Größe:"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatización api cli control socket agente hooks puertos entorno Tamaño del rango de Tamaño:"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatisation api cli contrôle socket agent hooks environnement Taille de la plage :"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automazione api cli controllo socket agente hook porte ambiente Dimensione intervallo Dimensione:"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 범위 크기 크기:"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatisering api cli kontroll socket agent hooks porter miljø Portområdestørrelse Størrelse:"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automatyzacja api cli sterowanie gniazdo agent haki porty środowisko Rozmiar zakresu portów Rozmiar:"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports automação api cli controle socket agente hooks portas ambiente Tamanho da Faixa de Tamanho:"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports автоматизация api cli управление сокет агент хуки порты окружение Размер диапазона портов Размер:"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม ขนาดช่วงพอร์ต ระบบอัตโนมัติ ขนาด:"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports otomasyon api cli kontrol soket ajan kancalar portlar ortam Port Aralığı Boyutu Boyut:"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports 自动化 api cli 控制 套接字 代理 钩子 端口 环境 端口范围大小 大小："
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 連接埠範圍大小 大小："
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.portRange cmux_port_end range size count env ports автоматизація api cli керування сокет агент хуки порти середовище Розмір діапазону портів Розмір:"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.enable-browser": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.enabled enable disable webview embedded browser tabs links"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.enabled enable disable webview embedded browser tabs links ブラウザ 有効 無効 webview 内蔵ブラウザ タブ リンク"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links ブラウザ 有効 無効 webview 内蔵ブラウザ タブ リンク"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن غير آمن المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links preglednik web adresna traka linkovi url ugrađen stranica kartice radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka lozinka tajna token vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links web webvisning adresselinje url indlejret side faner arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik adgangskode hemmelighed token legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links web adressleiste urls eingebettet seite arbeitsbereich tab farben palette badge ausgewählt hervorhebung indikator aktiv punkt passwort geheimnis token zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links navegador web barra de direcciones enlaces urls integrado página pestañas espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto contraseña secreto token credencial acceso permitir desactivar activar permiso inseguro • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links navigateur web barre adresse liens urls intégré page onglets espace de travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point mot passe secret jeton identifiant accès autoriser désactiver activer autorisation non sécurisé • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links web barra indirizzi link url incorporato pagina schede area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto password segreto token credenziale accesso consenti disabilita abilita autorizzazione non sicuro • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links nettleser web webvisning adresselinje lenker url innebygd side faner arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk passord hemmelighet token legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links przeglądarka web pasek adresu linki url osadzony strona karty obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka hasło sekret token poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links navegador web barra de endereço urls incorporado página abas workspace aba cores paleta selo selecionado destaque indicador ativo ponto senha segredo token credencial acesso permitir desativar ativar permissão inseguro • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links браузер веб адресная строка ссылки url встроенный страница вкладки рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ พื้นที่ทำงาน สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links tarayıcı web adres çubuğu bağlantılar url gömülü sayfa sekmeler çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta parola gizli token kimlik bilgisi erişim izin ver devre dışı etkinleştir güvensiz • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links 浏览器 网页 地址栏 链接 URL 内嵌 页面 标签页 工作区 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links 瀏覽器 網頁 位址列 連結 URL 內嵌 頁面 分頁 工作區 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.enabled enable disable webview embedded browser tabs links браузер веб адресний рядок посилання url вбудований сторінка вкладки робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.search-engine": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider オムニバー アドレスバー google duckduckgo bing 検索エンジン 検索プロバイダ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider オムニバー アドレスバー google duckduckgo bing 検索エンジン 検索プロバイダ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات بحث اقتراحات إكمال تلقائي مزود محرك المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider aplikacija opće postavke ponašanje dock traka menija status bočna preglednik web webview adresna linkovi url ugrađen stranica kartice pretraga prijedlozi automatsko dovršavanje pružatelj pretraživač Pretraži • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider app generelt indstillinger adfærd dock menulinje status sidepanel browser web webvisning adresselinje links url indlejret side faner søgning forslag autofuldførelse udbyder søgemaskine Søg • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider app allgemein einstellungen verhalten dock menüleiste status seitenleiste browser web webview adressleiste links urls eingebettet seite tabs suche vorschläge autovervollständigung anbieter suchmaschine Suchen • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider aplicación general preferencias comportamiento dock barra de menú estado lateral navegador web webview direcciones enlaces urls integrado página pestañas búsqueda sugerencias autocompletar proveedor motor Buscar • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider application général préférences comportement dock barre de menus état latérale navigateur web webview adresse liens urls intégré page onglets recherche suggestions saisie automatique fournisseur moteur Rechercher • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider app generale preferenze comportamento dock barra menu stato laterale browser web webview indirizzi link url incorporato pagina schede ricerca suggerimenti completamento automatico motore di Cerca • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 검색 제안 자동완성 제공자 엔진 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider app generelt innstillinger oppførsel dock menylinje status sidepanel nettleser web webvisning adresselinje lenker url innebygd side faner søk forslag autofullføring leverandør søkemotor • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider aplikacja ogólne preferencje zachowanie dock pasek menu status boczny przeglądarka web webview adresu linki url osadzony strona karty wyszukiwanie sugestie autouzupełnianie dostawca silnik wyszukiwania Szukaj • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider app geral preferências comportamento dock barra de menu status lateral navegador web webview endereço links urls incorporado página abas pesquisa sugestões autocompletar provedor mecanismo busca Pesquisar • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider приложение общие настройки поведение док строка меню статус боковая панель браузер веб webview адресная ссылки url встроенный страница вкладки поиск предложения автозаполнение провайдер поисковая система • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ ค้นหา คำแนะนำ เติมอัตโนมัติ ผู้ให้บริการ เครื่องมือค้นหา • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider uygulama genel tercihler davranış dock menü çubuğu durum kenar tarayıcı web webview adres bağlantılar url gömülü sayfa sekmeler arama öneriler otomatik tamamlama sağlayıcı motoru Ara • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 搜索 建议 自动完成 提供商 搜索引擎 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 搜尋 建議 自動完成 提供者 搜尋引擎 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.defaultSearchEngine omnibar address bar google duckduckgo bing search provider програма загальні параметри поведінка док рядок меню статус бічна панель браузер веб webview адресний посилання url вбудований сторінка вкладки пошук пропозиції автодоповнення постачальник пошукова система Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.search-suggestions": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions サジェスト 補完 アドレスバー 検索候補"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions サジェスト 補完 アドレスバー 検索候補"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات بحث اقتراحات إكمال تلقائي مزود محرك المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions aplikacija opće postavke ponašanje dock traka menija status bočna preglednik web webview adresna linkovi url ugrađen stranica kartice pretraga prijedlozi automatsko dovršavanje pružatelj pretraživač adresne trake Pretraži • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions app generelt indstillinger adfærd dock menulinje status sidepanel browser web webvisning adresselinje links url indlejret side faner søgning forslag autofuldførelse udbyder søgemaskine til adresselinjen Søg • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions app allgemein einstellungen verhalten dock menüleiste status seitenleiste browser web webview adressleiste links urls eingebettet seite tabs suche vorschläge autovervollständigung anbieter suchmaschine Adressleisten-Vorschläge Suchen • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions aplicación general preferencias comportamiento dock barra de menú estado lateral navegador web webview direcciones enlaces urls integrado página pestañas búsqueda sugerencias autocompletar proveedor motor la Buscar • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions application général préférences comportement dock barre de menus état latérale navigateur web webview adresse liens urls intégré page onglets recherche saisie automatique fournisseur moteur la d'adresse Rechercher • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions app generale preferenze comportamento dock barra menu stato laterale browser web webview indirizzi link url incorporato pagina schede ricerca suggerimenti completamento automatico provider motore di degli Cerca • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 검색 제안 자동완성 제공자 엔진 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions app generelt innstillinger oppførsel dock menylinje status sidepanel nettleser web webvisning adresselinje lenker url innebygd side faner søk forslag autofullføring leverandør søkemotor i adressefeltet • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions aplikacja ogólne preferencje zachowanie dock pasek menu status boczny przeglądarka web webview adresu linki url osadzony strona karty wyszukiwanie sugestie autouzupełnianie dostawca silnik wyszukiwania Podpowiedzi paska Szukaj • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions app geral preferências comportamento dock barra de menu status lateral navegador web webview endereço links urls incorporado página abas pesquisa sugestões autocompletar provedor mecanismo busca da Pesquisar • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions приложение общие настройки поведение док строка меню статус боковая панель браузер веб webview адресная ссылки url встроенный страница вкладки поиск предложения автозаполнение провайдер поисковая система Подсказки адресной строки • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ ค้นหา คำแนะนำ เติมอัตโนมัติ ผู้ให้บริการ เครื่องมือค้นหา คำแนะนำแถบที่อยู่ • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions uygulama genel tercihler davranış dock menü çubuğu durum kenar tarayıcı web webview adres bağlantılar url gömülü sayfa sekmeler arama öneriler otomatik tamamlama sağlayıcı motoru önerileri Ara • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 搜索 建议 自动完成 提供商 搜索引擎 地址栏建议 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 搜尋 建議 自動完成 提供者 搜尋引擎 網址列建議 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showSearchSuggestions suggest autocomplete address bar search suggestions програма загальні параметри поведінка док рядок меню статус бічна панель браузер веб webview адресний посилання url вбудований сторінка вкладки пошук пропозиції автодоповнення постачальник пошукова система Браузер: %@ Підказки адресного рядка •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.theme": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.theme web page theme color scheme light dark system"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.theme web page theme color scheme light dark system ウェブページ テーマ 配色 ライト ダーク システム"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system ウェブページ テーマ 配色 ライト ダーク システム"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع النظام المتصفح • %@ المظهر"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system preglednik webview adresna traka linkovi url ugrađen stranica kartice izgled tema boja boje shema svijetlo tamno sistem način Tamna Svijetla Sistemski • %@ preglednika"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system browser webvisning adresselinje links url indlejret side faner udseende tema farve farver skema lys mørk tilstand • %@ Browsertema"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system browser webview adressleiste links urls eingebettet seite tabs darstellung design farbe farben schema hell dunkel modus • %@ Browser-Design"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system navegador webview barra de direcciones enlaces urls integrado página pestañas apariencia tema colores esquema claro oscuro sistema modo • %@ del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system navigateur webview barre adresse liens urls intégré onglets apparence thème couleur couleurs schéma clair sombre système mode • %@ du"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system browser webview barra indirizzi link url incorporato pagina schede aspetto tema colore colori schema chiaro scuro sistema modalità Scura Chiara • %@ del"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 브라우저: %@ 테마: •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system nettleser webvisning adresselinje lenker url innebygd side faner utseende tema farge farger skjema lys mørk modus • %@ Nettlesertema"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system przeglądarka webview pasek adresu linki url osadzony strona karty wygląd motyw kolor kolory schemat jasny ciemny tryb Ciemna Jasna Systemowy • %@ przeglądarki"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system navegador webview barra de endereço links urls incorporado página abas aparência tema cor cores esquema claro escuro sistema modo • %@ do"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system браузер веб webview адресная строка ссылки url встроенный страница вкладки внешний вид тема цвет цвета схема светлый темный система режим Темная Светлая Темное Светлое Системное • %@ Системный браузера Системная"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด • %@ ธีมเบราว์เซอร์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system tarayıcı webview adres çubuğu bağlantılar url gömülü sayfa sekmeler görünüm tema renk renkler şema açık koyu sistem mod • %@ Teması"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 外观 主题 颜色 配色 浅色 深色 系统 模式 • %@ 浏览器主题"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 外觀 主題 顏色 配色 淺色 深色 系統 模式 • %@ 瀏覽器主題"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.theme web page theme color scheme light dark system браузер веб webview адресний рядок посилання url вбудований сторінка вкладки вигляд тема колір кольори схема світлий темний система режим Темна Світла Системна Браузер: %@ браузера: • браузера"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.terminal-links": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href クリック url ターミナルリンク ブラウザで開く href"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href クリック url ターミナルリンク ブラウザで開く href"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href طرفية صدفة تمرير سجل شريط شاشة متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات تركيز نقر ماوس تنشيط يتبع أول محرر ملف كود فتح مسار المتصفح • %@ الطرفية مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell povratni zapis traka za pomicanje ekran preglednik web webview adresna linkovi ugrađen stranica kartice fokus klik miš aktivacija prati prvi editor datoteka kod otvori putanja • %@ otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell scrollback rullepanel skærm web webvisning adresselinje indlejret side faner fokus klik mus aktivering følger første editor fil kode åbn sti • %@ åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell scrollback scrollleiste bildschirm web webview adressleiste urls eingebettet seite tabs fokus klicken maus aktivierung folgt erster editor datei code öffnen pfad • %@ offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell historial barra de desplazamiento pantalla navegador web webview direcciones enlaces urls integrado página pestañas foco clic ratón activación sigue primero editor archivo código abrir ruta • %@ abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell historique barre de défilement écran navigateur web webview adresse liens urls intégré page onglets focus clic souris activation suit premier éditeur fichier code ouvrir chemin • %@ le ouverte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href terminale shell cronologia barra di scorrimento schermo web webview indirizzi link incorporato pagina schede focus clic mouse attivazione segue primo editor file codice apri percorso • %@ aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href 터미널 셸 스크롤백 스크롤바 화면 브라우저 웹 웹뷰 주소 표시줄 링크 내장 페이지 탭 포커스 클릭 마우스 활성화 따름 첫 번째 편집기 파일 코드 열기 경로 브라우저: %@ • 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href skall tilbakerulling rullefelt skjerm nettleser web webvisning adresselinje lenker innebygd side faner fokus klikk mus aktivering følger første redigerer fil kode åpne bane • %@ åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href powłoka przewijanie pasek przewijania ekran przeglądarka web webview adresu linki osadzony strona karty fokus klik mysz aktywacja podąża pierwszy edytor plik kod otwórz ścieżka • %@ przeglądarkę otwarty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href shell histórico barra de rolagem tela navegador web webview endereço urls incorporado página abas foco clique mouse ativação segue primeiro editor arquivo código abrir caminho • %@ aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href терминал оболочка история прокрутки полоса экран браузер веб webview адресная строка ссылки встроенный страница вкладки фокус щелчок мышь активация следует первый редактор файл код открыть путь • %@ открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ ฝัง หน้า แท็บ โฟกัส คลิก เมาส์ เปิดใช้งาน ตาม ครั้งแรก ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง • %@ เปิดเบราว์เซอร์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href kabuk geri kaydırma çubuğu ekran tarayıcı web webview adres bağlantılar gömülü sayfa sekmeler odak tık fare etkinleştirme izler ilk düzenleyici dosya kod aç yol • %@ Tarayıcıyı açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href 终端 shell 回滚 滚动条 屏幕 浏览器 网页 WebView 地址栏 链接 内嵌 页面 标签页 焦点 点击 鼠标 激活 跟随 首次 编辑器 文件 代码 打开 路径 • %@ 打开浏览器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href 終端機 shell 回捲 捲動列 螢幕 瀏覽器 網頁 WebView 位址列 連結 內嵌 頁面 分頁 焦點 點按 滑鼠 啟用 跟隨 首次 編輯器 檔案 程式碼 開啟 路徑 • %@ 開啟瀏覽器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.openTerminalLinksInCmuxBrowser click url terminal links open in browser href термінал shell історія прокручування смуга екран браузер веб webview адресний рядок посилання вбудований сторінка вкладки фокус клацання миша активація слідує перший редактор файл код відкрити шлях Браузер: %@ • відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.intercept-open": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept open コマンド http https url ターミナル インターセプト"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept open コマンド http https url ターミナル インターセプト"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept طرفية صدفة تمرير سجل شريط شاشة متصفح ويب عرض العنوان روابط عناوين مضمّن صفحة تبويبات محرر ملف كود فتح مسار المتصفح • %@ الطرفية مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell povratni zapis traka za pomicanje ekran preglednik web webview adresna linkovi ugrađen stranica kartice editor datoteka kod otvori putanja • %@ otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell scrollback rullepanel skærm browser web webvisning adresselinje links indlejret side faner editor fil kode åbn sti • %@ åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell scrollback scrollleiste bildschirm browser web webview adressleiste links urls eingebettet seite tabs editor datei code öffnen pfad • %@ offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell historial barra de desplazamiento pantalla navegador web webview direcciones enlaces urls integrado página pestañas editor archivo código abrir ruta • %@ abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell historique barre de défilement écran navigateur web webview adresse liens urls intégré page onglets éditeur fichier code ouvrir chemin • %@ le ouverte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept terminale shell cronologia barra di scorrimento schermo browser web webview indirizzi link incorporato pagina schede editor file codice apri percorso • %@ aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept 터미널 셸 스크롤백 스크롤바 화면 브라우저 웹 웹뷰 주소 표시줄 링크 내장 페이지 탭 편집기 파일 코드 열기 경로 브라우저: %@ • 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept skall tilbakerulling rullefelt skjerm nettleser web webvisning adresselinje lenker innebygd side faner redigerer fil kode åpne bane • %@ åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept powłoka przewijanie pasek przewijania ekran przeglądarka web webview adresu linki osadzony strona karty edytor plik kod otwórz ścieżka • %@ przeglądarkę otwarty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept shell histórico barra de rolagem tela navegador web webview endereço links urls incorporado página abas editor arquivo código abrir caminho • %@ aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept терминал оболочка история прокрутки полоса экран браузер веб webview адресная строка ссылки встроенный страница вкладки редактор файл код открыть путь • %@ открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept เทอร์มินัล เชลล์ ประวัติเลื่อน แถบเลื่อน หน้าจอ เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ ฝัง หน้า แท็บ ตัวแก้ไข ไฟล์ โค้ด เปิด เส้นทาง • %@ เปิดเบราว์เซอร์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept kabuk geri kaydırma çubuğu ekran tarayıcı web webview adres bağlantılar gömülü sayfa sekmeler düzenleyici dosya kod aç yol • %@ Tarayıcıyı açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept 终端 shell 回滚 滚动条 屏幕 浏览器 网页 WebView 地址栏 链接 内嵌 页面 标签页 编辑器 文件 代码 打开 路径 • %@ 打开浏览器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept 終端機 shell 回捲 捲動列 螢幕 瀏覽器 網頁 WebView 位址列 連結 內嵌 頁面 分頁 編輯器 檔案 程式碼 開啟 路徑 • %@ 開啟瀏覽器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.interceptTerminalOpenCommandInCmuxBrowser open command http https url terminal intercept термінал shell історія прокручування смуга екран браузер веб webview адресний рядок посилання вбудований сторінка вкладки редактор файл код відкрити шлях Браузер: %@ • відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.host-whitelist": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 許可リスト ホワイトリスト ホスト ワイルドカード ドメイン 内蔵ブラウザ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 許可リスト ホワイトリスト ホスト ワイルドカード ドメイン 内蔵ブラウザ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser preglednik web webview adresna traka linkovi url ugrađen stranica kartice • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser web webvisning adresselinje links url indlejret side faner • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser web webview adressleiste links urls eingebettet seite tabs • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser navegador web webview barra de direcciones enlaces urls integrado página pestañas • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser navigateur web webview barre adresse liens urls intégré page onglets • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser web webview barra indirizzi link url incorporato pagina schede • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser nettleser web webvisning adresselinje lenker url innebygd side faner • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser przeglądarka web webview pasek adresu linki url osadzony strona karty • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser navegador web webview barra de endereço links urls incorporado página abas • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser браузер веб webview адресная строка ссылки url встроенный страница вкладки • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.hostsToOpenInEmbeddedBrowser allowlist whitelist host wildcard domain embedded browser браузер веб webview адресний рядок посилання url вбудований сторінка вкладки Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.external-patterns": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 拒否リスト ブロックリスト regex ルール 外部 デフォルトブラウザ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 拒否リスト ブロックリスト regex ルール 外部 デフォルトブラウザ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات إعادة ضبط مصنع افتراضي استعادة مسح المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser preglednik web webview adresna traka linkovi url ugrađen stranica kartice reset fabrički zadano vrati očisti • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser web webvisning adresselinje links url indlejret side faner nulstil fabrik standard gendan ryd • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser web webview adressleiste links urls eingebettet seite tabs zurücksetzen werkseinstellungen standard wiederherstellen löschen • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser navegador web webview barra de direcciones enlaces urls integrado página pestañas restablecer fábrica predeterminado restaurar borrar • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser navigateur web webview barre adresse liens urls intégré page onglets réinitialiser usine défaut restaurer effacer • %@ Par"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser web webview barra indirizzi link url incorporato pagina schede reimposta fabbrica predefinito ripristina cancella • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 재설정 초기화 기본값 복원 지우기 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser nettleser web webvisning adresselinje lenker url innebygd side faner tilbakestill fabrikk standard gjenopprett tøm • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser przeglądarka web webview pasek adresu linki url osadzony strona karty reset fabryczne domyślne przywróć wyczyść • %@ Domyślny"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser navegador web webview barra de endereço links urls incorporado página abas redefinir fábrica padrão restaurar limpar • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser браузер веб webview адресная строка ссылки url встроенный страница вкладки сброс заводские по умолчанию восстановить очистить • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler sıfırla fabrika varsayılan geri yükle temizle • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 重置 出厂 默认 恢复 清除 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 重置 出廠 預設 還原 清除 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.urlsToAlwaysOpenExternally denylist blocklist regex rules external default browser браузер веб webview адресний рядок посилання url вбудований сторінка вкладки скидання заводські типові відновити очистити Стандартний Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.http-allowlist": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 安全でない http 許可リスト localhost localtest 非https 警告"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 安全でない http 許可リスト localhost localtest 非https 警告"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن غير آمن المتصفح • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning preglednik web webview adresna traka linkovi url ugrađen stranica kartice lozinka tajna token vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning browser web webvisning adresselinje links url indlejret side faner adgangskode hemmelighed token legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning browser web webview adressleiste links urls eingebettet seite tabs passwort geheimnis token zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning navegador web webview barra de direcciones enlaces urls integrado página pestañas contraseña secreto token credencial acceso permitir desactivar activar permiso inseguro • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning navigateur web webview barre adresse liens urls intégré page onglets mot de passe secret jeton identifiant accès autoriser désactiver activer autorisation non sécurisé • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning browser web webview barra indirizzi link url incorporato pagina schede password segreto token credenziale accesso consenti disabilita abilita autorizzazione non sicuro • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음 브라우저: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning nettleser web webvisning adresselinje lenker url innebygd side faner passord hemmelighet token legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning przeglądarka web webview pasek adresu linki url osadzony strona karty hasło sekret token poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning navegador web webview barra de endereço links urls incorporado página abas senha segredo token credencial acesso permitir desativar ativar permissão inseguro • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning браузер веб webview адресная строка ссылки url встроенный страница вкладки пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler parola gizli token kimlik bilgisi erişim izin ver devre dışı etkinleştir güvensiz • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.insecureHttpHostsAllowedInEmbeddedBrowser insecure http allowlist localhost localtest non-https warning браузер веб webview адресний рядок посилання url вбудований сторінка вкладки пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно Браузер: %@ •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browserImport.import-data": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル 移行"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration chrome safari firefox brave edge arc ブックマーク 履歴 cookie プロファイル 移行"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration uvoz migracija oznake historija kolačići profili"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration import migrering bogmærker historik profiler"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration import lesezeichen verlauf profile"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration importar migración marcadores historial perfiles"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration importer favoris historique profils"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration importa migrazione segnalibri cronologia cookie profili"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 + 가져오기…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration import migrering bokmerker historikk informasjonskapsler profiler"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration import migracja zakładki historia ciasteczka profile"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration importar migração favoritos histórico perfis"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration импорт миграция закладки история профили"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration içe aktar geçiş yer imleri geçmiş çerezler profiller"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration 导入 迁移 书签 历史记录 Cookie 个人资料"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "chrome safari firefox brave edge arc bookmarks history cookies profiles migration імпорт міграція закладки історія профілі + Імпортувати… Імпортувати"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browserImport.import-hint": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 空のタブ オンボーディング ヒント インポート プロンプト 非表示"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 空のタブ オンボーディング ヒント インポート プロンプト 非表示"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة المتصفح لسان • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss preglednik web webview adresna traka linkovi url ugrađen stranica kartice uvoz migracija oznake historija kolačići profili radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka • %@"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss browser web webvisning adresselinje links url indlejret side faner migrering bogmærker historik cookies profiler arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik • %@"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss browser web webview adressleiste links urls eingebettet seite tabs migration lesezeichen verlauf cookies profile arbeitsbereich farben palette badge ausgewählt hervorhebung indikator aktiv punkt • %@"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss navegador web webview barra de direcciones enlaces urls integrado página pestañas importar migración marcadores historial cookies perfiles espacio trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto • %@"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss navigateur web webview barre adresse liens urls intégré page onglets importer migration favoris historique cookies profils espace de travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point • %@"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss browser web webview barra indirizzi link url incorporato pagina schede importa migrazione segnalibri cronologia cookie profili area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 작업공간 색상 팔레트 배지 선택됨 강조 표시기 활성 점 브라우저: %@ 가져오기… •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss nettleser web webvisning adresselinje lenker url innebygd side faner migrering bokmerker historikk informasjonskapsler profiler arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk • %@"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss przeglądarka web webview pasek adresu linki url osadzony strona karty migracja zakładki historia ciasteczka profile obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka • %@"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss navegador web webview barra de endereço links urls incorporado página abas importar migração favoritos histórico cookies perfis workspace aba cores paleta selo selecionado destaque indicador ativo ponto • %@"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss браузер веб webview адресная строка ссылки url встроенный страница вкладки импорт миграция закладки история cookies профили рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка • %@"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ พื้นที่ทำงาน สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด • %@"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler içe aktar geçiş yer imleri geçmiş çerezler profiller çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta • %@"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 导入 迁移 书签 历史记录 Cookie 个人资料 工作区 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 • %@"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 工作區 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 標籤頁 • %@"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.showImportHintOnBlankTabs blank tab onboarding hint import prompt dismiss браузер веб webview адресний рядок посилання url вбудований сторінка вкладки імпорт міграція закладки історія cookies профілі робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка Браузер: %@ Імпортувати… Імпортувати •"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.react-grab": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component react grab npm バージョン ツールバー inspect コンポーネント"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component react grab npm バージョン ツールバー inspect コンポーネント"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات الإصدار المتصفح • %@ الإصدار:"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component preglednik web webview adresna traka linkovi url ugrađen stranica kartice Verzija • %@ Verzija:"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component browser web webvisning adresselinje links url indlejret side faner • %@ Version:"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component browser web webview adressleiste links urls eingebettet seite tabs • %@ Version:"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component navegador web webview barra de direcciones enlaces urls integrado página pestañas Versión • %@ Versión:"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component navigateur web webview barre adresse liens urls intégré page onglets • %@ :"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component browser web webview barra indirizzi link url incorporato pagina schede Versione • %@ Versione:"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 버전 브라우저: %@ • 버전:"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component nettleser web webvisning adresselinje lenker url innebygd side faner Versjon • %@ Versjon:"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component przeglądarka web webview pasek adresu linki url osadzony strona karty Wersja • %@ Wersja:"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component navegador web webview barra de endereço links urls incorporado página abas Versão • %@ Versão:"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component браузер веб webview адресная строка ссылки url встроенный страница вкладки Версия • %@ Версия:"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ เวอร์ชัน • %@ เวอร์ชัน:"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler Sürüm • %@ Sürüm:"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 版本 • %@ 版本："
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 版本 • %@ 版本："
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "browser.reactGrabVersion react grab npm version toolbar cmd-shift-g inspect component браузер веб webview адресний рядок посилання url вбудований сторінка вкладки Версія Браузер: %@ • Версія:"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.browser.history": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "clear browser history visited pages suggestions omnibar"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "clear browser history visited pages suggestions omnibar ブラウザ履歴 閲覧履歴 訪問ページ サジェスト オムニバー 消去"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar ブラウザ履歴 閲覧履歴 訪問ページ サジェスト オムニバー 消去"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar متصفح ويب عرض شريط العنوان روابط عناوين مضمّن صفحة تبويبات استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية إعادة ضبط مصنع افتراضي استعادة مسح بحث اقتراحات إكمال تلقائي مزود محرك المتصفح • %@ السجل… السجل المتصفح؟"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar preglednik web webview adresna traka linkovi url ugrađen stranica kartice uvoz migracija oznake historija kolačići profili reset fabrički zadano vrati očisti pretraga prijedlozi automatsko dovršavanje pružatelj pretraživač Obriši historiju preglednika • %@ historiju… Obrisati preglednika?"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar web webvisning adresselinje links url indlejret side faner import migrering bogmærker historik cookies profiler nulstil fabrik standard gendan ryd søgning forslag autofuldførelse udbyder søgemaskine browserhistorik • %@ historik… browserhistorik?"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar web webview adressleiste links urls eingebettet seite tabs import migration lesezeichen verlauf cookies profile zurücksetzen werkseinstellungen standard wiederherstellen löschen suche vorschläge autovervollständigung anbieter suchmaschine Browserverlauf • %@ … löschen?"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar navegador web webview barra de direcciones enlaces urls integrado página pestañas importar migración marcadores historial cookies perfiles restablecer fábrica predeterminado restaurar borrar búsqueda sugerencias autocompletar proveedor motor del • %@ historial… ¿Borrar navegador?"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar navigateur web webview barre adresse liens urls intégré page onglets importer migration favoris historique cookies profils réinitialiser usine défaut restaurer effacer recherche saisie automatique fournisseur moteur de l'historique du • %@ l'historique... ?"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar web webview barra indirizzi link url incorporato pagina schede importa migrazione segnalibri cronologia cookie profili reimposta fabbrica predefinito ripristina cancella ricerca suggerimenti completamento automatico provider motore di • %@ cronologia… Cancellare la del browser?"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar 브라우저 웹 웹뷰 주소 표시줄 링크 url 내장 페이지 탭 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 재설정 초기화 기본값 복원 지우기 검색 제안 자동완성 제공자 엔진 브라우저: %@ (방문한 페이지) • 지우기… 기록을 지우시겠습니까?"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar nettleser web webvisning adresselinje lenker url innebygd side faner import migrering bokmerker historikk informasjonskapsler profiler tilbakestill fabrikk standard gjenopprett tøm søk forslag autofullføring leverandør søkemotor nettleserhistorikk • %@ Fjern … Tømme nettleserhistorikk?"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar przeglądarka web webview pasek adresu linki url osadzony strona karty import migracja zakładki historia ciasteczka profile reset fabryczne domyślne przywróć wyczyść wyszukiwanie sugestie autouzupełnianie dostawca silnik wyszukiwania historię przeglądarki • %@ historię… Wyczyścić przeglądarki?"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar navegador web webview barra de endereço links urls incorporado página abas importar migração favoritos histórico cookies perfis redefinir fábrica padrão restaurar limpar pesquisa sugestões autocompletar provedor mecanismo busca do • %@ Histórico… navegador?"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar браузер веб webview адресная строка ссылки url встроенный страница вкладки импорт миграция закладки история cookies профили сброс заводские по умолчанию восстановить очистить поиск предложения автозаполнение провайдер поисковая система историю браузера • %@ историю... браузера?"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar เบราว์เซอร์ เว็บ เว็บวิว แถบที่อยู่ ลิงก์ url ฝัง หน้า แท็บ นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ค้นหา คำแนะนำ เติมอัตโนมัติ ผู้ให้บริการ เครื่องมือค้นหา ล้างประวัติเบราว์เซอร์ • %@ ล้างประวัติ... ล้างประวัติ ล้างประวัติเบราว์เซอร์หรือไม่?"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar tarayıcı web webview adres çubuğu bağlantılar url gömülü sayfa sekmeler içe aktar geçiş yer imleri geçmiş çerezler profiller sıfırla fabrika varsayılan geri yükle temizle arama öneriler otomatik tamamlama sağlayıcı motoru Geçmişini • %@ Geçmişi Temizle… temizlensin mi?"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar 浏览器 网页 WebView 地址栏 链接 URL 内嵌 页面 标签页 导入 迁移 书签 历史记录 Cookie 个人资料 重置 出厂 默认 恢复 清除 搜索 建议 自动完成 提供商 搜索引擎 清除浏览器历史记录 • %@ 清除历史记录... 清除历史记录 清除浏览器历史记录？"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar 瀏覽器 網頁 WebView 位址列 連結 URL 內嵌 頁面 分頁 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 重置 出廠 預設 還原 清除 搜尋 建議 自動完成 提供者 搜尋引擎 清除瀏覽記錄 • %@ 清除記錄... 清除記錄 要清除瀏覽記錄嗎？"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "clear browser history visited pages suggestions omnibar браузер веб webview адресний рядок посилання url вбудований сторінка вкладки імпорт міграція закладки історія cookies профілі скидання заводські типові відновити очистити пошук пропозиції автодоповнення постачальник пошукова система Браузер: %@ (відвідані сторінки) історію браузера • історію… браузера?"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.globalHotkey.enable-hotkey": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "global hotkey enable system wide show hide all windows"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "global hotkey enable system wide show hide all windows グローバルホットキー 有効 システム全体 表示 非表示 全ウィンドウ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows グローバルホットキー 有効 システム全体 表示 非表示 全ウィンドウ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع كلمة مرور سر رمز اعتماد وصول سماح تعطيل تمكين إذن غير آمن النظام عام"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows tastatura prečica prečice komande tipke snimač izgled tema boja boje shema svijetlo tamno sistem način lozinka tajna token vjerodajnica pristup dozvoli onemogući omogući dozvola nesigurno Sistemski Globalno"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows tastatur genvej genveje kommandoer taster optager udseende tema farve farver skema lys mørk tilstand adgangskode hemmelighed token legitimationsoplysninger adgang tillad deaktiver aktiver tilladelse usikker Globalt"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows tastatur kurzbefehl tastenkürzel befehle tasten rekorder darstellung design farbe farben schema hell dunkel modus passwort geheimnis token zugangsdaten zugriff erlauben deaktivieren aktivieren berechtigung unsicher"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows teclado atajo atajos tecla rápida comandos teclas grabador apariencia tema color colores esquema claro oscuro sistema modo contraseña secreto token credencial acceso permitir desactivar activar permiso inseguro"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows clavier raccourci raccourcis touche globale commandes touches enregistreur apparence thème couleur couleurs schéma clair sombre système mode mot de passe secret jeton identifiant accès autoriser désactiver activer autorisation non sécurisé Général"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore aspetto tema colore colori schema chiaro scuro sistema modalità password segreto token credenziale accesso consenti disabilita abilita autorizzazione non sicuro Globale"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows 키보드 단축키 핫키 명령 키 기록기 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 비밀번호 비밀 토큰 자격 증명 접근 허용 비활성화 활성화 권한 안전하지 않음 전역 글로벌 모든 윈도우 표시/숨기기"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows tastatur snarvei snarveier hurtigtast kommandoer taster opptaker utseende tema farge farger skjema lys mørk modus passord hemmelighet token legitimasjon tilgang tillat deaktiver aktiver tillatelse usikker Globalt"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows klawiatura skrót skróty klawisz polecenia klawisze rejestrator wygląd motyw kolor kolory schemat jasny ciemny tryb hasło sekret token poświadczenie dostęp zezwól wyłącz włącz uprawnienie niezabezpieczone Systemowy Globalne"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows teclado atalho atalhos tecla rápida comandos teclas gravador aparência tema cor cores esquema claro escuro sistema modo senha segredo token credencial acesso permitir desativar ativar permissão inseguro"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows клавиатура сочетание клавиш горячая клавиша команды клавиши запись внешний вид тема цвет цвета схема светлый темный система режим пароль секрет токен учетные данные доступ разрешить отключить включить разрешение небезопасно Системное Глобальные Системный Системная"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด รหัสผ่าน ความลับ โทเค็น ข้อมูลรับรอง เข้าถึง อนุญาต ปิด เปิด สิทธิ์ ไม่ปลอดภัย ทั่วไป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici görünüm tema renk renkler şema açık koyu sistem mod parola gizli token kimlik bilgisi erişim izin ver devre dışı etkinleştir güvensiz Genel"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows 键盘 快捷键 热键 命令 按键 录制器 外观 主题 颜色 配色 浅色 深色 系统 模式 密码 密钥 令牌 凭据 访问 允许 禁用 启用 权限 不安全 全局"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 外觀 主題 顏色 配色 淺色 深色 系統 模式 密碼 密鑰 權杖 憑證 存取 允許 停用 啟用 權限 不安全 全域"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey enable system wide show hide all windows клавіатура скорочення гарячі клавіші команди записувач вигляд тема колір кольори схема світлий темний система режим пароль секрет токен облікові дані доступ дозволити вимкнути увімкнути дозвіл небезпечно Системна Глобальна"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.globalHotkey.shortcut": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "global hotkey shortcut recorder key command option control"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "global hotkey shortcut recorder key command option control グローバルホットキー ショートカット レコーダー command option control"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control グローバルホットキー ショートカット レコーダー command option control"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control أتمتة واجهة برمجة سطر أوامر تحكم مأخذ وكيل خطافات منافذ بيئة لوحة مفاتيح اختصار اختصارات مفتاح سريع تسجيل عام"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatizacija api cli kontrola socket agent kuke portovi okruženje tastatura prečica prečice komande tipke snimač Globalno"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatisering api cli kontrol socket agent hooks porte miljø tastatur genvej genveje kommandoer taster optager Globalt"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatisierung api cli steuerung socket agent hooks ports umgebung tastatur kurzbefehl tastenkürzel befehle tasten rekorder"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatización api cli socket agente hooks puertos entorno teclado atajo atajos tecla rápida comandos teclas grabador"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatisation api cli contrôle socket agent hooks ports environnement clavier raccourci raccourcis touche globale commandes touches enregistreur Général"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automazione api cli controllo socket agente hook porte ambiente tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore Globale"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control 자동화 api cli 제어 소켓 에이전트 훅 포트 환경 키보드 단축키 핫키 명령 키 기록기 전역 글로벌"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatisering api cli kontroll socket agent hooks porter miljø tastatur snarvei snarveier hurtigtast kommandoer taster opptaker Globalt"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automatyzacja api cli sterowanie gniazdo agent haki porty środowisko klawiatura skrót skróty klawisz polecenia klawisze rejestrator Globalne"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control automação api cli controle socket agente hooks portas ambiente teclado atalho atalhos tecla rápida comandos teclas gravador"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control автоматизация api cli управление сокет агент хуки порты окружение клавиатура сочетание клавиш горячая клавиша команды клавиши запись Глобальные"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control อัตโนมัติ api cli ควบคุม ซ็อกเก็ต เอเจนต์ ฮุก พอร์ต สภาพแวดล้อม แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก ทั่วไป"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control otomasyon api cli kontrol soket ajan kancalar portlar ortam klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici Genel"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control 自动化 api cli 控制 套接字 代理 钩子 端口 环境 键盘 快捷键 热键 命令 按键 录制器 全局"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control 自動化 api cli 控制 socket 代理程式 hook 連接埠 環境 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 全域"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "global hotkey shortcut recorder key command option control автоматизація api cli керування сокет агент хуки порти середовище клавіатура скорочення гарячі клавіші команди записувач Глобальна"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.keyboardShortcuts.shortcut-chords": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tmux prefix プレフィックス ctrl-b control-b 複数キー シーケンス コード settings json"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tmux prefix プレフィックス ctrl-b control-b 複数キー シーケンス コード settings json"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل إعدادات تكوين ملف مخطط وثائق مرجع تفضيلات الإعدادات… الإعدادات"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tastatura prečica prečice hotkey komande tipke snimač postavke konfiguracija datoteka šema dokumentacija referenca preferencije Postavke…"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tastatur genvej genveje hotkey kommandoer taster optager indstillinger konfiguration fil skema dokumentation reference præferencer Indstillinger…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder einstellungen konfiguration datei schema dokumentation referenz präferenzen …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json teclado atajo atajos tecla rápida comandos teclas grabador ajustes configuración archivo esquema documentación referencia preferencias Ajustes…"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json clavier raccourci raccourcis touche globale commandes touches enregistreur réglages configuration fichier schéma documentation référence préférences Réglages..."
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore impostazioni configurazione file schema documentazione riferimento preferenze Impostazioni…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json 키보드 단축키 핫키 명령 키 기록기 설정 구성 파일 스키마 문서 참조 환경설정 설정… settings.json 조합"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json tastatur snarvei snarveier hurtigtast kommandoer taster opptaker innstillinger konfigurasjon fil skjema dokumentasjon referanse preferanser …"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json klawiatura skrót skróty klawisz polecenia klawisze rejestrator ustawienia konfiguracja plik schemat dokumentacja referencja preferencje Ustawienia…"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json teclado atalho atalhos tecla rápida comandos teclas gravador configurações configuração arquivo esquema documentação referência preferências Ajustes… Ajustes"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json клавиатура сочетание клавиш горячая клавиша команды клавиши запись настройки конфигурация файл схема документация справочник предпочтения Настройки..."
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก การตั้งค่า การกำหนดค่า ไฟล์ สคีมา เอกสาร อ้างอิง ค่ากำหนด การตั้งค่า..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici ayarlar yapılandırma dosya şema belgeler başvuru tercihler Ayarlar…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json 键盘 快捷键 热键 命令 按键 录制器 设置 配置 文件 架构 文档 参考 偏好设置 设置..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 設定 設定檔 檔案 結構描述 文件 參考 偏好設定 設定..."
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "tmux prefix ctrl-b control-b multi key sequence chord settings json клавіатура скорочення гарячі клавіші команди записувач налаштування конфігурація файл схема документація довідник параметри Налаштування…"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.keyboardShortcuts.show-hints": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills コマンド長押し ctrl 長押し キーヒント 修飾キー オーバーレイ ピル"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills コマンド長押し ctrl 長押し キーヒント 修飾キー オーバーレイ ピル"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills tastatura prečica prečice hotkey komande tipke snimač"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills tastatur genvej genveje hotkey kommandoer taster optager"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills teclado atajo atajos tecla rápida comandos teclas grabador"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills clavier raccourci raccourcis touche globale commandes touches enregistreur"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills 키보드 단축키 핫키 명령 키 기록기"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills tastatur snarvei snarveier hurtigtast kommandoer taster opptaker"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills klawiatura skrót skróty klawisz polecenia klawisze rejestrator"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills teclado atalho atalhos tecla rápida comandos teclas gravador"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills клавиатура сочетание клавиш горячая клавиша команды клавиши запись"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills 键盘 快捷键 热键 命令 按键 录制器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "shortcuts.showModifierHoldHints hold command ctrl key hints modifier overlay pills клавіатура скорочення гарячі клавіші команди записувач"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.keyboardShortcuts.shortcuts": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json ホットキー キーバインド キー割り当て コマンド キーボード ショートカット settings json"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json ホットキー キーバインド キー割り当て コマンド キーボード ショートカット settings json"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل إعدادات تكوين ملف مخطط وثائق مرجع تفضيلات الإعدادات… المفاتيح الإعدادات"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json tastatura prečica prečice hotkey komande tipke snimač postavke konfiguracija datoteka šema dokumentacija referenca preferencije Postavke… na tastaturi"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json tastatur genvej genveje hotkey kommandoer taster optager indstillinger konfiguration fil skema dokumentation reference præferencer Indstillinger… Tastaturgenveje"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder einstellungen konfiguration datei schema dokumentation referenz präferenzen … Tastaturkurzbefehle"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json teclado atajo atajos tecla rápida comandos teclas grabador ajustes configuración archivo esquema documentación referencia preferencias Ajustes… de"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json clavier raccourci raccourcis touche globale commandes touches enregistreur réglages configuration fichier schéma documentation référence préférences Réglages..."
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore impostazioni configurazione file schema documentazione riferimento preferenze Impostazioni… Abbreviazioni da"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json 키보드 단축키 핫키 명령 키 기록기 설정 구성 파일 스키마 문서 참조 환경설정 설정… settings.json"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json tastatur snarvei snarveier hurtigtast kommandoer taster opptaker innstillinger konfigurasjon fil skjema dokumentasjon referanse preferanser … Tastatursnarveier"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json klawiatura skrót skróty klawisz polecenia klawisze rejestrator ustawienia konfiguracja plik schemat dokumentacja referencja preferencje Ustawienia… klawiaturowe"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json teclado atalho atalhos tecla rápida comandos teclas gravador configurações configuração arquivo esquema documentação referência preferências Ajustes… de Ajustes"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json клавиатура сочетание клавиш горячая клавиша команды клавиши запись настройки конфигурация файл схема документация справочник предпочтения Настройки... Сочетания"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก การตั้งค่า การกำหนดค่า ไฟล์ สคีมา เอกสาร อ้างอิง ค่ากำหนด การตั้งค่า... แป้นพิมพ์ลัด"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici ayarlar yapılandırma dosya şema belgeler başvuru tercihler Ayarlar… Kısayolları"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json 键盘 快捷键 热键 命令 按键 录制器 设置 配置 文件 架构 文档 参考 偏好设置 设置... 键盘快捷键"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 設定 設定檔 檔案 結構描述 文件 參考 偏好設定 設定... 鍵盤快速鍵"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "hotkeys keybindings key bindings commands keyboard accelerators shortcuts settings json клавіатура скорочення гарячі клавіші команди записувач налаштування конфігурація файл схема документація довідник параметри Налаштування… Комбінації клавіш"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.workspaceColors.indicator": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot ワークスペース タブ インジケータ アクティブ 色 ストライプ ドット"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot ワークスペース タブ インジケータ アクティブ 色 ストライプ ドット"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة مظهر سمة لون مخطط فاتح داكن نظام وضع لسان العمل • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka izgled tema boja shema svijetlo tamno sistem način • %@ radnog prostora"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik udseende tema farve skema lys mørk system tilstand • %@ Arbejdsområdefarve Arbejdsområdefarveindikator"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot arbeitsbereich farben palette badge ausgewählt hervorhebung indikator aktiv punkt darstellung design farbe schema hell dunkel system modus • %@ Arbeitsbereichsfarbe Arbeitsbereichsfarb-Indikator"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot espacio de trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto apariencia tema esquema claro oscuro sistema modo • %@ del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot espace de travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point apparence thème couleur schéma clair sombre système mode • %@ l'espace d'espace"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto aspetto tema colore schema chiaro scuro sistema modalità • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 작업 공간 • %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk utseende tema farge skjema lys mørk system modus • %@ Arbeidsområdefarge Arbeidsområdefarge-indikator"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka wygląd motyw kolor schemat jasny ciemny system tryb Przestrzeń robocza • %@ przestrzeni roboczej koloru"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot aba cores paleta selo selecionado destaque indicador ativo ponto aparência tema cor esquema claro escuro sistema modo Área de Trabalho • %@ da"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка внешний вид тема цвет схема светлый темный система режим Рабочее пространство • %@ рабочего пространства Активное"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ลักษณะ ธีม โครงร่าง สว่าง มืด ระบบ โหมด เวิร์กสเปซ • %@ สีเวิร์กสเปซ ใช้งานอยู่ ตัวบ่งชี้สีเวิร์กสเปซ"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta görünüm tema renk şema açık koyu sistem mod • %@ Rengi Etkin Göstergesi"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 外观 主题 配色 浅色 深色 系统 模式 • %@ 工作区颜色 活跃 工作区颜色指示器"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 外觀 主題 配色 淺色 深色 系統 模式 標籤頁 • %@ 工作區顏色 使用中 工作區顏色指示器"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.indicatorStyle tab indicator active workspace style color stripe dot робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка вигляд тема колір схема світлий темний система режим Робоча область • %@ робочої області кольору"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.workspaceColors.selection": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.selectionColor selected workspace color highlight background active tab"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 選択中 ワークスペース 色 ハイライト 背景 アクティブタブ"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 選択中 ワークスペース 色 ハイライト 背景 アクティブタブ"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة مظهر سمة لون مخطط فاتح داكن نظام وضع لسان العمل • %@"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka izgled tema boja shema svijetlo tamno sistem način • %@ radnog prostora"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab arbejdsområde fane farver palette badge valgt fremhævning indikator aktiv prik udseende tema farve skema lys mørk system tilstand • %@ Arbejdsområdefarve"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab arbeitsbereich farben palette badge ausgewählt hervorhebung indikator aktiv punkt darstellung design farbe schema hell dunkel system modus • %@ Arbeitsbereichsfarbe"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab espacio de trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto apariencia tema esquema claro oscuro sistema modo • %@ del"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab espace de travail onglet couleurs palette badge sélectionné surbrillance indicateur actif point apparence thème couleur schéma clair sombre système mode • %@ l'espace"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto aspetto tema colore schema chiaro scuro sistema modalità • %@"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 작업 공간 • %@"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk utseende tema farge skjema lys mørk system modus • %@ Arbeidsområdefarge"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka wygląd motyw kolor schemat jasny ciemny system tryb Przestrzeń robocza • %@ przestrzeni roboczej"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab aba cores paleta selo selecionado destaque indicador ativo ponto aparência tema cor esquema claro escuro sistema modo Área de Trabalho • %@ da"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка внешний вид тема цвет схема светлый темный система режим Рабочее пространство • %@ рабочего пространства Активное"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ลักษณะ ธีม โครงร่าง สว่าง มืด ระบบ โหมด เวิร์กสเปซ • %@ สีเวิร์กสเปซ ใช้งานอยู่"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta görünüm tema renk şema açık koyu sistem mod • %@ Rengi Etkin"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 外观 主题 配色 浅色 深色 系统 模式 • %@ 工作区颜色 活跃"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 外觀 主題 配色 淺色 深色 系統 模式 標籤頁 • %@ 工作區顏色 使用中"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.selectionColor selected workspace color highlight background active tab робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка вигляд тема колір схема світлий темний система режим Робоча область • %@ робочої області"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.workspaceColors.badge": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 未読 通知 バッジ 色 ドット 件数"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 未読 通知 バッジ 色 ドット 件数"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة مظهر سمة لون مخطط فاتح داكن نظام وضع إشعار إشعارات تنبيه غير مقروء رسالة رنين وميض صوت سطح المكتب واحد"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka izgled tema boja shema svijetlo tamno sistem način obavijest obavijesti upozorenje nepročitano poruka prsten bljesak zvuk desktop 1 obavještenje"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count arbejdsområde fane farver palette valgt fremhævning indikator aktiv prik udseende tema farve skema lys mørk system tilstand notifikation notifikationer advarsel ulæst besked ring blink lyd skrivebord 1"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count arbeitsbereich tab farben palette ausgewählt hervorhebung indikator aktiv punkt darstellung design farbe schema hell dunkel system modus benachrichtigung benachrichtigungen alarm ungelesen nachricht ring blinken ton desktop 1 ungelesene"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count espacio de trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto apariencia tema esquema claro oscuro sistema modo notificación notificaciones alerta no leído mensaje anillo destello sonido escritorio 1 leída"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count espace de travail onglet couleurs palette sélectionné surbrillance indicateur actif point apparence thème couleur schéma clair sombre système mode notifications alerte non lu message anneau flash son bureau 1 lue"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count area di lavoro scheda colori tavolozza selezionato evidenziazione indicatore attivo punto aspetto tema colore schema chiaro scuro sistema modalità notifica notifiche avviso non letto messaggio anello lampeggio suono scrivania 1 letta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 외관 테마 색 구성표 라이트 다크 시스템 모드 알림 읽지 않음 메시지 링 깜박임 소리 데스크탑 경고 않은 1개"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk utseende tema farge skjema lys mørk system modus varsling varsler ulest melding ring blink lyd skrivebord 1 varsel"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka wygląd motyw kolor schemat jasny ciemny system tryb powiadomienie powiadomienia alert nieprzeczytane wiadomość pierścień błysk dźwięk pulpit 1"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count workspace aba cores paleta selo selecionado destaque indicador ativo ponto aparência tema cor esquema claro escuro sistema modo notificação notificações alerta não lido mensagem anel piscar som desktop 1 lida"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка внешний вид тема цвет схема светлый темный система режим уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол 1"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด ลักษณะ ธีม โครงร่าง สว่าง มืด ระบบ โหมด การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ วงแหวน แฟลช เสียง เดสก์ท็อป 1 การแจ้งเตือนที่ยังไม่อ่าน"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta görünüm tema renk şema açık koyu sistem mod bildirim bildirimler uyarı okunmamış mesaj halka flaş ses masaüstü 1"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 外观 主题 配色 浅色 深色 系统 模式 通知 未读 消息 圆环 闪烁 声音 桌面 提醒 1 条未读通知"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 外觀 主題 配色 淺色 深色 系統 模式 通知 未讀 訊息 圓環 閃爍 聲音 桌面 提醒 1 則未讀通知"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.notificationBadgeColor unread notification badge color dot count робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка вигляд тема колір схема світлий темний система режим сповіщення непрочитане повідомлення кільце спалах звук стіл 1"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.workspaceColors.palette": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.colors workspace palette named colors custom color reset built-in"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "workspaceColors.colors workspace palette named colors custom color reset built-in ワークスペース パレット 名前付き色 カスタム色 リセット 組み込み"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in ワークスペース パレット 名前付き色 カスタム色 リセット 組み込み"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in مساحة عمل تبويب ألوان لوحة شارة محدد تمييز مؤشر نشط نقطة إعادة ضبط مصنع افتراضي استعادة مسح مظهر سمة لون مخطط فاتح داكن نظام وضع مخصص العمل مخصص: %@ • التعيين مخصصة تعيين اللوحة"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in radni prostor kartica boje paleta značka odabrano isticanje indikator aktivno tačka fabrički zadano vrati očisti izgled tema boja shema svijetlo tamno sistem način Prilagođena radnog prostora Prilagođeno: %@ • Resetovanje Prilagođene Resetuj paletu"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in arbejdsområde fane farver badge valgt fremhævning indikator aktiv prik nulstil fabrik standard gendan ryd udseende tema farve skema lys mørk system tilstand Tilpasset arbejdsområdefarve Brugerdefineret: %@ • Arbejdsområdefarver Brugerdefinerede"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in arbeitsbereich tab farben badge ausgewählt hervorhebung indikator aktiv punkt zurücksetzen werkseinstellungen standard wiederherstellen löschen darstellung design farbe schema hell dunkel system modus Benutzerdefinierte Arbeitsbereichsfarbe Benutzerdefiniert: %@ • Arbeitsbereichsfarben"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in espacio de trabajo pestaña colores paleta insignia seleccionado resaltado indicador activo punto restablecer fábrica predeterminado restaurar borrar apariencia tema esquema claro oscuro sistema modo personalizado del Personalizado: %@ • espacios personalizados"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in espace de travail onglet couleurs badge sélectionné surbrillance indicateur actif point réinitialiser usine défaut restaurer effacer apparence thème couleur schéma clair sombre système mode personnalisée l'espace Personnalisé : %@ • des espaces personnalisées la"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in area di lavoro scheda colori tavolozza badge selezionato evidenziazione indicatore attivo punto reimposta fabbrica predefinito ripristina cancella aspetto tema colore schema chiaro scuro sistema modalità personalizzato Personalizzato: %@ • personalizzati"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in 작업공간 탭 색상 팔레트 배지 선택됨 강조 표시기 활성 점 재설정 초기화 기본값 복원 지우기 외관 테마 색 구성표 라이트 다크 시스템 모드 사용자 지정 작업 공간 정의: %@ •"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in arbeidsområde fane farger palett merke valgt utheving indikator aktiv prikk tilbakestill fabrikk standard gjenopprett tøm utseende tema farge skjema lys mørk system modus Egendefinert arbeidsområdefarge Egendefinert: %@ • Arbeidsområdefarger Egendefinerte"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in obszar roboczy karta kolory paleta odznaka zaznaczone podświetlenie wskaźnik aktywny kropka fabryczne domyślne przywróć wyczyść wygląd motyw kolor schemat jasny ciemny system tryb Własny przestrzeni roboczej Przestrzeń robocza Niestandardowe: %@ • Resetuj roboczych Własne paletę"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in aba cores paleta selo selecionado destaque indicador ativo ponto redefinir fábrica padrão restaurar limpar aparência tema cor esquema claro escuro sistema modo Personalizada da Área de Trabalho Personalizado: %@ • Personalizadas"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in рабочая область вкладка цвета палитра значок выбранный подсветка индикатор активный точка сброс заводские по умолчанию восстановить очистить внешний вид тема цвет схема светлый темный система режим Пользовательский рабочего пространства Рабочее пространство Пользовательское: %@ • рабочих пространств Пользовательские Сбросить палитру"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in พื้นที่ทำงาน แท็บ สี จานสี ป้าย เลือก ไฮไลต์ ตัวบ่งชี้ ใช้งาน จุด รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ลักษณะ ธีม โครงร่าง สว่าง มืด ระบบ โหมด สีเวิร์กสเปซที่กำหนดเอง เวิร์กสเปซ กำหนดเอง: %@ • สีเวิร์กสเปซ สีที่กำหนดเอง รีเซ็ตจานสี"
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in çalışma alanı sekme renkler palet rozet seçili vurgulama gösterge aktif nokta sıfırla fabrika varsayılan geri yükle temizle görünüm tema renk şema açık koyu sistem mod Özel Rengi Özel: %@ • Renkleri Paleti"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in 工作区 标签页 颜色 调色板 徽章 已选中 高亮 指示器 活动 点 重置 出厂 默认 恢复 清除 外观 主题 配色 浅色 深色 系统 模式 自定义工作区颜色 自定义: %@ • 工作区颜色 自定义颜色 重置调色板"
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in 工作區 分頁 顏色 調色盤 徽章 已選取 反白 指示器 作用中 點 重置 出廠 預設 還原 清除 外觀 主題 配色 淺色 深色 系統 模式 自訂工作區顏色 自訂: %@ • 工作區顏色 自訂顏色 重置色板"
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "workspaceColors.colors workspace palette named colors custom color reset built-in робочий простір вкладка кольори палітра значок вибрано підсвічування індикатор активний крапка скидання заводські типові відновити очистити вигляд тема колір схема світлий темний система режим Скинути Власний робочої області Робоча область Власне: %@ • робочих областей Власні палітру"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.settingsJSON.open-file": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "open settings file json jsonc config editor ~/.config cmux preferences"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "open settings file json jsonc config editor ~/.config cmux preferences settings.json を開く json jsonc 設定ファイル エディタ ドットファイル 環境設定"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences settings.json を開く json jsonc 設定ファイル エディタ ドットファイル 環境設定"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إعدادات تكوين ملف مخطط وثائق مرجع محرر كود فتح مسار cmux.json الإعدادات الإعدادات… التفضيلات… مفتوح"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences aplikacija opće postavke ponašanje dock traka menija status bočna konfiguracija datoteka šema dokumentacija referenca preferencije kod otvori putanja cmux.json Postavke… otvoren"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences app generelt indstillinger adfærd dock menulinje status sidepanel konfiguration fil skema dokumentation reference præferencer kode åbn sti cmux.json Indstillinger… åben"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences app allgemein einstellungen verhalten dock menüleiste status seitenleiste konfiguration datei schema dokumentation referenz präferenzen code öffnen pfad cmux.json … offen"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences aplicación general preferencias comportamiento dock barra de menú estado lateral ajustes configuración archivo esquema documentación referencia código abrir ruta cmux.json Ajustes… Preferencias… abierto"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences application général préférences comportement dock barre de menus état latérale réglages configuration fichier schéma documentation référence éditeur code ouvrir chemin cmux.json les Réglages... Préférences... ouverte"
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences app generale preferenze comportamento dock barra menu stato laterale impostazioni configurazione schema documentazione riferimento codice apri percorso cmux.json Impostazioni… Preferenze… aperta"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 설정 구성 파일 스키마 문서 참조 편집기 코드 열기 경로 cmux.json 설정… settings.json 환경설정… 열림"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences app generelt innstillinger oppførsel dock menylinje status sidepanel konfigurasjon fil skjema dokumentasjon referanse preferanser redigerer kode åpne bane cmux.json … åpen"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences aplikacja ogólne preferencje zachowanie dock pasek menu status boczny ustawienia konfiguracja plik schemat dokumentacja referencja edytor kod otwórz ścieżka cmux.json Ustawienia… Preferencje… otwarty"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences app geral preferências comportamento dock barra de menu status lateral configurações configuração arquivo esquema documentação referência código abrir caminho cmux.json Ajustes Ajustes… Preferências… aberto"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences приложение общие настройки поведение док строка меню статус боковая панель конфигурация файл схема документация справочник предпочтения редактор код открыть путь cmux.json Настройки... открыт"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การตั้งค่า การกำหนดค่า ไฟล์ สคีมา เอกสาร อ้างอิง ตัวแก้ไข โค้ด เปิด เส้นทาง cmux.json เปิดการตั้งค่า การตั้งค่า..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences uygulama genel tercihler davranış dock menü çubuğu durum kenar ayarlar yapılandırma dosya şema belgeler başvuru düzenleyici kod aç yol cmux.json Ayarları Ayarlar… Tercihler… açık"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 设置 配置 文件 架构 文档 参考 编辑器 代码 打开 路径 cmux.json 打开设置 设置... 偏好设置..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 設定 設定檔 檔案 結構描述 文件 參考 編輯器 程式碼 開啟 路徑 cmux.json 開啟設定 設定... 偏好設定..."
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "open settings file json jsonc config editor ~/.config cmux preferences програма загальні параметри поведінка док рядок меню статус бічна панель налаштування конфігурація файл схема документація довідник редактор код відкрити шлях cmux.json Налаштування… Параметри… відкритий"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.settingsJSON.documentation": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "docs documentation schema reference settings json keys configuration"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "docs documentation schema reference settings json keys configuration ドキュメント スキーマ リファレンス settings json キー 構成"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration ドキュメント スキーマ リファレンス settings json キー 構成"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration لوحة مفاتيح اختصار اختصارات مفتاح سريع أوامر تسجيل إعدادات تكوين ملف مخطط وثائق مرجع تفضيلات المستندات الإعدادات… الإعدادات"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration tastatura prečica prečice hotkey komande tipke snimač postavke konfiguracija datoteka šema dokumentacija referenca preferencije Postavke…"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration tastatur genvej genveje hotkey kommandoer taster optager indstillinger konfiguration fil skema dokumentation præferencer Indstillinger…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration tastatur kurzbefehl tastenkürzel hotkey befehle tasten rekorder einstellungen konfiguration datei dokumentation referenz präferenzen …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration teclado atajo atajos tecla rápida comandos teclas grabador ajustes configuración archivo esquema documentación referencia preferencias Ajustes…"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration clavier raccourci raccourcis touche globale commandes touches enregistreur réglages fichier schéma référence préférences Réglages..."
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration tastiera scorciatoia scorciatoie tasto rapido comandi tasti registratore impostazioni configurazione file documentazione riferimento preferenze Impostazioni…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration 키보드 단축키 핫키 명령 키 기록기 설정 구성 파일 스키마 문서 참조 환경설정 설정… settings.json"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration tastatur snarvei snarveier hurtigtast kommandoer taster opptaker innstillinger konfigurasjon fil skjema dokumentasjon referanse preferanser …"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration klawiatura skrót skróty klawisz polecenia klawisze rejestrator ustawienia konfiguracja plik schemat dokumentacja referencja preferencje Ustawienia…"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration teclado atalho atalhos tecla rápida comandos teclas gravador configurações configuração arquivo esquema documentação referência preferências Ajustes… Ajustes"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration клавиатура сочетание клавиш горячая клавиша команды клавиши запись настройки конфигурация файл схема документация справочник предпочтения Настройки..."
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration แป้นพิมพ์ ทางลัด ปุ่มลัด คำสั่ง คีย์ ตัวบันทึก การตั้งค่า การกำหนดค่า ไฟล์ สคีมา เอกสาร อ้างอิง ค่ากำหนด การตั้งค่า..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration klavye kısayol kısayollar tuşu komutlar tuşlar kaydedici ayarlar yapılandırma dosya şema belgeler başvuru tercihler Ayarlar…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration 键盘 快捷键 热键 命令 按键 录制器 设置 配置 文件 架构 文档 参考 偏好设置 设置..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration 鍵盤 快捷鍵 熱鍵 命令 按鍵 錄製器 設定 設定檔 檔案 結構描述 文件 參考 偏好設定 設定..."
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "docs documentation schema reference settings json keys configuration клавіатура скорочення гарячі клавіші команди записувач налаштування конфігурація файл схема документація довідник параметри Налаштування…"
+                }
+            }
+        }
     },
     "settings.search.alias.setting.reset.reset-all": {
-          "extractionState": "manual",
-          "localizations": {
-                "en": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "factory reset restore defaults clear preferences"
-                      }
-                },
-                "ja": {
-                      "stringUnit": {
-                            "state": "translated",
-                            "value": "factory reset restore defaults clear preferences 初期化 リセット デフォルト 復元 設定を消去"
-                      }
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences"
                 }
-          }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences 初期化 リセット デフォルト 復元 設定を消去"
+                }
+            },
+            "ar": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي إعدادات تكوين ملف json مخطط وثائق مرجع إعادة ضبط مصنع افتراضي استعادة مسح الكل التفضيلات… التعيين تعيين"
+                }
+            },
+            "bs": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences aplikacija opće postavke ponašanje dock traka menija status bočna konfiguracija datoteka json šema dokumentacija referenca preferencije fabrički zadano vrati očisti Obriši sve Postavke… Resetovanje Resetuj"
+                }
+            },
+            "da": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences app generelt indstillinger adfærd dock menulinje status sidepanel konfiguration fil json skema dokumentation reference præferencer nulstil fabrik standard gendan ryd alle Indstillinger…"
+                }
+            },
+            "de": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences app allgemein einstellungen verhalten dock menüleiste status seitenleiste konfiguration datei json schema dokumentation referenz präferenzen zurücksetzen werkseinstellungen standard wiederherstellen löschen Alle …"
+                }
+            },
+            "es": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences aplicación general preferencias comportamiento dock barra de menú estado lateral ajustes configuración archivo json esquema documentación referencia restablecer fábrica predeterminado restaurar borrar todo Preferencias…"
+                }
+            },
+            "fr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences application général préférences comportement dock barre de menus état latérale réglages configuration fichier json schéma documentation référence réinitialiser usine défaut restaurer effacer Tout Préférences..."
+                }
+            },
+            "it": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences app generale preferenze comportamento dock barra menu stato laterale impostazioni configurazione file json schema documentazione riferimento reimposta fabbrica predefinito ripristina cancella tutto Preferenze…"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 설정 구성 파일 json 스키마 문서 참조 재설정 초기화 기본값 복원 지우기 모두 환경설정…"
+                }
+            },
+            "nb": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences app generelt innstillinger oppførsel dock menylinje status sidepanel konfigurasjon fil json skjema dokumentasjon referanse preferanser tilbakestill fabrikk standard gjenopprett tøm Fjern alle …"
+                }
+            },
+            "pl": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences aplikacja ogólne preferencje zachowanie dock pasek menu status boczny ustawienia konfiguracja plik json schemat dokumentacja referencja fabryczne domyślne przywróć wyczyść wszystko Preferencje… Resetuj"
+                }
+            },
+            "pt-BR": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences app geral preferências comportamento dock barra de menu status lateral configurações configuração arquivo json esquema documentação referência redefinir fábrica padrão restaurar limpar Tudo Preferências…"
+                }
+            },
+            "ru": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences приложение общие настройки поведение док строка меню статус боковая панель конфигурация файл json схема документация справочник предпочтения сброс заводские по умолчанию восстановить очистить все Настройки... Сбросить"
+                }
+            },
+            "th": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง รีเซ็ต โรงงาน ค่าเริ่มต้น กู้คืน ล้าง ล้างทั้งหมด การตั้งค่า..."
+                }
+            },
+            "tr": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences uygulama genel tercihler davranış dock menü çubuğu durum kenar ayarlar yapılandırma dosya json şema belgeler başvuru sıfırla fabrika varsayılan geri yükle temizle Tümünü Tercihler…"
+                }
+            },
+            "zh-Hans": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 设置 配置 文件 json 架构 文档 参考 重置 出厂 默认 恢复 清除 全部清除 偏好设置..."
+                }
+            },
+            "zh-Hant": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences 應用程式 一般 偏好設定 行為 Dock 選單列 狀態 側邊欄 設定 設定檔 檔案 json 結構描述 文件 參考 重置 出廠 預設 還原 清除 清除全部 偏好設定..."
+                }
+            },
+            "uk": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "factory reset restore defaults clear preferences програма загальні параметри поведінка док рядок меню статус бічна панель налаштування конфігурація файл json схема документація довідник скидання заводські типові відновити очистити Скинути все Параметри…"
+                }
+            }
+        }
     },
     "settings.search.prompt": {
       "extractionState": "manual",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69008,103 +69008,103 @@
             "ar": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب"
+                    "value": "auth authentication login logout sign in sign out email user profile team مصادقة تسجيل دخول خروج بريد إلكتروني مستخدم ملف شخصي فريق حساب"
                 }
             },
             "bs": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team autentikacija prijava odjava korisnik profil tim račun"
+                    "value": "auth authentication login logout sign in sign out email user profile team autentikacija prijava odjava korisnik profil tim račun"
                 }
             },
             "da": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team godkendelse logud bruger profil konto"
+                    "value": "auth authentication login logout sign in sign out email user profile team godkendelse logud bruger profil konto"
                 }
             },
             "de": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team authentifizierung anmeldung abmeldung benutzer profil konto"
+                    "value": "auth authentication login logout sign in sign out email user profile team authentifizierung anmeldung abmeldung benutzer profil konto"
                 }
             },
             "es": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta"
+                    "value": "auth authentication login logout sign in sign out email user profile team autenticación iniciar sesión cerrar correo usuario perfil equipo cuenta"
                 }
             },
             "fr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team authentification connexion déconnexion e-mail utilisateur profil équipe compte"
+                    "value": "auth authentication login logout sign in sign out email user profile team authentification connexion déconnexion e-mail utilisateur profil équipe compte"
                 }
             },
             "it": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team autenticazione accesso disconnessione utente profilo account"
+                    "value": "auth authentication login logout sign in sign out email user profile team autenticazione accesso disconnessione utente profilo account"
                 }
             },
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정 로그인…"
+                    "value": "auth authentication login logout sign in sign out email user profile team 인증 로그인 로그아웃 이메일 사용자 프로필 팀 계정 로그인…"
                 }
             },
             "nb": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team autentisering innlogging utlogging e-post bruker profil konto"
+                    "value": "auth authentication login logout sign in sign out email user profile team autentisering innlogging utlogging e-post bruker profil konto"
                 }
             },
             "pl": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team uwierzytelnianie logowanie wylogowanie użytkownik profil zespół konto"
+                    "value": "auth authentication login logout sign in sign out email user profile team uwierzytelnianie logowanie wylogowanie użytkownik profil zespół konto"
                 }
             },
             "pt-BR": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team autenticação sair usuário perfil equipe conta"
+                    "value": "auth authentication login logout sign in sign out email user profile team autenticação sair usuário perfil equipe conta"
                 }
             },
             "ru": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team аутентификация вход выход пользователь профиль команда аккаунт"
+                    "value": "auth authentication login logout sign in sign out email user profile team аутентификация вход выход пользователь профиль команда аккаунт"
                 }
             },
             "th": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี"
+                    "value": "auth authentication login logout sign in sign out email user profile team ยืนยันตัวตน เข้าสู่ระบบ ออกจากระบบ อีเมล ผู้ใช้ โปรไฟล์ ทีม บัญชี"
                 }
             },
             "tr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap"
+                    "value": "auth authentication login logout sign in sign out email user profile team kimlik doğrulama giriş çıkış e-posta kullanıcı profil takım hesap"
                 }
             },
             "zh-Hans": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team 认证 登录 退出登录 邮件 用户 个人资料 团队 账户"
+                    "value": "auth authentication login logout sign in sign out email user profile team 认证 登录 退出登录 邮件 用户 个人资料 团队 账户"
                 }
             },
             "zh-Hant": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶"
+                    "value": "auth authentication login logout sign in sign out email user profile team 驗證 登入 登出 郵件 使用者 個人資料 團隊 帳戶"
                 }
             },
             "uk": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "auth authentication login logout sign in out email user profile team автентифікація вхід вихід користувач профіль команда обліковий запис Увійти… Вийти"
+                    "value": "auth authentication login logout sign in sign out email user profile team автентифікація вхід вихід користувач профіль команда обліковий запис Увійти… Вийти"
                 }
             }
         }


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/3294.\n\nAdds settings search alias localizations for every locale currently present in the string catalog and Xcode project locale set, including ar, bs, da, de, es, fr, it, ko, nb, pl, pt-BR, ru, th, tr, uk, zh-Hans, and zh-Hant. English config/search tokens remain in each locale so users can search by settings.json keys too.\n\nVerification:\n- /Applications/Xcode.app/Contents/Developer/usr/bin/xcstringstool compile --dry-run --output-directory /tmp/cmux-searchalias-all-locales-xcstrings Resources/Localizable.xcstrings\n- alias key coverage script: 87 alias keys, 19 locales, 0 missing, 0 empty\n- git diff --check\n- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-searchalias-all-locales-unit -only-testing:cmuxTests/SettingsSearchIndexTests test\n- ./scripts/reload.sh --tag aliasloc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Localized settings search aliases for all locales to improve settings search. English `settings.json` keys still work in every locale, and the "sign out" alias phrase is preserved.

- **New Features**
  - Added alias entries for all current locales, including: ar, bs, da, de, es, fr, it, ko, nb, pl, pt-BR, ru, th, tr, uk, zh-Hans, zh-Hant.

<sup>Written for commit 3d9c054ddc3bf0f481fa6cb128863ccd9bf1c2c6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3296?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

