### PR TITLE
Record cmux launch smoke video with window capture

### DIFF
--- a/docs/recordings/cmux-launch-smoke.md
+++ b/docs/recordings/cmux-launch-smoke.md
@@ -1,0 +1,22 @@
+# cmux launch smoke
+
+## Repro Steps Attempted
+- `./scripts/reload.sh --tag recsmk --launch`
+- `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app"`
+- `./.cmux-loader/set-app-window-frame "cmux DEV recsmk" 20 90 1500 950 2`
+- `./.cmux-loader/record-video start repro 180`
+- Using computer-use on app `com.cmuxterm.app.debug.recsmk`:
+  - Brought/focused app text entry area (main terminal content)
+  - Typed `echo cmux cloud recording smoke OK`
+- `./.cmux-loader/record-video stop repro`
+
+## Outcome
+- cmux launch: ✅ launched successfully with tagged app path from `reload.sh`.
+- computer-use interaction: ✅ approved and interacted with the launched app; command was typed in terminal content area.
+- video artifact name: `repro`
+
+## Environment / Notes
+- recorded file: `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.mov`
+- `record-video stop repro` returned `status=ok`
+- macOS global scrollbar setting from runner context: `AppleShowScrollBars=unset`, `NSGlobalDomain AppleShowScrollBars=unset`
+- no blockers encountered


### PR DESCRIPTION
Task: Record cmux launch smoke video with window capture

Generated by cmux-loader.

Recorded videos:

- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25155655531

Codex final message:

Task completed. No code changes were made.

**Result**
- I completed the required launch-and-record smoke flow for tag `recsmk`.
- `repro` recording was created successfully (`status=ok`).
- Created `[docs/recordings/cmux-launch-smoke.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-launch-smoke.md)` with exact step log, outcomes, and notes.

**Verification**
- Built/Launched with: `./scripts/reload.sh --tag recsmk --launch`  
  App: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app`
- Approved for computer-use: `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app"`
- Window positioned: `./.cmux-loader/set-app-window-frame "cmux DEV recsmk" 20 90 1500 950 2`
- Started recording: `./.cmux-loader/record-video start repro 180`
- Computer-use interaction: focused main terminal content area in `com.cmuxterm.app.debug.recsmk` and typed `echo cmux cloud recording smoke OK`
- Stopped recording: `./.cmux-loader/record-video stop repro` → `status=ok`
- Recorded artifact: `repro` at `.runner/videos/repro.mov`
- Scrollbar settings noted from runner context: `AppleShowScrollBars=unset`, `NSGlobalDomain AppleShowScrollBars=unset`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recorded the cmux launch smoke flow with window capture and added `docs/recordings/cmux-launch-smoke.md` documenting steps, outcomes, and notes. The `repro` video artifact was created successfully at `.runner/videos/repro.mov` (status=ok).

<sup>Written for commit a781d745bfd9cf147023a69793f262365bd10789. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3349?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive smoke test documentation for the cmux launch feature, capturing execution workflow, test commands, approvals, and validation results confirming successful app launch and interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->