### PR TITLE
Add authenticated comeup handshakes

### DIFF
--- a/comeup/crates/cmx/src/main.rs
+++ b/comeup/crates/cmx/src/main.rs
@@ -15,18 +15,22 @@ use std::path::PathBuf;
 
 use anyhow::{Result, anyhow, bail};
 use comeup_client::UnixClient;
-use comeup_protocol::{ClientMsg, Command, Delta, Focus, ServerMsg, Viewport, VisibleTerminal};
+use comeup_protocol::{
+    ClientAuth, ClientMsg, Command, Delta, Focus, ServerMsg, Viewport, VisibleTerminal,
+};
 use tokio::io::{AsyncBufReadExt, BufReader};
 
 #[tokio::main]
 async fn main() -> Result<()> {
     let args = Args::parse(std::env::args().skip(1))?;
-    let mut client = UnixClient::connect(
+    let auth = client_auth();
+    let mut client = UnixClient::connect_with_auth(
         &args.socket,
         Viewport {
             cols: args.cols,
             rows: args.rows,
         },
+        auth,
     )
     .await?;
 
@@ -319,6 +323,13 @@ impl Args {
             rows,
         })
     }
+}
+
+fn client_auth() -> Option<ClientAuth> {
+    std::env::var("COMEUP_AUTH_TOKEN")
+        .ok()
+        .filter(|token| !token.is_empty())
+        .map(|token| ClientAuth::Bearer { token })
 }
 
 #[cfg(test)]

--- a/comeup/crates/cmx/tests/tui_sync.rs
+++ b/comeup/crates/cmx/tests/tui_sync.rs
@@ -4,7 +4,7 @@ use std::sync::mpsc;
 use std::time::Duration;
 
 use comeup_client::UnixClient;
-use comeup_daemon::{ServerOptions, serve_unix_socket};
+use comeup_daemon::{AuthPolicy, ServerOptions, serve_unix_socket};
 use comeup_protocol::{
     ClientMsg, Delta, ServerMsg, TerminalId, Viewport, VisibleTerminal, WorkspaceId,
 };
@@ -28,6 +28,7 @@ async fn real_cmx_tui_process_syncs_with_ios_shaped_client() {
                 shell: "/bin/cat".to_string(),
                 cwd: Some(server_cwd),
                 initial_viewport: Viewport { cols: 80, rows: 24 },
+                auth: AuthPolicy::Open,
             },
         )
         .await;

--- a/comeup/crates/comeup-client/src/lib.rs
+++ b/comeup/crates/comeup-client/src/lib.rs
@@ -13,7 +13,8 @@ use std::path::Path;
 
 use anyhow::{Context, Result, anyhow};
 use comeup_protocol::{
-    ClientId, ClientMsg, PROTOCOL_VERSION, ServerMsg, Snapshot, Viewport, read_msg, write_msg,
+    ClientAuth, ClientId, ClientMsg, PROTOCOL_VERSION, ServerMsg, Snapshot, Viewport, read_msg,
+    write_msg,
 };
 use tokio::io::BufReader;
 use tokio::net::UnixStream;
@@ -28,6 +29,14 @@ pub struct UnixClient {
 
 impl UnixClient {
     pub async fn connect(socket_path: impl AsRef<Path>, viewport: Viewport) -> Result<Self> {
+        Self::connect_with_auth(socket_path, viewport, None).await
+    }
+
+    pub async fn connect_with_auth(
+        socket_path: impl AsRef<Path>,
+        viewport: Viewport,
+        auth: Option<ClientAuth>,
+    ) -> Result<Self> {
         let stream = UnixStream::connect(socket_path.as_ref())
             .await
             .with_context(|| format!("connect {}", socket_path.as_ref().display()))?;
@@ -39,6 +48,7 @@ impl UnixClient {
             &ClientMsg::Hello {
                 version: PROTOCOL_VERSION,
                 viewport,
+                auth,
             },
         )
         .await

--- a/comeup/crates/comeup-daemon/src/bin/comeup-harness-server.rs
+++ b/comeup/crates/comeup-daemon/src/bin/comeup-harness-server.rs
@@ -13,7 +13,7 @@ use std::path::PathBuf;
 
 use anyhow::{Result, anyhow, bail};
 use comeup_daemon::{
-    ComeupServer, ServerOptions, serve_tcp_text_harness, serve_unix_socket_with_server,
+    AuthPolicy, ComeupServer, ServerOptions, serve_tcp_text_harness, serve_unix_socket_with_server,
 };
 use comeup_protocol::Viewport;
 
@@ -27,6 +27,7 @@ async fn main() -> Result<()> {
             cols: args.cols,
             rows: args.rows,
         },
+        auth: auth_policy()?,
     })?;
 
     let unix = serve_unix_socket_with_server(&args.socket, server.clone());
@@ -87,4 +88,17 @@ impl Args {
             rows,
         })
     }
