### PR TITLE
Show Toggle Pane Zoom for browser panes

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1791,6 +1791,13 @@ func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) {
     objc_setAssociatedObject(window, &fileDropOverlayKey, overlay, .OBJC_ASSOCIATION_RETAIN)
 }
 
+func shouldShowToggleSplitZoomCommandInPalette(
+    hasFocusedPanel: Bool,
+    workspaceHasSplits: Bool
+) -> Bool {
+    hasFocusedPanel && workspaceHasSplits
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -7046,11 +7053,13 @@ struct ContentView: View {
             CommandPaletteCommandContribution(
                 commandId: "palette.toggleSplitZoom",
                 title: constant(String(localized: "command.toggleSplitZoom.title", defaultValue: "Toggle Pane Zoom")),
-                subtitle: constant(String(localized: "command.toggleSplitZoom.subtitle", defaultValue: "Terminal Layout")),
+                subtitle: workspaceSubtitle,
                 keywords: ["terminal", "pane", "split", "zoom", "maximize"],
                 when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal) &&
-                    context.bool(CommandPaletteContextKeys.workspaceHasSplits)
+                    shouldShowToggleSplitZoomCommandInPalette(
+                        hasFocusedPanel: context.bool(CommandPaletteContextKeys.hasFocusedPanel),
+                        workspaceHasSplits: context.bool(CommandPaletteContextKeys.workspaceHasSplits)
+                    )
                 }
             )
         )

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3410,6 +3410,8 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #if DEBUG
     private var needsConfirmCloseOverrideForTesting: Bool?
     private var runtimeSurfaceFreedOutOfBandForTesting = false
