### PR TITLE
Make sidebar PR clickability default on

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -56023,13 +56023,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Off by default. Review items stay visible as plain text, and clicks in that area select the workspace row."
+            "value": "Review items stay visible as plain text, and clicks in that area select the workspace row."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "デフォルトではオフです。レビュー項目は通常のテキストとして表示され、その領域をクリックするとワークスペース行が選択されます。"
+            "value": "レビュー項目は通常のテキストとして表示され、その領域をクリックするとワークスペース行が選択されます。"
           }
         }
       }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -116,7 +116,7 @@ enum SidebarWorkspaceDetailSettings {
 
 enum SidebarPullRequestClickabilitySettings {
     static let key = "sidebarMakePullRequestClickable"
-    static let defaultClickable = false
+    static let defaultClickable = true
 
     static func isClickable(defaults: UserDefaults = .standard) -> Bool {
         if defaults.object(forKey: key) == nil {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -6358,7 +6358,7 @@ struct SettingsView: View {
                         }
                         .disabled(sidebarHideAllDetails)
                         SettingsCardDivider()
-                        SettingsCardRow(configurationReview: .json("sidebar.makePullRequestsClickable"), String(localized: "settings.app.makeSidebarPullRequestClickable", defaultValue: "Make Sidebar PR Clickable"), subtitle: String(localized: "settings.app.makeSidebarPullRequestClickable.subtitle", defaultValue: "Off by default. Review items stay visible as plain text, and clicks in that area select the workspace row.")) { Toggle("", isOn: $sidebarMakePullRequestClickable).labelsHidden().controlSize(.small).accessibilityIdentifier("SettingsSidebarPullRequestClickableToggle") }
+                        SettingsCardRow(configurationReview: .json("sidebar.makePullRequestsClickable"), String(localized: "settings.app.makeSidebarPullRequestClickable", defaultValue: "Make Sidebar PR Clickable"), subtitle: String(localized: "settings.app.makeSidebarPullRequestClickable.subtitle", defaultValue: "Review items stay visible as plain text, and clicks in that area select the workspace row.")) { Toggle("", isOn: $sidebarMakePullRequestClickable).labelsHidden().controlSize(.small).accessibilityIdentifier("SettingsSidebarPullRequestClickableToggle") }
                         .disabled(sidebarHideAllDetails || !sidebarShowPullRequest)
                         SettingsCardDivider()
                         SettingsCardRow(

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -3293,7 +3293,7 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         XCTAssertTrue(BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowser(defaults: defaults))
     }
     func testSidebarPullRequestClickabilityDefaultAndStoredValues() {
-        XCTAssertFalse(SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults))
+        XCTAssertTrue(SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults))
         defaults.set(true, forKey: SidebarPullRequestClickabilitySettings.key); XCTAssertTrue(SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults))
         defaults.set(false, forKey: SidebarPullRequestClickabilitySettings.key); XCTAssertFalse(SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults))
     }

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -278,7 +278,7 @@
         },
         "makePullRequestsClickable": {
           "type": "boolean",
-          "default": false,
+          "default": true,
           "description": "Allow sidebar pull request metadata to open links when clicked."
         },
         "openPullRequestLinksInCmuxBrowser": {


### PR DESCRIPTION
## Summary
- Fixes https://github.com/manaflow-ai/cmux/issues/3490 by changing the shared sidebar PR clickability default to on.
- Updates the Settings subtitle and cmux schema default so first-run UI, reset behavior, config export, and docs agree.
- Adds the regression assertion first in a separate commit so CI proves the old default was wrong.

## Verification
- jq empty Resources/Localizable.xcstrings web/data/cmux.schema.json web/data/cmux-settings.schema.json
- jq '.properties.sidebar.properties.makePullRequestsClickable.default' web/data/cmux.schema.json -> true
- rg found no remaining "Off by default" copy for this setting
- ./scripts/reload.sh --tag issue-3490-sidebar-pr-clickable-default-on --launch from a clean detached verification worktree; Settings > Sidebar showed Make Sidebar PR Clickable toggled on

## Notes
- Local XCTest execution skipped per repository policy.
- The original cmux3 worktree has a pre-existing dirty vendor/bonsplit submodule pointer; build verification used a clean detached worktree at this branch's commits with submodules checked out to committed SHAs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes a single user preference default and aligned copy/schema/tests; behavior only affects sidebar click handling and first-run/reset defaults.
> 
> **Overview**
> Turns **sidebar PR clickability** on by default by flipping `SidebarPullRequestClickabilitySettings.defaultClickable` and the `sidebar.makePullRequestsClickable` schema default.
> 
> Updates the Settings subtitle/localized copy to remove “Off by default” wording and adjusts the related XCTest to assert the new default behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d28cd5c649e28d38df7979ce296b4370c92d162. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make sidebar pull request links clickable by default. Fixes #3490 and aligns first-run behavior across Settings, schema, and tests.

- **Bug Fixes**
  - Set `SidebarPullRequestClickabilitySettings.defaultClickable` to true and `sidebar.makePullRequestsClickable` default to true in `web/data/cmux.schema.json`.
  - Updated Settings subtitle and localizations to remove “Off by default.”
  - Updated test to expect default true; stored true/false overrides still respected.

<sup>Written for commit 9d28cd5c649e28d38df7979ce296b4370c92d162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar pull request clickability is now enabled by default, allowing users to immediately click and navigate workspace rows without additional configuration
* **Documentation**
  * Updated settings descriptions and all language localizations to reflect the new default behavior by removing "Off by default" messaging

<!-- end of auto-generated comment: release notes by coderabbit.ai -->