+}
+
+fn auth_policy() -> Result<AuthPolicy> {
+    match env_auth_token() {
+        Some(token) => AuthPolicy::bearer_token(token),
+        None => Ok(AuthPolicy::Open),
+    }
+}
+
+fn env_auth_token() -> Option<String> {
+    std::env::var("COMEUP_AUTH_TOKEN")
+        .ok()
+        .filter(|token| !token.is_empty())
 }

--- a/comeup/crates/comeup-daemon/src/lib.rs
+++ b/comeup/crates/comeup-daemon/src/lib.rs
@@ -18,8 +18,8 @@ use std::time::Instant;
 use anyhow::{Context, Result, anyhow};
 use comeup_core::Model;
 use comeup_protocol::{
-    ClientId, ClientMsg, Command, Delta, PROTOCOL_VERSION, ServerMsg, TerminalId, Viewport,
-    VisibleTerminal, read_msg, write_msg,
+    ClientAuth, ClientId, ClientMsg, Command, Delta, PROTOCOL_VERSION, ServerMsg, TerminalId,
+    Viewport, VisibleTerminal, read_msg, write_msg,
 };
 use portable_pty::{ChildKiller, CommandBuilder, PtySize, native_pty_system};
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
@@ -32,16 +32,68 @@ pub struct ServerOptions {
     pub shell: String,
     pub cwd: Option<PathBuf>,
     pub initial_viewport: Viewport,
+    pub auth: AuthPolicy,
+}
+
+#[derive(Clone, Default)]
+pub enum AuthPolicy {
+    #[default]
+    Open,
+    BearerToken(String),
+}
+
+impl std::fmt::Debug for AuthPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Open => f.write_str("Open"),
+            Self::BearerToken(_) => f.write_str("BearerToken(<redacted>)"),
+        }
+    }
+}
+
+impl AuthPolicy {
+    pub fn bearer_token(token: impl Into<String>) -> Result<Self> {
+        let token = token.into();
+        if token.is_empty() {
+            return Err(anyhow!("auth token must not be empty"));
+        }
+        Ok(Self::BearerToken(token))
+    }
+
+    fn authorize(&self, auth: Option<&ClientAuth>) -> bool {
+        match self {
+            Self::Open => true,
+            Self::BearerToken(expected) => match auth {
+                Some(ClientAuth::Bearer { token }) => {
+                    constant_time_eq(expected.as_bytes(), token.as_bytes())
+                }
+                None => false,
+            },
+        }
+    }
+}
+
+fn constant_time_eq(left: &[u8], right: &[u8]) -> bool {
+    let max_len = left.len().max(right.len());
+    let mut diff = left.len() ^ right.len();
+    for index in 0..max_len {
+        let left_byte = left.get(index).copied().unwrap_or(0);
+        let right_byte = right.get(index).copied().unwrap_or(0);
+        diff |= usize::from(left_byte ^ right_byte);
+    }
+    diff == 0
 }
 
 #[derive(Debug, Clone)]
 pub struct ComeupServer {
     tx: mpsc::UnboundedSender<DaemonMsg>,
+    auth: AuthPolicy,
 }
 
 impl ComeupServer {
     pub fn start(opts: ServerOptions) -> Result<Self> {
         let (tx, rx) = mpsc::unbounded_channel();
+        let auth = opts.auth.clone();
         let mut terminals = HashMap::new();
         let terminal = PtyTerminal::spawn(
             1,
@@ -62,7 +114,7 @@ impl ComeupServer {
             tx: tx.clone(),
         };
         tokio::spawn(run_loop(rx, state));
-        Ok(Self { tx })
+        Ok(Self { tx, auth })
     }
 
     pub async fn connect(&self, viewport: Viewport) -> Result<LocalClient> {
@@ -80,6 +132,10 @@ impl ComeupServer {
 
     pub fn shutdown(&self) {
         let _ = self.tx.send(DaemonMsg::Shutdown);
+    }
+
+    fn authorize(&self, auth: Option<&ClientAuth>) -> bool {
+        self.auth.authorize(auth)
     }
 }
 
@@ -133,7 +189,12 @@ async fn handle_unix_client(server: ComeupServer, stream: UnixStream) -> Result<
     else {
         return Ok(());
     };
-    let ClientMsg::Hello { version, viewport } = hello else {
+    let ClientMsg::Hello {
+        version,
+        viewport,
+        auth,
+    } = hello
+    else {
         write_msg(
             &mut write_half,
             &ServerMsg::Error {
@@ -144,6 +205,17 @@ async fn handle_unix_client(server: ComeupServer, stream: UnixStream) -> Result<
         .ok();
         return Ok(());
     };
+    if !server.authorize(auth.as_ref()) {
+        write_msg(
+            &mut write_half,
+            &ServerMsg::Error {
+                message: "unauthorized".to_string(),
+            },
+        )
+        .await
+        .ok();
+        return Ok(());
+    }
     if version != PROTOCOL_VERSION {
         write_msg(
             &mut write_half,
@@ -218,7 +290,11 @@ async fn handle_tcp_text_client(server: ComeupServer, stream: TcpStream) -> Resu
             .ok();
         return Ok(());
     };
-    let viewport = parse_text_viewport(rest)?;
+    let (viewport, auth) = parse_text_hello(rest)?;
+    if !server.authorize(auth.as_ref()) {
+        write_half.write_all(b"ERROR unauthorized\n").await.ok();
+        return Ok(());
+    }
     let LocalClient {
         client_id,
         tx,
@@ -349,14 +425,75 @@ mod tests {
             other => panic!("unexpected message: {other:?}"),
         }
     }
+
+    #[test]
+    fn text_harness_hello_accepts_optional_bearer_auth() {
+        let (viewport, auth) =
+            parse_text_hello("90 30 AUTH bearer test-token").expect("parse hello");
+        assert_eq!(viewport, Viewport { cols: 90, rows: 30 });
+        assert_eq!(
+            auth,
+            Some(ClientAuth::Bearer {
+                token: "test-token".to_string()
+            })
+        );
+
+        let (viewport, auth) = parse_text_hello("80 24").expect("parse hello without auth");
+        assert_eq!(viewport, Viewport { cols: 80, rows: 24 });
+        assert_eq!(auth, None);
+    }
+
+    #[test]
+    fn text_harness_hello_rejects_unknown_options() {
+        assert!(parse_text_hello("90 30 TOKEN test-token").is_err());
+        assert!(parse_text_hello("90 30 AUTH basic test-token").is_err());
+        assert!(parse_text_hello("90 30 AUTH bearer").is_err());
+        assert!(parse_text_hello("90 30 AUTH bearer test-token extra").is_err());
+    }
+
+    #[test]
+    fn auth_policy_uses_constant_time_token_check() {
+        let policy = AuthPolicy::bearer_token("expected-token").expect("policy");
+        assert!(policy.authorize(Some(&ClientAuth::Bearer {
+            token: "expected-token".to_string()
+        })));
+        assert!(!policy.authorize(Some(&ClientAuth::Bearer {
+            token: "wrong-token".to_string()
+        })));
+        assert!(!policy.authorize(None));
+    }
 }
 
-fn parse_text_viewport(rest: &str) -> Result<Viewport> {
+fn parse_text_hello(rest: &str) -> Result<(Viewport, Option<ClientAuth>)> {
     let mut parts = rest.split_whitespace();
-    Ok(Viewport {
+    let viewport = Viewport {
         cols: parse_next::<u16>(&mut parts, "cols")?,
         rows: parse_next::<u16>(&mut parts, "rows")?,
-    })
+    };
+    let Some(option) = parts.next() else {
+        return Ok((viewport, None));
+    };
+    if option != "AUTH" {
+        return Err(anyhow!("unknown HELLO option: {option}"));
+    }
+    let scheme = parts
+        .next()
+        .ok_or_else(|| anyhow!("AUTH requires a scheme"))?;
+    if scheme != "bearer" {
+        return Err(anyhow!("unsupported AUTH scheme: {scheme}"));
+    }
+    let token = parts
+        .next()
+        .ok_or_else(|| anyhow!("AUTH bearer requires a token"))?;
+    if parts.next().is_some() {
+        return Err(anyhow!("unexpected trailing HELLO field"));
+    }
+    Ok((
+        viewport,
+        Some(ClientAuth::Bearer {
+            token: token.to_string(),
+        }),
+    ))
 }
 
 fn parse_next<T: std::str::FromStr>(

--- a/comeup/crates/comeup-daemon/tests/local_sync.rs
+++ b/comeup/crates/comeup-daemon/tests/local_sync.rs
@@ -1,7 +1,7 @@
 use std::os::unix::fs::PermissionsExt;
 use std::time::Duration;
 
-use comeup_daemon::{ComeupServer, ServerOptions};
+use comeup_daemon::{AuthPolicy, ComeupServer, ServerOptions};
 use comeup_protocol::{ClientMsg, Command, Delta, ServerMsg, Viewport, VisibleTerminal};
 use tokio::time::timeout;
 
@@ -14,6 +14,7 @@ async fn two_local_clients_receive_workspace_delta_and_terminal_output() {
         shell: "/bin/cat".to_string(),
         cwd: Some(dir.path().to_path_buf()),
         initial_viewport: Viewport { cols: 80, rows: 24 },
+        auth: AuthPolicy::Open,
     })
     .expect("start server");
 
@@ -107,6 +108,7 @@ async fn silent_disconnect_releases_visible_terminal_size() {
         shell: "/bin/cat".to_string(),
         cwd: Some(dir.path().to_path_buf()),
         initial_viewport: Viewport { cols: 80, rows: 24 },
+        auth: AuthPolicy::Open,
     })
     .expect("start server");
 
@@ -160,6 +162,7 @@ async fn visible_terminal_update_replaces_client_snapshot() {
         shell: "/bin/cat".to_string(),
         cwd: Some(dir.path().to_path_buf()),
         initial_viewport: Viewport { cols: 80, rows: 24 },
+        auth: AuthPolicy::Open,
     })
     .expect("start server");
 
@@ -214,6 +217,7 @@ async fn new_workspace_pty_starts_at_model_size() {
         shell: shell.display().to_string(),
         cwd: Some(dir.path().to_path_buf()),
         initial_viewport: Viewport { cols: 80, rows: 24 },
+        auth: AuthPolicy::Open,
     })
     .expect("start server");
 

--- a/comeup/crates/comeup-daemon/tests/unix_socket_sync.rs
+++ b/comeup/crates/comeup-daemon/tests/unix_socket_sync.rs
@@ -3,11 +3,14 @@ use std::time::Duration;
 
 use comeup_client::UnixClient;
 use comeup_daemon::{
-    ComeupServer, ServerOptions, serve_unix_socket, serve_unix_socket_with_server,
+    AuthPolicy, ComeupServer, ServerOptions, serve_unix_socket, serve_unix_socket_with_server,
 };
 use comeup_protocol::{
-    ClientMsg, Command, Delta, ServerMsg, Viewport, VisibleTerminal, WorkspaceId,
+    ClientAuth, ClientMsg, Command, Delta, PROTOCOL_VERSION, ServerMsg, Viewport, VisibleTerminal,
+    WorkspaceId, read_msg, write_msg,
 };
+use tokio::io::BufReader;
+use tokio::net::UnixStream;
 use tokio::time::timeout;
 
 const SENTINEL: &str = "COMEUP_SOCKET_SYNC_OK_138D";
@@ -24,6 +27,7 @@ async fn unix_socket_clients_sync_workspace_resize_and_terminal_output() {
                 shell: "/bin/cat".to_string(),
                 cwd: Some(dir.path().to_path_buf()),
                 initial_viewport: Viewport { cols: 80, rows: 24 },
+                auth: AuthPolicy::Open,
             },
         )
         .await;
@@ -119,6 +123,7 @@ async fn unix_socket_refuses_to_delete_non_socket_path() {
         shell: "/bin/cat".to_string(),
         cwd: Some(dir.path().to_path_buf()),
         initial_viewport: Viewport { cols: 80, rows: 24 },
+        auth: AuthPolicy::Open,
     })
     .expect("start server");
 
@@ -137,6 +142,58 @@ async fn unix_socket_refuses_to_delete_non_socket_path() {
     server.shutdown();
 }
 
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn unix_socket_requires_matching_bearer_auth() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let socket = dir.path().join("comeup.sock");
+    let server_socket = socket.clone();
+    let server_cwd = dir.path().to_path_buf();
+    let server = tokio::spawn(async move {
+        let _ = serve_unix_socket(
+            server_socket,
+            ServerOptions {
+                shell: "/bin/cat".to_string(),
+                cwd: Some(server_cwd),
+                initial_viewport: Viewport { cols: 80, rows: 24 },
+                auth: AuthPolicy::bearer_token("socket-secret").expect("auth policy"),
+            },
+        )
+        .await;
+    });
+    wait_for_socket(&socket).await;
+
+    assert!(matches!(
+        send_hello(&socket, None).await,
+        ServerMsg::Error { message } if message == "unauthorized"
+    ));
+    assert!(matches!(
+        send_hello(
+            &socket,
+            Some(ClientAuth::Bearer {
+                token: "wrong-secret".to_string()
+            })
+        )
+        .await,
+        ServerMsg::Error { message } if message == "unauthorized"
+    ));
+
+    let client = UnixClient::connect_with_auth(
+        &socket,
+        Viewport { cols: 90, rows: 30 },
+        Some(ClientAuth::Bearer {
+            token: "socket-secret".to_string(),
+        }),
+    )
+    .await
+    .expect("connect with auth");
+    assert_eq!(
+        terminal_size(client.snapshot(), client.snapshot().focus.terminal_id),
+        Viewport { cols: 90, rows: 30 }
+    );
+
+    server.abort();
+}
+
 async fn wait_for_socket(socket: &Path) {
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     while !socket.exists() {
@@ -147,6 +204,26 @@ async fn wait_for_socket(socket: &Path) {
         );
         tokio::time::sleep(Duration::from_millis(20)).await;
     }
+}
+
+async fn send_hello(socket: &Path, auth: Option<ClientAuth>) -> ServerMsg {
+    let stream = UnixStream::connect(socket).await.expect("connect socket");
+    let (read_half, mut write_half) = stream.into_split();
+    let mut reader = BufReader::new(read_half);
+    write_msg(
+        &mut write_half,
+        &ClientMsg::Hello {
+            version: PROTOCOL_VERSION,
+            viewport: Viewport { cols: 80, rows: 24 },
+            auth,
+        },
+    )
+    .await
+    .expect("write hello");
+    read_msg::<_, ServerMsg>(&mut reader)
+        .await
+        .expect("read server message")
+        .expect("server message")
 }
 
 fn terminal_size(snapshot: &comeup_protocol::Snapshot, terminal_id: u64) -> Viewport {

--- a/comeup/crates/comeup-protocol/src/lib.rs
+++ b/comeup/crates/comeup-protocol/src/lib.rs
@@ -118,10 +118,18 @@ pub enum Command {
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ClientAuth {
+    Bearer { token: String },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
 pub enum ClientMsg {
     Hello {
         version: u32,
         viewport: Viewport,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        auth: Option<ClientAuth>,
     },
     Command {
         id: u64,
@@ -238,6 +246,24 @@ mod tests {
             terminal_id: 7,
             input_seq: 9,
             data: b"echo hi\n".to_vec(),
+        };
+        let (mut writer, mut reader) = tokio::io::duplex(1024);
+        write_msg(&mut writer, &msg).await.expect("write");
+        let decoded = read_msg::<_, ClientMsg>(&mut reader)
+            .await
+            .expect("read")
+            .expect("message");
+        assert_eq!(decoded, msg);
+    }
+
+    #[tokio::test]
+    async fn messagepack_frame_round_trips_hello_auth() {
+        let msg = ClientMsg::Hello {
+            version: PROTOCOL_VERSION,
+            viewport: Viewport { cols: 90, rows: 30 },
+            auth: Some(ClientAuth::Bearer {
+                token: "secret-token".to_string(),
+            }),
         };
         let (mut writer, mut reader) = tokio::io::duplex(1024);
         write_msg(&mut writer, &msg).await.expect("write");

--- a/comeup/scripts/run-simulator-terminal-sync.sh
+++ b/comeup/scripts/run-simulator-terminal-sync.sh
@@ -8,12 +8,14 @@ cd "$ROOT"
 command -v xcodebuildmcp >/dev/null
 
 PORT="${COMEUP_TEXT_PORT:-17891}"
+SIMULATOR_ID="${COMEUP_SIMULATOR_ID:-}"
 SIMULATOR_NAME="${COMEUP_SIMULATOR_NAME:-iPhone 17 Pro}"
 WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/comeup-sim-sync.XXXXXX")"
 SOCKET="$WORK_DIR/comeup.sock"
 SERVER_LOG="$WORK_DIR/comeup-server.log"
 CMX_LOG="$WORK_DIR/cmx-pty-recorder.log"
 DERIVED_DATA="$WORK_DIR/DerivedData"
+AUTH_TOKEN="${COMEUP_AUTH_TOKEN:-comeup-sim-auth-token}"
 CMX_SENTINEL="CMX_SENTINEL_TO_SIM"
 SIM_SENTINEL="SIM_SENTINEL_FROM_IOS"
 SERVER_PID=""
@@ -97,6 +99,7 @@ cargo build -p comeup-daemon -p cmx
 
 "$REPO_ROOT/scripts/ensure-ghosttykit.sh"
 
+COMEUP_AUTH_TOKEN="$AUTH_TOKEN" \
 "$ROOT/target/debug/comeup-harness-server" \
   --socket "$SOCKET" \
   --tcp "127.0.0.1:$PORT" \
@@ -108,6 +111,7 @@ SERVER_PID=$!
 wait_for_socket "$SOCKET"
 wait_for_tcp "$PORT"
 
+COMEUP_AUTH_TOKEN="$AUTH_TOKEN" \
 "$ROOT/target/debug/cmx-pty-recorder" \
   --socket "$SOCKET" \
   --cols 120 \
@@ -119,15 +123,24 @@ CMX_PID=$!
 wait_for_log "$CMX_LOG" "COMEUP_TUI_READY client=1 terminal=1 size=120x40"
 
 WORKSPACE="$ROOT/simulator-harness/ComeupSimulatorHarness.xcworkspace"
+SIMULATOR_ARGS=(
+  --workspace-path "$WORKSPACE"
+  --scheme ComeupSimulatorHarness
+)
+if [[ -n "$SIMULATOR_ID" ]]; then
+  SIMULATOR_ARGS+=(--simulator-id "$SIMULATOR_ID")
+else
+  SIMULATOR_ARGS+=(--simulator-name "$SIMULATOR_NAME" --use-latest-os true)
+fi
+
 COMEUP_TEXT_PORT="$PORT" \
 TEST_RUNNER_COMEUP_TEXT_PORT="$PORT" \
+COMEUP_AUTH_TOKEN="$AUTH_TOKEN" \
+TEST_RUNNER_COMEUP_AUTH_TOKEN="$AUTH_TOKEN" \
 COMEUP_SEND_ON_CONNECT="$SIM_SENTINEL" \
 TEST_RUNNER_COMEUP_SEND_ON_CONNECT="$SIM_SENTINEL" \
 xcodebuildmcp simulator test \
-  --workspace-path "$WORKSPACE" \
-  --scheme ComeupSimulatorHarness \
-  --simulator-name "$SIMULATOR_NAME" \
-  --use-latest-os true \
+  "${SIMULATOR_ARGS[@]}" \
   --derived-data-path "$DERIVED_DATA" \
   --prefer-xcodebuild true \
   --output text

--- a/comeup/simulator-harness/ComeupSimulatorHarnessPackage/Sources/ComeupSimulatorHarnessFeature/ComeupLiveTerminalStore.swift
+++ b/comeup/simulator-harness/ComeupSimulatorHarnessPackage/Sources/ComeupSimulatorHarnessFeature/ComeupLiveTerminalStore.swift
@@ -23,6 +23,7 @@ public final class ComeupLiveTerminalStore: ObservableObject, GhosttyTerminalSur
     @Published public private(set) var accessibilityText = ""
 
     private let port: UInt16?
+    private let authToken: String?
     private let sendOnConnect: String?
     private let queue = DispatchQueue(label: "ComeupLiveTerminalStore.connection")
     private var connection: NWConnection?
@@ -37,6 +38,8 @@ public final class ComeupLiveTerminalStore: ObservableObject, GhosttyTerminalSur
     ) {
         let portText = environment["COMEUP_TEXT_PORT"] ?? environment["TEST_RUNNER_COMEUP_TEXT_PORT"]
         self.port = portText.flatMap(UInt16.init)
+        let authTokenText = environment["COMEUP_AUTH_TOKEN"] ?? environment["TEST_RUNNER_COMEUP_AUTH_TOKEN"]
+        self.authToken = authTokenText.flatMap { $0.isEmpty ? nil : $0 }
         self.sendOnConnect = environment["COMEUP_SEND_ON_CONNECT"]
         self.size = defaultSize
         self.state = port == nil ? .disabled : .connecting
@@ -89,7 +92,7 @@ public final class ComeupLiveTerminalStore: ObservableObject, GhosttyTerminalSur
         switch newState {
         case .ready:
             state = .connected
-            sendLine("HELLO \(size.cols) \(size.rows)")
+            sendLine(Self.helloLine(size: size, authToken: authToken))
             receiveNext()
         case .failed(let error):
             state = .failed(error.localizedDescription)
@@ -98,6 +101,14 @@ public final class ComeupLiveTerminalStore: ObservableObject, GhosttyTerminalSur
         default:
             break
         }
+    }
+
+    nonisolated static func helloLine(size: CmuxTerminalSize, authToken: String?) -> String {
+        var line = "HELLO \(size.cols) \(size.rows)"
+        if let authToken, !authToken.isEmpty {
+            line += " AUTH bearer \(authToken)"
+        }
+        return line
     }
 
     private func receiveNext() {

--- a/comeup/simulator-harness/ComeupSimulatorHarnessPackage/Tests/ComeupSimulatorHarnessFeatureTests/ComeupSimulatorHarnessFeatureTests.swift
+++ b/comeup/simulator-harness/ComeupSimulatorHarnessPackage/Tests/ComeupSimulatorHarnessFeatureTests/ComeupSimulatorHarnessFeatureTests.swift
@@ -90,6 +90,16 @@ func ghosttyRuntimeConfigURLsUseReadableOverride() throws {
 }
 
 @Test
+func liveTerminalStoreHelloLineCarriesOptionalBearerAuth() {
+    let size = CmuxTerminalSize(cols: 90, rows: 30)
+    #expect(ComeupLiveTerminalStore.helloLine(size: size, authToken: nil) == "HELLO 90 30")
+    #expect(
+        ComeupLiveTerminalStore.helloLine(size: size, authToken: "test-token")
+            == "HELLO 90 30 AUTH bearer test-token"
+    )
+}
+
+@Test
 func simulatorTextHarnessSyncsWithComeupDaemon() throws {
     let environment = ProcessInfo.processInfo.environment
     guard let portText = environment["COMEUP_TEXT_PORT"] ?? environment["TEST_RUNNER_COMEUP_TEXT_PORT"] else {
@@ -99,7 +109,9 @@ func simulatorTextHarnessSyncsWithComeupDaemon() throws {
     let client = try TextHarnessSocket(host: "127.0.0.1", port: port)
     defer { client.close() }
 
-    try client.sendLine("HELLO 90 30")
+    let authTokenText = environment["COMEUP_AUTH_TOKEN"] ?? environment["TEST_RUNNER_COMEUP_AUTH_TOKEN"]
+    let authToken = authTokenText.flatMap { $0.isEmpty ? nil : $0 }
+    try client.sendLine(ComeupLiveTerminalStore.helloLine(size: CmuxTerminalSize(cols: 90, rows: 30), authToken: authToken))
     let welcome = try client.readLine(containing: "WELCOME client=")
     #expect(welcome.contains("terminal=1"))
     #expect(welcome.contains("size=90x30"))

--- a/comeup/simulator-harness/ComeupSimulatorHarnessUITests/ComeupSimulatorHarnessUITests.swift
+++ b/comeup/simulator-harness/ComeupSimulatorHarnessUITests/ComeupSimulatorHarnessUITests.swift
@@ -13,6 +13,9 @@ final class ComeupSimulatorHarnessUITests: XCTestCase {
         if let port = environment["COMEUP_TEXT_PORT"] ?? environment["TEST_RUNNER_COMEUP_TEXT_PORT"] {
             app.launchEnvironment["COMEUP_TEXT_PORT"] = port
         }
+        if let authToken = environment["COMEUP_AUTH_TOKEN"] ?? environment["TEST_RUNNER_COMEUP_AUTH_TOKEN"] {
+            app.launchEnvironment["COMEUP_AUTH_TOKEN"] = authToken
+        }
         if let sendOnConnect = environment["COMEUP_SEND_ON_CONNECT"] ?? environment["TEST_RUNNER_COMEUP_SEND_ON_CONNECT"] {
             app.launchEnvironment["COMEUP_SEND_ON_CONNECT"] = sendOnConnect
         }


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/3417.

Summary:
- Adds optional bearer auth to the comeup MessagePack hello and text harness hello.
- Makes the daemon reject missing or wrong tokens when COMEUP_AUTH_TOKEN is set.
- Wires cmx, the simulator harness, and UI tests through env-based auth so secrets are not passed as command-line args.
- Keeps local open-auth behavior explicit with AuthPolicy::Open for existing tests.

Verification:
- cargo test -p comeup-protocol -p comeup-client -p comeup-daemon -p cmx
- COMEUP_KEEP_LOGS=1 COMEUP_SIMULATOR_ID=5E1A1E60-52E0-4ACE-B75B-67CFB27EECAB comeup/scripts/run-simulator-terminal-sync.sh
- ./scripts/reload.sh --tag authio
- ios/scripts/reload.sh --tag authio

Notes:
- The simulator sync script now uses COMEUP_AUTH_TOKEN for the Rust harness server, cmx pty recorder, and iOS test runner.
- The first iPhone 17 Pro destination spent time in Xcode diagnostics, so the full authenticated sync was verified on the fresh iPhone 17 simulator UUID above.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional bearer-token auth to Comeup handshakes (MessagePack and text). The daemon can now enforce tokens via COMEUP_AUTH_TOKEN, and clients/tests pass tokens through env for secure syncs.

- **New Features**
  - `comeup-protocol`: `ClientMsg::Hello` accepts optional `auth` with `ClientAuth::Bearer { token }`.
  - `comeup-daemon`: New `AuthPolicy` (`Open` or `BearerToken`); rejects unauthorized clients with constant‑time token checks.
  - `comeup-client`: Added `UnixClient::connect_with_auth(..., Option<ClientAuth>)`.
  - `cmx`: Reads COMEUP_AUTH_TOKEN and sends it during connect.
  - Text harness: HELLO supports "AUTH bearer <token>"; server enforces when configured.
  - Scripts and iOS harness/tests: `run-simulator-terminal-sync.sh` and simulator harness read/forward COMEUP_AUTH_TOKEN.

- **Migration**
  - To require auth, set COMEUP_AUTH_TOKEN in the server environment (e.g., when launching the `comeup-harness-server`).
  - Clients should pass the same token: use `UnixClient::connect_with_auth` or set COMEUP_AUTH_TOKEN (picked up by `cmx`, harness, and tests).
  - Local/dev stays open by default: use `AuthPolicy::Open` or unset COMEUP_AUTH_TOKEN.

<sup>Written for commit 46fbba4a281538b02f23fd38808a2a48e8ce0647. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

