### PR TITLE
Add sidebar.titleFontSize setting for workspace title

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9467,6 +9467,7 @@ private struct SidebarTabItemSettingsSnapshot: Equatable {
     let selectionColorHex: String?
     let notificationBadgeColorHex: String?
     let visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility
+    let titleFontSize: Double
 
     init(defaults: UserDefaults = .standard) {
         sidebarShortcutHintXOffset = Self.double(
@@ -9523,6 +9524,7 @@ private struct SidebarTabItemSettingsSnapshot: Equatable {
         activeTabIndicatorStyle = SidebarActiveTabIndicatorSettings.current(defaults: defaults)
         selectionColorHex = defaults.string(forKey: "sidebarSelectionColorHex")
         notificationBadgeColorHex = defaults.string(forKey: "sidebarNotificationBadgeColorHex")
+        titleFontSize = SidebarTabTitleFontSettings.resolvedSize(defaults: defaults)
     }
 
     private static func bool(
@@ -12688,7 +12690,7 @@ private struct TabItemView: View, Equatable {
                 }
 
                 Text(workspaceSnapshot.title)
-                    .font(.system(size: 12.5, weight: titleFontWeight))
+                    .font(.system(size: settings.titleFontSize, weight: titleFontWeight))
                     .foregroundColor(activePrimaryTextColor)
                     .lineLimit(1)
                     .truncationMode(.tail)

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -536,8 +536,6 @@ final class CmuxSettingsFileStore {
         if let value = jsonDouble(section["titleFontSize"]) {
             let clamped = min(max(value, SidebarTabTitleFontSettings.minSize), SidebarTabTitleFontSettings.maxSize)
             snapshot.managedUserDefaults[SidebarTabTitleFontSettings.userDefaultsKey] = .double(clamped)
-        } else if section.keys.contains("titleFontSize") {
-            logInvalid("sidebar.titleFontSize", sourcePath: sourcePath)
         }
     }
 
@@ -1270,6 +1268,7 @@ final class CmuxSettingsFileStore {
                     "showLog": true,
                     "showProgress": true,
                     "showCustomMetadata": true,
+                    "titleFontSize": SidebarTabTitleFontSettings.defaultSize,
                 ],
             ],
             [

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -60,6 +60,7 @@ final class CmuxSettingsFileStore {
         "sidebar.showLog",
         "sidebar.showProgress",
         "sidebar.showCustomMetadata",
+        "sidebar.titleFontSize",
         "workspaceColors.indicatorStyle",
         "workspaceColors.selectionColor",
         "workspaceColors.notificationBadgeColor",
@@ -531,6 +532,12 @@ final class CmuxSettingsFileStore {
         }
         if let value = jsonBool(section["showCustomMetadata"]) {
             snapshot.managedUserDefaults["sidebarShowStatusPills"] = .bool(value)
+        }
+        if let value = jsonDouble(section["titleFontSize"]) {
+            let clamped = min(max(value, SidebarTabTitleFontSettings.minSize), SidebarTabTitleFontSettings.maxSize)
+            snapshot.managedUserDefaults[SidebarTabTitleFontSettings.userDefaultsKey] = .double(clamped)
+        } else if section.keys.contains("titleFontSize") {
+            logInvalid("sidebar.titleFontSize", sourcePath: sourcePath)
         }
     }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -86,6 +86,20 @@ enum SidebarBranchLayoutSettings {
     }
 }
 
+enum SidebarTabTitleFontSettings {
+    static let userDefaultsKey = "sidebarTitleFontSize"
+    static let defaultSize: Double = 12.5
+    static let minSize: Double = 9
+    static let maxSize: Double = 24
+
+    static func resolvedSize(defaults: UserDefaults = .standard) -> Double {
+        guard let number = defaults.object(forKey: userDefaultsKey) as? NSNumber else {
+            return defaultSize
+        }
+        return min(max(number.doubleValue, minSize), maxSize)
+    }
+}
+
 enum SidebarWorkspaceDetailSettings {
     static let hideAllDetailsKey = "sidebarHideAllDetails"
     static let showNotificationMessageKey = "sidebarShowNotificationMessage"

--- a/web/data/cmux-settings.schema.json
+++ b/web/data/cmux-settings.schema.json
@@ -266,6 +266,13 @@
           "type": "boolean",
           "default": true,
           "description": "Show custom metadata pills."
+        },
+        "titleFontSize": {
+          "type": "number",
+          "minimum": 9,
+          "maximum": 24,
+          "default": 12.5,
+          "description": "Point size of the workspace title text in each sidebar tab. Other detail rows are unaffected."
         }
       }
     },


### PR DESCRIPTION
## Summary

Adds a `sidebar.titleFontSize` key to `~/.config/cmux/settings.json` that controls the point size of the **workspace title text** in each sidebar tab. Range 9–24pt, default 12.5pt (current hardcoded value).

Refs #1835 — that issue asks for general font settings in the Settings UI; this is a smaller first step that exposes the most-requested knob via the JSON settings file. Settings UI surface for it can come later.

## Why this scope

I limited the setting to the **workspace title only** (the prominent `Text(workspaceSnapshot.title)` row at `Sources/ContentView.swift:12690`). Secondary detail rows (branch / cwd / ports / log / notification message) keep their fixed sizes so the existing sidebar tab layout and width policy stay untouched, which keeps the PR small and reduces regression risk in `SidebarResize*UITests`.

If reviewers prefer a single `sidebar.fontSize` that scales every text row in the tab proportionally, happy to follow up — but that touches ~15 `.font(.system(size: …))` call sites and may need width-policy adjustments, so I figured a focused PR was a safer first cut.

## Implementation

- `web/data/cmux-settings.schema.json` — new `sidebar.titleFontSize` property (number, 9–24, default 12.5)
- `Sources/KeyboardShortcutSettingsFileStore.swift` — whitelist entry, parser that silently clamps out-of-range numeric values (matching the `sidebarAppearance.tintOpacity` precedent in the same function), and an entry in `defaultTemplate()` so newly-generated `settings.json` files surface the key alongside the other sidebar entries
- `Sources/TabManager.swift` — new `SidebarTabTitleFontSettings` enum next to the other sidebar settings namespaces, with `userDefaultsKey`, `defaultSize`, `minSize`, `maxSize`, and a `resolvedSize(defaults:)` helper
- `Sources/ContentView.swift` — adds `titleFontSize: Double` to `SidebarTabItemSettingsSnapshot`, populates it in `init`, and uses it in `TabItemView`'s title `.font(...)` modifier in place of the hardcoded `12.5`

Hot reload works through the existing path: file watcher → `managedUserDefaults` → `UserDefaults.didChangeNotification` → `SidebarTabItemSettingsStore.refreshSnapshot()` → SwiftUI re-render. `TabItemView`'s `Equatable` conformance compares `settings`, so the new `Double` field flows through the snapshot diff automatically (no `==` rewrite needed).

## Test plan

- [ ] Manual: write `{ "sidebar": { "titleFontSize": 18 } }` to `~/.config/cmux/settings.json`, observe sidebar tab titles render at 18pt
- [ ] Manual: change the value while the app is running, verify hot reload re-renders without restart
- [ ] Manual: out-of-range values (e.g. `5`, `100`) clamp silently to 9–24
- [ ] Manual: a fresh launch with no `settings.json` writes a template that includes the new `titleFontSize` line under `sidebar`
- [ ] No regression in `cmuxTests/SidebarWidthPolicyTests.swift` — title font is still inside the same `HStack` with `layoutPriority(1)` and width policy is unchanged

## Notes

- Did not add a parser unit test because there's no existing precedent for testing `parseSidebarSection` end-to-end and CLAUDE.md's test-quality policy discourages source-shape tests; happy to add a runtime-behavior test if reviewers point me at the right harness.
- Did not touch `CHANGELOG.md` since the release flow (`/release`) generates the entry from commits.