### PR TITLE
Optimize surface config reload

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */; };
 		D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */; };
 		D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */; };
+		D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */; };
 		D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */; };
 		D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */; };
 		D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */; };
@@ -459,6 +460,7 @@
 		A5001015 /* GhosttyTerminalView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalView.swift; sourceTree = "<group>"; };
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalViewSupport.swift; sourceTree = "<group>"; };
+		D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyApp+SurfaceConfigurationReload.swift"; sourceTree = "<group>"; };
 		D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneDropTargetView.swift; sourceTree = "<group>"; };
 		A5001016 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
@@ -864,10 +866,11 @@
 				A5001417 /* WorkspaceContentView.swift */,
 				E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */,
 				A5001014 /* GhosttyConfig.swift */,
-				A5001015 /* GhosttyTerminalView.swift */,
-				D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
-				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
-				D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */,
+					A5001015 /* GhosttyTerminalView.swift */,
+					D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
+					D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
+					D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
+					D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */,
 				A5001531 /* TerminalWindowPortal.swift */,
 				D0B10007A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift */,
 				A5001533 /* BrowserWindowPortal.swift */,
@@ -1361,10 +1364,11 @@
 				A5001407 /* WorkspaceContentView.swift in Sources */,
 				E30760000000000000000002 /* TmuxWorkspacePaneOverlayView.swift in Sources */,
 				A5001004 /* GhosttyConfig.swift in Sources */,
-				A5001005 /* GhosttyTerminalView.swift in Sources */,
-				D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */,
-				D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */,
-				D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
+					A5001005 /* GhosttyTerminalView.swift in Sources */,
+					D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */,
+					D0B1000AA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift in Sources */,
+					D0B10012A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift in Sources */,
+					D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
 				A5001532 /* TerminalWindowPortal.swift in Sources */,
 				D0B10006A1B2C3D4E5F60001 /* TerminalWindowPortalDebug.swift in Sources */,
 				A5001534 /* BrowserWindowPortal.swift in Sources */,

--- a/Sources/GhosttyApp+SurfaceConfigurationReload.swift
+++ b/Sources/GhosttyApp+SurfaceConfigurationReload.swift
@@ -1,20 +1,31 @@
+import Foundation
+
 extension GhosttyApp {
     func reloadSurfaceConfiguration(
         _ surface: ghostty_surface_t,
         soft: Bool = false,
         source: String = "unspecified"
     ) {
-        _ = source
         if soft, let config {
             ghostty_surface_update_config(surface, config)
-            GhosttyConfig.invalidateLoadCache()
+            finishSurfaceConfigurationReload(source: source, soft: soft, mode: "soft")
             return
         }
 
         guard let newConfig = ghostty_config_new() else { return }
         _ = loadDefaultConfigFilesWithLegacyFallback(newConfig)
+        // Ghostty Surface.updateConfig derives its own surface state from the
+        // passed config. The C API does not retain this temporary pointer.
         ghostty_surface_update_config(surface, newConfig)
-        GhosttyConfig.invalidateLoadCache()
+        finishSurfaceConfigurationReload(source: source, soft: soft, mode: "full")
         ghostty_config_free(newConfig)
+    }
+
+    private func finishSurfaceConfigurationReload(source: String, soft: Bool, mode: String) {
+#if DEBUG
+        cmuxDebugLog("surface.config.reload source=\(source) soft=\(soft) mode=\(mode)")
+#endif
+        GhosttyConfig.invalidateLoadCache()
+        NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
     }
 }

