### PR TITLE
Lazy load feed activity history

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
 		FEED0000000000000000F005 /* FeedPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F004 /* FeedPanelView.swift */; };
+		FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F010 /* FeedPanelViewModel.swift */; };
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
 		FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
@@ -373,6 +374,7 @@
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
+		FEED0000000000000000F010 /* FeedPanelViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelViewModel.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00A /* FeedPreviewWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPreviewWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedButtonStyleDebugWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
@@ -717,6 +719,7 @@
 			children = (
 				FEED0000000000000000F001 /* FeedCoordinator.swift */,
 				FEED0000000000000000F004 /* FeedPanelView.swift */,
+				FEED0000000000000000F010 /* FeedPanelViewModel.swift */,
 				FEED0000000000000000F00A /* FeedPreviewWindowController.swift */,
 				FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */,
 				FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */,
@@ -1429,6 +1432,7 @@
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
 				FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */,
 				FEED0000000000000000F005 /* FeedPanelView.swift in Sources */,
+				FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */,
 				FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */,
 				FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */,
 				FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */,

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamPersistence.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamPersistence.swift
@@ -9,6 +9,22 @@ import Foundation
 /// without awaiting disk IO; reads happen on the caller's executor since
 /// load runs once per process at launch.
 public actor WorkstreamPersistence {
+    public struct Page: Sendable, Equatable {
+        public let items: [WorkstreamItem]
+        public let hasMoreBefore: Bool
+        public let startOffset: UInt64?
+
+        public init(
+            items: [WorkstreamItem],
+            hasMoreBefore: Bool,
+            startOffset: UInt64?
+        ) {
+            self.items = items
+            self.hasMoreBefore = hasMoreBefore
+            self.startOffset = startOffset
+        }
+    }
+
     private let fileURL: URL
     private let encoder: JSONEncoder
     private let decoder: JSONDecoder
@@ -46,18 +62,35 @@ public actor WorkstreamPersistence {
     /// Loads the last `limit` items from the file. Order in the returned
     /// array is oldest-first. Missing file returns empty.
     public func loadRecent(limit: Int) throws -> [WorkstreamItem] {
-        guard limit > 0 else { return [] }
+        try loadPage(endingBefore: nil, limit: limit).items
+    }
+
+    /// Loads up to `limit` items ending before `endOffset`. Order in the
+    /// returned array is oldest-first. `startOffset` can be passed back
+    /// as `endOffset` to page older history without depending on line
+    /// counts, which keeps the cursor stable while new rows are appended.
+    public func loadPage(
+        endingBefore endOffset: UInt64? = nil,
+        limit: Int
+    ) throws -> Page {
+        guard limit > 0 else {
+            return Page(items: [], hasMoreBefore: false, startOffset: nil)
+        }
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            return []
+            return Page(items: [], hasMoreBefore: false, startOffset: nil)
         }
         let fh = try FileHandle(forReadingFrom: fileURL)
         defer { try? fh.close() }
         let fileSize = try fh.seekToEnd()
-        guard fileSize > 0 else { return [] }
+        let pageEnd = min(endOffset ?? fileSize, fileSize)
+        guard fileSize > 0, pageEnd > 0 else {
+            return Page(items: [], hasMoreBefore: false, startOffset: nil)
+        }
 
         let chunkSize = 64 * 1024
-        var offset = fileSize
+        var offset = pageEnd
         var tail = Data()
+        var lineRanges: [(range: Range<Int>, startOffset: UInt64)] = []
         while offset > 0 {
             let readSize = min(chunkSize, Int(offset))
             offset -= UInt64(readSize)
@@ -66,26 +99,32 @@ public actor WorkstreamPersistence {
                 break
             }
             tail.insert(contentsOf: chunk, at: 0)
-            let newlineCount = tail.reduce(0) { $1 == 0x0A ? $0 + 1 : $0 }
-            if newlineCount > limit {
+            lineRanges = Self.lineRanges(in: tail, baseOffset: offset)
+            if lineRanges.count > limit {
                 break
             }
         }
 
-        let lines = tail
-            .split(separator: 0x0A, omittingEmptySubsequences: true)
-            .suffix(limit)
+        if lineRanges.isEmpty {
+            lineRanges = Self.lineRanges(in: tail, baseOffset: offset)
+        }
+        let selectedRanges = lineRanges.suffix(limit)
         var out: [WorkstreamItem] = []
-        out.reserveCapacity(lines.count)
-        for line in lines {
-            let slice = Data(line)
+        out.reserveCapacity(selectedRanges.count)
+        for lineRange in selectedRanges {
+            let slice = tail.subdata(in: lineRange.range)
             if let item = try? decoder.decode(WorkstreamItem.self, from: slice) {
                 out.append(item)
             }
             // Malformed lines are dropped silently; the audit log is
             // append-only and we don't want a corrupt row to block startup.
         }
-        return out
+        let startOffset = selectedRanges.first?.startOffset
+        return Page(
+            items: out,
+            hasMoreBefore: (startOffset ?? 0) > 0,
+            startOffset: startOffset
+        )
     }
 
     /// Truncates the JSONL file. Used by `cmux feed clear`.
@@ -119,6 +158,36 @@ public actor WorkstreamPersistence {
         let fh = try FileHandle(forWritingTo: fileURL)
         handle = fh
         return fh
+    }
+
+    private static func lineRanges(
+        in data: Data,
+        baseOffset: UInt64
+    ) -> [(range: Range<Int>, startOffset: UInt64)] {
+        var ranges: [(range: Range<Int>, startOffset: UInt64)] = []
+        ranges.reserveCapacity(128)
+        var lineStart = 0
+        for (idx, byte) in data.enumerated() {
+            guard byte == 0x0A else { continue }
+            if lineStart < idx {
+                ranges.append(
+                    (
+                        range: lineStart..<idx,
+                        startOffset: baseOffset + UInt64(lineStart)
+                    )
+                )
+            }
+            lineStart = idx + 1
+        }
+        if lineStart < data.count {
+            ranges.append(
+                (
+                    range: lineStart..<data.count,
+                    startOffset: baseOffset + UInt64(lineStart)
+                )
+            )
+        }
+        return ranges
     }
 }
 

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamStore.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamStore.swift
@@ -8,6 +8,8 @@ import Glibc
 
 /// Size of the in-memory ring buffer. Older items are evicted to disk-only.
 public let WorkstreamDefaultRingCapacity = 2_000
+public let WorkstreamDefaultInitialLoadLimit = 300
+public let WorkstreamDefaultHistoryPageSize = 300
 
 /// Main-actor `@Observable` store that holds the Feed state.
 ///
@@ -20,6 +22,8 @@ public let WorkstreamDefaultRingCapacity = 2_000
 @Observable
 public final class WorkstreamStore {
     public private(set) var items: [WorkstreamItem] = []
+    public private(set) var hasMorePersistedItems = false
+    public private(set) var isLoadingOlderItems = false
 
     public var pending: [WorkstreamItem] {
         items.filter { $0.status.isPending }
@@ -32,7 +36,10 @@ public final class WorkstreamStore {
     private let transport: any WorkstreamTransport
     private let persistence: WorkstreamPersistence?
     private let ringCapacity: Int
+    private let initialLoadLimit: Int
+    private let historyPageSize: Int
     private let clock: @Sendable () -> Date
+    private var oldestLoadedPersistenceOffset: UInt64?
 
     /// Last known conversational context for each workstream. Tool hooks
     /// usually arrive without the surrounding user prompt, so the store
@@ -43,21 +50,24 @@ public final class WorkstreamStore {
         transport: any WorkstreamTransport = NullWorkstreamTransport(),
         persistence: WorkstreamPersistence? = nil,
         ringCapacity: Int = WorkstreamDefaultRingCapacity,
+        initialLoadLimit: Int = WorkstreamDefaultInitialLoadLimit,
+        historyPageSize: Int = WorkstreamDefaultHistoryPageSize,
         clock: @escaping @Sendable () -> Date = { Date() }
     ) {
         self.transport = transport
         self.persistence = persistence
         self.ringCapacity = ringCapacity
+        self.initialLoadLimit = initialLoadLimit
+        self.historyPageSize = historyPageSize
         self.clock = clock
     }
 
-    // MARK: - Lifecycle
-
-    /// Replays recent items from disk, then connects the transport.
     public func start() async {
         if let persistence {
-            if let recent = try? await persistence.loadRecent(limit: ringCapacity) {
-                items = recent
+            if let page = try? await persistence.loadPage(limit: min(initialLoadLimit, ringCapacity)) {
+                items = page.items
+                hasMorePersistedItems = page.hasMoreBefore
+                oldestLoadedPersistenceOffset = page.startOffset
                 rebuildContextIndex()
             }
         }
@@ -72,6 +82,34 @@ public final class WorkstreamStore {
             // Transport failures are non-fatal; the store stays usable for
             // locally-injected items and tests.
         }
+    }
+
+    public func loadOlderItems() async {
+        guard !isLoadingOlderItems, hasMorePersistedItems else { return }
+        guard let persistence, let oldestLoadedPersistenceOffset else {
+            hasMorePersistedItems = false
+            return
+        }
+
+        isLoadingOlderItems = true
+        defer { isLoadingOlderItems = false }
+
+        guard let page = try? await persistence.loadPage(
+            endingBefore: oldestLoadedPersistenceOffset,
+            limit: historyPageSize
+        ), !page.items.isEmpty else {
+            hasMorePersistedItems = false
+            return
+        }
+
+        let existingIds = Set(items.map(\.id))
+        let olderItems = page.items.filter { !existingIds.contains($0.id) }
+        if !olderItems.isEmpty {
+            items.insert(contentsOf: olderItems, at: 0)
+        }
+        self.oldestLoadedPersistenceOffset = page.startOffset ?? oldestLoadedPersistenceOffset
+        hasMorePersistedItems = page.hasMoreBefore
+        rebuildContextIndex()
     }
 
     // MARK: - Ingest

--- a/Packages/CMUXWorkstream/Tests/CMUXWorkstreamTests/WorkstreamPersistenceTests.swift
+++ b/Packages/CMUXWorkstream/Tests/CMUXWorkstreamTests/WorkstreamPersistenceTests.swift
@@ -52,6 +52,38 @@ struct WorkstreamPersistenceTests {
         #expect(loaded.last?.workstreamId == "s4")
     }
 
+    @Test("loadPage pages older rows before a stable byte cursor")
+    func loadPageBeforeCursor() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workstream-page-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let persistence = WorkstreamPersistence(fileURL: tmp)
+        for i in 0..<5 {
+            try await persistence.append(WorkstreamItem(
+                workstreamId: "s\(i)",
+                source: .claude,
+                kind: .permissionRequest,
+                payload: .permissionRequest(requestId: "r\(i)", toolName: "t", toolInputJSON: "{}", pattern: nil)
+            ))
+        }
+
+        let newest = try await persistence.loadPage(limit: 2)
+        #expect(newest.items.map(\.workstreamId) == ["s3", "s4"])
+        #expect(newest.hasMoreBefore)
+        let cursor = try #require(newest.startOffset)
+
+        try await persistence.append(WorkstreamItem(
+            workstreamId: "s5",
+            source: .claude,
+            kind: .permissionRequest,
+            payload: .permissionRequest(requestId: "r5", toolName: "t", toolInputJSON: "{}", pattern: nil)
+        ))
+
+        let older = try await persistence.loadPage(endingBefore: cursor, limit: 2)
+        #expect(older.items.map(\.workstreamId) == ["s1", "s2"])
+        #expect(older.hasMoreBefore)
+    }
+
     @Test("append redacts sensitive tool input before writing JSONL")
     func appendRedactsSensitiveToolInput() async throws {
         let tmp = FileManager.default.temporaryDirectory

--- a/Packages/CMUXWorkstream/Tests/CMUXWorkstreamTests/WorkstreamStoreTests.swift
+++ b/Packages/CMUXWorkstream/Tests/CMUXWorkstreamTests/WorkstreamStoreTests.swift
@@ -39,6 +39,40 @@ struct WorkstreamStoreTests {
         #expect(store.items.last?.workstreamId == "s4")
     }
 
+    @Test("start loads a small recent slice and pages older persisted rows on demand")
+    func lazyLoadPersistedHistory() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-workstream-store-page-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let persistence = WorkstreamPersistence(fileURL: tmp)
+        for i in 0..<5 {
+            try await persistence.append(WorkstreamItem(
+                workstreamId: "s\(i)",
+                source: .claude,
+                kind: .permissionRequest,
+                payload: .permissionRequest(requestId: "r\(i)", toolName: "t", toolInputJSON: "{}", pattern: nil)
+            ))
+        }
+
+        let store = WorkstreamStore(
+            persistence: persistence,
+            ringCapacity: 10,
+            initialLoadLimit: 2,
+            historyPageSize: 2
+        )
+        await store.start()
+        #expect(store.items.map(\.workstreamId) == ["s3", "s4"])
+        #expect(store.hasMorePersistedItems)
+
+        await store.loadOlderItems()
+        #expect(store.items.map(\.workstreamId) == ["s1", "s2", "s3", "s4"])
+        #expect(store.hasMorePersistedItems)
+
+        await store.loadOlderItems()
+        #expect(store.items.map(\.workstreamId) == ["s0", "s1", "s2", "s3", "s4"])
+        #expect(!store.hasMorePersistedItems)
+    }
+
     @Test("expireAbandonedItems expires items whose agent PID is dead")
     func expireAbandoned() {
         let clock = TestClock(initial: Date(timeIntervalSince1970: 0))

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -109571,6 +109571,40 @@
         }
       }
     },
+    "feed.history.loadOlder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Load older activity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いアクティビティを読み込む"
+          }
+        }
+      }
+    },
+    "feed.history.loadingOlder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading older activity..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いアクティビティを読み込み中..."
+          }
+        }
+      }
+    },
     "settings.account.error.missingRefreshToken": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -79,7 +79,13 @@ struct FeedPanelView: View {
     var body: some View {
         VStack(spacing: 0) {
             controlBar
-            FeedListView(filter: filter, items: viewModel.items)
+            FeedListView(
+                filter: filter,
+                items: viewModel.items,
+                hasMorePersistedItems: viewModel.hasMorePersistedItems,
+                isLoadingOlderItems: viewModel.isLoadingOlderItems,
+                onLoadOlderItems: viewModel.loadOlderItems
+            )
         }
     }
 
@@ -143,51 +149,6 @@ private struct FeedSecondaryFilterButton: View {
     }
 }
 
