### PR TITLE
Fix main window activation on app reopen

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5932,11 +5932,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func repairMainWindowOrderingAfterAppActivation() {
         guard NSApp.modalWindow == nil else { return }
-        if let keyWindow = NSApp.keyWindow,
-           keyWindow.isVisible,
-           !isMainTerminalWindow(keyWindow) {
-            return
+
+        let topmostVisible = NSApp.orderedWindows.first { window in
+            window.isVisible && !window.isMiniaturized
         }
+        if let topmostVisible {
+            if !isMainTerminalWindow(topmostVisible) {
+                return
+            }
+            if topmostVisible.isKeyWindow {
+                return
+            }
+        }
+
         _ = foregroundPreferredMainWindowForAppActivation()
     }
 
@@ -5947,8 +5955,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         if let mainWindow = NSApp.mainWindow,
-           isMainTerminalWindow(mainWindow) {
+           isMainTerminalWindow(mainWindow),
+           mainWindow.isVisible,
+           !mainWindow.isMiniaturized {
             return mainWindow
+        }
+
+        if let frontmost = NSApp.orderedWindows.first(where: { window in
+            window.isVisible
+                && !window.isMiniaturized
+                && isMainTerminalWindow(window)
+        }) {
+            return frontmost
         }
 
         return sortedMainWindowContextsForSessionSnapshot().compactMap { context in
@@ -13532,6 +13550,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return
         }
 #if DEBUG
+        cmuxDebugLog("mainWindow.bringToFront window={\(debugWindowToken(window))}")
         debugBringToFrontObserver?(window)
 #endif
         setActiveMainWindow(window)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -760,6 +760,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
     var debugCloseMainWindowConfirmationHandler: ((NSWindow) -> Bool)?
     var debugCreateMainWindowSourceIsNativeFullScreenOverride: Bool?
+    var debugBringToFrontObserver: ((NSWindow) -> Void)?
     // Keep debug-only windows alive when tests intentionally inject key mismatches.
     private var debugDetachedContextWindows: [NSWindow] = []
 
@@ -936,8 +937,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
-        if hasVisibleMainTerminalWindow() {
-            _ = synchronizeActiveMainWindowContext(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow)
+        if foregroundPreferredMainWindowForAppActivation() {
             return true
         }
         ensureInitialMainWindowIfNeeded()
@@ -1412,6 +1412,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         sentryBreadcrumb("app.didBecomeActive", category: "lifecycle", data: [
             "tabCount": tabManager?.tabs.count ?? 0
         ])
+        repairMainWindowOrderingAfterAppActivation()
+
         if TelemetrySettings.enabledForCurrentLaunch && !isRunningUnderXCTestCached {
             PostHogAnalytics.shared.trackActive(reason: "didBecomeActive")
         }
@@ -5917,11 +5919,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return createMainWindow(shouldActivate: shouldActivate)
     }
 
-    private func hasVisibleMainTerminalWindow() -> Bool {
-        mainWindowContexts.values.contains { context in
-            guard let window = resolvedWindow(for: context) else { return false }
-            return window.isVisible && !window.isMiniaturized
+    @discardableResult
+    private func foregroundPreferredMainWindowForAppActivation() -> Bool {
+        guard let window = preferredMainWindowForAppActivation() else {
+            return false
         }
+
+        _ = synchronizeActiveMainWindowContext(preferredWindow: window)
+        bringToFront(window)
+        return true
+    }
+
+    private func repairMainWindowOrderingAfterAppActivation() {
+        guard NSApp.modalWindow == nil else { return }
+        if let keyWindow = NSApp.keyWindow,
+           keyWindow.isVisible,
+           !isMainTerminalWindow(keyWindow) {
+            return
+        }
+        _ = foregroundPreferredMainWindowForAppActivation()
+    }
+
+    private func preferredMainWindowForAppActivation() -> NSWindow? {
+        if let keyWindow = NSApp.keyWindow,
+           isMainTerminalWindow(keyWindow) {
+            return keyWindow
+        }
+
+        if let mainWindow = NSApp.mainWindow,
+           isMainTerminalWindow(mainWindow) {
+            return mainWindow
+        }
+
+        return sortedMainWindowContextsForSessionSnapshot().compactMap { context in
+            guard let window = resolvedWindow(for: context),
+                  window.isVisible,
+                  !window.isMiniaturized else {
+                return nil
+            }
+            return window
+        }.first
     }
 
     @discardableResult
@@ -13494,6 +13531,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
            !TerminalController.socketCommandAllowsInAppFocusMutations() {
             return
         }
+#if DEBUG
+        debugBringToFrontObserver?(window)
+#endif
         setActiveMainWindow(window)
         if window.isMiniaturized {
             window.deminiaturize(nil)

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -146,13 +146,15 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
+        // shouldActivate:false orderFront's the window without making it key —
+        // the exact visible-but-not-key state the repair path must rescue.
         let windowId = appDelegate.createMainWindow(shouldActivate: false)
         defer { closeWindow(withId: windowId) }
         guard let window = window(withId: windowId) else {
             XCTFail("Expected created main window")
             return
         }
-        window.makeKeyAndOrderFront(nil)
+        XCTAssertFalse(window.isKeyWindow, "precondition: window must be visible but not key")
 
 #if DEBUG
         var observedWindow: NSWindow?
@@ -178,7 +180,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             XCTFail("Expected created main window")
             return
         }
-        window.makeKeyAndOrderFront(nil)
+        XCTAssertFalse(window.isKeyWindow, "precondition: window must be visible but not key")
 
 #if DEBUG
         var observedWindow: NSWindow?
@@ -189,6 +191,38 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             Notification(name: NSApplication.didBecomeActiveNotification, object: NSApp)
         )
         XCTAssertTrue(observedWindow === window)
+#else
+        XCTFail("debugBringToFrontObserver is only available in DEBUG")
+#endif
+    }
+
+    func testDidBecomeActiveDoesNotDisturbAuxiliaryFrontWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow(shouldActivate: false)
+        defer { closeWindow(withId: windowId) }
+
+        let auxiliary = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { auxiliary.close() }
+        auxiliary.makeKeyAndOrderFront(nil)
+
+#if DEBUG
+        var observedWindow: NSWindow?
+        appDelegate.debugBringToFrontObserver = { observedWindow = $0 }
+        defer { appDelegate.debugBringToFrontObserver = nil }
+
+        appDelegate.applicationDidBecomeActive(
+            Notification(name: NSApplication.didBecomeActiveNotification, object: NSApp)
+        )
+        XCTAssertNil(observedWindow, "repair must not steal focus from auxiliary front window")
 #else
         XCTFail("debugBringToFrontObserver is only available in DEBUG")
 #endif

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -97,6 +97,9 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         AppDelegate.shared?.shortcutLayoutCharacterProvider = KeyboardLayout.character(forKeyCode:modifierFlags:)
         AppDelegate.shared?.debugCloseMainWindowConfirmationHandler = nil
         AppDelegate.shared?.debugCreateMainWindowSourceIsNativeFullScreenOverride = nil
+#if DEBUG
+        AppDelegate.shared?.debugBringToFrontObserver = nil
+#endif
         AppDelegate.shared?.dismissNotificationsPopoverIfShown()
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         for action in KeyboardShortcutSettings.Action.allCases {
@@ -134,6 +137,60 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertFalse(appDelegate.debugHandleShortcutMonitorEvent(event: event))
 #else
         XCTFail("debugHandleShortcutMonitorEvent is only available in DEBUG")
+#endif
+    }
+
+    func testApplicationReopenBringsVisibleMainWindowToFront() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow(shouldActivate: false)
+        defer { closeWindow(withId: windowId) }
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected created main window")
+            return
+        }
+        window.makeKeyAndOrderFront(nil)
+
+#if DEBUG
+        var observedWindow: NSWindow?
+        appDelegate.debugBringToFrontObserver = { observedWindow = $0 }
+        defer { appDelegate.debugBringToFrontObserver = nil }
+
+        XCTAssertTrue(appDelegate.applicationShouldHandleReopen(NSApp, hasVisibleWindows: true))
+        XCTAssertTrue(observedWindow === window)
+#else
+        XCTFail("debugBringToFrontObserver is only available in DEBUG")
+#endif
+    }
+
+    func testDidBecomeActiveRepairsVisibleMainWindowOrdering() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow(shouldActivate: false)
+        defer { closeWindow(withId: windowId) }
+        guard let window = window(withId: windowId) else {
+            XCTFail("Expected created main window")
+            return
+        }
+        window.makeKeyAndOrderFront(nil)
+
+#if DEBUG
+        var observedWindow: NSWindow?
+        appDelegate.debugBringToFrontObserver = { observedWindow = $0 }
+        defer { appDelegate.debugBringToFrontObserver = nil }
+
+        appDelegate.applicationDidBecomeActive(
+            Notification(name: NSApplication.didBecomeActiveNotification, object: NSApp)
+        )
+        XCTAssertTrue(observedWindow === window)
+#else
+        XCTFail("debugBringToFrontObserver is only available in DEBUG")
 #endif
     }
 


