### PR TITLE
Add shared behavior policy to agent notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,6 +186,15 @@ When adding a regression test for a bug fix, use a two-commit structure so CI pr
 
 This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
 
+## Feedback reuse policy
+
+When user feedback reveals a durable cmux invariant, do not only patch the visible symptom. Before final handoff, decide whether the lesson should become a `CLAUDE.md` pitfall, skill update, docs update, behavior test, shared helper, or follow-up issue.
+
+- Put cmux implementation invariants here, not in cmuxterm-hq workflow docs.
+- If corrected behavior appears in multiple UI entrypoints, extract a shared action/helper or source of truth instead of duplicating the fix.
+- For optimistic UI or CLI updates, keep one mutation path, record pending state with a request id or previous snapshot, reconcile from the authoritative result, and handle failure with an explicit rollback or error state. Do not let each entrypoint maintain its own optimistic copy.
+- If the lesson is agent workflow rather than cmux behavior, update the cmuxterm-hq instructions or a skill instead of this file.
+
 ## Debug menu
 
 The app has a **Debug** menu in the macOS menu bar (only in DEBUG builds). Use it for visual iteration:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,14 +186,11 @@ When adding a regression test for a bug fix, use a two-commit structure so CI pr
 
 This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
 
-## Feedback reuse policy
+## Shared behavior policy
 
-When user feedback reveals a durable cmux invariant, do not only patch the visible symptom. Before final handoff, decide whether the lesson should become a `CLAUDE.md` pitfall, skill update, docs update, behavior test, shared helper, or follow-up issue.
-
-- Put cmux implementation invariants here, not in cmuxterm-hq workflow docs.
-- If corrected behavior appears in multiple UI entrypoints, extract a shared action/helper or source of truth instead of duplicating the fix.
+- When a behavior is exposed through multiple entrypoints (keyboard shortcut, command palette, context menu, CLI, settings, debug menu), implement one shared action/model path and verify every entrypoint that should invoke it. Do not patch one surface while leaving the others with duplicated logic.
 - For optimistic UI or CLI updates, keep one mutation path, record pending state with a request id or previous snapshot, reconcile from the authoritative result, and handle failure with an explicit rollback or error state. Do not let each entrypoint maintain its own optimistic copy.
-- If the lesson is agent workflow rather than cmux behavior, update the cmuxterm-hq instructions or a skill instead of this file.
+- When a user says tests missed a bug, add or adjust behavior-level coverage around the exact repro path before claiming the fix is complete.
 
 ## Debug menu
 


### PR DESCRIPTION
## Summary
- Adds a shared behavior policy for cmux code paths exposed through multiple entrypoints.
- Calls out optimistic update requirements: one mutation path, pending state with request id or previous snapshot, authoritative reconciliation, and explicit rollback or error handling.
- Requires behavior-level coverage when tests miss the user's reported path.

## Testing
- git diff --check -- CLAUDE.md

## Notes
- Meta-only instruction change, no tagged reload needed.