### PR TITLE
Record scrollbar right-edge terminal obstruction

### DIFF
--- a/docs/recordings/scrollbar-right-edge-2997.md
+++ b/docs/recordings/scrollbar-right-edge-2997.md
@@ -1,0 +1,53 @@
+# scrollbar-right-edge-2997
+
+- Task source URL: https://github.com/manaflow-ai/cmux/issues/2997
+- Recorded artifact: `repro`
+- Date: 2026-05-01
+- Host user-visible note: recording-only task
+
+## Environment notes
+- Scrollbar setting before launch: `defaults write -g AppleShowScrollBars -string Always` (confirmed by `defaults read -g AppleShowScrollBars`).
+- App launch/tag: `./scripts/reload.sh --tag scr2997 --launch`
+- App path used: `/Users/runner/Library/Developer/Xcode/DerivedData/cmux-scr2997/Build/Products/Debug/cmux DEV scr2997.app`
+- Approved app for computer-use with `./.cmux-loader/approve-computer-use-app`.
+- App window set via `./.cmux-loader/set-app-window-frame "cmux DEV scr2997" 20 90 1500 950 2`
+
+## Repro steps attempted
+1. Build and launch tagged app `scr2997`.
+2. Approve app for computer-use controller and position window with helper script.
+3. Preflight recording:
+   - `./.cmux-loader/record-video start preflight 10`
+   - moved pointer over terminal window and waited at least 4 seconds
+   - `./.cmux-loader/record-video stop preflight`
+4. Repro recording:
+   - `./.cmux-loader/record-video start repro 30`
+   - Focused terminal pane (text entry area).
+   - Executed Python generator:
+     - `python3 - <<'PY'`
+     - `import shutil`
+     - `cols = max(shutil.get_terminal_size().columns, 80)`
+     - `pattern = "1234567890"`
+     - `line = (pattern * ((cols // len(pattern)) + 2))[:cols]`
+     - `for i in range(180):`
+     - `    print(line)`
+     - `PY`
+   - Waited for output to accumulate with long right-edge marker lines.
+   - Ensured vertical scrollbar visible on terminal right side.
+   - Hovered pointer near terminal right edge for at least 2 seconds.
+   - Kept final pane state visible until capture duration elapsed.
+   - `./.cmux-loader/record-video stop repro`
+
+## In-video milestones to verify
+- `cmux DEV scr2997` terminal pane visible with generated multi-line numeric output.
+- Right-side terminal scrollbar shown in the terminal content area.
+- Pointer visible near right edge of terminal.
+- Final recorded state left visible for the remainder of the clip.
+
+## Result
+- Reproduction artifact captured successfully as `repro`.
+- `preflight` and `repro` stop logs reported `status=ok`.
+- `repro.log` did not report `primary recording missing`.
+- Manual interpretation of the screenshot-based artifact was not performed during this run; review is required to confirm exact amount of rightmost-text obstruction.
+
+## Blockers
+- None during recording workflow.


### PR DESCRIPTION
Addresses https://github.com/manaflow-ai/cmux/issues/2997

Generated by cmux-loader.

Recorded videos:

- preflight: .runner/videos/preflight.mov (ok)
- repro: .runner/videos/repro.mov (ok)

Run artifacts: https://github.com/manaflow-ai/cmux-loader/actions/runs/25195520384

Codex final message:

Implemented complete recording-only workflow for [https://github.com/manaflow-ai/cmux/issues/2997](https://github.com/manaflow-ai/cmux/issues/2997) on branch `loader/recording-scrollbar-right-edge-2997`.

- Built/approved/launched tagged app: `scr2997` (`cmux DEV scr2997.app`)
- Set scrollbars to `Always` before launch
- Ran and validated preflight (`preflight` status `ok`)
- Ran and saved required interaction capture `repro` (30s), then stopped successfully
- `repro.log` checked at:
  `/Users/runner/work/cmux-loader/cmux-loader/.runner/videos/repro.log`
  and does **not** report primary recording missing
- Created notes file: [scrollbar-right-edge-2997.md](/Users/runner/work/cmux-loader/cmux-loader/cmux/docs/recordings/scrollbar-right-edge-2997.md)
- Recorded artifact: `repro`

No product code changes were made, and no PR was opened.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Added specification documentation for verifying scrollbar behavior and terminal window display conditions, including recording procedures and verification milestones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->