### PR TITLE
Bridge OpenCode plan approvals into Feed

### DIFF
--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -1,10 +1,12 @@
 // cmux-feed-plugin-marker v1
 // Bridges OpenCode's plugin event bus to the cmux socket's feed.* verbs.
 // Installed by `cmux hooks setup` or `cmux hooks opencode install`.
-// DO NOT EDIT MANUALLY — cmux upgrades this file in place.
+// DO NOT EDIT MANUALLY - cmux upgrades this file in place.
 
 const net = require("node:net");
 const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
 
 const DEFAULT_SOCKET = `${os.homedir()}/.config/cmux/cmux.sock`;
 const SOCKET_PATH = process.env.CMUX_SOCKET_PATH || DEFAULT_SOCKET;
@@ -17,11 +19,20 @@ export const CMUXFeed = async (ctx) => {
   const messageRoles = new Map();
   const sessions = new Map();
 
+  const isObject = (value) => value && typeof value === "object" && !Array.isArray(value);
+
+  const firstString = (...values) => {
+    for (const value of values) {
+      if (typeof value === "string" && value.trim().length > 0) return value.trim();
+    }
+    return null;
+  };
+
   const normalizeText = (value, max = 1000) => {
     if (typeof value !== "string") return null;
     const normalized = value.replace(/\s+/g, " ").trim();
     if (!normalized) return null;
-    return normalized.length > max ? `${normalized.slice(0, max - 1)}…` : normalized;
+    return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized;
   };
 
   const sessionState = (sessionId) => {
@@ -42,6 +53,224 @@ export const CMUXFeed = async (ctx) => {
     if (state.lastUserMessage) context.lastUserMessage = state.lastUserMessage;
     if (state.assistantPreamble) context.assistantPreamble = state.assistantPreamble;
     return Object.keys(context).length > 0 ? context : undefined;
+  };
+
+  const clientMethod = (root, name) => {
+    const fn = root?.[name];
+    return typeof fn === "function" ? fn.bind(root) : null;
+  };
+
+  const rawClientRequest = async (method, options) => {
+    const raw = ctx?.client?._client || ctx?.client?.client;
+    const fn = raw && typeof raw[method] === "function" ? raw[method].bind(raw) : null;
+    if (!fn) throw new Error(`OpenCode SDK raw ${method} unavailable`);
+    return await fn({
+      ...options,
+      throwOnError: true,
+      headers: { "Content-Type": "application/json", ...(options.headers || {}) },
+    });
+  };
+
+  const replyPermission = async ({ sessionId, requestId, reply, message }) => {
+    try {
+      await rawClientRequest("post", {
+        url: "/permission/{requestID}/reply",
+        path: { requestID: requestId },
+        body: message ? { reply, message } : { reply },
+      });
+      return;
+    } catch (_) {}
+
+    const current = clientMethod(ctx?.client?.permission, "reply");
+    if (current) {
+      await current({ requestID: requestId, reply, message });
+      return;
+    }
+
+    const legacy = clientMethod(ctx?.client, "postSessionIdPermissionsPermissionId");
+    if (legacy && sessionId) {
+      await legacy({
+        path: { id: sessionId, permissionID: requestId },
+        body: { response: reply },
+      });
+    }
+  };
+
+  const replyQuestion = async (requestId, answers) => {
+    try {
+      await rawClientRequest("post", {
+        url: "/question/{requestID}/reply",
+        path: { requestID: requestId },
+        body: { answers },
+      });
+      return;
+    } catch (_) {}
+
+    const current = clientMethod(ctx?.client?.question, "reply");
+    if (current) await current({ requestID: requestId, answers });
+  };
+
+  const rejectQuestion = async (requestId) => {
+    try {
+      await rawClientRequest("post", {
+        url: "/question/{requestID}/reject",
+        path: { requestID: requestId },
+        body: {},
+      });
+      return;
+    } catch (_) {}
+
+    const current = clientMethod(ctx?.client?.question, "reject");
+    if (current) await current({ requestID: requestId });
+  };
+
+  const updateSessionPermission = async (sessionId, permission) => {
+    if (!sessionId || !permission.length) return;
+    try {
+      await rawClientRequest("patch", {
+        url: "/session/{sessionID}",
+        path: { sessionID: sessionId },
+        body: { permission },
+      });
+      return;
+    } catch (_) {}
+
+    const current = clientMethod(ctx?.client?.session, "update");
+    if (current) await current({ path: { id: sessionId }, body: { permission } });
+  };
+
+  const sendPlanFeedback = async (sessionId, text) => {
+    const message = normalizeText(text, 2000);
+    if (!sessionId || !message) return;
+    const body = {
+      agent: "plan",
+      parts: [{ type: "text", text: message }],
+    };
+    try {
+      await rawClientRequest("post", {
+        url: "/session/{sessionID}/prompt_async",
+        path: { sessionID: sessionId },
+        body,
+      });
+      return;
+    } catch (_) {}
+
+    const current = clientMethod(ctx?.client?.session, "promptAsync");
+    if (current) await current({ path: { id: sessionId }, body });
+  };
+
+  const permissionRulesForExitPlanMode = (mode) => {
+    switch (mode) {
+      case "manual":
+        return [
+          { permission: "edit", pattern: "*", action: "ask" },
+          { permission: "bash", pattern: "*", action: "ask" },
+          { permission: "external_directory", pattern: "*", action: "ask" },
+        ];
+      case "autoAccept":
+      case "bypassPermissions":
+        return [
+          { permission: "edit", pattern: "*", action: "allow" },
+          { permission: "bash", pattern: "*", action: "allow" },
+          { permission: "external_directory", pattern: "*", action: "allow" },
+        ];
+      default:
+        return [];
+    }
+  };
+
+  const permissionReplyForMode = (mode) => {
+    switch (mode) {
+      case "deny":
+        return "reject";
+      case "always":
+      case "all":
+      case "bypass":
+        return "always";
+      default:
+        return "once";
+    }
+  };
+
+  const permissionSessionRulesForMode = (permission, mode) => {
+    if (!permission) return [];
+    switch (mode) {
+      case "all":
+      case "bypass":
+        return [{ permission: "*", pattern: "*", action: "allow" }];
+      default:
+        return [];
+    }
+  };
+
+  const questionAnswers = (selections) => {
+    if (!Array.isArray(selections) || selections.length === 0) return [[]];
+    return selections.map((selection) => [String(selection)]);
+  };
+
+  const planExitInfo = (sid, questions) => {
+    const first = Array.isArray(questions) ? questions[0] : null;
+    if (!first) return null;
+    const prompt = firstString(first.question, first.prompt) || "";
+    const header = firstString(first.header, first.title) || "";
+    const labels = Array.isArray(first.options)
+      ? first.options.map((option) => firstString(option?.label, option?.title, option)).filter(Boolean)
+      : [];
+    const looksLikePlanExit =
+      header === "Build Agent" ||
+      /Plan at .+ is complete\./.test(prompt) ||
+      (labels.includes("Yes") && labels.includes("No") && /switch to the build agent/i.test(prompt));
+    if (!looksLikePlanExit) return null;
+
+    const match = prompt.match(/Plan at (.+?) is complete\./);
+    const rawPlanPath = match?.[1]?.trim();
+    const baseDir = ctx?.worktree || ctx?.directory || process.cwd();
+    const planFilePath = rawPlanPath
+      ? (path.isAbsolute(rawPlanPath) ? rawPlanPath : path.resolve(baseDir, rawPlanPath))
+      : null;
+    let plan = null;
+    if (planFilePath) {
+      try {
+        plan = fs.readFileSync(planFilePath, "utf8");
+      } catch (_) {}
+    }
+    return {
+      sid,
+      question: prompt,
+      plan: plan || prompt || "OpenCode plan is ready for review.",
+      planFilePath,
+    };
+  };
+
+  const handleExitPlanDecision = async (sid, requestId, decision) => {
+    const mode = decision?.mode || "manual";
+    const feedback = normalizeText(decision?.feedback, 2000);
+
+    if (feedback) {
+      await replyQuestion(requestId, [["No"]]);
+      await sendPlanFeedback(
+        sid,
+        `User rejected the plan via cmux Feed and wants this change: ${feedback}\n\nUpdate the plan file, then call plan_exit again.`
+      );
+      return;
+    }
+
+    if (mode === "deny") {
+      await replyQuestion(requestId, [["No"]]);
+      return;
+    }
+
+    if (mode === "ultraplan") {
+      await replyQuestion(requestId, [["No"]]);
+      await sendPlanFeedback(
+        sid,
+        "User chose Ultraplan via cmux Feed. Refine the plan more deeply, update the plan file, then call plan_exit again."
+      );
+      return;
+    }
+
+    await updateSessionPermission(sid, permissionRulesForExitPlanMode(mode));
+    await replyQuestion(requestId, [["Yes"]]);
   };
 
   const resolvePending = (requestId, value) => {
@@ -81,7 +310,7 @@ export const CMUXFeed = async (ctx) => {
             const requestId = msg?.result?.request_id || msg?.request_id || responseId;
             resolvePending(requestId, msg.result || msg);
           } catch (e) {
-            // swallow — malformed line, keep the connection alive.
+            // swallow - malformed line, keep the connection alive.
           }
         }
       });
