### PR TITLE
Add NSSpeechRecognitionUsageDescription to Info.plist

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -45,6 +45,8 @@
 	<string></string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>A program running within cmux would like to use your microphone.</string>
+	<key>NSSpeechRecognitionUsageDescription</key>
+	<string>A program running within cmux would like to use speech recognition.</string>
 	<key>NSCameraUsageDescription</key>
 	<string>A program running within cmux would like to use your camera.</string>
 	<key>NSBluetoothAlwaysUsageDescription</key>

--- a/Resources/InfoPlist.xcstrings
+++ b/Resources/InfoPlist.xcstrings
@@ -36,6 +36,17 @@
         }
       }
     },
+    "NSSpeechRecognitionUsageDescription": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A program running within cmux would like to use speech recognition."
+          }
+        }
+      }
+    },
     "NSMicrophoneUsageDescription": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Summary

CLI tools running inside cmux that use `Speech.framework` crash with `SIGABRT` *before* any permission prompt appears.

macOS's TCC walks up to the responsible parent app (`cmux.app`) when a child process requests a privacy-gated API. If the parent's `Info.plist` doesn't declare a usage description for that permission, TCC kills the child immediately rather than prompting. The crash report makes it explicit:

> This app has crashed because it attempted to access privacy-sensitive data without a usage description. The app's Info.plist must contain an `NSSpeechRecognitionUsageDescription` key with a string value explaining to the user how the app uses this data.

cmux already declares parent-app usage strings for hosted programs that need microphone, camera, Bluetooth, and AppleScript access in [`Resources/Info.plist`](https://github.com/johnmatthewtennant/cmux/blob/add-speech-recognition-usage-description/Resources/Info.plist#L46-L55). Speech recognition is the same TCC shape: Apple documents [`NSSpeechRecognitionUsageDescription`](https://developer.apple.com/documentation/bundleresources/information-property-list/nsspeechrecognitionusagedescription) as the required `Info.plist` key for Speech APIs. iTerm2 and Ghostty ship the same class of parent-terminal usage strings for microphone and speech recognition ([iTerm2 release plist](https://github.com/gnachman/iTerm2/blob/master/plists/release-iTerm2.plist#L187-L190), [Ghostty Xcode project](https://github.com/ghostty-org/ghostty/blob/main/macos/Ghostty.xcodeproj/project.pbxproj#L770-L774)).

## Changes

- `Resources/Info.plist`: add `NSSpeechRecognitionUsageDescription` next to the existing hosted-program privacy usage strings.
- `Resources/InfoPlist.xcstrings`: add the matching English localization entry.

## Test plan

- [x] Build cmux locally and run a CLI inside it that calls `SFSpeechRecognizer.requestAuthorization` (or any tool that links Speech.framework). Confirm a permission prompt appears instead of an immediate crash. *(Verified locally with a tagged debug build on 2026-04-29: prompt appears, no SIGABRT.)*

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add NSSpeechRecognitionUsageDescription to Info.plist and an English entry in InfoPlist.xcstrings. This prevents TCC from killing CLI tools using Speech.framework and shows the normal permission prompt instead.

<sup>Written for commit eece21309e1a8a4937e56f650f6d7d88444fa75f. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3301?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configured speech recognition permissions and added localized privacy descriptions to support speech recognition capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


-🤖
