### PR TITLE
Record cmux launch smoke video after DNS fix

### DIFF
--- a/docs/recordings/cmux-launch-smoke.md
+++ b/docs/recordings/cmux-launch-smoke.md
@@ -1,0 +1,29 @@
+# cmux Launch Smoke (DNS Fix)
+
+## Repro Steps Attempted
+1. Built and launched tagged app:
+   - `./scripts/reload.sh --tag recsmk --launch`
+   - App path from output: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app`
+2. Approved computer-use access for the launched app:
+   - `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app"`
+3. Sized the app window:
+   - `./.cmux-loader/set-app-window-frame "cmux DEV recsmk" 20 90 1500 950 2`
+4. Started required recording:
+   - `./.cmux-loader/record-video start repro 180`
+5. Used computer-use with app `com.cmuxterm.app.debug.recsmk`:
+   - Fetched app state and interacted with app window.
+   - Focused/selected terminal-related UI node 21 (Terminal content area) and issued typing actions:
+     - `echo cmux cloud recording smoke OK`
+     - Return key
+6. Stopped recording:
+   - `./.cmux-loader/record-video stop repro`
+
+## Results
+- cmux launched: **Yes** (tagged `cmux DEV recsmk` appeared and remained running).
+- computer-use interaction: **Yes** (approval recorded; app was brought to front and interacted with).
+- video artifact name: **`repro`** (`/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.mov`)
+
+## Blockers / Environment Notes
+- Repeated CUA synchronization responses (`"The user is still interacting..."`) occurred between rapid action calls, so each action required a re-query via `get_app_state` before the next.
+- CUA focus metadata stayed as `focused UI element is 0 standard window`, so terminal input confirmation was not observable from the accessibility tree after typing actions.
+- Runner macOS scrollbar context from task context: `AppleShowScrollBars=unset`.


### PR DESCRIPTION
Task: Record cmux launch smoke video after DNS fix

Generated by cmux-loader.

Recorded videos:

- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25154455814

Codex final message:

Completed. The recording-only task finished successfully.

- Executed required flow on tag `recsmk` and generated the required artifact `repro`.
- `./.cmux-loader/record-video start repro 180` then `./.cmux-loader/record-video stop repro` returned `status=ok` for `repro`.
- Created and tracked `[docs/recordings/cmux-launch-smoke.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-launch-smoke.md)` with exact steps, launch/interaction outcomes, blocker notes, and environment notes.

Verification performed:
- `scripts/reload.sh --tag recsmk --launch` succeeded with app path:
  `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app`
- `approve-computer-use-app` ran and included `com.cmuxterm.app.debug.recsmk`.
- `set-app-window-frame` succeeded.
- `record-video start/stop` succeeded (`status=ok`).

Recorded video name:
- `repro`

Environment notes:
- `AppleShowScrollBars` was `unset` (`defaults read -g`, `defaults read NSGlobalDomain`).
- CUA responded with transient “still interacting / re-query” messages between rapid actions, so commands were retried with state re-queries.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded the cmux launch smoke run after the DNS fix and added `docs/recordings/cmux-launch-smoke.md` with steps, results, and environment notes. Captured `repro.mov` successfully; verified launch and basic terminal input under tag `recsmk`.

<sup>Written for commit b4b050dbd372bfdae7862754ce6a94b8d69506c6. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3346?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recording documentation for cmux Launch Smoke (DNS Fix) test scenario, capturing launch command sequences, computer-use interaction and approval procedures, window management steps, application identifiers, test outcome metrics, video artifact generation details, and identified accessibility tree limitations including focus metadata gaps and terminal input confirmation challenges encountered during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->