### PR TITLE
Fix terminal focus after browser split

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -4,13 +4,13 @@
 20530	CLI/cmux.swift
 17229	Sources/TerminalController.swift
 15965	Sources/ContentView.swift
-14510	Sources/AppDelegate.swift
+14547	Sources/AppDelegate.swift
 13899	Sources/Workspace.swift
 13408	Sources/GhosttyTerminalView.swift
-10597	Sources/Panels/BrowserPanel.swift
+10607	Sources/Panels/BrowserPanel.swift
 8280	Sources/cmuxApp.swift
 7488	Sources/TabManager.swift
-6751	Sources/Panels/BrowserPanelView.swift
+6794	Sources/Panels/BrowserPanelView.swift
 5556	cmuxTests/AppDelegateShortcutRoutingTests.swift
 4590	cmuxTests/TerminalAndGhosttyTests.swift
 4588	cmuxTests/WorkspaceUnitTests.swift
@@ -36,8 +36,8 @@
 1879	Sources/FileExplorerView.swift
 1826	Sources/SessionIndexStore.swift
 1765	cmuxTests/ShortcutAndCommandPaletteTests.swift
+1602	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1591	Sources/KeyboardShortcutSettingsFileStore.swift
-1517	cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
 1454	Sources/TerminalNotificationStore.swift
 1365	Sources/Feed/FeedButtonStyleDebugWindowController.swift
 1342	Sources/WindowDragHandleView.swift

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11720,6 +11720,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         browserAddressBarFocusedPanelId
     }
 
+    func clearBrowserAddressBarFocus(panelId: UUID, reason: String) {
+        guard browserAddressBarFocusedPanelId == panelId else { return }
+        browserAddressBarFocusedPanelId = nil
+        stopBrowserOmnibarSelectionRepeat()
+#if DEBUG
+        cmuxDebugLog("addressBar CLEAR panelId=\(panelId.uuidString.prefix(8)) reason=\(reason)")
+#endif
+    }
+
     private func focusedBrowserAddressBarPanelIdForShortcutEvent(_ event: NSEvent) -> UUID? {
         guard let panelId = browserAddressBarFocusedPanelId else { return nil }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8828,8 +8828,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let timer = DispatchSource.makeTimerSource(queue: .main)
         timer.schedule(deadline: .now(), repeating: .milliseconds(100))
         timer.setEventHandler { [weak self] in
-            guard let self, let workspace = self.tabManager?.selectedWorkspace else { return }
-            self.writeGotoSplitTestData(self.gotoSplitFindStateSnapshot(for: workspace))
+            Task { @MainActor [weak self] in
+                guard let self, let workspace = self.tabManager?.selectedWorkspace else { return }
+                self.writeGotoSplitTestData(self.gotoSplitFindStateSnapshot(for: workspace))
+            }
         }
         gotoSplitUITestRecorder = timer
         timer.resume()
@@ -8900,22 +8902,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             self.recordGotoSplitUITestActiveElement(panelId: panelId, keyPrefix: "addressBarExit")
         })
 
-        gotoSplitUITestObservers.append(NotificationCenter.default.addObserver(
-            forName: .ghosttyDidBecomeFirstResponderSurface,
-            object: nil,
-            queue: .main
-        ) { [weak self] notification in
-            guard let self else { return }
-            guard let surfaceId = notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else {
-                return
-            }
-            guard let workspace = self.tabManager?.selectedWorkspace else { return }
-            var updates = self.gotoSplitFindStateSnapshot(for: workspace)
-            updates["terminalFirstResponderPanelId"] = surfaceId.uuidString
-            updates["terminalFirstResponderFocusedPanelMatches"] =
-                workspace.focusedPanelId == surfaceId ? "true" : "false"
-            self.writeGotoSplitTestData(updates)
-        })
     }
 
     private func recordGotoSplitUITestWebViewFocus(panelId: UUID, key: String) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8352,6 +8352,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard !didSetupGotoSplitUITest else { return }
         didSetupGotoSplitUITest = true
         let env = ProcessInfo.processInfo.environment
+        if env["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] == "1" {
+            installGotoSplitUITestFocusObserversIfNeeded()
+            startGotoSplitRecordOnlyRecorder()
+            return
+        }
         guard env["CMUX_UI_TEST_GOTO_SPLIT_SETUP"] == "1" else { return }
         guard tabManager != nil else { return }
 
@@ -8698,6 +8703,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } ?? ""
         updates["browserFindTotal"] = browserWithFind?.searchState?.total.map(String.init) ?? ""
         updates["browserFindVisible"] = browserWithFind == nil ? "false" : "true"
