### PR TITLE
Gate Claude OSC suppression on integration setting

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3392,7 +3392,8 @@ class GhosttyApp {
                     // The hook system manages notifications with proper lifecycle tracking;
                     // raw OSC notifications would duplicate or outlive the structured hooks.
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
-                    if let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
+                    if ClaudeCodeIntegrationSettings.hooksEnabled(),
+                       let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
                        workspace.agentPIDs["claude_code"] != nil {
                         return true
                     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3392,8 +3392,7 @@ class GhosttyApp {
                     // The hook system manages notifications with proper lifecycle tracking;
                     // raw OSC notifications would duplicate or outlive the structured hooks.
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
-                    if ClaudeCodeIntegrationSettings.hooksEnabled(),
-                       let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
+                    if ClaudeCodeIntegrationSettings.hooksEnabled(), let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
                        workspace.agentPIDs["claude_code"] != nil {
                         return true
                     }
@@ -3672,8 +3671,7 @@ class GhosttyApp {
             performOnMain {
                 // Suppress OSC notifications for workspaces with active Claude hook sessions.
                 let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? AppDelegate.shared?.tabManager
-                if ClaudeCodeIntegrationSettings.hooksEnabled(),
-                   let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
+                if ClaudeCodeIntegrationSettings.hooksEnabled(), let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
                    workspace.agentPIDs["claude_code"] != nil {
                     return
                 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3672,7 +3672,8 @@ class GhosttyApp {
             performOnMain {
                 // Suppress OSC notifications for workspaces with active Claude hook sessions.
                 let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? AppDelegate.shared?.tabManager
-                if let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
+                if ClaudeCodeIntegrationSettings.hooksEnabled(),
+                   let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
                    workspace.agentPIDs["claude_code"] != nil {
                     return
                 }

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -45,6 +45,7 @@ def run_wrapper(
     argv: list[str],
     node_options: str | None = None,
     tmpdir: str | None = None,
+    hooks_disabled: bool = False,
 ) -> tuple[int, list[str], list[str], str, str, str, str, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-test-") as td:
         tmp = Path(td)
@@ -165,6 +166,8 @@ exit 0
         env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
         env["CMUX_BUNDLED_CLI_PATH"] = str(bundled_cli_path)
         env["CLAUDECODE"] = "nested-session-sentinel"
+        if hooks_disabled:
+            env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir
@@ -412,6 +415,24 @@ def test_missing_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"missing socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def test_disabled_integration_skips_hook_injection(failures: list[str]) -> None:
+    code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
+        socket_state="live",
+        argv=["hello"],
+        hooks_disabled=True,
+    )
+    expect(code == 0, f"disabled integration: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["hello"], f"disabled integration: expected passthrough args, got {real_argv}", failures)
+    expect("--settings" not in real_argv, f"disabled integration: expected no --settings injection, got {real_argv}", failures)
+    expect("notifications_disabled" not in " ".join(real_argv), f"disabled integration: expected no notification suppression, got {real_argv}", failures)
+    expect(cmux_log == [], f"disabled integration: expected no cmux calls, got {cmux_log}", failures)
+    expect(claudecode == "__UNSET__", f"disabled integration: expected CLAUDECODE unset, got {claudecode!r}", failures)
+    expect(node_options == "__UNSET__", f"disabled integration: expected NODE_OPTIONS passthrough, got {node_options!r}", failures)
+    expect(runtime_node_options == "__UNSET__", f"disabled integration: expected runtime NODE_OPTIONS passthrough, got {runtime_node_options!r}", failures)
+    expect(child_node_options == "__UNSET__", f"disabled integration: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
+    expect(hook_cmux_bin == "__UNSET__", f"disabled integration: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
+
+
 def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="stale",
@@ -441,6 +462,7 @@ def main() -> int:
     test_live_socket_does_not_duplicate_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
     test_missing_socket_skips_hook_injection(failures)
+    test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
 
     if failures:

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -168,6 +168,8 @@ exit 0
         env["CLAUDECODE"] = "nested-session-sentinel"
         if hooks_disabled:
             env["CMUX_CLAUDE_HOOKS_DISABLED"] = "1"
+        else:
+            env.pop("CMUX_CLAUDE_HOOKS_DISABLED", None)
         env.pop("NODE_OPTIONS", None)
         if tmpdir is not None:
             env["TMPDIR"] = tmpdir


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/3418.\n\nThis keeps Claude Code integration enabled by default, but makes the disabled setting a full bypass:\n\n- app-side Claude OSC suppression now only runs when Claude Code Integration is enabled\n- wrapper regression coverage proves CMUX_CLAUDE_HOOKS_DISABLED=1 skips hook and preferredNotifChannel injection\n\nVerification:\n- bash -n Resources/bin/claude\n- python3 tests/test_claude_wrapper_hooks.py\n- ./scripts/reload.sh --tag claude-toggle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gate Claude OSC notification suppression and hook injection behind the integration toggle. When hooks are off, Ghostty shows raw OSC notifications and the wrapper fully bypasses hook and `--settings` injection.

- **Bug Fixes**
  - App: Guard both OSC parsing and display paths with `ClaudeCodeIntegrationSettings.hooksEnabled()` before suppressing notifications.
  - Wrapper tests: Isolate env (e.g., clear `NODE_OPTIONS`), add `hooks_disabled` flag and a test verifying `CMUX_CLAUDE_HOOKS_DISABLED=1` yields passthrough argv, no `--settings` or suppression, no cmux calls, and `CLAUDECODE`/`NODE_OPTIONS` unset.

<sup>Written for commit e6948da5315bea5de98b31c4260a4867c50b6169. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Desktop notification suppression for the Claude integration now also respects the integration's hooks-enabled setting, preventing incorrect suppression when hooks are disabled even if the Claude agent is present.

* **Tests**
  * Added a regression test and supporting test changes to verify that when hooks are disabled the wrapper skips hook injection, leaves related environment/settings untouched, and does not suppress notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->