### PR TITLE
Consolidate sidebar settings

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -8,7 +8,7 @@
 13932	Sources/Workspace.swift
 13400	Sources/GhosttyTerminalView.swift
 10597	Sources/Panels/BrowserPanel.swift
-8389	Sources/cmuxApp.swift
+8309	Sources/cmuxApp.swift
 7490	Sources/TabManager.swift
 6811	Sources/Panels/BrowserPanelView.swift
 5491	cmuxTests/AppDelegateShortcutRoutingTests.swift

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -20054,13 +20054,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidebar Appearance"
+            "value": "Sidebar"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイドバーの外観"
+            "value": "サイドバー"
           }
         }
       }
@@ -69501,13 +69501,13 @@
             "en": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry"
                 }
             },
             "ja": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 一般 環境設定 設定 動作 外観 ドック メニューバー 通知 サイドバー テレメトリ"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry 一般 環境設定 設定 動作 外観 ドック メニューバー 通知 テレメトリ"
                 }
             },
             "ar": {
@@ -69739,13 +69739,13 @@
             "en": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color"
+                    "value": "sidebar left rail navigation details branches badges material terminal background"
                 }
             },
             "ja": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color 左サイドバー ナビゲーション 色 透明度 不透明度 マテリアル"
+                    "value": "sidebar left rail navigation details branches badges material terminal background サイドバー 左 ナビゲーション 詳細 ブランチ バッジ マテリアル ターミナル 背景"
                 }
             },
             "ar": {
@@ -100325,115 +100325,115 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidebar Appearance"
+            "value": "Sidebar"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイドバーの外観"
+            "value": "サイドバー"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "侧边栏外观"
+            "value": "侧边栏"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "側邊欄外觀"
+            "value": "側邊欄"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사이드바 모양"
+            "value": "사이드바"
           }
         },
         "de": {
           "stringUnit": {
             "state": "translated",
-            "value": "Seitenleisten-Erscheinungsbild"
+            "value": "Seitenleiste"
           }
         },
         "es": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apariencia de la barra lateral"
+            "value": "Barra lateral"
           }
         },
         "fr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Apparence de la barre latérale"
+            "value": "Barre latérale"
           }
         },
         "it": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aspetto barra laterale"
+            "value": "Barra laterale"
           }
         },
         "da": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidebjælkeudseende"
+            "value": "Sidebjælke"
           }
         },
         "pl": {
           "stringUnit": {
             "state": "translated",
-            "value": "Wygląd paska bocznego"
+            "value": "Pasek boczny"
           }
         },
         "ru": {
           "stringUnit": {
             "state": "translated",
-            "value": "Внешний вид боковой панели"
+            "value": "Боковая панель"
           }
         },
         "bs": {
           "stringUnit": {
             "state": "translated",
-            "value": "Izgled bočne trake"
+            "value": "Bočna traka"
           }
         },
         "ar": {
           "stringUnit": {
             "state": "translated",
-            "value": "مظهر الشريط الجانبي"
+            "value": "الشريط الجانبي"
           }
         },
         "nb": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sidefelts utseende"
