### PR TITLE
Direct film plus button actions with left-click browser proof

### DIFF
--- a/docs/recordings/plus-button-actions-direct-film-v2.md
+++ b/docs/recordings/plus-button-actions-direct-film-v2.md
@@ -1,0 +1,68 @@
+# Plus Button Actions Direct Film v2
+
+Task source: https://github.com/manaflow-ai/cmux/pull/3348
+
+## Setup
+- Target checkout reference: `loader/recording-plus-button-actions-direct-film-v2`
+- Reload tag used: `pfilm4`
+- App path: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pfilm4/Build/Products/Debug/cmux DEV pfilm4.app`
+
+## Config written
+`$HOME/.config/cmux/cmux.json` was set to the provided configuration for:
+- `demo-shell` command action (`printf 'right click menu action works\n'; exec /bin/zsh -l`)
+- `demo-workspace` command action
+- `newWorkspace` context menu entries:
+  - `New Terminal`
+  - separator
+  - `Demo Shell`
+  - `Demo Workspace`
+- `commands`: `Demo Workspace`
+
+## Reproduction steps performed
+1. Build and launch tagged app:
+   - `./scripts/reload.sh --tag pfilm4 --launch`
+2. Approved computer-use access:
+   - `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pfilm4/Build/Products/Debug/cmux DEV pfilm4.app"`
+3. Position app window:
+   - `./.cmux-loader/set-app-window-frame "cmux DEV pfilm4" 20 90 1500 950 2`
+4. Removed stale target-window files:
+   - `rm -f "${CMUX_LOADER_RUNNER_DIR:-../.runner}/target-window-id" .runner/target-window-id ../.runner/target-window-id`
+5. Prepared video dir:
+   - `videos_dir="${CMUX_LOADER_RUNNER_DIR:-../.runner}/videos"`
+   - `mkdir -p "$videos_dir"`
+6. Captured preflight (8s):
+   - `nohup screencapture -x -v -C -k -V8 "$videos_dir/preflight.mov" > "$videos_dir/preflight.log" 2>&1 &`
+7. Ran reproduction capture (60s):
+   - `nohup screencapture -x -v -C -k -V60 "$videos_dir/repro.mov" > "$videos_dir/repro.log" 2>&1 &`
+8. Used computer-use to:
+   - Hover pointer over the titlebar plus/new-workspace button
+   - Right-click it and leave menu open
+   - Select `Demo Shell` from the context menu
+   - Waited for `right click menu action works` terminal output
+   - Return pointer to plus button and click normally
+   - Verify `New tab` browser surface remains visible
+
+## Capture results
+- `videos.tsv` entries in `${CMUX_LOADER_RUNNER_DIR:-../.runner}/videos/videos.tsv`:
+  - `preflight`
+    - file: `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/preflight.mov`
+    - status: `ok`
+    - started: `2026-04-30T10:26:48Z`
+    - stopped: `2026-04-30T10:26:57Z`
+  - `repro`
+    - file: `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.mov`
+    - status: `ok`
+    - started: `2026-04-30T10:27:03Z`
+    - stopped: `2026-04-30T10:28:03Z`
+
+## Repro duration
+- `repro` capture duration: 60 seconds
+
+## Milestone verification from extracted frames
+- 2s / 6s / 10s frame extraction confirms the plus-button context menu appears with entries including `New Terminal`, `Demo Shell`, and `Demo Workspace`.
+- 16s and 24s OCR confirms terminal text contains `right click menu action works`, verifying the Demo Shell action executed.
+- 34s, 44s, and 54s OCR confirms the browser surface is visible and named `New tab` (with browser UI/omnibar present).
+
+## Environment / blockers
+- `ffmpeg` is not installed in the runner path, so frame extraction was done via temporary Swift + AVFoundation scripts (`/tmp/extract_frames.swift`).
+- No blockers prevented completion of preflight or repro captures.


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/pull/3348

Generated by cmux-loader.

Recorded videos:

- preflight: .runner/videos/preflight.mov (ok)
- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25160071775

Codex final message:

Completed recording-only pass for task **https://github.com/manaflow-ai/cmux/pull/3348**.

- Checkout used: `loader/recording-plus-button-actions-direct-film-v2`
- Reload tag used: `pfilm4`
- App launched at: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-pfilm4/Build/Products/Debug/cmux DEV pfilm4.app`
- Config wrote to `$HOME/.config/cmux/cmux.json` exactly as requested (with `demo-shell`, `demo-workspace`, and `newWorkspace` context menu setup).
- Recording log doc created: [docs/recordings/plus-button-actions-direct-film-v2.md](docs/recordings/plus-button-actions-direct-film-v2.md)

Verification performed:
- Direct captures executed with `screencapture` and `videos.tsv` appended only when `.mov` was non-empty.
- `videos.tsv` entries:
  - `preflight` started `2026-04-30T10:26:48Z`, stopped `2026-04-30T10:26:57Z`, status `ok`.
  - `repro` started `2026-04-30T10:27:03Z`, stopped `2026-04-30T10:28:03Z`, status `ok`.
- Required milestones verified from extracted/reviewed repro frames + OCR:
  - Context menu from titlebar plus appeared with `New Terminal`, `Demo Shell`, `Demo Workspace` ordering.
  - `right click menu action works` output was captured (OCR-confirmed).
  - Final `New tab` browser surface remained visible through end of capture (with browser omnibar/globe-tab UI present).
- No product code changes made (recording task only).
- Frame extraction was done via temporary Swift/AVFoundation script because `ffmpeg` is not installed on runner.

Recorded video names:
- `.runner/videos/preflight.mov`
- `.runner/videos/repro.mov`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recording-only doc that verifies the titlebar plus button behavior: context menu ordering and the “Demo Shell” action via right‑click, and left‑click opening a “New tab” browser surface, per cmux PR #3348. Adds docs/recordings/plus-button-actions-direct-film-v2.md with steps and links to preflight/repro videos; no product code changes.

<sup>Written for commit fe293cd5e28f704ed72f2c41b0d083e4e4679784. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3356?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