+    private let debugForceRefreshCountLock = NSLock()
+    private var debugForceRefreshCountValue = 0
 #endif
     private enum PortalLifecycleState: String {
         case live
@@ -3869,6 +3871,25 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func debugDesiredFocusState() -> Bool {
         desiredFocusState
+    }
+
+    func debugForceRefreshCount() -> Int {
+        debugForceRefreshCountLock.lock()
+        defer { debugForceRefreshCountLock.unlock() }
+        return debugForceRefreshCountValue
+    }
+
+    @MainActor
+    func resetDebugForceRefreshCount() {
+        debugForceRefreshCountLock.lock()
+        debugForceRefreshCountValue = 0
+        debugForceRefreshCountLock.unlock()
+    }
+
+    private func recordDebugForceRefresh() {
+        debugForceRefreshCountLock.lock()
+        debugForceRefreshCountValue += 1
+        debugForceRefreshCountLock.unlock()
     }
 
     private static func surfaceLog(_ message: String) {
@@ -4421,6 +4442,9 @@ final class TerminalSurface: Identifiable, ObservableObject {
               view.bounds.height > 0 else {
             return
         }
+#if DEBUG
+        recordDebugForceRefresh()
+#endif
         guard let currentSurface = self.surface else { return }
 
         // Re-read self.surface before each ghostty call to guard against the surface
@@ -10010,6 +10034,12 @@ final class GhosttySurfaceScrollView: NSView {
                 window.makeFirstResponder(nil)
             }
         } else {
+            if !wasVisible {
+                // Workspace/sidebar selection can make an already-sized terminal visible again
+                // without a portal frame delta or a focus handoff. Reuse the portal refresh
+                // path so the Metal layer is nudged immediately on plain visibility restores.
+                refreshSurfaceNow(reason: "setVisibleInUI")
+            }
             scheduleAutomaticFirstResponderApply(reason: "setVisibleInUI")
         }
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11899,7 +11899,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let coordinator = context.coordinator
         let previousDesiredIsActive = coordinator.desiredIsActive
         let previousDesiredIsVisibleInUI = coordinator.desiredIsVisibleInUI
-        let previousDesiredShowsUnreadNotificationRing = coordinator.desiredShowsUnreadNotificationRing
         let previousDesiredPortalZPriority = coordinator.desiredPortalZPriority
         let desiredStateChanged =
             previousDesiredIsActive != isActive ||
@@ -12068,12 +12067,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 let hostId = ObjectIdentifier(host)
                 let geometryRevision = host.geometryRevision
                 let portalEntryMissing = !TerminalWindowPortalRegistry.isHostedView(hostedView, boundTo: host)
+                // Notification rings are hosted inside GhosttySurfaceScrollView and update in place.
+                // A ring-only state change must not resynchronize the window portal while SwiftUI is
+                // invalidating notification UI, or the terminal can be hidden until the next tab switch.
                 let shouldBindNow =
                     coordinator.lastBoundHostId != hostId ||
                     hostedView.superview == nil ||
                     portalEntryMissing ||
                     previousDesiredIsVisibleInUI != isVisibleInUI ||
-                    previousDesiredShowsUnreadNotificationRing != showsUnreadNotificationRing ||
                     previousDesiredPortalZPriority != portalZPriority
                 if portalBindingLive && shouldBindNow {
 #if DEBUG

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4621,6 +4621,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
             self.backgroundSurfaceStartQueued = false
             guard self.allowsRuntimeSurfaceCreation() else { return }
             guard self.surface == nil, let view = self.attachedView else { return }
+            guard view.window != nil else {
+                #if DEBUG
+                dlog(
+                    "surface.background_start.defer surface=\(self.id.uuidString.prefix(8)) reason=noWindow"
+                )
+                #endif
+                return
+            }
             #if DEBUG
             let startedAt = ProcessInfo.processInfo.systemUptime
             #endif

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -335,6 +335,35 @@ final class FullScreenShortcutTests: XCTestCase {
     }
 }
 
+final class ToggleSplitZoomCommandPaletteVisibilityTests: XCTestCase {
+    func testVisibleWhenWorkspaceHasSplitsAndBrowserPanelIsFocused() {
+        XCTAssertTrue(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: true,
+                workspaceHasSplits: true
+            )
+        )
+    }
+
+    func testHiddenWithoutSplits() {
+        XCTAssertFalse(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: true,
+                workspaceHasSplits: false
+            )
+        )
+    }
+
+    func testHiddenWithoutFocusedPanel() {
+        XCTAssertFalse(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: false,
+                workspaceHasSplits: true
+            )
+        )
+    }
+}
+
 
 final class CommandPaletteKeyboardNavigationTests: XCTestCase {
     func testArrowKeysMoveSelectionWithoutModifiers() {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -1801,6 +1801,59 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         throw XCTSkip("Debug-only regression test")
 #endif
     }
+
+    func testVisibilityRestoreRefreshesSurfaceWhileTerminalIsInactive() throws {
+#if DEBUG
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertNotNil(
+            surface.surface,
+            "Expected runtime surface before measuring visibility-restore redraws"
+        )
+
+        hostedView.setActive(false)
+        hostedView.setVisibleInUI(false)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        surface.resetDebugForceRefreshCount()
+        hostedView.setVisibleInUI(true)
+
+        let drained = expectation(description: "visible toggle drained")
+        DispatchQueue.main.async { drained.fulfill() }
+        wait(for: [drained], timeout: 1.0)
+
+        XCTAssertEqual(
+            surface.debugForceRefreshCount(),
+            1,
+            "Restoring panel visibility should force a redraw even when focus recovery is inactive"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
 }
 
 

--- a/tests_v2/test_terminal_notification_rendering.py
+++ b/tests_v2/test_terminal_notification_rendering.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""
+Regression test: an OSC 777 completion notification must not blank the focused
+terminal surface.
+
+The bug in issue 3026 was visible state loss, not terminal data loss: the
+sidebar still showed the session needed input, but the portal-hosted Ghostty
+surface went blank until a tab switch forced a refresh. This test exercises the
+real OSC notification path and checks both portal visibility and post-notification
+rendering.
+"""
+
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Callable, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET", "/tmp/cmux-debug.sock")
+
+
+def _wait_for(
+    predicate: Callable[[], bool],
+    *,
+    timeout_s: float = 5.0,
+    cadence_s: float = 0.05,
+    label: str = "condition",
+) -> None:
+    start = time.time()
+    while time.time() - start < timeout_s:
+        if predicate():
+            return
+        time.sleep(cadence_s)
+    raise cmuxError(f"Timed out waiting for {label}")
+
+
+def _focused_surface_id(c: cmux) -> str:
+    surfaces = c.list_surfaces()
+    if not surfaces:
+        raise cmuxError("Expected at least one terminal surface")
+    return next((sid for _idx, sid, focused in surfaces if focused), surfaces[0][1])
+
+
+def _surface_health_row(c: cmux, surface_id: str) -> Optional[dict]:
+    surface_id = surface_id.lower()
+    for row in c.surface_health():
+        if str(row.get("surface_id") or "").lower() == surface_id:
+            return row
+    return None
+
+
+def _rect_size(rect: object) -> tuple[float, float]:
+    if not isinstance(rect, dict):
+        return (0.0, 0.0)
+    return (
+        float(rect.get("width") or 0.0),
+        float(rect.get("height") or 0.0),
+    )
+
+
+def _assert_surface_visible(c: cmux, surface_id: str, context: str) -> None:
+    row = _surface_health_row(c, surface_id)
+    if row is None:
+        raise cmuxError(f"{context}: surface missing from health output: {surface_id}")
+
+    failures: list[str] = []
+    expected_true = [
+        "mapped",
+        "tree_visible",
+        "workspace_selected",
+        "surface_focused",
+        "runtime_surface_ready",
+        "hosted_view_in_window",
+        "hosted_view_has_superview",
+        "hosted_view_visible_in_ui",
+    ]
+    for key in expected_true:
+        if row.get(key) is not True:
+            failures.append(f"{key}={row.get(key)!r}")
+
+    expected_false = [
+        "hosted_view_hidden",
+        "hosted_view_hidden_or_ancestor_hidden",
+    ]
+    for key in expected_false:
+        if row.get(key) is not False:
+            failures.append(f"{key}={row.get(key)!r}")
+
+    width, height = _rect_size(row.get("hosted_view_frame"))
+    if width < 80 or height < 80:
+        failures.append(f"hosted_view_frame={row.get('hosted_view_frame')!r}")
+
+    if failures:
+        raise cmuxError(
+            f"{context}: terminal surface is not visibly mounted after notification.\n"
+            f"surface_id={surface_id}\n"
+            f"failures={', '.join(failures)}\n"
+            f"health_row={row}"
+        )
+
+
+def _assert_surface_stays_visible(
+    c: cmux,
+    surface_id: str,
+    *,
+    duration_s: float = 1.2,
+    cadence_s: float = 0.02,
+) -> None:
+    deadline = time.time() + duration_s
+    samples = 0
+    while time.time() < deadline:
+        _assert_surface_visible(c, surface_id, f"sample {samples}")
+        samples += 1
+        time.sleep(cadence_s)
+    if samples == 0:
+        _assert_surface_visible(c, surface_id, "final visibility sample")
+
+
+def _send_osc777_notification(c: cmux, surface_id: str, title: str, body: str) -> None:
+    # zsh/bash printf both interpret these escapes and emit the actual OSC 777.
+    c.send_surface(surface_id, f"printf '\\033]777;notify;{title};{body}\\007'\n")
+
+
+def _wait_for_notification(c: cmux, title: str, surface_id: str) -> None:
+    surface_id = surface_id.lower()
+
+    def seen() -> bool:
+        for item in c.list_notifications():
+            if str(item.get("title") or "") != title:
+                continue
+            if str(item.get("surface_id") or "").lower() == surface_id:
+                return True
+        return False
+
+    _wait_for(seen, timeout_s=5.0, label=f"notification {title!r}")
+
+
+def _wait_for_terminal_text(c: cmux, surface_id: str, text: str) -> None:
+    _wait_for(
+        lambda: text in c.read_terminal_text(surface_id),
+        timeout_s=5.0,
+        label=f"terminal text {text!r}",
+    )
+
+
+def _assert_renders_after_notification(c: cmux, surface_id: str, marker: str) -> None:
+    c.panel_snapshot_reset(surface_id)
+    before = c.panel_snapshot(surface_id, "notif_render_before")
+    baseline_present = int(c.render_stats(surface_id).get("presentCount") or 0)
+
+    c.send_surface(surface_id, f"printf '{marker}\\n'\n")
+    _wait_for_terminal_text(c, surface_id, marker)
+
+    def presented_new_contents() -> bool:
+        stats = c.render_stats(surface_id)
+        return int(stats.get("presentCount") or 0) > baseline_present
+
+    _wait_for(presented_new_contents, timeout_s=2.0, label="new layer presentation")
+    after = c.panel_snapshot(surface_id, "notif_render_after")
+    changed_pixels = int(after.get("changed_pixels") or 0)
+    if changed_pixels < 50:
+        raise cmuxError(
+            "Expected visible terminal pixels to change after OSC notification.\n"
+            f"changed_pixels={changed_pixels}\n"
+            f"before={before}\n"
+            f"after={after}"
+        )
+
+
+def main() -> int:
+    token = f"CMUX_OSC777_{int(time.time() * 1000)}"
+    notify_title = f"{token}_TITLE"
+    notify_body = f"{token}_BODY"
+    after_marker = f"{token}_AFTER_NOTIFY_RENDER"
+
+    with cmux(SOCKET_PATH) as c:
+        try:
+            c.activate_app()
+            time.sleep(0.25)
+
+            workspace_id = c.new_workspace()
+            c.select_workspace(workspace_id)
+            time.sleep(0.35)
+
+            surface_id = _focused_surface_id(c)
+            _wait_for(lambda: c.is_terminal_focused(surface_id), timeout_s=4.0, label="terminal focus")
+            _assert_surface_visible(c, surface_id, "before notification")
+
+            c.clear_notifications()
+            _wait_for(lambda: not c.list_notifications(), timeout_s=3.0, label="notifications cleared")
+
+            # Keep the window visible and focused while forcing the notification path to
+            # store an unread notification and show the pane ring.
+            c.set_app_focus(False)
+            _send_osc777_notification(c, surface_id, notify_title, notify_body)
+            _wait_for_notification(c, notify_title, surface_id)
+
+            _assert_surface_stays_visible(c, surface_id)
+            _assert_renders_after_notification(c, surface_id, after_marker)
+        finally:
+            try:
+                c.set_app_focus(None)
+            except Exception:
+                pass
+
+    print("PASS: OSC 777 notification keeps focused terminal visible and rendering")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Fix command palette visibility for `Toggle Pane Zoom` so it is available when a browser pane is focused.

## Problem

The command was previously gated behind terminal-only context:

- `panelIsTerminal == true`
- `workspaceHasSplits == true`

That meant the command disappeared in browser-pane context even though the underlying action still works at the workspace/pane level.

## Fix

Relax the visibility condition to:

- focused panel exists
- workspace has splits

Also switch the subtitle to the workspace-level label so the command reads naturally outside terminal-only context.

## Testing

- Added `ToggleSplitZoomCommandPaletteVisibilityTests`
- Ran:
  - `./scripts/test-unit.sh -only-testing:cmuxTests/ToggleSplitZoomCommandPaletteVisibilityTests test`

Closes #3439


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “Toggle Pane Zoom” visible in the command palette when a browser pane is focused. Also fix terminal blanking by forcing a redraw on visibility restore and avoiding portal rebinding during notification-only updates.

- **Bug Fixes**
  - Command palette: show `Toggle Pane Zoom` when any panel is focused and the workspace has splits; switch subtitle to the workspace label.
  - Rendering: force a refresh when a previously sized terminal becomes visible again; prevent portal rebinds on notification ring-only changes; defer background surface creation until the view is in a window to avoid CI main-thread stalls.

- **Testing**
  - Added Swift tests for palette visibility conditions.
  - Added a debug-only test to verify redraw on visibility restore while inactive.
  - Added `tests_v2/test_terminal_notification_rendering.py` to ensure OSC 777 notifications keep the focused terminal visible and rendering.

<sup>Written for commit f0d96dd096600f87ce4d43cf5e5ff8075b942836. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed terminal surface refresh behavior when panels become visible
  - Improved Toggle Split Zoom command availability in the command palette
  - Reduced unnecessary portal state recreation for notification updates

* **Tests**
  - Added test coverage for command palette visibility logic
  - Added regression test for notification rendering with active terminals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->