### PR TITLE
fix: track app appearance so theme = light:X,dark:Y resolves correctly

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1674,6 +1674,8 @@ class GhosttyApp {
     private let backgroundLogLock = NSLock()
     private var backgroundLogSequence: UInt64 = 0
     private var appObservers: [NSObjectProtocol] = []
+    private var appAppearanceObserver: NSKeyValueObservation?
+    private var lastAppliedAppColorScheme: ghostty_color_scheme_e?
     private var bellAudioSound: NSSound?
     private var backgroundEventCounter: UInt64 = 0
     private var defaultBackgroundUpdateScope: GhosttyDefaultBackgroundUpdateScope = .unscoped
@@ -2003,7 +2005,42 @@ class GhosttyApp {
             ghostty_app_set_focus(app, false)
         })
 
+        // Track the system appearance at the app level so libghostty resolves
+        // `theme = light:X,dark:Y` to the correct side. Without this, the
+        // app's conditional state stays at its default and surfaces render the
+        // wrong theme regardless of OS appearance. Mirrors standalone Ghostty
+        // (see ghostty/macos/Sources/App/macOS/AppDelegate.swift).
+        appAppearanceObserver = NSApplication.shared.observe(
+            \.effectiveAppearance,
+            options: [.new, .initial]
+        ) { [weak self] _, change in
+            guard let self,
+                  let app = self.app,
+                  let appearance = change.newValue else { return }
+            self.applyAppColorScheme(for: appearance, source: "appearanceObserver", app: app)
+        }
+
         #endif
+    }
+
+    private func applyAppColorScheme(
+        for appearance: NSAppearance,
+        source: String,
+        app: ghostty_app_t
+    ) {
+        let scheme = Self.appColorScheme(for: appearance)
+        if lastAppliedAppColorScheme == scheme { return }
+        lastAppliedAppColorScheme = scheme
+        ghostty_app_set_color_scheme(app, scheme)
+        if backgroundLogEnabled {
+            let label = scheme == GHOSTTY_COLOR_SCHEME_DARK ? "dark" : "light"
+            logBackground("app color scheme source=\(source) scheme=\(label)")
+        }
+    }
+
+    static func appColorScheme(for appearance: NSAppearance) -> ghostty_color_scheme_e {
+        let isDark = appearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+        return isDark ? GHOSTTY_COLOR_SCHEME_DARK : GHOSTTY_COLOR_SCHEME_LIGHT
     }
 
     private func loadInlineGhosttyConfig(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6503,9 +6503,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private func applySurfaceColorScheme(force: Bool = false) {
         guard let surface else { return }
         let bestMatch = effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
-        let scheme: ghostty_color_scheme_e = bestMatch == .darkAqua
-            ? GHOSTTY_COLOR_SCHEME_DARK
-            : GHOSTTY_COLOR_SCHEME_LIGHT
+        let scheme = GhosttyApp.appColorScheme(for: effectiveAppearance)
         if !force, appliedColorScheme == scheme {
             if GhosttyApp.shared.backgroundLogEnabled {
                 let schemeLabel = scheme == GHOSTTY_COLOR_SCHEME_DARK ? "dark" : "light"

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2010,6 +2010,8 @@ class GhosttyApp {
         // app's conditional state stays at its default and surfaces render the
         // wrong theme regardless of OS appearance. Mirrors standalone Ghostty
         // (see ghostty/macos/Sources/App/macOS/AppDelegate.swift).
+        // AppKit delivers effectiveAppearance KVO callbacks on the main thread,
+        // so applyAppColorScheme runs on main without an explicit dispatch.
         appAppearanceObserver = NSApplication.shared.observe(
             \.effectiveAppearance,
             options: [.new, .initial]


### PR DESCRIPTION
## Summary

- cmux only set the per-surface color scheme, never the app-level `config_conditional_state`. libghostty therefore kept resolving `theme = light:X,dark:Y` against the default `.light` state regardless of macOS appearance, leaving terminal panes stuck while cmux's own chrome followed the system.
- Mirror standalone Ghostty's `AppDelegate` by observing `NSApplication.shared.effectiveAppearance` and forwarding it to `ghostty_app_set_color_scheme` so libghostty's app-level conditional state stays in sync. Reference: `ghostty/macos/Sources/App/macOS/AppDelegate.swift:303`.
- Pure helper `appColorScheme(for:)` extracted for testing.

Closes #2922
Refs #706, #570, #2708

Fix demonstration: https://youtu.be/HGI_zX3Oe44

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Terminal now automatically matches your macOS appearance; the color scheme updates when switching between light and dark modes.
  * Appearance changes are logged for diagnostics when background logging is enabled, including their source and resolved light/dark label.

* **Refactor**
  * Improved internal handling to reduce redundant color-scheme updates for smoother behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->