### PR TITLE
Match Ghostty terminal scrollbar geometry

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9673,7 +9673,9 @@ final class GhosttySurfaceScrollView: NSView {
         scrollView.scrollerStyle = .overlay
         scrollView.drawsBackground = false
         scrollView.backgroundColor = .clear
-        scrollView.contentView.clipsToBounds = true
+        // Match upstream Ghostty: allow the surface to draw behind scroll-view
+        // chrome while the core terminal grid uses the content size.
+        scrollView.contentView.clipsToBounds = false
         scrollView.contentView.drawsBackground = false
         scrollView.contentView.backgroundColor = .clear
         scrollView.surfaceView = surfaceView
@@ -12204,11 +12206,11 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.frame.origin = visibleRect.origin
     }
 
-    /// Match upstream Ghostty behavior: use content area width (excluding non-content
-    /// regions such as scrollbar space) when telling libghostty the terminal size.
+    /// Match upstream Ghostty behavior: render the surface across the full viewport,
+    /// but tell libghostty about the scroll view's content width.
     @discardableResult
     private func synchronizeCoreSurface() -> Bool {
-        let width = max(0, surfaceView.frame.width)
+        let width = scrollView.contentSize.width
         let height = surfaceView.frame.height
         guard width > 0, height > 0 else { return false }
         return surfaceView.pushTargetSurfaceSize(CGSize(width: width, height: height))

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2690,12 +2690,6 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
 
         scrollView.scrollerStyle = .legacy
         scrollView.layoutSubtreeIfNeeded()
-        let legacyContentWidth = scrollView.contentSize.width
-        XCTAssertLessThan(
-            legacyContentWidth,
-            initialContentWidth,
-            "Legacy scrollbars should reserve width in the scroll view content area"
-        )
         assertPendingSurfaceWidth(
             initialSurfaceSize.width,
             "Changing the scroll view style alone should leave the terminal grid stale until the scroller-style observer runs"
@@ -2710,11 +2704,66 @@ final class GhosttySurfaceOverlayTests: XCTestCase {
             restoredContentWidth,
             initialContentWidth,
             accuracy: 0.5,
-            "Preferred scroller style changes should restore Ghostty's overlay scrollbar behavior so terminal content is not occluded by a persistent gutter"
+            "Preferred scroller style changes should restore Ghostty's overlay scrollbar behavior without a legacy gutter"
         )
         assertPendingSurfaceWidth(
             restoredContentWidth,
             "Preferred scroller style changes should restore the wider terminal grid when overlay scrollbars return"
+        )
+    }
+
+    func testSurfaceScrollViewMatchesGhosttyClipViewBehavior() {
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let scrollView = hostedView.subviews.first(where: { $0 is NSScrollView }) as? NSScrollView else {
+            XCTFail("Expected hosted terminal scroll view")
+            return
+        }
+
+        guard let pendingSurfaceWidth = hostedView.debugPendingSurfaceSize()?.width else {
+            XCTFail("Expected a pending terminal surface size")
+            return
+        }
+
+        XCTAssertEqual(scrollView.scrollerStyle, .overlay)
+        XCTAssertFalse(
+            scrollView.contentView.clipsToBounds,
+            "The terminal wrapper should allow Ghostty to draw behind scroll-view chrome"
+        )
+        XCTAssertEqual(
+            pendingSurfaceWidth,
+            scrollView.contentSize.width,
+            accuracy: 0.5,
+            "The terminal grid should use the same content width that upstream Ghostty reports to the core"
         )
     }
 

--- a/scripts/scrollbar-right-edge-tui.py
+++ b/scripts/scrollbar-right-edge-tui.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Interactive right-edge scrollbar probe for Ghostty and cmux.
+
+The default mode writes normal scrollback instead of using the alternate screen.
+That keeps the native terminal scrollbar involved while drawing an exact-width
+right-edge marker on every probe row.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import select
+import shutil
+import signal
+import sys
+import termios
+import tty
+from dataclasses import dataclass
+from typing import Any
+
+
+EDGE_MARKERS = "|]>X"
+PATTERN = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+
+
+@dataclass
+class ProbeConfig:
+    lines: int
+    width: int | None
+    plain: bool
+    no_clear: bool
+    once: bool
+
+
+def terminal_width(config: ProbeConfig) -> int:
+    if config.width is not None:
+        return max(8, config.width)
+    return max(8, shutil.get_terminal_size((80, 24)).columns)
+
+
+def styled_edge(marker: str, plain: bool) -> str:
+    if plain:
+        return marker
+    return f"\x1b[1;30;47m{marker}\x1b[0m"
+
+
+def exact_width_line(index: int, width: int, plain: bool) -> str:
+    marker = EDGE_MARKERS[(index - 1) % len(EDGE_MARKERS)]
+    body_width = max(0, width - 1)
+    label = f"{index:04d} w={width:03d} "
+    body = (label + (PATTERN * ((body_width // len(PATTERN)) + 2)))[:body_width]
+
+    suffix = f"{index % 10}R"
+    if body_width >= len(suffix):
+        body = body[: body_width - len(suffix)] + suffix
+
+    return body + styled_edge(marker, plain)
+
+
+def write_probe(config: ProbeConfig, append: bool = False) -> None:
+    width = terminal_width(config)
+    rows = shutil.get_terminal_size((80, 24)).lines
+
+    if not append and not config.no_clear:
+        sys.stdout.write("\x1b[2J\x1b[H")
+
+    sys.stdout.write(
+        "scrollbar right-edge probe\n"
+        f"terminal={os.environ.get('TERM', 'unknown')} cols={width} rows={rows}\n"
+        "compare Ghostty and cmux while scrolling; "
+        "the final bright cell should remain readable at the right edge\n"
+        "\n"
+    )
+
+    for index in range(1, config.lines + 1):
+        sys.stdout.write(exact_width_line(index, width, config.plain))
+        sys.stdout.write("\n")
+
+    sys.stdout.write(
+        "\n"
+        "keys: q quit, r repaint, s add scrollback, c clear+repaint\n"
+        "resize the window, press r, then scroll with the mouse or trackpad\n"
+    )
+    sys.stdout.flush()
+
+
+class RawMode:
+    def __init__(self) -> None:
+        self._old_attrs: list[Any] | None = None
+
+    def __enter__(self) -> "RawMode":
+        self._old_attrs = termios.tcgetattr(sys.stdin.fileno())
+        tty.setcbreak(sys.stdin.fileno())
+        return self
+
+    def __exit__(self, *_exc: object) -> None:
+        if self._old_attrs is not None:
+            termios.tcsetattr(sys.stdin.fileno(), termios.TCSADRAIN, self._old_attrs)
+
+
+def run_interactive(config: ProbeConfig) -> int:
+    if not sys.stdin.isatty() or not sys.stdout.isatty():
+        print("scrollbar-right-edge-tui requires a TTY, or pass --once", file=sys.stderr)
+        return 2
+
+    pending_resize = False
+
+    def handle_resize(_signum: int, _frame: object) -> None:
+        nonlocal pending_resize
+        pending_resize = True
+
+    old_winch = signal.signal(signal.SIGWINCH, handle_resize)
+    try:
+        write_probe(config)
+        with RawMode():
+            while True:
+                if pending_resize:
+                    pending_resize = False
+                    write_probe(config)
+
+                ready, _, _ = select.select([sys.stdin], [], [], 0.25)
+                if not ready:
+                    continue
+
+                key = sys.stdin.read(1)
+                if key in ("q", "\x03", "\x04"):
+                    sys.stdout.write("\n")
+                    sys.stdout.flush()
+                    return 0
+                if key == "r":
+                    write_probe(config)
+                elif key == "s":
+                    write_probe(config, append=True)
+                elif key == "c":
+                    write_probe(
+                        ProbeConfig(
+                            config.lines,
+                            config.width,
+                            config.plain,
+                            False,
+                            config.once,
+                        )
+                    )
+    finally:
+        signal.signal(signal.SIGWINCH, old_winch)
+
+
+def parse_args() -> ProbeConfig:
+    parser = argparse.ArgumentParser(
+        description="Draw exact-width right-edge probe rows for scrollbar comparison."
+    )
+    parser.add_argument(
+        "--lines",
+        type=int,
+        default=220,
+        help="probe rows to print per repaint, default: 220",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=None,
+        help="override detected terminal width",
+    )
+    parser.add_argument(
+        "--plain",
+        action="store_true",
+        help="disable ANSI styling on the final right-edge cell",
+    )
+    parser.add_argument(
+        "--no-clear",
+        action="store_true",
+        help="do not clear the visible screen before the first paint",
+    )
+    parser.add_argument(
+        "--once",
+        action="store_true",
+        help="print one probe and exit, useful for captured output checks",
+    )
+    args = parser.parse_args()
+
+    if args.lines < 1:
+        parser.error("--lines must be at least 1")
+
+    return ProbeConfig(
+        lines=args.lines,
+        width=args.width,
+        plain=args.plain,
+        no_clear=args.no_clear,
+        once=args.once,
+    )
+
+
+def main() -> int:
+    config = parse_args()
+    if config.once:
+        write_probe(config)
+        return 0
+    return run_interactive(config)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Match upstream Ghostty for terminal scroll wrapping: the surface renders across the full viewport, while libghostty receives `scrollView.contentSize.width`.
- Set the terminal scroll view clip view to allow drawing behind scroll-view chrome, matching `SurfaceScrollView.swift` in Ghostty.
- Add a regression test for the Ghostty-style wrapper geometry.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sb2997-match-tests -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testPreferredScrollerStyleChangeRestoresOverlayScrollbarWidth -only-testing:cmuxTests/GhosttySurfaceOverlayTests/testSurfaceScrollViewMatchesGhosttyClipViewBehavior test` passed.\n\n## Issues\n- Closes https://github.com/manaflow-ai/cmux/issues/2997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal now renders correctly with overlay scrollbars, allowing content to draw behind scrollbar chrome and preserving right-edge readability.
  * Terminal grid width now aligns with the full viewport content width when scrollbars change, improving layout stability.

* **Tests**
  * Updated tests to verify scrollbar style, clipping behavior, and reported surface width.

* **New Features**
  * Added an interactive CLI/TUI probe tool to visualize exact terminal right-edge alignment and test resize/scroll behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->