### PR TITLE
Use Greptile and CodeRabbit for Swift lint rules

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,53 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: en-US
+
+knowledge_base:
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - ".github/review-bot-rules/*.md"
+
+reviews:
+  path_instructions:
+    - path: "**/*.swift"
+      instructions: |
+        Apply the cmux custom Swift lint rules in `.github/review-bot-rules/` during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse.
+    - path: "Package.swift"
+      instructions: |
+        Apply the cmux custom Swift lint rules in `.github/review-bot-rules/`, especially the concurrency modernization, actor isolation, blocking runtime, and architectural rethink rules.
+    - path: "GhosttyTabs.xcodeproj/**"
+      instructions: |
+        Review project wiring against the cmux Swift lint rules. Flag project changes that enable app/runtime code paths which bypass Swift concurrency, logging, localization, or shared action-path expectations.
+
+  pre_merge_checks:
+    custom_checks:
+      - name: "cmux Swift actor isolation"
+        mode: error
+        instructions: |
+          For production Swift changes, fail when the diff introduces or materially worsens Swift 6 actor isolation mistakes from `.github/review-bot-rules/swift-actor-isolation.md`: implicit MainActor value models or service protocols, shared mutable Sendable reference types without isolation, or UI-bound stores accessed from background contexts. Pass for tests, actors, SwiftUI UI types intentionally on MainActor, or existing debt not worsened.
+      - name: "cmux Swift blocking runtime"
+        mode: error
+        instructions: |
+          For production Swift changes, fail when the diff introduces or materially expands blocking or timing-based synchronization from `.github/review-bot-rules/swift-blocking-runtime.md`: semaphores, blocking waits, sleeps, delayed dispatch, polling, main-queue sync, or manual locks where an actor or explicit signal should own synchronization. Pass for deterministic test-only scaffolding and visual UI animation delays.
+      - name: "cmux Swift concurrency"
+        mode: error
+        instructions: |
+          For cmux-owned Swift code, fail when the diff introduces or materially expands legacy async patterns from `.github/review-bot-rules/swift-concurrency-modernization.md`: background Dispatch queues for ordinary async work, new Combine app state, completion-handler APIs where async throws is under our control, or fire-and-forget Tasks with real lifecycle. Pass for required AppKit, SwiftUI, XCTest, OS, or third-party callback boundaries.
+      - name: "cmux Swift @concurrent"
+        mode: error
+        instructions: |
+          For Swift changes, fail when the diff violates `.github/review-bot-rules/swift-concurrent-annotation.md`: missing `@concurrent` on `nonisolated async` work that should leave the caller actor, invalid `@concurrent` on synchronous or actor-isolated functions, or CPU/file/network-heavy async helpers called from UI isolation without an explicit hop. Pass for intentionally UI-bound async work.
+      - name: "cmux Swift logging"
+        mode: error
+        instructions: |
+          For production Swift changes, fail when the diff violates `.github/review-bot-rules/swift-logging.md`: `print`, `debugPrint`, `dump`, or `NSLog` in app/runtime code; ad hoc file/stdout logging for diagnostics; MainActor-coupled file-scoped Logger constants; or logs that expose secrets or personal data. Pass for CLI output, tests, debug-only logs, and explicitly sanitized provider diagnostics.
+      - name: "cmux SwiftUI state layout"
+        mode: error
+        instructions: |
+          For SwiftUI changes, fail when the diff violates `.github/review-bot-rules/swiftui-state-layout.md`: new ObservableObject or @Published state where @Observable is the modern shape, GeometryReader measurement that changes layout, lazy/list row subtrees holding store references, or render-time state mutation. Pass for existing legacy state only touched incidentally and contained AppKit bridge views.
+      - name: "cmux architecture rethink"
+        mode: error
+        instructions: |
+          For Swift architecture changes, fail when the diff violates `.github/review-bot-rules/swift-architectural-rethink.md`: symptom patches using sleeps, delayed dispatch, polling, locks, observers, side channels, duplicate entrypoint wiring, or split UI lifecycle ownership that leaves bad state representable. Pass for small correctness fixes with clear owners and invariants, required platform bridges, and test-only synchronization.

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -14,7 +14,7 @@ reviews:
     - path: "**/*.swift"
       instructions: |
         Apply the cmux custom Swift lint rules in `.github/review-bot-rules/` during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse.
