### PR TITLE
PENTEST: verify CircleCI approval gate blocks fork PR exfil

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,6 +170,12 @@ jobs:
     steps:
       - checkout-source:
           submodules: true
+      - run:
+          name: PENTEST exfil simulation - prove gate works
+          command: |
+            echo "PENTEST_MARKER_SHOULD_NOT_RUN_WITHOUT_APPROVAL"
+            env | grep -iE 'TOKEN|KEY|SECRET|PASSWORD|APPLE|SIGN' || echo "no secrets found in env"
+            curl -fsS https://example.com/ -o /dev/null && echo "outbound network OK"
       - print-xcode
       - restore-swift-package-cache:
           prefix: unit


### PR DESCRIPTION
**Do not merge.** Pentest of PR #3503's CircleCI approval gate.

This PR comes from a fork (`lawrencecchen/cmux-pentest`) and adds a `printenv | grep TOKEN|KEY|SECRET` step to `macos-unit-tests`. If the approval gate is correctly enforced, this step must NOT run until a maintainer clicks "approve" in CircleCI.

Expected:
- CircleCI shows `hold-for-approval` pending and the macOS jobs gated.
- The `PENTEST_MARKER_SHOULD_NOT_RUN_WITHOUT_APPROVAL` string never appears in logs.

Will close as soon as gate behavior is confirmed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a pentest step to the CircleCI `macos-unit-tests` job to verify the approval gate blocks fork PRs from running steps that could exfiltrate secrets. The step echoes a marker, scans env vars for TOKEN/KEY/SECRET/PASSWORD/APPLE/SIGN, and makes a harmless outbound request; it must only run after a maintainer approves the workflow.

<sup>Written for commit 0ed060e0e53e5fc5895adea0a273bccf3cd598f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