### PR DESCRIPTION
## Summary

- **What changed?** `applicationShouldHandleReopen` and `applicationDidBecomeActive` now repair main-window ordering: pick a foreground-preferred visible main terminal window, sync the active context, and bring it to the front. The repair short-circuits when a main terminal is already topmost and key, and bails out when an auxiliary (non-main) window is the topmost visible window so it isn't disturbed. `preferredMainWindowForAppActivation` adds visibility/miniaturization guards on the `NSApp.mainWindow` fast path and uses `NSApp.orderedWindows` (front-to-back) before falling back to UUID-ordered context list.
- **Why?** On app reopen and Cmd+Tab activation a visible main window could remain behind other windows, or a non-main window could remain key, leaving the user without a usable terminal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app reopen and activation so the preferred main terminal window becomes key and front. Tightens activation guards to avoid stealing focus from auxiliary windows and prevents redundant bring-to-front on Cmd+Tab.

- **Bug Fixes**
  - On app reopen, pick the preferred visible, non-miniaturized main window, sync active context, and bring it forward.
  - On app activation, consult `NSApp.orderedWindows`: bail if an auxiliary window is frontmost or if a main terminal is already topmost and key; otherwise repair ordering.
  - DEBUG-only: emit `cmuxDebugLog` in bringToFront, keep `debugBringToFrontObserver`, and add tests for reopen, activation, and auxiliary-window protection.