-/// Bridges the `@Observable` WorkstreamStore to a Combine `@Published`
-/// snapshot so SwiftUI reliably re-renders the Feed panel on every
-/// mutation. This is the documented pattern for observing an
-/// Observable from outside SwiftUI's implicit body-tracking (singleton
-/// access + optional chain breaks the implicit path in our case).
-///
-/// Re-arms `withObservationTracking` after every change so the next
-/// mutation also fires. If the view is created before the store is
-/// installed, it waits for the coordinator's install notification.
-@MainActor
-final class FeedPanelViewModel: ObservableObject {
-    @Published private(set) var items: [WorkstreamItem] = []
-    private var storeInstalledObserver: NSObjectProtocol?
-
-    init() {
-        storeInstalledObserver = NotificationCenter.default.addObserver(
-            forName: FeedCoordinator.storeInstalledNotification,
-            object: FeedCoordinator.shared,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor in
-                self?.arm()
-            }
-        }
-        arm()
-    }
-
-    deinit {
-        if let storeInstalledObserver {
-            NotificationCenter.default.removeObserver(storeInstalledObserver)
-        }
-    }
-
-    private func arm() {
-        guard let store = FeedCoordinator.shared.store else { return }
-        withObservationTracking {
-            items = store.items
-        } onChange: { [weak self] in
-            Task { @MainActor in
-                self?.arm()
-            }
-        }
-    }
-}
-
 /// Feed content surface. Isolated so the outer panel's `@State`
 /// changes don't invalidate rows unnecessarily. Receives items as a
 /// plain value so its body never touches the live store, the parent