@@ -247,23 +476,36 @@ export const CMUXFeed = async (ctx) => {
           const requestId = props.id;
           if (!requestId) break;
           const sid = props.sessionID || "unknown";
+          const permission = firstString(props.permission, props.tool?.name) || "permission";
+          const metadata = isObject(props.metadata) ? props.metadata : {};
           const frame = base(sid, {
             hook_event_name: "PermissionRequest",
             _opencode_request_id: requestId,
-            tool_name: props.tool,
-            tool_input: props.input,
+            tool_name: permission,
+            tool_input: {
+              permission,
+              patterns: Array.isArray(props.patterns) ? props.patterns : [],
+              always: Array.isArray(props.always) ? props.always : [],
+              metadata,
+              tool: props.tool,
+            },
+            context: {
+              ...(contextForSession(sid) || {}),
+              permissionMode: "opencode",
+            },
           });
           const result = await pushBlocking(frame, requestId);
           if (result?.status === "resolved" && result.decision?.kind === "permission") {
             const mode = result.decision.mode;
-            const response = mode === "deny" ? "deny" : "approve";
-            const remember = (mode === "always" || mode === "all" || mode === "bypass");
             try {
-              await ctx.client.session.permissions({
-                path: { id: sid, permissionID: requestId },
-                body: { response, remember },
+              await updateSessionPermission(sid, permissionSessionRulesForMode(permission, mode));
+              await replyPermission({
+                sessionId: sid,
+                requestId,
+                reply: permissionReplyForMode(mode),
+                message: mode === "deny" ? "User denied permission via cmux Feed." : undefined,
               });
-            } catch (e) { /* ignore — opencode already moved on */ }
+            } catch (e) { /* ignore - opencode already moved on */ }
           }
           break;
         }
@@ -276,20 +518,52 @@ export const CMUXFeed = async (ctx) => {
             id: q.id || `q${idx}`,
             header: q.header || q.title,
             question: q.question || q.prompt || "",
-            multiSelect: q.multiSelect || q.multiple || false,
+            multiSelect: q.multiSelect === true || q.multiple === true,
             options: (q.options || []).map((o, optionIdx) => ({
               id: o.id || `opt${optionIdx}`,
               label: o.label || o.title || String(o),
               description: o.description || o.detail,
             })),
           }));
