### PR TITLE
Record cmux launch smoke video final verification

### DIFF
--- a/docs/recordings/cmux-launch-smoke.md
+++ b/docs/recordings/cmux-launch-smoke.md
@@ -1,0 +1,28 @@
+# cmux launch smoke recording
+
+## Repro steps attempted
+1. Ran:
+   - `./scripts/reload.sh --tag recsmk --launch`
+2. Captured app path from output:
+   - `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app`
+3. Ran:
+   - `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-recsmk/Build/Products/Debug/cmux DEV recsmk.app"`
+4. Ran:
+   - `./.cmux-loader/set-app-window-frame "cmux DEV recsmk" 20 90 1500 950 2`
+5. Ran:
+   - `./.cmux-loader/record-video start repro 180`
+6. Used computer-use to bring the tagged app frontmost and type in the terminal:
+   - `echo cmux cloud recording smoke OK`
+7. Ran:
+   - `./.cmux-loader/record-video stop repro`
+
+## Results
+- Did cmux launch? **Yes**.
+- Did computer-use interact with cmux? **Yes**.
+- Video artifact name: **repro**
+- Video path: `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.mov`
+
+## Environment notes / blockers
+- `AppleShowScrollBars` was unset (checked by default workflow notes).
+- `approve-computer-use-app` completed with `== done ==` and added `com.cmuxterm.app.debug.recsmk` approval.
+- No blocking issues for this task.


### PR DESCRIPTION
Task: Record cmux launch smoke video final verification

Generated by cmux-loader.

Recorded videos:

- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25156079185

Codex final message:

Implemented. I completed the recording-only flow and documented it in:

- [docs/recordings/cmux-launch-smoke.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-launch-smoke.md)

Recorded artifact:

- `repro` (path: `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.mov`)
- `record-video stop` reported: `status=ok`

Verification performed:

- Built and launched tagged app with `./scripts/reload.sh --tag recsmk --launch` (succeeded).
- Approved computer-use for `com.cmuxterm.app.debug.recsmk` via `approve-computer-use-app`.
- Positioned window with `.cmux-loader/set-app-window-frame "cmux DEV recsmk" 20 90 1500 950 2`.
- Used `computer-use` in the `cmux DEV recsmk` terminal and typed:
  - `echo cmux cloud recording smoke OK`
- Confirmed no blockers for this task; environment note: `AppleShowScrollBars` was unset.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added `docs/recordings/cmux-launch-smoke.md` documenting the final verification of the cmux launch smoke recording. Includes step-by-step repro with tag `recsmk`, confirms build/launch and `computer-use` interaction, and links the recorded video at `.runner/videos/repro.mov`.

<sup>Written for commit 5ae17b9a88b723baf596a74071c2955496281212. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3350?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added recording documentation for the cmux launch smoke test execution, including command details, loader actions, video artifacts, and environment notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->