### PR TITLE
Demo configurable plus button actions on macOS 15 runner

### DIFF
--- a/docs/recordings/plus-button-actions-demo-macos15.md
+++ b/docs/recordings/plus-button-actions-demo-macos15.md
@@ -1,0 +1,29 @@
+# plus-button-actions-demo-macos15
+
+- Task source URL: https://github.com/manaflow-ai/cmux/pull/3348
+- Checked out ref: `loader/recording-plus-button-actions-demo-macos15`
+- Reload tag used: `pbtn15`
+- App path used: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pbtn15/Build/Products/Debug/cmux DEV pbtn15.app`
+
+## Steps attempted
+1. Wrote `/Users/runner/.config/cmux/cmux.json` with the provided JSON configuration.
+2. Ran `./scripts/reload.sh --tag pbtn15 --launch`.
+3. Ran `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pbtn15/Build/Products/Debug/cmux DEV pbtn15.app"`.
+4. Ran `./.cmux-loader/set-app-window-frame "cmux DEV pbtn15" 20 90 1500 950 2`.
+5. Started recording: `./.cmux-loader/record-video start repro 180`.
+6. In UI:
+   - Right-clicked titlebar plus button (`titlebarControl.newTab`).
+   - Confirmed menu order was `New Terminal`, `Demo Shell`, `Demo Workspace`.
+   - Clicked `Demo Shell` and left terminal running command configured in `demo-shell`.
+   - Left-clicked titlebar plus button and observed browser tab opening.
+7. Stopped recording: `./.cmux-loader/record-video stop repro`.
+
+## Result
+- Configured left-click action worked: **Yes** (titlebar plus opened browser surface / browser tab via `cmux.newBrowser` override).
+- Right-click menu appeared in configured order: **Yes** (`New Terminal`, separator, `Demo Shell`, `Demo Workspace`).
+- Video artifact name: `repro`
+
+## Environment notes
+- Reload/approval logs indicated `cmuxterm.app.debug.pbtn15` launch and permissions were approved by helper scripts.
+- No blockers encountered.
+- DNS workaround script was not needed.


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/pull/3348

Generated by cmux-loader.

Recorded videos:

- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25157034841

Codex final message:

Done.

- Task source used: https://github.com/manaflow-ai/cmux/pull/3348  
- Checked-out ref: `loader/recording-plus-button-actions-demo-macos15`  
- Reload tag used: `pbtn15`  
- App path used: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pbtn15/Build/Products/Debug/cmux DEV pbtn15.app`  
- Output config file written: `/Users/runner/.config/cmux/cmux.json` (exact task payload).  

Recording result:
- Video artifact: `repro`  
- `./.cmux-loader/record-video stop repro` completed with `status=ok`.  

What I verified via GUI:
- Right-click menu on titlebar plus button appeared in configured order: `New Terminal`, separator, `Demo Shell`, `Demo Workspace`.  
- Clicking `Demo Shell` executed the configured command path (right-click action path demonstrated).  
- Left-click on titlebar plus opened a browser surface/tab as configured with `cmux.newBrowser`.  

No blockers encountered.

Report saved at: [docs/recordings/plus-button-actions-demo-macos15.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/plus-button-actions-demo-macos15.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recorded demo and short report verifying configurable titlebar plus-button actions on macOS 15. Confirms right‑click menu order (New Terminal, separator, Demo Shell, Demo Workspace) and that left‑click opens a browser tab via `cmux.newBrowser`; details and video link are in docs/recordings/plus-button-actions-demo-macos15.md.

<sup>Written for commit b63299885d49efe57122b591c6a04183696888c8. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3352?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

