### PR TITLE
fix: keep selection highlight uniform across colored and uncolored workspaces (#3308)

### DIFF
--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -70,66 +70,6 @@ func cmuxAccentColor() -> Color {
     Color(nsColor: cmuxAccentNSColor())
 }
 
-private func sidebarSelectedWorkspaceRelativeLuminance(_ color: NSColor) -> CGFloat {
-    guard let rgbColor = color.usingColorSpace(.sRGB) else { return 0 }
-    var red: CGFloat = 0
-    var green: CGFloat = 0
-    var blue: CGFloat = 0
-    var alpha: CGFloat = 0
-    rgbColor.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
-
-    func linearized(_ component: CGFloat) -> CGFloat {
-        if component <= 0.03928 {
-            return component / 12.92
-        }
-        return pow((component + 0.055) / 1.055, 2.4)
-    }
-
-    let linearRed = linearized(red)
-    let linearGreen = linearized(green)
-    let linearBlue = linearized(blue)
-    return (0.2126 * linearRed) + (0.7152 * linearGreen) + (0.0722 * linearBlue)
-}
-
-private func sidebarSelectedWorkspaceContrastRatio(
-    between first: NSColor,
-    and second: NSColor
-) -> CGFloat {
-    let firstLuminance = sidebarSelectedWorkspaceRelativeLuminance(first)
-    let secondLuminance = sidebarSelectedWorkspaceRelativeLuminance(second)
-    let lighter = max(firstLuminance, secondLuminance)
-    let darker = min(firstLuminance, secondLuminance)
-    return (lighter + 0.05) / (darker + 0.05)
-}
-
-private func sidebarSelectedWorkspaceReadableBackgroundNSColor(_ color: NSColor) -> NSColor {
-    let minimumContrast: CGFloat = 4.5
-    var adjusted = color.usingColorSpace(.sRGB) ?? color
-    var iteration = 0
-
-    while sidebarSelectedWorkspaceContrastRatio(between: adjusted, and: NSColor.white) < minimumContrast,
-          iteration < 12 {
-        guard let darkened = adjusted.blended(withFraction: 0.12, of: .black) else { break }
-        adjusted = darkened.usingColorSpace(.sRGB) ?? darkened
-        iteration += 1
-    }
-
-    return adjusted
-}
-
-private func sidebarSelectedWorkspaceCustomBackgroundNSColor(
-    hex: String,
-    colorScheme: ColorScheme
-) -> NSColor? {
-    guard let color = WorkspaceTabColorSettings.displayNSColor(
-        hex: hex,
-        colorScheme: colorScheme
-    ) else {
-        return nil
-    }
-    return sidebarSelectedWorkspaceReadableBackgroundNSColor(color)
-}
-
 struct SidebarRemoteErrorCopyEntry: Equatable {
     let workspaceTitle: String
     let target: String
@@ -169,16 +109,8 @@ enum SidebarRemoteErrorCopySupport {
 
 func sidebarSelectedWorkspaceBackgroundNSColor(
     for colorScheme: ColorScheme,
-    customHex: String? = nil,
     sidebarSelectionColorHex: String? = UserDefaults.standard.string(forKey: "sidebarSelectionColorHex")
 ) -> NSColor {
-    if let customHex,
-       let customColor = sidebarSelectedWorkspaceCustomBackgroundNSColor(
-        hex: customHex,
-        colorScheme: colorScheme
-       ) {
-        return customColor
-    }
     if let hex = sidebarSelectionColorHex,
        let parsed = NSColor(hex: hex) {
         return parsed
@@ -224,7 +156,6 @@ func sidebarWorkspaceRowBackgroundStyle(
 ) -> SidebarWorkspaceRowBackgroundStyle {
     let selectedBackground = sidebarSelectedWorkspaceBackgroundNSColor(
         for: colorScheme,
-        customHex: customColorHex,
         sidebarSelectionColorHex: sidebarSelectionColorHex
     )
     let accentBackground = cmuxAccentNSColor(for: colorScheme)

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -59,5 +61,134 @@ final class SidebarWidthPolicyTests: XCTestCase {
         XCTAssertTrue(range.contains(684))
         XCTAssertFalse(range.contains(675.9))
         XCTAssertFalse(range.contains(686.1))
+    }
+}
+
+final class SidebarWorkspaceSelectionColorTests: XCTestCase {
+    func testSelectedColoredWorkspaceUsesStandardSelectionBackgroundInLightAndDark() {
+        for colorScheme in [ColorScheme.light, .dark] {
+            let coloredSelected = sidebarWorkspaceRowBackgroundStyle(
+                activeTabIndicatorStyle: .solidFill,
+                isActive: true,
+                isMultiSelected: false,
+                customColorHex: "#E85D75",
+                colorScheme: colorScheme,
+                sidebarSelectionColorHex: nil
+            )
+            let standardSelected = sidebarWorkspaceRowBackgroundStyle(
+                activeTabIndicatorStyle: .solidFill,
+                isActive: true,
+                isMultiSelected: false,
+                customColorHex: nil,
+                colorScheme: colorScheme,
+                sidebarSelectionColorHex: nil
+            )
+
+            XCTAssertEqual(coloredSelected.opacity, standardSelected.opacity, accuracy: 0.001)
+            XCTAssertEqual(coloredSelected.opacity, 1, accuracy: 0.001)
+            assertColor(coloredSelected.color, equals: standardSelected.color)
+
+            let unselectedColored = sidebarWorkspaceRowBackgroundStyle(
+                activeTabIndicatorStyle: .solidFill,
+                isActive: false,
+                isMultiSelected: false,
+                customColorHex: "#E85D75",
+                colorScheme: colorScheme,
+                sidebarSelectionColorHex: nil
+            )
+            XCTAssertEqual(unselectedColored.opacity, 0.7, accuracy: 0.001)
+            XCTAssertFalse(
+                colorsAreEqual(coloredSelected.color, unselectedColored.color),
+                "Selected row should use the standard selection background, not the workspace tab color"
+            )
+        }
+    }
+
+    func testSelectedColoredWorkspaceUsesConfiguredSelectionBackground() {
+        let selectionHex = "#123456"
+        let coloredSelected = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: true,
+            isMultiSelected: false,
+            customColorHex: "#E85D75",
+            colorScheme: .light,
+            sidebarSelectionColorHex: selectionHex
+        )
+        let standardSelected = sidebarWorkspaceRowBackgroundStyle(
+            activeTabIndicatorStyle: .solidFill,
+            isActive: true,
+            isMultiSelected: false,
+            customColorHex: nil,
+            colorScheme: .light,
+            sidebarSelectionColorHex: selectionHex
+        )
+
+        XCTAssertEqual(coloredSelected.opacity, 1, accuracy: 0.001)
+        assertColor(coloredSelected.color, equals: standardSelected.color)
+        assertColor(coloredSelected.color, equals: NSColor(hex: selectionHex))
+    }
+
+    private func assertColor(
+        _ actual: NSColor?,
+        equals expected: NSColor?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let actual, let expected else {
+            XCTAssertNotNil(actual, file: file, line: line)
+            XCTAssertNotNil(expected, file: file, line: line)
+            return
+        }
+
+        XCTAssertTrue(
+            colorsAreEqual(actual, expected),
+            "Expected \(colorDescription(actual)) to equal \(colorDescription(expected))",
+            file: file,
+            line: line
+        )
+    }
+
+    private func colorsAreEqual(_ lhs: NSColor?, _ rhs: NSColor?) -> Bool {
+        guard let lhs, let rhs else {
+            return lhs == nil && rhs == nil
+        }
+        guard let lhsRGB = lhs.usingColorSpace(.sRGB),
+              let rhsRGB = rhs.usingColorSpace(.sRGB) else {
+            return false
+        }
+
+        var lhsRed: CGFloat = 0
+        var lhsGreen: CGFloat = 0
+        var lhsBlue: CGFloat = 0
+        var lhsAlpha: CGFloat = 0
+        var rhsRed: CGFloat = 0
+        var rhsGreen: CGFloat = 0
+        var rhsBlue: CGFloat = 0
+        var rhsAlpha: CGFloat = 0
+        lhsRGB.getRed(&lhsRed, green: &lhsGreen, blue: &lhsBlue, alpha: &lhsAlpha)
+        rhsRGB.getRed(&rhsRed, green: &rhsGreen, blue: &rhsBlue, alpha: &rhsAlpha)
+
+        return abs(lhsRed - rhsRed) <= 0.001 &&
+            abs(lhsGreen - rhsGreen) <= 0.001 &&
+            abs(lhsBlue - rhsBlue) <= 0.001 &&
+            abs(lhsAlpha - rhsAlpha) <= 0.001
+    }
+
+    private func colorDescription(_ color: NSColor) -> String {
+        guard let rgb = color.usingColorSpace(.sRGB) else {
+            return color.description
+        }
+        var red: CGFloat = 0
+        var green: CGFloat = 0
+        var blue: CGFloat = 0
+        var alpha: CGFloat = 0
+        rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+        return String(
+            format: "rgba(%.3f, %.3f, %.3f, %.3f)",
+            red,
+            green,
+            blue,
+            alpha
+        )
     }
 }


### PR DESCRIPTION
## Summary

Closes #3308.

This reverses #2565: workspace tab colors still identify unselected sidebar rows, but selected rows now always use the same standard selection background as uncolored workspaces.

## Changes

- Added a regression test for selected colored workspace rows in light and dark appearances: [`SidebarWorkspaceSelectionColorTests`](https://github.com/manaflow-ai/cmux/blob/issue-3308-uniform-selection-color/cmuxTests/SidebarWidthPolicyTests.swift#L67).
- Removed the selected-state custom tab color branch from [`sidebarWorkspaceRowBackgroundStyle`](https://github.com/manaflow-ai/cmux/blob/issue-3308-uniform-selection-color/Sources/Sidebar/SidebarAppearanceSupport.swift#L149).
- Left the unselected custom-color path intact.

## Verification

- Regression commit: https://github.com/manaflow-ai/cmux/commit/4cb20a895f88ac527627203fe5a11541402e9830
- Fix commit: https://github.com/manaflow-ai/cmux/commit/64e098d989b431cb04e217ac32dd9d5e27b6f4a4
- No-`xcodebuild` Swift harness:
  - Test-only source failed with: `selected colored row did not use standard selection background`.
  - Fixed source passed with exit 0.
- `./scripts/reload.sh --tag issue-3308-uniform-selection-color --launch` succeeded and launched the tagged dev app.
- GitHub Actions unit runs were dispatched for the test-only and fixed SHAs, but both were cancelled by the workflow timeout while in the unit-test step:
  - Test-only run: https://github.com/manaflow-ai/cmux/actions/runs/25128276448
  - Fixed run: https://github.com/manaflow-ai/cmux/actions/runs/25128426556

## Manual Verification

- Launched the tagged dev build.
- Created `Colored` and `Plain` workspaces.
- Assigned `#C0392B` to `Colored` via `workspace-action set-color`.
- Selected `Colored`: selected row used the standard blue selection highlight, with only the color rail retaining the assigned red.
- Selected `Plain`: selected row used the same standard blue selection highlight, and the unselected `Colored` row retained its assigned red rail.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only color selection behavior change with limited scope, plus new unit tests; no security or data-handling impact.
> 
> **Overview**
> Selected sidebar rows no longer derive their background from per-workspace custom tab colors; selection now always uses the standard configured selection color (or the default accent) regardless of workspace coloring.
> 
> This removes the contrast-adjustment/custom selected-background path from `sidebarSelectedWorkspaceBackgroundNSColor`/`sidebarWorkspaceRowBackgroundStyle` and adds `SidebarWorkspaceSelectionColorTests` to lock in the behavior across light/dark modes and with an explicit `sidebarSelectionColorHex`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64e098d989b431cb04e217ac32dd9d5e27b6f4a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make selected sidebar rows use the same selection highlight across colored and uncolored workspaces. Unselected rows keep their workspace color for identity.

- **Bug Fixes**
  - Reverted selected-state tinting by removing the custom color path in `sidebarWorkspaceRowBackgroundStyle`; selected rows now use the standard selection background or the configured `sidebarSelectionColorHex` in both light and dark modes.
  - Removed now-unused contrast/luminance helpers tied to selected-state custom colors.
  - Added `SidebarWorkspaceSelectionColorTests` to verify uniform selection for colored workspaces and preservation of custom color on unselected rows.

<sup>Written for commit 64e098d989b431cb04e217ac32dd9d5e27b6f4a4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3310?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Resolved an issue where custom workspace colors could interfere with selection backgrounds in the sidebar across light and dark color schemes.

* **Tests**
  * Added comprehensive tests to validate sidebar workspace selection color behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->