+            "value": "Sidefelt"
           }
         },
         "pt-BR": {
           "stringUnit": {
             "state": "translated",
-            "value": "Aparência da Barra Lateral"
+            "value": "Barra lateral"
           }
         },
         "th": {
           "stringUnit": {
             "state": "translated",
-            "value": "รูปลักษณ์แถบด้านข้าง"
+            "value": "แถบด้านข้าง"
           }
         },
         "tr": {
           "stringUnit": {
             "state": "translated",
-            "value": "Kenar Çubuğu Görünümü"
+            "value": "Kenar Çubuğu"
           }
         },
         "uk": {
           "stringUnit": {
             "state": "translated",
-            "value": "Зовнішній вигляд бічної панелі"
+            "value": "Бічна панель"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -69513,103 +69513,103 @@
             "ar": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry تطبيق عام تفضيلات سلوك شريط القائمة حالة الشريط الجانبي جانبي تنقل يسار تفاصيل إخفاء تخطيط استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية إعدادات تكوين ملف json مخطط وثائق مرجع إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب قياس استخدام تحليلات تعطل تقارير مجهول خصوصية الإشعارات التفضيلات… التطبيق"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry تطبيق عام تفضيلات سلوك شريط القائمة حالة استيراد ترحيل إشارات مرجعية سجل ملفات تعريف ارتباط شخصية إعدادات تكوين ملف json مخطط وثائق مرجع إشعار إشعارات تنبيه غير مقروء رسالة شارة رنين وميض صوت سطح المكتب قياس استخدام تحليلات تعطل تقارير مجهول خصوصية الإشعارات التفضيلات… التطبيق"
                 }
             },
             "bs": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplikacija opće postavke ponašanje traka menija bočna navigacija lijevo detalji sakrij raspored uvoz migracija oznake historija kolačići profili konfiguracija datoteka json šema dokumentacija referenca preferencije obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop telemetrija analitika rušenje izvještaji korištenje anonimno privatnost Obavještenja Postavke… Meni"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry aplikacija opće postavke ponašanje traka menija status uvoz migracija oznake historija kolačići profili konfiguracija datoteka json šema dokumentacija referenca preferencije obavijest obavijesti upozorenje nepročitano poruka značka prsten bljesak zvuk desktop telemetrija analitika rušenje izvještaji korištenje anonimno privatnost Obavještenja Postavke… Meni"
                 }
             },
             "da": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generelt indstillinger adfærd menulinje sidepanel navigation venstre detaljer skjul layout import migrering bogmærker historik cookies profiler konfiguration fil json skema dokumentation reference præferencer notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord telemetri analyse nedbrud rapporter brug anonym privatliv Indstillinger… Sidebjælke"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry app generelt indstillinger adfærd menulinje status import migrering bogmærker historik cookies profiler konfiguration fil json skema dokumentation reference præferencer notifikation notifikationer advarsel ulæst besked badge ring blink lyd skrivebord telemetri analyse nedbrud rapporter brug anonym privatliv Indstillinger…"
                 }
             },
             "de": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app allgemein einstellungen verhalten menüleiste seitenleiste navigation links details ausblenden layout import migration lesezeichen verlauf cookies profile konfiguration datei json schema dokumentation referenz präferenzen benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop telemetrie analyse absturz berichte nutzung anonym datenschutz … Menü"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry app allgemein einstellungen verhalten menüleiste status import migration lesezeichen verlauf cookies profile konfiguration datei json schema dokumentation referenz präferenzen benachrichtigung benachrichtigungen alarm ungelesen nachricht badge ring blinken ton desktop telemetrie analyse absturz berichte nutzung anonym datenschutz … Menü"
                 }
             },
             "es": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplicación preferencias comportamiento barra de menú estado lateral navegación izquierda detalles ocultar diseño importar migración marcadores historial cookies perfiles ajustes configuración archivo json esquema documentación referencia notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio telemetría analíticas fallos informes uso anónimo privacidad Preferencias… App"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry aplicación preferencias comportamiento barra de menú estado importar migración marcadores historial cookies perfiles ajustes configuración archivo json esquema documentación referencia notificación notificaciones alerta no leído mensaje insignia anillo destello sonido escritorio telemetría analíticas fallos informes uso anónimo privacidad Preferencias… App"
                 }
             },
             "fr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry application général préférences comportement barre de menus état latérale navigation gauche détails masquer disposition importer migration favoris historique cookies profils réglages configuration fichier json schéma documentation référence notification alerte non lu message badge anneau flash son bureau télémétrie analytique plantage rapports utilisation anonyme confidentialité Préférences... App"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry application général préférences comportement barre de menus état importer migration favoris historique cookies profils réglages configuration fichier json schéma documentation référence notification alerte non lu message badge anneau flash son bureau télémétrie analytique plantage rapports utilisation anonyme confidentialité Préférences... App"
                 }
             },
             "it": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generale preferenze comportamento barra stato laterale navigazione sinistra dettagli nascondi layout importa migrazione segnalibri cronologia cookie profili impostazioni configurazione file json schema documentazione riferimento notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania telemetria analisi crash rapporti utilizzo anonimo privacy Preferenze…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry app generale preferenze comportamento barra stato importa migrazione segnalibri cronologia cookie profili impostazioni configurazione file json schema documentazione riferimento notifica notifiche avviso non letto messaggio badge anello lampeggio suono scrivania telemetria analisi crash rapporti utilizzo anonimo privacy Preferenze…"
                 }
             },
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 앱 일반 환경설정 동작 독 메뉴 막대 상태 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 설정 구성 파일 json 스키마 문서 참조 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 텔레메트리 분석 충돌 보고서 사용량 익명 개인정보 환경설정…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry 앱 일반 환경설정 동작 독 메뉴 막대 상태 가져오기 마이그레이션 북마크 방문 기록 쿠키 프로필 설정 구성 파일 json 스키마 문서 참조 알림 읽지 않음 메시지 배지 링 깜박임 소리 데스크탑 경고 텔레메트리 분석 충돌 보고서 사용량 익명 개인정보 환경설정…"
                 }
             },
             "nb": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app generelt innstillinger oppførsel menylinje sidepanel navigasjon venstre detaljer skjul oppsett import migrering bokmerker historikk informasjonskapsler profiler konfigurasjon fil json skjema dokumentasjon referanse preferanser varsling varsler ulest melding merke ring blink lyd skrivebord telemetri analyse krasj rapporter bruk anonym personvern … Meny"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry app generelt innstillinger oppførsel menylinje status import migrering bokmerker historikk informasjonskapsler profiler konfigurasjon fil json skjema dokumentasjon referanse preferanser varsling varsler ulest melding merke ring blink lyd skrivebord telemetri analyse krasj rapporter bruk anonym personvern … Meny"
                 }
             },
             "pl": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry aplikacja ogólne preferencje zachowanie pasek boczny nawigacja lewy szczegóły ukryj układ import migracja zakładki historia ciasteczka profile ustawienia konfiguracja plik json schemat dokumentacja referencja powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit telemetria analityka awaria raporty użycie anonimowe prywatność Preferencje…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry aplikacja ogólne preferencje zachowanie status import migracja zakładki historia ciasteczka profile ustawienia konfiguracja plik json schemat dokumentacja referencja powiadomienie powiadomienia alert nieprzeczytane wiadomość odznaka pierścień błysk dźwięk pulpit telemetria analityka awaria raporty użycie anonimowe prywatność Preferencje…"
                 }
             },
             "pt-BR": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry app geral preferências comportamento barra de lateral navegação esquerda detalhes ocultar layout importar migração favoritos histórico cookies perfis configurações configuração arquivo json esquema documentação referência notificação notificações alerta não lido mensagem selo anel piscar som desktop telemetria análises falhas relatórios uso anônimo privacidade Preferências…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry app geral preferências comportamento barra de menu estado importar migração favoritos histórico cookies perfis configurações configuração arquivo json esquema documentação referência notificação notificações alerta não lido mensagem selo anel piscar som desktop telemetria análises falhas relatórios uso anônimo privacidade Preferências…"
                 }
             },
             "ru": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry приложение общие настройки поведение док строка меню статус боковая панель навигация слева детали скрыть макет импорт миграция закладки история cookies профили конфигурация файл json схема документация справочник предпочтения уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол телеметрия аналитика сбой отчеты использование анонимно приватность Настройки..."
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry приложение общие настройки поведение док строка меню статус импорт миграция закладки история cookies профили конфигурация файл json схема документация справочник предпочтения уведомление уведомления предупреждение непрочитанное сообщение бейдж кольцо вспышка звук рабочий стол телеметрия аналитика сбой отчеты использование анонимно приватность Настройки..."
                 }
             },
             "th": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป เทเลเมทรี วิเคราะห์ ขัดข้อง รายงาน การใช้งาน นิรนาม ความเป็นส่วนตัว การตั้งค่า... เมนู"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry แอป ทั่วไป ค่ากำหนด พฤติกรรม ด็อก แถบเมนู สถานะ นำเข้า ย้ายข้อมูล บุ๊กมาร์ก ประวัติ คุกกี้ โปรไฟล์ การตั้งค่า การกำหนดค่า ไฟล์ json สคีมา เอกสาร อ้างอิง การแจ้งเตือน ยังไม่ได้อ่าน ข้อความ ป้าย วงแหวน แฟลช เสียง เดสก์ท็อป เทเลเมทรี วิเคราะห์ ขัดข้อง รายงาน การใช้งาน นิรนาม ความเป็นส่วนตัว การตั้งค่า... เมนู"
                 }
             },
             "tr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry uygulama genel tercihler davranış menü çubuğu durum kenar gezinme sol ayrıntılar gizle düzen içe aktar geçiş yer imleri geçmiş çerezler profiller ayarlar yapılandırma dosya json şema belgeler başvuru bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü telemetri analiz çökme raporlar kullanım anonim gizlilik Tercihler…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry uygulama genel tercihler davranış menü çubuğu durum içe aktar geçiş yer imleri geçmiş çerezler profiller ayarlar yapılandırma dosya json şema belgeler başvuru bildirim bildirimler uyarı okunmamış mesaj rozet halka flaş ses masaüstü telemetri analiz çökme raporlar kullanım anonim gizlilik Tercihler…"
                 }
             },
             "zh-Hans": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 侧边栏 导航 左侧 详细信息 隐藏 布局 导入 迁移 书签 历史记录 Cookie 个人资料 设置 配置 文件 json 架构 文档 参考 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 遥测 分析 崩溃 报告 使用 匿名 隐私 偏好设置... 菜单"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry 应用 通用 偏好设置 行为 程序坞 菜单栏 状态 导入 迁移 书签 历史记录 Cookie 个人资料 设置 配置 文件 json 架构 文档 参考 通知 未读 消息 徽章 圆环 闪烁 声音 桌面 提醒 遥测 分析 崩溃 报告 使用 匿名 隐私 偏好设置... 菜单"
                 }
             },
             "zh-Hant": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry 應用程式 一般 偏好設定 行為 選單列 狀態 側邊欄 導覽 左側 詳細資訊 隱藏 版面 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 設定 設定檔 檔案 json 結構描述 文件 參考 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 遙測 分析 當機 報告 使用 匿名 隱私 偏好設定... 選單 App"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry 應用程式 一般 偏好設定 行為 選單列 狀態 匯入 移轉 書籤 瀏覽記錄 Cookie 個人檔案 設定 設定檔 檔案 json 結構描述 文件 參考 通知 未讀 訊息 徽章 圓環 閃爍 聲音 桌面 提醒 遙測 分析 當機 報告 使用 匿名 隱私 偏好設定... 選單 App"
                 }
             },
             "uk": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry програма загальні параметри поведінка док рядок меню статус бічна панель навігація ліворуч деталі приховати макет імпорт міграція закладки історія cookies профілі налаштування конфігурація файл json схема документація довідник сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл телеметрія аналітика збій звіти використання анонімно приватність Параметри…"
