### PR TITLE
Move nightly and release publishing to CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -468,9 +468,78 @@ jobs:
           path: .spm-cache
       - save-zig-cache
 
+  macos-nightly-publish:
+    executor: macos-xcode
+    steps:
+      - checkout-source:
+          submodules: true
+      - print-xcode
+      - restore-swift-package-cache:
+          prefix: nightly
+      - restore-zig-cache
+      - install-zig
+      - resolve-swift-packages:
+          scheme: cmux
+          source-packages-dir: .spm-cache
+      - run:
+          name: Build, sign, notarize, and publish nightly
+          no_output_timeout: 45m
+          command: ./scripts/ci/circleci-nightly.sh
+      - save-swift-package-cache:
+          prefix: nightly
+          path: .spm-cache
+      - save-zig-cache
+
+  macos-release-publish:
+    executor: macos-xcode
+    steps:
+      - checkout-source:
+          submodules: true
+      - print-xcode
+      - restore-swift-package-cache:
+          prefix: release-publish
+      - restore-zig-cache
+      - install-zig
+      - resolve-swift-packages:
+          scheme: cmux
+          source-packages-dir: .spm-cache
+      - run:
+          name: Build, sign, notarize, and publish release
+          no_output_timeout: 45m
+          command: ./scripts/ci/circleci-release.sh
+      - save-swift-package-cache:
+          prefix: release-publish
+          path: .spm-cache
+      - save-zig-cache
+
 workflows:
   ci:
     jobs:
-      - macos-unit-tests
-      - macos-debug-build
-      - macos-release-build
+      - macos-unit-tests:
+          filters:
+            tags:
+              ignore: /.*/
+      - macos-debug-build:
+          filters:
+            tags:
+              ignore: /.*/
+      - macos-release-build:
+          filters:
+            tags:
+              ignore: /.*/
+  nightly:
+    jobs:
+      - macos-nightly-publish:
+          filters:
+            branches:
+              only: main
+            tags:
+              ignore: /.*/
+  release:
+    jobs:
+      - macos-release-publish:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,6 @@
 name: Nightly macOS build
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
 name: Release macOS app
 
 on:
-  push:
-    tags:
-      - "v*"
   workflow_dispatch:
 
 permissions:

--- a/scripts/ci/circleci-macos-release-common.sh
+++ b/scripts/ci/circleci-macos-release-common.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+
+cmux_ci_repo="${CMUX_GITHUB_REPO:-manaflow-ai/cmux}"
+cmux_ci_create_dmg_version="${CREATE_DMG_VERSION:-8.0.0}"
+
+cmux_ci_require_env() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "Missing required environment variable: $name" >&2
+    exit 1
+  fi
+}
+
+cmux_ci_export_github_token() {
+  export GH_TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+  if [ -z "${GH_TOKEN:-}" ]; then
+    echo "Missing GH_TOKEN or GITHUB_TOKEN in CircleCI. Set a GitHub token with contents:write access." >&2
+    exit 1
+  fi
+}
+
+cmux_ci_decode_base64_to_file() {
+  local value="$1"
+  local output="$2"
+
+  if ! printf "%s" "$value" | base64 --decode > "$output" 2>/dev/null; then
+    printf "%s" "$value" | base64 -D > "$output"
+  fi
+}
+
+cmux_ci_select_xcode() {
+  set -euo pipefail
+
+  if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+    XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+  else
+    XCODE_APP="$(ls -d /Applications/Xcode*.app 2>/dev/null | head -n 1 || true)"
+    if [ -n "$XCODE_APP" ]; then
+      XCODE_DIR="$XCODE_APP/Contents/Developer"
+    else
+      echo "No Xcode.app found under /Applications" >&2
+      exit 1
+    fi
+  fi
+
+  export DEVELOPER_DIR="$XCODE_DIR"
+  xcodebuild -version
+  xcrun --sdk macosx --show-sdk-path
+}
+
+cmux_ci_install_build_deps() {
+  set -euo pipefail
+
+  if ! command -v node >/dev/null 2>&1 || ! command -v npm >/dev/null 2>&1; then
+    brew install node
+  fi
+  if ! command -v gh >/dev/null 2>&1; then
+    brew install gh
+  fi
+  if ! command -v go >/dev/null 2>&1; then
+    brew install go
+  fi
+
+  NPM_GLOBAL="$HOME/.npm-global"
+  mkdir -p "$NPM_GLOBAL"
+  npm install --global --prefix "$NPM_GLOBAL" "create-dmg@${cmux_ci_create_dmg_version}"
+  export PATH="$NPM_GLOBAL/bin:$PATH"
+
+  node --version
+  npm --version
+  gh --version | head -n 1
+  go version
+  create-dmg --version || true
+}
+
+cmux_ci_derive_sparkle_public_key() {
+  cmux_ci_require_env SPARKLE_PRIVATE_KEY
+  SPARKLE_PUBLIC_KEY="$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")"
+  export SPARKLE_PUBLIC_KEY
+  echo "Derived Sparkle public key: $SPARKLE_PUBLIC_KEY"
+}
+
+cmux_ci_build_universal_release_app() {
+  set -euo pipefail
+
+  local icon_name="${1:-}"
+  local icon_arg=()
+  if [ -n "$icon_name" ]; then
+    icon_arg=(ASSETCATALOG_COMPILER_APPICON_NAME="$icon_name")
+  fi
+
+  xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Release -derivedDataPath build-universal \
+    -destination "generic/platform=macOS" \
+    -clonedSourcePackagesDirPath .spm-cache \
+    -disableAutomaticPackageResolution \
+    ARCHS="arm64 x86_64" \
+    ONLY_ACTIVE_ARCH=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    "${icon_arg[@]}" \
+    build
+}
+
+cmux_ci_verify_binary_architectures() {
+  set -euo pipefail
+
+  local app_path="$1"
+  local app_binary="$app_path/Contents/MacOS/cmux"
+  local cli_binary="$app_path/Contents/Resources/bin/cmux"
+  local helper_binary="$app_path/Contents/Resources/bin/ghostty"
+  local app_archs cli_archs helper_archs
+
+  app_archs="$(lipo -archs "$app_binary")"
+  cli_archs="$(lipo -archs "$cli_binary")"
+  helper_archs="$(lipo -archs "$helper_binary")"
+  echo "App binary architectures: $app_archs"
+  echo "CLI binary architectures: $cli_archs"
+  echo "Ghostty helper architectures: $helper_archs"
+  [[ "$app_archs" == *arm64* && "$app_archs" == *x86_64* ]]
+  [[ "$cli_archs" == *arm64* && "$cli_archs" == *x86_64* ]]
+  [[ "$helper_archs" == *arm64* && "$helper_archs" == *x86_64* ]]
+}
+
+cmux_ci_import_signing_cert() {
+  set -euo pipefail
+
+  cmux_ci_require_env APPLE_CERTIFICATE_BASE64
+  cmux_ci_require_env APPLE_CERTIFICATE_PASSWORD
+
+  KEYCHAIN_PASSWORD="$(uuidgen)"
+  cmux_ci_decode_base64_to_file "$APPLE_CERTIFICATE_BASE64" /tmp/cert.p12
+  security delete-keychain build.keychain >/dev/null 2>&1 || true
+  security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+  security set-keychain-settings -lut 21600 build.keychain
+  security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+  security import /tmp/cert.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+  security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+  security list-keychains -d user -s build.keychain
+}
+
+cmux_ci_cleanup_keychain() {
+  security delete-keychain build.keychain >/dev/null 2>&1 || true
+  rm -f /tmp/cert.p12
+}
+
+cmux_ci_upload_dsyms_to_sentry() {
+  set -euo pipefail
+
+  if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+    echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
+    return 0
+  fi
+
+  export SENTRY_ORG="${SENTRY_ORG:-manaflow}"
+  export SENTRY_PROJECT="${SENTRY_PROJECT:-cmuxterm-macos}"
+  brew install getsentry/tools/sentry-cli || true
+  sentry-cli debug-files upload --include-sources build-universal/Build/Products/Release/
+}
+
+cmux_ci_upload_appcast_to_r2() {
+  set -euo pipefail
+
+  local channel="$1"
+  local should_upload="${2:-true}"
+  if [ "$should_upload" != "true" ]; then
+    echo "Skipping R2 $channel appcast upload"
+    return 0
+  fi
+
+  if [ -z "${CF_R2_ACCESS_KEY_ID:-}" ] || [ -z "${CF_R2_SECRET_ACCESS_KEY:-}" ] || [ -z "${CF_R2_ACCOUNT_ID:-}" ]; then
+    echo "R2 credentials are not set, skipping $channel appcast upload"
+    return 0
+  fi
+
+  command -v aws >/dev/null 2>&1 || brew install awscli
+
+  AWS_ACCESS_KEY_ID="$CF_R2_ACCESS_KEY_ID" \
+  AWS_SECRET_ACCESS_KEY="$CF_R2_SECRET_ACCESS_KEY" \
+  AWS_DEFAULT_REGION=auto \
+  aws s3 cp appcast.xml \
+    "s3://cmux-binaries/${channel}/appcast.xml" \
+    --endpoint-url "https://${CF_R2_ACCOUNT_ID}.r2.cloudflarestorage.com" \
+    --cache-control "no-cache, no-store, must-revalidate"
+
+  echo "R2 appcast upload complete: https://files.cmux.com/${channel}/appcast.xml"
+}
+
+cmux_ci_release_asset_guard() {
+  set -euo pipefail
+
+  local tag="$1"
+  local names_file="/tmp/cmux-release-asset-names.txt"
+  local guard_file="/tmp/cmux-release-asset-guard.env"
+  rm -f "$names_file" "$guard_file"
+
+  if ! gh release view "$tag" --repo "$cmux_ci_repo" --json assets --jq '.assets[].name' > "$names_file" 2>/tmp/cmux-release-view.err; then
+    if grep -qi "not found\\|404" /tmp/cmux-release-view.err; then
+      echo "Release $tag does not exist yet, continuing."
+      return 1
+    fi
+    cat /tmp/cmux-release-view.err >&2
+    return 2
+  fi
+
+  set +e
+  ASSET_NAMES_FILE="$names_file" node > "$guard_file" <<'NODE'
+const fs = require("node:fs");
+const { evaluateReleaseAssetGuard } = require("./scripts/release_asset_guard");
+const existingAssetNames = fs.readFileSync(process.env.ASSET_NAMES_FILE, "utf8")
+  .split(/\r?\n/)
+  .filter(Boolean);
+const result = evaluateReleaseAssetGuard({ existingAssetNames });
+
+console.log(`GUARD_STATE=${result.guardState}`);
+console.log(`SKIP_ALL=${result.shouldSkipBuildAndUpload ? "true" : "false"}`);
+console.log(`CONFLICTS=${JSON.stringify(result.conflicts)}`);
+console.log(`MISSING_IMMUTABLE_ASSETS=${JSON.stringify(result.missingImmutableAssets)}`);
+
+if (result.hasPartialConflict) {
+  process.exitCode = 3;
+}
+NODE
+  local node_status=$?
+  set -e
+  # shellcheck disable=SC1090
+  source "$guard_file"
+
+  if [ "$node_status" -eq 3 ]; then
+    echo "Release $tag has a partial immutable asset state." >&2
+    echo "Existing immutable assets: $CONFLICTS" >&2
+    echo "Missing immutable assets: $MISSING_IMMUTABLE_ASSETS" >&2
+    return 3
+  fi
+
+  if [ "${SKIP_ALL:-false}" = "true" ]; then
+    echo "Release $tag already has all immutable assets, skipping build and upload."
+    return 0
+  fi
+
+  echo "Release $tag exists without immutable release assets, continuing."
+  return 1
+}