@@ -195,6 +156,9 @@ final class FeedPanelViewModel: ObservableObject {
 private struct FeedListView: View {
     let filter: FeedPanelView.Filter
     let items: [WorkstreamItem]
+    let hasMorePersistedItems: Bool
+    let isLoadingOlderItems: Bool
+    let onLoadOlderItems: () -> Void
 
     @State private var focusSnapshot = FeedFocusSnapshot()
     @State private var scrollRequest: FeedScrollRequest?
@@ -205,7 +169,7 @@ private struct FeedListView: View {
         let rowActions = FeedRowActions.bound()
         ScrollViewReader { proxy in
             Group {
-                if snapshots.isEmpty {
+                if snapshots.isEmpty && !shouldShowActivityHistoryLoader {
                     emptyState
                 } else {
                     contentBody(
@@ -266,7 +230,7 @@ private struct FeedListView: View {
         case .activity:
             let stable = snapshots.filter(prefersStableSurface)
             let history = snapshots.filter { !prefersStableSurface($0) }
-            if history.isEmpty {
+            if history.isEmpty && !hasMorePersistedItems {
                 stableScrollSurface(
                     snapshots: stable,
                     actions: actions
@@ -282,7 +246,8 @@ private struct FeedListView: View {
                     }
                     historyList(
                         snapshots: history,
-                        actions: actions
+                        actions: actions,
+                        showsLoadMore: hasMorePersistedItems
                     )
                 }
             }
@@ -327,7 +292,8 @@ private struct FeedListView: View {
 
     private func historyList(
         snapshots: [FeedItemSnapshot],
-        actions: FeedRowActions
+        actions: FeedRowActions,
+        showsLoadMore: Bool
     ) -> some View {
         List {
             // Single chronological history stream. The plain List keeps
@@ -338,6 +304,15 @@ private struct FeedListView: View {
                     snapshot: snapshot,
                     actions: actions,
                     showsDivider: idx < snapshots.count - 1
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            }
+            if showsLoadMore {
+                FeedHistoryLoadMoreRow(
+                    isLoading: isLoadingOlderItems,
+                    action: onLoadOlderItems
                 )
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(.hidden)
@@ -385,8 +360,7 @@ private struct FeedListView: View {
     /// "You: …" echo line at the top of their card.
     private static func lastPromptByWorkstream(_ items: [WorkstreamItem]) -> [String: String] {
         var out: [String: String] = [:]
-        let sorted = items.sorted { $0.createdAt < $1.createdAt }
-        for item in sorted {
+        for item in items {
             if case .userPrompt(let text) = item.payload, !text.isEmpty {
                 out[item.workstreamId] = text
             }
@@ -417,7 +391,7 @@ private struct FeedListView: View {
         // in the chronological slot where they arrived so the user's
         // mental map of "this was the second request I got" doesn't
         // get shuffled when they answer it.
-        return base.sorted { $0.createdAt > $1.createdAt }
+        return Array(base.reversed())
     }
 
     private func visibleSnapshots(_ items: [WorkstreamItem]) -> [FeedItemSnapshot] {
@@ -432,6 +406,10 @@ private struct FeedListView: View {
 
     private func prefersStableSurface(_ snapshot: FeedItemSnapshot) -> Bool {
         snapshot.status.isPending || snapshot.kind == .stop
+    }
+
+    private var shouldShowActivityHistoryLoader: Bool {
+        filter == .activity && hasMorePersistedItems
     }
 
     private func selectRow(_ id: UUID, focusFeed: Bool) {

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -1,0 +1,104 @@
+import CMUXWorkstream
+import Foundation
+import Observation
+import SwiftUI
+
+/// Bridges the `@Observable` WorkstreamStore to a Combine `@Published`
+/// snapshot so SwiftUI reliably re-renders the Feed panel on every
+/// mutation.
+@MainActor
+final class FeedPanelViewModel: ObservableObject {
+    @Published private(set) var items: [WorkstreamItem] = []
+    @Published private(set) var hasMorePersistedItems = false
+    @Published private(set) var isLoadingOlderItems = false
+    private var storeInstalledObserver: NSObjectProtocol?
+
+    init() {
+        storeInstalledObserver = NotificationCenter.default.addObserver(
+            forName: FeedCoordinator.storeInstalledNotification,
+            object: FeedCoordinator.shared,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                self?.arm()
+            }
+        }
+        arm()
+    }
+
+    deinit {
+        if let storeInstalledObserver {
+            NotificationCenter.default.removeObserver(storeInstalledObserver)
+        }
+    }
+
+    private func arm() {
+        guard let store = FeedCoordinator.shared.store else { return }
+        withObservationTracking {
+            items = store.items
+            hasMorePersistedItems = store.hasMorePersistedItems
+            isLoadingOlderItems = store.isLoadingOlderItems
+        } onChange: { [weak self] in
+            Task { @MainActor in
+                self?.arm()
+            }
+        }
+    }
+
+    nonisolated func loadOlderItems() {
+        Task { @MainActor [weak self] in
+            guard let self, !self.isLoadingOlderItems, self.hasMorePersistedItems else { return }
+            await FeedCoordinator.shared.store?.loadOlderItems()
+        }
+    }
+}
+
+struct FeedHistoryLoadMoreRow: View {
+    let isLoading: Bool
+    let action: () -> Void
+
+    @State private var isVisible = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 6) {
+                if isLoading {
+                    ProgressView()
+                        .controlSize(.small)
+                        .scaleEffect(0.6)
+                        .frame(width: 12, height: 12)
+                }
+                Text(label)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+        }
+        .buttonStyle(.plain)
+        .disabled(isLoading)
+        .onAppear {
+            isVisible = true
+            requestLoadIfVisible()
+        }
+        .onDisappear {
+            isVisible = false
+        }
+        .onChange(of: isLoading) { _, loading in
+            guard !loading else { return }
+            requestLoadIfVisible()
+        }
+    }
+
+    private var label: String {
+        if isLoading {
+            return String(localized: "feed.history.loadingOlder", defaultValue: "Loading older activity...")
+        }
+        return String(localized: "feed.history.loadOlder", defaultValue: "Load older activity")
+    }
+
+    private func requestLoadIfVisible() {
+        guard isVisible, !isLoading else { return }
+        action()
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12291,35 +12291,32 @@ class TerminalController {
         var activeMode: String?
         var missingWindow = false
 
-        DispatchQueue.main.sync {
-            let preferredWindow: NSWindow?
-            if let requestedWindowId {
-                preferredWindow = AppDelegate.shared?.mainWindow(for: requestedWindowId)
-                missingWindow = preferredWindow == nil
-            } else {
-                preferredWindow = NSApp.keyWindow ?? NSApp.mainWindow
-            }
-            guard !missingWindow else { return }
-            let result = AppDelegate.shared?.debugRevealRightSidebarInActiveMainWindow(
-                mode: mode,
-                focusFirstItem: focusFirstItem,
-                preferredWindow: preferredWindow
-            )
-            focused = result?.revealed ?? false
-            focusApplied = result?.focusApplied ?? false
-            contextFound = result?.contextFound ?? false
-            stateFound = result?.stateFound ?? false
-            visible = result?.visible ?? false
-            activeMode = result?.activeMode
+        let preferredWindow: NSWindow?
+        if let requestedWindowId {
+            preferredWindow = AppDelegate.shared?.mainWindow(for: requestedWindowId)
+            missingWindow = preferredWindow == nil
+        } else {
+            preferredWindow = NSApp.keyWindow ?? NSApp.mainWindow
         }
-
-        if missingWindow {
+        guard !missingWindow else {
             return .err(
                 code: "not_found",
                 message: "Window not found",
                 data: requestedWindowId.map { ["window_id": $0.uuidString, "window_ref": v2Ref(kind: .window, uuid: $0)] }
             )
         }
+        let result = AppDelegate.shared?.debugRevealRightSidebarInActiveMainWindow(
+            mode: mode,
+            focusFirstItem: focusFirstItem,
+            preferredWindow: preferredWindow
+        )
+        focused = result?.revealed ?? false
+        focusApplied = result?.focusApplied ?? false
+        contextFound = result?.contextFound ?? false
+        stateFound = result?.stateFound ?? false
+        visible = result?.visible ?? false
+        activeMode = result?.activeMode
+
         return .ok([
             "focused": focused,
             "focus_applied": focusApplied,
@@ -12348,19 +12345,17 @@ class TerminalController {
         var visible = false
         var activeMode = ""
 
-        DispatchQueue.main.sync {
-            let result = AppDelegate.shared?.debugRevealRightSidebarInActiveMainWindow(
-                mode: mode,
-                focusFirstItem: false,
-                preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
-            )
-            revealed = result?.revealed ?? false
-            focusApplied = result?.focusApplied ?? false
-            contextFound = result?.contextFound ?? false
-            stateFound = result?.stateFound ?? false
-            visible = result?.visible ?? false
-            activeMode = result?.activeMode ?? ""
-        }
+        let result = AppDelegate.shared?.debugRevealRightSidebarInActiveMainWindow(
+            mode: mode,
+            focusFirstItem: false,
+            preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
+        )
+        revealed = result?.revealed ?? false
+        focusApplied = result?.focusApplied ?? false
+        contextFound = result?.contextFound ?? false
+        stateFound = result?.stateFound ?? false
+        visible = result?.visible ?? false
+        activeMode = result?.activeMode ?? ""
 
         let details = "mode=\(mode.rawValue) active=\(activeMode) visible=\(visible ? 1 : 0) " +
             "context=\(contextFound ? 1 : 0) state=\(stateFound ? 1 : 0) focus=\(focusApplied ? 1 : 0)"


### PR DESCRIPTION
## Summary
- Load only the recent Feed history slice at startup, then page older JSONL rows by byte cursor.
- Add an Activity footer sentinel that fetches older history while keeping rows below the snapshot boundary.
- Remove per-render Feed sorting and add localized older-activity loader text.

## Testing
- `./scripts/setup.sh` succeeded
- `./scripts/reload.sh --tag feedvirt` succeeded
- Local unit tests not run per repo policy; coverage was added for GitHub Actions.

## Issues
- Task: User-reported cmux nightly Activity feed lag after switching from Actionable to Activity with 2,288 persisted Feed rows.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lazy-loads Activity feed history using JSONL byte-cursor paging to cut initial load and tab-switch time. Adds a localized “Load older activity” footer that auto-fetches previous pages with a spinner.

- **New Features**
  - Introduced paging via `loadPage(endingBefore:limit:)` with a stable byte cursor; `loadRecent` now uses it.
  - `WorkstreamStore` loads a small recent slice at start, exposes `hasMorePersistedItems` and `isLoadingOlderItems`, and adds `loadOlderItems()`; new `WorkstreamDefaultInitialLoadLimit` and `WorkstreamDefaultHistoryPageSize`.
  - Feed Activity shows a `FeedHistoryLoadMoreRow` that auto-fetches on appear and after each page; localized “Load older activity” and “Loading older activity…” (en, ja).

- **Refactors**
  - Removed per-render sorting in the Feed list and switched to reversing append order for stability.
  - Added tests for persistence paging and lazy loading.
  - Simplified `TerminalController` sidebar helpers by removing main-thread sync wrappers.

<sup>Written for commit f80753313e5e1771432a34459774c12e8c31cd16. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Load older activity history progressively with a "Load older activity" action, spinner and automatic on-appear loading.
  * Initial startup loads a recent slice with older pages fetched on demand.

* **Behavior Changes**
  * Stable byte-offset cursor keeps paging consistent across appends.
  * Recent-item selection and filtered lists preserve input ordering (then reverse for filtered views).

* **Tests**
  * Added tests for paginated persistence and lazy-loading.

* **Localization**
  * Added localized strings for the history loader UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->