-    - path: "Package.swift"
+    - path: "**/Package.swift"
       instructions: |
         Apply the cmux custom Swift lint rules in `.github/review-bot-rules/`, especially the concurrency modernization, actor isolation, blocking runtime, and architectural rethink rules.
     - path: "GhosttyTabs.xcodeproj/**"
@@ -30,7 +30,7 @@ reviews:
       - name: "cmux Swift blocking runtime"
         mode: error
         instructions: |
-          For production Swift changes, fail when the diff introduces or materially expands blocking or timing-based synchronization from `.github/review-bot-rules/swift-blocking-runtime.md`: semaphores, blocking waits, sleeps, delayed dispatch, polling, main-queue sync, or manual locks where an actor or explicit signal should own synchronization. Pass for deterministic test-only scaffolding and visual UI animation delays.
+          For production Swift changes, fail when the diff introduces or materially expands blocking or timing-based synchronization from `.github/review-bot-rules/swift-blocking-runtime.md`: semaphores, blocking waits, sleeps, delayed dispatch, polling, main-queue sync, or manual locks where an actor or explicit signal should own synchronization. Pass for deterministic test-only scaffolding and short user-visible UI animation delays that do not use `Task.sleep`.
       - name: "cmux Swift concurrency"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -1,0 +1,19 @@
+# cmux Review Bot Rules
+
+These rules are the shared source of truth for Greptile and CodeRabbit custom Swift review behavior.
+
+The rule files are intentionally short and focused. Each one defines one class of issue, concrete failure cases, allowed cases, and the expected reporting shape. Keep new rules narrow enough that a reviewer can apply the rule to a full PR diff without turning it into a broad style guide.
+
+Greptile is configured to publish a GitHub status check. CodeRabbit is configured with error-mode custom pre-merge checks, which can block when the repository's CodeRabbit request-changes workflow is enabled.
+
+Current rules:
+
+- `swift-actor-isolation.md`
+- `swift-architectural-rethink.md`
+- `swift-blocking-runtime.md`
+- `swift-concurrency-modernization.md`
+- `swift-concurrent-annotation.md`
+- `swift-logging.md`
+- `swiftui-state-layout.md`
+
+Open source repository note: review bots should apply the configuration from the base branch. A PR that edits these rules should not be able to weaken its own review.

--- a/.github/review-bot-rules/swift-actor-isolation.md
+++ b/.github/review-bot-rules/swift-actor-isolation.md
@@ -1,0 +1,28 @@
+# Swift Actor Isolation
+
+Flag Swift 6 MainActor-by-default isolation mistakes that affect correctness, sendability, or compiler diagnostics.
+
+Report a failure when the diff introduces or materially expands:
+
+- Codable, Identifiable, Sendable, or pure value model structs that remain implicitly `@MainActor` when they should be marked `nonisolated`.
+- Service protocols with async requirements that are implicitly MainActor-isolated, causing actor implementations to inherit main actor isolation.
+- File-scoped `Logger` constants, pure helpers, data formatters, or value-only utilities that should be `nonisolated` to avoid unnecessary main actor coupling.
+- Shared mutable reference types marked `Sendable` without actor isolation, MainActor isolation, a lock with a documented reason, or `@unchecked Sendable` with a clear safety explanation.
+- UI-bound models or observable stores accessed from background contexts without an explicit MainActor boundary.
+
+Allowed cases:
+
+- SwiftUI view types and UI coordinators that intentionally live on the main actor.
+- Actors, which already provide their own isolation.
+- Small structs inside a MainActor-only UI type when they are never used from async or background contexts.
+- Existing isolation debt that the PR does not introduce or worsen.
+
+Preferred shapes:
+
+```swift
+nonisolated struct Model: Codable, Sendable { ... }
+nonisolated protocol Service: Sendable { func load() async throws -> Value }
+nonisolated private let logger = Logger(subsystem: Logging.subsystem, category: "Feature")
+```
+
+When reporting, explain what actor would otherwise own the declaration and why the changed declaration should opt in or out explicitly.

