### PR TITLE
Only gate forked CircleCI PR builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,10 +324,12 @@ jobs:
 workflows:
   ci-trusted:
     when:
-      not:
-        matches:
-          pattern: "^pull/.*"
-          value: << pipeline.git.branch >>
+      and:
+        - << pipeline.git.branch >>
+        - not:
+            matches:
+              pattern: "^pull/.*"
+              value: << pipeline.git.branch >>
     jobs:
       - macos-unit-tests
       - macos-debug-build
@@ -335,9 +337,11 @@ workflows:
 
   ci-gated:
     when:
-      matches:
-        pattern: "^pull/.*"
-        value: << pipeline.git.branch >>
+      or:
+        - matches:
+            pattern: "^pull/.*"
+            value: << pipeline.git.branch >>
+        - << pipeline.git.tag >>
     jobs:
       - hold-for-approval:
           type: approval

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -324,7 +324,10 @@ jobs:
 workflows:
   ci-trusted:
     when:
-      equal: [main, << pipeline.git.branch >>]
+      not:
+        matches:
+          pattern: "^pull/.*"
+          value: << pipeline.git.branch >>
     jobs:
       - macos-unit-tests
       - macos-debug-build
@@ -332,8 +335,9 @@ workflows:
 
   ci-gated:
     when:
-      not:
-        equal: [main, << pipeline.git.branch >>]
+      matches:
+        pattern: "^pull/.*"
+        value: << pipeline.git.branch >>
     jobs:
       - hold-for-approval:
           type: approval


### PR DESCRIPTION
## Summary
- run CircleCI jobs directly on trusted same-repo branches
- keep the manual approval gate for fork pull request refs under `pull/<number>`

## Verification
- `ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml"); puts "yaml ok"'`\n- `git diff --check`\n- this PR validates the policy by checking whether its own same-repo CircleCI jobs start without approval

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CircleCI so only forked PRs and tag builds are gated; same-repo branches run without approval for faster feedback. Uses a regex on `pipeline.git.branch` to gate `pull/<number>` refs and checks `pipeline.git.tag` to gate tag pipelines; all other branches run in the trusted workflow.

<sup>Written for commit 0a0b222997773a9cb5b4631b4013d0fc93e74d0a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI workflow routing to better distinguish pull-request pipelines from non-pull-request pipelines, refining how build pipelines are selected and processed to improve pipeline handling and approvals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->