### PR TITLE
TEMP vendor lint eval: CodeRabbit enforcement

### DIFF
--- a/Sources/ReviewBotVendorEnforcementEval.swift
+++ b/Sources/ReviewBotVendorEnforcementEval.swift
@@ -1,0 +1,33 @@
+import Foundation
+import SwiftUI
+
+@MainActor
+final class ReviewBotVendorEnforcementStore: ObservableObject {
+    @Published var count = 0
+
+    func refreshAfterFakeReadiness() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            self.count += 1
+        }
+
+        Task {
+            try? await Task.sleep(nanoseconds: 100_000_000)
+            self.count += 1
+        }
+    }
+
+    nonisolated func parseLargePayload(_ data: Data) async -> String {
+        String(decoding: data, as: UTF8.self)
+    }
+}
+
+struct ReviewBotVendorEnforcementPanel: View {
+    @StateObject private var store = ReviewBotVendorEnforcementStore()
+
+    var body: some View {
+        Text("count \(store.count)")
+            .onAppear {
+                store.refreshAfterFakeReadiness()
+            }
+    }
+}

--- a/Sources/ReviewBotVendorEnforcementEval.swift
+++ b/Sources/ReviewBotVendorEnforcementEval.swift
@@ -19,6 +19,11 @@ final class ReviewBotVendorEnforcementStore: ObservableObject {
     nonisolated func parseLargePayload(_ data: Data) async -> String {
         String(decoding: data, as: UTF8.self)
     }
+
+    func logAccessTokenForEval(_ token: String) {
+        print("token: \(token)")
+        NSLog("token: \(token)")
+    }
 }
 
 struct ReviewBotVendorEnforcementPanel: View {


### PR DESCRIPTION
Temporary eval PR. Do not merge.

This intentionally adds a small bad Swift fixture after https://github.com/manaflow-ai/cmux/pull/3496 merged. Goal: verify CodeRabbit now uses base-branch `profile: assertive` plus `request_changes_workflow: true`, and that Greptile/CodeRabbit catch timing, Task.sleep, legacy ObservableObject, missing @concurrent, onAppear side effects, and unlocalized Text.

@coderabbitai review
@greptile-apps review

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a temporary Swift fixture to validate CodeRabbit request-changes enforcement with the base-branch assertive profile. It intentionally uses timing APIs, Task.sleep, a nonisolated method on a @MainActor type, onAppear side effects, unlocalized Text, and plain-text access token logging (print/NSLog) to ensure vendor lint flags them.

<sup>Written for commit 7ebb4fea74d7b6f7086c4f70755cfa12de6aa8aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a vendor-evaluation panel that displays a live counter and automatically refreshes when opened.
  * Improved asynchronous update handling so the UI reflects background increments reliably.
  * Added support for processing large payloads and evaluation logging to aid diagnostics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->