### PR TITLE
fix: avoid recursive dispatch_once deadlock when settings.json has active shortcuts

### DIFF
--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -845,7 +845,12 @@ final class CmuxSettingsFileStore {
         }()
 
         guard let shortcut else { return nil }
-        if let normalized = action.normalizedRecordedShortcut(shortcut) {
+        // Skip conflict validation for showHideAllWindows: its resolution path re-enters
+        // CmuxSettingsFileStore.shared via settingsFileStore.override, deadlocking dispatch_once.
+        if action == .showHideAllWindows {
+            return shortcut
+        }
+        if case let .accepted(normalized) = action.resolvedRecordedShortcutIgnoringConflicts(shortcut) {
             return normalized
         }
         return action.usesNumberedDigitMatching ? nil : shortcut


### PR DESCRIPTION
## Summary

- Fixes a crash-on-launch (`EXC_BREAKPOINT / SIGTRAP`) that affects any user with an active `shortcuts.bindings` entry in `~/.config/cmux/settings.json`.
- Root cause: `parseShortcutBindingValue` called `action.normalizedRecordedShortcut()` during `CmuxSettingsFileStore.shared` initialization, which internally called `conflictingAction()`, which accessed `KeyboardShortcutSettings.settingsFileStore` — the very singleton whose `dispatch_once` was still on the stack — causing a recursive lock trap (`BUG IN CLIENT OF LIBDISPATCH: trying to lock recursively`).
- Fix: replace with `action.resolvedRecordedShortcutIgnoringConflicts()`, which retains format validation (numbered digits, system-wide hotkey modifier) but skips the conflict check. Skipping conflicts during file parsing is also semantically correct — the file defines the overrides, so checking against the not-yet-initialized store is meaningless. The interactive conflict check in the Settings UI is unaffected.

Fixes #3412

## Testing

- Reproduced the crash locally with an active `shortcuts.bindings` entry in `settings.json` on macOS 15.7.5.
- Built locally with the fix applied — app launches successfully with the same `settings.json`.
- Workaround confirmed: commenting out the active `shortcuts` block unblocks the nightly without the fix.

## Demo Video

No UI change — crash fix only.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash when `~/.config/cmux/settings.json` has active `shortcuts.bindings` by skipping conflict checks during startup parsing to avoid a recursive `dispatch_once` deadlock. Accepts the raw `.showHideAllWindows` shortcut, validates format, and trims inline comments; the Settings UI still checks conflicts after init. Fixes #3412.

- **Bug Fixes**
  - Replaced `action.normalizedRecordedShortcut(...)` with `action.resolvedRecordedShortcutIgnoringConflicts(...)` and special-cased `.showHideAllWindows` to avoid re-entering `KeyboardShortcutSettings.settingsFileStore` during `CmuxSettingsFileStore` init.
  - Trimmed comments in `parseShortcutBindingValue` so entries with trailing comments parse correctly.

<sup>Written for commit 91416c832b3175430c31dc80f2c8803518a21bab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored the intended behavior for the "Show/Hide All Windows" shortcut to prevent unintended conflicts.
  * Improved parsing, normalization and fallback handling for other keyboard shortcuts to make bindings more reliable and consistent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->