### PR TITLE
Fix sidebar state sync for tab renames

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12566,13 +12566,118 @@ struct SidebarWorkspaceSnapshotBuilder {
         let branchLinesContainBranch: Bool
         let pullRequestRows: [PullRequestDisplay]
         let listeningPorts: [Int]
+
+        struct ContextMenuImmediateFields: Equatable {
+            let title: String
+            let customDescription: String?
+            let isPinned: Bool
+            let customColorHex: String?
+        }
+
+        var contextMenuImmediateFields: ContextMenuImmediateFields {
+            ContextMenuImmediateFields(
+                title: title,
+                customDescription: customDescription,
+                isPinned: isPinned,
+                customColorHex: customColorHex
+            )
+        }
+
+        func applyingContextMenuImmediateFields(from snapshot: Snapshot) -> Snapshot {
+            guard contextMenuImmediateFields != snapshot.contextMenuImmediateFields else { return self }
+            return Snapshot(
+                title: snapshot.title,
+                customDescription: snapshot.customDescription,
+                isPinned: snapshot.isPinned,
+                customColorHex: snapshot.customColorHex,
+                remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
+                remoteConnectionStatusText: remoteConnectionStatusText,
+                remoteStateHelpText: remoteStateHelpText,
+                copyableSidebarSSHError: copyableSidebarSSHError,
+                latestSubmittedMessage: latestSubmittedMessage,
+                metadataEntries: metadataEntries,
+                metadataBlocks: metadataBlocks,
+                latestLog: latestLog,
+                progress: progress,
+                compactGitBranchSummaryText: compactGitBranchSummaryText,
+                compactBranchDirectoryRow: compactBranchDirectoryRow,
+                branchDirectoryLines: branchDirectoryLines,
+                branchLinesContainBranch: branchLinesContainBranch,
+                pullRequestRows: pullRequestRows,
+                listeningPorts: listeningPorts
+            )
+        }
     }
 }
 
