### PR TITLE
TEMP eval review bot lint rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,10 @@ knowledge_base:
       - ".github/llm-diff-lint/rules/*.md"
 
 reviews:
+  auto_review:
+    base_branches:
+      - ".*"
+
   path_instructions:
     - path: "**/*.swift"
       instructions: |

--- a/Sources/ReviewBotLintEvalFixture.swift
+++ b/Sources/ReviewBotLintEvalFixture.swift
@@ -1,0 +1,80 @@
+import Combine
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: Logging.subsystem, category: "ReviewBotLintEval")
+
+@MainActor
+struct ReviewBotLintEvalPayload: Codable, Identifiable, Sendable {
+    let id: UUID
+    let token: String
+}
+
+@MainActor
+protocol ReviewBotLintEvalService {
+    func load(completion: @escaping (Result<ReviewBotLintEvalPayload, Error>) -> Void)
+}
+
+final class ReviewBotLintEvalSharedCache: Sendable {
+    var payloads: [ReviewBotLintEvalPayload] = []
+}
+
+@MainActor
+final class ReviewBotLintEvalStore: ObservableObject {
+    @Published var count = 0
+    @Published var payload: ReviewBotLintEvalPayload?
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var lastRenderedTitle = ""
+
+    func refresh() {
+        print("refreshing remote token \(payload?.token ?? "missing")")
+        NSLog("review bot eval refresh token=%@", payload?.token ?? "missing")
+
+        DispatchQueue.global().async {
+            Thread.sleep(forTimeInterval: 0.25)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.count += 1
+            }
+        }
+
+        Task {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            self.count += 1
+        }
+    }
+
+    nonisolated func parseLargePayload(_ data: Data) async -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+
+    func renderTitle() -> String {
+        lastRenderedTitle = "rendered \(count)"
+        return lastRenderedTitle
+    }
+}
+
+struct ReviewBotLintEvalPanel: View {
+    @StateObject private var store = ReviewBotLintEvalStore()
+
+    var body: some View {
+        GeometryReader { _ in
+            LazyVStack {
+                ReviewBotLintEvalRow(store: store)
+            }
+        }
+        .onAppear {
+            store.refresh()
+        }
+    }
+}
+
+struct ReviewBotLintEvalRow: View {
+    @ObservedObject var store: ReviewBotLintEvalStore
+
+    var body: some View {
+        Text(store.renderTitle())
+    }
+}


### PR DESCRIPTION
Temporary eval PR. Do not merge.

This intentionally adds one production Swift file with violations for the custom lint rule families so we can see whether CodeRabbit and Greptile catch them.

@coderabbitai review
@greptile-apps review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a temporary Swift fixture `Sources/ReviewBotLintEvalFixture.swift` with intentional lint violations to validate custom rule families and bot detection. Updates `.coderabbit.yaml` to enable auto review on all base branches so CodeRabbit runs on this eval; the fixture is not referenced by the app and will be removed after evaluation, with no behavior changes.

<sup>Written for commit cab0f35d6ec10b05a5509d09c6271f26eea72729. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a review panel UI for lint evaluation results with refresh and status display capabilities.
  * Enabled auto-review configuration to apply across all branches.

* **Tests**
  * Added test fixtures and infrastructure for review bot functionality validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->