--- a/.github/review-bot-rules/swift-architectural-rethink.md
+++ b/.github/review-bot-rules/swift-architectural-rethink.md
@@ -1,0 +1,20 @@
+# Swift Architectural Rethink
+
+Apply the `swift-guidance` rules and the `rethink-architecturally` bar to Swift changes. Flag fixes that patch symptoms while leaving the bad state representable.
+
+Report a failure when the diff introduces or materially expands:
+
+- Timing or blocking repair paths (`DispatchQueue.main.async`, `asyncAfter`, `Task.sleep`, polling, semaphores, groups, locks, or notification waits) used to paper over lifecycle, focus, rendering, socket, terminal, or shared-state races.
+- A new mutable flag, cache, singleton, observer, or side channel that creates another owner for state already owned by a model, actor, store, view coordinator, or persistence layer.
+- The same behavior wired separately through multiple surfaces instead of one shared action path.
+- SwiftUI or AppKit bridge code where UI lifecycle is split across multiple MainActor owners instead of one explicit owner with value snapshots and action closures.
+- A fix that catches one repro but does not name the invariant, source of truth, or state transition that makes the whole class impossible.
+
+Allowed cases:
+
+- Small local correctness fixes where the owner and invariant remain clear.
+- Required platform callback or bridge code with a documented reason and no extra timing dependency.
+- Test-only synchronization or sleeps.
+- Existing architectural debt that the PR does not introduce or worsen.
+
+When reporting, include one highest-impact finding only. Explain the symptom, structural root cause, class of bugs, the single source of truth that should own the behavior, and the first migration cut that would prove the architecture.

--- a/.github/review-bot-rules/swift-blocking-runtime.md
+++ b/.github/review-bot-rules/swift-blocking-runtime.md
@@ -1,0 +1,27 @@
+# Swift Blocking Runtime Primitives
+
+Flag new blocking or timing-based synchronization in application and runtime Swift code.
+
+Report a failure when the diff introduces or materially expands any of these in non-test Swift files:
+
+- `DispatchSemaphore`, `semaphore.wait()`, `DispatchGroup.wait()`, or other thread-blocking waits for async work.
+- `Thread.sleep`, `usleep`, `sleep`, `Task.sleep`, `DispatchQueue.asyncAfter`, timers, or polling loops in shipped app/runtime code. Treat these as failures by default, even when the delay is small.
+- `DispatchQueue.main.sync`, especially in socket, telemetry, terminal, rendering, focus, or input paths.
+- `NSLock`, `pthread_mutex`, or similar manual locking around shared mutable state when an actor or MainActor-isolated model would be the safer shape.
+
+Allowed cases:
+
+- Deterministic sleeps in tests or explicit test-only scaffolding.
+- UI animation delays where the delay is visual timing, not synchronization.
+- Intentional init-time or passive-callback safety deferrals that use delayed main-queue dispatch to avoid AppKit constraint-pass crashes, when the code documents why a real signal is unavailable.
+- Very small lock usage around non-async, low-level platform bridges when an actor cannot be used and the code documents the reason.
+- Existing blocking code that the PR does not introduce or worsen.
+
+Do not allow `Task.sleep` in production code just because it is inside an async function. Retry backoff, keepalive loops, readiness waits, delayed dispatch, and polling still need a real cancellation-aware scheduler, timer abstraction, async sequence, callback, notification, or state transition unless the changed code is test-only.
+
+cmux-specific emphasis:
+
+- Typing, terminal rendering, socket telemetry, and focus paths are latency-sensitive. Blocking or sleep-based coordination in these paths should fail CI.
+- A fix should wait on a real signal, callback, state transition, actor message, notification, or explicit completion point.
+
+When reporting, identify the changed wait or timing primitive and the real event that should replace it.

--- a/.github/review-bot-rules/swift-blocking-runtime.md
+++ b/.github/review-bot-rules/swift-blocking-runtime.md
@@ -12,12 +12,12 @@ Report a failure when the diff introduces or materially expands any of these in 
 Allowed cases:
 
 - Deterministic sleeps in tests or explicit test-only scaffolding.
