### PR TITLE
Restore sidebar edge fades

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -88,6 +88,7 @@
 		A50019B0 /* SettingsSearchAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B1 /* SettingsSearchAliases.swift */; };
 		A50019B2 /* SettingsSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B3 /* SettingsSearchIndexTests.swift */; };
 		A5001002 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001012 /* ContentView.swift */; };
+		C0DE35010000000000000001 /* SidebarScrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35010000000000000002 /* SidebarScrim.swift */; };
 		62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 		C3408A000000000000000001 /* ContentView+RightSidebarCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */; };
 		D7AB00000000000000000003 /* ContentView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */; };
@@ -443,6 +444,7 @@
 		A50019B1 /* SettingsSearchAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchAliases.swift; sourceTree = "<group>"; };
 		A50019B3 /* SettingsSearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchIndexTests.swift; sourceTree = "<group>"; };
 		A5001012 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		C0DE35010000000000000002 /* SidebarScrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarScrim.swift; sourceTree = "<group>"; };
 		C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+RightSidebarCommandPalette.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ContentView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		D7AB34300000000000000002 /* SidebarDropPlanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarDropPlanner.swift; sourceTree = "<group>"; };
@@ -838,6 +840,7 @@
 				A50019A1 /* SettingsNavigation.swift */,
 				A50019B1 /* SettingsSearchAliases.swift */,
 				A5001012 /* ContentView.swift */,
+				C0DE35010000000000000002 /* SidebarScrim.swift */,
 				C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */,
 				D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */,
 				D7AB34300000000000000002 /* SidebarDropPlanner.swift */,
@@ -1344,6 +1347,7 @@
 				A50019A0 /* SettingsNavigation.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
 				A5001002 /* ContentView.swift in Sources */,
