### PR TITLE
Show Toggle Pane Zoom for browser panes

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1613,6 +1613,13 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
     }
 }
 
+func shouldShowToggleSplitZoomCommandInPalette(
+    hasFocusedPanel: Bool,
+    workspaceHasSplits: Bool
+) -> Bool {
+    hasFocusedPanel && workspaceHasSplits
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -7669,11 +7676,13 @@ struct ContentView: View {
             CommandPaletteCommandContribution(
                 commandId: "palette.toggleSplitZoom",
                 title: constant(String(localized: "command.toggleSplitZoom.title", defaultValue: "Toggle Pane Zoom")),
-                subtitle: constant(String(localized: "command.toggleSplitZoom.subtitle", defaultValue: "Terminal Layout")),
+                subtitle: workspaceSubtitle,
                 keywords: ["terminal", "pane", "split", "zoom", "maximize"],
                 when: { context in
-                    context.bool(CommandPaletteContextKeys.panelIsTerminal) &&
-                    context.bool(CommandPaletteContextKeys.workspaceHasSplits)
+                    shouldShowToggleSplitZoomCommandInPalette(
+                        hasFocusedPanel: context.bool(CommandPaletteContextKeys.hasFocusedPanel),
+                        workspaceHasSplits: context.bool(CommandPaletteContextKeys.workspaceHasSplits)
+                    )
                 }
             )
         )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1613,6 +1613,7 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
     }
 }
 
+/// Shows the command when a focused pane exists in a split workspace.
 func shouldShowToggleSplitZoomCommandInPalette(
     hasFocusedPanel: Bool,
     workspaceHasSplits: Bool

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -387,6 +387,35 @@ final class FullScreenShortcutTests: XCTestCase {
     }
 }
 
+final class ToggleSplitZoomCommandPaletteVisibilityTests: XCTestCase {
+    func testVisibleWhenWorkspaceHasSplitsAndBrowserPanelIsFocused() {
+        XCTAssertTrue(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: true,
+                workspaceHasSplits: true
+            )
+        )
+    }
+
+    func testHiddenWithoutSplits() {
+        XCTAssertFalse(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: true,
+                workspaceHasSplits: false
+            )
+        )
+    }
+
+    func testHiddenWithoutFocusedPanel() {
+        XCTAssertFalse(
+            shouldShowToggleSplitZoomCommandInPalette(
+                hasFocusedPanel: false,
+                workspaceHasSplits: true
+            )
+        )
+    }
+}
+
 
 final class CommandPaletteKeyboardNavigationTests: XCTestCase {
     func testArrowKeysMoveSelectionWithoutModifiers() {

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -388,7 +388,7 @@ final class FullScreenShortcutTests: XCTestCase {
 }
 
 final class ToggleSplitZoomCommandPaletteVisibilityTests: XCTestCase {
-    func testVisibleWhenWorkspaceHasSplitsAndBrowserPanelIsFocused() {
+    func testVisibleWhenWorkspaceHasSplitsAndAnyPanelIsFocused() {
         XCTAssertTrue(
             shouldShowToggleSplitZoomCommandInPalette(
                 hasFocusedPanel: true,


### PR DESCRIPTION
## Summary

Fix command palette visibility for `Toggle Pane Zoom` so it is available when a browser pane is focused.

## Problem

The command was previously gated behind terminal-only context:

- `panelIsTerminal == true`
- `workspaceHasSplits == true`

That meant the command disappeared in browser-pane context even though the underlying action still works at the workspace/pane level.

## Fix

Relax the visibility condition to:

- focused panel exists
- workspace has splits

Also switch the subtitle to the workspace-level label so the command reads naturally outside terminal-only context.

## Testing

- Added `ToggleSplitZoomCommandPaletteVisibilityTests`
- Ran:
  - `./scripts/test-unit.sh -only-testing:cmuxTests/ToggleSplitZoomCommandPaletteVisibilityTests test`

Closes #3439

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make “Toggle Pane Zoom” visible in the Command Palette when a browser pane is focused, not just terminals. Prevents the command from disappearing even though the action works at the workspace level.

- **Bug Fixes**
  - Show when any panel is focused and the workspace has splits (`shouldShowToggleSplitZoomCommandInPalette`).
  - Use the workspace-level subtitle via `workspaceSubtitle` for consistent wording.
  - Add unit tests for the new visibility logic.

<sup>Written for commit 0fcbfff09807922eef9a3cb8b9f2925799760128. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * "Toggle Split Zoom" now appears in the command palette whenever a panel is focused and the workspace has split panes, not limited to terminal panels.
  * Command subtitle now updates dynamically to reflect the current workspace context.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->