+          const planExit = planExitInfo(sid, questions);
+          if (planExit) {
+            const frame = base(sid, {
+              hook_event_name: "ExitPlanMode",
+              _opencode_request_id: requestId,
+              tool_name: "plan_exit",
+              tool_input: {
+                plan: planExit.plan,
+                planFilePath: planExit.planFilePath,
+                question: planExit.question,
+              },
+              context: {
+                ...(contextForSession(sid) || {}),
+                permissionMode: "plan",
+              },
+            });
+            const result = await pushBlocking(frame, requestId);
+            if (result?.status === "resolved" && result.decision?.kind === "exit_plan") {
+              try {
+                await handleExitPlanDecision(sid, requestId, result.decision);
+              } catch (_) {}
+            }
+            break;
+          }
+
           const frame = base(sid, {
             hook_event_name: "AskUserQuestion",
             _opencode_request_id: requestId,
-            tool_name: "AskUserQuestion",
+            tool_name: "question",
             tool_input: { questions },
           });
-          await pushBlocking(frame, requestId);
+          const result = await pushBlocking(frame, requestId);
+          if (result?.status === "resolved" && result.decision?.kind === "question") {
+            try {
+              await replyQuestion(requestId, questionAnswers(result.decision.selections));
+            } catch (_) {
+              try { await rejectQuestion(requestId); } catch (_) {}
+            }
+          }
           break;
         }
         default:

