### PR TITLE
TEMP vendor lint eval: architecture and concurrent

### DIFF
--- a/Sources/ReviewBotVendorArchitectureEval.swift
+++ b/Sources/ReviewBotVendorArchitectureEval.swift
@@ -1,0 +1,54 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ReviewBotVendorFocusCoordinator: ObservableObject {
+    @Published var activeWorkspaceID: UUID?
+    @Published var pendingFocusSurfaceID: UUID?
+
+    private static var lastKnownSurfaceID: UUID?
+    private var didScheduleRepair = false
+
+    func restoreFocus(workspaceID: UUID, surfaceID: UUID, payload: Data) {
+        activeWorkspaceID = workspaceID
+        pendingFocusSurfaceID = surfaceID
+        Self.lastKnownSurfaceID = surfaceID
+
+        if !didScheduleRepair {
+            didScheduleRepair = true
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
+                self.pendingFocusSurfaceID = Self.lastKnownSurfaceID
+            }
+        }
+
+        Task {
+            let decoded = await decodeLargeWorkspacePayload(payload)
+            if decoded.contains(surfaceID.uuidString) {
+                try? await Task.sleep(nanoseconds: 150_000_000)
+                self.pendingFocusSurfaceID = surfaceID
+            }
+        }
+    }
+
+    nonisolated func decodeLargeWorkspacePayload(_ data: Data) async -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+}
+
+struct ReviewBotVendorArchitectureEvalPanel: View {
+    @StateObject private var coordinator = ReviewBotVendorFocusCoordinator()
+    let workspaceID: UUID
+    let surfaceID: UUID
+    let payload: Data
+
+    var body: some View {
+        Text(coordinator.pendingFocusSurfaceID?.uuidString ?? "missing")
+            .onAppear {
+                coordinator.restoreFocus(
+                    workspaceID: workspaceID,
+                    surfaceID: surfaceID,
+                    payload: payload
+                )
+            }
+    }
+}


### PR DESCRIPTION
Temporary eval PR. Do not merge.

This intentionally adds a focused Swift fixture after https://github.com/manaflow-ai/cmux/pull/3493 merged, so Greptile and CodeRabbit use the base-branch vendor rules.

Expected findings: architectural symptom patching with split focus ownership, delayed DispatchQueue repair, untracked Task with Task.sleep, legacy ObservableObject/@Published, missing @concurrent on heavy nonisolated async decoding, and unlocalized Text fallback.

@coderabbitai review
@greptile-apps review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a temporary Swift fixture to evaluate vendor architecture and concurrency lint rules using the base-branch config. It simulates a focus-restore flow in SwiftUI to surface expected rule findings.

- **New Features**
  - Added ReviewBotVendorFocusCoordinator and ReviewBotVendorArchitectureEvalPanel fixture.
  - Intentionally includes: delayed main-queue repair, fire-and-forget Task with Task.sleep, nonisolated async decoding missing @concurrent, ObservableObject/@Published state, and a nonlocalized Text("missing") fallback.

<sup>Written for commit 8068137c790f9f005d088d30ba6f5e500588e61e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added architecture evaluation panel for vendor review coordination
  * Implemented workspace focus surface restoration to preserve context during operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->