### PR TITLE
Skip sidebar PR polling when hidden and make interval configurable

### DIFF
--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -910,6 +910,23 @@ class TabManager: ObservableObject {
     private nonisolated static let workspacePullRequestPollJitterFraction = 0.10
     private nonisolated static let workspacePullRequestProbeTimeout: TimeInterval = 5.0
     private nonisolated static let mergedPullRequestBadgeStaleAfter: TimeInterval = 14 * 24 * 60 * 60
+
+    nonisolated static let sidebarShowPullRequestDefaultsKey = "sidebarShowPullRequest"
+    nonisolated static let workspacePullRequestPollIntervalDefaultsKey = "workspacePullRequestPollIntervalSeconds"
+    nonisolated static let workspacePullRequestPollIntervalMinSeconds: TimeInterval = 30
+    nonisolated static let workspacePullRequestPollIntervalMaxSeconds: TimeInterval = 3600
+
+    nonisolated static func sidebarShowPullRequestEnabled(defaults: UserDefaults = .standard) -> Bool {
+        guard defaults.object(forKey: sidebarShowPullRequestDefaultsKey) != nil else { return true }
+        return defaults.bool(forKey: sidebarShowPullRequestDefaultsKey)
+    }
+
+    nonisolated static func workspacePullRequestBackgroundPollInterval(defaults: UserDefaults = .standard) -> TimeInterval {
+        guard let value = defaults.object(forKey: workspacePullRequestPollIntervalDefaultsKey) as? NSNumber else {
+            return backgroundPollInterval
+        }
+        return min(max(value.doubleValue, workspacePullRequestPollIntervalMinSeconds), workspacePullRequestPollIntervalMaxSeconds)
+    }
     @Published var selectedTabId: UUID? {
         willSet {
 #if DEBUG
@@ -1087,6 +1104,16 @@ class TabManager: ObservableObject {
             }
         })
 
+        observers.append(NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated { [weak self] in
+                self?.handlePullRequestPollSettingsChange()
+            }
+        })
+
         startAgentPIDSweepTimer()
         startWorkspaceGitMetadataPollTimer()
         startSelectedWorkspaceGitMetadataPollTimer()
@@ -1164,6 +1191,12 @@ class TabManager: ObservableObject {
     }
 
     private func updateWorkspacePullRequestPollTimer() {
+        guard Self.sidebarShowPullRequestEnabled() else {
+            workspacePullRequestPollTimer?.cancel()
+            workspacePullRequestPollTimer = nil
+            return
+        }
+
         guard workspacePullRequestRefreshTask == nil else {
             workspacePullRequestPollTimer?.cancel()
             workspacePullRequestPollTimer = nil
@@ -1238,6 +1271,11 @@ class TabManager: ObservableObject {
         reason: String,
         allowCachedResultsOverride: Bool? = nil
     ) {
+        guard Self.sidebarShowPullRequestEnabled() else {
+            resetWorkspacePullRequestRefreshState()
+            return
+        }
+
         let now = Date()
         var candidateSeeds: [WorkspacePullRequestCandidateSeed] = []
         var requestedKeys: [WorkspaceGitProbeKey] = []
@@ -1606,16 +1644,18 @@ class TabManager: ObservableObject {
             return
         }
 
+        let configuredBackgroundInterval = Self.workspacePullRequestBackgroundPollInterval()
+
         if case .unsupportedRepository = resolution {
             workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
-            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: Self.backgroundPollInterval))
+            workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: configuredBackgroundInterval))
             return
         }
 
         workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)
         let baseInterval = isSelectedFocusedPanel(workspace: workspace, panelId: panelId)
             ? Self.selectedPollInterval
-            : Self.backgroundPollInterval
+            : configuredBackgroundInterval
         workspacePullRequestNextPollAtByKey[key] = now.addingTimeInterval(Self.jitteredPollInterval(base: baseInterval))
     }
 
@@ -1657,6 +1697,19 @@ class TabManager: ObservableObject {
         workspacePullRequestRepoCacheBySlug.removeAll()
         workspacePullRequestFollowUpShouldBypassRepoCache = false
         updateWorkspacePullRequestPollTimer()
+    }
+
+    private var lastObservedSidebarShowPullRequestEnabled = TabManager.sidebarShowPullRequestEnabled()
+
+    private func handlePullRequestPollSettingsChange() {
+        let enabled = Self.sidebarShowPullRequestEnabled()
+        if enabled == lastObservedSidebarShowPullRequestEnabled { return }
+        lastObservedSidebarShowPullRequestEnabled = enabled
+        if enabled {
+            refreshTrackedWorkspacePullRequestsIfNeeded(reason: "sidebarShowPullRequestEnabled")
+        } else {
+            resetWorkspacePullRequestRefreshState()
+        }
     }
 
     private var activeWorkspaceGitProbeKeys: Set<WorkspaceGitProbeKey> {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -927,6 +927,7 @@ class TabManager: ObservableObject {
         }
         return min(max(value.doubleValue, workspacePullRequestPollIntervalMinSeconds), workspacePullRequestPollIntervalMaxSeconds)
     }
