### PR TITLE
Tighten CodeRabbit Swift lint enforcement

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -10,6 +10,8 @@ knowledge_base:
       - ".github/review-bot-rules/*.md"
 
 reviews:
+  profile: assertive
+  request_changes_workflow: true
   path_instructions:
     - path: "**/*.swift"
       instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -4,7 +4,7 @@ These rules are the shared source of truth for Greptile and CodeRabbit custom Sw
 
 The rule files are intentionally short and focused. Each one defines one class of issue, concrete failure cases, allowed cases, and the expected reporting shape. Keep new rules narrow enough that a reviewer can apply the rule to a full PR diff without turning it into a broad style guide.
 
-Greptile is configured to publish a GitHub status check. CodeRabbit is configured with error-mode custom pre-merge checks, which can block when the repository's CodeRabbit request-changes workflow is enabled.
+Greptile is configured to publish a GitHub status check and inline findings. CodeRabbit is configured with assertive review, request-changes workflow, and error-mode custom pre-merge checks so unresolved findings can block merge through CodeRabbit's review flow.
 
 Current rules:
 


### PR DESCRIPTION
## Summary

Follow-up from the vendor lint evals after https://github.com/manaflow-ai/cmux/pull/3493 merged.

- Switch CodeRabbit to `assertive` review profile
- Enable CodeRabbit `request_changes_workflow`
- Document that CodeRabbit error-mode checks can block through the review flow

## Eval evidence

Temporary eval PRs:

- Comprehensive fixture: https://github.com/manaflow-ai/cmux/pull/3494
- Architecture and @concurrent fixture: https://github.com/manaflow-ai/cmux/pull/3495

Greptile caught the target rule families on both evals. CodeRabbit used `.coderabbit.yaml` after it landed on `main`, but `mode: error` was still advisory because request-changes workflow was not enabled.

## Validation

- `jq empty .greptile/config.json .greptile/files.json`
- `ruby -ryaml -rjson -e 'puts JSON.generate(YAML.load_file(".coderabbit.yaml"))' > /tmp/coderabbit-blocking-mode.json`\n- `bun x ajv-cli validate --strict=false -s /Users/lawrence/fun/cmuxterm-hq/worktrees/feat-deepseek-diff-lint/tmp/coderabbit-schema.json -d /tmp/coderabbit-blocking-mode.json`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable blocking Swift lint via `CodeRabbit` by switching to the assertive review profile and turning on the request-changes workflow. Update the review-bot rules README to note `Greptile` inline findings/status check and that unresolved error‑mode findings in `CodeRabbit` can block merge.

<sup>Written for commit 5755057868ffe798dfb9ea46077a6a156c6749ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced code review automation configuration with more assertive review practices and streamlined request-changes workflow to strengthen quality assurance processes.

* **Documentation**
  * Updated review bot configuration documentation to reflect current system setup and workflow capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->