### PR TITLE
fix(cli): handle tmux show-options in __tmux-compat dispatcher

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13091,17 +13091,18 @@ struct CMUXCLI {
         case "set-option", "set", "set-window-option", "setw", "source-file", "refresh-client", "attach-session", "detach-client":
             return
 
-        case "show-options", "show-option", "showopt", "show-window-options", "show-window-option", "showw":
+        case "show-options", "show", "show-window-options", "showw":
             // tmux's show-options is read-only: omx/codex/agents probe it for
             // capability defaults (e.g. `tmux show-options -sv extended-keys`).
             // Returning real tmux 3.x defaults keeps clients on the safe path
             // (extended-keys=off → use legacy key encoding) without requiring
-            // a real tmux server.
-            // tmux accepts clustered short flags like `-sv` (= `-s -v`), so
-            // detect `-v` anywhere in any single-dash cluster.
-            let valueOnly = rawArgs.contains { token in
-                token.hasPrefix("-") && !token.hasPrefix("--") && token.dropFirst().contains("v")
-            }
+            // a real tmux server. Unknown options print nothing and exit 0.
+            let parsed = try parseTmuxArguments(
+                rawArgs,
+                valueFlags: ["-t"],
+                boolFlags: ["-A", "-H", "-Z", "-g", "-p", "-q", "-s", "-v", "-w"]
+            )
+            let valueOnly = parsed.hasFlag("-v")
             let knownDefaults: [String: String] = [
                 "extended-keys": "off",
                 "focus-events": "off",
@@ -13111,12 +13112,10 @@ struct CMUXCLI {
                 "status": "on",
                 "history-limit": "2000"
             ]
-            let names = rawArgs.filter { !$0.hasPrefix("-") }
-            if names.isEmpty {
-                return
-            }
-            for name in names {
-                let value = knownDefaults[name] ?? ""
+            for name in parsed.positional {
+                guard let value = knownDefaults[name] else {
+                    continue
+                }
                 if valueOnly {
                     print(value)
                 } else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13091,6 +13091,40 @@ struct CMUXCLI {
         case "set-option", "set", "set-window-option", "setw", "source-file", "refresh-client", "attach-session", "detach-client":
             return
 
+        case "show-options", "show-option", "showopt", "show-window-options", "show-window-option", "showw":
+            // tmux's show-options is read-only: omx/codex/agents probe it for
+            // capability defaults (e.g. `tmux show-options -sv extended-keys`).
+            // Returning real tmux 3.x defaults keeps clients on the safe path
+            // (extended-keys=off → use legacy key encoding) without requiring
+            // a real tmux server.
+            // tmux accepts clustered short flags like `-sv` (= `-s -v`), so
+            // detect `-v` anywhere in any single-dash cluster.
+            let valueOnly = rawArgs.contains { token in
+                token.hasPrefix("-") && !token.hasPrefix("--") && token.dropFirst().contains("v")
+            }
+            let knownDefaults: [String: String] = [
+                "extended-keys": "off",
+                "focus-events": "off",
+                "mouse": "off",
+                "default-terminal": "tmux-256color",
+                "default-shell": ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh",
+                "status": "on",
+                "history-limit": "2000"
+            ]
+            let names = rawArgs.filter { !$0.hasPrefix("-") }
+            if names.isEmpty {
+                return
+            }
+            for name in names {
+                let value = knownDefaults[name] ?? ""
+                if valueOnly {
+                    print(value)
+                } else {
+                    print("\(name) \(value)")
+                }
+            }
+            return
+
         case "-V", "-v":
             print("tmux 3.4")
             return

--- a/tests_v2/test_tmux_compat_matrix.py
+++ b/tests_v2/test_tmux_compat_matrix.py
@@ -269,6 +269,18 @@ def main() -> int:
         shown = _run_cli(cli, ["display-message", "-p", msg])
         _must(msg in shown.stdout, f"display-message -p should print message: {shown.stdout!r}")
 
+        # show-options must succeed for known and unknown options so omx/codex
+        # capability probes (e.g. `tmux show-options -sv extended-keys`) do not
+        # blow up the agent before it starts. Regression for the bug where
+        # show-options threw "Unsupported tmux compatibility command".
+        ek = _run_cli(cli, ["show-options", "-sv", "extended-keys"])
+        _must(ek.stdout.strip() == "off", f"show-options -sv extended-keys should print 'off', got: {ek.stdout!r}")
+        unknown = _run_cli(cli, ["show-options", "-sv", "definitely-not-a-real-option"])
+        _must(unknown.returncode == 0, f"show-options for unknown option should exit 0, got code={unknown.returncode}, stderr={unknown.stderr!r}")
+        _must(unknown.stdout.strip() == "", f"show-options for unknown option should be empty, got: {unknown.stdout!r}")
+        named = _run_cli(cli, ["show-options", "-s", "extended-keys"])
+        _must("extended-keys" in named.stdout and "off" in named.stdout, f"show-options without -v should print name and value: {named.stdout!r}")
+
     print("PASS: tmux compatibility matrix commands are wired and tested")
     return 0
 

--- a/tests_v2/test_tmux_compat_matrix.py
+++ b/tests_v2/test_tmux_compat_matrix.py
@@ -273,13 +273,18 @@ def main() -> int:
         # capability probes (e.g. `tmux show-options -sv extended-keys`) do not
         # blow up the agent before it starts. Regression for the bug where
         # show-options threw "Unsupported tmux compatibility command".
-        ek = _run_cli(cli, ["show-options", "-sv", "extended-keys"])
-        _must(ek.stdout.strip() == "off", f"show-options -sv extended-keys should print 'off', got: {ek.stdout!r}")
-        unknown = _run_cli(cli, ["show-options", "-sv", "definitely-not-a-real-option"])
-        _must(unknown.returncode == 0, f"show-options for unknown option should exit 0, got code={unknown.returncode}, stderr={unknown.stderr!r}")
-        _must(unknown.stdout.strip() == "", f"show-options for unknown option should be empty, got: {unknown.stdout!r}")
+        # Cover every real tmux alias so an alias-specific regression cannot slip in.
+        for show_cmd in ("show-options", "show", "show-window-options", "showw"):
+            ek = _run_cli(cli, [show_cmd, "-sv", "extended-keys"])
+            _must(ek.stdout == "off\n", f"{show_cmd} -sv extended-keys should print exactly 'off\\n', got: {ek.stdout!r}")
+            unknown = _run_cli(cli, [show_cmd, "-sv", "definitely-not-a-real-option"])
+            _must(unknown.returncode == 0, f"{show_cmd} for unknown option should exit 0, got code={unknown.returncode}, stderr={unknown.stderr!r}")
+            _must(unknown.stdout == "", f"{show_cmd} for unknown option should print nothing, got: {unknown.stdout!r}")
         named = _run_cli(cli, ["show-options", "-s", "extended-keys"])
-        _must("extended-keys" in named.stdout and "off" in named.stdout, f"show-options without -v should print name and value: {named.stdout!r}")
+        _must(named.stdout == "extended-keys off\n", f"show-options without -v should print 'name value', got: {named.stdout!r}")
+        # -t <target> must not be misparsed as an option name.
+        targeted = _run_cli(cli, ["show-options", "-t", "main", "-sv", "extended-keys"])
+        _must(targeted.stdout == "off\n", f"show-options -t target should treat target as flag value, got: {targeted.stdout!r}")
 
     print("PASS: tmux compatibility matrix commands are wired and tested")
     return 0


### PR DESCRIPTION
## Summary

- omx/codex probes capabilities on startup with `tmux show-options -sv extended-keys`. The shim at `~/.cmuxterm/omx-bin/tmux` forwards that to `cmux __tmux-compat`, but `runClaudeTeamsTmuxCompat` had no case for `show-options`, so the default arm threw `Unsupported tmux compatibility command: show-options` and the user saw that error every time they ran `cmux omx`.
- Added a read-only handler for `show-options` / `show-option` / `showopt` and the `show-window-options` aliases next to the existing `set-option` no-op. Known server options return real tmux 3.x defaults (`extended-keys=off`, `focus-events=off`, `mouse=off`, `default-terminal=tmux-256color`, …) so clients take the correct fallback path; unknown options print empty and exit 0. Clustered short flags like `-sv` are recognized by scanning each single-dash token for `v`, matching tmux's parsing.
- Two-commit structure per the regression-test policy: a failing test in `tests_v2/test_tmux_compat_matrix.py` (CI red without the fix), then the fix in `CLI/cmux.swift` (CI green).

## Repro

```
$ ~/.cmuxterm/omx-bin/tmux show-options -sv extended-keys
Error: Unsupported tmux compatibility command: show-options
exit=1
```

After the fix:

```
$ ~/.cmuxterm/omx-bin/tmux show-options -sv extended-keys
off
exit=0
```

End-to-end verification: built the tagged dev app via `./scripts/reload.sh --tag fix-tmux-show-options --launch` and ran `cmux omx` inside a workspace there — codex (`OpenAI Codex v0.128.0`) starts cleanly, no `Unsupported tmux compatibility command` error.

## Test plan

- [ ] `tests_v2/test_tmux_compat_matrix.py` runs in CI against a live cmux socket.
  - First commit (test only) should show the new assertions failing.
  - Second commit (fix) should turn them green.
- [ ] Manual: `cmux omx` no longer prints `Error: Unsupported tmux compatibility command: show-options` on startup.
- [ ] `cmux __tmux-compat show-options -sv extended-keys` → stdout `off`, exit 0.
- [ ] `cmux __tmux-compat show-options -sv <unknown-option>` → empty stdout, exit 0.
- [ ] `cmux __tmux-compat show-options -s extended-keys` → stdout `extended-keys off`, exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI can show option defaults without a running tmux server, with support for condensed (value-only) and verbose (name+value) outputs.
  * Improved flag parsing (including clustered single-dash flags) and handling of unknown option names (ignored, no error). Environment-derived defaults (e.g., default shell) are respected.

* **Tests**
  * Expanded tests covering display formats, known/unknown options, and correct handling of target arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->