+                    "value": "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry програма загальні параметри поведінка док рядок меню статус імпорт міграція закладки історія cookies профілі налаштування конфігурація файл json схема документація довідник сповіщення непрочитане повідомлення значок кільце спалах звук робочий стіл телеметрія аналітика збій звіти використання анонімно приватність Параметри…"
                 }
             }
         }
@@ -69751,103 +69751,103 @@
             "ar": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color شريط جانبي تنقل يسار تفاصيل إخفاء تخطيط مظهر سمة لون ألوان مخطط فاتح داكن نظام وضع أيسر شفافية اللون"
+                    "value": "sidebar left rail navigation details branches badges material terminal background الشريط الجانبي تنقل يسار تفاصيل فروع شارات مادة طرفية خلفية"
                 }
             },
             "bs": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color bočna traka navigacija lijevo detalji sakrij raspored izgled tema boja boje shema svijetlo tamno sistem način Lijeva Prozirnost nijanse"
+                    "value": "sidebar left rail navigation details branches badges material terminal background bočna traka navigacija lijevo detalji grane značke materijal terminal pozadina"
                 }
             },
             "da": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color sidepanel venstre detaljer skjul layout udseende tema farve farver skema lys mørk system tilstand skinne Farvetone gennemsigtighed"
+                    "value": "sidebar left rail navigation details branches badges material terminal background sidebjælke navigation venstre detaljer grene badges materiale terminal baggrund"
                 }
             },
             "de": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color seitenleiste links details ausblenden layout darstellung design farbe farben schema hell dunkel system modus Linke Leiste Farbton-Deckkraft"
+                    "value": "sidebar left rail navigation details branches badges material terminal background seitenleiste navigation links details zweige badges material terminal hintergrund"
                 }
             },
             "es": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color barra lateral navegación izquierda detalles ocultar diseño apariencia tema colores esquema claro oscuro sistema modo Opacidad del tinte"
+                    "value": "sidebar left rail navigation details branches badges material terminal background barra lateral navegación izquierda detalles ramas insignias material terminal fondo"
                 }
             },
             "fr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color barre latérale gauche détails masquer disposition apparence thème couleur couleurs schéma clair sombre système mode Opacité de la teinte"
+                    "value": "sidebar left rail navigation details branches badges material terminal background barre latérale navigation gauche détails branches badges matériau terminal arrière-plan"
                 }
             },
             "it": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color barra laterale navigazione sinistra dettagli nascondi layout aspetto tema colore colori schema chiaro scuro sistema modalità Opacità tinta"
+                    "value": "sidebar left rail navigation details branches badges material terminal background barra laterale navigazione sinistra dettagli branch badge materiale terminale sfondo"
                 }
             },
             "ko": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color 사이드바 탐색 왼쪽 세부사항 숨기기 레이아웃 외관 테마 색상 색 구성표 라이트 다크 시스템 모드 레일 색조 불투명도"