-private final class SidebarTabItemContextMenuState: ObservableObject {
-    var isVisible = false
-    var hasDeferredWorkspaceObservationInvalidation = false
-    var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
+@MainActor
+final class SidebarWorkspaceRowStore: ObservableObject {
+    enum Phase: Equatable {
+        case live
+        case contextMenuVisible(pendingSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?)
+    }
+
+    struct State: Equatable {
+        let snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
+        let phase: Phase
+    }
+
+    @Published private(set) var snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
+    private(set) var phase: Phase = .live
+
+    var isContextMenuVisible: Bool {
+        if case .contextMenuVisible = phase {
+            return true
+        }
+        return false
+    }
+
+    func refresh(next: SidebarWorkspaceSnapshotBuilder.Snapshot, force: Bool = false) {
+        apply(Self.reducedState(current: snapshot, phase: phase, next: next, force: force))
+    }
+
+    func beginContextMenu() {
+        phase = .contextMenuVisible(pendingSnapshot: nil)
+    }
+
+    func endContextMenu() {
+        if case .contextMenuVisible(let pendingSnapshot) = phase,
+           let pendingSnapshot,
+           snapshot != pendingSnapshot {
+            snapshot = pendingSnapshot
+        }
+        phase = .live
+    }
+
+    static func reducedState(
+        current: SidebarWorkspaceSnapshotBuilder.Snapshot?,
+        phase: Phase,
+        next: SidebarWorkspaceSnapshotBuilder.Snapshot,
+        force: Bool
+    ) -> State {
+        guard case .contextMenuVisible = phase else {
+            return State(
+                snapshot: force || current != next ? next : current,
+                phase: .live
+            )
+        }
+
+        let displayedBaseline = current ?? next
+        let displayedSnapshot = displayedBaseline.applyingContextMenuImmediateFields(from: next)
+        let hasDeferredChanges = force || displayedSnapshot != next
+
+        return State(
+            snapshot: displayedSnapshot,
+            phase: .contextMenuVisible(pendingSnapshot: hasDeferredChanges ? next : nil)
+        )
+    }
+
+    private func apply(_ state: State) {
+        if snapshot != state.snapshot {
+            snapshot = state.snapshot
+        }
+        phase = state.phase
+    }
 }
 
 private struct TabItemView: View, Equatable {
@@ -12632,8 +12737,7 @@ private struct TabItemView: View, Equatable {
     let settings: SidebarTabItemSettingsSnapshot
     let livePresentation: SidebarTabItemPresentationSnapshot
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
-    @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
-    @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
+    @StateObject private var workspaceRowStore = SidebarWorkspaceRowStore()
     @State private var isHovering = false
     @State private var rowHeight: CGFloat = 1
 
@@ -12674,7 +12778,7 @@ private struct TabItemView: View, Equatable {
     }
 
     private var workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot {
-        workspaceSnapshotStorage ?? makeWorkspaceSnapshot()
+        workspaceRowStore.snapshot ?? makeWorkspaceSnapshot()
     }
 
     private var activeTabIndicatorStyle: SidebarActiveTabIndicatorStyle {
@@ -13250,7 +13354,7 @@ private struct TabItemView: View, Equatable {
             updateSelection()
         }
         .onHover { hovering in
-            guard !contextMenuState.isVisible else { return }
+            guard !workspaceRowStore.isContextMenuVisible else { return }
             isHovering = hovering
         }
         .safeHelp(workspaceSnapshot.title)
@@ -13266,57 +13370,21 @@ private struct TabItemView: View, Equatable {
         .contextMenu {
             workspaceContextMenu
                 .onAppear {
-                    contextMenuState.isVisible = true
-                    contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-                    contextMenuState.pendingWorkspaceSnapshot = nil
+                    workspaceRowStore.beginContextMenu()
                     frozenPresentation = livePresentation
                 }
                 .onDisappear {
-                    contextMenuState.isVisible = false
                     frozenPresentation = nil
                     if isHovering {
                         isHovering = false
                     }
-                    flushDeferredWorkspaceObservationInvalidation()
+                    workspaceRowStore.endContextMenu()
                 }
         }
     }
 
     private func refreshWorkspaceSnapshot(force: Bool = false) {
-        let nextSnapshot = makeWorkspaceSnapshot()
-
-        if contextMenuState.isVisible {
-            let deferredBaseline = contextMenuState.pendingWorkspaceSnapshot ?? workspaceSnapshotStorage
-            // Color changes are driven by explicit clicks in the Workspace Color
-            // submenu, and SwiftUI's context-menu content does not reliably fire
-            // `.onDisappear` after a button tap (issue #3037). Apply color
-            // changes immediately so the row reflects the user's selection
-            // instead of waiting on a flush that may never happen.
-            if deferredBaseline?.customColorHex != nextSnapshot.customColorHex {
-                workspaceSnapshotStorage = nextSnapshot
-                contextMenuState.pendingWorkspaceSnapshot = nil
-                contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-                return
-            }
-            if force || deferredBaseline != nextSnapshot {
-                contextMenuState.hasDeferredWorkspaceObservationInvalidation = true
-                contextMenuState.pendingWorkspaceSnapshot = nextSnapshot
-            }
-            return
-        }
-
-        if force || workspaceSnapshotStorage != nextSnapshot {
-            workspaceSnapshotStorage = nextSnapshot
-        }
-    }
-
-    private func flushDeferredWorkspaceObservationInvalidation() {
-        guard contextMenuState.hasDeferredWorkspaceObservationInvalidation else { return }
-        contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
-        if let pendingSnapshot = contextMenuState.pendingWorkspaceSnapshot {
-            workspaceSnapshotStorage = pendingSnapshot
-        }
-        contextMenuState.pendingWorkspaceSnapshot = nil
+        workspaceRowStore.refresh(next: makeWorkspaceSnapshot(), force: force)
     }
 
     private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7390,6 +7390,7 @@ final class Workspace: Identifiable, ObservableObject {
             sidebarObservationSignal($customDescription),
             sidebarObservationSignal($isPinned),
             sidebarObservationSignal($customColor),
+            sidebarObservationSignal($panelCustomTitles),
             sidebarObservationSignal($terminalScrollBarHidden),
             sidebarObservationSignal($latestSubmittedMessage),
         ]
@@ -8403,13 +8404,20 @@ final class Workspace: Identifiable, ObservableObject {
             panelCustomTitles[panelId] = trimmed
         }
 
-        guard let panel = panels[panelId], let tabId = surfaceIdFromPanelId(panelId) else { return }
+        guard let panel = panels[panelId] else { return }
         let baseTitle = panelTitles[panelId] ?? panel.displayTitle
-        bonsplitController.updateTab(
-            tabId,
-            title: resolvedPanelTitle(panelId: panelId, fallback: baseTitle),
-            hasCustomTitle: panelCustomTitles[panelId] != nil
-        )
+        let resolvedTitle = resolvedPanelTitle(panelId: panelId, fallback: baseTitle)
+        if let tabId = surfaceIdFromPanelId(panelId) {
+            bonsplitController.updateTab(
+                tabId,
+                title: resolvedTitle,
+                hasCustomTitle: panelCustomTitles[panelId] != nil
+            )
+        }
+
+        if panels.count == 1, customTitle == nil, self.title != resolvedTitle {
+            self.title = resolvedTitle
+        }
     }
 
     func isPanelPinned(_ panelId: UUID) -> Bool {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2921,6 +2921,117 @@ final class WorkspacePanelCustomTitleTests: XCTestCase {
     }
 }
 
+@MainActor
+final class SidebarWorkspaceRowStoreTests: XCTestCase {
+    func testContextMenuTitleAndPinChangesUpdateDisplayedFieldsAndDeferNoisyFields() {
+        let current = Self.snapshot(
+            title: "old-title",
+            isPinned: false,
+            customColorHex: nil,
+            remoteConnectionStatusText: "Connected",
+            latestSubmittedMessage: "old message",
+            listeningPorts: [3000]
+        )
+        let next = Self.snapshot(
+            title: "new-title",
+            isPinned: true,
+            customColorHex: nil,
+            remoteConnectionStatusText: "Disconnected",
+            latestSubmittedMessage: "new message",
+            listeningPorts: [3000, 4000]
+        )
+
+        let state = SidebarWorkspaceRowStore.reducedState(
+            current: current,
+            phase: .contextMenuVisible(pendingSnapshot: nil),
+            next: next,
+            force: false
+        )
+
+        XCTAssertEqual(state.snapshot?.title, "new-title")
+        XCTAssertTrue(state.snapshot?.isPinned == true)
+        XCTAssertEqual(state.snapshot?.remoteConnectionStatusText, "Connected")
+        XCTAssertEqual(state.snapshot?.latestSubmittedMessage, "old message")
+        XCTAssertEqual(state.snapshot?.listeningPorts, [3000])
+        XCTAssertEqual(state.phase, .contextMenuVisible(pendingSnapshot: next))
+    }
+
+    func testContextMenuImmediateOnlyChangeDoesNotCreateDeferredFlush() {
+        let current = Self.snapshot(
+            title: "old-title",
+            customDescription: nil,
+            isPinned: false,
+            customColorHex: nil
+        )
+        let next = Self.snapshot(
+            title: "new-title",
+            customDescription: "description",
+            isPinned: true,
+            customColorHex: "#C0392B"
+        )
+
+        let state = SidebarWorkspaceRowStore.reducedState(
+            current: current,
+            phase: .contextMenuVisible(pendingSnapshot: nil),
+            next: next,
+            force: false
+        )
+
+        XCTAssertEqual(state.snapshot, next)
+        XCTAssertEqual(state.phase, .contextMenuVisible(pendingSnapshot: nil))
+    }
+
+    func testEndingContextMenuFlushesDeferredSnapshot() {
+        let store = SidebarWorkspaceRowStore()
+        let current = Self.snapshot(title: "old-title", remoteConnectionStatusText: "Connected")
+        let next = Self.snapshot(title: "new-title", remoteConnectionStatusText: "Disconnected")
+
+        store.refresh(next: current, force: true)
+        store.beginContextMenu()
+        store.refresh(next: next)
+
+        XCTAssertEqual(store.snapshot?.title, "new-title")
+        XCTAssertEqual(store.snapshot?.remoteConnectionStatusText, "Connected")
+
+        store.endContextMenu()
+
+        XCTAssertEqual(store.snapshot, next)
+        XCTAssertFalse(store.isContextMenuVisible)
+    }
+
+    private static func snapshot(
+        title: String = "workspace",
+        customDescription: String? = nil,
+        isPinned: Bool = false,
+        customColorHex: String? = nil,
+        remoteConnectionStatusText: String = "Disconnected",
+        latestSubmittedMessage: String? = nil,
+        listeningPorts: [Int] = []
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+        SidebarWorkspaceSnapshotBuilder.Snapshot(
+            title: title,
+            customDescription: customDescription,
+            isPinned: isPinned,
+            customColorHex: customColorHex,
+            remoteWorkspaceSidebarText: nil,
+            remoteConnectionStatusText: remoteConnectionStatusText,
+            remoteStateHelpText: "",
+            copyableSidebarSSHError: nil,
+            latestSubmittedMessage: latestSubmittedMessage,
+            metadataEntries: [],
+            metadataBlocks: [],
+            latestLog: nil,
+            progress: nil,
+            compactGitBranchSummaryText: nil,
+            compactBranchDirectoryRow: nil,
+            branchDirectoryLines: [],
+            branchLinesContainBranch: false,
+            pullRequestRows: [],
+            listeningPorts: listeningPorts
+        )
+    }
+}
+
 
 @MainActor
 final class WorkspaceTeardownTests: XCTestCase {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2879,6 +2879,48 @@ final class WorkspaceNotificationReorderTests: XCTestCase {
     }
 }
 
+@MainActor
+final class WorkspacePanelCustomTitleTests: XCTestCase {
+    func testSinglePanelCustomTitleUpdatesWorkspaceTitleForSidebarRows() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        XCTAssertTrue(workspace.updatePanelTitle(panelId: panelId, title: "runtime-title"))
+
+        workspace.setPanelCustomTitle(panelId: panelId, title: "custom-tab-title")
+
+        XCTAssertEqual(workspace.panelTitle(panelId: panelId), "custom-tab-title")
+        XCTAssertEqual(
+            workspace.title,
+            "custom-tab-title",
+            "A single-surface workspace should project tab renames into the sidebar row title"
+        )
+    }
+
+    func testClearingSinglePanelCustomTitleRestoresWorkspaceRuntimeTitle() {
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected focused panel in new workspace")
+            return
+        }
+
+        XCTAssertTrue(workspace.updatePanelTitle(panelId: panelId, title: "runtime-title"))
+        workspace.setPanelCustomTitle(panelId: panelId, title: "custom-tab-title")
+
+        workspace.setPanelCustomTitle(panelId: panelId, title: nil)
+
+        XCTAssertEqual(workspace.panelTitle(panelId: panelId), "runtime-title")
+        XCTAssertEqual(
+            workspace.title,
+            "runtime-title",
+            "Clearing a single-surface custom tab title should refresh the sidebar row title"
+        )
+    }
+}
+
 
 @MainActor
 final class WorkspaceTeardownTests: XCTestCase {


### PR DESCRIPTION
Summary:
- Reproduced stale sidebar title state on cmux-macmini: tab rename updated the active surface title but left the single-surface workspace title unchanged.
- Propagate single-panel custom title changes into the workspace title used by sidebar rows.
- Move sidebar row snapshot phase/pending ownership into SidebarWorkspaceRowStore so context-menu-open refresh behavior has one tested state machine.
- Apply title, description, pin, and color sidebar snapshot fields immediately while a context menu is open, while still deferring noisier metadata.

Testing:
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS" -derivedDataPath /tmp/cmux-sbsync-unit test -only-testing:cmuxTests/WorkspacePanelCustomTitleTests -only-testing:cmuxTests/SidebarWorkspaceRowStoreTests
- ./scripts/reload.sh --tag sbs2 --launch
- Dogfood via /tmp/cmux-debug-sbs2.sock: created a workspace, renamed the focused tab, verified workspace and surface titles both updated, toggled pin, set/cleared workspace color, then closed the test workspace.

Notes:
- First commit adds the sidebar rename regression tests. Second commit adds the fix and row snapshot store.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar now refreshes reliably while context menus are open, avoiding flicker and stale rows.
  * Panel custom titles update immediately and correctly propagate to the workspace title.
  * Hover and interaction behavior is suppressed appropriately while a context menu is active.

* **Tests**
  * Added tests covering panel title behavior and sidebar snapshot handling during context-menu interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->