### PR TITLE
Fix shortcut settings dispatch_once launch crash

### DIFF
--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -13,6 +13,9 @@ enum KeyboardShortcutSettings {
             notifySettingsFileDidChange()
         }
     }
+    #if DEBUG
+    static var shortcutLookupObserver: ((Action) -> Void)?
+    #endif
 
     enum ShortcutRecordingRejection: Equatable {
         case bareKeyNotAllowed
@@ -659,6 +662,9 @@ enum KeyboardShortcutSettings {
     }
 
     static func shortcut(for action: Action) -> StoredShortcut {
+        #if DEBUG
+        shortcutLookupObserver?(action)
+        #endif
         if let managedShortcut = settingsFileStore.override(for: action) {
             return managedShortcut
         }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -9,9 +9,7 @@ enum KeyboardShortcutSettings {
     static let actionUserInfoKey = "action"
     static let settingsFileDisplayPath = "~/.config/cmux/cmux.json"
     static var settingsFileStore: KeyboardShortcutSettingsFileStore = .shared {
-        didSet {
-            notifySettingsFileDidChange()
-        }
+        didSet { notifySettingsFileDidChange() }
     }
     #if DEBUG
     static var shortcutLookupObserver: ((Action) -> Void)?
@@ -727,9 +725,7 @@ enum KeyboardShortcutSettings {
         postDidChangeNotification(action: conflictingAction)
     }
 
-    static func notifySettingsFileDidChange() {
-        postDidChangeNotification()
-    }
+    static func notifySettingsFileDidChange(center: NotificationCenter = .default) { postDidChangeNotification(center: center) }
 
     static func resetShortcut(for action: Action) {
         UserDefaults.standard.removeObject(forKey: action.defaultsKey)

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -210,7 +210,7 @@ final class CmuxSettingsFileStore {
         }
 
         if previousShortcuts != resolved.shortcuts || previousActiveSourcePath != resolved.path {
-            KeyboardShortcutSettings.notifySettingsFileDidChange()
+            KeyboardShortcutSettings.notifySettingsFileDidChange(center: notificationCenter)
         }
     }
 

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreMigrationTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreMigrationTests.swift
@@ -6,6 +6,14 @@ import XCTest
 @testable import cmux
 #endif
 
+private final class ShortcutSettingsNotificationCounter: @unchecked Sendable {
+    var count = 0
+}
+
+private final class ShortcutSettingsLookupRecorder: @unchecked Sendable {
+    var actions: [String] = []
+}
+
 final class KeyboardShortcutSettingsFileStoreMigrationTests: XCTestCase {
     func testBootstrapMigratesLegacySettingsIntoCanonicalConfig() throws {
         let directoryURL = try makeTemporaryDirectory()
@@ -96,6 +104,86 @@ final class KeyboardShortcutSettingsFileStoreMigrationTests: XCTestCase {
             StoredShortcut(key: "i", command: true, shift: false, option: false, control: false)
         )
         XCTAssertEqual(store.activeSourcePath, primaryURL.path)
+    }
+
+    func testLegacySettingsShortcutBindingsParseWithoutRuntimeConflictLookup() throws {
+        let originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
+        defer {
+            KeyboardShortcutSettings.shortcutLookupObserver = nil
+            KeyboardShortcutSettings.resetAll()
+            KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
+        }
+        KeyboardShortcutSettings.resetAll()
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let runtimeStoreURL = directoryURL.appendingPathComponent("runtime/cmux.json", isDirectory: false)
+        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+            primaryPath: runtimeStoreURL.path,
+            fallbackPath: nil,
+            notificationCenter: NotificationCenter(),
+            startWatching: false
+        )
+        KeyboardShortcutSettings.setShortcut(
+            StoredShortcut(key: "2", command: true, shift: false, option: false, control: false),
+            for: .openBrowser
+        )
+        let lookupRecorder = ShortcutSettingsLookupRecorder()
+        KeyboardShortcutSettings.shortcutLookupObserver = { action in
+            lookupRecorder.actions.append(action.rawValue)
+        }
+
+        let primaryURL = directoryURL.appendingPathComponent("primary/cmux.json", isDirectory: false)
+        let legacySettingsURL = directoryURL.appendingPathComponent("fallback/settings.json", isDirectory: false)
+        let parsingNotificationCenter = NotificationCenter()
+        let defaultNotificationCounter = ShortcutSettingsNotificationCounter()
+        let parsingNotificationCounter = ShortcutSettingsNotificationCounter()
+        let defaultNotificationObserver = NotificationCenter.default.addObserver(
+            forName: KeyboardShortcutSettings.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            defaultNotificationCounter.count += 1
+        }
+        let parsingNotificationObserver = parsingNotificationCenter.addObserver(
+            forName: KeyboardShortcutSettings.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            parsingNotificationCounter.count += 1
+        }
+        defer {
+            NotificationCenter.default.removeObserver(defaultNotificationObserver)
+            parsingNotificationCenter.removeObserver(parsingNotificationObserver)
+        }
+        try writeSettingsFile(
+            """
+            {
+              "shortcuts": {
+                "bindings": {
+                  "selectWorkspaceByNumber": "cmd+2"
+                }
+              }
+            }
+            """,
+            to: legacySettingsURL
+        )
+
+        let store = KeyboardShortcutSettingsFileStore(
+            primaryPath: primaryURL.path,
+            fallbackPath: legacySettingsURL.path,
+            notificationCenter: parsingNotificationCenter,
+            startWatching: false
+        )
+
+        XCTAssertEqual(lookupRecorder.actions, [])
+        XCTAssertEqual(defaultNotificationCounter.count, 0)
+        XCTAssertEqual(parsingNotificationCounter.count, 1)
+        XCTAssertEqual(
+            store.override(for: .selectWorkspaceByNumber),
+            StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
+        )
     }
 
     func testSettingsFileURLForEditingReturnsCanonicalConfigWhenLegacyFallbackExists() throws {


### PR DESCRIPTION
## Summary
- fixes #3412 by keeping settings-file shortcut parsing out of runtime shortcut conflict lookup
- adds a regression proving file-managed shortcut parsing is independent of current runtime shortcut conflicts
- preserves interactive recorder conflict validation for Settings UI and socket-driven shortcut writes

## Verification
- not run locally: project policy says never run local tests; CI should run the two commits separately so the first commit proves the regression
- code-intel diagnostics checked `Sources/KeyboardShortcutSettingsFileStore.swift`
- final local launch verification will use `./scripts/reload.sh --tag issue-3412-keyboard-shortcut-dispatch-once-deadlock --launch` with an active shortcut binding

## Notes
- Commit 1 adds the failing regression only.
- Commit 2 applies the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized changes to shortcut lookup instrumentation and notification routing, plus a regression test to prevent reintroducing runtime lookups during file parsing.
> 
> **Overview**
> Fixes settings-file shortcut parsing to be *pure* with respect to runtime shortcut state by adding a DEBUG-only `KeyboardShortcutSettings.shortcutLookupObserver` hook and a regression test that asserts no calls to `shortcut(for:)` occur while parsing legacy bindings.
> 
> Routes settings-file reload change notifications through the file store’s injected `NotificationCenter` (via `notifySettingsFileDidChange(center:)`) instead of always using `NotificationCenter.default`, with tests verifying only the intended center receives the event.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93695868fa505d287c398f642b001bb793e6ccbb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup deadlock by making settings-file shortcut parsing pure and independent of runtime conflict state. Preserves saved-preference precedence from main and keeps conflict checks in the interactive recorder; closes #3412.

- **Bug Fixes**
  - Parse legacy and managed bindings without consulting runtime shortcuts; DEBUG `KeyboardShortcutSettings.shortcutLookupObserver` asserts zero runtime reads and proper normalization.
  - Route file-store reloads through the store’s injected `NotificationCenter` via `notifySettingsFileDidChange(center:)`; tests prove no posts to `NotificationCenter.default` and a single post to the injected center.
  - Preserve lookup order: saved user defaults win; managed file overrides apply only when no saved preference exists.

<sup>Written for commit 93695868fa505d287c398f642b001bb793e6ccbb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring legacy keyboard shortcut settings parse correctly without interfering with runtime lookups, preserving recognition of previously saved shortcuts.
* **Chores**
  * CI test runner now detects and surfaces fatal unit-test crashes earlier for faster failure diagnosis.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->