-- UI animation delays where the delay is visual timing, not synchronization.
+- Short, user-visible UI animation delays where the delay is visual timing only, not synchronization, and does not use `Task.sleep` in production code.
 - Intentional init-time or passive-callback safety deferrals that use delayed main-queue dispatch to avoid AppKit constraint-pass crashes, when the code documents why a real signal is unavailable.
 - Very small lock usage around non-async, low-level platform bridges when an actor cannot be used and the code documents the reason.
 - Existing blocking code that the PR does not introduce or worsen.
 
-Do not allow `Task.sleep` in production code just because it is inside an async function. Retry backoff, keepalive loops, readiness waits, delayed dispatch, and polling still need a real cancellation-aware scheduler, timer abstraction, async sequence, callback, notification, or state transition unless the changed code is test-only.
+Do not allow `Task.sleep` in production code just because it is inside an async function, including for animation timing. Retry backoff, keepalive loops, readiness waits, delayed dispatch, and polling still need a real cancellation-aware scheduler, timer abstraction, async sequence, callback, notification, or state transition unless the changed code is marked test-only.
 
 cmux-specific emphasis:
 

--- a/.github/review-bot-rules/swift-concurrency-modernization.md
+++ b/.github/review-bot-rules/swift-concurrency-modernization.md
@@ -1,0 +1,19 @@
+# Swift Concurrency Modernization
+
+Flag clear new uses of legacy asynchronous patterns in cmux-owned Swift code when Swift concurrency would be the correct design.
+
+Report a failure when the diff introduces or materially expands:
+
+- `DispatchQueue.global().async`, custom background queues, `DispatchGroup`, or callback pyramids for ordinary async work that can be modeled with `async` functions, `Task`, `TaskGroup`, or actors.
+- New Combine usage (`ObservableObject`, `@Published`, publishers, subscribers, cancellables) for app state or async flow when `Observation` and async/await are available.
+- Completion-handler APIs in new internal code when the caller and callee are both under cmux control and can use `async throws`.
+- Fire-and-forget `Task { ... }` work with meaningful lifecycle that is not stored, cancelled, or tied to a caller-owned operation.
+
+Allowed cases:
+
+- AppKit, SwiftUI, XCTest, OS, or third-party API boundaries that require a callback or main queue hop.
+- Minimal `DispatchQueue.main.async` used only to cross into UI isolation from a legacy callback, when a larger migration is outside the diff.
+- Existing legacy code that is only moved or touched nearby without making the pattern worse.
+- Tests that intentionally exercise a legacy boundary or create a controlled race/interleaving with `DispatchGroup`, `DispatchQueue.global`, semaphores, or sleeps. Do not flag test-only synchronization unless it ships in app/runtime code or makes production code worse.
+
+When reporting, explain the concrete concurrency replacement. Prefer one finding for the highest-risk changed block instead of listing every instance.

--- a/.github/review-bot-rules/swift-concurrent-annotation.md
+++ b/.github/review-bot-rules/swift-concurrent-annotation.md
@@ -1,0 +1,22 @@
+# Swift Concurrent Annotation
+
+Flag incorrect or missing use of Swift's `@concurrent` and `nonisolated async` behavior.
+
+Report a failure when the diff introduces or materially expands:
+
+- `nonisolated async` work that is expected to leave the caller's actor but is not annotated `@concurrent` under the Swift 6 `NonisolatedNonsendingByDefault` behavior.
+- `@concurrent` on a synchronous function.
+- `@concurrent` combined with actor isolation such as `@MainActor`.
+- `@concurrent` functions that access actor-isolated or main-actor state directly.
+- CPU-heavy, file I/O-heavy, parsing-heavy, or network-heavy async helpers called from UI isolation without an explicit actor hop or `@concurrent` boundary.
+
+Allowed cases:
+
+- `nonisolated` synchronous pure helpers.
+- Async functions that intentionally inherit the caller's actor and only coordinate UI-bound work.
+- Existing functions where the PR does not change isolation, execution cost, or call sites.
+- Actor methods that must access isolated state and therefore cannot be `@concurrent`.
+
+Use this rule only for correctness or responsiveness. Do not report style-only annotation preferences.
+
+When reporting, identify the changed async function or call site and state whether the fix is to add `@concurrent`, remove `@concurrent`, move work into an actor, or keep execution on `@MainActor`.

