### PR TITLE
Add simulator viewer panel and CLI foundation

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2362,6 +2362,9 @@ struct CMUXCLI {
                 throw CLIError(message: "Usage: cmux auth <status|login|logout>")
             }
 
+        case "sim", "simulator":
+            try runSimulatorCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
+
         case "vm", "cloud":
             let sub = commandArgs.first?.lowercased() ?? "ls"
             let rest = Array(commandArgs.dropFirst())
@@ -3486,6 +3489,250 @@ struct CMUXCLI {
                 try? FileManager.default.removeItem(at: entry.url)
             }
         }
+    }
+
+    // MARK: - Simulator Commands
+
+    private func runSimulatorCommand(
+        commandArgs: [String],
+        client: SocketClient,
+        jsonOutput: Bool,
+        idFormat: CLIIDFormat
+    ) throws {
+        let subcommand = commandArgs.first?.lowercased()
+        let rest = subcommand == nil ? [] : Array(commandArgs.dropFirst())
+
+        switch subcommand {
+        case nil:
+            if jsonOutput || isatty(STDIN_FILENO) == 0 || isatty(STDOUT_FILENO) == 0 {
+                try printSimulatorList(client: client, jsonOutput: jsonOutput)
+            } else {
+                try runSimulatorTUI(client: client, idFormat: idFormat)
+            }
+        case "list", "ls":
+            try printSimulatorList(client: client, jsonOutput: jsonOutput)
+        case "boot":
+            let udid = try simulatorUDIDArgument(rest, usage: "cmux sim boot <udid>")
+            let payload = try client.sendV2(method: "simulator.boot", params: ["udid": udid], responseTimeout: 60)
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                print("OK boot \(udid)")
+            }
+        case "shutdown":
+            let udid = try simulatorUDIDArgument(rest, usage: "cmux sim shutdown <udid>")
+            let payload = try client.sendV2(method: "simulator.shutdown", params: ["udid": udid], responseTimeout: 30)
+            if jsonOutput {
+                print(jsonString(payload))
+            } else {
+                print("OK shutdown \(udid)")
+            }
+        case "open":
+            let params = try simulatorOpenParams(rest, client: client)
+            let payload = try client.sendV2(method: "simulator.open", params: params)
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat))
+        default:
+            throw CLIError(message: "Usage: cmux sim [list|open|boot|shutdown]")
+        }
+    }
+
+    private func simulatorUDIDArgument(_ args: [String], usage: String) throws -> String {
+        let (udidOpt, remaining) = parseOption(args, name: "--udid")
+        let positional = remaining.first
+        let trailing = Array(remaining.dropFirst())
+        if let extra = trailing.first {
+            throw CLIError(message: "\(usage): unexpected argument '\(extra)'")
+        }
+        guard let udid = udidOpt ?? positional, !udid.isEmpty else {
+            throw CLIError(message: usage)
+        }
+        return udid
+    }
+
+    private func simulatorOpenParams(_ args: [String], client: SocketClient) throws -> [String: Any] {
+        let (udidOpt, rem0) = parseOption(args, name: "--udid")
+        let (directionOpt, rem1) = parseOption(rem0, name: "--direction")
+        let (workspaceOpt, rem2) = parseOption(rem1, name: "--workspace")
+        let (surfaceOpt, rem3) = parseOption(rem2, name: "--surface")
+        let (windowOpt, rem4) = parseOption(rem3, name: "--window")
+        if let unknown = rem4.first {
+            throw CLIError(message: "sim open: unexpected argument '\(unknown)'")
+        }
+
+        var params: [String: Any] = ["direction": directionOpt ?? "right"]
+        if let udidOpt { params["udid"] = udidOpt }
+
+        if let surfaceRaw = surfaceOpt ?? (windowOpt == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil),
+           let surface = try normalizeSurfaceHandle(surfaceRaw, client: client) {
+            params["surface_id"] = surface
+        }
+        let workspaceRaw = workspaceOpt ?? (windowOpt == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+        if let workspaceRaw,
+           let workspace = try normalizeWorkspaceHandle(workspaceRaw, client: client) {
+            params["workspace_id"] = workspace
+        }
+        if let windowRaw = windowOpt,
+           let window = try normalizeWindowHandle(windowRaw, client: client) {
+            params["window_id"] = window
+        }
+        return params
+    }
+
+    private func printSimulatorList(client: SocketClient, jsonOutput: Bool) throws {
+        let payload = try client.sendV2(method: "simulator.list")
+        if jsonOutput {
+            print(jsonString(payload))
+            return
+        }
+
+        let devices = simulatorDevices(from: payload)
+        if devices.isEmpty {
+            print("No simulators found.")
+            return
+        }
+        let grouped = Dictionary(grouping: devices, by: { $0.runtime })
+        for runtime in grouped.keys.sorted() {
+            print(runtime.isEmpty ? "Unknown Runtime" : runtime)
+            for device in (grouped[runtime] ?? []).sorted(by: { $0.name < $1.name }) {
+                let state = device.isBooted ? "booted" : device.state.lowercased()
+                print("  \(state.padding(toLength: 10, withPad: " ", startingAt: 0)) \(device.name)  \(device.shortUDID)")
+            }
+        }
+    }
+
+    private struct CLISimulatorDevice {
+        let udid: String
+        let shortUDID: String
+        let name: String
+        let runtime: String
+        let state: String
+        let isBooted: Bool
+    }
+
+    private func simulatorDevices(from payload: [String: Any]) -> [CLISimulatorDevice] {
+        let rawDevices = (payload["devices"] as? [[String: Any]]) ?? []
+        return rawDevices.compactMap { raw in
+            guard let udid = raw["udid"] as? String,
+                  let name = raw["name"] as? String else {
+                return nil
+            }
+            return CLISimulatorDevice(
+                udid: udid,
+                shortUDID: (raw["short_udid"] as? String) ?? String(udid.prefix(8)),
+                name: name,
+                runtime: (raw["runtime"] as? String) ?? "",
+                state: (raw["state"] as? String) ?? "Unknown",
+                isBooted: (raw["is_booted"] as? Bool) ?? false
+            )
+        }
+    }
+
+    private func runSimulatorTUI(client: SocketClient, idFormat: CLIIDFormat) throws {
+        var original = termios()
+        guard tcgetattr(STDIN_FILENO, &original) == 0 else {
+            try printSimulatorList(client: client, jsonOutput: false)
+            return
+        }
+        var raw = original
+        cfmakeraw(&raw)
+        tcsetattr(STDIN_FILENO, TCSANOW, &raw)
+        defer {
+            tcsetattr(STDIN_FILENO, TCSANOW, &original)
+            print("\u{1B}[?25h\u{1B}[?1049l", terminator: "")
+            fflush(stdout)
+        }
+
+        print("\u{1B}[?1049h\u{1B}[?25l", terminator: "")
+        var devices = simulatorDevices(from: try client.sendV2(method: "simulator.list"))
+        var selectedIndex = 0
+        var message = ""
+
+        while true {
+            if selectedIndex >= devices.count {
+                selectedIndex = max(0, devices.count - 1)
+            }
+            renderSimulatorTUI(devices: devices, selectedIndex: selectedIndex, message: message)
+            message = ""
+
+            guard let byte = readTUIByte(timeoutSeconds: 2) else {
+                devices = simulatorDevices(from: try client.sendV2(method: "simulator.list"))
+                continue
+            }
+
+            switch byte {
+            case 3, 113:
+                return
+            case 106:
+                selectedIndex = min(devices.count - 1, selectedIndex + 1)
+            case 107:
+                selectedIndex = max(0, selectedIndex - 1)
+            case 13, 32:
+                guard devices.indices.contains(selectedIndex) else { continue }
+                let device = devices[selectedIndex]
+                var params = try simulatorOpenParams([], client: client)
+                params["udid"] = device.udid
+                let payload = try client.sendV2(method: "simulator.open", params: params)
+                message = v2OKSummary(payload, idFormat: idFormat)
+            case 98:
+                guard devices.indices.contains(selectedIndex) else { continue }
+                let device = devices[selectedIndex]
+                _ = try client.sendV2(method: "simulator.boot", params: ["udid": device.udid], responseTimeout: 60)
+                devices = simulatorDevices(from: try client.sendV2(method: "simulator.list"))
+                message = "boot requested: \(device.name)"
+            case 115:
+                guard devices.indices.contains(selectedIndex) else { continue }
+                let device = devices[selectedIndex]
+                _ = try client.sendV2(method: "simulator.shutdown", params: ["udid": device.udid], responseTimeout: 30)
+                devices = simulatorDevices(from: try client.sendV2(method: "simulator.list"))
+                message = "shutdown requested: \(device.name)"
+            case 114:
+                devices = simulatorDevices(from: try client.sendV2(method: "simulator.list"))
+                message = "refreshed"
+            case 27:
+                if readTUIByte(timeoutSeconds: 0.02) == 91,
+                   let arrow = readTUIByte(timeoutSeconds: 0.02) {
+                    if arrow == 65 {
+                        selectedIndex = max(0, selectedIndex - 1)
+                    } else if arrow == 66 {
+                        selectedIndex = min(devices.count - 1, selectedIndex + 1)
+                    }
+                }
+            default:
+                continue
+            }
+        }
+    }
+
+    private func renderSimulatorTUI(devices: [CLISimulatorDevice], selectedIndex: Int, message: String) {
+        var lines: [String] = []
+        lines.append("\u{1B}[H\u{1B}[2Jcmux sim")
+        lines.append("Enter open  b boot  s shutdown  r refresh  q quit")
+        if !message.isEmpty {
+            lines.append(message)
+        }
+        lines.append("")
+
+        let grouped = Dictionary(grouping: Array(devices.enumerated()), by: { $0.element.runtime })
+        for runtime in grouped.keys.sorted() {
+            lines.append(runtime.isEmpty ? "Unknown Runtime" : runtime)
+            for (index, device) in (grouped[runtime] ?? []).sorted(by: { $0.element.name < $1.element.name }) {
+                let cursor = index == selectedIndex ? ">" : " "
+                let state = device.isBooted ? "booted" : device.state.lowercased()
+                lines.append("\(cursor) \(state.padding(toLength: 10, withPad: " ", startingAt: 0)) \(device.name)  \(device.shortUDID)")
+            }
+        }
+        print(lines.joined(separator: "\n"), terminator: "")
+        fflush(stdout)
+    }
+
+    private func readTUIByte(timeoutSeconds: Double) -> UInt8? {
+        var descriptor = pollfd(fd: STDIN_FILENO, events: Int16(POLLIN), revents: 0)
+        let timeoutMilliseconds = Int32(max(0, timeoutSeconds * 1_000))
+        let ready = poll(&descriptor, 1, timeoutMilliseconds)
+        guard ready > 0 else { return nil }
+        var byte: UInt8 = 0
+        let count = read(STDIN_FILENO, &byte, 1)
+        return count == 1 ? byte : nil
     }
 
     // MARK: - Markdown Commands
@@ -9729,6 +9976,25 @@ struct CMUXCLI {
               cmux browser open https://example.com
               cmux browser surface:1 navigate https://google.com
               cmux browser --surface surface:1 snapshot --interactive
+            """
+        case "sim", "simulator":
+            return """
+            Usage: cmux sim [list|open|boot|shutdown] [options]
+
+            Manage Apple simulators through the running cmux app.
+            With no subcommand, opens an interactive TUI when stdin/stdout are TTYs;
+            otherwise falls back to plain list output.
+
+            Subcommands:
+              list [--json]
+              open [--udid <udid>] [--direction right|down|left|up] [--workspace <ref>] [--surface <ref>] [--window <ref>]
+              boot <udid>
+              shutdown <udid>
+
+            Examples:
+              cmux sim
+              cmux sim list
+              cmux sim open --udid 12345678-90AB-CDEF-1234-567890ABCDEF --direction down
             """
         // Legacy browser aliases — point users to `cmux browser --help`
         case "open-browser":
@@ -20368,6 +20634,7 @@ export default CMUXSessionRestore;
           version
           capabilities
           auth <status|login|logout>
+          sim [list|open|boot|shutdown]              (alias: simulator)
           vm <new|ls|rm|exec|shell|ssh> [args...]    (alias: cloud)
           rpc <method> [json-params]
           identify [--workspace <id|ref|index>] [--surface <id|ref|index>] [--no-caller]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */; };
 		5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */ = {isa = PBXBuildFile; productRef = 29813FE5A6CBC1019289A251 /* CMUXAuthCore */; };
 		AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */ = {isa = PBXBuildFile; productRef = AA11BB22CC33DD44EE550002 /* CMUXWorkstream */; };
+		C5A1D001A1B2C3D4E5F60718 /* CMUXSimulator in Frameworks */ = {isa = PBXBuildFile; productRef = C5A1D003A1B2C3D4E5F60718 /* CMUXSimulator */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
 		FEED0000000000000000F005 /* FeedPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F004 /* FeedPanelView.swift */; };
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
@@ -649,6 +650,7 @@
 				A5001290 /* MarkdownUI in Frameworks */,
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
 				AA11BB22CC33DD44EE550001 /* CMUXWorkstream in Frameworks */,
+				C5A1D001A1B2C3D4E5F60718 /* CMUXSimulator in Frameworks */,
 				F20F85FC5900550685FA33AD /* StackAuth in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1072,6 +1074,7 @@
 				A5001291 /* MarkdownUI */,
 				29813FE5A6CBC1019289A251 /* CMUXAuthCore */,
 				AA11BB22CC33DD44EE550002 /* CMUXWorkstream */,
+				C5A1D003A1B2C3D4E5F60718 /* CMUXSimulator */,
 				A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */,
 				A8BD195031FC4B82B4354297 /* StackAuth */,
 			);
@@ -1195,6 +1198,7 @@
 				A5001260 /* XCLocalSwiftPackageReference "bonsplit" */,
 				40B63BB4A170F0BD2D1DEFD1 /* XCLocalSwiftPackageReference "CMUXAuthCore" */,
 				AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */,
+				C5A1D002A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXSimulator" */,
 				A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */,
 				28B798BB9086C8E6B60C3355 /* XCLocalSwiftPackageReference "stack-auth-swift-sdk-prerelease" */,
 			);
@@ -1964,6 +1968,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXWorkstream;
 		};
+		C5A1D002A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXSimulator" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/CMUXSimulator;
+		};
 		A500D012A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXDebugLog" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/CMUXDebugLog;
@@ -2019,6 +2027,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA11BB22CC33DD44EE550003 /* XCLocalSwiftPackageReference "CMUXWorkstream" */;
 			productName = CMUXWorkstream;
+		};
+		C5A1D003A1B2C3D4E5F60718 /* CMUXSimulator */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C5A1D002A1B2C3D4E5F60718 /* XCLocalSwiftPackageReference "CMUXSimulator" */;
+			productName = CMUXSimulator;
 		};
 		A500D013A1B2C3D4E5F60718 /* CMUXDebugLog */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Packages/CMUXSimulator/Package.swift
+++ b/Packages/CMUXSimulator/Package.swift
@@ -1,0 +1,26 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "CMUXSimulator",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .library(name: "CMUXSimulator", targets: ["CMUXSimulator"])
+    ],
+    targets: [
+        .target(
+            name: "CMUXSimulator",
+            linkerSettings: [
+                .linkedFramework("AppKit"),
+                .linkedFramework("IOSurface"),
+                .linkedFramework("QuartzCore")
+            ]
+        ),
+        .testTarget(
+            name: "CMUXSimulatorTests",
+            dependencies: ["CMUXSimulator"]
+        )
+    ]
+)

--- a/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorHIDInput.swift
+++ b/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorHIDInput.swift
@@ -1,0 +1,287 @@
+import Foundation
+import ObjectiveC
+
+final class CMUXSimulatorHIDInput: @unchecked Sendable {
+    private let device: NSObject
+    private let simulatorKitPath: String
+    private let lock = NSLock()
+
+    private var client: AnyObject?
+    private var mouseFunction: MouseFunction?
+    private var buttonFunction: ButtonFunction?
+    private var scrollFunction: ScrollFunction?
+    private var createPointerService: ServiceFunction?
+    private var createMouseService: ServiceFunction?
+    private var removePointerService: ServiceFunction?
+
+    private typealias MouseFunction = @convention(c) (
+        UnsafePointer<CGPoint>,
+        UnsafePointer<CGPoint>?,
+        UInt32,
+        UInt32,
+        UInt32,
+        Double,
+        Double,
+        Double,
+        Double
+    ) -> UnsafeMutableRawPointer?
+    private typealias ButtonFunction = @convention(c) (UInt32, UInt32, UInt32) -> UnsafeMutableRawPointer?
+    private typealias ScrollFunction = @convention(c) (UInt32, Double, Double, Double) -> UnsafeMutableRawPointer?
+    private typealias ServiceFunction = @convention(c) () -> UnsafeMutableRawPointer?
+
+    private enum Wire {
+        static let touchDigitizer: UInt32 = 0x32
+        static let buttonTarget: UInt32 = 0x33
+        static let nsEventDown: UInt32 = 1
+        static let nsEventUp: UInt32 = 2
+        static let nsEventMoved: UInt32 = 5
+        static let nsEventDragged: UInt32 = 6
+        static let directionDown: UInt32 = 1
+        static let directionMove: UInt32 = 0
+        static let directionUp: UInt32 = 2
+    }
+
+    init(device: NSObject, simulatorKitPath: String) {
+        self.device = device
+        self.simulatorKitPath = simulatorKitPath
+    }
+
+    deinit {
+        if let client, let removePointerService, let message = removePointerService() {
+            send(message: message, to: client)
+        }
+    }
+
+    func sendHover(at point: CMUXSimulatorPoint, size: CMUXSimulatorSize) throws -> Bool {
+        try sendTouch(phase: .hover, first: point, second: nil, size: size)
+    }
+
+    func sendTouch(
+        phase: CMUXSimulatorTouchPhase,
+        first: CMUXSimulatorPoint,
+        second: CMUXSimulatorPoint?,
+        size: CMUXSimulatorSize
+    ) throws -> Bool {
+        guard let client = try ensureClient() else { return false }
+        let event = mouseEvent(for: phase)
+        return sendMouse(
+            client: client,
+            first: first,
+            second: second,
+            eventType: event.type,
+            direction: event.direction,
+            size: size
+        )
+    }
+
+    func sendScroll(deltaX: Double, deltaY: Double) throws -> Bool {
+        guard let client = try ensureClient(), let scrollFunction else { return false }
+        guard let message = scrollFunction(Wire.touchDigitizer, deltaX, deltaY, 0) else { return false }
+        send(message: message, to: client)
+        return true
+    }
+
+    func sendButton(_ action: CMUXSimulatorHardwareAction) throws -> Bool {
+        guard let client = try ensureClient(), let buttonFunction else { return false }
+        guard let codes = buttonCodes(for: action) else {
+            throw CMUXSimulatorError.actionUnsupported("\(action.displayName) is not supported by SimulatorKit HID.")
+        }
+        guard let down = buttonFunction(codes.button, Wire.directionDown, codes.target) else { return false }
+        send(message: down, to: client)
+        guard let up = buttonFunction(codes.button, Wire.directionUp, codes.target) else { return false }
+        send(message: up, to: client)
+        return true
+    }
+
+    private func mouseEvent(for phase: CMUXSimulatorTouchPhase) -> (type: UInt32, direction: UInt32) {
+        switch phase {
+        case .down:
+            return (Wire.nsEventDown, Wire.directionDown)
+        case .move:
+            return (Wire.nsEventDragged, Wire.directionMove)
+        case .up:
+            return (Wire.nsEventUp, Wire.directionUp)
+        case .hover:
+            return (Wire.nsEventMoved, Wire.directionMove)
+        }
+    }
+
+    private func buttonCodes(for action: CMUXSimulatorHardwareAction) -> (button: UInt32, target: UInt32)? {
+        switch action {
+        case .home:
+            return (0x0, Wire.buttonTarget)
+        case .lock:
+            return (0x1, Wire.buttonTarget)
+        case .volumeUp, .volumeDown, .screenshot, .rotateLeft, .rotateRight, .shake:
+            return nil
+        }
+    }
+
+    private func sendMouse(
+        client: AnyObject,
+        first: CMUXSimulatorPoint,
+        second: CMUXSimulatorPoint?,
+        eventType: UInt32,
+        direction: UInt32,
+        size: CMUXSimulatorSize
+    ) -> Bool {
+        guard let mouseFunction,
+              size.width > 0,
+              size.height > 0 else {
+            return false
+        }
+
+        var firstPoint = CGPoint(
+            x: clamp(first.x / size.width),
+            y: clamp(first.y / size.height)
+        )
+
+        let message: UnsafeMutableRawPointer?
+        if let second {
+            var secondPoint = CGPoint(
+                x: clamp(second.x / size.width),
+                y: clamp(second.y / size.height)
+            )
+            message = withUnsafePointer(to: &firstPoint) { firstPointer in
+                withUnsafePointer(to: &secondPoint) { secondPointer in
+                    mouseFunction(
+                        firstPointer,
+                        secondPointer,
+                        Wire.touchDigitizer,
+                        eventType,
+                        direction,
+                        1.0,
+                        1.0,
+                        size.width,
+                        size.height
+                    )
+                }
+            }
+        } else {
+            message = withUnsafePointer(to: &firstPoint) { firstPointer in
+                mouseFunction(
+                    firstPointer,
+                    nil,
+                    Wire.touchDigitizer,
+                    eventType,
+                    direction,
+                    1.0,
+                    1.0,
+                    size.width,
+                    size.height
+                )
+            }
+        }
+
+        guard let message else { return false }
+        send(message: message, to: client)
+        return true
+    }
+
+    private func ensureClient() throws -> AnyObject? {
+        lock.lock()
+        defer { lock.unlock() }
+        if let client { return client }
+
+        resolveFunctions()
+        guard mouseFunction != nil else {
+            throw CMUXSimulatorError.inputUnavailable("SimulatorKit mouse HID function is unavailable.")
+        }
+        guard let clientClass = CMUXSimulatorRuntime.findHIDClientClass() else {
+            throw CMUXSimulatorError.inputUnavailable("SimulatorKit HID client class is unavailable.")
+        }
+
+        let allocateSelector = NSSelectorFromString("alloc")
+        guard let metaClass = object_getClass(clientClass),
+              let allocateImplementation = class_getMethodImplementation(metaClass, allocateSelector) else {
+            throw CMUXSimulatorError.inputUnavailable("SimulatorKit HID client cannot be allocated.")
+        }
+
+        typealias AllocateFunction = @convention(c) (AnyClass, Selector) -> AnyObject?
+        guard let allocated = unsafeBitCast(allocateImplementation, to: AllocateFunction.self)(
+            clientClass,
+            allocateSelector
+        ) else {
+            throw CMUXSimulatorError.inputUnavailable("SimulatorKit HID client allocation failed.")
+        }
+
+        let initSelector = NSSelectorFromString("initWithDevice:error:")
+        guard let initImplementation = class_getMethodImplementation(clientClass, initSelector) else {
+            throw CMUXSimulatorError.inputUnavailable("SimulatorKit HID client initializer is unavailable.")
+        }
+
+        typealias InitFunction = @convention(c) (
+            AnyObject,
+            Selector,
+            AnyObject,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> AnyObject?
+
+        var error: NSError?
+        guard let initialized = unsafeBitCast(initImplementation, to: InitFunction.self)(
+            allocated,
+            initSelector,
+            device,
+            &error
+        ) else {
+            throw CMUXSimulatorError.inputUnavailable(error?.localizedDescription ?? "SimulatorKit HID client initialization failed.")
+        }
+
+        client = initialized
+        warmServices(on: initialized)
+        return initialized
+    }
+
+    private func resolveFunctions() {
+        guard mouseFunction == nil else { return }
+        guard let handle = dlopen(simulatorKitPath, RTLD_NOW | RTLD_GLOBAL) else { return }
+        mouseFunction = dlsym(handle, "IndigoHIDMessageForMouseNSEvent").map {
+            unsafeBitCast($0, to: MouseFunction.self)
+        }
+        buttonFunction = dlsym(handle, "IndigoHIDMessageForButton").map {
+            unsafeBitCast($0, to: ButtonFunction.self)
+        }
+        scrollFunction = dlsym(handle, "IndigoHIDMessageForScrollEvent").map {
+            unsafeBitCast($0, to: ScrollFunction.self)
+        }
+        createPointerService = dlsym(handle, "IndigoHIDMessageToCreatePointerService").map {
+            unsafeBitCast($0, to: ServiceFunction.self)
+        }
+        createMouseService = dlsym(handle, "IndigoHIDMessageToCreateMouseService").map {
+            unsafeBitCast($0, to: ServiceFunction.self)
+        }
+        removePointerService = dlsym(handle, "IndigoHIDMessageToRemovePointerService").map {
+            unsafeBitCast($0, to: ServiceFunction.self)
+        }
+    }
+
+    private func warmServices(on client: AnyObject) {
+        if let createPointerService, let message = createPointerService() {
+            send(message: message, to: client)
+        }
+        if let createMouseService, let message = createMouseService() {
+            send(message: message, to: client)
+        }
+    }
+
+    private func send(message: UnsafeMutableRawPointer, to client: AnyObject) {
+        let selector = NSSelectorFromString("sendWithMessage:freeWhenDone:completionQueue:completion:")
+        guard let clientClass = object_getClass(client),
+              let implementation = class_getMethodImplementation(clientClass, selector) else {
+            return
+        }
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            UnsafeMutableRawPointer,
+            ObjCBool,
+            AnyObject?,
+            AnyObject?
+        ) -> Void
+        unsafeBitCast(implementation, to: Function.self)(client, selector, message, true, nil, nil)
+    }
+
+    private func clamp(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+}

--- a/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorRuntime.swift
+++ b/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorRuntime.swift
@@ -1,0 +1,555 @@
+import Darwin
+import AppKit
+import Foundation
+import ObjectiveC
+
+public final class CMUXSimulatorRuntime: @unchecked Sendable {
+    public static let shared = CMUXSimulatorRuntime()
+    public static let minimumXcodeMajor = 26
+
+    private let deviceSetPath: String?
+    private let inputLock = NSLock()
+    private var inputSessions: [String: CMUXSimulatorHIDInput] = [:]
+
+    public init(deviceSetPath: String? = nil) {
+        self.deviceSetPath = deviceSetPath
+    }
+
+    public func listDevices() throws -> [CMUXSimulatorDevice] {
+        try requireCapabilities()
+        guard let set = resolveDeviceSet() else {
+            throw CMUXSimulatorError.capabilityUnavailable("CoreSimulator device set is unavailable.")
+        }
+        return availableDevices(in: set).map(deviceSummary)
+            .sorted { lhs, rhs in
+                if lhs.runtime != rhs.runtime { return lhs.runtime < rhs.runtime }
+                return lhs.name < rhs.name
+            }
+    }
+
+    public func device(udid: String) throws -> CMUXSimulatorDevice {
+        guard let device = try resolveDevice(udid: udid) else {
+            throw CMUXSimulatorError.deviceNotFound(udid)
+        }
+        return deviceSummary(from: device)
+    }
+
+    public func boot(udid: String) throws {
+        guard let device = try resolveDevice(udid: udid) else {
+            throw CMUXSimulatorError.deviceNotFound(udid)
+        }
+
+        let bootWithOptions = NSSelectorFromString("bootWithOptions:error:")
+        if device.responds(to: bootWithOptions) {
+            var error: NSError?
+            let options: NSDictionary = ["persist": true]
+            if Self.invokeBoolWithObjectAndError(device, bootWithOptions, options, &error) {
+                return
+            }
+        }
+
+        let boot = NSSelectorFromString("bootWithError:")
+        if device.responds(to: boot) {
+            var error: NSError?
+            if Self.invokeBoolWithError(device, boot, &error) {
+                return
+            }
+        }
+
+        throw CMUXSimulatorError.bootFailed("Failed to boot simulator \(udid).")
+    }
+
+    public func shutdown(udid: String) throws {
+        guard let device = try resolveDevice(udid: udid) else {
+            throw CMUXSimulatorError.deviceNotFound(udid)
+        }
+        let shutdown = NSSelectorFromString("shutdownWithError:")
+        guard device.responds(to: shutdown) else {
+            throw CMUXSimulatorError.shutdownFailed("CoreSimulator does not expose shutdownWithError:.")
+        }
+        var error: NSError?
+        guard Self.invokeBoolWithError(device, shutdown, &error) else {
+            throw CMUXSimulatorError.shutdownFailed(error?.localizedDescription ?? "Failed to shut down simulator \(udid).")
+        }
+    }
+
+    public func screenStream(udid: String) throws -> CMUXSimulatorScreenStream {
+        guard let device = try resolveDevice(udid: udid) else {
+            throw CMUXSimulatorError.deviceNotFound(udid)
+        }
+        return CMUXSimulatorScreenStream(device: device)
+    }
+
+    public func performHardwareAction(_ action: CMUXSimulatorHardwareAction, udid: String) throws -> Bool {
+        switch action {
+        case .home, .lock:
+            return try inputSession(udid: udid).sendButton(action)
+        case .screenshot:
+            let destination = FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent("Desktop", isDirectory: true)
+                .appendingPathComponent("cmux-simulator-\(udid.prefix(8)).png")
+            try runSimctl(["io", udid, "screenshot", destination.path])
+            return true
+        case .shake:
+            try runSimctl(["spawn", udid, "notifyutil", "-p", "com.apple.UIKit.SimulatorShake"])
+            return true
+        case .volumeUp, .volumeDown, .rotateLeft, .rotateRight:
+            throw CMUXSimulatorError.actionUnsupported("\(action.displayName) is not available through this SimulatorKit bridge yet.")
+        }
+    }
+
+    public func openInSimulatorApp(udid: String) throws {
+        try Self.runProcess(
+            executable: "/usr/bin/open",
+            arguments: ["-a", "Simulator", "--args", "-CurrentDeviceUDID", udid]
+        )
+    }
+
+    public func revealDeviceContainer(udid: String) {
+        let url = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Developer/CoreSimulator/Devices", isDirectory: true)
+            .appendingPathComponent(udid, isDirectory: true)
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    public func installOrCopyFile(_ url: URL, udid: String) throws {
+        let path = url.path
+        let ext = url.pathExtension.lowercased()
+        if ext == "app" {
+            try runSimctl(["install", udid, path])
+            if let bundleID = Self.bundleIdentifier(in: url) {
+                try runSimctl(["launch", udid, bundleID])
+            }
+            return
+        }
+        if ["png", "jpg", "jpeg", "heic", "mov", "mp4", "m4v"].contains(ext) {
+            try runSimctl(["addmedia", udid, path])
+            return
+        }
+        if ext == "mobileconfig" {
+            try runSimctl(["openurl", udid, url.absoluteString])
+            return
+        }
+        throw CMUXSimulatorError.actionUnsupported("Unsupported simulator drop: \(url.lastPathComponent)")
+    }
+
+    func inputSession(udid: String) throws -> CMUXSimulatorHIDInput {
+        inputLock.lock()
+        defer { inputLock.unlock() }
+        if let session = inputSessions[udid] {
+            return session
+        }
+        guard let device = try resolveDevice(udid: udid) else {
+            throw CMUXSimulatorError.deviceNotFound(udid)
+        }
+        let session = CMUXSimulatorHIDInput(device: device, simulatorKitPath: Self.simulatorKitPath())
+        inputSessions[udid] = session
+        return session
+    }
+
+    func resolveDevice(udid: String) throws -> NSObject? {
+        try requireCapabilities()
+        guard let set = resolveDeviceSet() else { return nil }
+        return availableDevices(in: set).first { device in
+            ((device.value(forKey: "UDID") as? NSUUID)?.uuidString ?? "") == udid
+        }
+    }
+
+    public static func probeCapabilities() -> CMUXSimulatorCapabilityReport {
+        var failures: [String] = []
+        let developerDir = developerDirectory()
+        let xcodeMajor = xcodeMajorVersion()
+        if let xcodeMajor {
+            if xcodeMajor < minimumXcodeMajor {
+                failures.append("Xcode \(minimumXcodeMajor)+ is required for SimulatorKit preview HID; found Xcode \(xcodeMajor).")
+            }
+        } else {
+            failures.append("Unable to determine the active Xcode version.")
+        }
+
+        failures.append(contentsOf: loadFrameworks())
+
+        if NSClassFromString("SimServiceContext") == nil {
+            failures.append("CoreSimulator class SimServiceContext is unavailable.")
+        }
+        if NSClassFromString("_TtC12SimulatorKit24SimDeviceLegacyHIDClient") == nil,
+           findHIDClientClass() == nil {
+            failures.append("SimulatorKit HID client class is unavailable.")
+        }
+
+        if let handle = dlopen(simulatorKitPath(), RTLD_NOW | RTLD_GLOBAL) {
+            for symbol in [
+                "IndigoHIDMessageForMouseNSEvent",
+                "IndigoHIDMessageForButton",
+                "IndigoHIDMessageForScrollEvent"
+            ] where dlsym(handle, symbol) == nil {
+                failures.append("SimulatorKit symbol \(symbol) is unavailable.")
+            }
+        }
+
+        return CMUXSimulatorCapabilityReport(
+            xcodeMajorVersion: xcodeMajor,
+            minimumXcodeMajorVersion: minimumXcodeMajor,
+            developerDirectory: developerDir,
+            failures: failures
+        )
+    }
+
+    private func requireCapabilities() throws {
+        let report = Self.probeCapabilities()
+        guard report.isUsable else {
+            throw CMUXSimulatorError.capabilityUnavailable(report.failureSummary ?? "Simulator runtime is unavailable.")
+        }
+    }
+
+    private func resolveDeviceSet() -> NSObject? {
+        guard let contextClass = NSClassFromString("SimServiceContext") else {
+            return nil
+        }
+        let contextSelector = NSSelectorFromString("sharedServiceContextForDeveloperDir:error:")
+        var contextError: NSError?
+        guard let context = Self.invokeClassObjectWithObjectAndError(
+            contextClass,
+            contextSelector,
+            Self.developerDirectory() as NSString,
+            &contextError
+        ) else {
+            return nil
+        }
+
+        if let deviceSetPath,
+           let custom = customDeviceSet(context: context, path: deviceSetPath) {
+            return custom
+        }
+
+        let defaultSet = NSSelectorFromString("defaultDeviceSetWithError:")
+        var setError: NSError?
+        return Self.invokeObjectWithError(context, defaultSet, &setError)
+    }
+
+    private func customDeviceSet(context: NSObject, path: String) -> NSObject? {
+        let selector = NSSelectorFromString("deviceSetWithPath:error:")
+        guard context.responds(to: selector) else { return nil }
+        let candidates = [path, (path as NSString).appendingPathComponent("Devices")]
+        for candidate in candidates where Self.isDirectory(candidate) {
+            var error: NSError?
+            if let set = Self.invokeObjectWithObjectAndError(context, selector, candidate as NSString, &error),
+               !availableDevices(in: set).isEmpty {
+                return set
+            }
+        }
+        return nil
+    }
+
+    private func availableDevices(in set: NSObject) -> [NSObject] {
+        (set.value(forKey: "availableDevices") as? [NSObject]) ?? []
+    }
+
+    private func deviceSummary(from device: NSObject) -> CMUXSimulatorDevice {
+        let udid = (device.value(forKey: "UDID") as? NSUUID)?.uuidString ?? ""
+        let name = (device.value(forKey: "name") as? String) ?? "Unknown"
+        let rawState = (device.value(forKey: "state") as? NSNumber)?.uintValue ?? UInt.max
+        let runtime = (device.value(forKey: "runtime") as? NSObject).flatMap { runtime in
+            (runtime.value(forKey: "name") as? String) ??
+                (runtime.value(forKey: "versionString") as? String) ??
+                (runtime.value(forKey: "identifier") as? String)
+        } ?? ""
+
+        let deviceType = device.value(forKey: "deviceType") as? NSObject
+        let pointsValue = deviceType?.value(forKey: "mainScreenSize") as? NSValue
+        let pointSize = pointsValue?.sizeValue ?? .zero
+        let scale = (deviceType?.value(forKey: "mainScreenScale") as? NSNumber)?.doubleValue ?? 0
+        let pixelSize = scale > 0
+            ? CMUXSimulatorSize(width: pointSize.width * scale, height: pointSize.height * scale)
+            : .zero
+
+        return CMUXSimulatorDevice(
+            udid: udid,
+            name: name,
+            state: Self.state(rawState),
+            runtime: runtime,
+            screenSizePoints: CMUXSimulatorSize(width: pointSize.width, height: pointSize.height),
+            screenSizePixels: pixelSize
+        )
+    }
+
+    private static func state(_ raw: UInt) -> CMUXSimulatorState {
+        switch raw {
+        case 0: return .creating
+        case 1: return .shutdown
+        case 2: return .booting
+        case 3: return .booted
+        case 4: return .shuttingDown
+        default: return .unknown
+        }
+    }
+
+    private static func bundleIdentifier(in appURL: URL) -> String? {
+        guard let bundle = Bundle(url: appURL) else { return nil }
+        return bundle.bundleIdentifier
+    }
+
+    private func runSimctl(_ arguments: [String]) throws {
+        try Self.runProcess(executable: "/usr/bin/xcrun", arguments: ["simctl"] + arguments)
+    }
+
+    private static func runProcess(executable: String, arguments: [String]) throws {
+        let process = Process()
+        let stderr = Pipe()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardError = stderr
+        do {
+            try process.run()
+        } catch {
+            throw CMUXSimulatorError.processFailed(error.localizedDescription)
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let data = stderr.fileHandleForReading.readDataToEndOfFile()
+            let message = String(data: data, encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            throw CMUXSimulatorError.processFailed(message ?? "\(executable) exited \(process.terminationStatus)")
+        }
+    }
+}
+
+extension CMUXSimulatorRuntime {
+    nonisolated(unsafe) private static var frameworkLoadLock = NSLock()
+    nonisolated(unsafe) private static var frameworkLoadFailures: [String]?
+
+    static func loadFrameworks() -> [String] {
+        frameworkLoadLock.lock()
+        defer { frameworkLoadLock.unlock() }
+        if let frameworkLoadFailures {
+            return frameworkLoadFailures
+        }
+
+        var failures: [String] = []
+        for path in coreSimulatorPaths() where FileManager.default.fileExists(atPath: path) {
+            if dlopen(path, RTLD_NOW | RTLD_GLOBAL) != nil {
+                break
+            }
+        }
+        if NSClassFromString("SimServiceContext") == nil {
+            failures.append("Failed to load CoreSimulator.framework: \(dlerrorDescription()).")
+        }
+
+        let simulatorKit = simulatorKitPath()
+        if dlopen(simulatorKit, RTLD_NOW | RTLD_GLOBAL) == nil {
+            failures.append("Failed to load SimulatorKit.framework at \(simulatorKit): \(dlerrorDescription()).")
+        }
+
+        frameworkLoadFailures = failures
+        return failures
+    }
+
+    static func developerDirectory() -> String {
+        if let selected = xcodeSelectDeveloperDirectory(), hasSimulatorKit(at: selected) {
+            return selected
+        }
+        let canonical = "/Applications/Xcode.app/Contents/Developer"
+        if hasSimulatorKit(at: canonical) {
+            return canonical
+        }
+        let applications = (try? FileManager.default.contentsOfDirectory(atPath: "/Applications")) ?? []
+        for app in applications.sorted()
+        where app.hasPrefix("Xcode") && app.hasSuffix(".app") {
+            let developer = "/Applications/\(app)/Contents/Developer"
+            if hasSimulatorKit(at: developer) {
+                return developer
+            }
+        }
+        return selectedDeveloperDirectoryFallback()
+    }
+
+    static func simulatorKitPath() -> String {
+        (developerDirectory() as NSString)
+            .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
+    }
+
+    static func findHIDClientClass() -> AnyClass? {
+        if let canonical = NSClassFromString("_TtC12SimulatorKit24SimDeviceLegacyHIDClient") {
+            return canonical
+        }
+
+        let selector = NSSelectorFromString("initWithDevice:error:")
+        let expectedSuffixes = [
+            "SimDeviceLegacyHIDClient",
+            "HIDClient"
+        ]
+
+        let count = objc_getClassList(nil, 0)
+        guard count > 0 else { return nil }
+        let classes = UnsafeMutablePointer<AnyClass?>.allocate(capacity: Int(count))
+        defer { classes.deallocate() }
+        let actualCount = objc_getClassList(AutoreleasingUnsafeMutablePointer(classes), count)
+        guard actualCount > 0 else { return nil }
+
+        for index in 0..<Int(actualCount) {
+            guard let candidate = classes[index] else { continue }
+            let name = NSStringFromClass(candidate)
+            guard expectedSuffixes.contains(where: { name.hasSuffix($0) }) else { continue }
+            if class_getInstanceMethod(candidate, selector) != nil {
+                return candidate
+            }
+        }
+        return nil
+    }
+
+    private static func coreSimulatorPaths() -> [String] {
+        [
+            "/Library/Developer/PrivateFrameworks/CoreSimulator.framework/CoreSimulator",
+            (developerDirectory() as NSString)
+                .appendingPathComponent("Library/PrivateFrameworks/CoreSimulator.framework/CoreSimulator")
+        ]
+    }
+
+    private static func xcodeSelectDeveloperDirectory() -> String? {
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcode-select")
+        process.arguments = ["-p"]
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        return String(data: data, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .nilIfEmpty
+    }
+
+    private static func selectedDeveloperDirectoryFallback() -> String {
+        xcodeSelectDeveloperDirectory() ?? "/Applications/Xcode.app/Contents/Developer"
+    }
+
+    private static func hasSimulatorKit(at developerDirectory: String) -> Bool {
+        let path = (developerDirectory as NSString)
+            .appendingPathComponent("Library/PrivateFrameworks/SimulatorKit.framework/SimulatorKit")
+        return FileManager.default.fileExists(atPath: path)
+    }
+
+    private static func xcodeMajorVersion() -> Int? {
+        let process = Process()
+        let stdout = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/xcodebuild")
+        process.arguments = ["-version"]
+        process.standardOutput = stdout
+        process.standardError = Pipe()
+        do {
+            try process.run()
+        } catch {
+            return nil
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else { return nil }
+        let data = stdout.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8) ?? ""
+        let firstLine = output.split(separator: "\n").first ?? ""
+        let components = firstLine.split(separator: " ")
+        guard components.count >= 2 else { return nil }
+        let version = components[1].split(separator: ".").first.map(String.init)
+        return version.flatMap(Int.init)
+    }
+
+    private static func isDirectory(_ path: String) -> Bool {
+        var isDirectory: ObjCBool = false
+        return FileManager.default.fileExists(atPath: path, isDirectory: &isDirectory) && isDirectory.boolValue
+    }
+
+    static func dlerrorDescription() -> String {
+        guard let error = dlerror() else { return "unknown dlopen error" }
+        return String(cString: error)
+    }
+
+    static func invokeBoolWithError(_ target: NSObject, _ selector: Selector, _ error: inout NSError?) -> Bool {
+        guard let implementation = class_getMethodImplementation(type(of: target), selector) else {
+            return false
+        }
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> Bool
+        return unsafeBitCast(implementation, to: Function.self)(target, selector, &error)
+    }
+
+    static func invokeBoolWithObjectAndError(
+        _ target: NSObject,
+        _ selector: Selector,
+        _ object: AnyObject,
+        _ error: inout NSError?
+    ) -> Bool {
+        guard let implementation = class_getMethodImplementation(type(of: target), selector) else {
+            return false
+        }
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            AnyObject,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> Bool
+        return unsafeBitCast(implementation, to: Function.self)(target, selector, object, &error)
+    }
+
+    static func invokeObjectWithError(_ target: NSObject, _ selector: Selector, _ error: inout NSError?) -> NSObject? {
+        guard let implementation = class_getMethodImplementation(type(of: target), selector) else {
+            return nil
+        }
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> AnyObject?
+        return unsafeBitCast(implementation, to: Function.self)(target, selector, &error) as? NSObject
+    }
+
+    static func invokeObjectWithObjectAndError(
+        _ target: NSObject,
+        _ selector: Selector,
+        _ object: AnyObject,
+        _ error: inout NSError?
+    ) -> NSObject? {
+        guard let implementation = class_getMethodImplementation(type(of: target), selector) else {
+            return nil
+        }
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            AnyObject,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> AnyObject?
+        return unsafeBitCast(implementation, to: Function.self)(target, selector, object, &error) as? NSObject
+    }
+
+    static func invokeClassObjectWithObjectAndError(
+        _ target: AnyClass,
+        _ selector: Selector,
+        _ object: AnyObject,
+        _ error: inout NSError?
+    ) -> NSObject? {
+        guard let metaClass = object_getClass(target),
+              let implementation = class_getMethodImplementation(metaClass, selector) else {
+            return nil
+        }
+        typealias Function = @convention(c) (
+            AnyClass,
+            Selector,
+            AnyObject,
+            AutoreleasingUnsafeMutablePointer<NSError?>
+        ) -> AnyObject?
+        return unsafeBitCast(implementation, to: Function.self)(target, selector, object, &error) as? NSObject
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorScreenStream.swift
+++ b/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorScreenStream.swift
@@ -1,0 +1,144 @@
+import Foundation
+import IOSurface
+import ObjectiveC
+
+public final class CMUXSimulatorScreenStream: @unchecked Sendable {
+    private let device: NSObject
+    private let callbackQueue = DispatchQueue(label: "com.cmux.simulator.screen", qos: .userInteractive)
+    private var ioClient: NSObject?
+    private var descriptors: [NSObject] = []
+    private var callbackIDs: [ObjectIdentifier: NSUUID] = [:]
+    private var frameHandler: ((IOSurface) -> Void)?
+
+    init(device: NSObject) {
+        self.device = device
+    }
+
+    deinit {
+        stop()
+    }
+
+    public func start(onFrame: @escaping (IOSurface) -> Void) throws {
+        frameHandler = onFrame
+        guard let io = device.perform(NSSelectorFromString("io"))?.takeUnretainedValue() as? NSObject else {
+            throw CMUXSimulatorError.screenUnavailable("Simulator IO client is unavailable.")
+        }
+        ioClient = io
+        try wireFramebufferCallbacks(ioClient: io)
+    }
+
+    public func stop() {
+        let selector = NSSelectorFromString("unregisterScreenCallbacksWithUUID:")
+        for descriptor in descriptors {
+            guard let uuid = callbackIDs[ObjectIdentifier(descriptor)],
+                  descriptor.responds(to: selector) else {
+                continue
+            }
+            descriptor.perform(selector, with: uuid)
+        }
+        descriptors.removeAll()
+        callbackIDs.removeAll()
+        ioClient = nil
+        frameHandler = nil
+    }
+
+    private func wireFramebufferCallbacks(ioClient: NSObject) throws {
+        ioClient.perform(NSSelectorFromString("updateIOPorts"))
+        guard let ports = ioClient.value(forKey: "deviceIOPorts") as? [NSObject] else {
+            throw CMUXSimulatorError.screenUnavailable("SimulatorKit returned no IO ports.")
+        }
+
+        let portIdentifier = NSSelectorFromString("portIdentifier")
+        let descriptorSelector = NSSelectorFromString("descriptor")
+        let framebufferSurface = NSSelectorFromString("framebufferSurface")
+        let candidates = ports.compactMap { port -> NSObject? in
+            guard port.responds(to: portIdentifier),
+                  let identifier = port.perform(portIdentifier)?.takeUnretainedValue(),
+                  "\(identifier)" == "com.apple.framebuffer.display",
+                  port.responds(to: descriptorSelector),
+                  let descriptor = port.perform(descriptorSelector)?.takeUnretainedValue() as? NSObject,
+                  descriptor.responds(to: framebufferSurface) else {
+                return nil
+            }
+            return descriptor
+        }
+
+        guard !candidates.isEmpty else {
+            throw CMUXSimulatorError.screenUnavailable("No framebuffer display descriptor is available.")
+        }
+
+        descriptors = candidates
+        for descriptor in candidates {
+            try registerCallbacks(on: descriptor)
+        }
+        captureLatest()
+    }
+
+    private func registerCallbacks(on descriptor: NSObject) throws {
+        let selector = NSSelectorFromString(
+            "registerScreenCallbacksWithUUID:callbackQueue:frameCallback:" +
+            "surfacesChangedCallback:propertiesChangedCallback:"
+        )
+        guard descriptor.responds(to: selector),
+              let implementation = class_getMethodImplementation(type(of: descriptor), selector) else {
+            throw CMUXSimulatorError.screenUnavailable("Framebuffer callbacks are unavailable.")
+        }
+
+        let uuid = NSUUID()
+        callbackIDs[ObjectIdentifier(descriptor)] = uuid
+
+        let frameCallback: @convention(block) () -> Void = { [weak self] in
+            self?.callbackQueue.async {
+                self?.captureLatest()
+            }
+        }
+        let surfacesChangedCallback: @convention(block) () -> Void = { [weak self] in
+            self?.callbackQueue.async {
+                self?.captureLatest()
+            }
+        }
+        let propertiesChangedCallback: @convention(block) () -> Void = {}
+
+        typealias Function = @convention(c) (
+            AnyObject,
+            Selector,
+            AnyObject,
+            AnyObject,
+            AnyObject,
+            AnyObject,
+            AnyObject
+        ) -> Void
+
+        unsafeBitCast(implementation, to: Function.self)(
+            descriptor,
+            selector,
+            uuid,
+            callbackQueue as AnyObject,
+            frameCallback as AnyObject,
+            surfacesChangedCallback as AnyObject,
+            propertiesChangedCallback as AnyObject
+        )
+    }
+
+    private func captureLatest() {
+        let selector = NSSelectorFromString("framebufferSurface")
+        var bestSurface: IOSurface?
+        var bestArea = 0
+
+        for descriptor in descriptors {
+            guard let surfaceObject = descriptor.perform(selector)?.takeUnretainedValue() else {
+                continue
+            }
+            let surface = unsafeBitCast(surfaceObject, to: IOSurface.self)
+            let area = IOSurfaceGetWidth(surface) * IOSurfaceGetHeight(surface)
+            if area > bestArea {
+                bestSurface = surface
+                bestArea = area
+            }
+        }
+
+        if let bestSurface {
+            frameHandler?(bestSurface)
+        }
+    }
+}

--- a/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorViewer.swift
+++ b/Packages/CMUXSimulator/Sources/CMUXSimulator/CMUXSimulatorViewer.swift
@@ -1,0 +1,819 @@
+import AppKit
+import IOSurface
+import QuartzCore
+import SwiftUI
+
+public struct CMUXSimulatorViewer: View {
+    private let runtime: CMUXSimulatorRuntime
+    private let initialUDID: String?
+    private let onDeviceSelected: (CMUXSimulatorDevice) -> Void
+    private let onDetach: (() -> Void)?
+
+    @State private var devices: [CMUXSimulatorDevice] = []
+    @State private var selectedUDID: String?
+    @State private var errorMessage: String?
+    @State private var statusMessage: String?
+    @State private var metrics = CMUXSimulatorFrameMetrics(pixelSize: .zero, fps: 0)
+
+    public init(
+        runtime: CMUXSimulatorRuntime = .shared,
+        initialUDID: String? = nil,
+        onDeviceSelected: @escaping (CMUXSimulatorDevice) -> Void = { _ in },
+        onDetach: (() -> Void)? = nil
+    ) {
+        self.runtime = runtime
+        self.initialUDID = initialUDID
+        self.onDeviceSelected = onDeviceSelected
+        self.onDetach = onDetach
+        _selectedUDID = State(initialValue: initialUDID)
+    }
+
+    public var body: some View {
+        ZStack {
+            Color(nsColor: .black)
+            if let selectedUDID {
+                CMUXSimulatorCanvas(
+                    runtime: runtime,
+                    udid: selectedUDID,
+                    deviceSize: selectedDevice?.screenSizePoints ?? .zero,
+                    onError: { errorMessage = $0 },
+                    onStatus: { statusMessage = $0 },
+                    onMetrics: { metrics = $0 }
+                )
+                .overlay(alignment: .topLeading) {
+                    simulatorHUD
+                }
+                .contextMenu {
+                    contextMenuItems
+                }
+            } else {
+                picker
+            }
+
+            if let message = errorMessage {
+                banner(message: message, isError: true)
+            } else if let statusMessage {
+                banner(message: statusMessage, isError: false)
+            }
+        }
+        .task {
+            loadDevices()
+        }
+    }
+
+    private var selectedDevice: CMUXSimulatorDevice? {
+        guard let selectedUDID else { return nil }
+        return devices.first { $0.udid == selectedUDID }
+    }
+
+    private var picker: some View {
+        VStack(spacing: 12) {
+            Text(String(localized: "simulator.picker.title", defaultValue: "Choose a Simulator"))
+                .font(.headline)
+            if devices.isEmpty {
+                Text(String(localized: "simulator.picker.empty", defaultValue: "No simulators found."))
+                    .foregroundStyle(.secondary)
+            } else {
+                ScrollView {
+                    LazyVStack(alignment: .leading, spacing: 6) {
+                        ForEach(groupedDevices, id: \.runtime) { group in
+                            Text(group.runtime.isEmpty ? String(localized: "simulator.runtime.unknown", defaultValue: "Unknown Runtime") : group.runtime)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .padding(.top, 4)
+                            ForEach(group.devices) { device in
+                                Button {
+                                    select(device)
+                                } label: {
+                                    HStack(spacing: 8) {
+                                        Circle()
+                                            .fill(device.isBooted ? Color.green : Color.secondary.opacity(0.45))
+                                            .frame(width: 7, height: 7)
+                                        VStack(alignment: .leading, spacing: 2) {
+                                            Text(device.name)
+                                                .font(.system(size: 13, weight: .medium))
+                                            Text("\(device.state.displayName) · \(device.shortUDID)")
+                                                .font(.caption)
+                                                .foregroundStyle(.secondary)
+                                        }
+                                        Spacer()
+                                    }
+                                    .contentShape(Rectangle())
+                                }
+                                .buttonStyle(.plain)
+                            }
+                        }
+                    }
+                    .padding(12)
+                }
+                .frame(width: 360, height: 340)
+            }
+            Button(String(localized: "simulator.action.refresh", defaultValue: "Refresh")) {
+                loadDevices()
+            }
+        }
+        .padding(22)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var groupedDevices: [(runtime: String, devices: [CMUXSimulatorDevice])] {
+        Dictionary(grouping: devices, by: \.runtime)
+            .map { ($0.key, $0.value.sorted { $0.name < $1.name }) }
+            .sorted { $0.runtime < $1.runtime }
+    }
+
+    private var simulatorHUD: some View {
+        HStack(alignment: .top) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill((selectedDevice?.isBooted ?? false) ? Color.green : Color.secondary)
+                    .frame(width: 7, height: 7)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(selectedDevice?.name ?? String(localized: "simulator.device.loading", defaultValue: "Simulator"))
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(selectedDevice?.runtime ?? "")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+
+            Spacer()
+
+            VStack(spacing: 6) {
+                ForEach(CMUXSimulatorHardwareAction.allCases, id: \.rawValue) { action in
+                    Button {
+                        perform(action)
+                    } label: {
+                        Image(systemName: iconName(for: action))
+                            .frame(width: 24, height: 24)
+                    }
+                    .buttonStyle(.borderless)
+                    .help(localizedActionTitle(action))
+                }
+            }
+            .padding(6)
+            .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+
+            if let onDetach {
+                Button {
+                    onDetach()
+                } label: {
+                    Image(systemName: "xmark")
+                        .frame(width: 24, height: 24)
+                }
+                .buttonStyle(.borderless)
+                .help(String(localized: "simulator.action.detach", defaultValue: "Detach"))
+                .padding(6)
+                .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            metricsView
+                .offset(y: 34)
+        }
+        .padding(10)
+    }
+
+    private var metricsView: some View {
+        let pointSize = selectedDevice?.screenSizePoints ?? .zero
+        let pixelSize = metrics.pixelSize.width > 0 ? metrics.pixelSize : (selectedDevice?.screenSizePixels ?? .zero)
+        return Text(
+            String(
+                format: "%.0f×%.0f pt · %.0f×%.0f px · %.0f fps · Touch",
+                pointSize.width,
+                pointSize.height,
+                pixelSize.width,
+                pixelSize.height,
+                metrics.fps
+            )
+        )
+        .font(.caption2.monospacedDigit())
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 5)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    @ViewBuilder
+    private var contextMenuItems: some View {
+        Button(String(localized: "simulator.action.home", defaultValue: "Home")) { perform(.home) }
+        Button(String(localized: "simulator.action.lock", defaultValue: "Lock")) { perform(.lock) }
+        Button(String(localized: "simulator.action.screenshot", defaultValue: "Screenshot")) { perform(.screenshot) }
+        Button(String(localized: "simulator.action.shake", defaultValue: "Shake")) { perform(.shake) }
+        Divider()
+        Button(String(localized: "simulator.action.openInSimulator", defaultValue: "Open in Simulator.app")) {
+            guard let selectedUDID else { return }
+            do {
+                try runtime.openInSimulatorApp(udid: selectedUDID)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+        Button(String(localized: "simulator.action.revealContainer", defaultValue: "Reveal Container in Finder")) {
+            guard let selectedUDID else { return }
+            runtime.revealDeviceContainer(udid: selectedUDID)
+        }
+        Button(String(localized: "simulator.action.copyUDID", defaultValue: "Copy UDID")) {
+            guard let selectedUDID else { return }
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(selectedUDID, forType: .string)
+        }
+    }
+
+    private func banner(message: String, isError: Bool) -> some View {
+        VStack {
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(isError ? Color.white : Color.primary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(isError ? Color.red.opacity(0.9) : Color(nsColor: .controlBackgroundColor), in: RoundedRectangle(cornerRadius: 8))
+                .padding(.top, 12)
+            Spacer()
+        }
+    }
+
+    private func select(_ device: CMUXSimulatorDevice) {
+        selectedUDID = device.udid
+        onDeviceSelected(device)
+        if !device.isBooted {
+            Task.detached {
+                do {
+                    try runtime.boot(udid: device.udid)
+                } catch {
+                    await MainActor.run { errorMessage = error.localizedDescription }
+                }
+                await MainActor.run { loadDevices() }
+            }
+        }
+    }
+
+    private func loadDevices() {
+        Task.detached {
+            do {
+                let loaded = try runtime.listDevices()
+                await MainActor.run {
+                    devices = loaded
+                    if let initialUDID,
+                       selectedUDID == nil,
+                       let matched = loaded.first(where: { $0.udid == initialUDID }) {
+                        select(matched)
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func perform(_ action: CMUXSimulatorHardwareAction) {
+        guard let selectedUDID else { return }
+        Task.detached {
+            do {
+                let succeeded = try runtime.performHardwareAction(action, udid: selectedUDID)
+                await MainActor.run {
+                    statusMessage = succeeded ? localizedActionTitle(action) : String(localized: "simulator.action.failed", defaultValue: "Action failed")
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func iconName(for action: CMUXSimulatorHardwareAction) -> String {
+        switch action {
+        case .home: return "circle"
+        case .lock: return "lock"
+        case .volumeUp: return "speaker.wave.2"
+        case .volumeDown: return "speaker.wave.1"
+        case .screenshot: return "camera"
+        case .rotateLeft: return "rotate.left"
+        case .rotateRight: return "rotate.right"
+        case .shake: return "waveform.path"
+        }
+    }
+
+    private func localizedActionTitle(_ action: CMUXSimulatorHardwareAction) -> String {
+        switch action {
+        case .home: return String(localized: "simulator.action.home", defaultValue: "Home")
+        case .lock: return String(localized: "simulator.action.lock", defaultValue: "Lock")
+        case .volumeUp: return String(localized: "simulator.action.volumeUp", defaultValue: "Volume Up")
+        case .volumeDown: return String(localized: "simulator.action.volumeDown", defaultValue: "Volume Down")
+        case .screenshot: return String(localized: "simulator.action.screenshot", defaultValue: "Screenshot")
+        case .rotateLeft: return String(localized: "simulator.action.rotateLeft", defaultValue: "Rotate Left")
+        case .rotateRight: return String(localized: "simulator.action.rotateRight", defaultValue: "Rotate Right")
+        case .shake: return String(localized: "simulator.action.shake", defaultValue: "Shake")
+        }
+    }
+}
+
+public struct CMUXSimulatorDebugView: View {
+    private let runtime: CMUXSimulatorRuntime
+    @State private var devices: [CMUXSimulatorDevice] = []
+    @State private var selectedUDID: String?
+    @State private var errorMessage: String?
+
+    public init(runtime: CMUXSimulatorRuntime = .shared) {
+        self.runtime = runtime
+    }
+
+    public var body: some View {
+        NavigationSplitView {
+            List(devices, selection: $selectedUDID) { device in
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(device.name)
+                    Text("\(device.runtime) · \(device.state.displayName)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .tag(device.udid)
+                .contextMenu {
+                    Button(String(localized: "simulator.action.boot", defaultValue: "Boot")) { boot(device) }
+                    Button(String(localized: "simulator.action.shutdown", defaultValue: "Shutdown")) { shutdown(device) }
+                    Button(String(localized: "simulator.action.copyUDID", defaultValue: "Copy UDID")) {
+                        NSPasteboard.general.clearContents()
+                        NSPasteboard.general.setString(device.udid, forType: .string)
+                    }
+                }
+            }
+            .frame(minWidth: 260)
+            .toolbar {
+                Button {
+                    loadDevices()
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .help(String(localized: "simulator.action.refresh", defaultValue: "Refresh"))
+            }
+        } detail: {
+            CMUXSimulatorViewer(runtime: runtime, initialUDID: selectedUDID)
+                .id(selectedUDID ?? "none")
+        }
+        .task {
+            loadDevices()
+        }
+        .overlay(alignment: .top) {
+            if let errorMessage {
+                Text(errorMessage)
+                    .font(.caption)
+                    .foregroundStyle(.white)
+                    .padding(8)
+                    .background(Color.red.opacity(0.9), in: RoundedRectangle(cornerRadius: 8))
+                    .padding()
+            }
+        }
+    }
+
+    private func loadDevices() {
+        Task.detached {
+            do {
+                let loaded = try runtime.listDevices()
+                await MainActor.run {
+                    devices = loaded
+                    if selectedUDID == nil {
+                        selectedUDID = loaded.first(where: \.isBooted)?.udid ?? loaded.first?.udid
+                    }
+                }
+            } catch {
+                await MainActor.run {
+                    errorMessage = error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func boot(_ device: CMUXSimulatorDevice) {
+        Task.detached {
+            do {
+                try runtime.boot(udid: device.udid)
+                await MainActor.run { loadDevices() }
+            } catch {
+                await MainActor.run { errorMessage = error.localizedDescription }
+            }
+        }
+    }
+
+    private func shutdown(_ device: CMUXSimulatorDevice) {
+        Task.detached {
+            do {
+                try runtime.shutdown(udid: device.udid)
+                await MainActor.run { loadDevices() }
+            } catch {
+                await MainActor.run { errorMessage = error.localizedDescription }
+            }
+        }
+    }
+}
+
+private struct CMUXSimulatorCanvas: NSViewRepresentable {
+    let runtime: CMUXSimulatorRuntime
+    let udid: String
+    let deviceSize: CMUXSimulatorSize
+    let onError: (String) -> Void
+    let onStatus: (String) -> Void
+    let onMetrics: (CMUXSimulatorFrameMetrics) -> Void
+
+    func makeNSView(context: Context) -> CMUXSimulatorCanvasView {
+        let view = CMUXSimulatorCanvasView()
+        view.configure(
+            runtime: runtime,
+            udid: udid,
+            deviceSize: deviceSize,
+            onError: onError,
+            onStatus: onStatus,
+            onMetrics: onMetrics
+        )
+        return view
+    }
+
+    func updateNSView(_ nsView: CMUXSimulatorCanvasView, context: Context) {
+        nsView.configure(
+            runtime: runtime,
+            udid: udid,
+            deviceSize: deviceSize,
+            onError: onError,
+            onStatus: onStatus,
+            onMetrics: onMetrics
+        )
+    }
+}
+
+private final class CMUXSimulatorCanvasView: NSView {
+    private let surfaceLayer = CALayer()
+    private let pointerLayer = CAShapeLayer()
+    private let frameQueue = DispatchQueue(label: "com.cmux.simulator.layer", qos: .userInteractive)
+
+    private var runtime: CMUXSimulatorRuntime?
+    private var udid: String?
+    private var deviceSize = CMUXSimulatorSize.zero
+    private var stream: CMUXSimulatorScreenStream?
+    private var onError: ((String) -> Void)?
+    private var onStatus: ((String) -> Void)?
+    private var onMetrics: ((CMUXSimulatorFrameMetrics) -> Void)?
+    private var trackingAreaRef: NSTrackingArea?
+    private var isTouchDown = false
+    private var twoFingerMode = false
+    private var lastFrameTimes: [CFTimeInterval] = []
+    private var lastMetricsEmission: CFTimeInterval = 0
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.backgroundColor = NSColor.black.cgColor
+        surfaceLayer.contentsGravity = .resizeAspect
+        surfaceLayer.backgroundColor = NSColor.black.cgColor
+        layer?.addSublayer(surfaceLayer)
+
+        pointerLayer.fillColor = NSColor.controlAccentColor.withAlphaComponent(0.35).cgColor
+        pointerLayer.strokeColor = NSColor.controlAccentColor.withAlphaComponent(0.8).cgColor
+        pointerLayer.lineWidth = 1
+        pointerLayer.isHidden = true
+        layer?.addSublayer(pointerLayer)
+
+        registerForDraggedTypes([.fileURL])
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    func configure(
+        runtime: CMUXSimulatorRuntime,
+        udid: String,
+        deviceSize: CMUXSimulatorSize,
+        onError: @escaping (String) -> Void,
+        onStatus: @escaping (String) -> Void,
+        onMetrics: @escaping (CMUXSimulatorFrameMetrics) -> Void
+    ) {
+        let changedDevice = self.udid != udid
+        self.runtime = runtime
+        self.udid = udid
+        self.deviceSize = deviceSize
+        self.onError = onError
+        self.onStatus = onStatus
+        self.onMetrics = onMetrics
+        if changedDevice {
+            startStream()
+        }
+        needsLayout = true
+    }
+
+    override func layout() {
+        super.layout()
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        surfaceLayer.frame = bounds
+        updatePointerLayer(at: nil)
+        CATransaction.commit()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaRef {
+            removeTrackingArea(trackingAreaRef)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .mouseEnteredAndExited, .mouseMoved, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        trackingAreaRef = area
+        addTrackingArea(area)
+    }
+
+    override func resetCursorRects() {
+        addCursorRect(bounds, cursor: .crosshair)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        pointerLayer.isHidden = false
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        pointerLayer.isHidden = true
+        if isTouchDown {
+            finishTouch(with: event)
+        }
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        guard let point = devicePoint(for: event) else { return }
+        updatePointerLayer(at: event.locationInWindow)
+        _ = try? input()?.sendHover(at: point, size: effectiveDeviceSize())
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        guard let point = devicePoint(for: event) else { return }
+        isTouchDown = true
+        twoFingerMode = event.modifierFlags.contains(.option)
+        updatePointerLayer(at: event.locationInWindow)
+        do {
+            if twoFingerMode {
+                let pair = twoFingerPoints(midpoint: point, event: event)
+                _ = try input()?.sendTouch(phase: .down, first: pair.first, second: pair.second, size: effectiveDeviceSize())
+            } else {
+                _ = try input()?.sendTouch(phase: .down, first: point, second: nil, size: effectiveDeviceSize())
+            }
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    override func mouseDragged(with event: NSEvent) {
+        guard isTouchDown, let point = devicePoint(for: event) else { return }
+        updatePointerLayer(at: event.locationInWindow)
+        do {
+            if twoFingerMode {
+                let pair = twoFingerPoints(midpoint: point, event: event)
+                _ = try input()?.sendTouch(phase: .move, first: pair.first, second: pair.second, size: effectiveDeviceSize())
+            } else {
+                _ = try input()?.sendTouch(phase: .move, first: point, second: nil, size: effectiveDeviceSize())
+            }
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        finishTouch(with: event)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        do {
+            _ = try input()?.sendScroll(deltaX: Double(event.scrollingDeltaX), deltaY: Double(event.scrollingDeltaY))
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        if event.modifierFlags.intersection([.command, .control]).isEmpty == false {
+            super.keyDown(with: event)
+            return
+        }
+        onStatus?(String(localized: "simulator.keyboard.unsupported", defaultValue: "Keyboard input is not wired yet."))
+    }
+
+    override func draggingEntered(_ sender: NSDraggingInfo) -> NSDragOperation {
+        .copy
+    }
+
+    override func performDragOperation(_ sender: NSDraggingInfo) -> Bool {
+        guard let runtime,
+              let udid,
+              let items = sender.draggingPasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
+            return false
+        }
+        var succeeded = false
+        for url in items {
+            do {
+                try runtime.installOrCopyFile(url, udid: udid)
+                succeeded = true
+            } catch {
+                onError?(error.localizedDescription)
+            }
+        }
+        return succeeded
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let menu = NSMenu()
+        addMenuItem(String(localized: "simulator.action.home", defaultValue: "Home"), action: #selector(menuHome), to: menu)
+        addMenuItem(String(localized: "simulator.action.lock", defaultValue: "Lock"), action: #selector(menuLock), to: menu)
+        addMenuItem(String(localized: "simulator.action.screenshot", defaultValue: "Screenshot"), action: #selector(menuScreenshot), to: menu)
+        addMenuItem(String(localized: "simulator.action.shake", defaultValue: "Shake"), action: #selector(menuShake), to: menu)
+        menu.addItem(.separator())
+        addMenuItem(String(localized: "simulator.action.openInSimulator", defaultValue: "Open in Simulator.app"), action: #selector(menuOpenInSimulator), to: menu)
+        addMenuItem(String(localized: "simulator.action.revealContainer", defaultValue: "Reveal Container in Finder"), action: #selector(menuRevealContainer), to: menu)
+        addMenuItem(String(localized: "simulator.action.copyUDID", defaultValue: "Copy UDID"), action: #selector(menuCopyUDID), to: menu)
+        return menu
+    }
+
+    private func startStream() {
+        stream?.stop()
+        stream = nil
+        guard let runtime, let udid else { return }
+        do {
+            let stream = try runtime.screenStream(udid: udid)
+            self.stream = stream
+            try stream.start { [weak self] surface in
+                self?.display(surface)
+            }
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    private func display(_ surface: IOSurface) {
+        frameQueue.async { [weak self] in
+            guard let self else { return }
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            self.surfaceLayer.contents = surface
+            CATransaction.commit()
+            self.recordFrame(surface)
+        }
+    }
+
+    private func recordFrame(_ surface: IOSurface) {
+        let now = CACurrentMediaTime()
+        lastFrameTimes.append(now)
+        lastFrameTimes = lastFrameTimes.filter { now - $0 <= 1.0 }
+        guard now - lastMetricsEmission > 0.5 else { return }
+        lastMetricsEmission = now
+        let metrics = CMUXSimulatorFrameMetrics(
+            pixelSize: CMUXSimulatorSize(
+                width: Double(IOSurfaceGetWidth(surface)),
+                height: Double(IOSurfaceGetHeight(surface))
+            ),
+            fps: Double(lastFrameTimes.count)
+        )
+        DispatchQueue.main.async { [weak self] in
+            self?.onMetrics?(metrics)
+        }
+    }
+
+    private func finishTouch(with event: NSEvent) {
+        guard isTouchDown, let point = devicePoint(for: event) else {
+            isTouchDown = false
+            twoFingerMode = false
+            return
+        }
+        defer {
+            isTouchDown = false
+            twoFingerMode = false
+        }
+        do {
+            if twoFingerMode {
+                let pair = twoFingerPoints(midpoint: point, event: event)
+                _ = try input()?.sendTouch(phase: .up, first: pair.first, second: pair.second, size: effectiveDeviceSize())
+            } else {
+                _ = try input()?.sendTouch(phase: .up, first: point, second: nil, size: effectiveDeviceSize())
+            }
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    private func input() throws -> CMUXSimulatorHIDInput? {
+        guard let runtime, let udid else { return nil }
+        return try runtime.inputSession(udid: udid)
+    }
+
+    private func effectiveDeviceSize() -> CMUXSimulatorSize {
+        if deviceSize.width > 0, deviceSize.height > 0 {
+            return deviceSize
+        }
+        return CMUXSimulatorSize(width: max(bounds.width, 1), height: max(bounds.height, 1))
+    }
+
+    private func devicePoint(for event: NSEvent) -> CMUXSimulatorPoint? {
+        let local = convert(event.locationInWindow, from: nil)
+        let rect = contentRect()
+        guard rect.contains(local), rect.width > 0, rect.height > 0 else { return nil }
+        let size = effectiveDeviceSize()
+        let x = Double((local.x - rect.minX) / rect.width) * size.width
+        let y = Double((rect.maxY - local.y) / rect.height) * size.height
+        return CMUXSimulatorPoint(x: x, y: y)
+    }
+
+    private func contentRect() -> CGRect {
+        let size = effectiveDeviceSize()
+        guard size.width > 0, size.height > 0, bounds.width > 0, bounds.height > 0 else {
+            return bounds
+        }
+        let targetAspect = CGFloat(size.width / size.height)
+        let boundsAspect = bounds.width / bounds.height
+        if boundsAspect > targetAspect {
+            let width = bounds.height * targetAspect
+            return CGRect(x: bounds.midX - width / 2, y: bounds.minY, width: width, height: bounds.height)
+        } else {
+            let height = bounds.width / targetAspect
+            return CGRect(x: bounds.minX, y: bounds.midY - height / 2, width: bounds.width, height: height)
+        }
+    }
+
+    private func twoFingerPoints(midpoint: CMUXSimulatorPoint, event: NSEvent) -> (first: CMUXSimulatorPoint, second: CMUXSimulatorPoint) {
+        let spread = event.modifierFlags.contains(.shift) ? 160.0 : 96.0
+        return (
+            CMUXSimulatorPoint(x: midpoint.x - spread / 2, y: midpoint.y),
+            CMUXSimulatorPoint(x: midpoint.x + spread / 2, y: midpoint.y)
+        )
+    }
+
+    private func updatePointerLayer(at windowPoint: NSPoint?) {
+        guard let windowPoint else {
+            pointerLayer.isHidden = true
+            return
+        }
+        let local = convert(windowPoint, from: nil)
+        let radius: CGFloat = 5
+        pointerLayer.path = CGPath(ellipseIn: CGRect(x: local.x - radius, y: local.y - radius, width: radius * 2, height: radius * 2), transform: nil)
+        pointerLayer.isHidden = false
+    }
+
+    private func addMenuItem(_ title: String, action: Selector, to menu: NSMenu) {
+        let item = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        item.target = self
+        menu.addItem(item)
+    }
+
+    @objc private func menuHome() { perform(.home) }
+    @objc private func menuLock() { perform(.lock) }
+    @objc private func menuScreenshot() { perform(.screenshot) }
+    @objc private func menuShake() { perform(.shake) }
+
+    @objc private func menuOpenInSimulator() {
+        guard let runtime, let udid else { return }
+        do {
+            try runtime.openInSimulatorApp(udid: udid)
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    @objc private func menuRevealContainer() {
+        guard let runtime, let udid else { return }
+        runtime.revealDeviceContainer(udid: udid)
+    }
+
+    @objc private func menuCopyUDID() {
+        guard let udid else { return }
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(udid, forType: .string)
+    }
+
+    private func perform(_ action: CMUXSimulatorHardwareAction) {
+        guard let runtime, let udid else { return }
+        do {
+            _ = try runtime.performHardwareAction(action, udid: udid)
+            onStatus?(localizedActionTitle(action))
+        } catch {
+            onError?(error.localizedDescription)
+        }
+    }
+
+    private func localizedActionTitle(_ action: CMUXSimulatorHardwareAction) -> String {
+        switch action {
+        case .home: return String(localized: "simulator.action.home", defaultValue: "Home")
+        case .lock: return String(localized: "simulator.action.lock", defaultValue: "Lock")
+        case .volumeUp: return String(localized: "simulator.action.volumeUp", defaultValue: "Volume Up")
+        case .volumeDown: return String(localized: "simulator.action.volumeDown", defaultValue: "Volume Down")
+        case .screenshot: return String(localized: "simulator.action.screenshot", defaultValue: "Screenshot")
+        case .rotateLeft: return String(localized: "simulator.action.rotateLeft", defaultValue: "Rotate Left")
+        case .rotateRight: return String(localized: "simulator.action.rotateRight", defaultValue: "Rotate Right")
+        case .shake: return String(localized: "simulator.action.shake", defaultValue: "Shake")
+        }
+    }
+}

--- a/Packages/CMUXSimulator/Sources/CMUXSimulator/SimulatorTypes.swift
+++ b/Packages/CMUXSimulator/Sources/CMUXSimulator/SimulatorTypes.swift
@@ -1,0 +1,171 @@
+import Foundation
+
+public enum CMUXSimulatorState: String, Codable, Hashable, Sendable {
+    case creating
+    case shutdown
+    case booting
+    case booted
+    case shuttingDown
+    case unknown
+
+    public var isBooted: Bool { self == .booted }
+
+    public var displayName: String {
+        switch self {
+        case .creating: return "Creating"
+        case .shutdown: return "Shutdown"
+        case .booting: return "Booting"
+        case .booted: return "Booted"
+        case .shuttingDown: return "Shutting Down"
+        case .unknown: return "Unknown"
+        }
+    }
+}
+
+public struct CMUXSimulatorSize: Codable, Hashable, Sendable {
+    public var width: Double
+    public var height: Double
+
+    public init(width: Double, height: Double) {
+        self.width = width
+        self.height = height
+    }
+
+    public static let zero = CMUXSimulatorSize(width: 0, height: 0)
+}
+
+public struct CMUXSimulatorDevice: Identifiable, Codable, Hashable, Sendable {
+    public var id: String { udid }
+    public let udid: String
+    public let name: String
+    public let state: CMUXSimulatorState
+    public let runtime: String
+    public let screenSizePoints: CMUXSimulatorSize
+    public let screenSizePixels: CMUXSimulatorSize
+
+    public init(
+        udid: String,
+        name: String,
+        state: CMUXSimulatorState,
+        runtime: String,
+        screenSizePoints: CMUXSimulatorSize = .zero,
+        screenSizePixels: CMUXSimulatorSize = .zero
+    ) {
+        self.udid = udid
+        self.name = name
+        self.state = state
+        self.runtime = runtime
+        self.screenSizePoints = screenSizePoints
+        self.screenSizePixels = screenSizePixels
+    }
+
+    public var isBooted: Bool { state.isBooted }
+
+    public var shortUDID: String {
+        String(udid.prefix(8))
+    }
+}
+
+public enum CMUXSimulatorTouchPhase: Sendable {
+    case down
+    case move
+    case up
+    case hover
+}
+
+public struct CMUXSimulatorPoint: Hashable, Sendable {
+    public var x: Double
+    public var y: Double
+
+    public init(x: Double, y: Double) {
+        self.x = x
+        self.y = y
+    }
+}
+
+public enum CMUXSimulatorHardwareAction: String, CaseIterable, Sendable {
+    case home
+    case lock
+    case volumeUp
+    case volumeDown
+    case screenshot
+    case rotateLeft
+    case rotateRight
+    case shake
+
+    public var displayName: String {
+        switch self {
+        case .home: return "Home"
+        case .lock: return "Lock"
+        case .volumeUp: return "Volume Up"
+        case .volumeDown: return "Volume Down"
+        case .screenshot: return "Screenshot"
+        case .rotateLeft: return "Rotate Left"
+        case .rotateRight: return "Rotate Right"
+        case .shake: return "Shake"
+        }
+    }
+}
+
+public struct CMUXSimulatorCapabilityReport: Sendable {
+    public let xcodeMajorVersion: Int?
+    public let minimumXcodeMajorVersion: Int
+    public let developerDirectory: String
+    public let failures: [String]
+
+    public init(
+        xcodeMajorVersion: Int?,
+        minimumXcodeMajorVersion: Int,
+        developerDirectory: String,
+        failures: [String]
+    ) {
+        self.xcodeMajorVersion = xcodeMajorVersion
+        self.minimumXcodeMajorVersion = minimumXcodeMajorVersion
+        self.developerDirectory = developerDirectory
+        self.failures = failures
+    }
+
+    public var isUsable: Bool {
+        failures.isEmpty
+    }
+
+    public var failureSummary: String? {
+        failures.first
+    }
+}
+
+public enum CMUXSimulatorError: Error, LocalizedError, Equatable {
+    case capabilityUnavailable(String)
+    case deviceNotFound(String)
+    case bootFailed(String)
+    case shutdownFailed(String)
+    case screenUnavailable(String)
+    case inputUnavailable(String)
+    case actionUnsupported(String)
+    case processFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .capabilityUnavailable(let message),
+             .bootFailed(let message),
+             .shutdownFailed(let message),
+             .screenUnavailable(let message),
+             .inputUnavailable(let message),
+             .actionUnsupported(let message),
+             .processFailed(let message):
+            return message
+        case .deviceNotFound(let udid):
+            return "Simulator not found: \(udid)"
+        }
+    }
+}
+
+public struct CMUXSimulatorFrameMetrics: Equatable, Sendable {
+    public let pixelSize: CMUXSimulatorSize
+    public let fps: Double
+
+    public init(pixelSize: CMUXSimulatorSize, fps: Double) {
+        self.pixelSize = pixelSize
+        self.fps = fps
+    }
+}

--- a/Packages/CMUXSimulator/Tests/CMUXSimulatorTests/CMUXSimulatorTests.swift
+++ b/Packages/CMUXSimulator/Tests/CMUXSimulatorTests/CMUXSimulatorTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import CMUXSimulator
+
+final class CMUXSimulatorTests: XCTestCase {
+    func testDeviceShortUDIDUsesFirstEightCharacters() {
+        let device = CMUXSimulatorDevice(
+            udid: "12345678-90AB-CDEF-1234-567890ABCDEF",
+            name: "iPhone",
+            state: .booted,
+            runtime: "iOS 26.4"
+        )
+
+        XCTAssertEqual(device.shortUDID, "12345678")
+        XCTAssertTrue(device.isBooted)
+    }
+
+    func testCapabilityReportSummarizesFirstFailure() {
+        let report = CMUXSimulatorCapabilityReport(
+            xcodeMajorVersion: 25,
+            minimumXcodeMajorVersion: 26,
+            developerDirectory: "/Applications/Xcode.app/Contents/Developer",
+            failures: ["Xcode 26+ is required.", "SimulatorKit is unavailable."]
+        )
+
+        XCTAssertFalse(report.isUsable)
+        XCTAssertEqual(report.failureSummary, "Xcode 26+ is required.")
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -110230,6 +110230,181 @@
         "en": { "stringUnit": { "state": "translated", "value": "Process" } },
         "ja": { "stringUnit": { "state": "translated", "value": "プロセス" } }
       }
+    },
+    "commandPalette.kind.simulator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Simulator" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シミュレータ" } }
+      }
+    },
+    "debug.menu.simulatorDebug": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iOS Simulators…" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iOSシミュレータ…" } }
+      }
+    },
+    "debug.simulator.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iOS Simulators" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iOSシミュレータ" } }
+      }
+    },
+    "simulator.action.boot": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Boot" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "起動" } }
+      }
+    },
+    "simulator.action.copyUDID": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Copy UDID" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "UDIDをコピー" } }
+      }
+    },
+    "simulator.action.detach": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Detach" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "切り離す" } }
+      }
+    },
+    "simulator.action.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Action failed" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "操作に失敗しました" } }
+      }
+    },
+    "simulator.action.home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Home" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ホーム" } }
+      }
+    },
+    "simulator.action.lock": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Lock" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ロック" } }
+      }
+    },
+    "simulator.action.openInSimulator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Open in Simulator.app" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Simulator.appで開く" } }
+      }
+    },
+    "simulator.action.refresh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Refresh" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "更新" } }
+      }
+    },
+    "simulator.action.revealContainer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Reveal Container in Finder" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コンテナをFinderで表示" } }
+      }
+    },
+    "simulator.action.rotateLeft": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Rotate Left" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "左に回転" } }
+      }
+    },
+    "simulator.action.rotateRight": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Rotate Right" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "右に回転" } }
+      }
+    },
+    "simulator.action.screenshot": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Screenshot" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "スクリーンショット" } }
+      }
+    },
+    "simulator.action.shake": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Shake" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シェイク" } }
+      }
+    },
+    "simulator.action.shutdown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Shutdown" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "終了" } }
+      }
+    },
+    "simulator.action.volumeDown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Volume Down" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "音量を下げる" } }
+      }
+    },
+    "simulator.action.volumeUp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Volume Up" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "音量を上げる" } }
+      }
+    },
+    "simulator.device.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Simulator" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シミュレータ" } }
+      }
+    },
+    "simulator.keyboard.unsupported": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Keyboard input is not wired yet." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "キーボード入力はまだ接続されていません。" } }
+      }
+    },
+    "simulator.panel.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Simulator" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シミュレータ" } }
+      }
+    },
+    "simulator.picker.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No simulators found." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シミュレータが見つかりません。" } }
+      }
+    },
+    "simulator.picker.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Choose a Simulator" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シミュレータを選択" } }
+      }
+    },
+    "simulator.runtime.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Unknown Runtime" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "不明なランタイム" } }
+      }
     }
   }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6564,6 +6564,8 @@ struct ContentView: View {
             return String(localized: "commandPalette.kind.markdown", defaultValue: "Markdown")
         case .filePreview:
             return String(localized: "commandPalette.kind.filePreview", defaultValue: "File Preview")
+        case .simulator:
+            return String(localized: "commandPalette.kind.simulator", defaultValue: "Simulator")
         }
     }
 
@@ -6577,6 +6579,8 @@ struct ContentView: View {
             return ["markdown", "note", "preview"]
         case .filePreview:
             return ["file", "preview", "text", "pdf", "image"]
+        case .simulator:
+            return ["simulator", "ios", "ipad", "tvos", "watchos", "visionos"]
         }
     }
 

--- a/Sources/Panels/Panel.swift
+++ b/Sources/Panels/Panel.swift
@@ -8,6 +8,7 @@ public enum PanelType: String, Codable, Sendable {
     case browser
     case markdown
     case filePreview = "filepreview"
+    case simulator
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.singleValueContainer()

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Foundation
 import Bonsplit
+import CMUXSimulator
 
 /// View that renders the appropriate panel view based on panel type
 struct PanelContentView: View {
@@ -65,6 +66,71 @@ struct PanelContentView: View {
                     onRequestPanelFocus: onRequestPanelFocus
                 )
             }
+        case .simulator:
+            if let simulatorPanel = panel as? SimulatorPanel {
+                SimulatorPanelView(
+                    panel: simulatorPanel,
+                    onRequestPanelFocus: onRequestPanelFocus
+                )
+            }
         }
+    }
+}
+
+@MainActor
+final class SimulatorPanel: Panel, ObservableObject {
+    let id: UUID
+    let panelType: PanelType = .simulator
+    private(set) var workspaceId: UUID
+    @Published private(set) var deviceUDID: String?
+    @Published private(set) var displayTitle: String
+    @Published private(set) var focusFlashToken: Int = 0
+
+    var displayIcon: String? { "iphone" }
+
+    init(workspaceId: UUID, deviceUDID: String? = nil) {
+        id = UUID()
+        self.workspaceId = workspaceId
+        self.deviceUDID = deviceUDID
+        let baseTitle = String(localized: "simulator.panel.title", defaultValue: "Simulator")
+        displayTitle = deviceUDID.map { "\(baseTitle) \($0.prefix(8))" } ?? baseTitle
+    }
+
+    func selectDevice(_ device: CMUXSimulatorDevice) {
+        deviceUDID = device.udid
+        displayTitle = device.name
+    }
+
+    func close() {}
+
+    func focus() {}
+
+    func unfocus() {}
+
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {
+        _ = reason
+        guard NotificationPaneFlashSettings.isEnabled() else { return }
+        focusFlashToken += 1
+    }
+}
+
+private struct SimulatorPanelView: View {
+    @ObservedObject var panel: SimulatorPanel
+    let onRequestPanelFocus: () -> Void
+
+    var body: some View {
+        CMUXSimulatorViewer(
+            initialUDID: panel.deviceUDID,
+            onDeviceSelected: { device in
+                Task { @MainActor in
+                    panel.selectDevice(device)
+                    onRequestPanelFocus()
+                }
+            }
+        )
+        .onTapGesture {
+            onRequestPanelFocus()
+        }
+        .focusable()
     }
 }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Carbon.HIToolbox
+import CMUXSimulator
 import CMUXWorkstream
 import Foundation
 import Bonsplit
@@ -2713,6 +2714,14 @@ class TerminalController {
             return v2Result(id: id, self.v2MarkdownOpen(params: params))
         case "file.open":
             return v2Result(id: id, self.v2FileOpen(params: params))
+        case "simulator.list":
+            return v2Result(id: id, self.v2SimulatorList(params: params))
+        case "simulator.boot":
+            return v2Result(id: id, self.v2SimulatorBoot(params: params))
+        case "simulator.shutdown":
+            return v2Result(id: id, self.v2SimulatorShutdown(params: params))
+        case "simulator.open":
+            return v2Result(id: id, self.v2SimulatorOpen(params: params))
 
         case "surface.read_text":
             return v2Result(id: id, self.v2SurfaceReadText(params: params))
@@ -2884,6 +2893,10 @@ class TerminalController {
             "app.simulate_active",
             "file.open",
             "markdown.open",
+            "simulator.list",
+            "simulator.boot",
+            "simulator.shutdown",
+            "simulator.open",
             "browser.open_split",
             "browser.navigate",
             "browser.back",
@@ -8783,6 +8796,140 @@ class TerminalController {
                 try? FileManager.default.removeItem(at: entry.url)
             }
         }
+    }
+
+    // MARK: - Simulator
+
+    private func v2SimulatorDevicePayload(_ device: CMUXSimulatorDevice) -> [String: Any] {
+        [
+            "udid": device.udid,
+            "short_udid": device.shortUDID,
+            "name": device.name,
+            "state": device.state.displayName,
+            "runtime": device.runtime,
+            "is_booted": device.isBooted,
+            "screen_points": [
+                "width": device.screenSizePoints.width,
+                "height": device.screenSizePoints.height
+            ],
+            "screen_pixels": [
+                "width": device.screenSizePixels.width,
+                "height": device.screenSizePixels.height
+            ]
+        ]
+    }
+
+    private func v2SimulatorList(params: [String: Any]) -> V2CallResult {
+        _ = params
+        do {
+            let devices = try CMUXSimulatorRuntime.shared.listDevices()
+            let report = CMUXSimulatorRuntime.probeCapabilities()
+            return .ok([
+                "devices": devices.map(v2SimulatorDevicePayload),
+                "minimum_xcode_major": report.minimumXcodeMajorVersion,
+                "xcode_major": v2OrNull(report.xcodeMajorVersion),
+                "developer_dir": report.developerDirectory
+            ])
+        } catch {
+            return .err(code: "simulator_unavailable", message: error.localizedDescription, data: nil)
+        }
+    }
+
+    private func v2SimulatorBoot(params: [String: Any]) -> V2CallResult {
+        guard let udid = v2String(params, "udid") else {
+            return .err(code: "invalid_params", message: "Missing 'udid' parameter", data: nil)
+        }
+        do {
+            try CMUXSimulatorRuntime.shared.boot(udid: udid)
+            let device = try CMUXSimulatorRuntime.shared.device(udid: udid)
+            return .ok(["device": v2SimulatorDevicePayload(device)])
+        } catch {
+            return .err(code: "simulator_boot_failed", message: error.localizedDescription, data: ["udid": udid])
+        }
+    }
+
+    private func v2SimulatorShutdown(params: [String: Any]) -> V2CallResult {
+        guard let udid = v2String(params, "udid") else {
+            return .err(code: "invalid_params", message: "Missing 'udid' parameter", data: nil)
+        }
+        do {
+            try CMUXSimulatorRuntime.shared.shutdown(udid: udid)
+            let device = try CMUXSimulatorRuntime.shared.device(udid: udid)
+            return .ok(["device": v2SimulatorDevicePayload(device)])
+        } catch {
+            return .err(code: "simulator_shutdown_failed", message: error.localizedDescription, data: ["udid": udid])
+        }
+    }
+
+    private func v2SimulatorOpen(params: [String: Any]) -> V2CallResult {
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+
+        var result: V2CallResult = .err(code: "internal_error", message: "Failed to create simulator panel", data: nil)
+        v2MainSync {
+            guard let ws = v2ResolveWorkspace(params: params, tabManager: tabManager) else {
+                result = .err(code: "not_found", message: "Workspace not found", data: nil)
+                return
+            }
+
+            let shouldFocus = v2FocusAllowed(requested: v2Bool(params, "focus") ?? true)
+            if shouldFocus {
+                v2MaybeFocusWindow(for: tabManager)
+                v2MaybeSelectWorkspace(tabManager, workspace: ws)
+            }
+
+            let sourceSurfaceId = v2UUID(params, "surface_id") ?? ws.focusedPanelId
+            guard let sourceSurfaceId else {
+                result = .err(code: "not_found", message: "No focused surface to split", data: nil)
+                return
+            }
+            guard ws.panels[sourceSurfaceId] != nil else {
+                result = .err(code: "not_found", message: "Source surface not found", data: ["surface_id": sourceSurfaceId.uuidString])
+                return
+            }
+
+            let sourcePaneUUID = ws.paneId(forPanelId: sourceSurfaceId)?.id
+            let directionRaw = v2String(params, "direction") ?? "right"
+            guard let direction = parseSplitDirection(directionRaw) else {
+                result = .err(code: "invalid_params", message: "Invalid direction '\(directionRaw)' (left|right|up|down)", data: nil)
+                return
+            }
+
+            let createdPanel = ws.newSimulatorSplit(
+                from: sourceSurfaceId,
+                orientation: direction.isHorizontal ? .horizontal : .vertical,
+                insertFirst: direction == .left || direction == .up,
+                deviceUDID: v2String(params, "udid"),
+                focus: shouldFocus
+            )
+
+            guard let simulatorPanelId = createdPanel?.id else {
+                result = .err(code: "internal_error", message: "Failed to create simulator panel", data: nil)
+                return
+            }
+
+            let targetPaneUUID = ws.paneId(forPanelId: simulatorPanelId)?.id
+            let windowId = v2ResolveWindowId(tabManager: tabManager)
+            result = .ok([
+                "window_id": v2OrNull(windowId?.uuidString),
+                "window_ref": v2Ref(kind: .window, uuid: windowId),
+                "workspace_id": ws.id.uuidString,
+                "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                "pane_id": v2OrNull(targetPaneUUID?.uuidString),
+                "pane_ref": v2Ref(kind: .pane, uuid: targetPaneUUID),
+                "surface_id": simulatorPanelId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: simulatorPanelId),
+                "source_surface_id": sourceSurfaceId.uuidString,
+                "source_surface_ref": v2Ref(kind: .surface, uuid: sourceSurfaceId),
+                "source_pane_id": v2OrNull(sourcePaneUUID?.uuidString),
+                "source_pane_ref": v2Ref(kind: .pane, uuid: sourcePaneUUID),
+                "target_pane_id": v2OrNull(targetPaneUUID?.uuidString),
+                "target_pane_ref": v2Ref(kind: .pane, uuid: targetPaneUUID),
+                "udid": v2OrNull(v2String(params, "udid"))
+            ])
+        }
+        return result
     }
 
     // MARK: - Markdown

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -444,6 +444,8 @@ extension Workspace {
             browserSnapshot = nil
             markdownSnapshot = nil
             filePreviewSnapshot = SessionFilePreviewPanelSnapshot(filePath: filePreviewPanel.filePath)
+        case .simulator:
+            return nil
         }
 
         return SessionPanelSnapshot(
@@ -693,6 +695,8 @@ extension Workspace {
             }
             applySessionPanelMetadata(snapshot, toPanelId: filePreviewPanel.id)
             return filePreviewPanel.id
+        case .simulator:
+            return nil
         }
     }
 
@@ -7367,6 +7371,7 @@ final class Workspace: Identifiable, ObservableObject {
         static let browser = "browser"
         static let markdown = "markdown"
         static let filePreview = "filePreview"
+        static let simulator = "simulator"
     }
 
     enum PanelShellActivityState: String {
@@ -8110,6 +8115,29 @@ final class Workspace: Identifiable, ObservableObject {
         panelSubscriptions[markdownPanel.id] = subscription
     }
 
+    private func installSimulatorPanelSubscription(_ simulatorPanel: SimulatorPanel) {
+        let subscription = simulatorPanel.$displayTitle
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self, weak simulatorPanel] newTitle in
+                guard let self,
+                      let simulatorPanel,
+                      let tabId = self.surfaceIdFromPanelId(simulatorPanel.id) else { return }
+                guard let existing = self.bonsplitController.tab(tabId) else { return }
+                if self.panelTitles[simulatorPanel.id] != newTitle {
+                    self.panelTitles[simulatorPanel.id] = newTitle
+                }
+                let resolvedTitle = self.resolvedPanelTitle(panelId: simulatorPanel.id, fallback: newTitle)
+                guard existing.title != resolvedTitle else { return }
+                self.bonsplitController.updateTab(
+                    tabId,
+                    title: resolvedTitle,
+                    hasCustomTitle: self.panelCustomTitles[simulatorPanel.id] != nil
+                )
+            }
+        panelSubscriptions[simulatorPanel.id] = subscription
+    }
+
     private func installFilePreviewPanelSubscription(_ filePreviewPanel: FilePreviewPanel) {
         let titleAndDirty = Publishers.CombineLatest(
             filePreviewPanel.$displayTitle.removeDuplicates(),
@@ -8187,6 +8215,10 @@ final class Workspace: Identifiable, ObservableObject {
         panels[panelId] as? FilePreviewPanel
     }
 
+    func simulatorPanel(for panelId: UUID) -> SimulatorPanel? {
+        panels[panelId] as? SimulatorPanel
+    }
+
     private func surfaceKind(for panel: any Panel) -> String {
         switch panel.panelType {
         case .terminal:
@@ -8197,6 +8229,8 @@ final class Workspace: Identifiable, ObservableObject {
             return SurfaceKind.markdown
         case .filePreview:
             return SurfaceKind.filePreview
+        case .simulator:
+            return SurfaceKind.simulator
         }
     }
 
@@ -10400,6 +10434,110 @@ final class Workspace: Identifiable, ObservableObject {
 
         installMarkdownPanelSubscription(markdownPanel)
         return markdownPanel
+    }
+
+    func newSimulatorSplit(
+        from panelId: UUID,
+        orientation: SplitOrientation,
+        insertFirst: Bool = false,
+        deviceUDID: String?,
+        focus: Bool = true
+    ) -> SimulatorPanel? {
+        guard let sourceTabId = surfaceIdFromPanelId(panelId) else { return nil }
+        var sourcePaneId: PaneID?
+        for paneId in bonsplitController.allPaneIds {
+            let tabs = bonsplitController.tabs(inPane: paneId)
+            if tabs.contains(where: { $0.id == sourceTabId }) {
+                sourcePaneId = paneId
+                break
+            }
+        }
+
+        guard let paneId = sourcePaneId else { return nil }
+
+        let simulatorPanel = SimulatorPanel(workspaceId: id, deviceUDID: deviceUDID)
+        panels[simulatorPanel.id] = simulatorPanel
+        panelTitles[simulatorPanel.id] = simulatorPanel.displayTitle
+
+        let newTab = Bonsplit.Tab(
+            title: simulatorPanel.displayTitle,
+            icon: simulatorPanel.displayIcon,
+            kind: SurfaceKind.simulator,
+            isDirty: simulatorPanel.isDirty,
+            isLoading: false,
+            isPinned: false
+        )
+        surfaceIdToPanelId[newTab.id] = simulatorPanel.id
+        let previousFocusedPanelId = focusedPanelId
+
+        isProgrammaticSplit = true
+        defer { isProgrammaticSplit = false }
+        guard bonsplitController.splitPane(paneId, orientation: orientation, withTab: newTab, insertFirst: insertFirst) != nil else {
+            surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            panels.removeValue(forKey: simulatorPanel.id)
+            panelTitles.removeValue(forKey: simulatorPanel.id)
+            return nil
+        }
+
+        let previousHostedView = focusedTerminalPanel?.hostedView
+        if focus {
+            focusPanel(simulatorPanel.id)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: simulatorPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installSimulatorPanelSubscription(simulatorPanel)
+        return simulatorPanel
+    }
+
+    @discardableResult
+    func newSimulatorSurface(
+        inPane paneId: PaneID,
+        deviceUDID: String?,
+        focus: Bool? = nil
+    ) -> SimulatorPanel? {
+        let shouldFocusNewTab = focus ?? (bonsplitController.focusedPaneId == paneId)
+        let previousFocusedPanelId = focusedPanelId
+        let previousHostedView = focusedTerminalPanel?.hostedView
+
+        let simulatorPanel = SimulatorPanel(workspaceId: id, deviceUDID: deviceUDID)
+        panels[simulatorPanel.id] = simulatorPanel
+        panelTitles[simulatorPanel.id] = simulatorPanel.displayTitle
+
+        guard let newTabId = bonsplitController.createTab(
+            title: simulatorPanel.displayTitle,
+            icon: simulatorPanel.displayIcon,
+            kind: SurfaceKind.simulator,
+            isDirty: simulatorPanel.isDirty,
+            isLoading: false,
+            isPinned: false,
+            inPane: paneId
+        ) else {
+            panels.removeValue(forKey: simulatorPanel.id)
+            panelTitles.removeValue(forKey: simulatorPanel.id)
+            return nil
+        }
+
+        surfaceIdToPanelId[newTabId] = simulatorPanel.id
+        if shouldFocusNewTab {
+            bonsplitController.focusPane(paneId)
+            bonsplitController.selectTab(newTabId)
+            simulatorPanel.focus()
+            applyTabSelection(tabId: newTabId, inPane: paneId)
+        } else {
+            preserveFocusAfterNonFocusSplit(
+                preferredPanelId: previousFocusedPanelId,
+                splitPanelId: simulatorPanel.id,
+                previousHostedView: previousHostedView
+            )
+        }
+
+        installSimulatorPanelSubscription(simulatorPanel)
+        return simulatorPanel
     }
 
     @discardableResult

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2,6 +2,7 @@ import AppKit
 import SwiftUI
 import Darwin
 import Bonsplit
+import CMUXSimulator
 import UniformTypeIdentifiers
 @main
 struct cmuxApp: App {
@@ -364,6 +365,14 @@ struct cmuxApp: App {
                         )
                     ) {
                         FeedButtonStyleDebugWindowController.shared.show()
+                    }
+                    Button(
+                        String(
+                            localized: "debug.menu.simulatorDebug",
+                            defaultValue: "iOS Simulators…"
+                        )
+                    ) {
+                        SimulatorDebugWindowController.shared.show()
                     }
                     Button(
                         String(
@@ -1112,6 +1121,7 @@ struct cmuxApp: App {
         FeedPreviewWindowController.shared.show()
         FeedTextEditorDebugWindowController.shared.show()
         FeedButtonStyleDebugWindowController.shared.show()
+        SimulatorDebugWindowController.shared.show()
         BonsplitTabBarDebugWindowController.shared.show()
     }
 #endif
@@ -1146,7 +1156,42 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.backgroundDebug",
     "cmux.startupAppearanceDebug",
     "cmux.bonsplitTabBarDebug",
+    "cmux.simulatorDebug",
 ]
+
+#if DEBUG
+private final class SimulatorDebugWindowController: NSWindowController, NSWindowDelegate {
+    static let shared = SimulatorDebugWindowController()
+
+    private init() {
+        let contentView = CMUXSimulatorDebugView()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 980, height: 720),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "debug.simulator.title", defaultValue: "iOS Simulators")
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.simulatorDebug")
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: contentView)
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show() {
+        guard let window else { return }
+        window.center()
+        showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+    }
+}
+#endif
 
 /// Returns whether the given window should handle the standard close shortcut
 /// as a standalone auxiliary window instead of routing it through workspace or


### PR DESCRIPTION
## Summary
- Adds `Packages/CMUXSimulator` for runtime-loaded CoreSimulator and SimulatorKit access, with capability probing, lifecycle, IOSurface screen callbacks, and Indigo HID touch/scroll/button dispatch.
- Adds an ephemeral `.simulator` bonsplit panel, DEBUG simulator picker window, `simulator.*` v2 socket methods, and `cmux sim` / `cmux simulator` CLI commands with TUI/list/open/boot/shutdown flows.
- Renders frames by assigning IOSurface objects to a CALayer, with SwiftUI HUD updates limited to coarse metrics and status.

## Testing
- `swift build --package-path Packages/CMUXSimulator`
- `./scripts/setup.sh`
- `./scripts/reload.sh --tag simview`
- `/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-simview/Build/Products/Debug/cmux DEV simview.app/Contents/Resources/bin/cmux sim --help`

## Issues
- Task: cmux iOS Simulator Viewer high-level spec from chat


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS Simulator viewer panel and a new CLI to list, boot, open, and shut down simulators with live screen streaming and basic HID input. Implements the high‑level cmux iOS Simulator Viewer spec and exposes new v2 socket methods to integrate with the app.

- **New Features**
  - New `CMUXSimulator` package with runtime CoreSimulator/SimulatorKit loading, capability checks (Xcode 26+), IOSurface frame streaming, and Indigo HID touch/scroll/button support.
  - New ephemeral `.simulator` panel with a SwiftUI viewer and a minimal HUD; added “iOS Simulators…” debug window and command‑palette kind.
  - New v2 socket methods: `simulator.list`, `simulator.boot`, `simulator.shutdown`, `simulator.open`.
  - New CLI: `cmux sim` / `cmux simulator` with list/open/boot/shutdown flows and a TUI.

<sup>Written for commit b63b32a8cb516d7f7a69063cfb658a416787d461. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added iOS Simulator integration with CLI commands (`sim list`, `sim boot`, `sim shutdown`, `sim open`) and interactive terminal UI
  * New simulator panel for device selection, control, and live screen streaming
  * Support for hardware actions: home, lock, screenshot, shake, and volume controls
  * HID input for touch, hover, scroll, and button interactions
  * File installation and copying to simulator devices
  * Debug view for managing multiple simulators

<!-- end of auto-generated comment: release notes by coderabbit.ai -->