+
     @Published var selectedTabId: UUID? {
         willSet {
 #if DEBUG
@@ -1700,13 +1701,21 @@ class TabManager: ObservableObject {
     }
 
     private var lastObservedSidebarShowPullRequestEnabled = TabManager.sidebarShowPullRequestEnabled()
+    private var lastObservedWorkspacePullRequestPollInterval = TabManager.workspacePullRequestBackgroundPollInterval()
 
     private func handlePullRequestPollSettingsChange() {
         let enabled = Self.sidebarShowPullRequestEnabled()
-        if enabled == lastObservedSidebarShowPullRequestEnabled { return }
+        let interval = Self.workspacePullRequestBackgroundPollInterval()
+        let enabledChanged = enabled != lastObservedSidebarShowPullRequestEnabled
+        let intervalChanged = interval != lastObservedWorkspacePullRequestPollInterval
+        guard enabledChanged || (enabled && intervalChanged) else { return }
         lastObservedSidebarShowPullRequestEnabled = enabled
+        lastObservedWorkspacePullRequestPollInterval = interval
         if enabled {
-            refreshTrackedWorkspacePullRequestsIfNeeded(reason: "sidebarShowPullRequestEnabled")
+            if intervalChanged {
+                workspacePullRequestNextPollAtByKey = workspacePullRequestNextPollAtByKey.mapValues { _ in .distantPast }
+            }
+            refreshTrackedWorkspacePullRequestsIfNeeded(reason: "sidebarPullRequestPollSettingsChanged")
         } else {
             resetWorkspacePullRequestRefreshState()
         }

--- a/cmuxTests/WorkspacePullRequestSidebarTests.swift
+++ b/cmuxTests/WorkspacePullRequestSidebarTests.swift
@@ -179,4 +179,51 @@ final class WorkspacePullRequestSidebarTests: XCTestCase {
             "Pull request refresh blocked the main run loop for \(maxTickGap) seconds"
         )
     }
+
+    private func makeIsolatedDefaults() throws -> UserDefaults {
+        let suiteName = "cmux-tests.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+
+    func testSidebarShowPullRequestEnabledDefaultsToTrue() throws {
+        let defaults = try makeIsolatedDefaults()
+        XCTAssertTrue(TabManager.sidebarShowPullRequestEnabled(defaults: defaults))
+    }
+
+    func testSidebarShowPullRequestEnabledHonorsExplicitFalse() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(false, forKey: TabManager.sidebarShowPullRequestDefaultsKey)
+        XCTAssertFalse(TabManager.sidebarShowPullRequestEnabled(defaults: defaults))
+    }
+
+    func testWorkspacePullRequestBackgroundPollIntervalDefaultsTo60() throws {
+        let defaults = try makeIsolatedDefaults()
+        XCTAssertEqual(TabManager.workspacePullRequestBackgroundPollInterval(defaults: defaults), 60)
+    }
+
+    func testWorkspacePullRequestBackgroundPollIntervalClampsBelowMinimum() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(5, forKey: TabManager.workspacePullRequestPollIntervalDefaultsKey)
+        XCTAssertEqual(
+            TabManager.workspacePullRequestBackgroundPollInterval(defaults: defaults),
+            TabManager.workspacePullRequestPollIntervalMinSeconds
+        )
+    }
+
+    func testWorkspacePullRequestBackgroundPollIntervalClampsAboveMaximum() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(99_999, forKey: TabManager.workspacePullRequestPollIntervalDefaultsKey)
+        XCTAssertEqual(
+            TabManager.workspacePullRequestBackgroundPollInterval(defaults: defaults),
+            TabManager.workspacePullRequestPollIntervalMaxSeconds
+        )
+    }
+
+    func testWorkspacePullRequestBackgroundPollIntervalAcceptsCustomValueInRange() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(180, forKey: TabManager.workspacePullRequestPollIntervalDefaultsKey)
+        XCTAssertEqual(TabManager.workspacePullRequestBackgroundPollInterval(defaults: defaults), 180)
+    }
 }


### PR DESCRIPTION
## Summary

The sidebar PR poller in `TabManager` runs on every workspace branch unconditionally. With many worktrees open it generates a constant stream of GitHub API calls even when "Show Pull Requests in Sidebar" is disabled and no PR badge is rendered.

This PR (placeholder description — happy to expand):

- Gates `refreshTrackedWorkspacePullRequestsIfNeeded` and `updateWorkspacePullRequestPollTimer` on the existing `sidebarShowPullRequest` user default. When the toggle is off, in-flight refresh state is dropped and the poll timer is cancelled. Toggling back on resumes polling immediately via `UserDefaults.didChangeNotification`.
- Adds a hidden `workspacePullRequestPollIntervalSeconds` user default (default 60s, clamped 30..3600) so heavy-worktree users can ease the cadence without code changes. The selected-workspace 10s cadence is unchanged.
- Adds unit coverage for both helpers in `WorkspacePullRequestSidebarTests`.

No UI changes in this PR — the existing toggle now actually controls polling, and the interval is set via `defaults write com.cmuxterm.app workspacePullRequestPollIntervalSeconds -int 300`. Happy to add a Settings UI control in a follow-up.

## Test plan

- [ ] Unit tests pass (CI)
- [ ] Manual: toggle Settings → Sidebar → \"Show Pull Requests in Sidebar\" off; confirm no \`gh\` / api.github.com PR requests fire from the app while the toggle is off
- [ ] Manual: toggle back on; confirm PR badges return within ~10s for the selected workspace and within the configured interval for others
- [ ] Manual: \`defaults write com.cmuxterm.app workspacePullRequestPollIntervalSeconds -int 300\`; confirm background polls space out to ~5min

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sidebar pull-request polling can be enabled/disabled at runtime.
  * Background pull-request polling interval is configurable (30–3600 seconds) with min/max clamping and applied jitter.
  * Settings changes take effect immediately and fully stop scheduled polling when disabled.

* **Tests**
  * Added test coverage for pull-request sidebar preferences, polling configuration, and isolated settings handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->