### PR TITLE
Require explicit Dock config

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -105309,23 +105309,6 @@
         }
       }
     },
-    "dock.default.feed.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Feed"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "フィード"
-          }
-        }
-      }
-    },
     "dock.empty.subtitle": {
       "extractionState": "manual",
       "localizations": {
@@ -105428,19 +105411,19 @@
         }
       }
     },
-    "dock.source.builtIn": {
+    "dock.source.title": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Built-in Dock"
+            "value": "Dock"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "組み込みDock"
+            "value": "Dock"
           }
         }
       }

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -280,7 +280,7 @@ final class DockControlsStore: ObservableObject {
 
         guard let workspaceId else {
             replaceControls(with: [])
-            sourceLabel = String(localized: "dock.source.builtIn", defaultValue: "Built-in Dock")
+            sourceLabel = String(localized: "dock.source.title", defaultValue: "Dock")
             return
         }
 
@@ -389,15 +389,6 @@ final class DockControlsStore: ObservableObject {
     }
 
     private static func resolve(rootDirectory: String?) throws -> DockConfigResolution {
-        if shouldUseBuiltInFeedControlForUITest {
-            return DockConfigResolution(
-                controls: [defaultFeedControl()],
-                sourceURL: nil,
-                baseDirectory: rootDirectory.flatMap(Self.existingDirectory) ?? FileManager.default.homeDirectoryForCurrentUser.path,
-                isProjectSource: false
-            )
-        }
-
         if let projectURL = projectConfigURL(rootDirectory: rootDirectory) {
             return try loadConfig(
                 from: projectURL,
@@ -416,20 +407,11 @@ final class DockControlsStore: ObservableObject {
         }
 
         return DockConfigResolution(
-            controls: [defaultFeedControl()],
+            controls: [],
             sourceURL: nil,
             baseDirectory: rootDirectory.flatMap(Self.existingDirectory) ?? FileManager.default.homeDirectoryForCurrentUser.path,
             isProjectSource: false
         )
-    }
-
-    private static var shouldUseBuiltInFeedControlForUITest: Bool {
-        guard ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1",
-              let readyPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEED_TUI_READY_PATH"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines) else {
-            return false
-        }
-        return !readyPath.isEmpty
     }
 
     private static func loadConfig(
@@ -462,48 +444,9 @@ final class DockControlsStore: ObservableObject {
         )
     }
 
-    private static func defaultFeedControl() -> DockControlDefinition {
-        defaultFeedControl(command: defaultFeedCommand())
-    }
-
-    private static func defaultFeedControl(command: String) -> DockControlDefinition {
-        var env: [String: String] = [:]
-        var forceOpenTUI = false
-        if let readyPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEED_TUI_READY_PATH"],
-           !readyPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            env["CMUX_FEED_TUI_READY_PATH"] = readyPath
-            if let bunPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEED_TUI_BUN_PATH"]?
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-               !bunPath.isEmpty {
-                env["CMUX_FEED_TUI_BUN_PATH"] = bunPath
-            }
-            forceOpenTUI = true
-        }
-        let resolvedCommand = command + (forceOpenTUI ? " --opentui" : "")
-        return DockControlDefinition(
-            id: "feed",
-            title: String(localized: "dock.default.feed.title", defaultValue: "Feed"),
-            command: resolvedCommand,
-            env: env
-        )
-    }
-
-    private static func defaultFeedCommand() -> String {
-        if let bundledCLIURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
-           FileManager.default.isExecutableFile(atPath: bundledCLIURL.path) {
-            return "\(shellSingleQuoted(bundledCLIURL.path)) feed tui"
-        }
-        return "cmux feed tui"
-    }
-
-    private static func shellSingleQuoted(_ value: String) -> String {
-        if value.isEmpty { return "''" }
-        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
-    }
-
     private static func sourceLabel(for resolution: DockConfigResolution) -> String {
         if resolution.sourceURL == nil {
-            return String(localized: "dock.source.builtIn", defaultValue: "Built-in Dock")
+            return String(localized: "dock.source.title", defaultValue: "Dock")
         }
         return resolution.isProjectSource
             ? String(localized: "dock.source.project", defaultValue: "Project Dock")
@@ -535,7 +478,13 @@ final class DockControlsStore: ObservableObject {
     }
 
     private static func globalConfigURL() -> URL {
-        FileManager.default.homeDirectoryForCurrentUser
+        if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1",
+           let testPath = ProcessInfo.processInfo.environment["CMUX_UI_TEST_DOCK_CONFIG_PATH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !testPath.isEmpty {
+            return URL(fileURLWithPath: testPath)
+        }
+        return FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".config/cmux/dock.json", isDirectory: false)
     }
 
@@ -563,7 +512,6 @@ final class DockControlsStore: ObservableObject {
             withIntermediateDirectories: true
         )
         let file = DockConfigFile(controls: [
-            defaultFeedControl(command: "cmux feed tui"),
             DockControlDefinition(
                 id: "git",
                 title: "Git",

--- a/cmuxUITests/FeedSidebarUITests.swift
+++ b/cmuxUITests/FeedSidebarUITests.swift
@@ -59,9 +59,6 @@ final class FeedSidebarUITests: XCTestCase {
             app.launchEnvironment["PATH"] = path
         }
         let bunPath = resolvedBunPathForFeedTUI()
-        if let bunPath {
-            app.launchEnvironment["CMUX_UI_TEST_FEED_TUI_BUN_PATH"] = bunPath
-        }
         try writeFeedDockConfig(bunPath: bunPath)
         launchAndEnsureUsable(app)
 

--- a/cmuxUITests/FeedSidebarUITests.swift
+++ b/cmuxUITests/FeedSidebarUITests.swift
@@ -12,6 +12,7 @@ final class FeedSidebarUITests: XCTestCase {
     private var diagnosticsPath = ""
     private var feedResultPath = ""
     private var feedTUIReadyPath = ""
+    private var dockConfigPath = ""
     private var requestId = ""
     private let modeKey = "socketControlMode"
     private let launchTag = "ui-tests-feed-sidebar"
@@ -23,11 +24,13 @@ final class FeedSidebarUITests: XCTestCase {
         diagnosticsPath = "/tmp/cmux-feed-sidebar-\(UUID().uuidString).json"
         feedResultPath = "/tmp/cmux-feed-sidebar-result-\(UUID().uuidString).json"
         feedTUIReadyPath = "/tmp/cmux-feed-sidebar-tui-ready-\(UUID().uuidString).json"
+        dockConfigPath = "/tmp/cmux-feed-sidebar-dock-\(UUID().uuidString).json"
         requestId = "uitest-\(UUID().uuidString)"
         removeSocketFile()
         try? FileManager.default.removeItem(atPath: diagnosticsPath)
         try? FileManager.default.removeItem(atPath: feedResultPath)
         try? FileManager.default.removeItem(atPath: feedTUIReadyPath)
+        try? FileManager.default.removeItem(atPath: dockConfigPath)
     }
 
     func testFeedReceivesAndResolvesPermissionRequest() throws {
@@ -49,12 +52,15 @@ final class FeedSidebarUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_FEED_SIDEBAR_RESULT_PATH"] = feedResultPath
         app.launchEnvironment["CMUX_UI_TEST_FEED_SIDEBAR_REQUEST_ID"] = requestId
         app.launchEnvironment["CMUX_UI_TEST_FEED_TUI_READY_PATH"] = feedTUIReadyPath
+        app.launchEnvironment["CMUX_UI_TEST_DOCK_CONFIG_PATH"] = dockConfigPath
         if let path = ProcessInfo.processInfo.environment["PATH"], !path.isEmpty {
             app.launchEnvironment["PATH"] = path
         }
-        if let bunPath = resolvedBunPathForFeedTUI() {
+        let bunPath = resolvedBunPathForFeedTUI()
+        if let bunPath {
             app.launchEnvironment["CMUX_UI_TEST_FEED_TUI_BUN_PATH"] = bunPath
         }
+        try writeFeedDockConfig(bunPath: bunPath)
         launchAndEnsureUsable(app)
 
         XCTAssertTrue(
@@ -334,6 +340,23 @@ final class FeedSidebarUITests: XCTestCase {
             return [:]
         }
         return object
+    }
+
+    private func writeFeedDockConfig(bunPath: String?) throws {
+        var env = ["CMUX_FEED_TUI_READY_PATH": feedTUIReadyPath]
+        if let bunPath, !bunPath.isEmpty {
+            env["CMUX_FEED_TUI_BUN_PATH"] = bunPath
+        }
+        let config: [String: Any] = [
+            "controls": [[
+                "id": "feed",
+                "title": "Feed",
+                "command": "cmux feed tui --opentui",
+                "env": env
+            ]]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: config, options: [.prettyPrinted, .sortedKeys])
+        try data.write(to: URL(fileURLWithPath: dockConfigPath), options: .atomic)
     }
 
     private func pollUntil(timeout: TimeInterval, interval: TimeInterval = 0.1, _ predicate: () -> Bool) -> Bool {

--- a/cmuxUITests/FeedSidebarUITests.swift
+++ b/cmuxUITests/FeedSidebarUITests.swift
@@ -24,7 +24,9 @@ final class FeedSidebarUITests: XCTestCase {
         diagnosticsPath = "/tmp/cmux-feed-sidebar-\(UUID().uuidString).json"
         feedResultPath = "/tmp/cmux-feed-sidebar-result-\(UUID().uuidString).json"
         feedTUIReadyPath = "/tmp/cmux-feed-sidebar-tui-ready-\(UUID().uuidString).json"
-        dockConfigPath = "/tmp/cmux-feed-sidebar-dock-\(UUID().uuidString).json"
+        dockConfigPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-feed-sidebar-dock-\(UUID().uuidString).json")
+            .path
         requestId = "uitest-\(UUID().uuidString)"
         removeSocketFile()
         try? FileManager.default.removeItem(atPath: diagnosticsPath)

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -1,10 +1,10 @@
 # Dock
 
-Dock lets you pin TUIs into the right sidebar. Each Dock control runs as its own Ghostty terminal section, so tools keep normal terminal keyboard behavior such as arrow keys, `j` / `k`, and `Ctrl-C`. Feed stays available as the built-in right-sidebar Feed on `Ctrl-4`; Dock is the separate TUI surface on `Ctrl-5` when the right sidebar is focused.
+Dock lets you pin TUIs into the right sidebar. Each Dock control runs as its own Ghostty terminal section, so tools keep normal terminal keyboard behavior such as arrow keys, `j` / `k`, and `Ctrl-C`. Feed stays available as the right-sidebar Feed on `Ctrl-4`; Dock is the separate TUI surface on `Ctrl-5` when the right sidebar is focused.
 
 Dock starts each command inside the terminal's non-interactive login shell. That keeps normal login PATH and toolchain setup without running prompt code before the TUI starts. When the command exits, Dock drops into an interactive login shell in the same section.
 
-The built-in Dock starts with Feed:
+Dock is configured with JSON. Add a Feed control to run the keyboard-first Feed TUI there:
 
 ```json
 {
@@ -20,7 +20,7 @@ The built-in Dock starts with Feed:
 
 `cmux feed tui` is the keyboard-first OpenTUI version of Feed. It runs in the alternate screen, preserves the Dock control's workspace cwd, and shows a latest-first timeline of permission requests, plans, questions, and activity. Use `j` / `k` or arrow keys to move, Enter to accept the default action, `d` to deny, `f` to send replan feedback, `r` to refresh, and `q` or `Ctrl-C` to quit.
 
-OpenTUI currently runs through Bun. On first launch, cmux prepares `~/.cmuxterm/feed-tui-opentui` and installs `@opentui/core` there. Run `cmux feed tui --opentui` to dogfood OpenTUI in isolation. If Bun is missing or the install fails, the default `cmux feed tui` falls back to the legacy built-in Feed TUI so Dock still opens.
+OpenTUI currently runs through Bun. On first launch, cmux prepares `~/.cmuxterm/feed-tui-opentui` and installs `@opentui/core` there. Run `cmux feed tui --opentui` to dogfood OpenTUI in isolation. If Bun is missing or the install fails, the default `cmux feed tui` falls back to the legacy Feed TUI so the command still opens.
 
 ## Team Config
 
@@ -55,7 +55,7 @@ Commit `.cmux/dock.json` in a repo to share controls with teammates:
 }
 ```
 
-The order of `controls` is the order shown in Dock. Reorder entries in the file to reorder Dock sections. Omit the built-in `feed` entry if the team does not want it.
+The order of `controls` is the order shown in Dock. Reorder entries in the file to reorder Dock controls. Remove an entry from the file to remove it from Dock.
 
 `height` is optional and acts as a preferred minimum. Dock expands controls to use the available sidebar height. Controls without a `height` split the remaining space after fixed-height controls are placed.
 
@@ -63,7 +63,8 @@ cmux looks for config in this order:
 
 1. `.cmux/dock.json` in the current project or a parent directory
 2. `~/.config/cmux/dock.json`
-3. the built-in Feed control
+
+If neither file exists, Dock opens empty and offers to create a starter config. cmux does not add any Dock controls automatically.
 
 Relative `cwd` values resolve from the repo root for `.cmux/dock.json` and from the home directory for the global config.
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -1,6 +1,6 @@
 # Feed
 
-Feed is cmux's inline surface for AI agent decisions. It stays in the right sidebar on `Ctrl-4`. The keyboard-first OpenTUI Feed can also run in the separate right-sidebar [Dock](dock.md) with `cmux feed tui`. It shows three things that need a human response:
+Feed is cmux's inline surface for AI agent decisions. It stays in the right sidebar on `Ctrl-4`. The keyboard-first OpenTUI Feed can also run in the separate right-sidebar [Dock](dock.md) after you add a Dock control that runs `cmux feed tui`. It shows three things that need a human response:
 
 - **Permission requests:** Agent wants to run a tool, edit a file, or execute a shell command. Pick Once / Always / All tools / Bypass / Deny.
 - **ExitPlanMode:** Agent finished planning and is ready to start editing. Pick Ultraplan / Manual / Auto.


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/3217.

Changes:
- Removes the built-in Feed fallback from Dock.
- Leaves Dock empty unless `.cmux/dock.json` or `~/.config/cmux/dock.json` exists.
- Updates Feed sidebar UI test setup to provide a temporary custom Dock config.
- Updates Dock docs to describe Feed as an example control, not a default control.

Verification:
- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-dock-json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Behavior**
  * Dock no longer includes a built-in default Feed; add a Feed control in your Dock config to enable it.
  * When no Dock config exists, Dock opens empty and offers to create a starter configuration.
  * Dock source label simplified to “Dock” for consistency.

* **Documentation**
  * Guides updated with examples and instructions for configuring the Feed in Dock and managing Dock contents.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->