### PR TITLE
Add hover tooltips to workspace and pane tabs

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12743,10 +12743,8 @@ private struct TabItemView: View, Equatable {
         let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
         let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
         let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
-        let latestNotificationSubtitle = latestNotificationText
-        let effectiveSubtitle = latestNotificationSubtitle
+        let effectiveSubtitle = latestNotificationText
         let detailVisibility = visibleAuxiliaryDetails
-        let workspaceTooltip = workspaceSnapshot.title
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
@@ -12847,7 +12845,6 @@ private struct TabItemView: View, Equatable {
                 }
             }
 
-            // Latest log entry
             if detailVisibility.showsLog, let latestLog = workspaceSnapshot.latestLog {
                 HStack(spacing: 4) {
                     Image(systemName: logLevelIcon(latestLog.level))
@@ -12862,7 +12859,6 @@ private struct TabItemView: View, Equatable {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
-            // Progress bar
             if detailVisibility.showsProgress, let progress = workspaceSnapshot.progress {
                 VStack(alignment: .leading, spacing: 2) {
                     GeometryReader { geo in
@@ -13120,7 +13116,7 @@ private struct TabItemView: View, Equatable {
             guard !contextMenuState.isVisible else { return }
             isHovering = hovering
         }
-        .safeHelp(workspaceTooltip)
+        .safeHelp(workspaceSnapshot.title)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(accessibilityTitle))
         .accessibilityHint(Text(accessibilityHintText))

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12746,6 +12746,7 @@ private struct TabItemView: View, Equatable {
         let latestNotificationSubtitle = latestNotificationText
         let effectiveSubtitle = latestNotificationSubtitle
         let detailVisibility = visibleAuxiliaryDetails
+        let workspaceTooltip = workspaceSnapshot.title
 
         VStack(alignment: .leading, spacing: 4) {
             HStack(spacing: 8) {
@@ -13119,6 +13120,7 @@ private struct TabItemView: View, Equatable {
             guard !contextMenuState.isVisible else { return }
             isHovering = hovering
         }
+        .safeHelp(workspaceTooltip)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(accessibilityTitle))
         .accessibilityHint(Text(accessibilityHintText))

--- a/cmuxTests/SidebarIdentifierFormattingTests.swift
+++ b/cmuxTests/SidebarIdentifierFormattingTests.swift
@@ -58,7 +58,20 @@ final class SidebarIdentifierFormattingTests: XCTestCase {
         )
     }
 
-    private func makeHarness() throws -> SidebarHarness {
+    func testWorkspaceRowTooltipUsesWorkspaceTitle() throws {
+        let workspaceTitle = "Tooltip Workspace"
+        let harness = try makeHarness(workspaceTitle: workspaceTitle)
+        defer { harness.tearDown() }
+
+        let tooltips = renderedTooltips(in: harness.window.contentView)
+
+        XCTAssertTrue(
+            tooltips.contains(workspaceTitle),
+            "Expected workspace row tooltip to use the workspace title. Tooltips: \(tooltips)"
+        )
+    }
+
+    private func makeHarness(workspaceTitle: String? = nil) throws -> SidebarHarness {
         _ = NSApplication.shared
 
         let defaults = UserDefaults.standard
@@ -82,6 +95,9 @@ final class SidebarIdentifierFormattingTests: XCTestCase {
         guard let workspace = tabManager.selectedWorkspace,
               let panelId = workspace.focusedPanelId else {
             throw HarnessError.missingWorkspace
+        }
+        if let workspaceTitle {
+            tabManager.setCustomTitle(tabId: workspace.id, title: workspaceTitle)
         }
 
         let pullRequestURL = try XCTUnwrap(URL(string: "https://github.com/manaflow-ai/cmux/pull/1234"))


### PR DESCRIPTION
## Summary
- Show workspace titles as hover tooltips on sidebar workspace rows.
- Point vendor/bonsplit at the tab-title tooltip change from https://github.com/manaflow-ai/bonsplit/pull/109.
- Add a sidebar tooltip coverage test for workspace rows.

## Testing
- ./scripts/reload.sh --tag tips passed.
- Local test suite not run, per repo instruction to route tests through CI.

## Issues
- Related task: add tooltips on hover of workspaces and bonsplit tabs
- Related: https://github.com/manaflow-ai/bonsplit/pull/109

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds hover tooltips to sidebar workspace rows and `bonsplit` tabs using their titles. Completes the Linear task and adds a test for workspace row tooltips.

- **New Features**
  - Sidebar workspace rows and `bonsplit` tabs show their titles on hover.
  - Added a unit test verifying the workspace row tooltip uses the workspace title.

- **Dependencies**
  - Updated `vendor/bonsplit` to include tab-title tooltip support.

<sup>Written for commit 4a9194ab1074e09da0148647b848b1363df7ca38. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3329?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace sidebar tabs now show tooltips that use the workspace title, improving identification and clarity.

* **Tests**
  * Added test coverage to verify workspace-row tooltips display the correct workspace title.

* **Chores**
  * Updated a vendor dependency reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->