### PR TITLE
docs(gateway): add LLM gateway guide + cmux-with-gateway.sh wrapper (refs #3317)

### DIFF
--- a/docs/llm-gateway.md
+++ b/docs/llm-gateway.md
@@ -1,0 +1,93 @@
+# Using cmux with an LLM gateway (LiteLLM, Helicone, OpenRouter, …)
+
+> Status: documentation + workaround for [#3317](https://github.com/manaflow-ai/cmux/issues/3317). The native `env_passthrough` feature is proposed there and not yet implemented; this page describes the **current** state and a **shell-wrapper** workaround that works today.
+
+A growing number of cmux users front their LLM traffic with a local proxy/gateway like [LiteLLM](https://github.com/BerriAI/litellm), [Helicone](https://www.helicone.ai/), or [OpenRouter](https://openrouter.ai/) (used as a gateway). The gateway typically provides:
+
+- Multi-provider failover (Anthropic → OpenRouter → Gemini → local Ollama)
+- Auto-injected prompt caching (~90% savings on repeated system prompts)
+- Centralized budget caps and rate limiting (often Redis-backed, surviving restarts)
+- One key to rotate instead of N provider keys
+- Unified observability (e.g. Langfuse) with per-call tags
+
+The coding agents that cmux launches (Claude Code, Codex CLI, Gemini CLI) all support pointing at a custom base URL via env vars:
+
+| Agent | Base URL env var | API key env var |
+|---|---|---|
+| Claude Code | `ANTHROPIC_BASE_URL` | `ANTHROPIC_API_KEY` |
+| Codex CLI | `OPENAI_BASE_URL` | `OPENAI_API_KEY` |
+| Gemini CLI | `GOOGLE_GENERATIVE_AI_BASE_URL` | `GOOGLE_API_KEY` |
+
+If the gateway is reachable from the agent process, all the gateway features above flow through transparently — the agent itself is unchanged.
+
+## The current friction with cmux
+
+cmux launches agents via internal launchers (`claudeTeams`, `codex`, `gemini`, …). Today these launchers do not have an explicit "preserve these env vars" mechanism, and cmux's wrapper logic can interact with parent-shell env in ways that prevent gateway vars from reaching the child reliably across all paths (split panes, restored sessions, claude-teams sub-agents).
+
+The clean fix is the opt-in `env_passthrough` config proposed in [#3317](https://github.com/manaflow-ai/cmux/issues/3317). Until that lands, the workaround below works today.
+
+## Workaround: shell wrapper
+
+A small shell wrapper is shipped at `scripts/cmux-with-gateway.sh`. It reads gateway config from a single env file (default: `~/.cmux/gateway.env`), exports the variables, then `exec`s the real `cmux` binary so cmux inherits the gateway env from its parent process.
+
+### 1. Drop your gateway config in `~/.cmux/gateway.env`
+
+```bash
+# ~/.cmux/gateway.env
+ANTHROPIC_BASE_URL=http://localhost:4000
+ANTHROPIC_API_KEY=sk-litellm-...
+
+OPENAI_BASE_URL=http://localhost:4000/v1
+OPENAI_API_KEY=sk-litellm-...
+
+GOOGLE_GENERATIVE_AI_BASE_URL=http://localhost:4000
+GOOGLE_API_KEY=sk-litellm-...
+```
+
+Permissions: this file holds your gateway master key. `chmod 600 ~/.cmux/gateway.env`.
+
+### 2. Use the wrapper instead of `cmux` directly
+
+```bash
+./scripts/cmux-with-gateway.sh                    # launches cmux normally
+./scripts/cmux-with-gateway.sh sessions list      # forwards args
+./scripts/cmux-with-gateway.sh claude-teams ...   # works for any subcommand
+```
+
+Optionally alias it:
+
+```bash
+alias cmux=$HOME/path/to/cmux/scripts/cmux-with-gateway.sh
+```
+
+### 3. Verify
+
+Inside a fresh cmux pane:
+
+```bash
+echo "$ANTHROPIC_BASE_URL"
+# → http://localhost:4000
+```
+
+If you get an empty line, your wrapper isn't being used or the file isn't being sourced — `./scripts/cmux-with-gateway.sh --debug` prints what it loaded.
+
+## What this workaround does *not* fix
+
+- **Sub-agent / claude-teams paths** that re-spawn the agent through cmux's internal wrapper logic may still drop gateway env vars depending on how the spawn chain looks. The native fix in [#3317](https://github.com/manaflow-ai/cmux/issues/3317) is required for this to be robust end-to-end.
+- **`NODE_OPTIONS` interaction** — if your gateway client also injects `NODE_OPTIONS` (some do, some don't), see [#2841](https://github.com/manaflow-ai/cmux/issues/2841).
+- **Per-launcher exclusion** — the wrapper exports the env globally; you can't say "Codex yes, Claude no" with this approach. The native config in #3317 supports per-launcher granularity.
+
+## Recommended companion features
+
+These are tracked in the same proposal series and complement gateway routing:
+
+- **Per-session caps** ([#3318](https://github.com/manaflow-ai/cmux/issues/3318)) — kill runaway sessions before they burn the gateway's monthly budget.
+- **Auto-tagging** ([#3319](https://github.com/manaflow-ai/cmux/issues/3319)) — surface cmux project/workspace/tab as gateway tags so cost dashboards segment correctly.
+- **Model-tier policy** ([#3326](https://github.com/manaflow-ai/cmux/issues/3326)) — declarative per-project model assignment, ideal once gateway aliases (`fast`, `code`, `cheap`) are in play.
+
+## See also
+
+- [#3317](https://github.com/manaflow-ai/cmux/issues/3317) — native `env_passthrough` proposal (this doc is the workaround until it lands).
+- [#2841](https://github.com/manaflow-ai/cmux/issues/2841) — `NODE_OPTIONS` preservation.
+- [LiteLLM proxy quick-start](https://docs.litellm.ai/docs/proxy/quick_start)
+- [Anthropic SDK base URL override](https://docs.anthropic.com/en/api/getting-started)

--- a/docs/llm-gateway.md
+++ b/docs/llm-gateway.md
@@ -16,7 +16,7 @@ The coding agents that cmux launches (Claude Code, Codex CLI, Gemini CLI) all su
 |---|---|---|
 | Claude Code | `ANTHROPIC_BASE_URL` | `ANTHROPIC_API_KEY` |
 | Codex CLI | `OPENAI_BASE_URL` | `OPENAI_API_KEY` |
-| Gemini CLI | `GOOGLE_GENERATIVE_AI_BASE_URL` | `GOOGLE_API_KEY` |
+| Gemini CLI | `GOOGLE_GENERATIVE_AI_BASE_URL` | `GEMINI_API_KEY` |
 
 If the gateway is reachable from the agent process, all the gateway features above flow through transparently — the agent itself is unchanged.
 
@@ -41,7 +41,7 @@ OPENAI_BASE_URL=http://localhost:4000/v1
 OPENAI_API_KEY=sk-litellm-...
 
 GOOGLE_GENERATIVE_AI_BASE_URL=http://localhost:4000
-GOOGLE_API_KEY=sk-litellm-...
+GEMINI_API_KEY=sk-litellm-...
 ```
 
 Permissions: this file holds your gateway master key. `chmod 600 ~/.cmux/gateway.env`.

--- a/docs/llm-gateway.md
+++ b/docs/llm-gateway.md
@@ -69,7 +69,7 @@ echo "$ANTHROPIC_BASE_URL"
 # → http://localhost:4000
 ```
 
-If you get an empty line, your wrapper isn't being used or the file isn't being sourced — `./scripts/cmux-with-gateway.sh --debug` prints what it loaded.
+If you get an empty line, your wrapper isn't being used or the file isn't being loaded — `./scripts/cmux-with-gateway.sh --debug` prints what it loaded. (The wrapper parses `KEY=VALUE` lines rather than `source`-ing the file, so it never executes shell code from your credential file.)
 
 ## What this workaround does *not* fix
 

--- a/scripts/cmux-with-gateway.sh
+++ b/scripts/cmux-with-gateway.sh
@@ -49,7 +49,7 @@ resolve_cmux() {
   while IFS= read -r cand; do
     [[ -z "$cand" || "$cand" == "$SCRIPT_PATH" ]] && continue
     [[ -x "$cand" ]] && { printf '%s\n' "$cand"; return 0; }
-  done < <(command -v -a cmux 2>/dev/null || true)
+  done < <(type -aP cmux 2>/dev/null || true)
 
   for cand in \
     "/Applications/cmux.app/Contents/Resources/bin/cmux" \

--- a/scripts/cmux-with-gateway.sh
+++ b/scripts/cmux-with-gateway.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# cmux-with-gateway.sh — workaround wrapper that pre-exports LLM gateway env
+# vars before exec'ing cmux, so gateway-fronted agents (Claude Code, Codex,
+# Gemini CLI) reach a local proxy like LiteLLM / Helicone / OpenRouter.
+#
+# Tracking issue: https://github.com/manaflow-ai/cmux/issues/3317
+# Documentation:  docs/llm-gateway.md
+#
+# Usage:
+#   cmux-with-gateway.sh                  # forwards no args (launches cmux UI)
+#   cmux-with-gateway.sh sessions list    # any cmux subcommand
+#   cmux-with-gateway.sh --debug ...      # print what was loaded, then run
+#
+# Config file (default ~/.cmux/gateway.env). Each line is KEY=VALUE.
+# Lines starting with # are comments. Values are taken verbatim — do not quote.
+#
+# Override config path with CMUX_GATEWAY_ENV_FILE.
+# Override cmux binary with CMUX_BIN.
+
+set -euo pipefail
+
+CMUX_GATEWAY_ENV_FILE="${CMUX_GATEWAY_ENV_FILE:-$HOME/.cmux/gateway.env}"
+DEBUG=0
+
+if [[ "${1:-}" == "--debug" ]]; then
+  DEBUG=1
+  shift
+fi
+
+# Resolve cmux binary:
+#   1. $CMUX_BIN if set
+#   2. cmux on $PATH (excluding ourselves to avoid recursion)
+#   3. /Applications/cmux.app/Contents/Resources/bin/cmux
+#   4. ~/Applications/cmux.app/Contents/Resources/bin/cmux
+SCRIPT_PATH="$(cd "$(dirname "$0")" && pwd)/$(basename "$0")"
+
+resolve_cmux() {
+  if [[ -n "${CMUX_BIN:-}" ]]; then
+    if [[ -x "$CMUX_BIN" ]]; then
+      printf '%s\n' "$CMUX_BIN"
+      return 0
+    fi
+    echo "cmux-with-gateway: CMUX_BIN=$CMUX_BIN is not executable" >&2
+    return 1
+  fi
+
+  local cand
+  while IFS= read -r cand; do
+    [[ -z "$cand" || "$cand" == "$SCRIPT_PATH" ]] && continue
+    [[ -x "$cand" ]] && { printf '%s\n' "$cand"; return 0; }
+  done < <(command -v -a cmux 2>/dev/null || true)
+
+  for cand in \
+    "/Applications/cmux.app/Contents/Resources/bin/cmux" \
+    "$HOME/Applications/cmux.app/Contents/Resources/bin/cmux"; do
+    [[ -x "$cand" ]] && { printf '%s\n' "$cand"; return 0; }
+  done
+
+  echo "cmux-with-gateway: cmux binary not found. Set CMUX_BIN or add cmux to PATH." >&2
+  return 1
+}
+
+CMUX_BIN_RESOLVED="$(resolve_cmux)"
+
+# Load gateway env file. Each non-empty, non-comment line of the form KEY=VALUE
+# is exported. We deliberately do NOT `source` the file (avoids running shell
+# code from a credential file).
+LOADED_KEYS=()
+if [[ -f "$CMUX_GATEWAY_ENV_FILE" ]]; then
+  # Refuse to load a world-readable credential file.
+  if [[ "$(uname -s)" == "Darwin" ]]; then
+    PERMS="$(stat -f '%A' "$CMUX_GATEWAY_ENV_FILE")"
+  else
+    PERMS="$(stat -c '%a' "$CMUX_GATEWAY_ENV_FILE")"
+  fi
+  if [[ "$PERMS" != "600" && "$PERMS" != "400" ]]; then
+    echo "cmux-with-gateway: refusing to load $CMUX_GATEWAY_ENV_FILE (mode $PERMS); chmod 600 it" >&2
+    exit 2
+  fi
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    # strip leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    [[ -z "$line" || "${line:0:1}" == "#" ]] && continue
+    if [[ "$line" != *=* ]]; then
+      echo "cmux-with-gateway: ignoring malformed line: $line" >&2
+      continue
+    fi
+    key="${line%%=*}"
+    value="${line#*=}"
+    # accept only sane env-var names
+    if [[ ! "$key" =~ ^[A-Z_][A-Z0-9_]*$ ]]; then
+      echo "cmux-with-gateway: ignoring suspicious key: $key" >&2
+      continue
+    fi
+    export "$key"="$value"
+    LOADED_KEYS+=("$key")
+  done < "$CMUX_GATEWAY_ENV_FILE"
+elif (( DEBUG )); then
+  echo "cmux-with-gateway: $CMUX_GATEWAY_ENV_FILE not found, running cmux without gateway env" >&2
+fi
+
+if (( DEBUG )); then
+  echo "cmux-with-gateway: cmux binary  -> $CMUX_BIN_RESOLVED" >&2
+  echo "cmux-with-gateway: env file     -> $CMUX_GATEWAY_ENV_FILE" >&2
+  echo "cmux-with-gateway: loaded keys  -> ${LOADED_KEYS[*]:-<none>}" >&2
+fi
+
+exec "$CMUX_BIN_RESOLVED" "$@"

--- a/tests/test_cmux_with_gateway_wrapper.py
+++ b/tests/test_cmux_with_gateway_wrapper.py
@@ -4,9 +4,10 @@
 The wrapper pre-exports LLM gateway env vars (e.g. ``ANTHROPIC_BASE_URL``)
 before exec'ing ``cmux``. See ``docs/llm-gateway.md`` for full description.
 
-Run locally — does not require Xcode, the cmux VM, or Bun:
-
-    python3 tests/test_cmux_with_gateway_wrapper.py
+Per repo policy, all tests run via GitHub Actions or on the cmux VM
+(see CONTRIBUTING.md and scripts/run-tests-v1.sh). This file is hermetic and
+intentionally does not depend on Xcode, the cmux VM, or Bun, so it can be
+included in CI alongside the rest of the suite.
 """
 
 from __future__ import annotations
@@ -214,6 +215,30 @@ def test_debug_flag_prints_loaded_keys(tmp: Path) -> None:
     assert "OPENAI_BASE_URL" in result.stderr
 
 
+def test_debug_flag_never_prints_secret_values(tmp: Path) -> None:
+    """Regression: --debug must surface key *names* but never values.
+
+    The env file holds the gateway master key. If the wrapper's --debug output
+    ever leaks values to stderr, a screen recording or a pasted log dump
+    exposes the credential. (Stdout is the child cmux's namespace and is
+    irrelevant here — what cmux does with the env is its own concern.)
+    """
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    secret = "sk-litellm-DO-NOT-LEAK-1234567890abcdef"
+    _write_secure(
+        gateway_env,
+        f"ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        f"ANTHROPIC_API_KEY={secret}\n",
+    )
+    result = _run_wrapper(["--debug"], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    # Names must surface so the user can verify what loaded.
+    assert "ANTHROPIC_API_KEY" in result.stderr
+    # The wrapper's own debug output (stderr) must not contain values.
+    assert secret not in result.stderr, "secret value leaked to wrapper stderr"
+
+
 def test_cmux_bin_not_executable_fails_clearly(tmp: Path) -> None:
     not_executable = tmp / "notcmux"
     not_executable.write_text("#!/bin/sh\necho hi\n")
@@ -249,6 +274,7 @@ TESTS = [
     test_refuses_world_readable_env_file,
     test_no_env_file_runs_cmux_anyway,
     test_debug_flag_prints_loaded_keys,
+    test_debug_flag_never_prints_secret_values,
     test_cmux_bin_not_executable_fails_clearly,
 ]
 

--- a/tests/test_cmux_with_gateway_wrapper.py
+++ b/tests/test_cmux_with_gateway_wrapper.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""Tests for ``scripts/cmux-with-gateway.sh``.
+
+The wrapper pre-exports LLM gateway env vars (e.g. ``ANTHROPIC_BASE_URL``)
+before exec'ing ``cmux``. See ``docs/llm-gateway.md`` for full description.
+
+Run locally — does not require Xcode, the cmux VM, or Bun:
+
+    python3 tests/test_cmux_with_gateway_wrapper.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = REPO_ROOT / "scripts" / "cmux-with-gateway.sh"
+
+FAKE_CMUX_TEMPLATE = """#!/usr/bin/env bash
+# Fake cmux: prints a JSON line so the test can inspect argv + env we care about.
+python3 - "$@" <<'PY'
+import json, os, sys
+out = {
+    "argv": sys.argv[1:],
+    "env": {k: os.environ.get(k, "") for k in (
+        "ANTHROPIC_BASE_URL",
+        "ANTHROPIC_API_KEY",
+        "OPENAI_BASE_URL",
+        "OPENAI_API_KEY",
+        "GOOGLE_GENERATIVE_AI_BASE_URL",
+        "INJECTED",
+        "BAD_KEY",
+    )},
+}
+print(json.dumps(out))
+PY
+"""
+
+SENSITIVE_KEYS = (
+    "ANTHROPIC_BASE_URL",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_BASE_URL",
+    "OPENAI_API_KEY",
+    "GOOGLE_GENERATIVE_AI_BASE_URL",
+    "INJECTED",
+    "BAD_KEY",
+)
+
+
+def _make_fake_cmux(tmpdir: Path) -> Path:
+    bin_dir = tmpdir / "bin"
+    bin_dir.mkdir()
+    fake = bin_dir / "cmux"
+    fake.write_text(FAKE_CMUX_TEMPLATE)
+    fake.chmod(0o755)
+    return fake
+
+
+def _write_secure(path: Path, content: str) -> None:
+    path.write_text(content)
+    path.chmod(0o600)
+
+
+def _run_wrapper(
+    args: list[str],
+    fake_cmux: Path,
+    gateway_env: Path | None,
+) -> subprocess.CompletedProcess:
+    env = os.environ.copy()
+    env["CMUX_BIN"] = str(fake_cmux)
+    if gateway_env is not None:
+        env["CMUX_GATEWAY_ENV_FILE"] = str(gateway_env)
+    for key in SENSITIVE_KEYS:
+        env.pop(key, None)
+    return subprocess.run(
+        ["bash", str(WRAPPER), *args],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def _parse(stdout: str) -> dict:
+    last = [line for line in stdout.splitlines() if line.strip()][-1]
+    return json.loads(last)
+
+
+# --- individual tests ---
+
+
+def test_wrapper_exists_and_is_executable() -> None:
+    assert WRAPPER.exists(), "wrapper script missing"
+    assert os.access(WRAPPER, os.X_OK), "wrapper is not executable"
+
+
+def test_exports_keys_from_env_file(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(
+        gateway_env,
+        "ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        "ANTHROPIC_API_KEY=sk-test-anthropic\n"
+        "OPENAI_BASE_URL=http://localhost:4000/v1\n",
+    )
+    result = _run_wrapper([], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+    assert payload["env"]["ANTHROPIC_API_KEY"] == "sk-test-anthropic"
+    assert payload["env"]["OPENAI_BASE_URL"] == "http://localhost:4000/v1"
+
+
+def test_forwards_argv(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(gateway_env, "ANTHROPIC_BASE_URL=http://x\n")
+    result = _run_wrapper(
+        ["sessions", "list", "--json"], fake_cmux, gateway_env
+    )
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["argv"] == ["sessions", "list", "--json"]
+
+
+def test_ignores_comments_and_blank_lines(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(
+        gateway_env,
+        "# top comment\n"
+        "\n"
+        "ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        "   \n"
+        "# trailing comment\n",
+    )
+    result = _run_wrapper([], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+
+
+def test_rejects_malformed_lines(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(
+        gateway_env,
+        "ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        "this-line-has-no-equals-sign\n"
+        "ANTHROPIC_API_KEY=ok\n",
+    )
+    result = _run_wrapper([], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+    assert payload["env"]["ANTHROPIC_API_KEY"] == "ok"
+    assert "ignoring malformed line" in result.stderr
+
+
+def test_rejects_suspicious_key_names(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(
+        gateway_env,
+        "ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        "lowercase_key=ignored\n"
+        "BAD-KEY-WITH-DASHES=ignored\n"
+        "BAD_KEY=ok\n",
+    )
+    result = _run_wrapper([], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == "http://localhost:4000"
+    assert payload["env"]["BAD_KEY"] == "ok"
+    assert "ignoring suspicious key: lowercase_key" in result.stderr
+    assert "ignoring suspicious key: BAD-KEY-WITH-DASHES" in result.stderr
+
+
+def test_refuses_world_readable_env_file(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    gateway_env.write_text("ANTHROPIC_BASE_URL=http://localhost:4000\n")
+    gateway_env.chmod(0o644)
+    result = _run_wrapper([], fake_cmux, gateway_env)
+    assert result.returncode == 2, result.stdout + result.stderr
+    assert "refusing to load" in result.stderr
+
+
+def test_no_env_file_runs_cmux_anyway(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    missing = tmp / "nonexistent.env"
+    result = _run_wrapper([], fake_cmux, missing)
+    assert result.returncode == 0, result.stderr
+    payload = _parse(result.stdout)
+    assert payload["env"]["ANTHROPIC_BASE_URL"] == ""
+
+
+def test_debug_flag_prints_loaded_keys(tmp: Path) -> None:
+    fake_cmux = _make_fake_cmux(tmp)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(
+        gateway_env,
+        "ANTHROPIC_BASE_URL=http://localhost:4000\n"
+        "OPENAI_BASE_URL=http://localhost:4000/v1\n",
+    )
+    result = _run_wrapper(["--debug"], fake_cmux, gateway_env)
+    assert result.returncode == 0, result.stderr
+    assert "ANTHROPIC_BASE_URL" in result.stderr
+    assert "OPENAI_BASE_URL" in result.stderr
+
+
+def test_cmux_bin_not_executable_fails_clearly(tmp: Path) -> None:
+    not_executable = tmp / "notcmux"
+    not_executable.write_text("#!/bin/sh\necho hi\n")
+    not_executable.chmod(0o644)
+    gateway_env = tmp / "gateway.env"
+    _write_secure(gateway_env, "ANTHROPIC_BASE_URL=http://x\n")
+    env = os.environ.copy()
+    env["CMUX_BIN"] = str(not_executable)
+    env["CMUX_GATEWAY_ENV_FILE"] = str(gateway_env)
+    for key in SENSITIVE_KEYS:
+        env.pop(key, None)
+    result = subprocess.run(
+        ["bash", str(WRAPPER)],
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode != 0
+    assert "not executable" in result.stderr
+
+
+# --- driver ---
+
+
+TESTS = [
+    test_wrapper_exists_and_is_executable,
+    test_exports_keys_from_env_file,
+    test_forwards_argv,
+    test_ignores_comments_and_blank_lines,
+    test_rejects_malformed_lines,
+    test_rejects_suspicious_key_names,
+    test_refuses_world_readable_env_file,
+    test_no_env_file_runs_cmux_anyway,
+    test_debug_flag_prints_loaded_keys,
+    test_cmux_bin_not_executable_fails_clearly,
+]
+
+
+def main() -> int:
+    passed = 0
+    failed: list[tuple[str, str]] = []
+    for fn in TESTS:
+        name = fn.__name__
+        try:
+            sig_takes_tmp = "tmp" in fn.__code__.co_varnames
+            if sig_takes_tmp:
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    fn(Path(tmpdir))
+            else:
+                fn()
+            print(f"PASS  {name}")
+            passed += 1
+        except AssertionError as exc:
+            print(f"FAIL  {name}: {exc}")
+            failed.append((name, str(exc)))
+        except Exception as exc:  # noqa: BLE001
+            print(f"ERROR {name}: {exc!r}")
+            failed.append((name, repr(exc)))
+    total = len(TESTS)
+    print(f"\n{passed}/{total} passed")
+    return 0 if not failed else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Documents how to use cmux with a local LLM proxy/gateway (LiteLLM, Helicone, OpenRouter-as-gateway, etc.) so that agents cmux launches (Claude Code, Codex, Gemini CLI) inherit `ANTHROPIC_BASE_URL`, `OPENAI_BASE_URL`, `GOOGLE_GENERATIVE_AI_BASE_URL` and matching API keys.

The native fix is proposed as opt-in `env_passthrough` config in #3317. This PR ships **documentation + a shell-wrapper workaround** that unblocks users today without touching the launcher pipeline. The wrapper is intentionally narrow in scope so it can be merged independently of any Swift-side change.

## What's in this PR

- **`docs/llm-gateway.md`** — end-to-end guide: why a gateway, what cmux currently does (and doesn't), step-by-step setup with `~/.cmux/gateway.env`, verification, the limits of this workaround, and pointers to companion proposals (#3318 caps, #3319 tags, #3326 model policy). Links back to #3317 for the native solution.

- **`scripts/cmux-with-gateway.sh`** — small bash wrapper:
  - Reads `~/.cmux/gateway.env` (override via `CMUX_GATEWAY_ENV_FILE`).
  - **Refuses to load the file** unless it's mode `600` or `400` — it holds the gateway master key.
  - **Does not `source` the file** — parses line-by-line; rejects malformed lines and suspicious key names, logs to stderr, doesn't abort.
  - Resolves the cmux binary via `$CMUX_BIN`, `$PATH` (skipping itself), or the standard `~/Applications/cmux.app/...` path.
  - `exec`s cmux so it inherits the env directly.
  - `--debug` prints what was loaded.

- **`tests/test_cmux_with_gateway_wrapper.py`** — 10 hermetic tests using a fake `cmux` shim (no Xcode, no VM, no Bun). Pure stdlib, runnable with `python3 tests/test_cmux_with_gateway_wrapper.py`. Covers:
  - Happy path: env vars exported, argv forwarded
  - Comment / blank-line handling
  - Malformed-line tolerance (logged, not fatal)
  - Suspicious key-name rejection (`lowercase`, `dashed-keys`)
  - Permission refusal on world-readable env file
  - Missing env file falls through cleanly
  - `--debug` flag emits expected stderr
  - Bad `$CMUX_BIN` fails with a clear message

```
PASS  test_wrapper_exists_and_is_executable
PASS  test_exports_keys_from_env_file
PASS  test_forwards_argv
PASS  test_ignores_comments_and_blank_lines
PASS  test_rejects_malformed_lines
PASS  test_rejects_suspicious_key_names
PASS  test_refuses_world_readable_env_file
PASS  test_no_env_file_runs_cmux_anyway
PASS  test_debug_flag_prints_loaded_keys
PASS  test_cmux_bin_not_executable_fails_clearly
10/10 passed
```

## What this PR explicitly does NOT do

- **No Swift changes.** The launcher-level `env_passthrough` is the right native fix and lives in #3317 — that needs maintainer review of `CLI/cmux.swift` paths around `claudeTeamsLaunchArguments` / `exportAgentLaunchCommandEnvironment` and the existing env-restore logic discussed in #2841.
- **No claude-teams sub-agent fix.** The wrapper exports gateway env into the parent shell that runs cmux, which propagates to top-level launches. Sub-agent paths that re-spawn through internal wrappers may still drop env vars depending on the spawn chain — the doc states this limitation explicitly.
- **No per-launcher granularity.** That's a #3317 feature; the wrapper exports globally.

## Test plan

- [x] `python3 tests/test_cmux_with_gateway_wrapper.py` — 10/10 pass on macOS 14
- [x] `bash -n scripts/cmux-with-gateway.sh` — clean
- [ ] Manual smoke: drop a real LiteLLM at `localhost:4000`, run `./scripts/cmux-with-gateway.sh`, open a Claude Code pane, confirm requests hit the proxy (verifiable via `curl http://localhost:4000/spend/logs` or Langfuse).

## Refs

- Closes the documentation/workaround portion of #3317 (native config still TODO).
- Companions: #3318 (caps), #3319 (auto-tags), #3326 (model policy), #2841 (`NODE_OPTIONS` adjacent).

---

Filed as proposal #1 of 10 from [`liberathio/cmux-improvements`](https://github.com/liberathio/cmux-improvements). Happy to iterate on naming, file location, or to drop the wrapper script entirely if maintainers prefer doc-only — the docs alone are still valuable as an interim guide.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a wrapper script to preload and manage environment variables for cmux operations, including security validation and optional debug mode.

* **Documentation**
  * Added guide for routing agent traffic through external LLM gateways using environment variable configuration.

* **Tests**
  * Added comprehensive test suite validating wrapper script functionality, including argument forwarding, environment variable loading, security checks, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->