### PR TITLE
Record cmux Settings colors search

### DIFF
--- a/docs/recordings/cmux-settings-colors-search-7.md
+++ b/docs/recordings/cmux-settings-colors-search-7.md
@@ -1,0 +1,52 @@
+# cmux Settings Colors Search Recording
+
+## Task
+- Task: recording-cmux-settings-colors-search-7
+- Branch/tag: `setclr7`
+- Date: 2026-04-30
+
+## Steps Attempted
+1. Built and launched tagged app:
+   - `./scripts/reload.sh --tag setclr7 --launch`
+   - App path: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr7/Build/Products/Debug/cmux DEV setclr7.app`
+2. Approved computer-use access:
+   - `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr7/Build/Products/Debug/cmux DEV setclr7.app"`
+3. Sized app window:
+   - `./.cmux-loader/set-app-window-frame "cmux DEV setclr7" 20 90 1500 950 2`
+4. Cleared target window IDs before preflight:
+   - `rm -f "$CMUX_LOADER_RUNNER_DIR/target-window-id" ../.runner/target-window-id .runner/target-window-id`
+   - Verified absent with `test ! -f "$CMUX_LOADER_RUNNER_DIR/target-window-id"`
+5. Started and completed preflight capture:
+   - `./.cmux-loader/record-video start preflight 8`
+   - Used computer-use to keep pointer over cmux window during bounded interval.
+   - `while ./.cmux-loader/record-video status | grep -q "running name=preflight"; do sleep 1; done`
+   - `./.cmux-loader/record-video stop preflight`
+6. Cleared target window IDs again before repro:
+   - same `rm -f ...` command and check
+7. Started and completed repro capture:
+   - `./.cmux-loader/record-video start repro 30`
+   - Brought `cmux DEV setclr7` frontmost, opened Settings with `Cmd-,` via computer-use.
+   - Focused search field in Settings and typed exactly `colors`.
+   - Left Settings visible until recording elapsed.
+   - `while ./.cmux-loader/record-video status | grep -q "running name=repro"; do sleep 1; done`
+   - `./.cmux-loader/record-video stop repro`
+
+## Verification
+- Preflight primary recording log check:
+  - `../.runner/videos/preflight.log` did not contain `primary recording missing`.
+  - Result: preflight succeeded.
+- Repro primary recording log check:
+  - `../.runner/videos/repro.log` did not contain `primary recording missing`.
+  - Result: repro succeeded.
+
+## Outcomes
+- Settings opened via `Cmd-,`: **Yes**
+- Search field accepted `colors`: **Yes** (field value showed `colors` in Settings search)
+
+## Video Artifacts
+- `preflight` → `preflight.mov`
+- `repro` → `repro.mov`
+
+## Blockers / Environment Notes
+- No recording blockers encountered.
+- Runner scrollbar context from loader info: `AppleShowScrollBars=unset` / `NSGlobalDomain AppleShowScrollBars=unset`.


### PR DESCRIPTION
Task: Record cmux Settings colors search

Generated by cmux-loader.

Recorded videos:

- preflight: .runner/videos/preflight.mov (ok)
- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25161037474

Codex final message:

Implemented. Recording-only task completed successfully.

### Outcome
- Built/launch verified with tag `setclr7` and approved computer-use for `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr7/Build/Products/Debug/cmux DEV setclr7.app`.
- Window was resized to `20 90 1500 950` and target window-id files were cleared before both captures.
- Preflight capture ran for the bounded window; no blocker found.
- Repro capture ran for the bounded window; Settings opened with `Cmd-,`, search was focused, and `colors` was entered in Settings search.
- Report created at `[docs/recordings/cmux-settings-colors-search-7.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-settings-colors-search-7.md)`.

### Verification
- `../.runner/videos/preflight.log`: no `primary recording missing` (status ok).
- `../.runner/videos/repro.log`: no `primary recording missing` (status ok).
- Settings opened: **Yes**.
- Search field accepted `colors`: **Yes**.

### Video artifacts
- `preflight` → `preflight.mov`
- `repro` → `repro.mov`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added a recording and doc verifying that cmux Settings opens with Cmd-, and the search field accepts “colors” for tag `setclr7`. Includes preflight and repro captures with passing log checks; see docs/recordings/cmux-settings-colors-search-7.md.

<sup>Written for commit 04f0dfc8618231a55583b322773da165885fcadc. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3357?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for the Settings search interaction workflow, including environment preparation, video capture procedures, and validation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->