### PR TITLE
Limit free Cloud VM creates with Stack credits

### DIFF
--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -237,6 +237,7 @@ actor VMClient {
         } catch {
             throw VMClientError.notSignedIn
         }
+        let teamID = await AuthManager.shared.resolvedTeamID
 
         guard var url = URLComponents(url: AuthEnvironment.vmAPIBaseURL, resolvingAgainstBaseURL: false) else {
             throw VMClientError.malformedResponse("bad vmAPIBaseURL")
@@ -253,6 +254,9 @@ actor VMClient {
         }
         req.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
         req.setValue(tokens.refreshToken, forHTTPHeaderField: "X-Stack-Refresh-Token")
+        if let teamID, !teamID.isEmpty {
+            req.setValue(teamID, forHTTPHeaderField: "X-Cmux-Team-Id")
+        }
         if let jsonBody {
             req.setValue("application/json", forHTTPHeaderField: "content-type")
             req.httpBody = try JSONSerialization.data(withJSONObject: jsonBody, options: [])

--- a/web/.env.example
+++ b/web/.env.example
@@ -50,7 +50,7 @@ PGUSER=
 
 # Stack Auth create-credit gating. The free plan consumes one team-scoped Stack Auth
 # item credit per successful create. Configure the Stack Auth free/include-by-default
-# product to grant 20 of this item.
+# product to grant 20 of this item. Set this to "none" to disable create credits.
 CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID=cmux-vm-create-credit
 CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST=
 # Optional global or provider-specific overrides. Paid plans use create credits only when

--- a/web/.env.example
+++ b/web/.env.example
@@ -48,7 +48,13 @@ PGHOST=
 PGPORT=
 PGUSER=
 
-# Optional Stack Auth create-credit gating. Leave unset to use active VM limits only.
+# Stack Auth create-credit gating. The free plan consumes one team-scoped Stack Auth
+# item credit per successful create. Configure the Stack Auth free/include-by-default
+# product to grant 20 of this item.
+CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID=cmux-vm-create-credit
+CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST=
+# Optional global or provider-specific overrides. Paid plans use create credits only when
+# a plan-specific or global item id is configured.
 CMUX_VM_CREATE_CREDIT_COST=
 CMUX_VM_CREATE_CREDIT_COST_E2B=
 CMUX_VM_CREATE_CREDIT_COST_FREESTYLE=

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -15,10 +15,14 @@ import {
   isVmImageConfigError,
   isVmLimitExceededError,
 } from "../../../services/vms/errors";
-import { resolveVmEntitlements } from "../../../services/vms/entitlements";
+import {
+  isVmBillingTeamResolutionError,
+  resolveVmEntitlements,
+} from "../../../services/vms/entitlements";
 import { resolveVmImage } from "../../../services/vms/images/resolver";
 import {
   jsonResponse,
+  requestedVmTeamIdFromRequest,
   withAuthedVmApiRoute,
 } from "../../../services/vms/routeHelpers";
 import {
@@ -37,7 +41,29 @@ export async function GET(request: Request): Promise<Response> {
     { "cmux.vm.operation": "list" },
     "/api/vm GET failed",
     async ({ user, span }) => {
-      const entries = await runVmWorkflow(listUserVms(user.id));
+      let billingTeamId: string | null = null;
+      const requestedBillingTeamId = requestedVmTeamIdFromRequest(request);
+      try {
+        if (requestedBillingTeamId || user.billingCustomerType === "team") {
+          const entitlements = resolveVmEntitlements(user, process.env, {
+            requestedBillingTeamId,
+            requireTeam: false,
+          });
+          billingTeamId = entitlements.billingTeamId;
+          setSpanAttributes(span, {
+            "cmux.billing.team_id_set": !!billingTeamId,
+            "cmux.billing.customer_type": entitlements.billingCustomerType,
+            "cmux.billing.plan_id": entitlements.planId,
+          });
+        }
+      } catch (err) {
+        if (isVmBillingTeamResolutionError(err)) {
+          return jsonResponse({ error: err.code, reason: err.message }, err.status);
+        }
+        throw err;
+      }
+
+      const entries = await runVmWorkflow(listUserVms(user.id, billingTeamId));
       setSpanAttributes(span, { "cmux.vm.count": entries.length });
       // REST adapter: expose `id` at the top level so existing CLI + curl users don't need to
       // learn the new `providerVmId` field name. Swift CLI reads `vm["id"]`.
@@ -63,7 +89,7 @@ export async function POST(request: Request): Promise<Response> {
       // Runtime-validate the payload before we call a paid provider. An invalid `provider`
       // (client sending `"aws"` or `"docker"`) previously slipped past the type cast and
       // surfaced as a 500 from the driver after provisioning had already half-succeeded.
-      let body: { image?: string; provider?: ProviderId };
+      let body: { image?: string; provider?: ProviderId; billingTeamId?: string };
       try {
         // Allow callers to send no body at all. The handler already falls through to
         // default provider/image, so a bare `curl -X POST /api/vm` should create a default
@@ -96,9 +122,14 @@ export async function POST(request: Request): Promise<Response> {
             );
           }
         }
+        const bodyBillingTeamId = candidate.billingTeamId ?? candidate.teamId;
+        if (bodyBillingTeamId !== undefined && typeof bodyBillingTeamId !== "string") {
+          return jsonResponse({ error: "`teamId` must be a string when provided" }, 400);
+        }
         body = {
           image: typeof candidate.image === "string" ? candidate.image : undefined,
           provider: candidate.provider as ProviderId | undefined,
+          billingTeamId: typeof bodyBillingTeamId === "string" ? bodyBillingTeamId.trim() : undefined,
         };
       } catch {
         return jsonResponse({ error: "invalid JSON body" }, 400);
@@ -152,11 +183,24 @@ export async function POST(request: Request): Promise<Response> {
         "cmux.idempotency_key_set": !!idempotencyKey,
       });
 
-      const entitlements = resolveVmEntitlements(user);
+      const requestedBillingTeamId = body.billingTeamId || requestedVmTeamIdFromRequest(request);
+      let entitlements;
+      try {
+        entitlements = resolveVmEntitlements(user, process.env, {
+          requestedBillingTeamId,
+          requireTeam: true,
+        });
+      } catch (err) {
+        if (isVmBillingTeamResolutionError(err)) {
+          return jsonResponse({ error: err.code, reason: err.message }, err.status);
+        }
+        throw err;
+      }
       setSpanAttributes(span, {
         "cmux.billing.team_id_set": !!entitlements.billingTeamId,
-        "cmux.billing.customer_type": user.billingCustomerType,
+        "cmux.billing.customer_type": entitlements.billingCustomerType,
         "cmux.billing.plan_id": entitlements.planId,
+        "cmux.billing.requested_team_id_set": !!requestedBillingTeamId,
         "cmux.vm.max_active": entitlements.maxActiveVms,
       });
 
@@ -164,7 +208,7 @@ export async function POST(request: Request): Promise<Response> {
       try {
         created = await runVmWorkflow(createVm({
           userId: user.id,
-          billingCustomerType: user.billingCustomerType,
+          billingCustomerType: entitlements.billingCustomerType,
           billingTeamId: entitlements.billingTeamId,
           billingPlanId: entitlements.planId,
           maxActiveVms: entitlements.maxActiveVms,

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -110,9 +110,9 @@ Set these Vercel environment variables per production/staging environment:
 - `E2B_CMUXD_WS_TEMPLATE`, E2B template alias/name for WebSocket PTY sandboxes.
 - `FREESTYLE_SANDBOX_SNAPSHOT`, Freestyle snapshot id.
 - `CMUX_VM_DEFAULT_PROVIDER`, `freestyle` or `e2b`.
-- `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID`, Stack Auth team item used as the free-plan create-credit bucket. Defaults to `cmux-vm-create-credit`.
+- `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID`, Stack Auth team item used as the free-plan create-credit bucket. Defaults to `cmux-vm-create-credit`; set to `none`, `disabled`, `off`, or `false` to opt out.
 - `CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST`, optional free-plan per-create cost. Defaults to `1`.
-- `CMUX_VM_CREATE_CREDIT_ITEM_ID`, optional global Stack Auth item used as a prepaid create-credit bucket for every plan without a plan-specific item.
+- `CMUX_VM_CREATE_CREDIT_ITEM_ID`, optional global Stack Auth item used as a prepaid create-credit bucket for every plan without a plan-specific item. Set to `none`, `disabled`, `off`, or `false` to opt out of create credits for plans without a plan-specific value.
 - `CMUX_VM_CREATE_CREDIT_COST`, default `1`.
 - `CMUX_VM_CREATE_CREDIT_COST_E2B`, optional provider-specific override.
 - `CMUX_VM_CREATE_CREDIT_COST_FREESTYLE`, optional provider-specific override.
@@ -217,6 +217,6 @@ Operational note: Freestyle creates are currently disabled in staging and produc
 
 ## Usage, limits, and pricing
 
-The usage ledger is in Postgres. VM create pricing gates use Stack Auth payment items. The free plan uses the team-scoped item `cmux-vm-create-credit` by default. Configure the Stack Auth free product as team-owned, include-by-default, and grant 20 of that item with no repeat and no expiry. The create workflow inserts the idempotent VM row first, reserves one Stack Auth create credit only for a newly inserted row, calls the provider, and refunds the credit if provisioning fails before a usable VM exists.
+The usage ledger is in Postgres. VM create pricing gates use Stack Auth payment items. The free plan uses the team-scoped item `cmux-vm-create-credit` by default. Configure the Stack Auth free product as team-owned, include-by-default, and grant 20 of that item with no repeat and no expiry. Set `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID=none` in local or self-hosted deployments that intentionally do not use Stack Auth create credits. The create workflow inserts the idempotent VM row first, reserves one Stack Auth create credit only for a newly inserted row, calls the provider, and refunds the credit if provisioning fails before a usable VM exists.
 
 Plan limits are team-based. Stack Auth personal teams should stay enabled for both dev/staging and production projects. New VM rows store `billing_team_id` and `billing_plan_id`; the free plan allows one active VM at a time and 20 total successful creates by default. Paid plan activation should write a readable plan id such as `pro` into Stack Auth team read-only metadata (`cmuxVmPlan`) or equivalent billing sync metadata, then configure the matching `CMUX_VM_PLAN_<PLAN>_MAX_ACTIVE_VMS` env var. Paid plans only consume Stack Auth create credits when `CMUX_VM_PLAN_<PLAN>_CREATE_CREDIT_ITEM_ID` or the global `CMUX_VM_CREATE_CREDIT_ITEM_ID` is configured.

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -7,7 +7,7 @@ Backend for `cmux vm new/ls/rm/exec/attach` and the sidebar Cloud VM surface. St
 ```text
 services/vms/
   auth.ts             Stack Auth request verification helpers
-  billingGateway.ts   Stack Auth VM create credit reservations
+  billingGateway.ts   Stack Auth VM create-credit reservations
   entitlements.ts     Team plan and active VM limit resolution
   drivers/            Provider SDK adapters for E2B and Freestyle
   images/             Checked-in known-good provider image manifest
@@ -110,7 +110,9 @@ Set these Vercel environment variables per production/staging environment:
 - `E2B_CMUXD_WS_TEMPLATE`, E2B template alias/name for WebSocket PTY sandboxes.
 - `FREESTYLE_SANDBOX_SNAPSHOT`, Freestyle snapshot id.
 - `CMUX_VM_DEFAULT_PROVIDER`, `freestyle` or `e2b`.
-- `CMUX_VM_CREATE_CREDIT_ITEM_ID`, optional Stack Auth team item used as a prepaid create-credit bucket. When unset, create credits are disabled and only active VM limits apply.
+- `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID`, Stack Auth team item used as the free-plan create-credit bucket. Defaults to `cmux-vm-create-credit`.
+- `CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST`, optional free-plan per-create cost. Defaults to `1`.
+- `CMUX_VM_CREATE_CREDIT_ITEM_ID`, optional global Stack Auth item used as a prepaid create-credit bucket for every plan without a plan-specific item.
 - `CMUX_VM_CREATE_CREDIT_COST`, default `1`.
 - `CMUX_VM_CREATE_CREDIT_COST_E2B`, optional provider-specific override.
 - `CMUX_VM_CREATE_CREDIT_COST_FREESTYLE`, optional provider-specific override.
@@ -215,6 +217,6 @@ Operational note: Freestyle creates are currently disabled in staging and produc
 
 ## Usage, limits, and pricing
 
-The usage ledger is in Postgres. VM create pricing gates use Stack Auth payment items when `CMUX_VM_CREATE_CREDIT_ITEM_ID` is configured. The create workflow inserts the idempotent VM row first, reserves one Stack Auth create credit only for a newly inserted row, calls the provider, and refunds the credit if provisioning fails before a usable VM exists.
+The usage ledger is in Postgres. VM create pricing gates use Stack Auth payment items. The free plan uses the team-scoped item `cmux-vm-create-credit` by default. Configure the Stack Auth free product as team-owned, include-by-default, and grant 20 of that item with no repeat and no expiry. The create workflow inserts the idempotent VM row first, reserves one Stack Auth create credit only for a newly inserted row, calls the provider, and refunds the credit if provisioning fails before a usable VM exists.
 
-Plan limits are team-based. Stack Auth personal teams should stay enabled for both dev/staging and production projects. New VM rows store `billing_team_id` and `billing_plan_id`; the free plan allows one active VM by default. Paid plan activation should write a readable plan id such as `pro` into Stack Auth team read-only metadata (`cmuxVmPlan`) or equivalent billing sync metadata, then configure the matching `CMUX_VM_PLAN_<PLAN>_MAX_ACTIVE_VMS` env var.
+Plan limits are team-based. Stack Auth personal teams should stay enabled for both dev/staging and production projects. New VM rows store `billing_team_id` and `billing_plan_id`; the free plan allows one active VM at a time and 20 total successful creates by default. Paid plan activation should write a readable plan id such as `pro` into Stack Auth team read-only metadata (`cmuxVmPlan`) or equivalent billing sync metadata, then configure the matching `CMUX_VM_PLAN_<PLAN>_MAX_ACTIVE_VMS` env var. Paid plans only consume Stack Auth create credits when `CMUX_VM_PLAN_<PLAN>_CREATE_CREDIT_ITEM_ID` or the global `CMUX_VM_CREATE_CREDIT_ITEM_ID` is configured.

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -43,6 +43,12 @@ calls use `Authorization: Bearer` plus `X-Stack-Refresh-Token` and are not subje
 For cookie calls, `POST`/`DELETE` routes reject cross-site `Origin` or `Sec-Fetch-Site` requests
 before any VM workflow runs.
 
+Cloud VM billing is team-scoped. The native client sends the selected Stack team in
+`X-Cmux-Team-Id`; browser callers may send that header or `teamId`/`billingTeamId` in the request.
+The backend validates membership before create or team-filtered list. If Stack returns one team,
+the backend treats it as the personal team created on sign-up. If Stack returns no team, or multiple
+teams without a selected/requested team, create fails before providers or billing are called.
+
 The auth regression tests live in `web/tests/vm-route-auth.test.ts`. They verify unauthenticated create, list, destroy, attach, SSH endpoint, and exec requests return `401` before the VM workflow runs, and that cross-site cookie mutations are rejected.
 
 ## State model
@@ -219,4 +225,4 @@ Operational note: Freestyle creates are currently disabled in staging and produc
 
 The usage ledger is in Postgres. VM create pricing gates use Stack Auth payment items. The free plan uses the team-scoped item `cmux-vm-create-credit` by default. Configure the Stack Auth free product as team-owned, include-by-default, and grant 20 of that item with no repeat and no expiry. Set `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID=none` in local or self-hosted deployments that intentionally do not use Stack Auth create credits. The create workflow inserts the idempotent VM row first, reserves one Stack Auth create credit only for a newly inserted row, calls the provider, and refunds the credit if provisioning fails before a usable VM exists.
 
-Plan limits are team-based. Stack Auth personal teams should stay enabled for both dev/staging and production projects. New VM rows store `billing_team_id` and `billing_plan_id`; the free plan allows one active VM at a time and 20 total successful creates by default. Paid plan activation should write a readable plan id such as `pro` into Stack Auth team read-only metadata (`cmuxVmPlan`) or equivalent billing sync metadata, then configure the matching `CMUX_VM_PLAN_<PLAN>_MAX_ACTIVE_VMS` env var. Paid plans only consume Stack Auth create credits when `CMUX_VM_PLAN_<PLAN>_CREATE_CREDIT_ITEM_ID` or the global `CMUX_VM_CREATE_CREDIT_ITEM_ID` is configured.
+Plan limits are team-based. Stack Auth personal teams should stay enabled for both dev/staging and production projects (`createTeamOnSignUp` / `teams.createPersonalTeamOnSignUp`). New VM rows store `billing_team_id` and `billing_plan_id`; the free plan allows one active VM at a time and 20 total successful creates by default. Paid plan activation should write a readable plan id such as `pro` into Stack Auth team read-only metadata (`cmuxVmPlan`) or equivalent billing sync metadata, then configure the matching `CMUX_VM_PLAN_<PLAN>_MAX_ACTIVE_VMS` env var. Paid plans only consume Stack Auth create credits when `CMUX_VM_PLAN_<PLAN>_CREATE_CREDIT_ITEM_ID` or the global `CMUX_VM_CREATE_CREDIT_ITEM_ID` is configured.

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -6,7 +6,15 @@ export type AuthedUser = {
   primaryEmail: string | null;
   billingCustomerType: "team" | "user";
   billingTeamId: string;
+  selectedTeamId: string | null;
+  teams: readonly AuthedTeam[];
   teamIds: readonly string[];
+  userBillingPlanId: string | null;
+  billingPlanId: string | null;
+};
+
+export type AuthedTeam = {
+  id: string;
   billingPlanId: string | null;
 };
 
@@ -56,7 +64,10 @@ async function authedUserFromStackUser(user: StackUserLike): Promise<AuthedUser>
     selectedTeam?.id,
     ...listedTeams.map((team) => team.id),
   ]);
-  const billingTeam = selectedTeam ?? listedTeams[0] ?? null;
+  const teams = uniqueTeams([selectedTeam, ...listedTeams]);
+  const billingTeam = selectedTeam ?? (teams.length === 1 ? teams[0] : null);
+  const userBillingPlanId = planIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
+  const billingPlanId = planIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
 
   return {
     id: user.id,
@@ -64,10 +75,14 @@ async function authedUserFromStackUser(user: StackUserLike): Promise<AuthedUser>
     primaryEmail: user.primaryEmail,
     billingCustomerType: billingTeam ? "team" : "user",
     billingTeamId: billingTeam?.id ?? user.id,
+    selectedTeamId: selectedTeam?.id ?? null,
+    teams: teams.map((team) => ({
+      id: team.id,
+      billingPlanId: planIdFromMetadata(team.clientReadOnlyMetadata),
+    })),
     teamIds,
-    billingPlanId: planIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ??
-      planIdFromMetadata(user.clientReadOnlyMetadata) ??
-      null,
+    userBillingPlanId,
+    billingPlanId,
   };
 }
 
@@ -104,6 +119,17 @@ function planIdFromMetadata(metadata: unknown): string | null {
 
 function uniqueStrings(values: readonly (string | undefined)[]): readonly string[] {
   return [...new Set(values.filter((value): value is string => typeof value === "string" && value.length > 0))];
+}
+
+function uniqueTeams(values: readonly (TeamLike | null | undefined)[]): readonly TeamLike[] {
+  const teams: TeamLike[] = [];
+  const seen = new Set<string>();
+  for (const team of values) {
+    if (!team || seen.has(team.id)) continue;
+    seen.add(team.id);
+    teams.push(team);
+  }
+  return teams;
 }
 
 export function unauthorized(): Response {

--- a/web/services/vms/billingGateway.ts
+++ b/web/services/vms/billingGateway.ts
@@ -39,6 +39,8 @@ export class VmBillingGateway extends Context.Tag("cmux/VmBillingGateway")<
   VmBillingGatewayShape
 >() {}
 
+export const DEFAULT_FREE_CREATE_CREDIT_ITEM_ID = "cmux-vm-create-credit";
+
 export const VmBillingGatewayLive = Layer.succeed(
   VmBillingGateway,
   makeStackVmBillingGateway(process.env),
@@ -47,18 +49,18 @@ export const VmBillingGatewayLive = Layer.succeed(
 export function makeStackVmBillingGateway(
   env: Record<string, string | undefined>,
 ): VmBillingGatewayShape {
-  const itemId = env.CMUX_VM_CREATE_CREDIT_ITEM_ID?.trim();
-  if (!itemId) return noOpVmBillingGateway();
-
   return {
     reserveCreate: (input) =>
       Effect.tryPromise({
         try: async () => {
+          const itemId = createCreditItemId(input.billingPlanId, env);
+          if (!itemId) return { kind: "none" };
+
           const { getStackServerApp, isStackConfigured } = await import("../../app/lib/stack");
           if (!isStackConfigured()) {
-            throw new Error("Stack Auth is required when CMUX_VM_CREATE_CREDIT_ITEM_ID is configured");
+            throw new Error(`Stack Auth is required for Cloud VM create credits (${itemId})`);
           }
-          const amount = createCreditCost(input.provider, env);
+          const amount = createCreditCost(input.billingPlanId, input.provider, env);
           const customer = billingCustomer(input);
           const item = customer.type === "team"
             ? await getStackServerApp().getItem({ teamId: customer.id, itemId })
@@ -119,17 +121,66 @@ function billingCustomer(input: {
   return { type: "user", id: input.userId };
 }
 
+function createCreditItemId(
+  planId: string,
+  env: Record<string, string | undefined>,
+): string | null {
+  const planSpecific = env[createCreditItemIdEnvKey(planId)]?.trim();
+  if (planSpecific) return planSpecific;
+
+  const global = env.CMUX_VM_CREATE_CREDIT_ITEM_ID?.trim();
+  if (global) return global;
+
+  return normalizedPlanId(planId) === "free" ? DEFAULT_FREE_CREATE_CREDIT_ITEM_ID : null;
+}
+
+function createCreditItemIdEnvKey(planId: string): string {
+  return `CMUX_VM_PLAN_${planEnvKey(planId)}_CREATE_CREDIT_ITEM_ID`;
+}
+
 function createCreditCost(
+  planId: string,
   provider: ProviderId,
   env: Record<string, string | undefined>,
 ): number {
+  const planKey = planEnvKey(planId);
   const providerKey = `CMUX_VM_CREATE_CREDIT_COST_${provider.toUpperCase()}`;
-  const raw = env[providerKey] ?? env.CMUX_VM_CREATE_CREDIT_COST ?? "1";
+  const planProviderKey = `CMUX_VM_PLAN_${planKey}_CREATE_CREDIT_COST_${provider.toUpperCase()}`;
+  const planKeyDefault = `CMUX_VM_PLAN_${planKey}_CREATE_CREDIT_COST`;
+  const configured = firstConfiguredEnv(env, [
+    planProviderKey,
+    planKeyDefault,
+    providerKey,
+    "CMUX_VM_CREATE_CREDIT_COST",
+  ]);
+  const raw = configured?.value ?? "1";
+  const key = configured?.key ??
+    `${planProviderKey} or ${planKeyDefault} or ${providerKey} or CMUX_VM_CREATE_CREDIT_COST`;
   const value = raw.trim();
-  if (!/^\d+$/.test(value)) throw new Error(`${providerKey} or CMUX_VM_CREATE_CREDIT_COST must be a positive integer`);
+  if (!/^\d+$/.test(value)) throw new Error(`${key} must be a positive integer`);
   const parsed = Number(value);
   if (!Number.isSafeInteger(parsed) || parsed <= 0) {
-    throw new Error(`${providerKey} or CMUX_VM_CREATE_CREDIT_COST must be a positive integer`);
+    throw new Error(`${key} must be a positive integer`);
   }
   return parsed;
+}
+
+function firstConfiguredEnv(
+  env: Record<string, string | undefined>,
+  keys: readonly string[],
+): { readonly key: string; readonly value: string } | null {
+  for (const key of keys) {
+    const value = env[key];
+    if (value?.trim()) return { key, value };
+  }
+  return null;
+}
+
+function normalizedPlanId(planId: string): string {
+  const normalized = planId.trim().toLowerCase();
+  return normalized || "free";
+}
+
+function planEnvKey(planId: string): string {
+  return normalizedPlanId(planId).replace(/[^a-zA-Z0-9]/g, "_").toUpperCase();
 }

--- a/web/services/vms/billingGateway.ts
+++ b/web/services/vms/billingGateway.ts
@@ -125,13 +125,29 @@ function createCreditItemId(
   planId: string,
   env: Record<string, string | undefined>,
 ): string | null {
-  const planSpecific = env[createCreditItemIdEnvKey(planId)]?.trim();
-  if (planSpecific) return planSpecific;
+  const planSpecific = resolvedCreateCreditItemIdValue(env[createCreditItemIdEnvKey(planId)]);
+  if (planSpecific.kind === "disabled") return null;
+  if (planSpecific.kind === "item") return planSpecific.itemId;
 
-  const global = env.CMUX_VM_CREATE_CREDIT_ITEM_ID?.trim();
-  if (global) return global;
+  const global = resolvedCreateCreditItemIdValue(env.CMUX_VM_CREATE_CREDIT_ITEM_ID);
+  if (global.kind === "disabled") return null;
+  if (global.kind === "item") return global.itemId;
 
   return normalizedPlanId(planId) === "free" ? DEFAULT_FREE_CREATE_CREDIT_ITEM_ID : null;
+}
+
+function resolvedCreateCreditItemIdValue(
+  raw: string | undefined,
+): { readonly kind: "unset" } | { readonly kind: "disabled" } | { readonly kind: "item"; readonly itemId: string } {
+  const value = raw?.trim();
+  if (!value) return { kind: "unset" };
+  return isDisabledCreateCreditValue(value)
+    ? { kind: "disabled" }
+    : { kind: "item", itemId: value };
+}
+
+function isDisabledCreateCreditValue(value: string): boolean {
+  return ["disabled", "false", "none", "off"].includes(value.toLowerCase());
 }
 
 function createCreditItemIdEnvKey(planId: string): string {

--- a/web/services/vms/entitlements.ts
+++ b/web/services/vms/entitlements.ts
@@ -1,20 +1,110 @@
 import type { AuthedUser } from "./auth";
+import type { BillingCustomerType } from "./billingGateway";
 
 export type VmEntitlements = {
   readonly planId: string;
+  readonly billingCustomerType: BillingCustomerType;
   readonly billingTeamId: string;
   readonly maxActiveVms: number;
 };
 
+export type VmEntitlementOptions = {
+  readonly requestedBillingTeamId?: string | null;
+  readonly requireTeam?: boolean;
+};
+
+export type VmBillingTeamErrorCode =
+  | "vm_billing_team_required"
+  | "vm_billing_team_not_found";
+
+export class VmBillingTeamResolutionError extends Error {
+  readonly code: VmBillingTeamErrorCode;
+  readonly status: number;
+
+  constructor(input: {
+    readonly code: VmBillingTeamErrorCode;
+    readonly status: number;
+    readonly message: string;
+  }) {
+    super(input.message);
+    this.name = "VmBillingTeamResolutionError";
+    this.code = input.code;
+    this.status = input.status;
+  }
+}
+
 export function resolveVmEntitlements(
   user: AuthedUser,
   env: Record<string, string | undefined> = process.env,
+  options: VmEntitlementOptions = {},
 ): VmEntitlements {
-  const planId = normalizedPlanId(user.billingPlanId ?? env.CMUX_VM_DEFAULT_PLAN ?? "free");
+  const billing = resolveBillingContext(user, options);
+  const planId = normalizedPlanId(billing.billingPlanId ?? env.CMUX_VM_DEFAULT_PLAN ?? "free");
   return {
     planId,
-    billingTeamId: user.billingTeamId,
+    billingCustomerType: billing.billingCustomerType,
+    billingTeamId: billing.billingTeamId,
     maxActiveVms: activeVmLimitForPlan(planId, env),
+  };
+}
+
+export function isVmBillingTeamResolutionError(err: unknown): err is VmBillingTeamResolutionError {
+  return err instanceof VmBillingTeamResolutionError;
+}
+
+function resolveBillingContext(
+  user: AuthedUser,
+  options: VmEntitlementOptions,
+): {
+  readonly billingCustomerType: BillingCustomerType;
+  readonly billingTeamId: string;
+  readonly billingPlanId: string | null;
+} {
+  const requestedTeamId = normalizedOptionalString(options.requestedBillingTeamId);
+  if (requestedTeamId) {
+    const team = user.teams.find((candidate) => candidate.id === requestedTeamId);
+    if (!team) {
+      throw new VmBillingTeamResolutionError({
+        code: "vm_billing_team_not_found",
+        status: 403,
+        message: "The requested billing team is not available for this Stack Auth user.",
+      });
+    }
+    return {
+      billingCustomerType: "team",
+      billingTeamId: team.id,
+      billingPlanId: team.billingPlanId ?? user.userBillingPlanId,
+    };
+  }
+
+  if (user.billingCustomerType === "team") {
+    return {
+      billingCustomerType: "team",
+      billingTeamId: user.billingTeamId,
+      billingPlanId: user.billingPlanId ?? user.userBillingPlanId,
+    };
+  }
+
+  if (user.teams.length > 1) {
+    throw new VmBillingTeamResolutionError({
+      code: "vm_billing_team_required",
+      status: 409,
+      message: "This Stack Auth user has multiple teams. Send X-Cmux-Team-Id so Cloud VM billing is explicit.",
+    });
+  }
+
+  if (options.requireTeam) {
+    throw new VmBillingTeamResolutionError({
+      code: "vm_billing_team_required",
+      status: 409,
+      message: "Stack Auth did not return a team. Enable personal team creation on sign-up before creating Cloud VMs.",
+    });
+  }
+
+  return {
+    billingCustomerType: "user",
+    billingTeamId: user.billingTeamId,
+    billingPlanId: user.userBillingPlanId,
   };
 }
 
@@ -33,6 +123,11 @@ function activeVmLimitForPlan(planId: string, env: Record<string, string | undef
 function normalizedPlanId(planId: string): string {
   const normalized = planId.trim().toLowerCase();
   return normalized || "free";
+}
+
+function normalizedOptionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
 }
 
 function positiveInteger(raw: string, key: string): number {

--- a/web/services/vms/errors.ts
+++ b/web/services/vms/errors.ts
@@ -97,3 +97,52 @@ export function isVmCreateCreditsInsufficientError(err: unknown): err is VmCreat
 export function isVmBillingError(err: unknown): err is VmBillingError {
   return (err as { _tag?: string } | null)?._tag === "VmBillingError";
 }
+
+const vmWorkflowErrorTags = new Set([
+  "VmDatabaseError",
+  "VmProviderOperationError",
+  "VmNotFoundError",
+  "VmCreateInProgressError",
+  "VmCreateFailedError",
+  "VmCreateDisabledError",
+  "VmImageConfigError",
+  "VmLimitExceededError",
+  "VmCreateCreditsInsufficientError",
+  "VmBillingError",
+]);
+
+export function vmWorkflowErrorCause(err: unknown): VmWorkflowError | null {
+  if (!err || typeof err !== "object") return null;
+  const tag = (err as { _tag?: unknown })._tag;
+  if (typeof tag === "string" && vmWorkflowErrorTags.has(tag)) {
+    return err as VmWorkflowError;
+  }
+  const fiberCause = effectFiberFailureCause(err);
+  const fiberFailure = vmWorkflowErrorFromEffectCause(fiberCause);
+  if (fiberFailure) return fiberFailure;
+  const cause = (err as { cause?: unknown }).cause;
+  if (cause && cause !== err) return vmWorkflowErrorCause(cause);
+  return null;
+}
+
+function effectFiberFailureCause(err: object): unknown {
+  const symbol = Object.getOwnPropertySymbols(err).find((candidate) =>
+    candidate.description === "effect/Runtime/FiberFailure/Cause"
+  );
+  return symbol ? (err as Record<symbol, unknown>)[symbol] : null;
+}
+
+function vmWorkflowErrorFromEffectCause(cause: unknown): VmWorkflowError | null {
+  if (!cause || typeof cause !== "object") return null;
+  const tag = (cause as { _tag?: unknown })._tag;
+  if (tag === "Fail") {
+    const failure = (cause as { failure?: unknown; error?: unknown }).failure ??
+      (cause as { error?: unknown }).error;
+    return vmWorkflowErrorCause(failure);
+  }
+  if (tag === "Sequential" || tag === "Parallel") {
+    return vmWorkflowErrorFromEffectCause((cause as { left?: unknown }).left) ??
+      vmWorkflowErrorFromEffectCause((cause as { right?: unknown }).right);
+  }
+  return vmWorkflowErrorFromEffectCause((cause as { cause?: unknown }).cause);
+}

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -16,7 +16,7 @@ export type BeginCreateResult =
   | { readonly inserted: false; readonly vm: CloudVmRow };
 
 export type VmRepositoryShape = {
-  readonly listUserVms: (userId: string) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
+  readonly listUserVms: (userId: string, billingTeamId?: string | null) => Effect.Effect<CloudVmRow[], VmDatabaseError>;
   readonly beginCreate: (input: {
     readonly userId: string;
     readonly billingTeamId: string;
@@ -104,13 +104,17 @@ async function findByIdempotencyKey(
 }
 
 export const VmRepositoryLive = Layer.succeed(VmRepository, {
-  listUserVms: (userId) =>
+  listUserVms: (userId, billingTeamId) =>
     dbEffect("listUserVms", async () => {
       const db = cloudDb();
+      const teamId = billingTeamId?.trim();
       return await db
         .select()
         .from(cloudVms)
-        .where(and(eq(cloudVms.userId, userId), ne(cloudVms.status, "destroyed")))
+        .where(teamId
+          ? and(eq(cloudVms.userId, userId), eq(cloudVms.billingTeamId, teamId), ne(cloudVms.status, "destroyed"))
+          : and(eq(cloudVms.userId, userId), ne(cloudVms.status, "destroyed"))
+        )
         .orderBy(desc(cloudVms.createdAt));
     }),
 

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -65,6 +65,28 @@ export function notFoundVm(vmId: string): Response {
   return jsonResponse({ error: `vm not found: ${vmId}` }, 404);
 }
 
+export function requestedVmTeamIdFromRequest(request: Request): string | null {
+  const fromHeader = normalizedOptionalString(
+    request.headers.get("x-cmux-team-id") ??
+      request.headers.get("x-cmux-billing-team-id"),
+  );
+  if (fromHeader) return fromHeader;
+
+  let url: URL;
+  try {
+    url = new URL(request.url);
+  } catch {
+    return null;
+  }
+
+  return normalizedOptionalString(
+    url.searchParams.get("teamId") ??
+      url.searchParams.get("team_id") ??
+      url.searchParams.get("billingTeamId") ??
+      url.searchParams.get("billing_team_id"),
+  );
+}
+
 function requiresBrowserMutationProtection(method: string, bearer: StackBearer | null): boolean {
   if (!["POST", "PUT", "PATCH", "DELETE"].includes(method.toUpperCase())) {
     return false;
@@ -109,4 +131,9 @@ function allowedBrowserOrigins(): Set<string> {
       .filter((origin) => origin.length > 0),
   );
   return cachedAllowedOrigins;
+}
+
+function normalizedOptionalString(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
 }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -52,10 +52,10 @@ export async function runVmWorkflow<A>(
   }
 }
 
-export function listUserVms(userId: string) {
+export function listUserVms(userId: string, billingTeamId?: string | null) {
   return Effect.gen(function* () {
     const repo = yield* VmRepository;
-    const rows = yield* repo.listUserVms(userId);
+    const rows = yield* repo.listUserVms(userId, billingTeamId);
     return rows.filter((row) => row.providerVmId).map(vmEntryFromRow);
   });
 }

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -19,6 +19,7 @@ import {
   VmCreateFailedError,
   VmCreateInProgressError,
   VmNotFoundError,
+  vmWorkflowErrorCause,
   type VmWorkflowError,
 } from "./errors";
 import { isProviderNotFoundError } from "./providerErrors";
@@ -41,10 +42,14 @@ export type VmEntry = {
 
 export const VmWorkflowLive = Layer.mergeAll(VmRepositoryLive, VmProviderGatewayLive, VmBillingGatewayLive);
 
-export function runVmWorkflow<A>(
+export async function runVmWorkflow<A>(
   program: Effect.Effect<A, VmWorkflowError, VmRepository | VmProviderGateway | VmBillingGateway>,
 ): Promise<A> {
-  return Effect.runPromise(program.pipe(Effect.provide(VmWorkflowLive)));
+  try {
+    return await Effect.runPromise(program.pipe(Effect.provide(VmWorkflowLive)));
+  } catch (err) {
+    throw vmWorkflowErrorCause(err) ?? err;
+  }
 }
 
 export function listUserVms(userId: string) {
@@ -100,7 +105,33 @@ export function createVm(input: {
       imageVersion: input.imageVersion ?? null,
       vmId: create.vm.id,
       idempotencyKey: input.idempotencyKey,
-    });
+    }).pipe(
+      Effect.tapError((err) =>
+        Effect.all([
+          repo.markCreateFailed({
+            id: create.vm.id,
+            code: "billing_reserve_failed",
+            message: errorMessage(err),
+          }),
+          repo.recordUsageEvent({
+            userId: input.userId,
+            billingTeamId: input.billingTeamId,
+            billingPlanId: input.billingPlanId,
+            vmId: create.vm.id,
+            eventType: "vm.create.billing_failed",
+            provider: input.provider,
+            imageId: input.image,
+            metadata: {
+              idempotencyKeySet: !!input.idempotencyKey,
+              imageVersion: input.imageVersion ?? null,
+              errorTag: typeof err === "object" && err !== null && "_tag" in err
+                ? String((err as { _tag?: unknown })._tag)
+                : null,
+            },
+          }),
+        ], { discard: true }).pipe(Effect.catchAll(() => Effect.void))
+      ),
+    );
 
     yield* recordCreditEvent(repo, create.vm, "vm.create.credit.reserved", creditReservation)
       .pipe(Effect.catchAll(() => Effect.void));

--- a/web/tests/vm-billing-gateway.test.ts
+++ b/web/tests/vm-billing-gateway.test.ts
@@ -62,6 +62,30 @@ describe("Stack VM billing gateway", () => {
     expect(getItem).not.toHaveBeenCalled();
   });
 
+  test("allows the default free-plan create-credit item to be disabled", async () => {
+    stackConfigured = false;
+    const gateway = makeStackVmBillingGateway({
+      CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID: "none",
+    });
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput()));
+
+    expect(reservation).toEqual({ kind: "none" });
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  test("allows the global create-credit item to disable the free-plan default", async () => {
+    stackConfigured = false;
+    const gateway = makeStackVmBillingGateway({
+      CMUX_VM_CREATE_CREDIT_ITEM_ID: "disabled",
+    });
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput()));
+
+    expect(reservation).toEqual({ kind: "none" });
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
   test("preserves global Stack Auth create-credit items for paid plans", async () => {
     const gateway = makeStackVmBillingGateway({
       CMUX_VM_CREATE_CREDIT_ITEM_ID: "global-vm-create-credit",

--- a/web/tests/vm-billing-gateway.test.ts
+++ b/web/tests/vm-billing-gateway.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import {
+  DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+  makeStackVmBillingGateway,
+  type VmBillingGatewayShape,
+} from "../services/vms/billingGateway";
+import { VmCreateCreditsInsufficientError } from "../services/vms/errors";
+
+type ReserveCreateInput = Parameters<VmBillingGatewayShape["reserveCreate"]>[0];
+
+let stackConfigured = true;
+const tryDecreaseQuantity = mock(async () => true);
+const increaseQuantity = mock(async () => undefined);
+const getItem = mock(async () => ({
+  tryDecreaseQuantity,
+  increaseQuantity,
+}));
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getItem }),
+  isStackConfigured: () => stackConfigured,
+}));
+
+beforeEach(() => {
+  stackConfigured = true;
+  tryDecreaseQuantity.mockClear();
+  tryDecreaseQuantity.mockResolvedValue(true);
+  increaseQuantity.mockClear();
+  getItem.mockClear();
+});
+
+describe("Stack VM billing gateway", () => {
+  test("consumes the default free-plan Stack Auth create-credit item", async () => {
+    const gateway = makeStackVmBillingGateway({});
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput()));
+
+    expect(getItem).toHaveBeenCalledWith({
+      teamId: "team-billing",
+      itemId: DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+    });
+    expect(tryDecreaseQuantity).toHaveBeenCalledWith(1);
+    expect(reservation).toEqual({
+      kind: "stack_item",
+      itemId: DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+      customerType: "team",
+      customerId: "team-billing",
+      amount: 1,
+    });
+  });
+
+  test("does not require create credits for paid plans by default", async () => {
+    stackConfigured = false;
+    const gateway = makeStackVmBillingGateway({});
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput({
+      billingPlanId: "pro",
+    })));
+
+    expect(reservation).toEqual({ kind: "none" });
+    expect(getItem).not.toHaveBeenCalled();
+  });
+
+  test("preserves global Stack Auth create-credit items for paid plans", async () => {
+    const gateway = makeStackVmBillingGateway({
+      CMUX_VM_CREATE_CREDIT_ITEM_ID: "global-vm-create-credit",
+    });
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput({
+      billingPlanId: "pro",
+    })));
+
+    expect(getItem).toHaveBeenCalledWith({
+      teamId: "team-billing",
+      itemId: "global-vm-create-credit",
+    });
+    expect(reservation).toEqual(expect.objectContaining({
+      itemId: "global-vm-create-credit",
+      amount: 1,
+    }));
+  });
+
+  test("allows plan-specific Stack Auth item and cost overrides", async () => {
+    const gateway = makeStackVmBillingGateway({
+      CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID: "free-vm-create-credit",
+      CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST_FREESTYLE: "2",
+    });
+
+    const reservation = await Effect.runPromise(gateway.reserveCreate(createInput({
+      provider: "freestyle",
+    })));
+
+    expect(getItem).toHaveBeenCalledWith({
+      teamId: "team-billing",
+      itemId: "free-vm-create-credit",
+    });
+    expect(tryDecreaseQuantity).toHaveBeenCalledWith(2);
+    expect(reservation).toEqual(expect.objectContaining({
+      itemId: "free-vm-create-credit",
+      amount: 2,
+    }));
+  });
+
+  test("fails before provider create when Stack Auth create credits are exhausted", async () => {
+    tryDecreaseQuantity.mockResolvedValue(false);
+    const gateway = makeStackVmBillingGateway({});
+
+    const error = await Effect.runPromise(
+      gateway.reserveCreate(createInput()).pipe(Effect.flip),
+    );
+
+    expect(error).toBeInstanceOf(VmCreateCreditsInsufficientError);
+    expect(error).toMatchObject({
+      itemId: DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+      billingCustomerId: "team-billing",
+      amount: 1,
+    });
+  });
+
+  test("refunds a reserved Stack Auth create credit", async () => {
+    const gateway = makeStackVmBillingGateway({});
+
+    await Effect.runPromise(gateway.refundCreate({
+      kind: "stack_item",
+      itemId: DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+      customerType: "team",
+      customerId: "team-billing",
+      amount: 1,
+    }));
+
+    expect(getItem).toHaveBeenCalledWith({
+      teamId: "team-billing",
+      itemId: DEFAULT_FREE_CREATE_CREDIT_ITEM_ID,
+    });
+    expect(increaseQuantity).toHaveBeenCalledWith(1);
+  });
+});
+
+function createInput(overrides: Partial<ReserveCreateInput> = {}): ReserveCreateInput {
+  return {
+    userId: "user-billing",
+    billingCustomerType: "team" as const,
+    billingTeamId: "team-billing",
+    billingPlanId: "free",
+    provider: "e2b" as const,
+    image: "cmuxd-ws:test",
+    imageVersion: "test-version",
+    vmId: "vm-billing",
+    idempotencyKey: "idem-billing",
+    ...overrides,
+  };
+}

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -188,6 +188,196 @@ describe("VM REST auth", () => {
     }));
   });
 
+  test("uses the native client's requested Stack team for billing", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: {
+        id: "team-1",
+        clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+      },
+      listTeams: async () => [
+        {
+          id: "team-1",
+          clientReadOnlyMetadata: { cmuxVmPlan: "pro" },
+        },
+        {
+          id: "team-2",
+          clientReadOnlyMetadata: { cmuxVmPlan: "free" },
+        },
+      ],
+    });
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-team-2",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+          "x-cmux-team-id": "team-2",
+        },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      billingCustomerType: "team",
+      billingTeamId: "team-2",
+      billingPlanId: "free",
+      maxActiveVms: 1,
+    }));
+  });
+
+  test("rejects a requested Stack team the caller does not belong to", async () => {
+    getUser.mockResolvedValue(authedStackUser());
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+          "x-cmux-team-id": "team-other",
+        },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toMatchObject({ error: "vm_billing_team_not_found" });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("uses the single Stack team when personal team auto-create populated listTeams", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: null,
+      listTeams: async () => [{
+        id: "team-personal",
+        clientReadOnlyMetadata: { cmuxVmPlan: "free" },
+      }],
+    });
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-personal-team",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({
+      billingCustomerType: "team",
+      billingTeamId: "team-personal",
+      billingPlanId: "free",
+    }));
+  });
+
+  test("rejects VM create when Stack Auth returns no teams", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: null,
+      listTeams: async () => [],
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "vm_billing_team_required" });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("rejects VM create when Stack Auth returns multiple teams but no selected/requested team", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: null,
+      listTeams: async () => [
+        { id: "team-1", clientReadOnlyMetadata: { cmuxVmPlan: "free" } },
+        { id: "team-2", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+      ],
+    });
+
+    const response = await POST(
+      new Request("https://cmux.test/api/vm", {
+        method: "POST",
+        headers: { origin: "https://cmux.test" },
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test" }),
+      }),
+    );
+
+    expect(response.status).toBe(409);
+    expect(await response.json()).toMatchObject({ error: "vm_billing_team_required" });
+    expect(runVmWorkflow).not.toHaveBeenCalled();
+  });
+
+  test("filters VM list to the requested Stack team", async () => {
+    getUser.mockResolvedValue({
+      id: "user-1",
+      displayName: null,
+      primaryEmail: "user@example.com",
+      selectedTeam: {
+        id: "team-1",
+        clientReadOnlyMetadata: { cmuxVmPlan: "free" },
+      },
+      listTeams: async () => [
+        { id: "team-1", clientReadOnlyMetadata: { cmuxVmPlan: "free" } },
+        { id: "team-2", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } },
+      ],
+    });
+    runVmWorkflow.mockResolvedValue([{
+      providerVmId: "provider-vm-team-2",
+      provider: "e2b",
+      image: "cmuxd-ws:test",
+      imageVersion: "test-version",
+      createdAt: 1_777_000_000_000,
+    }]);
+
+    const response = await GET(
+      new Request("https://cmux.test/api/vm", {
+        headers: {
+          authorization: "Bearer access-token",
+          "x-stack-refresh-token": "refresh-token",
+          "x-cmux-team-id": "team-2",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(listUserVms).toHaveBeenCalledWith("user-1", "team-2");
+    expect(await response.json()).toMatchObject({
+      vms: [{ id: "provider-vm-team-2", provider: "e2b" }],
+    });
+  });
+
   test("blocks authenticated cookie mutations from cross-site origins before workflow", async () => {
     getUser.mockResolvedValue(authedStackUser());
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -484,6 +484,64 @@ describe("VM Effect workflows", () => {
 
     expect(error).toBeInstanceOf(VmCreateCreditsInsufficientError);
     expect(createCalls).toBe(0);
+
+    const [failedVm] = await sql<{
+      status: string;
+      failureCode: string | null;
+      providerVmId: string | null;
+    }[]>`
+      select status, failure_code as "failureCode", provider_vm_id as "providerVmId"
+      from cloud_vms
+      where user_id = 'user-workflow-credit-empty'
+    `;
+    expect(failedVm).toMatchObject({
+      status: "failed",
+      failureCode: "billing_reserve_failed",
+      providerVmId: null,
+    });
+
+    const usageEvents = await sql<{ eventType: string }[]>`
+      select event_type as "eventType" from cloud_vm_usage_events
+      where user_id = 'user-workflow-credit-empty'
+    `;
+    expect(usageEvents.map((event) => event.eventType)).toContain("vm.create.billing_failed");
+
+    const [active] = await sql<{ total: number }[]>`
+      select count(*)::int as total from cloud_vms
+      where billing_team_id = 'team-workflow-credit-empty'
+        and status in ('provisioning', 'running', 'paused')
+    `;
+    expect(active?.total).toBe(0);
+
+    const recoveryProvider: VmProviderGatewayShape = {
+      create: () => Effect.succeed({
+        provider: "freestyle" as const,
+        providerVmId: "provider-vm-credit-recovered",
+        status: "running" as const,
+        image: "snapshot-credit-recovered",
+        createdAt: Date.now(),
+      }),
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+    };
+
+    const recovered = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-credit-empty",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-credit-empty",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-credit-recovered",
+        idempotencyKey: "credit-empty-2",
+      }).pipe(Effect.provide(providerLayer(recoveryProvider))),
+    );
+
+    expect(recovered.providerVmId).toBe("provider-vm-credit-recovered");
   });
 
   dbTest("refunds a reserved Stack Auth credit when provider create fails", async () => {


### PR DESCRIPTION
## Summary
- make free-plan Cloud VM creates consume the Stack Auth `cmux-vm-create-credit` item by default
- keep paid plans on active VM limits unless a plan-specific or global create-credit item is configured
- document the Stack Auth free pricing setup: team include-by-default product grants 20 create credits

## Tests
- `bun tsc --noEmit`
- `bun test`
- `bun run db:check`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Limits free Cloud VM creates by spending Stack Auth team credits on the free plan and adds explicit team billing selection and filtering to avoid ambiguous creates.

- **New Features**
  - Free plan spends one `cmux-vm-create-credit` per create by default. Supports `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID` and `CMUX_VM_PLAN_FREE_CREATE_CREDIT_COST[_<PROVIDER>]`, plus global `CMUX_VM_CREATE_CREDIT_ITEM_ID` and `CMUX_VM_CREATE_CREDIT_COST[_<PROVIDER>]`. Set any item id to `none`/`disabled`/`off`/`false` to disable. On reserve errors, mark the VM failed with `billing_reserve_failed` and emit `vm.create.billing_failed`. Error unwrapping is clearer.
  - Team billing is explicit. Accepts `X-Cmux-Team-Id` or `billingTeamId`/`teamId` in the request and filters list by team. Validates membership; returns `vm_billing_team_required` or `vm_billing_team_not_found` when needed. The Swift client now sends `X-Cmux-Team-Id`.

- **Migration**
  - In Stack Auth, configure the free team product as include-by-default and grant 20 of `cmux-vm-create-credit`. Enable personal team creation on sign-up so single-team users can create without an explicit team.
  - To opt out for free, set `CMUX_VM_PLAN_FREE_CREATE_CREDIT_ITEM_ID=none`. Paid plans only use credits when `CMUX_VM_PLAN_<PLAN>_CREATE_CREDIT_ITEM_ID` or `CMUX_VM_CREATE_CREDIT_ITEM_ID` is set.

<sup>Written for commit c04e92f9b0a91df22c232d0cffd4b50767fc1ca8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Team-scoped billing: VM listing/creation respects a selected billing team and client includes team header.

* **Documentation**
  * Clarified free-plan create-credit defaults, opt-outs, pricing, reservation/refund rules, and plan vs global overrides.

* **Chores**
  * Added environment controls for free-plan create-credit item and cost.

* **Bug Fixes**
  * Better error classification; failed creates now persist failure state and emit billing-failure events.

* **Tests**
  * Added end-to-end tests for reservation, overrides, failures, refunds, and recovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->