<sup>Written for commit 70d2aa3dfc9b7c1ae80ebefc4ab9188c57f9d924. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

## Testing

- Unit tests in `cmuxTests/AppDelegateShortcutRoutingTests.swift`:
  - `testApplicationReopenBringsVisibleMainWindowToFront` — visible-but-not-key main window is brought to the front on reopen.
  - `testDidBecomeActiveRepairsVisibleMainWindowOrdering` — same on `applicationDidBecomeActive`.
  - `testDidBecomeActiveDoesNotDisturbAuxiliaryFrontWindow` — when a non-main window is frontmost, the repair does not steal focus.
- Manual verification: launch the app, hide it, click the dock icon → preferred main window comes forward; switch away with Cmd+Tab and back → main window key + front; with the Settings/auxiliary panel frontmost, Cmd+Tab back leaves the panel in place.
- DEBUG builds emit `mainWindow.bringToFront window={...}` in `/tmp/cmux-debug*.log` for trace.

## Demo Video

This PR fixes a focus/ordering regression — there is no new visual surface to demo. The behavior is verified via the unit tests above and the manual steps in Testing.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed main-window ordering when the app becomes active or is reopened, ensuring the preferred terminal window is brought to the front and its context is synced for a more consistent experience.
* **Tests**
  * Added tests (and a debug-only observability hook) to verify reopen and activate flows restore correct window ordering and front/key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