--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -71,25 +71,39 @@ export const CMUXFeed = async (ctx) => {
     });
   };
 
-  const replyPermission = async ({ sessionId, requestId, reply, message }) => {
+  const tryRawClientRequest = async (method, options) => {
     try {
-      await rawClientRequest("post", {
+      await rawClientRequest(method, options);
+      return true;
+    } catch (_) {
+      return false;
+    }
+  };
+
+  const callClientMethod = async (root, name, args) => {
+    const fn = clientMethod(root, name);
+    if (!fn) return false;
+    await fn(args);
+    return true;
+  };
+
+  const replyPermission = async ({ sessionId, requestId, reply, message }) => {
+    if (
+      await tryRawClientRequest("post", {
         url: "/permission/{requestID}/reply",
         path: { requestID: requestId },
         body: message ? { reply, message } : { reply },
-      });
-      return;
-    } catch (_) {}
-
-    const current = clientMethod(ctx?.client?.permission, "reply");
-    if (current) {
-      await current({ requestID: requestId, reply, message });
+      })
+    ) {
       return;
     }
 
-    const legacy = clientMethod(ctx?.client, "postSessionIdPermissionsPermissionId");
-    if (legacy && sessionId) {
-      await legacy({
+    if (await callClientMethod(ctx?.client?.permission, "reply", { requestID: requestId, reply, message })) {
+      return;
+    }
+
+    if (sessionId) {
+      await callClientMethod(ctx?.client, "postSessionIdPermissionsPermissionId", {
         path: { id: sessionId, permissionID: requestId },
         body: { response: reply },
       });
@@ -97,46 +111,46 @@ export const CMUXFeed = async (ctx) => {
   };
 
   const replyQuestion = async (requestId, answers) => {
-    try {
-      await rawClientRequest("post", {
+    if (
+      await tryRawClientRequest("post", {
         url: "/question/{requestID}/reply",
         path: { requestID: requestId },
         body: { answers },
-      });
+      })
+    ) {
       return;
-    } catch (_) {}
+    }
 
-    const current = clientMethod(ctx?.client?.question, "reply");
-    if (current) await current({ requestID: requestId, answers });
+    await callClientMethod(ctx?.client?.question, "reply", { requestID: requestId, answers });
   };
 
   const rejectQuestion = async (requestId) => {
-    try {
-      await rawClientRequest("post", {
+    if (
+      await tryRawClientRequest("post", {
         url: "/question/{requestID}/reject",
         path: { requestID: requestId },
         body: {},
-      });
+      })
+    ) {
       return;
-    } catch (_) {}
+    }
 
-    const current = clientMethod(ctx?.client?.question, "reject");
-    if (current) await current({ requestID: requestId });
+    await callClientMethod(ctx?.client?.question, "reject", { requestID: requestId });
   };
 
   const updateSessionPermission = async (sessionId, permission) => {
     if (!sessionId || !permission.length) return;
-    try {
-      await rawClientRequest("patch", {
+    if (
+      await tryRawClientRequest("patch", {
         url: "/session/{sessionID}",
         path: { sessionID: sessionId },
         body: { permission },
-      });
+      })
+    ) {
       return;
-    } catch (_) {}
+    }
 
-    const current = clientMethod(ctx?.client?.session, "update");
-    if (current) await current({ path: { id: sessionId }, body: { permission } });
+    await callClientMethod(ctx?.client?.session, "update", { path: { id: sessionId }, body: { permission } });
   };
 
   const sendPlanFeedback = async (sessionId, text) => {
@@ -146,17 +160,17 @@ export const CMUXFeed = async (ctx) => {
       agent: "plan",
       parts: [{ type: "text", text: message }],
     };
-    try {
-      await rawClientRequest("post", {
+    if (
+      await tryRawClientRequest("post", {
         url: "/session/{sessionID}/prompt_async",
         path: { sessionID: sessionId },
         body,
-      });
+      })
+    ) {
       return;
-    } catch (_) {}
+    }
 
-    const current = clientMethod(ctx?.client?.session, "promptAsync");
-    if (current) await current({ path: { id: sessionId }, body });
+    await callClientMethod(ctx?.client?.session, "promptAsync", { path: { id: sessionId }, body });
   };
 
   const permissionRulesForExitPlanMode = (mode) => {

--- a/Resources/opencode-plugin.js
+++ b/Resources/opencode-plugin.js
@@ -11,6 +11,7 @@ const path = require("node:path");
 const DEFAULT_SOCKET = `${os.homedir()}/.config/cmux/cmux.sock`;
 const SOCKET_PATH = process.env.CMUX_SOCKET_PATH || DEFAULT_SOCKET;
 const REPLY_TIMEOUT_MS = 120_000;
+const MAX_PLAN_BYTES = 128 * 1024;
 
 export const CMUXFeed = async (ctx) => {
   let client = null;
@@ -87,6 +88,11 @@ export const CMUXFeed = async (ctx) => {
     return true;
   };
 
+  const legacyPermissionBody = (reply) => ({
+    response: reply === "reject" ? "deny" : "approve",
+    remember: reply === "always",
+  });
+
   const replyPermission = async ({ sessionId, requestId, reply, message }) => {
     if (
       await tryRawClientRequest("post", {
@@ -105,7 +111,7 @@ export const CMUXFeed = async (ctx) => {
     if (sessionId) {
       await callClientMethod(ctx?.client, "postSessionIdPermissionsPermissionId", {
         path: { id: sessionId, permissionID: requestId },
-        body: { response: reply },
+        body: legacyPermissionBody(reply),
       });
     }
   };
@@ -139,7 +145,7 @@ export const CMUXFeed = async (ctx) => {
   };
 
   const updateSessionPermission = async (sessionId, permission) => {
-    if (!sessionId || !permission.length) return;
+    if (!sessionId || !permission.length) return true;
     if (
       await tryRawClientRequest("patch", {
         url: "/session/{sessionID}",
@@ -147,10 +153,10 @@ export const CMUXFeed = async (ctx) => {
         body: { permission },
       })
     ) {
-      return;
+      return true;
     }
 
-    await callClientMethod(ctx?.client?.session, "update", { path: { id: sessionId }, body: { permission } });
+    return await callClientMethod(ctx?.client?.session, "update", { path: { id: sessionId }, body: { permission } });
   };
 
   const sendPlanFeedback = async (sessionId, text) => {
@@ -222,6 +228,35 @@ export const CMUXFeed = async (ctx) => {
     return selections.map((selection) => [String(selection)]);
   };
 
+  const resolveSessionPlanPath = (sid, rawPlanPath) => {
+    if (!rawPlanPath) return null;
+    const root = path.resolve(sessionState(sid).cwd || ctx?.worktree || ctx?.directory || process.cwd());
+    const raw = String(rawPlanPath);
+    const relativeInput = path.isAbsolute(raw)
+      ? path.relative(root, path.resolve(raw))
+      : raw;
+    const candidate = path.resolve(root, relativeInput);
+    const relative = path.relative(root, candidate);
+    if (!relative || relative.startsWith("..") || path.isAbsolute(relative)) return null;
+    return candidate;
+  };
+
+  const readPlanFile = (planFilePath) => {
+    const stat = fs.statSync(planFilePath);
+    if (!stat.isFile()) return null;
+    const fd = fs.openSync(planFilePath, "r");
+    try {
+      const length = Math.min(stat.size, MAX_PLAN_BYTES);
+      const buffer = Buffer.alloc(length);
+      const bytes = fs.readSync(fd, buffer, 0, length, 0);
+      const text = buffer.subarray(0, bytes).toString("utf8");
+      if (stat.size <= bytes) return text;
+      return `${text}\n\n[cmux truncated plan file at ${bytes} bytes.]`;
+    } finally {
+      fs.closeSync(fd);
+    }
+  };
+
   const planExitInfo = (sid, questions) => {
     const first = Array.isArray(questions) ? questions[0] : null;
     if (!first) return null;
@@ -238,14 +273,11 @@ export const CMUXFeed = async (ctx) => {
 
     const match = prompt.match(/Plan at (.+?) is complete\./);
     const rawPlanPath = match?.[1]?.trim();
-    const baseDir = ctx?.worktree || ctx?.directory || process.cwd();
-    const planFilePath = rawPlanPath
-      ? (path.isAbsolute(rawPlanPath) ? rawPlanPath : path.resolve(baseDir, rawPlanPath))
-      : null;
+    const planFilePath = resolveSessionPlanPath(sid, rawPlanPath);
     let plan = null;
     if (planFilePath) {
       try {
-        plan = fs.readFileSync(planFilePath, "utf8");
+        plan = readPlanFile(planFilePath);
       } catch (_) {}
     }
     return {
@@ -258,7 +290,7 @@ export const CMUXFeed = async (ctx) => {
 
   const handleExitPlanDecision = async (sid, requestId, decision) => {
     const mode = decision?.mode || "manual";
-    const feedback = normalizeText(decision?.feedback, 2000);
+    const feedback = normalizeText(decision?.feedback, 1800);
 
     if (feedback) {
       await replyQuestion(requestId, [["No"]]);
@@ -283,7 +315,21 @@ export const CMUXFeed = async (ctx) => {
       return;
     }
 
-    await updateSessionPermission(sid, permissionRulesForExitPlanMode(mode));
+    const rules = permissionRulesForExitPlanMode(mode);
+    let permissionsApplied = true;
+    try {
+      permissionsApplied = await updateSessionPermission(sid, rules);
+    } catch (_) {
+      permissionsApplied = false;
+    }
+    if (!permissionsApplied) {
+      await replyQuestion(requestId, [["No"]]);
+      await sendPlanFeedback(
+        sid,
+        "cmux could not apply the selected permission mode. Ask the user to approve the plan again before switching to build mode."
+      );
+      return;
+    }
     await replyQuestion(requestId, [["Yes"]]);
   };
 
@@ -513,6 +559,8 @@ export const CMUXFeed = async (ctx) => {
             const mode = result.decision.mode;
             try {
               await updateSessionPermission(sid, permissionSessionRulesForMode(permission, mode));
+            } catch (_) {}
+            try {
               await replyPermission({
                 sessionId: sid,
                 requestId,


### PR DESCRIPTION
## Summary
- Updates the bundled OpenCode Feed plugin for current OpenCode `permission.asked` and `question.asked` APIs.
- Converts OpenCode `plan_exit` questions into Feed ExitPlan cards, including plan file contents.
- Applies OpenCode session permission rules from Feed plan decisions so manual approval routes later edit/bash prompts through Feed.

## Testing
- `node --check Resources/opencode-plugin.js`
- Mocked OpenCode plugin runtime harness: plan_exit -> ExitPlanMode, manual approval -> session permission ask rules, permission approval -> `/permission/{requestID}/reply` once
- `./scripts/reload.sh --tag opplan`
- Verified built app resource contains `plan_exit`, `ExitPlanMode`, and `/permission/{requestID}/reply` bridge

## Issues
- Related: https://github.com/anomalyco/opencode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Expanded bidirectional capability for richer handling of permissions and plan-exit questions
  * Improved intelligent routing of questions with plan-exit scenario detection

* **Improvements**
  * Enhanced permission information with normalized data, detailed metadata, and tool context
  * Better question handling including multi-select support and improved resolution paths
  * Refined text formatting and presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->