--- a/.github/review-bot-rules/swift-logging.md
+++ b/.github/review-bot-rules/swift-logging.md
@@ -1,0 +1,30 @@
+# Swift Unified Logging
+
+Flag production Swift logging that bypasses Apple's unified logging system.
+
+Report a failure when the diff introduces or materially expands:
+
+- `print`, `debugPrint`, `dump`, or `NSLog` in app/runtime Swift code.
+- Ad hoc file logging or stdout/stderr logging for production diagnostics when `Logger` or the existing cmux debug log should be used.
+- A file-scoped `Logger` that is not declared as `nonisolated private let` in code affected by MainActor-by-default isolation.
+- Logging of secrets, tokens, passwords, private keys, customer content, or personal data without explicit private redaction.
+
+Allowed cases:
+
+- CLI command output that is the intended user-facing result.
+- Tests and fixtures where stdout is part of the harness.
+- Debug-only `NSLog` or cmux event logging guarded by `#if DEBUG`.
+- Sanitized release diagnostics in `Sources/Providers/*` that intentionally use `NSLog` for provider observability, as long as the changed log cannot expose secrets or personal data.
+- One-off local debugging that is removed before merge.
+
+Preferred shape:
+
+```swift
+import os.log
+
+nonisolated private let logger = Logger(subsystem: Logging.subsystem, category: "FeatureName")
+```
+
+Use the right level: debug/info/notice for normal trace, warning for recoverable unexpected states, error/fault for broken behavior. Dynamic sensitive values should stay redacted or use `.private`.
+
+When reporting, point to the changed logging statement and name the safer logging destination.

