### PR TITLE
Route Codex permission approvals through Feed

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19366,7 +19366,6 @@ export default CMUXSessionRestore;
         event: String,
         toolName: String
     ) -> (String, Bool) {
-        let event = normalizedFeedEventName(event)
         if source == "claude" {
             switch event {
             case "PermissionRequest":
@@ -19395,27 +19394,9 @@ export default CMUXSessionRestore;
             }
         }
 
-        if source == "codex" {
-            switch event {
-            case "PermissionRequest":
-                return ("PermissionRequest", true)
-            case "PostToolUse":
-                return ("PostToolUse", false)
-            case "UserPromptSubmit":
-                return ("UserPromptSubmit", false)
-            case "SessionStart":
-                return ("SessionStart", false)
-            case "SessionEnd":
-                return ("SessionEnd", false)
-            case "Stop", "SubagentStop":
-                return ("Stop", false)
-            default:
-                return ("PreToolUse", false)
-            }
-        }
-
         switch event {
         case "PreToolUse", "beforeShellExecution":
+            if source == "codex" { return ("PreToolUse", false) }
             switch toolName {
             case "ExitPlanMode":
                 return ("ExitPlanMode", true)
@@ -19448,20 +19429,6 @@ export default CMUXSessionRestore;
             return ("Notification", false)
         default:
             return ("PreToolUse", false)
-        }
-    }
-
-    private static func normalizedFeedEventName(_ rawEvent: String) -> String {
-        switch rawEvent {
-        case "preToolUse": return "PreToolUse"
-        case "permissionRequest": return "PermissionRequest"
-        case "postToolUse": return "PostToolUse"
-        case "sessionStart": return "SessionStart"
-        case "sessionEnd": return "SessionEnd"
-        case "userPromptSubmit": return "UserPromptSubmit"
-        case "subagentStop": return "SubagentStop"
-        case "stop": return "Stop"
-        default: return rawEvent
         }
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -16282,7 +16282,7 @@ struct CMUXCLI {
                 .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit"),
                 .init(agentEvent: "Stop", cmuxSubcommand: "stop"),
             ],
-            feedHookEvents: ["PreToolUse"],
+            feedHookEvents: ["PreToolUse", "PermissionRequest"],
             postInstallAction: .codexConfigToml
         ),
         AgentHookDef(
@@ -18657,6 +18657,9 @@ export default CMUXSessionRestore;
         guard item.canResolve else { return "Resolved or informational item" }
         switch item.kind {
         case "permissionRequest":
+            if item.source == "codex" {
+                return "Permission: Enter/o once, d deny"
+            }
             return "Permission: Enter/o once, a always, l all tools, b bypass, d deny"
         case "exitPlan":
             return "Plan: Enter default, a auto, m manual, u ultraplan, b bypass, f replan, d deny"
@@ -18696,11 +18699,11 @@ export default CMUXSessionRestore;
             switch key {
             case .enter, .once:
                 mode = "once"
-            case .always:
+            case .always where item.source != "codex":
                 mode = "always"
-            case .all:
+            case .all where item.source != "codex":
                 mode = "all"
-            case .bypass:
+            case .bypass where item.source != "codex":
                 mode = "bypass"
             case .deny:
                 mode = "deny"
@@ -19363,6 +19366,7 @@ export default CMUXSessionRestore;
         event: String,
         toolName: String
     ) -> (String, Bool) {
+        let event = normalizedFeedEventName(event)
         if source == "claude" {
             switch event {
             case "PermissionRequest":
@@ -19386,6 +19390,25 @@ export default CMUXSessionRestore;
                 return ("Stop", false)
             case "Notification":
                 return ("Notification", false)
+            default:
+                return ("PreToolUse", false)
+            }
+        }
+
+        if source == "codex" {
+            switch event {
+            case "PermissionRequest":
+                return ("PermissionRequest", true)
+            case "PostToolUse":
+                return ("PostToolUse", false)
+            case "UserPromptSubmit":
+                return ("UserPromptSubmit", false)
+            case "SessionStart":
+                return ("SessionStart", false)
+            case "SessionEnd":
+                return ("SessionEnd", false)
+            case "Stop", "SubagentStop":
+                return ("Stop", false)
             default:
                 return ("PreToolUse", false)
             }
@@ -19428,6 +19451,20 @@ export default CMUXSessionRestore;
         }
     }
 
+    private static func normalizedFeedEventName(_ rawEvent: String) -> String {
+        switch rawEvent {
+        case "preToolUse": return "PreToolUse"
+        case "permissionRequest": return "PermissionRequest"
+        case "postToolUse": return "PostToolUse"
+        case "sessionStart": return "SessionStart"
+        case "sessionEnd": return "SessionEnd"
+        case "userPromptSubmit": return "UserPromptSubmit"
+        case "subagentStop": return "SubagentStop"
+        case "stop": return "Stop"
+        default: return rawEvent
+        }
+    }
+
     /// Tools that mutate state and deserve a user-visible approve/
     /// deny prompt in Feed. Keyed on the canonical tool names Claude,
     /// Codex, and similar agents emit. Read-only tools (Read, Grep,
@@ -19466,7 +19503,7 @@ export default CMUXSessionRestore;
             return s
         }
 
-        func claudePermissionRequestDecision(
+        func permissionRequestHookDecision(
             behavior: String,
             message: String? = nil,
             updatedInput: [String: Any]? = nil,
@@ -19534,7 +19571,7 @@ export default CMUXSessionRestore;
             let mode = decision["mode"] as? String ?? "deny"
             if source == "claude" {
                 if mode == "deny" {
-                    return encode(claudePermissionRequestDecision(
+                    return encode(permissionRequestHookDecision(
                         behavior: "deny",
                         message: "User denied permission via cmux Feed."
                     ))
@@ -19549,23 +19586,19 @@ export default CMUXSessionRestore;
                         "destination": "session",
                     ]]
                 }
-                return encode(claudePermissionRequestDecision(
+                return encode(permissionRequestHookDecision(
                     behavior: "allow",
                     updatedPermissions: updatedPermissions
                 ))
             }
             if source == "codex" {
                 if mode == "deny" {
-                    return encode([
-                        "decision": "block",
-                        "reason": "User denied permission via cmux Feed."
-                    ])
+                    return encode(permissionRequestHookDecision(
+                        behavior: "deny",
+                        message: "User denied permission via cmux Feed."
+                    ))
                 }
-                var out: [String: Any] = ["decision": "approve"]
-                if mode == "always" || mode == "all" || mode == "bypass" {
-                    out["remember"] = (mode == "bypass") ? "always" : "session"
-                }
-                return encode(out)
+                return encode(permissionRequestHookDecision(behavior: "allow"))
             }
             if mode == "deny" {
                 return encode(nonClaudePreToolDecision(
@@ -19588,19 +19621,19 @@ export default CMUXSessionRestore;
                 .trimmingCharacters(in: .whitespacesAndNewlines)
             if source == "claude" {
                 if let feedback, !feedback.isEmpty {
-                    return encode(claudePermissionRequestDecision(
+                    return encode(permissionRequestHookDecision(
                         behavior: "deny",
                         message: "User rejected the plan via cmux Feed and wants this change: \(feedback)"
                     ))
                 }
                 if mode == "deny" {
-                    return encode(claudePermissionRequestDecision(
+                    return encode(permissionRequestHookDecision(
                         behavior: "deny",
                         message: "User rejected the plan via cmux Feed."
                     ))
                 }
                 if mode == "ultraplan" {
-                    return encode(claudePermissionRequestDecision(
+                    return encode(permissionRequestHookDecision(
                         behavior: "deny",
                         message: "User chose Ultraplan via cmux Feed. Refine this plan with Ultraplan on Claude Code on the web."
                     ))
@@ -19619,7 +19652,7 @@ export default CMUXSessionRestore;
                         "destination": "session",
                     ]]
                 }
-                return encode(claudePermissionRequestDecision(
+                return encode(permissionRequestHookDecision(
                     behavior: "allow",
                     updatedInput: jsonDictionary(from: toolInput),
                     updatedPermissions: updatedPermissions
@@ -19668,7 +19701,7 @@ export default CMUXSessionRestore;
             if selections == [Self.skipInterviewAndPlanAnswer] {
                 let message = "User chose Skip interview and plan immediately via cmux Feed. Do not ask more interview questions. Write the plan now."
                 if source == "claude" {
-                    return encode(claudePermissionRequestDecision(
+                    return encode(permissionRequestHookDecision(
                         behavior: "deny",
                         message: message
                     ))
@@ -19684,7 +19717,7 @@ export default CMUXSessionRestore;
                     toolInput: toolInput,
                     selections: selections
                 )
-                return encode(claudePermissionRequestDecision(
+                return encode(permissionRequestHookDecision(
                     behavior: "allow",
                     updatedInput: updatedInput
                 ))

--- a/Resources/feed-tui/index.ts
+++ b/Resources/feed-tui/index.ts
@@ -715,6 +715,8 @@ class FeedApp {
     switch (item.kind) {
       case "permissionRequest":
         if (item.source === "codex") {
+          // Codex PermissionRequest hooks only accept allow/deny for this
+          // invocation. Persistent allow/bypass modes are Claude/OpenCode-only.
           return ["deny"].includes(action);
         }
         return ["deny", "always", "all", "bypass"].includes(action);

--- a/Resources/feed-tui/index.ts
+++ b/Resources/feed-tui/index.ts
@@ -669,6 +669,9 @@ class FeedApp {
     }
     switch (item.kind) {
       case "permissionRequest":
+        if (item.source === "codex") {
+          return "Enter once | d deny";
+        }
         return "Enter once | a always | l all | b bypass | d deny";
       case "exitPlan":
         return "Enter default | a auto | m manual | u ultra | b bypass | f replan | d deny";
@@ -711,6 +714,9 @@ class FeedApp {
     }
     switch (item.kind) {
       case "permissionRequest":
+        if (item.source === "codex") {
+          return ["deny"].includes(action);
+        }
         return ["deny", "always", "all", "bypass"].includes(action);
       case "exitPlan":
         return ["deny", "always", "manual", "ultraplan", "bypass"].includes(action);

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -1403,23 +1403,19 @@ private struct PermissionActionArea: View {
             codeBlock
             if status.isPending {
                 HStack(spacing: 6) {
-                    FeedButton(
-                        label: String(localized: "feed.permission.deny", defaultValue: "Deny"),
-                        kind: .dark, size: .medium, fullWidth: true
-                    ) { onApprove(.deny) }.accessibilityIdentifier("FeedPermissionDenyButton")
-                    FeedButton(
-                        label: String(localized: "feed.permission.once", defaultValue: "Allow Once"),
-                        kind: .light, size: .medium, fullWidth: true
-                    ) { onApprove(.once) }.accessibilityIdentifier("FeedPermissionAllowOnceButton")
+                    FeedButton(label: String(localized: "feed.permission.deny", defaultValue: "Deny"),
+                               kind: .dark, size: .medium, fullWidth: true) { onApprove(.deny) }
+                        .accessibilityIdentifier("FeedPermissionDenyButton")
+                    FeedButton(label: String(localized: "feed.permission.once", defaultValue: "Allow Once"),
+                               kind: .light, size: .medium, fullWidth: true) { onApprove(.once) }
+                        .accessibilityIdentifier("FeedPermissionAllowOnceButton")
                     if source != .codex {
-                        FeedButton(
-                            label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
-                            kind: .primary, size: .medium, fullWidth: true
-                        ) { onApprove(.always) }.accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
-                        FeedButton(
-                            label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
-                            kind: .destructive, size: .medium, fullWidth: true
-                        ) { onApprove(.bypass) }.accessibilityIdentifier("FeedPermissionBypassButton")
+                        FeedButton(label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
+                                   kind: .primary, size: .medium, fullWidth: true) { onApprove(.always) }
+                            .accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
+                        FeedButton(label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
+                                   kind: .destructive, size: .medium, fullWidth: true) { onApprove(.bypass) }
+                            .accessibilityIdentifier("FeedPermissionBypassButton")
                     }
                 }
             } else if let badge = submittedBadge {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -1202,6 +1202,7 @@ struct FeedItemRow: View, Equatable {
             PermissionActionArea(
                 toolName: toolName,
                 toolInputJSON: toolInputJSON,
+                source: snapshot.source,
                 status: snapshot.status,
                 onApprove: { mode in
                     actions.approvePermission(snapshot.id, mode)
@@ -1392,6 +1393,7 @@ private struct FeedLabeledTextRow: View {
 private struct PermissionActionArea: View {
     let toolName: String
     let toolInputJSON: String
+    let source: WorkstreamSource
     let status: WorkstreamStatus
     let onApprove: (WorkstreamPermissionMode) -> Void
 
@@ -1409,14 +1411,16 @@ private struct PermissionActionArea: View {
                         label: String(localized: "feed.permission.once", defaultValue: "Allow Once"),
                         kind: .light, size: .medium, fullWidth: true
                     ) { onApprove(.once) }.accessibilityIdentifier("FeedPermissionAllowOnceButton")
-                    FeedButton(
-                        label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
-                        kind: .primary, size: .medium, fullWidth: true
-                    ) { onApprove(.always) }.accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
-                    FeedButton(
-                        label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
-                        kind: .destructive, size: .medium, fullWidth: true
-                    ) { onApprove(.bypass) }.accessibilityIdentifier("FeedPermissionBypassButton")
+                    if source != .codex {
+                        FeedButton(
+                            label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
+                            kind: .primary, size: .medium, fullWidth: true
+                        ) { onApprove(.always) }.accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
+                        FeedButton(
+                            label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
+                            kind: .destructive, size: .medium, fullWidth: true
+                        ) { onApprove(.bypass) }.accessibilityIdentifier("FeedPermissionBypassButton")
+                    }
                 }
             } else if let badge = submittedBadge {
                 FeedButton(

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -109,7 +109,7 @@ For Claude Code, the cmux wrapper launches Claude with `--allow-dangerously-skip
 
 For Claude Code, AskUserQuestion is answered by allowing the PermissionRequest with an updated tool input containing the selected answers. Other agents use their native question reply shape where available.
 
-Codex's `request_user_input` and `update_plan` currently surface through its app-server request/notification path, not through command hooks. cmux can route Codex permission approvals through `PermissionRequest`; Codex plan-mode questions still fall back to Codex's own TUI until Codex exposes those app-server frames to hook-based integrations.
+Codex's `request_user_input` and `update_plan` currently surface through its app-server request/notification path, not through command hooks. A stock `codex` TUI running in a cmux terminal keeps those frames inside Codex's in-process app-server client, so its plan-mode questions still fall back to Codex's own TUI. cmux can route Codex permission approvals through `PermissionRequest`; showing Codex plan questions in Feed would require launching Codex against a shared standalone app server and adding a Codex app-server Feed adapter, or upstream Codex hook coverage for those frames.
 
 ## Timeout behavior
 
@@ -140,6 +140,8 @@ Double-click a Feed row and cmux focuses the cmux workspace + surface where the 
 ## Troubleshooting
 
 **Feed shows nothing even though the agent is running.** Check that the hook got installed: `cat ~/.codex/hooks.json` (or similar) should contain a `cmux hooks feed --source codex` entry. Re-run `cmux hooks setup`.
+
+**Codex plan-mode question stays in the terminal.** Codex `request_user_input` is not a hook event in the stock TUI path. Feed only sees Codex permission hooks today.
 
 **Agent hangs on a permission request.** Feed never blocks the agent longer than 120 seconds; if you see a longer hang, the hook failed to reach the socket. Verify `$CMUX_SOCKET_PATH` matches the running app (default is `~/.config/cmux/cmux.sock`).
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -62,7 +62,7 @@ Installs Feed-relevant hooks for every supported CLI whose binary is on `PATH`:
 | Agent        | Config                                    | Feed trigger             |
 |--------------|-------------------------------------------|--------------------------|
 | Claude Code  | wrapper-injected                          | PermissionRequest        |
-| Codex        | `~/.codex/hooks.json`                     | PreToolUse               |
+| Codex        | `~/.codex/hooks.json`                     | PermissionRequest        |
 | Cursor CLI   | `~/.cursor/hooks.json`                    | beforeShellExecution     |
 | Gemini       | `~/.gemini/settings.json`                 | PreToolUse               |
 | Copilot      | `~/.copilot/config.json`                  | PreToolUse               |
@@ -108,6 +108,8 @@ For Claude Code, the cmux wrapper launches Claude with `--allow-dangerously-skip
 **AskUserQuestion**
 
 For Claude Code, AskUserQuestion is answered by allowing the PermissionRequest with an updated tool input containing the selected answers. Other agents use their native question reply shape where available.
+
+Codex's `request_user_input` and `update_plan` currently surface through its app-server request/notification path, not through command hooks. cmux can route Codex permission approvals through `PermissionRequest`; Codex plan-mode questions still fall back to Codex's own TUI until Codex exposes those app-server frames to hook-based integrations.
 
 ## Timeout behavior
 

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -123,6 +123,14 @@ def assert_permission_output(stdout: dict, behavior: str) -> None:
         raise AssertionError(f"wrong permission behavior: {stdout!r}")
 
 
+def assert_codex_allow_has_no_persistent_fields(stdout: dict) -> None:
+    decision = stdout["hookSpecificOutput"]["decision"]
+    forbidden = {"updatedInput", "updatedPermissions", "setMode", "remember"}
+    present = forbidden.intersection(decision)
+    if present:
+        raise AssertionError(f"Codex permission output included unsupported fields {present}: {stdout!r}")
+
+
 def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home"
     codex_home.mkdir()
@@ -196,6 +204,27 @@ def test_permission_reply_uses_codex_permission_request_schema(cli_path: str, ro
         raise AssertionError(f"deny output should include a message: {stdout!r}")
 
 
+def test_codex_persistent_permission_modes_degrade_to_once(cli_path: str, root: Path) -> None:
+    payload = {
+        "session_id": "codex-session",
+        "turn_id": "turn-persistent",
+        "cwd": "/tmp/project",
+        "hook_event_name": "PermissionRequest",
+        "tool_name": "Bash",
+        "tool_input": {"command": "printf hi"},
+    }
+
+    for mode in ["always", "all", "bypass"]:
+        stdout, _ = run_feed_hook(
+            cli_path,
+            root / f"cmux-{mode}.sock",
+            payload,
+            {"kind": "permission", "mode": mode},
+        )
+        assert_permission_output(stdout, "allow")
+        assert_codex_allow_has_no_persistent_fields(stdout)
+
+
 def test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path: str, root: Path) -> None:
     stdout, frame = run_feed_hook(
         cli_path,
@@ -231,6 +260,7 @@ def main() -> int:
         try:
             test_install_adds_codex_permission_request_hook(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
+            test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)
             test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)
         except Exception as exc:
             print(f"FAIL: {exc}")

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""
+Regression tests for Codex Feed hook wiring and decision output.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+class FakeCmuxSocket:
+    def __init__(self, path: Path, decision: dict | None):
+        self.path = path
+        self.decision = decision
+        self.frames: list[dict] = []
+        self._ready = threading.Event()
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._run, daemon=True)
+
+    def __enter__(self) -> "FakeCmuxSocket":
+        self.path.unlink(missing_ok=True)
+        self._thread.start()
+        if not self._ready.wait(timeout=3):
+            raise RuntimeError("fake socket did not start")
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        self._stop.set()
+        try:
+            with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as client:
+                client.connect(str(self.path))
+        except OSError:
+            pass
+        self._thread.join(timeout=3)
+        self.path.unlink(missing_ok=True)
+
+    def _run(self) -> None:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as server:
+            server.bind(str(self.path))
+            server.listen(4)
+            self._ready.set()
+            while not self._stop.is_set():
+                try:
+                    conn, _ = server.accept()
+                except OSError:
+                    continue
+                with conn:
+                    data = b""
+                    while b"\n" not in data:
+                        chunk = conn.recv(65536)
+                        if not chunk:
+                            break
+                        data += chunk
+                    line = data.split(b"\n", 1)[0]
+                    if not line:
+                        continue
+                    frame = json.loads(line.decode("utf-8"))
+                    self.frames.append(frame)
+                    result: dict = {"status": "acknowledged"}
+                    if self.decision is not None:
+                        result = {
+                            "status": "resolved",
+                            "decision": self.decision,
+                        }
+                    response = {
+                        "id": frame.get("id"),
+                        "ok": True,
+                        "result": result,
+                    }
+                    conn.sendall(json.dumps(response).encode("utf-8") + b"\n")
+
+
+def run_feed_hook(cli_path: str, socket_path: Path, payload: dict, decision: dict | None) -> tuple[dict, dict]:
+    env = os.environ.copy()
+    env["CMUX_SURFACE_ID"] = "surface-codex-feed-test"
+    env["CMUX_WORKSPACE_ID"] = "workspace-codex-feed-test"
+    with FakeCmuxSocket(socket_path, decision) as fake:
+        result = subprocess.run(
+            [
+                cli_path,
+                "--socket",
+                str(socket_path),
+                "hooks",
+                "feed",
+                "--source",
+                "codex",
+                "--event",
+                payload.get("hook_event_name", ""),
+            ],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=10,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks feed failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        if not fake.frames:
+            raise AssertionError("hooks feed did not send feed.push")
+        stdout = json.loads(result.stdout.strip() or "{}")
+        return stdout, fake.frames[0]
+
+
+def assert_permission_output(stdout: dict, behavior: str) -> None:
+    hook_output = stdout.get("hookSpecificOutput")
+    if not isinstance(hook_output, dict):
+        raise AssertionError(f"missing hookSpecificOutput: {stdout!r}")
+    if hook_output.get("hookEventName") != "PermissionRequest":
+        raise AssertionError(f"wrong hook event output: {stdout!r}")
+    decision = hook_output.get("decision")
+    if not isinstance(decision, dict) or decision.get("behavior") != behavior:
+        raise AssertionError(f"wrong permission behavior: {stdout!r}")
+
+
+def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home"
+    codex_home.mkdir()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
+    hook_groups = hooks.get("hooks", {})
+    for event_name in ["PreToolUse", "PermissionRequest"]:
+        groups = hook_groups.get(event_name)
+        if not groups:
+            raise AssertionError(f"missing {event_name} hook group: {hooks!r}")
+        command = groups[-1]["hooks"][0]["command"]
+        if f"cmux hooks feed --source codex --event {event_name}" not in command:
+            raise AssertionError(f"wrong {event_name} feed command: {command!r}")
+        if groups[-1]["hooks"][0].get("timeout") != 120_000:
+            raise AssertionError(f"wrong {event_name} timeout: {groups[-1]!r}")
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "codex_hooks = true" not in config_toml:
+        raise AssertionError(f"codex_hooks feature was not enabled: {config_toml!r}")
+
+
+def test_permission_reply_uses_codex_permission_request_schema(cli_path: str, root: Path) -> None:
+    socket_path = root / "cmux.sock"
+    payload = {
+        "session_id": "codex-session",
+        "turn_id": "turn-1",
+        "cwd": "/tmp/project",
+        "hook_event_name": "PermissionRequest",
+        "tool_name": "Bash",
+        "tool_input": {"command": "printf hi"},
+    }
+
+    stdout, frame = run_feed_hook(
+        cli_path,
+        socket_path,
+        payload,
+        {"kind": "permission", "mode": "once"},
+    )
+    assert_permission_output(stdout, "allow")
+    params = frame["params"]
+    if params.get("wait_timeout_seconds") != 120:
+        raise AssertionError(f"PermissionRequest should block for Feed reply: {frame!r}")
+    event = params["event"]
+    if event.get("hook_event_name") != "PermissionRequest" or event.get("_source") != "codex":
+        raise AssertionError(f"wrong feed event: {event!r}")
+
+    stdout, _ = run_feed_hook(
+        cli_path,
+        root / "cmux-deny.sock",
+        payload,
+        {"kind": "permission", "mode": "deny"},
+    )
+    assert_permission_output(stdout, "deny")
+    message = stdout["hookSpecificOutput"]["decision"].get("message", "")
+    if "denied" not in message:
+        raise AssertionError(f"deny output should include a message: {stdout!r}")
+
+
+def test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path: str, root: Path) -> None:
+    stdout, frame = run_feed_hook(
+        cli_path,
+        root / "cmux-pretool.sock",
+        {
+            "session_id": "codex-session",
+            "turn_id": "turn-2",
+            "cwd": "/tmp/project",
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "printf hi"},
+        },
+        None,
+    )
+    if stdout != {}:
+        raise AssertionError(f"PreToolUse telemetry should not emit a decision: {stdout!r}")
+    params = frame["params"]
+    if params.get("wait_timeout_seconds") != 0:
+        raise AssertionError(f"Codex PreToolUse should not wait for Feed reply: {frame!r}")
+    if params["event"].get("hook_event_name") != "PreToolUse":
+        raise AssertionError(f"wrong PreToolUse event: {frame!r}")
+
+
+def main() -> int:
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-codex-feed-hooks-") as td:
+        root = Path(td)
+        try:
+            test_install_adds_codex_permission_request_hook(cli_path, root)
+            test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
+            test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)
+        except Exception as exc:
+            print(f"FAIL: {exc}")
+            return 1
+
+    print("PASS: Codex Feed hooks use native permission approvals")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- install Codex Feed on PermissionRequest in addition to PreToolUse telemetry
- emit Codex-compatible PermissionRequest hook decisions from Feed replies
- hide unsupported persistent permission modes for Codex Feed cards
- document that Codex plan/user-input events are app-server-only today

## Verification
- ./scripts/reload.sh --tag codexfp
- CMUX_CLI_BIN="/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-codexfp/Build/Products/Debug/cmux DEV codexfp.app/Contents/Resources/bin/cmux" python3 tests/test_codex_feed_hooks.py
- python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
- ./tests/test_ci_swift_file_length_budget.sh
- python3 -m py_compile tests/test_codex_feed_hooks.py
- git diff --check