--- a/scripts/ci/circleci-nightly.sh
+++ b/scripts/ci/circleci-nightly.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# shellcheck source=./circleci-macos-release-common.sh
+source "$ROOT_DIR/scripts/ci/circleci-macos-release-common.sh"
+
+trap cmux_ci_cleanup_keychain EXIT
+
+cmux_ci_export_github_token
+
+FORCE_BUILD="${CMUX_FORCE_NIGHTLY:-false}"
+REQUESTED_REF="${CIRCLE_BRANCH:-main}"
+IS_MAIN_REF=false
+if [ "${CIRCLE_TAG:-}" = "" ] && [ "$REQUESTED_REF" = "main" ]; then
+  IS_MAIN_REF=true
+fi
+
+if [ "$IS_MAIN_REF" = "true" ]; then
+  HEAD_SHA="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+else
+  HEAD_SHA="${CIRCLE_SHA1:-$(git rev-parse HEAD)}"
+fi
+SHORT_SHA="$(printf "%s" "$HEAD_SHA" | cut -c1-7)"
+
+NIGHTLY_SHA="$(git ls-remote origin 'refs/tags/nightly^{}' | awk '{print $1}' | head -n 1 || true)"
+if [ -z "$NIGHTLY_SHA" ]; then
+  NIGHTLY_SHA="$(git ls-remote origin refs/tags/nightly | awk '{print $1}' | head -n 1 || true)"
+fi
+
+SHOULD_BUILD=false
+SHOULD_PUBLISH=false
+if [ "$IS_MAIN_REF" != "true" ] || [ "$FORCE_BUILD" = "true" ] || [ "$NIGHTLY_SHA" != "$HEAD_SHA" ]; then
+  SHOULD_BUILD=true
+fi
+if [ "$IS_MAIN_REF" = "true" ]; then
+  SHOULD_PUBLISH=true
+fi
+
+cat <<EOF
+Nightly build decision
+requested ref: $REQUESTED_REF
+build HEAD: $HEAD_SHA
+nightly tag: ${NIGHTLY_SHA:-"(missing)"}
+force build: $FORCE_BUILD
+should build: $SHOULD_BUILD
+should publish: $SHOULD_PUBLISH
+EOF
+
+if [ "$SHOULD_BUILD" != "true" ]; then
+  echo "Nightly is already current, skipping."
+  exit 0
+fi
+
+git fetch origin "$HEAD_SHA" --depth=1
+git checkout --force "$HEAD_SHA"
+git submodule sync --recursive
+git submodule update --init --recursive
+
+if [ "$SHOULD_PUBLISH" = "true" ]; then
+  CURRENT_MAIN_SHA="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+  if [ "$CURRENT_MAIN_SHA" != "$HEAD_SHA" ]; then
+    echo "Main moved before build. Build SHA: $HEAD_SHA, current main SHA: $CURRENT_MAIN_SHA. Skipping publish."
+    exit 0
+  fi
+fi
+
+cmux_ci_select_xcode
+cmux_ci_install_build_deps
+./scripts/download-prebuilt-ghosttykit.sh
+cmux_ci_derive_sparkle_public_key
+
+cmux_ci_build_universal_release_app AppIcon-Nightly
+
+CMUX_APP_PATH="build-universal/Build/Products/Release/cmux.app" \
+  ./tests/test_bundled_ghostty_theme_picker_helper.sh
+
+APP_PATH="build-universal/Build/Products/Release/cmux.app"
+cmux_ci_verify_binary_architectures "$APP_PATH"
+
+CLI_BINARY="$APP_PATH/Contents/Resources/bin/cmux"
+[ -x "$CLI_BINARY" ] || { echo "cmux CLI binary not found at $CLI_BINARY" >&2; exit 1; }
+CMUX_CLI_BIN="$CLI_BINARY" python3 tests/test_cli_version_memory_guard.py
+
+if [ "$SHOULD_PUBLISH" = "true" ]; then
+  CURRENT_MAIN_SHA="$(git ls-remote origin refs/heads/main | awk '{print $1}')"
+  if [ "$CURRENT_MAIN_SHA" != "$HEAD_SHA" ]; then
+    echo "Main moved after build. Build SHA: $HEAD_SHA, current main SHA: $CURRENT_MAIN_SHA. Skipping publish."
+    exit 0
+  fi
+fi
+
+APP_DIR="build-universal/Build/Products/Release"
+BASE_MARKETING="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_DIR/cmux.app/Contents/Info.plist")"
+NIGHTLY_BUILD="${CMUX_NIGHTLY_BUILD:-$(date -u +%Y%m%d%H%M%S)}"
+NIGHTLY_MARKETING_VERSION="${BASE_MARKETING}-nightly.${NIGHTLY_BUILD}"
+NIGHTLY_REMOTE_DAEMON_VERSION="$NIGHTLY_MARKETING_VERSION"
+NIGHTLY_DMG_IMMUTABLE="cmux-nightly-macos-${NIGHTLY_BUILD}.dmg"
+export NIGHTLY_BUILD NIGHTLY_MARKETING_VERSION NIGHTLY_REMOTE_DAEMON_VERSION NIGHTLY_DMG_IMMUTABLE
+
+APP_PLIST="$APP_DIR/cmux.app/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleName cmux NIGHTLY" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleDisplayName cmux NIGHTLY" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleIdentifier com.cmuxterm.app.nightly" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_PLIST" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string ${SPARKLE_PUBLIC_KEY}" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://files.cmux.com/nightly/appcast.xml" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString ${NIGHTLY_MARKETING_VERSION}" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion ${NIGHTLY_BUILD}" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Delete :CMUXCommit" "$APP_PLIST" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :CMUXCommit string ${SHORT_SHA}" "$APP_PLIST"
+mv "$APP_DIR/cmux.app" "$APP_DIR/cmux NIGHTLY.app"
+
+echo "Nightly app name: cmux NIGHTLY"
+echo "Nightly bundle ID: com.cmuxterm.app.nightly"
+echo "Nightly marketing version: $NIGHTLY_MARKETING_VERSION"
+echo "Nightly build number: $NIGHTLY_BUILD"
+echo "Nightly immutable DMG: $NIGHTLY_DMG_IMMUTABLE"
+echo "Commit SHA: $SHORT_SHA"
+
+./scripts/build_remote_daemon_release_assets.sh \
+  --version "$NIGHTLY_REMOTE_DAEMON_VERSION" \
+  --release-tag "nightly" \
+  --repo "$cmux_ci_repo" \
+  --output-dir "remote-daemon-assets" \
+  --asset-suffix "$NIGHTLY_BUILD"
+MANIFEST_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8")), separators=(",",":")))' "remote-daemon-assets/cmuxd-remote-manifest-${NIGHTLY_BUILD}.json")"
+NIGHTLY_APP_PLIST="$APP_DIR/cmux NIGHTLY.app/Contents/Info.plist"
+plutil -remove CMUXRemoteDaemonManifestJSON "$NIGHTLY_APP_PLIST" >/dev/null 2>&1 || true
+plutil -insert CMUXRemoteDaemonManifestJSON -string "$MANIFEST_JSON" "$NIGHTLY_APP_PLIST"
+
+for platform in darwin-arm64 darwin-amd64 linux-arm64 linux-amd64; do
+  cp "remote-daemon-assets/cmuxd-remote-${platform}-${NIGHTLY_BUILD}" \
+     "remote-daemon-assets/cmuxd-remote-${platform}"
+done
+(
+  cd remote-daemon-assets
+  shasum -a 256 \
+    cmuxd-remote-darwin-arm64 \
+    cmuxd-remote-darwin-amd64 \
+    cmuxd-remote-linux-arm64 \
+    cmuxd-remote-linux-amd64 \
+    > cmuxd-remote-checksums.txt
+)
+cp "remote-daemon-assets/cmuxd-remote-manifest-${NIGHTLY_BUILD}.json" \
+   "remote-daemon-assets/cmuxd-remote-manifest.json"
+
+cmux_ci_import_signing_cert
+
+cmux_ci_require_env APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64
+NIGHTLY_APP_PATH="$APP_DIR/cmux NIGHTLY.app"
+PROFILE_PATH="$NIGHTLY_APP_PATH/Contents/embedded.provisionprofile"
+TMP_PROFILE="$(mktemp /tmp/cmux-nightly-profile.XXXXXX)"
+TMP_PLIST="$(mktemp /tmp/cmux-nightly-profile.XXXXXX.plist)"
+cmux_ci_decode_base64_to_file "$APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64" "$TMP_PROFILE"
+security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
+APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
+if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app.nightly" ]; then
+  echo "Nightly provisioning profile targets unexpected app ID: $APP_ID" >&2
+  exit 1
+fi
+WEBAUTHN_ENTITLEMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.web-browser.public-key-credential" "$TMP_PLIST")"
+if [ "$WEBAUTHN_ENTITLEMENT" != "true" ]; then
+  echo "Nightly provisioning profile is missing WebAuthn browser entitlement" >&2
+  exit 1
+fi
+PROVISIONS_ALL_DEVICES="$(/usr/libexec/PlistBuddy -c "Print :ProvisionsAllDevices" "$TMP_PLIST")"
+if [ "$PROVISIONS_ALL_DEVICES" != "true" ]; then
+  echo "Nightly provisioning profile is not a Developer ID all-devices profile" >&2
+  exit 1
+fi
+cp "$TMP_PROFILE" "$PROFILE_PATH"
+rm -f "$TMP_PROFILE" "$TMP_PLIST"
+
+cmux_ci_require_env APPLE_SIGNING_IDENTITY
+./scripts/sign-cmux-bundle.sh \
+  "$NIGHTLY_APP_PATH" \
+  cmux.nightly.entitlements \
+  "$APPLE_SIGNING_IDENTITY"
+
+cmux_ci_require_env APPLE_ID
+cmux_ci_require_env APPLE_APP_SPECIFIC_PASSWORD
+cmux_ci_require_env APPLE_TEAM_ID
+
+notarize_and_package() {
+  local app_path="$1"
+  local dmg_release="$2"
+  local dmg_immutable="$3"
+  local zip_submit="${dmg_release%.dmg}-notary.zip"
+  local dmg_tmp_dir created_dmg app_submit_json app_submit_id app_status dmg_submit_json dmg_submit_id dmg_status
+
+  ditto -c -k --sequesterRsrc --keepParent "$app_path" "$zip_submit"
+  app_submit_json="$(xcrun notarytool submit "$zip_submit" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+  app_submit_id="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$app_submit_json")"
+  app_status="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$app_submit_json")"
+  if [ "$app_status" != "Accepted" ]; then
+    echo "App notarization failed for $app_path with status: $app_status" >&2
+    xcrun notarytool log "$app_submit_id" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+    exit 1
+  fi
+  xcrun stapler staple "$app_path"
+  xcrun stapler validate "$app_path"
+  spctl -a -vv --type execute "$app_path"
+  rm -f "$zip_submit"
+
+  dmg_tmp_dir="$(mktemp -d)"
+  create-dmg \
+    --identity="$APPLE_SIGNING_IDENTITY" \
+    "$app_path" \
+    "$dmg_tmp_dir"
+  created_dmg="$(find "$dmg_tmp_dir" -maxdepth 1 -name '*.dmg' | head -n 1)"
+  if [ -z "$created_dmg" ]; then
+    echo "Failed to locate created DMG for $app_path" >&2
+    exit 1
+  fi
+  mv "$created_dmg" "$dmg_release"
+  rm -rf "$dmg_tmp_dir"
+
+  dmg_submit_json="$(xcrun notarytool submit "$dmg_release" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+  dmg_submit_id="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$dmg_submit_json")"
+  dmg_status="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$dmg_submit_json")"
+  if [ "$dmg_status" != "Accepted" ]; then
+    echo "DMG notarization failed for $dmg_release with status: $dmg_status" >&2
+    xcrun notarytool log "$dmg_submit_id" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+    exit 1
+  fi
+  xcrun stapler staple "$dmg_release"
+  xcrun stapler validate "$dmg_release"
+  cp "$dmg_release" "$dmg_immutable"
+}
+
+notarize_and_package \
+  "$NIGHTLY_APP_PATH" \
+  "cmux-nightly-macos.dmg" \
+  "$NIGHTLY_DMG_IMMUTABLE"
+
+cmux_ci_upload_dsyms_to_sentry
+
+cmux_ci_require_env SPARKLE_PRIVATE_KEY
+./scripts/sparkle_generate_appcast.sh "$NIGHTLY_DMG_IMMUTABLE" nightly appcast.xml
+cp appcast.xml appcast-universal.xml
+
+if [ "$SHOULD_PUBLISH" != "true" ]; then
+  echo "Branch nightly build complete. CircleCI artifacts are not published for branch nightlies."
+  exit 0
+fi
+
+git config user.name "circleci[bot]"
+git config user.email "circleci[bot]@users.noreply.github.com"
+git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${cmux_ci_repo}.git"
+git tag -f nightly "$HEAD_SHA"
+git push origin refs/tags/nightly --force
+
+python3 ./scripts/prune_nightly_release_assets.py \
+  --repo "$cmux_ci_repo" \
+  --release-tag nightly \
+  --keep-builds 100 \
+  --execute
+
+cat > /tmp/cmux-nightly-release-notes.md <<EOF
+Automated nightly build for \`${SHORT_SHA}\`.
+
+**cmux NIGHTLY** is published as a universal app:
+- bundle ID \`com.cmuxterm.app.nightly\`
+- feed \`appcast.xml\`
+- compatibility feed \`appcast-universal.xml\` for older universal nightlies
+
+[Download cmux-nightly-macos.dmg](https://github.com/manaflow-ai/cmux/releases/download/nightly/cmux-nightly-macos.dmg)
+EOF
+
+nightly_files=(
+  "$NIGHTLY_DMG_IMMUTABLE"
+  cmux-nightly-macos.dmg
+  appcast.xml
+  appcast-universal.xml
+  remote-daemon-assets/cmuxd-remote-darwin-arm64-${NIGHTLY_BUILD}
+  remote-daemon-assets/cmuxd-remote-darwin-amd64-${NIGHTLY_BUILD}
+  remote-daemon-assets/cmuxd-remote-linux-arm64-${NIGHTLY_BUILD}
+  remote-daemon-assets/cmuxd-remote-linux-amd64-${NIGHTLY_BUILD}
+  remote-daemon-assets/cmuxd-remote-checksums-${NIGHTLY_BUILD}.txt
+  remote-daemon-assets/cmuxd-remote-manifest-${NIGHTLY_BUILD}.json
+  remote-daemon-assets/cmuxd-remote-darwin-arm64
+  remote-daemon-assets/cmuxd-remote-darwin-amd64
+  remote-daemon-assets/cmuxd-remote-linux-arm64
+  remote-daemon-assets/cmuxd-remote-linux-amd64
+  remote-daemon-assets/cmuxd-remote-checksums.txt
+  remote-daemon-assets/cmuxd-remote-manifest.json
+)
+
+if gh release view nightly --repo "$cmux_ci_repo" >/dev/null 2>&1; then
+  gh release edit nightly \
+    --repo "$cmux_ci_repo" \
+    --title "Nightly" \
+    --prerelease \
+    --notes-file /tmp/cmux-nightly-release-notes.md
+else
+  gh release create nightly \
+    --repo "$cmux_ci_repo" \
+    --title "Nightly" \
+    --prerelease \
+    --latest=false \
+    --notes-file /tmp/cmux-nightly-release-notes.md
+fi
+gh release upload nightly --repo "$cmux_ci_repo" --clobber "${nightly_files[@]}"
+
+cmux_ci_upload_appcast_to_r2 nightly true

--- a/scripts/ci/circleci-release.sh
+++ b/scripts/ci/circleci-release.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$ROOT_DIR"
+
+# shellcheck source=./circleci-macos-release-common.sh
+source "$ROOT_DIR/scripts/ci/circleci-macos-release-common.sh"
+
+trap cmux_ci_cleanup_keychain EXIT
+
+cmux_ci_export_github_token
+
+TAG="${CIRCLE_TAG:-${GITHUB_REF_NAME:-}}"
+if [ -z "$TAG" ]; then
+  echo "Release publishing requires CIRCLE_TAG or GITHUB_REF_NAME." >&2
+  exit 1
+fi
+if [[ "$TAG" != v* ]]; then
+  echo "Release tag must start with v, got: $TAG" >&2
+  exit 1
+fi
+export GITHUB_REF_NAME="$TAG"
+
+./tests/test_ci_sparkle_build_monotonic.sh
+
+set +e
+cmux_ci_release_asset_guard "$TAG"
+guard_status=$?
+set -e
+case "$guard_status" in
+  0) exit 0 ;;
+  1) ;;
+  *) exit "$guard_status" ;;
+esac
+
+cmux_ci_select_xcode
+cmux_ci_install_build_deps
+./scripts/download-prebuilt-ghosttykit.sh
+cmux_ci_derive_sparkle_public_key
+
+cmux_ci_build_universal_release_app
+APP_PATH="build-universal/Build/Products/Release/cmux.app"
+APP_PLIST="$APP_PATH/Contents/Info.plist"
+
+cmux_ci_verify_binary_architectures "$APP_PATH"
+
+APP_VERSION="$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PLIST")"
+./scripts/build_remote_daemon_release_assets.sh \
+  --version "$APP_VERSION" \
+  --release-tag "$TAG" \
+  --repo "$cmux_ci_repo" \
+  --output-dir "remote-daemon-assets"
+MANIFEST_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8")), separators=(",",":")))' remote-daemon-assets/cmuxd-remote-manifest.json)"
+plutil -remove CMUXRemoteDaemonManifestJSON "$APP_PLIST" >/dev/null 2>&1 || true
+plutil -insert CMUXRemoteDaemonManifestJSON -string "$MANIFEST_JSON" "$APP_PLIST"
+
+CLI_BINARY="$APP_PATH/Contents/Resources/bin/cmux"
+[ -x "$CLI_BINARY" ] || { echo "cmux CLI binary not found at $CLI_BINARY" >&2; exit 1; }
+CMUX_CLI_BIN="$CLI_BINARY" python3 tests/test_cli_version_memory_guard.py
+
+HELPER_BINARY="$APP_PATH/Contents/Resources/bin/ghostty"
+[ -x "$HELPER_BINARY" ] || { echo "Ghostty theme picker helper not found at $HELPER_BINARY" >&2; exit 1; }
+
+/usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_PLIST" >/dev/null 2>&1 || true
+/usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string ${SPARKLE_PUBLIC_KEY}" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$APP_PLIST"
+/usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$APP_PLIST"
+
+cmux_ci_import_signing_cert
+
+cmux_ci_require_env APPLE_RELEASE_PROVISIONING_PROFILE_BASE64
+PROFILE_PATH="$APP_PATH/Contents/embedded.provisionprofile"
+TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
+TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
+cmux_ci_decode_base64_to_file "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" "$TMP_PROFILE"
+security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
+APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
+if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then
+  echo "Release provisioning profile targets unexpected app ID: $APP_ID" >&2
+  exit 1
+fi
+WEBAUTHN_ENTITLEMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.web-browser.public-key-credential" "$TMP_PLIST")"
+if [ "$WEBAUTHN_ENTITLEMENT" != "true" ]; then
+  echo "Release provisioning profile missing WebAuthn browser entitlement" >&2
+  exit 1
+fi
+PROVISIONS_ALL_DEVICES="$(/usr/libexec/PlistBuddy -c "Print :ProvisionsAllDevices" "$TMP_PLIST")"
+if [ "$PROVISIONS_ALL_DEVICES" != "true" ]; then
+  echo "Release provisioning profile is not a Developer ID all-devices profile" >&2
+  exit 1
+fi
+cp "$TMP_PROFILE" "$PROFILE_PATH"
+rm -f "$TMP_PROFILE" "$TMP_PLIST"
+
+cmux_ci_require_env APPLE_SIGNING_IDENTITY
+./scripts/sign-cmux-bundle.sh \
+  "$APP_PATH" \
+  cmux.release.entitlements \
+  "$APPLE_SIGNING_IDENTITY"
+
+cmux_ci_require_env APPLE_ID
+cmux_ci_require_env APPLE_APP_SPECIFIC_PASSWORD
+cmux_ci_require_env APPLE_TEAM_ID
+
+ZIP_SUBMIT="cmux-notary.zip"
+DMG_RELEASE="cmux-macos.dmg"
+ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_SUBMIT"
+APP_SUBMIT_JSON="$(xcrun notarytool submit "$ZIP_SUBMIT" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+APP_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$APP_SUBMIT_JSON")"
+APP_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$APP_SUBMIT_JSON")"
+if [ "$APP_STATUS" != "Accepted" ]; then
+  echo "App notarization failed with status: $APP_STATUS" >&2
+  xcrun notarytool log "$APP_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+  exit 1
+fi
+xcrun stapler staple "$APP_PATH"
+xcrun stapler validate "$APP_PATH"
+spctl -a -vv --type execute "$APP_PATH"
+rm -f "$ZIP_SUBMIT"
+
+create-dmg \
+  --identity="$APPLE_SIGNING_IDENTITY" \
+  "$APP_PATH" \
+  ./
+mv ./cmux*.dmg "$DMG_RELEASE"
+
+DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
+DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"
+if [ "$DMG_STATUS" != "Accepted" ]; then
+  echo "DMG notarization failed with status: $DMG_STATUS" >&2
+  xcrun notarytool log "$DMG_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+  exit 1
+fi
+xcrun stapler staple "$DMG_RELEASE"
+xcrun stapler validate "$DMG_RELEASE"
+
+cmux_ci_upload_dsyms_to_sentry
+
+cmux_ci_require_env SPARKLE_PRIVATE_KEY
+./scripts/sparkle_generate_appcast.sh "$DMG_RELEASE" "$TAG" appcast.xml
+
+release_files=(
+  cmux-macos.dmg
+  appcast.xml
+  remote-daemon-assets/cmuxd-remote-darwin-arm64
+  remote-daemon-assets/cmuxd-remote-darwin-amd64
+  remote-daemon-assets/cmuxd-remote-linux-arm64
+  remote-daemon-assets/cmuxd-remote-linux-amd64
+  remote-daemon-assets/cmuxd-remote-checksums.txt
+  remote-daemon-assets/cmuxd-remote-manifest.json
+)
+
+if gh release view "$TAG" --repo "$cmux_ci_repo" >/dev/null 2>&1; then
+  gh release upload "$TAG" --repo "$cmux_ci_repo" "${release_files[@]}"
+else
+  gh release create "$TAG" --repo "$cmux_ci_repo" --title "$TAG" --generate-notes "${release_files[@]}"
+fi
+
+latest="$(gh release list --repo "$cmux_ci_repo" --exclude-drafts --exclude-pre-releases --json tagName -q '.[].tagName' | sort -V | tail -1)"
+if [ -n "$latest" ] && [ "$latest" != "$TAG" ]; then
+  echo "Skipping R2 stable upload: $TAG is not the latest release ($latest)"
+else
+  cmux_ci_upload_appcast_to_r2 stable true
+fi


### PR DESCRIPTION
## Summary
- add CircleCI nightly publishing on main pushes and release publishing on v* tags
- keep WarpBuild nightly/release workflows as manual fallback
- keep CircleCI-triggered jobs wired through GitHub checks/statuses

## Verification
- bash -n scripts/ci/circleci-macos-release-common.sh scripts/ci/circleci-release.sh scripts/ci/circleci-nightly.sh
- ruby YAML parse for .circleci/config.yml, .github/workflows/nightly.yml, .github/workflows/release.yml
- actionlint on edited GitHub workflows, ignoring known custom WarpBuild runner labels
- git diff --check
- ./tests/test_ci_self_hosted_guard.sh
- ./tests/test_ci_create_dmg_pinned.sh
- ./tests/test_ci_ghosttykit_checksum_verification.sh
- node scripts/release_asset_guard.test.js

## Notes
CircleCI release publishing needs the same signing, notarization, GitHub, Sparkle, and optional R2/Sentry environment variables configured in CircleCI. The old WarpBuild workflows remain available through manual workflow_dispatch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Move macOS nightly and release publishing to CircleCI. Nightlies run on `main` and releases on `v*` tags; jobs build, sign, notarize, and publish DMGs, appcasts, and remote daemon assets, while CircleCI continues reporting statuses via GitHub checks and GitHub Actions remain manual-only as a fallback.

- **Migration**
  - Configure in CircleCI: `GH_TOKEN`, `APPLE_CERTIFICATE_BASE64`, `APPLE_CERTIFICATE_PASSWORD`, `APPLE_SIGNING_IDENTITY`, `APPLE_ID`, `APPLE_APP_SPECIFIC_PASSWORD`, `APPLE_TEAM_ID`, `SPARKLE_PRIVATE_KEY`; optional `SENTRY_AUTH_TOKEN`, `CF_R2_ACCESS_KEY_ID`, `CF_R2_SECRET_ACCESS_KEY`, `CF_R2_ACCOUNT_ID`.
  - `nightly.yml` and `release.yml` are manual-only; automated publishing now runs in CircleCI.
  - Release asset guard prevents duplicate immutable assets; stable appcast uploads to R2 only when publishing the latest release.

<sup>Written for commit 46ed7f67036e443d366cb74ff64f69050bc5f71e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CircleCI configuration to add macOS nightly and release publishing jobs.
  * Modified GitHub Actions workflow triggers: nightly builds now run manually only, and release builds are triggered by version tags.

* **New Features**
  * Implemented automated macOS app building, signing, notarization, and publishing pipeline for nightly and release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->