### PR TITLE
Fix OpenCode feed plugin resource lookup

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19086,15 +19086,17 @@ export default CMUXSessionRestore;
         appendIfExisting(Bundle.main.resourceURL?.appendingPathComponent("opencode-plugin.js", isDirectory: false))
 
         if let executableURL = resolvedExecutableURL() {
-            var current = executableURL.deletingLastPathComponent().standardizedFileURL
-            while true {
-                appendIfExisting(current.appendingPathComponent("opencode-plugin.js", isDirectory: false))
-                appendIfExisting(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
+            let execDir = executableURL.deletingLastPathComponent().standardizedFileURL
+            for relativePath in ["opencode-plugin.js", "../opencode-plugin.js", "../../Resources/opencode-plugin.js", "../../../Contents/Resources/opencode-plugin.js"] {
+                appendIfExisting(execDir.appendingPathComponent(relativePath, isDirectory: false).standardizedFileURL)
+            }
+
+            var current = execDir
+            for _ in 0..<4 {
                 if current.pathExtension == "app" {
                     appendIfExisting(current.appendingPathComponent("Contents/Resources/opencode-plugin.js", isDirectory: false))
                     break
                 }
-
                 let projectMarker = current.appendingPathComponent("GhosttyTabs.xcodeproj/project.pbxproj")
                 let repoResource = current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false)
                 if fileManager.fileExists(atPath: projectMarker.path),
@@ -19102,9 +19104,7 @@ export default CMUXSessionRestore;
                     appendIfExisting(repoResource)
                     break
                 }
-
-                guard let parent = parentSearchURL(for: current) else { break }
-                current = parent
+                current = current.deletingLastPathComponent().standardizedFileURL
             }
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19057,22 +19057,54 @@ export default CMUXSessionRestore;
 
     private func bundledOpenCodePluginSource() throws -> String {
         // The plugin JS is bundled into the .app via `Resources/opencode-plugin.js`.
-        // When running from the dev CLI binary (out of DerivedData), Bundle.main
-        // might resolve to the .app bundle or fall back to a checked-in resource
-        // copy next to the running binary.
-        if let url = Bundle.main.url(forResource: "opencode-plugin", withExtension: "js"),
-           let contents = try? String(contentsOf: url, encoding: .utf8) {
-            return contents
+        // The `cmux` CLI is often launched from `Contents/Resources/bin/cmux`,
+        // where Bundle.main can be the CLI executable rather than the containing
+        // app. Search the real executable path before falling back to repo dev
+        // paths used by `swift run`-style local builds.
+        for url in openCodePluginResourceCandidates() {
+            if let contents = try? String(contentsOf: url, encoding: .utf8) {
+                return contents
+            }
         }
-        // Fallback for `swift run`-style local dev.
+        throw CLIError(message: "bundled opencode-plugin.js not found (Bundle.main, app bundle, executable, and repo fallbacks)")
+    }
+
+    private func openCodePluginResourceCandidates() -> [URL] {
+        var candidates: [URL] = []
+        var seen: Set<String> = []
+
+        func append(_ url: URL?) {
+            guard let url else { return }
+            let standardized = url.standardizedFileURL
+            guard seen.insert(standardized.path).inserted else { return }
+            candidates.append(standardized)
+        }
+
+        append(Bundle.main.url(forResource: "opencode-plugin", withExtension: "js"))
+        append(Bundle.main.resourceURL?.appendingPathComponent("opencode-plugin.js", isDirectory: false))
+
+        if let executableURL = resolvedExecutableURL() {
+            var current = executableURL.deletingLastPathComponent().standardizedFileURL
+            while true {
+                append(current.appendingPathComponent("opencode-plugin.js", isDirectory: false))
+                append(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
+                if current.lastPathComponent == "Contents" {
+                    append(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
+                }
+                if current.pathExtension == "app" {
+                    append(current.appendingPathComponent("Contents/Resources/opencode-plugin.js", isDirectory: false))
+                }
+                guard let parent = parentSearchURL(for: current) else { break }
+                current = parent
+            }
+        }
+
         let devRelative = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Resources/opencode-plugin.js")
-        if let contents = try? String(contentsOf: devRelative, encoding: .utf8) {
-            return contents
-        }
-        throw CLIError(message: "bundled opencode-plugin.js not found (Bundle.main + fallback)")
+        append(devRelative)
+        return candidates
     }
 
     private func installOpenCodePlugin(projectLocal: Bool) throws {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -19070,30 +19070,39 @@ export default CMUXSessionRestore;
     }
 
     private func openCodePluginResourceCandidates() -> [URL] {
+        let fileManager = FileManager.default
         var candidates: [URL] = []
         var seen: Set<String> = []
 
-        func append(_ url: URL?) {
+        func appendIfExisting(_ url: URL?) {
             guard let url else { return }
             let standardized = url.standardizedFileURL
             guard seen.insert(standardized.path).inserted else { return }
+            guard fileManager.fileExists(atPath: standardized.path) else { return }
             candidates.append(standardized)
         }
 
-        append(Bundle.main.url(forResource: "opencode-plugin", withExtension: "js"))
-        append(Bundle.main.resourceURL?.appendingPathComponent("opencode-plugin.js", isDirectory: false))
+        appendIfExisting(Bundle.main.url(forResource: "opencode-plugin", withExtension: "js"))
+        appendIfExisting(Bundle.main.resourceURL?.appendingPathComponent("opencode-plugin.js", isDirectory: false))
 
         if let executableURL = resolvedExecutableURL() {
             var current = executableURL.deletingLastPathComponent().standardizedFileURL
             while true {
-                append(current.appendingPathComponent("opencode-plugin.js", isDirectory: false))
-                append(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
-                if current.lastPathComponent == "Contents" {
-                    append(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
-                }
+                appendIfExisting(current.appendingPathComponent("opencode-plugin.js", isDirectory: false))
+                appendIfExisting(current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false))
                 if current.pathExtension == "app" {
-                    append(current.appendingPathComponent("Contents/Resources/opencode-plugin.js", isDirectory: false))
+                    appendIfExisting(current.appendingPathComponent("Contents/Resources/opencode-plugin.js", isDirectory: false))
+                    break
                 }
+
+                let projectMarker = current.appendingPathComponent("GhosttyTabs.xcodeproj/project.pbxproj")
+                let repoResource = current.appendingPathComponent("Resources/opencode-plugin.js", isDirectory: false)
+                if fileManager.fileExists(atPath: projectMarker.path),
+                   fileManager.fileExists(atPath: repoResource.path) {
+                    appendIfExisting(repoResource)
+                    break
+                }
+
                 guard let parent = parentSearchURL(for: current) else { break }
                 current = parent
             }
@@ -19103,7 +19112,7 @@ export default CMUXSessionRestore;
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .appendingPathComponent("Resources/opencode-plugin.js")
-        append(devRelative)
+        appendIfExisting(devRelative)
         return candidates
     }
 

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1706,16 +1706,10 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         XCTAssertTrue(pluginSource.contains("cmux-opencode-session-plugin-marker"))
         XCTAssertTrue(pluginSource.contains("\"opencode-hook\""))
 
-        let feedPluginURL = configDir
-            .appendingPathComponent("plugins", isDirectory: true)
-            .appendingPathComponent("cmux-feed.js", isDirectory: false)
-        let feedPluginSource = try String(contentsOf: feedPluginURL, encoding: .utf8)
-        XCTAssertTrue(feedPluginSource.contains("cmux-feed-plugin-marker"))
+        XCTAssertTrue(try String(contentsOf: configDir.appendingPathComponent("plugins/cmux-feed.js"), encoding: .utf8).contains("cmux-feed-plugin-marker"))
 
-        let data = try Data(contentsOf: configURL)
-        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data, options: []) as? [String: Any])
-        let plugins = try XCTUnwrap(json["plugin"] as? [String])
-        XCTAssertEqual(plugins, ["other-plugin", "./plugins/cmux-session.js"])
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: try Data(contentsOf: configURL), options: []) as? [String: Any])
+        XCTAssertEqual(try XCTUnwrap(json["plugin"] as? [String]), ["other-plugin", "./plugins/cmux-session.js"])
     }
 
     func testAgentHookLaunchEnvironmentDoesNotPersistPathOrShell() throws {

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1706,6 +1706,12 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         XCTAssertTrue(pluginSource.contains("cmux-opencode-session-plugin-marker"))
         XCTAssertTrue(pluginSource.contains("\"opencode-hook\""))
 
+        let feedPluginURL = configDir
+            .appendingPathComponent("plugins", isDirectory: true)
+            .appendingPathComponent("cmux-feed.js", isDirectory: false)
+        let feedPluginSource = try String(contentsOf: feedPluginURL, encoding: .utf8)
+        XCTAssertTrue(feedPluginSource.contains("cmux-feed-plugin-marker"))
+
         let data = try Data(contentsOf: configURL)
         let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data, options: []) as? [String: Any])
         let plugins = try XCTUnwrap(json["plugin"] as? [String])


### PR DESCRIPTION
## Summary
- Resolve the OpenCode feed plugin from the containing app bundle or executable-adjacent resources when `Bundle.main` misses it.
- Extend the OpenCode hook install test to assert `cmux-feed.js` is emitted.

## Testing
- `./scripts/reload.sh --tag hookjs` passed

## Issues
- Related: latest nightly `cmux hooks setup` error `bundled opencode-plugin.js not found (Bundle.main + fallback)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes OpenCode plugin and feed plugin resource lookup so `cmux` reliably loads bundled JS from app bundles or executable-adjacent paths. Bounds the search to avoid nightly `cmux hooks setup` failures when `opencode-plugin.js` isn’t found.

- **Bug Fixes**
  - Adds ordered, bounded lookup across `Bundle.main` and `Bundle.main.resourceURL`, the real executable and parent dirs (including `.app/Contents/Resources`), then a dev/repo fallback; limits ascent to 4 levels, stops at `.app` or a repo marker, normalizes paths, filters to existing files, and dedupes.
  - Updates the OpenCode hook install test to assert the `cmux-feed.js` marker within the file budget.

<sup>Written for commit 3a70b2382bd5ca369d6ab0073f1a2f4eea2de418. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved plugin resource discovery across various install layouts to make locating bundled plugins more reliable.
  * Expanded and clearer error reporting when plugin resources cannot be found, helping diagnose missing or misplaced files.

* **Tests**
  * Strengthened install-time validation by verifying the generated plugin bundle includes the expected feed marker alongside the session plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->