+
+        let currentResponder = (NSApp.keyWindow ?? NSApp.mainWindow)?.firstResponder
+        updates["firstResponderTerminalPanelId"] =
+            cmuxOwningGhosttyView(for: currentResponder)?.terminalSurface?.id.uuidString ?? ""
+
         updates.merge(cmuxFindResponderSnapshot()) { _, new in new }
         return updates
     }
@@ -8810,6 +8820,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         timer.resume()
     }
 
+    private func startGotoSplitRecordOnlyRecorder() {
+        guard isGotoSplitUITestRecordingEnabled() else { return }
+        gotoSplitUITestRecorder?.cancel()
+        gotoSplitUITestRecorder = nil
+
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now(), repeating: .milliseconds(100))
+        timer.setEventHandler { [weak self] in
+            guard let self, let workspace = self.tabManager?.selectedWorkspace else { return }
+            self.writeGotoSplitTestData(self.gotoSplitFindStateSnapshot(for: workspace))
+        }
+        gotoSplitUITestRecorder = timer
+        timer.resume()
+    }
+
     private func recordGotoSplitUITestState(browserPanelId: UUID) {
         guard let tabManager,
               let workspace = tabManager.selectedWorkspace,
@@ -8873,6 +8898,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             guard let panelId = notification.object as? UUID else { return }
             self.recordGotoSplitUITestWebViewFocus(panelId: panelId, key: "webViewFocusedAfterAddressBarExit")
             self.recordGotoSplitUITestActiveElement(panelId: panelId, keyPrefix: "addressBarExit")
+        })
+
+        gotoSplitUITestObservers.append(NotificationCenter.default.addObserver(
+            forName: .ghosttyDidBecomeFirstResponderSurface,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let self else { return }
+            guard let surfaceId = notification.userInfo?[GhosttyNotificationKey.surfaceId] as? UUID else {
+                return
+            }
+            guard let workspace = self.tabManager?.selectedWorkspace else { return }
+            var updates = self.gotoSplitFindStateSnapshot(for: workspace)
+            updates["terminalFirstResponderPanelId"] = surfaceId.uuidString
+            updates["terminalFirstResponderFocusedPanelMatches"] =
+                workspace.focusedPanelId == surfaceId ? "true" : "false"
+            self.writeGotoSplitTestData(updates)
         })
     }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5343,7 +5343,8 @@ extension BrowserPanel {
     }
 
     func ownedFocusIntent(for responder: NSResponder, in window: NSWindow) -> PanelFocusIntent? {
-        if AppDelegate.shared?.focusedBrowserAddressBarPanelId() == id {
+        if AppDelegate.shared?.focusedBrowserAddressBarPanelId() == id,
+           browserOmnibarPanelId(for: responder) == id {
             return .browser(.addressBar)
         }
 
@@ -5374,17 +5375,26 @@ extension BrowserPanel {
             return yielded
         case .addressBar:
             guard AppDelegate.shared?.focusedBrowserAddressBarPanelId() == id else { return false }
-            let yielded = window.makeFirstResponder(nil)
-#if DEBUG
-            if yielded {
-                cmuxDebugLog("focus.handoff.yield panel=\(id.uuidString.prefix(5)) target=addressBar")
+            guard browserOmnibarPanelId(for: window.firstResponder) == id else {
+                clearAddressBarFocusTrackingForYield()
+                return false
             }
+            browserPrepareOmnibarForProgrammaticBlur(panelId: id, responder: window.firstResponder)
+            clearAddressBarFocusTrackingForYield()
+#if DEBUG
+            cmuxDebugLog("focus.handoff.yield panel=\(id.uuidString.prefix(5)) target=addressBar")
 #endif
-            return yielded
+            return true
         case .webView:
             guard Self.responderChainContains(window.firstResponder, target: webView) else { return false }
             return window.makeFirstResponder(nil)
         }
+    }
+
+    private func clearAddressBarFocusTrackingForYield() {
+        endSuppressWebViewFocusForAddressBar()
+        AppDelegate.shared?.clearBrowserAddressBarFocus(panelId: id, reason: "yield")
+        NotificationCenter.default.post(name: .browserDidBlurAddressBar, object: id)
     }
 
     @discardableResult

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1171,6 +1171,7 @@ struct BrowserPanelView: View {
             }
 
             OmnibarTextFieldRepresentable(
+                panelId: panel.id,
                 text: Binding(
                     get: { omnibarState.buffer },
                     set: { newValue in
@@ -3209,8 +3210,10 @@ func browserOmnibarShouldReacquireFocusAfterEndEditing(
 }
 
 private final class OmnibarNativeTextField: NSTextField {
+    var panelId: UUID?
     var onPointerDown: (() -> Void)?
     var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
+    var suppressNextFocusReacquireOnEndEditing = false
     /// Anchor index for Shift+click selection extension, reset on non-shift clicks.
     private var shiftClickAnchor: Int?
 
@@ -3371,6 +3374,7 @@ private final class OmnibarNativeTextField: NSTextField {
 }
 
 private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
+    let panelId: UUID
     @Binding var text: String
     @Binding var isFocused: Bool
     let selectAllRequestId: UInt64
@@ -3508,6 +3512,9 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         }
 
         private func shouldReacquireFocusAfterEndEditing(window: NSWindow?) -> Bool {
+            if parentField?.suppressNextFocusReacquireOnEndEditing == true {
+                return false
+            }
             if pointerDownBlurIntent(window: window) {
                 return false
             }
@@ -3531,22 +3538,24 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             }
             attachSelectionObserverIfNeeded()
             if let field = obj.object as? OmnibarNativeTextField {
+                field.suppressNextFocusReacquireOnEndEditing = false
                 applyPendingSelectAllIfPossible(field: field)
             }
             publishSelectionState()
         }
 
         func controlTextDidEndEditing(_ obj: Notification) {
+            let shouldReacquire = shouldReacquireFocusAfterEndEditing(window: parentField?.window)
 #if DEBUG
             let nextOther = nextResponderIsOtherTextField(window: parentField?.window)
             let pointerBlur = pointerDownBlurIntent(window: parentField?.window)
             logFocusEvent(
                 "controlTextDidEndEditing",
-                detail: "nextOther=\(nextOther ? 1 : 0) pointerBlur=\(pointerBlur ? 1 : 0) shouldReacquire=\(shouldReacquireFocusAfterEndEditing(window: parentField?.window) ? 1 : 0)"
+                detail: "nextOther=\(nextOther ? 1 : 0) pointerBlur=\(pointerBlur ? 1 : 0) shouldReacquire=\(shouldReacquire ? 1 : 0)"
             )
 #endif
             if parent.isFocused {
-                if shouldReacquireFocusAfterEndEditing(window: parentField?.window) {
+                if shouldReacquire {
 #if DEBUG
                     logFocusEvent("controlTextDidEndEditing.reacquire.begin")
 #endif
@@ -3591,6 +3600,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 #endif
                 parent.onFieldLostFocus()
             }
+            parentField?.suppressNextFocusReacquireOnEndEditing = false
             detachSelectionObserver()
         }
 
@@ -3888,6 +3898,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
 
     func makeNSView(context: Context) -> OmnibarNativeTextField {
         let field = OmnibarNativeTextField(frame: .zero)
+        field.panelId = panelId
         field.identifier = browserOmnibarTextFieldIdentifier
         field.font = .systemFont(ofSize: 12)
         field.placeholderString = placeholder
@@ -3911,6 +3922,7 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     func updateNSView(_ nsView: OmnibarNativeTextField, context: Context) {
         context.coordinator.parent = self
         context.coordinator.parentField = nsView
+        nsView.panelId = panelId
         nsView.placeholderString = placeholder
         context.coordinator.queueSelectAllRequest(selectAllRequestId)
 
@@ -4042,6 +4054,37 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
         coordinator.detachSelectionObserver()
         coordinator.parentField = nil
     }
+}
+
+func browserOmnibarPanelId(for responder: NSResponder?) -> UUID? {
+    browserOmnibarField(for: responder)?.panelId
+}
+
+@discardableResult
+func browserPrepareOmnibarForProgrammaticBlur(panelId: UUID, responder: NSResponder?) -> Bool {
+    guard let field = browserOmnibarField(for: responder),
+          field.panelId == panelId else {
+        return false
+    }
+    field.suppressNextFocusReacquireOnEndEditing = true
+    return true
+}
+
+private func browserOmnibarField(for responder: NSResponder?) -> OmnibarNativeTextField? {
+    guard let responder else { return nil }
+
+    if let field = responder as? OmnibarNativeTextField {
+        return field
+    }
+
+    if let editor = responder as? NSTextView,
+       editor.isFieldEditor,
+       let field = cmuxFieldEditorOwnerView(editor) as? OmnibarNativeTextField,
+       field.currentEditor() === editor {
+        return field
+    }
+
+    return nil
 }
 
 private struct OmnibarSuggestionsView: View {

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -787,6 +787,7 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
 
     func testTerminalSplitAfterBrowserSplitFocusesCreatedTerminal() {
         let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
         app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
         launchAndEnsureForeground(app)

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -785,6 +785,58 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
     }
 
+    func testTerminalSplitAfterBrowserSplitFocusesCreatedTerminal() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_GOTO_SPLIT_PATH"] = dataPath
+        launchAndEnsureForeground(app)
+
+        let window = app.windows.firstMatch
+        _ = window.waitForExistence(timeout: 2.0)
+
+        app.typeKey("d", modifierFlags: [.command])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "right" else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 2 && data["focusedPanelKind"] == "terminal"
+            },
+            "Expected Cmd+D to create and focus a right terminal split. data=\(String(describing: loadData()))"
+        )
+
+        app.typeKey("d", modifierFlags: [.command, .shift, .option])
+        let omnibar = app.textFields["BrowserOmnibarTextField"].firstMatch
+        XCTAssertTrue(omnibar.waitForExistence(timeout: 8.0), "Expected browser omnibar after Cmd+Option+Shift+D")
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                data["webViewFocusedAfterAddressBarFocus"] == "false" &&
+                    (data["webViewFocusedAfterAddressBarFocusPanelId"]?.isEmpty == false)
+            },
+            "Expected Cmd+Option+Shift+D to create and focus a browser split. data=\(String(describing: loadData()))"
+        )
+
+        app.typeKey("d", modifierFlags: [.command, .shift])
+        XCTAssertTrue(
+            waitForDataMatch(timeout: 6.0) { data in
+                guard data["lastSplitDirection"] == "down" else { return false }
+                guard let focusedPanelId = data["focusedPanelId"], !focusedPanelId.isEmpty else { return false }
+                guard let paneCountAfterSplit = Int(data["paneCountAfterSplit"] ?? "") else { return false }
+                return paneCountAfterSplit >= 4 && data["focusedPanelKind"] == "terminal"
+            },
+            "Expected Cmd+Shift+D from browser split to create and select a terminal. data=\(String(describing: loadData()))"
+        )
+
+        guard let focusedPanelId = loadData()?["focusedPanelId"], !focusedPanelId.isEmpty else {
+            XCTFail("Missing focusedPanelId after terminal split. data=\(String(describing: loadData()))")
+            return
+        }
+
+        XCTAssertTrue(
+            waitForStableTerminalFirstResponder(panelId: focusedPanelId, stableDuration: 1.0, timeout: 6.0),
+            "Expected newly created terminal to own AppKit first responder. focusedPanelId=\(focusedPanelId) data=\(String(describing: loadData()))"
+        )
+    }
+
     func testCmdOptionPaneSwitchPreservesFindFieldFocus() {
         runFindFocusPersistenceScenario(route: .cmdOptionArrows, useAutofocusRacePage: false)
     }
@@ -1385,6 +1437,38 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
             guard let data = self.loadData() else { return false }
             return predicate(data)
         }
+    }
+
+    private func waitForStableTerminalFirstResponder(
+        panelId: String,
+        stableDuration: TimeInterval,
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        var stableSince: Date?
+
+        while Date() < deadline {
+            let matches = loadData().map { data in
+                data["focusedPanelId"] == panelId &&
+                    data["focusedPanelKind"] == "terminal" &&
+                    data["firstResponderTerminalPanelId"] == panelId
+            } ?? false
+
+            if matches {
+                if stableSince == nil {
+                    stableSince = Date()
+                }
+                if let stableSince, Date().timeIntervalSince(stableSince) >= stableDuration {
+                    return true
+                }
+            } else {
+                stableSince = nil
+            }
+
+            RunLoop.current.run(until: Date().addingTimeInterval(0.1))
+        }
+
+        return false
     }
 
     private func waitForNonExistence(_ element: XCUIElement, timeout: TimeInterval) -> Bool {


### PR DESCRIPTION
Summary:
- Add a regression test for terminal focus after opening a browser split from a split terminal.
- Clear stale browser omnibar focus ownership before handing focus to a terminal split.
- Track the actual omnibar panel that owns the field editor before yielding browser address-bar focus.

Testing:
- `./scripts/reload.sh --tag focusbr2`
- Red test-only e2e: https://github.com/manaflow-ai/cmux/actions/runs/25296290122
- Green full-fix e2e: https://github.com/manaflow-ai/cmux/actions/runs/25296464882

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a focus regression when splitting: after opening a browser split from a split terminal, the next terminal split now gets focus and stays the AppKit first responder. Adds a regression test and record-only mode to keep this behavior stable.

- **Bug Fixes**
  - Only treat the address bar as focused if the field editor belongs to that exact panel; clear stale ownership via `clearBrowserAddressBarFocus`.
  - On handoff from address bar to terminal, suppress the omnibar’s auto-reacquire for that specific field so it doesn’t steal focus back.
  - Add UI snapshot key `firstResponderTerminalPanelId` and a record-only mode (`CMUX_UI_TEST_GOTO_SPLIT_RECORD_ONLY`) to verify the new terminal owns focus consistently.

<sup>Written for commit aa9574090a4ede3a8e2841a40a2a4a9c4bb03c4c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved browser address-bar focus handling to avoid incorrect focus ownership and unwanted re-focus after programmatic blurs.
  * Better stability when switching between browser and terminal panels so terminal first responder remains consistent after splits.

* **Tests**
  * Added a UI test that verifies terminal focus is preserved after a sequence of split operations and includes stability polling for responder state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->