+                    "value": "sidebar left rail navigation details branches badges material terminal background 사이드바 탐색 왼쪽 세부사항 브랜치 배지 머티리얼 터미널 배경"
                 }
             },
             "nb": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color sidepanel navigasjon venstre detaljer skjul oppsett utseende tema farge farger skjema lys mørk system modus skinne Fargetone-opasitet"
+                    "value": "sidebar left rail navigation details branches badges material terminal background sidefelt navigasjon venstre detaljer grener merker materiale terminal bakgrunn"
                 }
             },
             "pl": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color pasek boczny nawigacja lewy szczegóły ukryj układ wygląd motyw kolor kolory schemat jasny ciemny system tryb Lewa listwa Krycie odcienia"
+                    "value": "sidebar left rail navigation details branches badges material terminal background pasek boczny nawigacja lewy szczegóły gałęzie odznaki materiał terminal tło"
                 }
             },
             "pt-BR": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color barra lateral navegação esquerda detalhes ocultar layout aparência tema cor cores esquema claro escuro sistema modo Trilho Esquerdo Opacidade da Tonalidade"
+                    "value": "sidebar left rail navigation details branches badges material terminal background barra lateral navegação esquerda detalhes branches badges material terminal fundo"
                 }
             },
             "ru": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color боковая панель навигация слева детали скрыть макет внешний вид тема цвет цвета схема светлый темный система режим Левая полоса Непрозрачность оттенка"
+                    "value": "sidebar left rail navigation details branches badges material terminal background боковая панель навигация слева детали ветки бейджи материал терминал фон"
                 }
             },
             "th": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color แถบด้านข้าง นำทาง ซ้าย รายละเอียด ซ่อน เค้าโครง ลักษณะ ธีม สี โครงร่าง สว่าง มืด ระบบ โหมด แถบด้านซ้าย ความทึบของโทนสี"
+                    "value": "sidebar left rail navigation details branches badges material terminal background แถบด้านข้าง นำทาง ซ้าย รายละเอียด branch badge วัสดุ เทอร์มินัล พื้นหลัง"
                 }
             },
             "tr": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color kenar çubuğu gezinme sol ayrıntılar gizle düzen görünüm tema renk renkler şema açık koyu sistem mod Şerit Tonu Opaklığı"
+                    "value": "sidebar left rail navigation details branches badges material terminal background kenar çubuğu gezinme sol ayrıntılar dallar rozetler materyal terminal arka plan"
                 }
             },
             "zh-Hans": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color 侧边栏 导航 左侧 详细信息 隐藏 布局 外观 主题 颜色 配色 浅色 深色 系统 模式 左侧导轨 色调不透明度"
+                    "value": "sidebar left rail navigation details branches badges material terminal background 侧边栏 导航 左侧 详细信息 分支 徽章 材质 终端 背景"
                 }
             },
             "zh-Hant": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color 側邊欄 導覽 左側 詳細資訊 隱藏 版面 外觀 主題 顏色 配色 淺色 深色 系統 模式 左側軌道 色調不透明度"
+                    "value": "sidebar left rail navigation details branches badges material terminal background 側邊欄 導覽 左側 詳細資訊 分支 徽章 材質 終端機 背景"
                 }
             },
             "uk": {
                 "stringUnit": {
                     "state": "translated",
-                    "value": "left rail navigation tint transparency opacity material color бічна панель навігація ліворуч деталі приховати макет вигляд тема колір кольори схема світлий темний система режим Лівий рейл Непрозорість відтінку"
+                    "value": "sidebar left rail navigation details branches badges material terminal background бічна панель навігація ліворуч деталі гілки бейджі матеріал термінал фон"
                 }
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -7088,7 +7088,7 @@ struct ContentView: View {
                         ? String(localized: "command.disableMatchTerminalBackground.title", defaultValue: "Disable Match Terminal Background")
                         : String(localized: "command.enableMatchTerminalBackground.title", defaultValue: "Enable Match Terminal Background")
                 },
-                subtitle: constant(String(localized: "command.matchTerminalBackground.subtitle", defaultValue: "Sidebar Appearance")),
+                subtitle: constant(String(localized: "command.matchTerminalBackground.subtitle", defaultValue: "Sidebar")),
                 keywords: ["match", "terminal", "background", "transparency", "sidebar", "surface", "chrome"]
             )
         )

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -27,7 +27,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .workspaceColors:
             return String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors")
         case .sidebarAppearance:
-            return String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar Appearance")
+            return String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar")
         case .automation:
             return String(localized: "settings.section.automation", defaultValue: "Automation")
         case .browser:
@@ -85,7 +85,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .workspaceColors:
             return "\(title) palette tabs"
         case .sidebarAppearance:
-            return "\(title) sidebar tint details branches badges"
+            return "\(title) sidebar details branches badges material terminal background"
         case .automation:
             return "\(title) socket integrations hooks ports claude cursor gemini"
         case .browser:
@@ -305,24 +305,20 @@ enum SettingsSearchIndex {
         setting(.app, "warn-before-quit", String(localized: "settings.app.warnBeforeQuit", defaultValue: "Warn Before Quit"), "cmd q confirmation"),
         setting(.app, "rename-selects-name", String(localized: "settings.app.renameSelectsName", defaultValue: "Rename Selects Existing Name"), "command palette rename text selection"),
         setting(.app, "palette-search-all", String(localized: "settings.app.commandPaletteSearchAllSurfaces", defaultValue: "Command Palette Searches All Surfaces"), "cmd p search terminal browser markdown"),
-        setting(.app, "hide-sidebar-details", String(localized: "settings.app.hideAllSidebarDetails", defaultValue: "Hide All Sidebar Details"), "workspace sidebar compact"),
-        setting(.app, "sidebar-branch-layout", String(localized: "settings.app.sidebarBranchLayout", defaultValue: "Sidebar Branch Layout"), "branch directory vertical inline"),
-        setting(.app, "show-notification-message", String(localized: "settings.app.showNotificationMessage", defaultValue: "Show Notification Message in Sidebar"), "workspace latest notification"),
-        setting(.app, "show-branch-directory", String(localized: "settings.app.showBranchDirectory", defaultValue: "Show Branch + Directory in Sidebar"), "git cwd path"),
-        setting(.app, "show-pull-requests", String(localized: "settings.app.showPullRequests", defaultValue: "Show Pull Requests in Sidebar"), "review pr mr link"),
-        setting(.app, "open-pr-links", String(localized: "settings.app.openSidebarPRLinks", defaultValue: "Open Sidebar PR Links in cmux Browser"), "pull request link browser"),
-        setting(.app, "open-port-links", String(localized: "settings.app.openSidebarPortLinks", defaultValue: "Open Sidebar Port Links in cmux Browser"), "port link browser"),
-        setting(.app, "show-ssh", String(localized: "settings.app.showSSH", defaultValue: "Show SSH in Sidebar"), "remote target"),
-        setting(.app, "show-ports", String(localized: "settings.app.showPorts", defaultValue: "Show Listening Ports in Sidebar"), "localhost port"),
-        setting(.app, "show-log", String(localized: "settings.app.showLog", defaultValue: "Show Latest Log in Sidebar"), "status message"),
-        setting(.app, "show-progress", String(localized: "settings.app.showProgress", defaultValue: "Show Progress in Sidebar"), "progress bar"),
-        setting(.app, "show-metadata", String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar"), "report meta status block"),
         setting(.terminal, "scrollbar", String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"), "terminal shell scrollback"),
         setting(.sidebarAppearance, "match-terminal", String(localized: "settings.sidebarAppearance.matchTerminalBackground", defaultValue: "Match Terminal Background"), "sidebar material transparency"),
-        setting(.sidebarAppearance, "light-tint", String(localized: "settings.sidebarAppearance.tintColorLight", defaultValue: "Light Mode Tint"), "sidebar color light"),
-        setting(.sidebarAppearance, "dark-tint", String(localized: "settings.sidebarAppearance.tintColorDark", defaultValue: "Dark Mode Tint"), "sidebar color dark"),
-        setting(.sidebarAppearance, "tint-opacity", String(localized: "settings.sidebarAppearance.tintOpacity", defaultValue: "Tint Opacity"), "sidebar color opacity"),
-        setting(.sidebarAppearance, "reset-tint", String(localized: "settings.sidebarAppearance.reset", defaultValue: "Reset Sidebar Tint"), "restore default sidebar appearance"),
+        setting(.sidebarAppearance, "hide-sidebar-details", String(localized: "settings.app.hideAllSidebarDetails", defaultValue: "Hide All Sidebar Details"), "workspace sidebar compact"),
+        setting(.sidebarAppearance, "sidebar-branch-layout", String(localized: "settings.app.sidebarBranchLayout", defaultValue: "Sidebar Branch Layout"), "branch directory vertical inline"),
+        setting(.sidebarAppearance, "show-notification-message", String(localized: "settings.app.showNotificationMessage", defaultValue: "Show Notification Message in Sidebar"), "workspace latest notification"),
+        setting(.sidebarAppearance, "show-branch-directory", String(localized: "settings.app.showBranchDirectory", defaultValue: "Show Branch + Directory in Sidebar"), "git cwd path"),
+        setting(.sidebarAppearance, "show-pull-requests", String(localized: "settings.app.showPullRequests", defaultValue: "Show Pull Requests in Sidebar"), "review pr mr link"),
+        setting(.sidebarAppearance, "open-pr-links", String(localized: "settings.app.openSidebarPRLinks", defaultValue: "Open Sidebar PR Links in cmux Browser"), "pull request link browser"),
+        setting(.sidebarAppearance, "open-port-links", String(localized: "settings.app.openSidebarPortLinks", defaultValue: "Open Sidebar Port Links in cmux Browser"), "port link browser"),
+        setting(.sidebarAppearance, "show-ssh", String(localized: "settings.app.showSSH", defaultValue: "Show SSH in Sidebar"), "remote target"),
+        setting(.sidebarAppearance, "show-ports", String(localized: "settings.app.showPorts", defaultValue: "Show Listening Ports in Sidebar"), "localhost port"),
+        setting(.sidebarAppearance, "show-log", String(localized: "settings.app.showLog", defaultValue: "Show Latest Log in Sidebar"), "status message"),
+        setting(.sidebarAppearance, "show-progress", String(localized: "settings.app.showProgress", defaultValue: "Show Progress in Sidebar"), "progress bar"),
+        setting(.sidebarAppearance, "show-metadata", String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar"), "report meta status block"),
         setting(.automation, "socket-mode", String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"), "unix socket api access password auth"),
         setting(.automation, "socket-password", String(localized: "settings.automation.socketPassword", defaultValue: "Socket Password"), "socket auth credential"),
         setting(.automation, "claude-code", String(localized: "settings.automation.claudeCode", defaultValue: "Claude Code Integration"), "agent hooks notifications"),
@@ -387,26 +383,23 @@ enum SettingsSearchIndex {
         "app.warnBeforeQuit": settingID(for: .app, idSuffix: "warn-before-quit"),
         "app.renameSelectsExistingName": settingID(for: .app, idSuffix: "rename-selects-name"),
         "app.commandPaletteSearchesAllSurfaces": settingID(for: .app, idSuffix: "palette-search-all"),
-        "sidebar.hideAllDetails": settingID(for: .app, idSuffix: "hide-sidebar-details"),
-        "sidebar.branchLayout": settingID(for: .app, idSuffix: "sidebar-branch-layout"),
-        "sidebar.showNotificationMessage": settingID(for: .app, idSuffix: "show-notification-message"),
-        "sidebar.showBranchDirectory": settingID(for: .app, idSuffix: "show-branch-directory"),
-        "sidebar.showPullRequests": settingID(for: .app, idSuffix: "show-pull-requests"),
-        "sidebar.openPullRequestLinksInCmuxBrowser": settingID(for: .app, idSuffix: "open-pr-links"),
-        "sidebar.openPortLinksInCmuxBrowser": settingID(for: .app, idSuffix: "open-port-links"),
-        "sidebar.showSSH": settingID(for: .app, idSuffix: "show-ssh"),
-        "sidebar.showPorts": settingID(for: .app, idSuffix: "show-ports"),
-        "sidebar.showLog": settingID(for: .app, idSuffix: "show-log"),
-        "sidebar.showProgress": settingID(for: .app, idSuffix: "show-progress"),
-        "sidebar.showCustomMetadata": settingID(for: .app, idSuffix: "show-metadata"),
+        "sidebar.hideAllDetails": settingID(for: .sidebarAppearance, idSuffix: "hide-sidebar-details"),
+        "sidebar.branchLayout": settingID(for: .sidebarAppearance, idSuffix: "sidebar-branch-layout"),
+        "sidebar.showNotificationMessage": settingID(for: .sidebarAppearance, idSuffix: "show-notification-message"),
+        "sidebar.showBranchDirectory": settingID(for: .sidebarAppearance, idSuffix: "show-branch-directory"),
+        "sidebar.showPullRequests": settingID(for: .sidebarAppearance, idSuffix: "show-pull-requests"),
+        "sidebar.openPullRequestLinksInCmuxBrowser": settingID(for: .sidebarAppearance, idSuffix: "open-pr-links"),
+        "sidebar.openPortLinksInCmuxBrowser": settingID(for: .sidebarAppearance, idSuffix: "open-port-links"),
+        "sidebar.showSSH": settingID(for: .sidebarAppearance, idSuffix: "show-ssh"),
+        "sidebar.showPorts": settingID(for: .sidebarAppearance, idSuffix: "show-ports"),
+        "sidebar.showLog": settingID(for: .sidebarAppearance, idSuffix: "show-log"),
+        "sidebar.showProgress": settingID(for: .sidebarAppearance, idSuffix: "show-progress"),
+        "sidebar.showCustomMetadata": settingID(for: .sidebarAppearance, idSuffix: "show-metadata"),
         "terminal.showScrollBar": settingID(for: .terminal, idSuffix: "scrollbar"),
         "workspaceColors.indicatorStyle": settingID(for: .workspaceColors, idSuffix: "indicator"),
         "workspaceColors.selectionColor": settingID(for: .workspaceColors, idSuffix: "selection"),
         "workspaceColors.notificationBadgeColor": settingID(for: .workspaceColors, idSuffix: "badge"),
         "sidebarAppearance.matchTerminalBackground": settingID(for: .sidebarAppearance, idSuffix: "match-terminal"),
-        "sidebarAppearance.lightModeTintColor": settingID(for: .sidebarAppearance, idSuffix: "light-tint"),
-        "sidebarAppearance.darkModeTintColor": settingID(for: .sidebarAppearance, idSuffix: "dark-tint"),
-        "sidebarAppearance.tintOpacity": settingID(for: .sidebarAppearance, idSuffix: "tint-opacity"),
         "automation.socketControlMode": settingID(for: .automation, idSuffix: "socket-mode"),
         "automation.socketPassword": settingID(for: .automation, idSuffix: "socket-password"),
         "automation.claudeCodeIntegration": settingID(for: .automation, idSuffix: "claude-code"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -4,11 +4,11 @@ enum SettingsSearchAliasIndex {
         case .account:
             return localized("settings.search.alias.section.account", defaultValue: "auth authentication login logout sign in sign out email user profile team")
         case .app:
-            return localized("settings.search.alias.section.app", defaultValue: "general preferences prefs behavior chrome dock menubar menu bar status notifications sidebar telemetry")
+            return localized("settings.search.alias.section.app", defaultValue: "general preferences prefs behavior chrome dock menubar menu bar status notifications telemetry")
         case .terminal:
             return localized("settings.search.alias.section.terminal", defaultValue: "shell scrollback scrollbar scroll bar ghostty tty pty")
         case .sidebarAppearance:
-            return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "left rail navigation tint transparency opacity material color")
+            return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "sidebar left rail navigation details branches badges material terminal background")
         case .automation:
             return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports")
         case .browser:
@@ -61,24 +61,20 @@ enum SettingsSearchAliasIndex {
         "app:warn-before-quit": localized("settings.search.alias.setting.app.warn-before-quit", defaultValue: "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"),
         "app:rename-selects-name": localized("settings.search.alias.setting.app.rename-selects-name", defaultValue: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),
         "app:palette-search-all": localized("settings.search.alias.setting.app.palette-search-all", defaultValue: "app.commandPaletteSearchesAllSurfaces command palette search all surfaces cmd-p terminal browser markdown"),
-        "app:hide-sidebar-details": localized("settings.search.alias.setting.app.hide-sidebar-details", defaultValue: "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"),
-        "app:sidebar-branch-layout": localized("settings.search.alias.setting.app.sidebar-branch-layout", defaultValue: "sidebar.branchLayout git branch layout vertical inline cwd directory"),
-        "app:show-notification-message": localized("settings.search.alias.setting.app.show-notification-message", defaultValue: "sidebar.showNotificationMessage latest message unread notification text sidebar"),
-        "app:show-branch-directory": localized("settings.search.alias.setting.app.show-branch-directory", defaultValue: "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"),
-        "app:show-pull-requests": localized("settings.search.alias.setting.app.show-pull-requests", defaultValue: "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"),
-        "app:open-pr-links": localized("settings.search.alias.setting.app.open-pr-links", defaultValue: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
-        "app:open-port-links": localized("settings.search.alias.setting.app.open-port-links", defaultValue: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
-        "app:show-ssh": localized("settings.search.alias.setting.app.show-ssh", defaultValue: "sidebar.showSSH remote host target ssh server"),
-        "app:show-ports": localized("settings.search.alias.setting.app.show-ports", defaultValue: "sidebar.showPorts localhost port listener dev server url"),
-        "app:show-log": localized("settings.search.alias.setting.app.show-log", defaultValue: "sidebar.showLog log status latest message imperative"),
-        "app:show-progress": localized("settings.search.alias.setting.app.show-progress", defaultValue: "sidebar.showProgress progress bar percent status set_progress"),
-        "app:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
         "terminal:scrollbar": localized("settings.search.alias.setting.terminal.scrollbar", defaultValue: "terminal.showScrollBar scrollback scrollbar scroll bar right edge alternate screen tui"),
         "sidebarAppearance:match-terminal": localized("settings.search.alias.setting.sidebarAppearance.match-terminal", defaultValue: "sidebarAppearance.matchTerminalBackground transparent background material terminal background sync"),
-        "sidebarAppearance:light-tint": localized("settings.search.alias.setting.sidebarAppearance.light-tint", defaultValue: "sidebarAppearance.lightModeTintColor light color sidebar tint hex daytime"),
-        "sidebarAppearance:dark-tint": localized("settings.search.alias.setting.sidebarAppearance.dark-tint", defaultValue: "sidebarAppearance.darkModeTintColor dark color sidebar tint hex nighttime"),
-        "sidebarAppearance:tint-opacity": localized("settings.search.alias.setting.sidebarAppearance.tint-opacity", defaultValue: "sidebarAppearance.tintOpacity alpha transparency intensity blend"),
-        "sidebarAppearance:reset-tint": localized("settings.search.alias.setting.sidebarAppearance.reset-tint", defaultValue: "restore default clear tint colors opacity"),
+        "sidebarAppearance:hide-sidebar-details": localized("settings.search.alias.setting.app.hide-sidebar-details", defaultValue: "sidebar.hideAllDetails compact sidebar hide details only title minimal left rail"),
+        "sidebarAppearance:sidebar-branch-layout": localized("settings.search.alias.setting.app.sidebar-branch-layout", defaultValue: "sidebar.branchLayout git branch layout vertical inline cwd directory"),
+        "sidebarAppearance:show-notification-message": localized("settings.search.alias.setting.app.show-notification-message", defaultValue: "sidebar.showNotificationMessage latest message unread notification text sidebar"),
+        "sidebarAppearance:show-branch-directory": localized("settings.search.alias.setting.app.show-branch-directory", defaultValue: "sidebar.showBranchDirectory git branch cwd path directory folder repo sidebar"),
+        "sidebarAppearance:show-pull-requests": localized("settings.search.alias.setting.app.show-pull-requests", defaultValue: "sidebar.showPullRequests pr mr review github gitlab bitbucket pull request merge request"),
+        "sidebarAppearance:open-pr-links": localized("settings.search.alias.setting.app.open-pr-links", defaultValue: "sidebar.openPullRequestLinksInCmuxBrowser pr links github browser default external embedded"),
+        "sidebarAppearance:open-port-links": localized("settings.search.alias.setting.app.open-port-links", defaultValue: "sidebar.openPortLinksInCmuxBrowser ports localhost links browser default external embedded"),
+        "sidebarAppearance:show-ssh": localized("settings.search.alias.setting.app.show-ssh", defaultValue: "sidebar.showSSH remote host target ssh server"),
+        "sidebarAppearance:show-ports": localized("settings.search.alias.setting.app.show-ports", defaultValue: "sidebar.showPorts localhost port listener dev server url"),
+        "sidebarAppearance:show-log": localized("settings.search.alias.setting.app.show-log", defaultValue: "sidebar.showLog log status latest message imperative"),
+        "sidebarAppearance:show-progress": localized("settings.search.alias.setting.app.show-progress", defaultValue: "sidebar.showProgress progress bar percent status set_progress"),
+        "sidebarAppearance:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
         "automation:socket-mode": localized("settings.search.alias.setting.automation.socket-mode", defaultValue: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),
         "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),
         "automation:claude-code": localized("settings.search.alias.setting.automation.claude-code", defaultValue: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2837,7 +2837,7 @@ private struct SidebarDebugView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 14) {
-                Text("Sidebar Appearance")
+                Text(String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar"))
                     .font(.headline)
 
                 Toggle(String(localized: "settings.sidebarAppearance.matchTerminalBackground", defaultValue: "Match Terminal Background"), isOn: $matchTerminalBackground)
@@ -6281,6 +6281,42 @@ struct SettingsView: View {
                                 )
                         }
 
+                    }
+
+                    SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))
+                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .terminal))
+                    SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("terminal.showScrollBar"),
+                            String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"),
+                            subtitle: showTerminalScrollBar
+                                ? String(localized: "settings.terminal.scrollBar.subtitleOn", defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace.")
+                                : String(localized: "settings.terminal.scrollBar.subtitleOff", defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches.")
+                        ) {
+                            Toggle("", isOn: showTerminalScrollBarBinding)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsTerminalScrollBarToggle")
+                                .accessibilityLabel(
+                                    String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar")
+                                )
+                        }
+                    }
+
+                    SettingsSectionHeader(title: String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar"))
+                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .sidebarAppearance))
+                    SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .json("sidebarAppearance.matchTerminalBackground"),
+                            String(localized: "settings.sidebarAppearance.matchTerminalBackground", defaultValue: "Match Terminal Background"),
+                            subtitle: String(localized: "settings.sidebarAppearance.matchTerminalBackground.subtitle", defaultValue: "Use the same background color and transparency as the terminal.")
+                        ) {
+                            Toggle("", isOn: $sidebarMatchTerminalBackground)
+                                .labelsHidden()
+                                .toggleStyle(.switch)
+                                .controlSize(.small)
+                        }
+
                         SettingsCardDivider()
 
                         SettingsCardRow(
@@ -6443,122 +6479,6 @@ struct SettingsView: View {
                                 .controlSize(.small)
                         }
                         .disabled(sidebarHideAllDetails)
-                    }
-
-                    SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))
-                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .terminal))
-                    SettingsCard {
-                        SettingsCardRow(
-                            configurationReview: .json("terminal.showScrollBar"),
-                            String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar"),
-                            subtitle: showTerminalScrollBar
-                                ? String(localized: "settings.terminal.scrollBar.subtitleOn", defaultValue: "Shows the right-edge terminal scroll bar in shell scrollback. cmux hides it automatically for alternate-screen style TUI surfaces and you can also disable it per workspace.")
-                                : String(localized: "settings.terminal.scrollBar.subtitleOff", defaultValue: "Hides the right-edge terminal scroll bar everywhere. Changes apply immediately and persist across relaunches.")
-                        ) {
-                            Toggle("", isOn: showTerminalScrollBarBinding)
-                                .labelsHidden()
-                                .controlSize(.small)
-                                .accessibilityIdentifier("SettingsTerminalScrollBarToggle")
-                                .accessibilityLabel(
-                                    String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar")
-                                )
-                        }
-                    }
-
-                    SettingsSectionHeader(title: String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar Appearance"))
-                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .sidebarAppearance))
-                    SettingsCard {
-                        SettingsCardRow(
-                            configurationReview: .json("sidebarAppearance.matchTerminalBackground"),
-                            String(localized: "settings.sidebarAppearance.matchTerminalBackground", defaultValue: "Match Terminal Background"),
-                            subtitle: String(localized: "settings.sidebarAppearance.matchTerminalBackground.subtitle", defaultValue: "Use the same background color and transparency as the terminal.")
-                        ) {
-                            Toggle("", isOn: $sidebarMatchTerminalBackground)
-                                .labelsHidden()
-                                .toggleStyle(.switch)
-                                .controlSize(.small)
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("sidebarAppearance.lightModeTintColor"),
-                            String(localized: "settings.sidebarAppearance.tintColorLight", defaultValue: "Light Mode Tint"),
-                            subtitle: String(localized: "settings.sidebarAppearance.tintColorLight.subtitle", defaultValue: "Sidebar tint color when using light appearance.")
-                        ) {
-                            HStack(spacing: 8) {
-                                ColorPicker(
-                                    String(localized: "settings.sidebarAppearance.tintColorLight.picker", defaultValue: "Light tint"),
-                                    selection: settingsSidebarTintLightBinding,
-                                    supportsOpacity: false
-                                )
-                                .labelsHidden()
-                                .frame(width: 38)
-
-                                Text(sidebarTintHexLight ?? String(localized: "settings.sidebarAppearance.defaultLabel", defaultValue: "Default"))
-                                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 76, alignment: .trailing)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("sidebarAppearance.darkModeTintColor"),
-                            String(localized: "settings.sidebarAppearance.tintColorDark", defaultValue: "Dark Mode Tint"),
-                            subtitle: String(localized: "settings.sidebarAppearance.tintColorDark.subtitle", defaultValue: "Sidebar tint color when using dark appearance.")
-                        ) {
-                            HStack(spacing: 8) {
-                                ColorPicker(
-                                    String(localized: "settings.sidebarAppearance.tintColorDark.picker", defaultValue: "Dark tint"),
-                                    selection: settingsSidebarTintDarkBinding,
-                                    supportsOpacity: false
-                                )
-                                .labelsHidden()
-                                .frame(width: 38)
-
-                                Text(sidebarTintHexDark ?? String(localized: "settings.sidebarAppearance.defaultLabel", defaultValue: "Default"))
-                                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 76, alignment: .trailing)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .json("sidebarAppearance.tintOpacity"),
-                            String(localized: "settings.sidebarAppearance.tintOpacity", defaultValue: "Tint Opacity"),
-                            subtitle: String(localized: "settings.sidebarAppearance.tintOpacity.subtitle", defaultValue: "How strongly the tint color shows over the sidebar material.")
-                        ) {
-                            HStack(spacing: 8) {
-                                Slider(value: $sidebarTintOpacity, in: 0...1)
-                                    .frame(width: 140)
-                                Text(String(format: "%.0f%%", sidebarTintOpacity * 100))
-                                    .font(.system(size: 12, weight: .medium, design: .monospaced))
-                                    .foregroundStyle(.secondary)
-                                    .frame(width: 36, alignment: .trailing)
-                            }
-                        }
-
-                        SettingsCardDivider()
-
-                        SettingsCardRow(
-                            configurationReview: .action,
-                            String(localized: "settings.sidebarAppearance.reset", defaultValue: "Reset Sidebar Tint"),
-                            subtitle: String(localized: "settings.sidebarAppearance.reset.subtitle", defaultValue: "Restore default sidebar appearance."),
-                            searchAnchorID: SettingsSearchIndex.settingID(for: .sidebarAppearance, idSuffix: "reset-tint")
-                        ) {
-                            Button(String(localized: "settings.sidebarAppearance.reset.button", defaultValue: "Reset")) {
-                                sidebarTintHexLight = nil
-                                sidebarTintHexDark = nil
-                                sidebarTintHex = SidebarTintDefaults.hex
-                                sidebarTintOpacity = SidebarTintDefaults.opacity
-                            }
-                            .buttonStyle(.bordered)
-                            .controlSize(.small)
-                        }
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.automation", defaultValue: "Automation"))


### PR DESCRIPTION
## Summary
- Rename Sidebar Appearance to Sidebar.
- Move sidebar display controls out of App and into Sidebar.
- Remove the sidebar tint picker, opacity, and reset rows from Settings.

## Testing
- `./scripts/reload.sh --tag sidebar`
- `git diff --check`
- `./tests/test_ci_swift_file_length_budget.sh`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`

## Notes
- Existing sidebar tint config keys still decode for backward compatibility, but they are no longer exposed in Settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Renamed "Sidebar Appearance" to "Sidebar" and moved Terminal and Sidebar sections earlier in Settings for quicker access.
  * Expanded sidebar-related search keywords to improve discoverability.

* **Removals**
  * Removed sidebar tint controls and related tint search aliases.

* **Localization**
  * Updated localized strings across multiple languages to reflect the label and token changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->