### PR TITLE
Record cmux Settings colors search

### DIFF
--- a/docs/recordings/cmux-settings-colors-search-10.md
+++ b/docs/recordings/cmux-settings-colors-search-10.md
@@ -1,0 +1,40 @@
+# cmux Settings Search for Colors (Task recording-cmux-settings-colors-search-10)
+
+Recorded by: loader/recording-cmux-settings-colors-search-10
+Date: 2026-04-30
+Environment notes:
+- Runner macOS scroll bar setting from task context: `AppleShowScrollBars=unset`
+- Tagged app built with: `./scripts/reload.sh --tag setc10 --launch`
+- App path used for approval and launch: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setc10/Build/Products/Debug/cmux DEV setc10.app`
+- App bundle used for computer-use: `com.cmuxterm.app.debug.setc10`
+- Command used to clear target ids: `rm -f "$CMUX_LOADER_RUNNER_DIR/target-window-id" ../.runner/target-window-id .runner/target-window-id`
+
+## Attempted steps
+1. Built and launched tagged app with `./scripts/reload.sh --tag setc10 --launch`.
+2. Ran `./.cmux-loader/approve-computer-use-app "/Users/runner/Library/Developer/Xcode/DerivedData/cmux-setc10/Build/Products/Debug/cmux DEV setc10.app"`.
+3. Sized window with `./.cmux-loader/set-app-window-frame "cmux DEV setc10" 20 90 1500 950 2`.
+4. Cleared persisted target window IDs.
+5. Started preflight capture with `./.cmux-loader/record-video start preflight 8`.
+6. Focused cmux window area using computer-use, then waited for recording duration to elapse.
+7. Stopped preflight with `./.cmux-loader/record-video stop preflight`.
+8. Inspected `../.runner/videos/preflight.log`.
+9. Cleared persisted target window IDs again.
+10. Started repro capture with `./.cmux-loader/record-video start repro 30`.
+11. Used computer-use on `com.cmuxterm.app.debug.setc10` to open Settings.
+12. Focused Settings search and typed `colors`.
+13. Kept Settings visible until 30-second capture elapsed.
+14. Stopped repro with `./.cmux-loader/record-video stop repro`.
+15. Inspected `../.runner/videos/repro.log`.
+
+## Outcomes
+- preflight primary recording succeeded: Yes (`preflight` status=ok)
+- Settings opened during repro: Yes (`cmd-comma` opened Settings in-cmux)
+- Search field accepted `colors`: Yes (tree output showed `Value: colors` in search text field)
+
+## Video artifacts
+- `preflight` -> `.runner/videos/preflight.mov`
+- `repro` -> `.runner/videos/repro.mov`
+
+## Blockers / notes
+- No recording blockers were encountered.
+- Both required logs reported normal pre-capture prompt handling and successful completion (`click-screen-capture-allow: done`).


### PR DESCRIPTION
Task: Record cmux Settings colors search

Generated by cmux-loader.

Recorded videos:

- preflight: .runner/videos/preflight.mov (ok)
- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25162219442

Codex final message:

Recording-only task completed successfully.

- App built/launch flow used: `./scripts/reload.sh --tag setc10 --launch` (tagged debug build only), approved for computer-use, and window sized with `./.cmux-loader/set-app-window-frame`.
- Target window-id files were cleared before both captures as requested.
- Preflight recording completed successfully (`status=ok`); log check did not show `"primary recording missing"`.
- Repro recording completed successfully (`status=ok`); log check did not show `"primary recording missing"`.
- Settings was opened via `cmd-comma`; Settings search field accepted the exact text `colors` (confirmed by UI state showing `search text field ... Value: colors`).
- Notes file created at [docs/recordings/cmux-settings-colors-search-10.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/cmux-settings-colors-search-10.md).

Recorded video names:
- `preflight` → `.runner/videos/preflight.mov`
- `repro` → `.runner/videos/repro.mov`

I did not make any product code changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a recording and notes for the cmux Settings search for “colors” to verify the flow. Includes docs/recordings/cmux-settings-colors-search-10.md and preflight/repro videos; confirms Settings opens via cmd-, and the search field accepts “colors”.

<sup>Written for commit 197361737f0a0ad5d57ac66b5bbeaf92eeef7e79. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3359?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new recording documentation capturing environment setup and execution steps for color settings search workflows, including video artifacts and status confirmations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->