### PR TITLE
fix(cli): expand tmux short-form format variables (#S, #I, #D, ...) in __tmux-compat

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10217,13 +10217,79 @@ struct CMUXCLI {
         return nil
     }
 
+    /// Maps tmux's documented single-character short-form format tokens (e.g.
+    /// `#S`, `#I`, `#D`) to the long-form context keys the renderer already
+    /// understands. See tmux(1) FORMATS.
+    ///
+    /// Without this mapping, callers that issue mixed format strings such as
+    /// `#S:#I #{pane_id}` (used by oh-my-claudecode's team mode) only get the
+    /// long-form token substituted, leaving the literal `#S:#I` prefix in the
+    /// output and breaking downstream parsers.
+    private static let tmuxShortFormVars: [Character: String] = [
+        "D": "pane_id",
+        "F": "window_flags",
+        "H": "host",
+        "I": "window_index",
+        "P": "pane_index",
+        "S": "session_name",
+        "T": "pane_title",
+        "W": "window_name",
+        "h": "host_short",
+    ]
+
+    /// Walks `format` and substitutes single-character short-form variables
+    /// (`#S`, `#I`, `#D`, ...) using `context`.
+    ///
+    /// `##` is a literal `#`. `#{...}` long-form tokens are left untouched
+    /// here (the caller substitutes them separately). Unknown short-forms pass
+    /// through unchanged, matching tmux's documented behavior.
+    private func tmuxExpandShortFormVars(
+        _ format: String,
+        context: [String: String]
+    ) -> String {
+        var result = ""
+        result.reserveCapacity(format.count)
+        var iter = format.makeIterator()
+        while let ch = iter.next() {
+            guard ch == "#" else {
+                result.append(ch)
+                continue
+            }
+            guard let next = iter.next() else {
+                result.append("#")
+                break
+            }
+            if next == "#" {
+                // `##` is a literal `#`.
+                result.append("#")
+                continue
+            }
+            if next == "{" {
+                // Long-form `#{...}` — leave the `#{` for the caller's pass.
+                result.append("#")
+                result.append("{")
+                continue
+            }
+            if let key = Self.tmuxShortFormVars[next], let value = context[key] {
+                result.append(value)
+                continue
+            }
+            // Unknown / unresolved short-form: pass through literally.
+            result.append("#")
+            result.append(next)
+        }
+        return result
+    }
+
     private func tmuxRenderFormat(
         _ format: String?,
         context: [String: String],
         fallback: String
     ) -> String {
         guard let format, !format.isEmpty else { return fallback }
-        var rendered = format
+        // Substitute short-form tokens first so the long-form pass and the
+        // `#{...}`-strip step below don't see them.
+        var rendered = tmuxExpandShortFormVars(format, context: context)
         for (key, value) in context {
             rendered = rendered.replacingOccurrences(of: "#{\(key)}", with: value)
         }

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -168,11 +168,73 @@ func parseTmuxArgs(args []string, valueFlags, boolFlags []string) *tmuxParsed {
 
 var tmuxFormatVarRe = regexp.MustCompile(`#\{[^}]+\}`)
 
+// tmuxShortFormVars maps tmux's documented single-character short-form format
+// tokens (e.g. `#S`, `#I`, `#D`) to the corresponding long-form context keys
+// (e.g. `session_name`, `window_index`, `pane_id`). See tmux(1) FORMATS.
+//
+// Without this mapping, callers that issue mixed format strings such as
+// `#S:#I #{pane_id}` (used by oh-my-claudecode's team mode) only get the
+// long-form token substituted, leaving the literal `#S:#I` prefix in the
+// output and breaking downstream parsers.
+var tmuxShortFormVars = map[byte]string{
+	'D': "pane_id",
+	'F': "window_flags",
+	'H': "host",
+	'I': "window_index",
+	'P': "pane_index",
+	'S': "session_name",
+	'T': "pane_title",
+	'W': "window_name",
+	'h': "host_short",
+}
+
+// tmuxExpandShortFormVars walks `format` and substitutes single-character
+// short-form variables (`#S`, `#I`, `#D`, ...) using `context`.
+//
+// `##` is a literal `#`. `#{...}` long-form tokens are left untouched here
+// (the caller substitutes them separately). Unknown short-forms pass through
+// unchanged, matching tmux's documented behavior.
+func tmuxExpandShortFormVars(format string, context map[string]string) string {
+	var b strings.Builder
+	b.Grow(len(format))
+	for i := 0; i < len(format); i++ {
+		c := format[i]
+		if c != '#' || i+1 >= len(format) {
+			b.WriteByte(c)
+			continue
+		}
+		next := format[i+1]
+		if next == '#' {
+			// `##` is a literal `#`.
+			b.WriteByte('#')
+			i++
+			continue
+		}
+		if next == '{' {
+			// Long-form `#{...}` — leave the `#` for the caller's pass.
+			b.WriteByte('#')
+			continue
+		}
+		if longKey, ok := tmuxShortFormVars[next]; ok {
+			if value, found := context[longKey]; found {
+				b.WriteString(value)
+				i++
+				continue
+			}
+		}
+		// Unknown / unresolved short-form: pass through literally.
+		b.WriteByte('#')
+	}
+	return b.String()
+}
+
 func tmuxRenderFormat(format string, context map[string]string, fallback string) string {
 	if format == "" {
 		return fallback
 	}
-	rendered := format
+	// Substitute short-form tokens first so the long-form pass and the
+	// `#{...}`-strip step below don't see them.
+	rendered := tmuxExpandShortFormVars(format, context)
 	for key, value := range context {
 		rendered = strings.ReplaceAll(rendered, "#{"+key+"}", value)
 	}

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go
@@ -92,6 +92,84 @@ func TestTmuxRenderFormat(t *testing.T) {
 	}
 }
 
+// TestTmuxRenderFormatShortForm covers the single-character tmux format
+// tokens (`#S`, `#I`, `#D`, ...) and the `##` escape. The mixed-form case is
+// the exact regression that breaks oh-my-claudecode's `omc team` workers
+// inside cmux: OMC issues `display-message -p '#S:#I #{pane_id}'` and the
+// previous renderer left `#S:#I` literal, producing
+// `Failed to resolve tmux context: "#S:#I %<uuid>"` downstream.
+func TestTmuxRenderFormatShortForm(t *testing.T) {
+	ctx := map[string]string{
+		"session_name": "cmux",
+		"window_index": "0",
+		"pane_id":      "%abc-123",
+		"pane_index":   "1",
+		"window_name":  "main",
+		"window_flags": "*",
+		"pane_title":   "zsh",
+	}
+	tests := []struct {
+		name     string
+		format   string
+		fallback string
+		want     string
+	}{
+		{"short-form session", "#S", "fallback", "cmux"},
+		{"short-form session:window", "#S:#I", "", "cmux:0"},
+		{"short-form trio", "#S:#I #D", "", "cmux:0 %abc-123"},
+		{"OMC mixed short+long format", "#S:#I #{pane_id}", "", "cmux:0 %abc-123"},
+		{"all documented short-forms", "#S #I #D #P #W #F #T", "", "cmux 0 %abc-123 1 main * zsh"},
+		{"hash escape midstring", "a##b", "fallback", "a#b"},
+		{"hash escape preceding letter", "##S", "fallback", "#S"},
+		{"unknown short-form passes through", "#X", "fallback", "#X"},
+		{"trailing hash literal", "lit#", "fallback", "lit#"},
+		{"empty format returns fallback", "", "fallback", "fallback"},
+		{"long-form unchanged", "#{session_name}", "fallback", "cmux"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tmuxRenderFormat(tt.format, ctx, tt.fallback)
+			if got != tt.want {
+				t.Errorf("tmuxRenderFormat(%q) = %q, want %q", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestTmuxExpandShortFormVars exercises the short-form expansion helper in
+// isolation so its behavior is locked in independent of the long-form pass.
+func TestTmuxExpandShortFormVars(t *testing.T) {
+	ctx := map[string]string{
+		"session_name": "cmux",
+		"window_index": "0",
+		"pane_id":      "%abc-123",
+	}
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{"plain text", "hello", "hello"},
+		{"single short-form", "#S", "cmux"},
+		{"hash escape", "a##b", "a#b"},
+		{"hash escape then letter", "##S", "#S"},
+		{"long-form left untouched", "#{pane_id}", "#{pane_id}"},
+		{"unknown short-form passes through", "#X", "#X"},
+		{"unknown var with key not in context", "#H", "#H"},
+		{"trailing hash", "abc#", "abc#"},
+		{"adjacent short-forms", "#S#I", "cmux0"},
+		{"short followed by long", "#S #{pane_id}", "cmux #{pane_id}"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tmuxExpandShortFormVars(tt.format, ctx)
+			if got != tt.want {
+				t.Errorf("tmuxExpandShortFormVars(%q) = %q, want %q", tt.format, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTmuxSendKeysText(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
## Summary

- `tmuxRenderFormat` only substituted long-form `#{var}` tokens. Single-character format variables documented in tmux(1) FORMATS (`#S`, `#I`, `#D`, `#P`, `#W`, `#F`, `#T`, `#H`, `#h`) were left literal in the output.
- This breaks oh-my-claudecode's `omc team` flow inside cmux: OMC issues `display-message -p '#S:#I #{pane_id}'` and parses the result as `<session>:<window> <pane_id>`. The renderer returned `#S:#I %<uuid>`, producing `Failed to resolve tmux context: "#S:#I %<uuid>"` downstream and breaking team-mode worker dispatch.
- Added a single-pass walker (`tmuxExpandShortFormVars`) that substitutes the documented short-form tokens from the existing format context, honors `##` as a literal `#`, leaves `#{...}` long-form tokens untouched for the existing pass, and lets unknown short-forms pass through unchanged (matching tmux's documented behavior).
- Applied the fix to **both** `tmuxRenderFormat` implementations so local and remote stay consistent:
  - `daemon/remote/cmd/cmuxd-remote/tmux_compat.go` (Go, used over the remote SSH proxy)
  - `CLI/cmux.swift` (Swift, used by the local app's `cmux __tmux-compat`)

## Repro

Before:
```
$ cmux __tmux-compat display-message -p '#S:#I #{pane_id}'
#S:#I %abc-123
```
…and oh-my-claudecode logs `Failed to resolve tmux context: "#S:#I %abc-123"`.

After:
```
$ cmux __tmux-compat display-message -p '#S:#I #{pane_id}'
cmux:0 %abc-123
```

## Relationship to #3391

PR #3391 adds a `show-options` **command handler** to the `__tmux-compat` dispatcher. This PR fixes the **format renderer** that downstream commands (e.g. `display-message -p`) use. Same file in the Swift CLI but disjoint code paths — they should land independently.

## Test plan

- [x] New Go tests in `daemon/remote/cmd/cmuxd-remote/tmux_compat_test.go`:
  - `TestTmuxRenderFormatShortForm` — covers OMC mixed `#S:#I #{pane_id}` regression, every documented short-form, `##` escape, unknown short-form pass-through, trailing `#`, empty format → fallback, long-form unchanged.
  - `TestTmuxExpandShortFormVars` — locks in the helper's behavior in isolation (plain text, `##`, `##S`, long-form left untouched, adjacent short-forms `#S#I`, mixed short+long).
- [ ] Maintainer to verify Swift parity (the Swift implementation mirrors the Go one line-for-line; no Swift test added because there is no equivalent test target — happy to add one if pointed at the right harness).
- [ ] Manual: with this change, `omc team` workers boot inside cmux without the `Failed to resolve tmux context` error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand tmux short-form variables (#S, #I, #D, etc.) in `__tmux-compat` so mixed formats render correctly. Fixes OMC team mode failing on `display-message -p '#S:#I #{pane_id}'`.

- **Bug Fixes**
  - Add a short-form expander that maps `#D #F #H #I #P #S #T #W #h` from the format context, respects `##` as a literal `#`, leaves `#{...}` untouched, and passes unknown short-forms through.
  - Apply the change to both renderers for parity: `daemon/remote/cmd/cmuxd-remote/tmux_compat.go` (Go) and `CLI/cmux.swift` (Swift).
  - Add Go tests covering mixed short+long formats and edge cases; confirms `#S:#I #{pane_id}` → `cmux:0 %abc-123`.

<sup>Written for commit cbdd720be1a26d6a933e3e92cd1cbccbf3d06d20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for tmux short-form format tokens (e.g., `#S`, `#I`, `#D`), improving tmux compatibility and format string flexibility.

* **Tests**
  * Added comprehensive test coverage for short-form token rendering, escape handling, and mixed format scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->