### PR TITLE
Clamp Settings window away from display edge

### DIFF
--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -3,7 +3,6 @@ import AppKit
 final class WindowDecorationsController {
     private var observers: [NSObjectProtocol] = []
     private var didStart = false
-    private var trafficLightBaseFrames: [ObjectIdentifier: [NSWindow.ButtonType: NSRect]] = [:]
     private var minimalModeSidebarChromeHoverMonitor: Any?
     private var lastMinimalModeTitlebarClick: MinimalModeTitlebarClickRecord?
     private var lastKnownPresentationMode = WorkspacePresentationModeSettings.mode()
@@ -43,7 +42,6 @@ final class WindowDecorationsController {
         }
         let shouldHideButtons = shouldHideTrafficLights(for: window)
         hideStandardButtons(on: window, hidden: shouldHideButtons)
-        applyTrafficLightOffset(on: window, hidden: shouldHideButtons)
         applyMinimalModeSidebarTitlebarClickTarget(to: window)
     }
 
@@ -359,34 +357,6 @@ final class WindowDecorationsController {
         window.standardWindowButton(.zoomButton)?.isHidden = hidden
     }
 
-    private func applyTrafficLightOffset(on window: NSWindow, hidden: Bool) {
-        DispatchQueue.main.async { [weak self, weak window] in
-            guard let self, let window else { return }
-            let offset = hidden ? NSPoint.zero : self.trafficLightOffset(for: window)
-            self.applyTrafficLightOffsetNow(on: window, offset: offset)
-        }
-    }
-
-    private func applyTrafficLightOffsetNow(on window: NSWindow, offset: NSPoint) {
-        let key = ObjectIdentifier(window)
-        let buttonTypes: [NSWindow.ButtonType] = [.closeButton, .miniaturizeButton, .zoomButton]
-        var baseFrames = trafficLightBaseFrames[key] ?? [:]
-
-        for type in buttonTypes {
-            guard let button = window.standardWindowButton(type) else { continue }
-            if baseFrames[type] == nil || (baseFrames[type]?.isEmpty ?? true) {
-                baseFrames[type] = button.frame
-            }
-        }
-
-        trafficLightBaseFrames[key] = baseFrames
-
-        for type in buttonTypes {
-            guard let button = window.standardWindowButton(type), let base = baseFrames[type] else { continue }
-            button.setFrameOrigin(NSPoint(x: base.origin.x + offset.x, y: base.origin.y + offset.y))
-        }
-    }
-
     private func applyMinimalModeSidebarTitlebarClickTarget(to window: NSWindow) {
         let shouldInstall = isMainWorkspaceWindow(window)
             && WorkspacePresentationModeSettings.isMinimal()
@@ -458,10 +428,6 @@ final class WindowDecorationsController {
         guard let target = minimalModeSidebarTitlebarClickTargets.object(forKey: window) else { return }
         target.removeFromSuperview()
         minimalModeSidebarTitlebarClickTargets.removeObject(forKey: window)
-    }
-
-    private func trafficLightOffset(for window: NSWindow) -> NSPoint {
-        return .zero
     }
 
     private func shouldHideTrafficLights(for window: NSWindow) -> Bool {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2488,6 +2488,7 @@ enum SettingsWindowPresenter {
     static let windowID = "settings"
     static let windowIdentifier = "cmux.settings"
     static let minimumSize = NSSize(width: 820, height: 540)
+    private static let visibleAreaInset: CGFloat = 18
 
     private static var openWindow: (@MainActor () -> Void)?
     private static weak var settingsWindow: NSWindow?
@@ -2505,8 +2506,10 @@ enum SettingsWindowPresenter {
     static func configure(window: NSWindow) {
         settingsWindow = window
         window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
+        window.isRestorable = false
         window.minSize = minimumSize
         window.contentMinSize = minimumSize
+        clampToVisibleAreaIfNeeded(window)
     }
 
     static func show(navigationTarget: SettingsNavigationTarget? = nil) {
@@ -2559,9 +2562,28 @@ enum SettingsWindowPresenter {
         if window.isMiniaturized {
             window.deminiaturize(nil)
         }
+        clampToVisibleAreaIfNeeded(window)
         NSRunningApplication.current.activate(options: [.activateAllWindows])
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
+    }
+
+    private static func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
+        guard let screen = window.screen ?? NSScreen.main else { return }
+        var frame = window.frame
+        let visibleFrame = screen.visibleFrame
+        let minX = visibleFrame.minX + visibleAreaInset
+        let minY = visibleFrame.minY + visibleAreaInset
+        let maxX = max(minX, visibleFrame.maxX - visibleAreaInset - frame.width)
+        let maxY = max(minY, visibleFrame.maxY - visibleAreaInset - frame.height)
+        let clampedOrigin = NSPoint(
+            x: min(max(frame.origin.x, minX), maxX),
+            y: min(max(frame.origin.y, minY), maxY)
+        )
+
+        guard clampedOrigin != frame.origin else { return }
+        frame.origin = clampedOrigin
+        window.setFrame(frame, display: true)
     }
 }
 


### PR DESCRIPTION
## Summary
- clamp the Settings window to the visible display with an 18 px inset when it is configured or focused
- disable Settings window restoration so stale edge placements do not reopen flush against the display
- remove the dead traffic-light reframe path that was still caching and reapplying button frames with a zero offset

## Verification
- ./scripts/reload.sh --tag setwin
- Reproduced on cmux-macmini by forcing Settings to X=0,Y=30, then verified the patched setmm build moves it to X=18,Y=48 when Settings is opened again

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clamp the Settings window to the visible screen with an 18px inset and disable restoration to prevent reopening flush against the display. Also remove the unused traffic-light reframe path that was reapplying zero-offset button frames.

- **Bug Fixes**
  - Clamp on configure and when showing to keep the window inside the screen’s visible area.
  - Set `isRestorable = false` to avoid restoring stale edge positions.

- **Refactors**
  - Remove traffic-light offset logic and cached base frames from `WindowDecorationsController`.

<sup>Written for commit 7c1da75a80a3a2832996cabbccc5acb409eea69a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Settings window now clamps to and remains within the visible screen area when opened or refocused, preventing it from appearing off-screen.
* Window decoration (traffic-light) buttons no longer shift position unexpectedly; their visibility is updated without repositioning, keeping window controls stable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->