+				C0DE35010000000000000001 /* SidebarScrim.swift in Sources */,
 				C3408A000000000000000001 /* ContentView+RightSidebarCommandPalette.swift in Sources */,
 				D7AB00000000000000000003 /* ContentView+MoveTabToNewWorkspace.swift in Sources */,
 				D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10012,13 +10012,11 @@ struct VerticalTabsSidebar: View {
                     .frame(width: 0, height: 0)
                 )
                 .safeAreaInset(edge: .top, spacing: 0) {
-                    Color.clear
-                        .frame(height: workspaceScrollTopVisibilityInset)
+                    Color.clear.frame(height: workspaceScrollTopVisibilityInset)
                         .allowsHitTesting(false)
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {
-                    Color.clear
-                        .frame(height: sidebarBottomScrimHeight)
+                    Color.clear.frame(height: sidebarBottomScrimHeight)
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
@@ -12439,72 +12437,6 @@ private struct SidebarDevFooter: View {
     }
 }
 #endif
-
-private struct SidebarTopScrim: View {
-    let height: CGFloat
-
-    var body: some View {
-        SidebarEdgeScrim(height: height, edge: .top)
-    }
-}
-
-private struct SidebarBottomScrim: View {
-    let height: CGFloat
-
-    var body: some View {
-        SidebarEdgeScrim(height: height, edge: .bottom)
-    }
-}
-
-private struct SidebarEdgeScrim: View {
-    enum Edge {
-        case top
-        case bottom
-    }
-
-    let height: CGFloat
-    let edge: Edge
-
-    var body: some View {
-        SidebarEdgeBlurEffect()
-            .frame(height: height)
-            .mask(
-                LinearGradient(
-                    colors: gradientColors,
-                    startPoint: .top,
-                    endPoint: .bottom
-                )
-            )
-    }
-
-    private var gradientColors: [Color] {
-        let colors = [
-            Color.black.opacity(0.95),
-            Color.black.opacity(0.75),
-            Color.black.opacity(0.35),
-            Color.clear,
-        ]
-        switch edge {
-        case .top:
-            return colors
-        case .bottom:
-            return Array(colors.reversed())
-        }
-    }
-}
-
-private struct SidebarEdgeBlurEffect: NSViewRepresentable {
-    func makeNSView(context: Context) -> NSVisualEffectView {
-        let view = NSVisualEffectView()
-        view.blendingMode = .withinWindow
-        view.material = .underWindowBackground
-        view.state = .active
-        view.isEmphasized = false
-        return view
-    }
-
-    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
-}
 
 private struct SidebarScrollViewResolver: NSViewRepresentable {
     let onResolve: (NSScrollView?) -> Void

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9809,6 +9809,10 @@ struct VerticalTabsSidebar: View {
         SidebarWorkspaceListMetrics.topScrimHeight
     }
 
+    private var sidebarBottomScrimHeight: CGFloat {
+        SidebarWorkspaceListMetrics.bottomScrimHeight
+    }
+
     private var isMinimalMode: Bool {
         WorkspacePresentationModeSettings.mode(for: workspacePresentationMode) == .minimal
     }
@@ -9909,7 +9913,7 @@ struct VerticalTabsSidebar: View {
             workspaceTerminalScrollBarHiddenById: workspaceTerminalScrollBarHiddenById
         )
 
-        VStack(spacing: 0) {
+        ZStack(alignment: .bottomLeading) {
             workspaceScrollArea(renderContext: renderContext)
             SidebarFooter(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -10012,8 +10016,17 @@ struct VerticalTabsSidebar: View {
                         .frame(height: workspaceScrollTopVisibilityInset)
                         .allowsHitTesting(false)
                 }
+                .safeAreaInset(edge: .bottom, spacing: 0) {
+                    Color.clear
+                        .frame(height: sidebarBottomScrimHeight)
+                        .allowsHitTesting(false)
+                }
                 .overlay(alignment: .top) {
                     SidebarTopScrim(height: sidebarTopScrimHeight)
+                        .allowsHitTesting(false)
+                }
+                .overlay(alignment: .bottom) {
+                    SidebarBottomScrim(height: sidebarBottomScrimHeight)
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
@@ -12431,9 +12444,66 @@ private struct SidebarTopScrim: View {
     let height: CGFloat
 
     var body: some View {
-        Color.clear
-            .frame(height: height)
+        SidebarEdgeScrim(height: height, edge: .top)
     }
+}
+
+private struct SidebarBottomScrim: View {
+    let height: CGFloat
+
+    var body: some View {
+        SidebarEdgeScrim(height: height, edge: .bottom)
+    }
+}
+
+private struct SidebarEdgeScrim: View {
+    enum Edge {
+        case top
+        case bottom
+    }
+
+    let height: CGFloat
+    let edge: Edge
+
+    var body: some View {
+        SidebarEdgeBlurEffect()
+            .frame(height: height)
+            .mask(
+                LinearGradient(
+                    colors: gradientColors,
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+    }
+
+    private var gradientColors: [Color] {
+        let colors = [
+            Color.black.opacity(0.95),
+            Color.black.opacity(0.75),
+            Color.black.opacity(0.35),
+            Color.clear,
+        ]
+        switch edge {
+        case .top:
+            return colors
+        case .bottom:
+            return Array(colors.reversed())
+        }
+    }
+}
+
+private struct SidebarEdgeBlurEffect: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.blendingMode = .withinWindow
+        view.material = .underWindowBackground
+        view.state = .active
+        view.isEmphasized = false
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
 }
 
 private struct SidebarScrollViewResolver: NSViewRepresentable {

--- a/Sources/SidebarScrim.swift
+++ b/Sources/SidebarScrim.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+
+struct SidebarTopScrim: View {
+    let height: CGFloat
+
+    var body: some View {
+        SidebarEdgeScrim(height: height, edge: .top)
+    }
+}
+
+struct SidebarBottomScrim: View {
+    let height: CGFloat
+
+    var body: some View {
+        SidebarEdgeScrim(height: height, edge: .bottom)
+    }
+}
+
+struct SidebarEdgeScrim: View {
+    enum Edge {
+        case top
+        case bottom
+    }
+
+    let height: CGFloat
+    let edge: Edge
+
+    var body: some View {
+        SidebarEdgeBlurEffect()
+            .frame(height: height)
+            .mask(
+                LinearGradient(
+                    colors: gradientColors,
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+    }
+
+    private var gradientColors: [Color] {
+        let colors = [
+            Color.black.opacity(0.95),
+            Color.black.opacity(0.75),
+            Color.black.opacity(0.35),
+            Color.clear,
+        ]
+        switch edge {
+        case .top:
+            return colors
+        case .bottom:
+            return Array(colors.reversed())
+        }
+    }
+}
+
+struct SidebarEdgeBlurEffect: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.blendingMode = .withinWindow
+        view.material = .underWindowBackground
+        view.state = .active
+        view.isEmphasized = false
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -32,6 +32,7 @@ enum SidebarWorkspaceListMetrics {
     static let firstRowTopOffset: CGFloat = MinimalModeChromeMetrics.titlebarHeight + 2
     static let rowVerticalPadding: CGFloat = 8
     static let topScrimHeight: CGFloat = firstRowTopOffset + 20
+    static let bottomScrimHeight: CGFloat = topScrimHeight
 
     static var scrollTopInset: CGFloat {
         max(0, firstRowTopOffset - rowVerticalPadding)


### PR DESCRIPTION
## Summary
- Restores the sidebar top edge opacity fade.
- Adds a matching bottom edge fade above the footer/help button area.

## Testing
- ./scripts/reload.sh --tag sidefade succeeded.

## Issues
- Plain-text task: restore the sidebar top opacity fade and add a bottom opacity fade near the help button.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the sidebar top fade and adds a matching bottom fade above the footer/help area to improve depth and readability without changing interactions. Uses a native blur scrim masked by a gradient at both edges.

- **New Features**
  - Add top/bottom scrims via `SidebarTopScrim` and `SidebarBottomScrim`, built on shared `SidebarEdgeScrim` + `SidebarEdgeBlurEffect` with a gradient mask (reversed for bottom).
  - Render scrims inside the workspace scroll area; switch layout to `ZStack` so the footer overlays; add top/bottom `.safeAreaInset` padding; disable hit testing on scrims/insets; set `SidebarWorkspaceListMetrics.bottomScrimHeight` = `topScrimHeight` for consistent spacing.

<sup>Written for commit 3031fdb74d99c877c07ebe150d373bc1b331d6ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a bottom gradient/blur overlay to the sidebar workspace scroll area to match the top scrim, improving visual depth and scroll feedback at the bottom edge.

* **Refactor**
  * Unified top and bottom scrim rendering into a shared edge scrim with directional fade and blur.
  * Adjusted sidebar layout layering to support the new bottom overlay.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->