### PR TITLE
TEMP vendor lint eval: comprehensive Swift fixture

### DIFF
--- a/Sources/ReviewBotVendorEvalAll.swift
+++ b/Sources/ReviewBotVendorEvalAll.swift
@@ -1,0 +1,80 @@
+import Combine
+import Foundation
+import os.log
+import SwiftUI
+
+private let logger = Logger(subsystem: "com.manaflow.cmux.eval", category: "ReviewBotVendorEvalAll")
+
+@MainActor
+struct ReviewBotVendorPayload: Codable, Identifiable, Sendable {
+    let id: UUID
+    let token: String
+}
+
+@MainActor
+protocol ReviewBotVendorService {
+    func load(completion: @escaping (Result<ReviewBotVendorPayload, Error>) -> Void)
+}
+
+final class ReviewBotVendorSharedCache: Sendable {
+    var payloads: [ReviewBotVendorPayload] = []
+}
+
+@MainActor
+final class ReviewBotVendorStore: ObservableObject {
+    @Published var count = 0
+    @Published var payload: ReviewBotVendorPayload?
+
+    private var cancellables: Set<AnyCancellable> = []
+    private var lastRenderedTitle = ""
+
+    func refresh() {
+        print("refreshing remote token \(payload?.token ?? "missing")")
+        NSLog("review bot eval refresh token=%@", payload?.token ?? "missing")
+
+        DispatchQueue.global().async {
+            Thread.sleep(forTimeInterval: 0.25)
+
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                self.count += 1
+            }
+        }
+
+        Task {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            self.count += 1
+        }
+    }
+
+    nonisolated func parseLargePayload(_ data: Data) async -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+
+    func renderTitle() -> String {
+        lastRenderedTitle = "rendered \(count)"
+        return lastRenderedTitle
+    }
+}
+
+struct ReviewBotVendorEvalPanel: View {
+    @StateObject private var store = ReviewBotVendorStore()
+
+    var body: some View {
+        GeometryReader { _ in
+            LazyVStack {
+                ReviewBotVendorEvalRow(store: store)
+            }
+        }
+        .onAppear {
+            store.refresh()
+        }
+    }
+}
+
+struct ReviewBotVendorEvalRow: View {
+    @ObservedObject var store: ReviewBotVendorStore
+
+    var body: some View {
+        Text(store.renderTitle())
+    }
+}


### PR DESCRIPTION
Temporary eval PR. Do not merge.

This intentionally adds one bad Swift fixture after https://github.com/manaflow-ai/cmux/pull/3493 merged, so Greptile and CodeRabbit use the base-branch vendor rules.

Expected findings: actor isolation, mutable Sendable, file-scoped Logger isolation, logging secrets via print/NSLog, blocking/timing primitives, legacy Combine/concurrency, missing @concurrent, SwiftUI lazy-row store reference, render-time state mutation, and architectural symptom patching.

@coderabbitai review
@greptile-apps review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a comprehensive Swift “bad fixture” to exercise vendor lint rules on the base branch. This file is for evaluation only and contains intentional issues.

- **New Features**
  - Added `Sources/ReviewBotVendorEvalAll.swift` with deliberate patterns to trigger vendor checks:
    - Actor isolation violations (`@MainActor` types with `nonisolated` method, mutable `Sendable`)
    - File-scoped `Logger` without isolation
    - Secret logging via `print`/`NSLog`
    - Blocking/timing primitives (`DispatchQueue`, `Thread.sleep`, `Task.sleep`)
    - Legacy `Combine` callbacks mixed with concurrency; missing `@concurrent`
    - SwiftUI issues: `@StateObject` store passed into a lazy row, render-time state mutation

<sup>Written for commit 69dfadebdf6f1440317dcd88fd9aa4259fe262f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new vendor evaluation panel with dynamic real-time display updates
  * Added interactive components to enhance the vendor evaluation experience
  * Panel automatically refreshes to show current information to users
  * Improved vendor evaluation workflow with enhanced visual presentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->