### PR TITLE
Record cmux Settings colors search

### DIFF
--- a/docs/recordings/cmux-settings-colors-search.md
+++ b/docs/recordings/cmux-settings-colors-search.md
@@ -1,0 +1,29 @@
+# cmux settings colors search recording
+
+## Task
+Recording-only for settings search in colors.
+
+## Exact steps attempted
+1. Ran `./scripts/reload.sh --tag setclr --launch`.
+2. App path from reload output: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr/Build/Products/Debug/cmux DEV setclr.app`.
+3. Ran `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr/Build/Products/Debug/cmux DEV setclr.app"`.
+4. Ran `./.cmux-loader/set-app-window-frame "cmux DEV setclr" 20 90 1500 950 2`.
+5. Ran `rm -f ../.runner/target-window-id`.
+6. Ran `./.cmux-loader/record-video start repro 180`.
+7. Used computer-use in `cmux DEV setclr` and pressed the standard settings shortcut `⌘,`.
+8. Settings opened in-app (`Window: Settings`, app `cmux DEV setclr`).
+9. Focused search field and typed exactly `colors`.
+10. Kept the search field and visible results onscreen for ~3 seconds.
+11. Ran `./.cmux-loader/record-video stop repro`.
+
+## Outcome
+- Settings opened: `yes`.
+- Search field accepted `colors`: `yes` (search field value became `colors` and results list updated).
+
+## Video artifact
+- `repro`
+
+## Environment notes / blockers
+- No blockers encountered during recording.
+- approval output for computer-use was verbose but succeeded with `approved_computer_use_app`.
+- macOS scroll-bar setting check from this run: `AppleShowScrollBars=unset`.


### PR DESCRIPTION
Task: Record cmux Settings colors search

Generated by cmux-loader.

Recorded videos:

- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25157776530

Codex final message:

Done.  
`repro` was recorded successfully (`record-video stop repro` returned `status=ok`) and includes the required flow:
- Built/launch tag `setclr` app
- Approved computer-use for `com.cmuxterm.app.debug.setclr`
- Resized window to `20 90 1500 950`
- Removed `../.runner/target-window-id`
- Opened Settings in `cmux DEV setclr` with `⌘,`
- Focused Settings search field and typed exactly `colors`
- Left results visible for several seconds before stopping

Recording artifact:
- Video name: `repro`  
- Output path: `../.runner/videos/repro.mov` (from stop output)

Notes file created:
- [cmux-settings-colors-search.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-settings-colors-search.md)

No blockers. No product code changes made.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds documentation for the cmux Settings “colors” search recording to support reproducible QA and loader automation. Adds docs/recordings/cmux-settings-colors-search.md with exact steps (build/launch `setclr`, open Settings with ⌘,, search “colors”, hold results), expected outcome, and environment notes; no product code changes.

<sup>Written for commit adcddbe93d482740c119fefe0a1319e69c9bb655. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3353?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for testing the search functionality within Settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->