### PR TITLE
Fix SSH command wrappers for fish shells

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,7 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+
+# Local agent/session notes
+TODO.md
+LOCAL_NOTES.md

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4834,7 +4834,7 @@ struct CMUXCLI {
             target: sshOptions.displayDestination,
             relayPort: sshOptions.remoteRelayPort
         )
-        let combinedLocalCommand = combinedLocalShellCommand([
+        let combinedLocalCommand = combinedLocalCommandForSSH([
             deferredRemoteReconnectCommand,
             sshConnectionTimingCommand,
         ])
@@ -5212,8 +5212,10 @@ struct CMUXCLI {
         let installSSHPrefix = baseSSHArguments(options, localCommand: localCommand).map(shellQuote).joined(separator: " ")
         let sessionSSHPrefix = baseSSHArguments(options).map(shellQuote).joined(separator: " ")
         let remoteCommandTemplate = sshPercentEscapedRemoteCommand(
-            stagedRemoteBootstrapCommandShell(
-                remoteRelayPort: options.remoteRelayPort
+            posixShellRemoteCommand(
+                stagedRemoteBootstrapCommandShell(
+                    remoteRelayPort: options.remoteRelayPort
+                )
             )
         )
         let remoteBootstrapInstallCommand = "/bin/sh -c " + shellQuote(
@@ -5247,6 +5249,10 @@ struct CMUXCLI {
         var lines = remoteBootstrapTTYCaptureLines(remoteRelayPort: remoteRelayPort, includeRelayRPC: true)
         lines.append("/bin/sh \"$HOME/.cmux/relay/\(remoteRelayPort).bootstrap.sh\"")
         return lines.joined(separator: "\n")
+    }
+
+    private func posixShellRemoteCommand(_ command: String) -> String {
+        "/bin/sh -c " + shellQuote(command)
     }
 
     private func remoteBootstrapInstallShell(remoteRelayPort: Int) -> String {
@@ -6744,7 +6750,8 @@ struct CMUXCLI {
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
         return [
-            "cmux_ssh_log_path=\"$(tr -d '\\r\\n' < /tmp/cmux-last-debug-log-path 2>/dev/null || true)\";",
+            "cmux_ssh_log_path=\"\";",
+            "if [ -r /tmp/cmux-last-debug-log-path ]; then cmux_ssh_log_path=\"$(tr -d '\\r\\n' < /tmp/cmux-last-debug-log-path 2>/dev/null || true)\"; fi;",
             "if [ -n \"$cmux_ssh_log_path\" ]; then",
             "cmux_ssh_ts=\"$(python3 -c 'from datetime import datetime, timezone; print(datetime.now(timezone.utc).isoformat(timespec=\"milliseconds\").replace(\"+00:00\", \"Z\"))' 2>/dev/null || date -u +%Y-%m-%dT%H:%M:%SZ)\";",
             "printf '%s [cmux-cli] cli.ssh.handshake target=\(escapedTarget) relayPort=\(relayPort) stage=ssh.connected workspace=%s surface=%s\\n' \"$cmux_ssh_ts\" \"${CMUX_WORKSPACE_ID:-nil}\" \"${CMUX_SURFACE_ID:-nil}\" >> \"$cmux_ssh_log_path\";",
@@ -6761,6 +6768,11 @@ struct CMUXCLI {
         }
         guard !filtered.isEmpty else { return nil }
         return filtered.joined(separator: " ")
+    }
+
+    private func combinedLocalCommandForSSH(_ parts: [String?]) -> String? {
+        guard let command = combinedLocalShellCommand(parts) else { return nil }
+        return "/bin/sh -c \(shellQuote(command))"
     }
 
     private func shouldDeferRemoteReconnect(in options: [String]) -> Bool {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3915,6 +3915,10 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             "Expected the bootstrap install SSH hop to signal foreground auth readiness via LocalCommand, saw \(firstInvocation)"
         )
         XCTAssertTrue(
+            localCommand.hasPrefix("/bin/sh -c "),
+            "Expected LocalCommand to force a POSIX shell so non-POSIX login shells such as fish can execute it, saw \(localCommand)"
+        )
+        XCTAssertTrue(
             localCommand.contains("%%s\\n"),
             "Expected LocalCommand to percent-escape literal percent signs for OpenSSH, saw \(localCommand)"
         )
@@ -3929,6 +3933,26 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             0,
             "Expected LocalCommand shell snippet to parse cleanly, stderr: \(localCommandSyntaxCheck.stderr)"
         )
+        let fishExecutable = [
+            "/opt/homebrew/bin/fish",
+            "/usr/local/bin/fish",
+            "/usr/bin/fish",
+            "/bin/fish",
+        ].first { FileManager.default.isExecutableFile(atPath: $0) }
+        guard let fishExecutable else {
+            throw XCTSkip("fish is not installed")
+        }
+        let fishLocalCommandCheck = runProcess(
+            executablePath: fishExecutable,
+            arguments: ["-n", "-c", localCommand],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertEqual(
+            fishLocalCommandCheck.status,
+            0,
+            "Expected LocalCommand wrapper to parse cleanly when the user's login shell is fish, stderr: \(fishLocalCommandCheck.stderr)"
+        )
         let destinationIndex = try XCTUnwrap(firstInvocation.lastIndex(of: "cmux-macmini"))
         let remoteCommandArgs = Array(firstInvocation.suffix(from: firstInvocation.index(after: destinationIndex)))
 
@@ -3937,7 +3961,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             1,
             "Expected the staged bootstrap installer to be passed as one SSH remote command, saw \(firstInvocation)"
         )
-        XCTAssertTrue(remoteCommandArgs[0].contains("/bin/sh -lc"), "Expected a POSIX shell wrapper in \(remoteCommandArgs)")
+        XCTAssertTrue(remoteCommandArgs[0].contains("/bin/sh -c"), "Expected a POSIX shell wrapper in \(remoteCommandArgs)")
         XCTAssertTrue(remoteCommandArgs[0].contains("set -eu"), "Expected installer command body in \(remoteCommandArgs)")
         XCTAssertFalse(remoteCommandArgs.contains("sh"))
         XCTAssertFalse(remoteCommandArgs.contains("-c"))
@@ -3949,6 +3973,29 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         XCTAssertFalse(
             secondInvocation.contains(where: { $0.contains("LocalCommand=") }),
             "Expected only the bootstrap install hop to trigger LocalCommand, saw \(secondInvocation)"
+        )
+        let secondRemoteCommandOption = try XCTUnwrap(
+            secondInvocation.first(where: { $0.hasPrefix("RemoteCommand=") })
+        )
+        let secondRemoteCommand = String(secondRemoteCommandOption.dropFirst("RemoteCommand=".count))
+        XCTAssertTrue(
+            secondRemoteCommand.contains("/bin/sh -c"),
+            "Expected the interactive remote command to force a POSIX shell so fish login shells can execute it, saw \(secondInvocation)"
+        )
+        XCTAssertTrue(
+            secondRemoteCommand.contains("cmux_bootstrap_tty=") || secondRemoteCommand.contains("cmux_bootstrap_tty\\\""),
+            "Expected staged remote bootstrap command body in \(secondRemoteCommand)"
+        )
+        let remoteFishCommandCheck = runProcess(
+            executablePath: fishExecutable,
+            arguments: ["-n", "-c", secondRemoteCommand],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertEqual(
+            remoteFishCommandCheck.status,
+            0,
+            "Expected staged remote command wrapper to parse cleanly when the remote login shell is fish, stderr: \(remoteFishCommandCheck.stderr)"
         )
 
         XCTAssertEqual(foregroundAuthState.commands.count, 1)


### PR DESCRIPTION
Fixes #2706.

This is a minimal version of the fish shell SSH fix.

cmux generates POSIX shell snippets for SSH `LocalCommand` and `RemoteCommand`. OpenSSH may execute those snippets through the user's login shell. When that shell is fish, assignments such as `cmux_reconnect_cli=...` or `cmux_bootstrap_tty=...` fail to parse.

This patch:

- wraps the fully combined SSH `LocalCommand` in `/bin/sh -c`
- wraps the interactive SSH `RemoteCommand` bootstrap in `/bin/sh -c`
- avoids printing `/tmp/cmux-last-debug-log-path: No such file or directory` when the debug log path file is absent
- adds regression coverage that validates generated commands with `fish -n -c` when fish is available

Manually tested with fish as the login shell locally and on the remote host:

```bash
cmux ssh user@host
```

Before this patch, both local `LocalCommand` and remote `RemoteCommand` could fail with:

```text
fish: Unsupported use of '='
```

After this patch, the SSH session logs in successfully.

Related: #2749 also attempts to fix this, but includes many unrelated changes. This PR keeps the fix scoped to the SSH shell wrapper regression.

Tested with:

```bash
CMUX_SKIP_ZIG_BUILD=1 xcodebuild test \
  -project GhosttyTabs.xcodeproj \
  -scheme cmux-unit \
  -only-testing:cmuxTests/CLINotifyProcessIntegrationTests/testSSHBootstrapStartupCommandPassesRemoteInstallScriptAsSingleSSHCommand \
  -destination 'platform=macOS,arch=arm64' \
  CODE_SIGNING_ALLOWED=NO
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force POSIX shell wrappers for SSH LocalCommand and both installer and interactive RemoteCommand so fish login shells parse cleanly; fixes #2706. Also silences missing debug-log warnings and extends regression tests.

- **Bug Fixes**
  - Wrap LocalCommand in `/bin/sh -c`.
  - Wrap installer and interactive `RemoteCommand` in `/bin/sh -c`.
  - Guard reads of `/tmp/cmux-last-debug-log-path` to avoid "No such file or directory".
  - Add tests that run both local and remote snippets through `fish -n -c` when fish is installed.

<sup>Written for commit d624edda775faa1387b6b9ee73a8808fd50af21d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH remote command composition and shell invocation for more reliable remote execution
  * Safer SSH handshake logging to avoid spurious log path assignments

* **Tests**
  * Strengthened bootstrap command tests and added shell-compatibility validation (includes optional fish-shell checks)

* **Chores**
  * Ignore local scratch and note files (tmp/, TODO.md, LOCAL_NOTES.md)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->