### PR TITLE
Record cmux Settings colors search

### DIFF
--- a/docs/recordings/cmux-settings-colors-search-8.md
+++ b/docs/recordings/cmux-settings-colors-search-8.md
@@ -1,0 +1,27 @@
+# cmux Settings search for colors
+
+## Steps attempted
+- Ran tagged build and launch: `./scripts/reload.sh --tag setclr8 --launch`
+- Approved computer-use app: `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setclr8/Build/Products/Debug/cmux DEV setclr8.app"`
+- Sized window: `./.cmux-loader/set-app-window-frame "cmux DEV setclr8" 20 90 1500 950 2`
+- Cleared target window id files before preflight: `rm -f "$CMUX_LOADER_RUNNER_DIR/target-window-id" ../.runner/target-window-id .runner/target-window-id`
+- Started/finished preflight capture: `./.cmux-loader/record-video start preflight 8` then waited, then `./.cmux-loader/record-video stop preflight`
+- Cleared target window id files again before repro
+- Started repro capture: `./.cmux-loader/record-video start repro 30`
+- Brought app frontmost via computer-use and opened Settings with standard shortcut: `Cmd` + `,`
+- Focused Settings search field and typed exactly `colors`
+- Left Settings visible with search results until capture elapsed, then stopped with `./.cmux-loader/record-video stop repro`
+
+## Results
+- Preflight primary recording succeeded: yes (`status=ok`)
+- Preflight log (`../.runner/videos/preflight.log`): no `primary recording missing`
+- Settings opened via shortcut: yes (Settings window appeared)
+- Search field accepted `colors`: yes (search field value updated to `colors` and palette results visible)
+
+## Artifacts
+- `preflight`
+- `repro`
+
+## Notes / blockers
+- No blockers encountered.
+- Environment note: preflight/repro logs only showed setup-assistant capture permission handling.


### PR DESCRIPTION
Task: Record cmux Settings colors search

Generated by cmux-loader.

Recorded videos:

- preflight: .runner/videos/preflight.mov (ok)
- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25161534999

Codex final message:

Completed. Recording-only task finished and documented at [/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-settings-colors-search-8.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-settings-colors-search-8.md).

1. Verification:
- Tagged build/launch succeeded with `setclr8`.
- `./.cmux-loader/approve-computer-use-app` completed for `cmux DEV setclr8`.
- Window framed to `20 90 1500 950`.
- Preflight: `preflight` recording ran and stopped with `status=ok`; `../.runner/videos/preflight.log` had no `primary recording missing`.
- Repro: opened Settings via `Cmd+,`, focused Settings search field, typed exactly `colors`, and left it visible until recording end.
- Repro stop also returned `status=ok`; `../.runner/videos/repro.log` had no `primary recording missing`.
- No blockers encountered.

2. Artifacts:
- `preflight`
- `repro`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recording and documentation for the cmux Settings search for “colors”. Includes successful preflight and repro captures verifying opening Settings via Cmd+, typing “colors”, and seeing results; no functional changes.

<sup>Written for commit 3e8fada9aa5d6ac15b8627be653d37d104fed37b. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3358?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new documentation page recording the end-to-end testing procedure for the Settings color search feature, including executed commands, observed results, and generated test artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->