### PR TITLE
Fix CircleCI Bun install prefix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,12 @@ commands:
           name: Install Bun
           command: |
             BUN_VERSION="1.3.3"
-            npm install --global "bun@$BUN_VERSION"
+            NPM_GLOBAL="$HOME/.npm-global"
+            mkdir -p "$NPM_GLOBAL"
+            npm install --global --prefix "$NPM_GLOBAL" "bun@$BUN_VERSION"
+            BASH_ENV="${BASH_ENV:-$HOME/.bash_env}"
+            echo "export PATH=\"$NPM_GLOBAL/bin:\$PATH\"" >> "$BASH_ENV"
+            export PATH="$NPM_GLOBAL/bin:$PATH"
             test "$(bun --version)" = "$BUN_VERSION"
 
   install-zig:


### PR DESCRIPTION
Fixes the new CircleCI setup failing in the Linux web jobs because npm global install is not writable in the CircleCI Docker executor.\n\nChanges:\n- install pinned Bun into a user-owned npm prefix\n- persist that prefix through `BASH_ENV` for later CircleCI steps\n- keep the `bun --version` pin check\n\nVerification:\n- locally ran the updated install command with a temp npm prefix and confirmed `bun --version` prints `1.3.3`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Linux web jobs on CircleCI by installing `bun` to a user-owned `npm` prefix and exporting the PATH so later steps can find it. Keeps `bun` pinned to version 1.3.3 to avoid drift.

- **Bug Fixes**
  - Install `bun@1.3.3` with `npm --global --prefix $HOME/.npm-global`.
  - Add `$HOME/.npm-global/bin` to PATH via `BASH_ENV` for subsequent steps.
  - Verify with `bun --version` equals `1.3.3`.

<sup>Written for commit 8c66c0fbb3cfb5cade28d3daea495134e8437767. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build system configuration to improve installation process reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->