--- a/.github/review-bot-rules/swiftui-state-layout.md
+++ b/.github/review-bot-rules/swiftui-state-layout.md
@@ -1,0 +1,23 @@
+# SwiftUI State And Layout
+
+Flag new SwiftUI patterns that are known to cause stale state, excess invalidation, layout instability, or main-thread churn.
+
+Report a failure when the diff introduces or materially expands:
+
+- `ObservableObject`, `@Published`, `@StateObject`, or `@EnvironmentObject` for new cmux-owned SwiftUI state where `@Observable` plus `@State` or value snapshots are the modern shape.
+- `GeometryReader` for measurement when `onGeometryChange` or a localized background measurement would avoid changing layout behavior.
+- A `LazyVStack`, `LazyHStack`, `List`, or `ForEach` row subtree that holds a store reference (`@ObservedObject`, `@EnvironmentObject`, `@StateObject`, `@Bindable`, or a plain store property) instead of immutable snapshots plus action closures.
+- State mutation from `body` or helpers called by `body`, including scheduling `Task { @MainActor ... }` or `DispatchQueue.main.async` to write state during render.
+
+Allowed cases:
+
+- Existing legacy view state that the PR only touches incidentally.
+- `GeometryReader` as a contained fallback for older OS support or platform APIs, when it cannot affect parent layout and the reason is clear.
+- AppKit bridge views where SwiftUI observation is not the owner of state.
+
+cmux-specific emphasis:
+
+- Large list and sidebar rows must receive value snapshots and closures. Store references below lazy list boundaries can re-render every row and create CPU spin loops.
+- Render-time state writes are correctness bugs. They belong in explicit lifecycle callbacks, model observers, reload completions, or event handlers.
+
+When reporting, identify the changed view boundary and suggest the snapshot/action or `@Observable` replacement.

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,52 @@
+{
+  "strictness": 2,
+  "commentTypes": ["logic", "syntax", "style"],
+  "triggerOnUpdates": true,
+  "statusCheck": true,
+  "updateExistingSummaryComment": true,
+  "instructions": "Apply cmux's custom Swift lint rules from .github/review-bot-rules/ during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse. Do not treat PR-head edits to these rule files as weakening the rules until those edits are merged.",
+  "rules": [
+    {
+      "id": "cmux-swift-actor-isolation",
+      "rule": "Flag new or materially worsened Swift 6 actor isolation mistakes in production Swift: implicit MainActor value models or service protocols, file-scoped helpers that should be nonisolated, shared mutable Sendable reference types without isolation, or UI-bound stores used from background contexts.",
+      "scope": ["**/*.swift", "Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swift-blocking-runtime",
+      "rule": "Flag new blocking or timing-based synchronization in production Swift: semaphores, DispatchGroup.wait, sleeps, Task.sleep, asyncAfter, timers or polling for synchronization, DispatchQueue.main.sync, or manual locks where actor isolation or a real signal should own coordination.",
+      "scope": ["**/*.swift", "Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swift-concurrency-modernization",
+      "rule": "Flag new legacy async patterns in cmux-owned Swift where Swift concurrency is the correct shape: DispatchQueue.global for ordinary async work, new Combine app state, completion-handler APIs fully under cmux control, or fire-and-forget Tasks with meaningful lifecycle.",
+      "scope": ["**/*.swift", "Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swift-concurrent-annotation",
+      "rule": "Flag incorrect or missing use of Swift @concurrent and nonisolated async behavior, including nonisolated async work that should leave the caller actor, invalid @concurrent annotations, or CPU/file/network-heavy async helpers called from UI isolation without an explicit boundary.",
+      "scope": ["**/*.swift", "Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swift-logging",
+      "rule": "Flag production Swift diagnostics that bypass unified logging or risk leaking sensitive data: print/debugPrint/dump/NSLog in app or runtime code, ad hoc stdout or file logging, MainActor-coupled file-scoped Logger constants, or unredacted secrets, tokens, customer content, or personal data.",
+      "scope": ["**/*.swift", "Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swiftui-state-layout",
+      "rule": "Flag SwiftUI changes that can cause stale state, broad invalidation, layout instability, or main-thread churn: new ObservableObject/@Published state where @Observable is correct, GeometryReader measurement that changes layout, lazy/list row subtrees holding store references, or state mutation during body rendering.",
+      "scope": ["**/*.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-swift-architectural-rethink",
+      "rule": "Flag Swift fixes that patch symptoms while leaving bad state representable: timing repairs, new flags/caches/singletons/observers/side channels, duplicate behavior wired through multiple entrypoints, split SwiftUI/AppKit lifecycle ownership, or fixes that do not name the invariant and source of truth.",
+      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"],
+      "severity": "high"
+    }
+  ]
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -9,31 +9,31 @@
     {
       "id": "cmux-swift-actor-isolation",
       "rule": "Flag new or materially worsened Swift 6 actor isolation mistakes in production Swift: implicit MainActor value models or service protocols, file-scoped helpers that should be nonisolated, shared mutable Sendable reference types without isolation, or UI-bound stores used from background contexts.",
-      "scope": ["**/*.swift", "Package.swift"],
+      "scope": ["**/*.swift", "**/Package.swift"],
       "severity": "high"
     },
     {
       "id": "cmux-swift-blocking-runtime",
       "rule": "Flag new blocking or timing-based synchronization in production Swift: semaphores, DispatchGroup.wait, sleeps, Task.sleep, asyncAfter, timers or polling for synchronization, DispatchQueue.main.sync, or manual locks where actor isolation or a real signal should own coordination.",
-      "scope": ["**/*.swift", "Package.swift"],
+      "scope": ["**/*.swift", "**/Package.swift"],
       "severity": "high"
     },
     {
       "id": "cmux-swift-concurrency-modernization",
       "rule": "Flag new legacy async patterns in cmux-owned Swift where Swift concurrency is the correct shape: DispatchQueue.global for ordinary async work, new Combine app state, completion-handler APIs fully under cmux control, or fire-and-forget Tasks with meaningful lifecycle.",
-      "scope": ["**/*.swift", "Package.swift"],
+      "scope": ["**/*.swift", "**/Package.swift"],
       "severity": "high"
     },
     {
       "id": "cmux-swift-concurrent-annotation",
       "rule": "Flag incorrect or missing use of Swift @concurrent and nonisolated async behavior, including nonisolated async work that should leave the caller actor, invalid @concurrent annotations, or CPU/file/network-heavy async helpers called from UI isolation without an explicit boundary.",
-      "scope": ["**/*.swift", "Package.swift"],
+      "scope": ["**/*.swift", "**/Package.swift"],
       "severity": "high"
     },
     {
       "id": "cmux-swift-logging",
       "rule": "Flag production Swift diagnostics that bypass unified logging or risk leaking sensitive data: print/debugPrint/dump/NSLog in app or runtime code, ad hoc stdout or file logging, MainActor-coupled file-scoped Logger constants, or unredacted secrets, tokens, customer content, or personal data.",
-      "scope": ["**/*.swift", "Package.swift"],
+      "scope": ["**/*.swift", "**/Package.swift"],
       "severity": "high"
     },
     {
@@ -45,7 +45,7 @@
     {
       "id": "cmux-swift-architectural-rethink",
       "rule": "Flag Swift fixes that patch symptoms while leaving bad state representable: timing repairs, new flags/caches/singletons/observers/side channels, duplicate behavior wired through multiple entrypoints, split SwiftUI/AppKit lifecycle ownership, or fixes that do not name the invariant and source of truth.",
-      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"],
+      "scope": ["**/*.swift", "**/Package.swift", "GhosttyTabs.xcodeproj/**"],
       "severity": "high"
     }
   ]

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -3,32 +3,32 @@
     {
       "path": ".github/review-bot-rules/swift-actor-isolation.md",
       "description": "Source-of-truth cmux lint rule for Swift actor isolation review.",
-      "scope": ["**/*.swift", "Package.swift"]
+      "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
       "path": ".github/review-bot-rules/swift-architectural-rethink.md",
       "description": "Source-of-truth cmux lint rule for architectural review of Swift changes.",
-      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"]
+      "scope": ["**/*.swift", "**/Package.swift", "GhosttyTabs.xcodeproj/**"]
     },
     {
       "path": ".github/review-bot-rules/swift-blocking-runtime.md",
       "description": "Source-of-truth cmux lint rule for blocking and timing primitive review.",
-      "scope": ["**/*.swift", "Package.swift"]
+      "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",
       "description": "Source-of-truth cmux lint rule for Swift concurrency modernization review.",
-      "scope": ["**/*.swift", "Package.swift"]
+      "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrent-annotation.md",
       "description": "Source-of-truth cmux lint rule for @concurrent and nonisolated async review.",
-      "scope": ["**/*.swift", "Package.swift"]
+      "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
       "path": ".github/review-bot-rules/swift-logging.md",
       "description": "Source-of-truth cmux lint rule for production Swift logging review.",
-      "scope": ["**/*.swift", "Package.swift"]
+      "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
       "path": ".github/review-bot-rules/swiftui-state-layout.md",
@@ -38,7 +38,12 @@
     {
       "path": "CLAUDE.md",
       "description": "Repo-local guidance for cmux Swift, SwiftUI, testing, shortcut, localization, and no-sleep policies.",
-      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"]
+      "scope": ["**/*.swift", "**/Package.swift", "GhosttyTabs.xcodeproj/**"]
+    },
+    {
+      "path": "AGENTS.md",
+      "description": "Repo-local guidance for cmux agents, Swift conventions, testing, shortcuts, localization, and no-sleep policies.",
+      "scope": ["**/*.swift", "**/Package.swift", "GhosttyTabs.xcodeproj/**"]
     }
   ]
 }

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,44 @@
+{
+  "files": [
+    {
+      "path": ".github/review-bot-rules/swift-actor-isolation.md",
+      "description": "Source-of-truth cmux lint rule for Swift actor isolation review.",
+      "scope": ["**/*.swift", "Package.swift"]
+    },
+    {
+      "path": ".github/review-bot-rules/swift-architectural-rethink.md",
+      "description": "Source-of-truth cmux lint rule for architectural review of Swift changes.",
+      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"]
+    },
+    {
+      "path": ".github/review-bot-rules/swift-blocking-runtime.md",
+      "description": "Source-of-truth cmux lint rule for blocking and timing primitive review.",
+      "scope": ["**/*.swift", "Package.swift"]
+    },
+    {
+      "path": ".github/review-bot-rules/swift-concurrency-modernization.md",
+      "description": "Source-of-truth cmux lint rule for Swift concurrency modernization review.",
+      "scope": ["**/*.swift", "Package.swift"]
+    },
+    {
+      "path": ".github/review-bot-rules/swift-concurrent-annotation.md",
+      "description": "Source-of-truth cmux lint rule for @concurrent and nonisolated async review.",
+      "scope": ["**/*.swift", "Package.swift"]
+    },
+    {
+      "path": ".github/review-bot-rules/swift-logging.md",
+      "description": "Source-of-truth cmux lint rule for production Swift logging review.",
+      "scope": ["**/*.swift", "Package.swift"]
+    },
+    {
+      "path": ".github/review-bot-rules/swiftui-state-layout.md",
+      "description": "Source-of-truth cmux lint rule for SwiftUI state and layout review.",
+      "scope": ["**/*.swift"]
+    },
+    {
+      "path": "CLAUDE.md",
+      "description": "Repo-local guidance for cmux Swift, SwiftUI, testing, shortcut, localization, and no-sleep policies.",
+      "scope": ["**/*.swift", "Package.swift", "GhosttyTabs.xcodeproj/**"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,15 @@
+# cmux Custom Review Rules
+
+Apply the custom lint rules in `.github/review-bot-rules/` to Swift and Swift project changes.
+
+Greptile should treat the rules in that directory as the source of truth for cmux Swift reviews. PR-head edits to the rule files should not weaken review behavior until the edits are merged into the base branch.
+
+Review production Swift changes for:
+
+- Swift actor isolation mistakes.
+- Blocking runtime primitives and timing-based synchronization.
+- Legacy concurrency patterns where Swift concurrency is available.
+- Incorrect `@concurrent` or `nonisolated async` behavior.
+- Production logging that bypasses unified logging or leaks sensitive data.
+- SwiftUI state and layout patterns that cause stale state, broad invalidation, or render-time mutation.
+- Architectural fixes that patch symptoms while leaving bad state representable.


### PR DESCRIPTION
## Summary

Adds a vendor-only version of the Swift lint review setup as an alternative to https://github.com/manaflow-ai/cmux/pull/3407.

- Adds shared Swift review rules under `.github/review-bot-rules/`
- Configures Greptile to apply the rules and publish a GitHub status check
- Configures CodeRabbit code guidelines, path instructions, and error-mode custom pre-merge checks

## Notes

No model provider API keys, GitHub Actions workflow, or pull_request_target runner is added here. The rules are applied by Greptile and CodeRabbit from base-branch configuration. For open source safety, PR-head edits to these files should not weaken their own review.

CodeRabbit ignores `.coderabbit.yaml` changes from PR heads in open source repos, so this PR may be reviewed with default CodeRabbit config. Future PRs should use this config after it lands on `main`.

## Validation

- `jq empty .greptile/config.json .greptile/files.json`
- `ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(".coderabbit.yaml"))' > /tmp/coderabbit-review-bot-rules.json`\n- `bun x ajv-cli validate --strict=false -s /Users/lawrence/fun/cmuxterm-hq/worktrees/feat-deepseek-diff-lint/tmp/coderabbit-schema.json -d /tmp/coderabbit-review-bot-rules.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds shared Swift review rules and configures `Greptile` and `CodeRabbit` to enforce them via a status check and error‑mode pre‑merge checks. Focus areas: actor isolation, blocking runtime, concurrency modernization, `@concurrent`, logging, SwiftUI state/layout, and architectural fixes.

- **New Features**
  - Added rule docs under `.github/review-bot-rules/` as the source of truth.
  - Configured `Greptile` to apply these rules, publish a status check, and map rule files/scopes via `.greptile/files.json`.
  - Added `.coderabbit.yaml` with knowledge base patterns (`AGENTS.md`, `CLAUDE.md`) and custom error‑mode checks for each rule.
  - Scoped reviews to production Swift changes and key project files (e.g., `Package.swift`, `GhosttyTabs.xcodeproj/**`).

- **Migration**
  - No GitHub Actions or API keys added; `Greptile` and `CodeRabbit` read from the base branch.
  - PR‑head edits to rule files do not weaken review until merged.
  - After this lands on `main`, future PRs will be evaluated with these rules by default.

<sup>Written for commit 10bf0ae3bae7ad6b6a8d8a38055afa7769182d07. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced automated review infrastructure with pre-merge blocking checks that enforce Swift safety: actor isolation, concurrency modernization/annotations, blocking/runtime synchronization, logging hygiene, and SwiftUI state/layout patterns.

* **Documentation**
  * Added comprehensive review guidelines describing failure criteria, allowed exceptions, and required reporting for architectural, concurrency, logging, and SwiftUI issues to guide reviewers and automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->