### PR TITLE
Move automatic macOS checks to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -398,6 +398,7 @@ jobs:
 
             CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_version_memory_guard.py
             CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_contract_help.py
+            CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_operation_deadline.py
       - save-swift-package-cache:
           prefix: unit
       - save-zig-cache
@@ -470,10 +471,6 @@ jobs:
 workflows:
   ci:
     jobs:
-      - workflow-guard-tests
-      - remote-daemon-tests
-      - web-typecheck
-      - web-db-migrations
       - macos-unit-tests
       - macos-debug-build
       - macos-release-build

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -1,10 +1,7 @@
 name: Build GhosttyKit
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -1,10 +1,7 @@
 name: macOS Compatibility
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   compat-tests:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
+    inputs:
+      run_warpbuild_macos:
+        description: Run preserved WarpBuild macOS jobs
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -139,6 +146,7 @@ jobs:
           bun test tests/vm-db-read-model.test.ts
 
   tests:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 30
     steps:
@@ -312,6 +320,7 @@ jobs:
     # Keep lag validation separate from UI regressions so functional UI failures
     # and performance regressions stay isolated. Broader interactive UI suites
     # still run via test-e2e.yml on GitHub-hosted runners.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 20
     steps:
@@ -487,6 +496,7 @@ jobs:
     # Compile the same unsigned universal Release app that nightly builds before
     # signing, notarization, and publishing. This catches DEBUG/Release boundary
     # mistakes before they reach main.
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
     runs-on: warp-macos-26-arm64-6x
     timeout-minutes: 20
     steps:
@@ -578,6 +588,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
   ui-regressions:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_warpbuild_macos }}
     runs-on: warp-macos-15-arm64-6x
     timeout-minutes: 25
     steps:


### PR DESCRIPTION
## Summary
- keep GitHub Actions automatic PR/push coverage focused on Linux jobs
- run CircleCI as the automatic macOS check surface
- keep WarpBuild macOS workflows available by manual dispatch for fallback

## Verification
- git diff --check
- YAML parsed for edited workflow/config files
- actionlint on edited GitHub workflows, ignoring known custom WarpBuild runner labels
- ./tests/test_ci_self_hosted_guard.sh
- ./tests/test_ci_create_dmg_pinned.sh
- ./tests/test_ci_unit_test_spm_retry.sh
- ./tests/test_ci_scheme_testaction_debug.sh
- ./tests/test_ci_ghosttykit_checksum_verification.sh
- node scripts/release_asset_guard.test.js
- ./tests/test_ci_ghosttykit_checksum_present.sh
- ./tests/test_ci_swift_warning_budget.sh
- ./tests/test_ci_swift_file_length_budget.sh
- python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move automatic macOS CI from GitHub Actions to CircleCI to keep PR/push checks fast and reliable. GitHub Actions now runs Linux-only by default; macOS WarpBuild jobs are opt-in via manual dispatch.

- **Refactors**
  - CircleCI now runs macOS unit/debug/release jobs and adds `test_cli_socket_operation_deadline.py`; removed non-macOS jobs from the macOS workflow.
  - GitHub Actions macOS workflows (`build-ghosttykit.yml`, `ci-macos-compat.yml`) switched to `workflow_dispatch` only.
  - `ci.yml` adds a manual `run_warpbuild_macos` input to conditionally run preserved WarpBuild macOS jobs; default is off.

<sup>Written for commit 168f85639e0da71fb103990f0a861f21a933e738. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configurations: Several automated workflows now require manual triggering via workflow dispatch. Added conditional job execution for platform-specific builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->