--- a/Sources/GhosttyApp+SurfaceConfigurationReload.swift
+++ b/Sources/GhosttyApp+SurfaceConfigurationReload.swift
@@ -1,5 +1,3 @@
-import Foundation
-
 extension GhosttyApp {
     func reloadSurfaceConfiguration(
         _ surface: ghostty_surface_t,
@@ -26,6 +24,8 @@ extension GhosttyApp {
         cmuxDebugLog("surface.config.reload source=\(source) soft=\(soft) mode=\(mode)")
 #endif
         GhosttyConfig.invalidateLoadCache()
-        NotificationCenter.default.post(name: .ghosttyConfigDidReload, object: nil)
+        // Do not post .ghosttyConfigDidReload here. Its observers read the
+        // app-scoped GhosttyApp.config, which this surface-only path leaves
+        // unchanged to avoid desyncing the app and other surfaces.
     }
 }

--- a/Sources/GhosttyApp+SurfaceConfigurationReload.swift
+++ b/Sources/GhosttyApp+SurfaceConfigurationReload.swift
@@ -1,0 +1,20 @@
+extension GhosttyApp {
+    func reloadSurfaceConfiguration(
+        _ surface: ghostty_surface_t,
+        soft: Bool = false,
+        source: String = "unspecified"
+    ) {
+        _ = source
+        if soft, let config {
+            ghostty_surface_update_config(surface, config)
+            GhosttyConfig.invalidateLoadCache()
+            return
+        }
+
+        guard let newConfig = ghostty_config_new() else { return }
+        _ = loadDefaultConfigFilesWithLegacyFallback(newConfig)
+        ghostty_surface_update_config(surface, newConfig)
+        GhosttyConfig.invalidateLoadCache()
+        ghostty_config_free(newConfig)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2064,7 +2064,7 @@ class GhosttyApp {
         )
     }
 
-    private func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) -> Bool {
+    func loadDefaultConfigFilesWithLegacyFallback(_ config: ghostty_config_t) -> Bool {
         #if DEBUG
         let startupPreviewProfile = GhosttyStartupAppearancePreviewState.profile
         if startupPreviewProfile.loadsRealUserConfig {
@@ -2964,34 +2964,6 @@ class GhosttyApp {
         logThemeAction("reload end source=\(source) soft=\(soft) mode=full")
     }
 
-    func reloadSurfaceConfiguration(
-        _ surface: ghostty_surface_t,
-        soft: Bool = false,
-        source: String = "unspecified"
-    ) {
-        logThemeAction("surface reload begin source=\(source) soft=\(soft)")
-        if soft {
-            guard let config else {
-                logThemeAction("surface reload skipped source=\(source) soft=\(soft) reason=no_cached_config")
-                return
-            }
-            ghostty_surface_update_config(surface, config)
-            GhosttyConfig.invalidateLoadCache()
-            logThemeAction("surface reload end source=\(source) soft=\(soft) mode=soft")
-            return
-        }
-
-        guard let newConfig = ghostty_config_new() else {
-            logThemeAction("surface reload skipped source=\(source) soft=\(soft) reason=config_alloc_failed")
-            return
-        }
-        _ = loadDefaultConfigFilesWithLegacyFallback(newConfig)
-        ghostty_surface_update_config(surface, newConfig)
-        GhosttyConfig.invalidateLoadCache()
-        ghostty_config_free(newConfig)
-        logThemeAction("surface reload end source=\(source) soft=\(soft) mode=full")
-    }
-
     private func scheduleSurfaceRefreshAfterConfigurationReload(source: String) {
         DispatchQueue.main.async {
             AppDelegate.shared?.refreshTerminalSurfacesAfterGhosttyConfigReload(source: source)
@@ -3769,11 +3741,7 @@ class GhosttyApp {
                 "reload request target=surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") soft=\(soft)"
             )
             return performOnMain {
-                GhosttyApp.shared.reloadSurfaceConfiguration(
-                    target.target.surface,
-                    soft: soft,
-                    source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")"
-                )
+                GhosttyApp.shared.reloadSurfaceConfiguration(target.target.surface, soft: soft, source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")")
                 surfaceView.terminalSurface?.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
                 surfaceView.terminalSurface?.forceRefresh(reason: "surface.reloadConfig")
                 return true

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2964,6 +2964,34 @@ class GhosttyApp {
         logThemeAction("reload end source=\(source) soft=\(soft) mode=full")
     }
 
+    func reloadSurfaceConfiguration(
+        _ surface: ghostty_surface_t,
+        soft: Bool = false,
+        source: String = "unspecified"
+    ) {
+        logThemeAction("surface reload begin source=\(source) soft=\(soft)")
+        if soft {
+            guard let config else {
+                logThemeAction("surface reload skipped source=\(source) soft=\(soft) reason=no_cached_config")
+                return
+            }
+            ghostty_surface_update_config(surface, config)
+            GhosttyConfig.invalidateLoadCache()
+            logThemeAction("surface reload end source=\(source) soft=\(soft) mode=soft")
+            return
+        }
+
+        guard let newConfig = ghostty_config_new() else {
+            logThemeAction("surface reload skipped source=\(source) soft=\(soft) reason=config_alloc_failed")
+            return
+        }
+        _ = loadDefaultConfigFilesWithLegacyFallback(newConfig)
+        ghostty_surface_update_config(surface, newConfig)
+        GhosttyConfig.invalidateLoadCache()
+        ghostty_config_free(newConfig)
+        logThemeAction("surface reload end source=\(source) soft=\(soft) mode=full")
+    }
+
     private func scheduleSurfaceRefreshAfterConfigurationReload(source: String) {
         DispatchQueue.main.async {
             AppDelegate.shared?.refreshTerminalSurfacesAfterGhosttyConfigReload(source: source)
@@ -3741,11 +3769,13 @@ class GhosttyApp {
                 "reload request target=surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil") soft=\(soft)"
             )
             return performOnMain {
-                // Keep all runtime theme/default-background state in the same path.
-                GhosttyApp.shared.reloadConfiguration(
+                GhosttyApp.shared.reloadSurfaceConfiguration(
+                    target.target.surface,
                     soft: soft,
                     source: "action.reload_config.surface tab=\(surfaceView.tabId?.uuidString ?? "nil") surface=\(surfaceView.terminalSurface?.id.uuidString ?? "nil")"
                 )
+                surfaceView.terminalSurface?.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
+                surfaceView.terminalSurface?.forceRefresh(reason: "surface.reloadConfig")
                 return true
             }
         case GHOSTTY_ACTION_KEY_SEQUENCE:


### PR DESCRIPTION
## Summary
- Match upstream Ghostty surface-targeted reload semantics by updating only the target surface.
- Avoid app-wide cmux config reload and refresh of every terminal after a surface reload action.

## Testing
- ./scripts/reload.sh --tag task-pty-terminal-startup-latency

## Issues
- Related: PTY terminal startup latency investigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Optimize surface config reload by updating only the targeted terminal surface, matching upstream Ghostty behavior and avoiding app-wide refresh work. Keep it surface-scoped (no global notification) with source-tagged debug logs.

- **Refactors**
  - Added `GhosttyApp.reloadSurfaceConfiguration(surface, soft, source)`; soft reuses existing app config, full rebuilds from defaults; both invalidate the load cache; no `.ghosttyConfigDidReload` on this path.
  - Switched the surface reload action to this API, then refresh the host background and force-refresh that surface only.
  - Moved logic into `GhosttyApp+SurfaceConfigurationReload.swift`; exposed `loadDefaultConfigFilesWithLegacyFallback` for the extension.
  - Removed app-wide reload from surface-targeted actions.

<sup>Written for commit 8178f2ef616f1634609a1ae7b027d836cfd4d58d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-window configuration reloads so you can update a single terminal surface without restarting or affecting other windows.

* **Bug Fixes**
  * Hosted view backgrounds and terminal displays refresh reliably after per-surface config changes.
  * Reloads apply non‑disruptively when possible, reducing interruptions to active sessions.

* **Improvements**
  * Soft (non‑full) reloads use cached configs when available for faster, quieter updates.
  * Better handling of default/legacy config files for more robust reloads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->