### PR TITLE
Rename right sidebar Sessions to Vault

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -104888,19 +104888,19 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Show Sidebar Sessions"
+            "value": "Show Sidebar Vault"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "サイドバーのセッションを表示"
+            "value": "サイドバーのボールトを表示"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "사이드바 세션 표시"
+            "value": "사이드바 볼트 표시"
           }
         }
       }
@@ -105395,13 +105395,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sessions"
+            "value": "Vault"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッション"
+            "value": "ボールト"
           }
         }
       }
@@ -105463,13 +105463,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Untitled session"
+            "value": "Untitled chat"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "無題のセッション"
+            "value": "無題のチャット"
           }
         }
       }
@@ -105514,13 +105514,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Reload sessions"
+            "value": "Reload Vault"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッションを再読み込み"
+            "value": "ボールトを再読み込み"
           }
         }
       }
@@ -105531,13 +105531,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scanning sessions…"
+            "value": "Loading Vault…"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッションをスキャン中…"
+            "value": "ボールトを読み込み中…"
           }
         }
       }
@@ -105548,13 +105548,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No sessions found"
+            "value": "Vault is empty"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッションが見つかりません"
+            "value": "ボールトは空です"
           }
         }
       }
@@ -105565,13 +105565,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Sessions from Claude Code, Codex, and OpenCode will appear here."
+            "value": "Claude Code, Codex, and OpenCode history will appear here."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Claude Code、Codex、OpenCode のセッションがここに表示されます。"
+            "value": "Claude Code、Codex、OpenCode の履歴がここに表示されます。"
           }
         }
       }
@@ -105582,13 +105582,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No sessions"
+            "value": "No chats"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッションなし"
+            "value": "チャットなし"
           }
         }
       }
@@ -105837,13 +105837,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Search sessions"
+            "value": "Search Vault"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "セッションを検索"
+            "value": "ボールトを検索"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -105403,6 +105403,12 @@
             "state": "translated",
             "value": "ボールト"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "볼트"
+          }
         }
       }
     },
@@ -105471,6 +105477,12 @@
             "state": "translated",
             "value": "無題のチャット"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "제목 없는 채팅"
+          }
         }
       }
     },
@@ -105522,6 +105534,12 @@
             "state": "translated",
             "value": "ボールトを再読み込み"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "볼트 새로고침"
+          }
         }
       }
     },
@@ -105538,6 +105556,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ボールトを読み込み中…"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "볼트를 불러오는 중…"
           }
         }
       }
@@ -105556,6 +105580,12 @@
             "state": "translated",
             "value": "ボールトは空です"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "볼트가 비어 있습니다"
+          }
         }
       }
     },
@@ -105573,6 +105603,12 @@
             "state": "translated",
             "value": "Claude Code、Codex、OpenCode の履歴がここに表示されます。"
           }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Claude Code, Codex 및 OpenCode의 기록이 여기에 표시됩니다."
+          }
         }
       }
     },
@@ -105589,6 +105625,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "チャットなし"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "대화 없음"
           }
         }
       }
@@ -105844,6 +105886,12 @@
           "stringUnit": {
             "state": "translated",
             "value": "ボールトを検索"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "볼트 검색"
           }
         }
       }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -130,7 +130,7 @@ enum KeyboardShortcutSettings {
             case .focusRightSidebar: return String(localized: "shortcut.focusRightSidebar.label", defaultValue: "Focus Right Sidebar")
             case .switchRightSidebarToFiles: return String(localized: "shortcut.switchRightSidebarToFiles.label", defaultValue: "Show Sidebar Files")
             case .switchRightSidebarToFind: return String(localized: "shortcut.switchRightSidebarToFind.label", defaultValue: "Show Sidebar Find")
-            case .switchRightSidebarToSessions: return String(localized: "shortcut.switchRightSidebarToSessions.label", defaultValue: "Show Sidebar Sessions")
+            case .switchRightSidebarToSessions: return String(localized: "shortcut.switchRightSidebarToSessions.label", defaultValue: "Show Sidebar Vault")
             case .switchRightSidebarToFeed: return String(localized: "shortcut.switchRightSidebarToFeed.label", defaultValue: "Show Sidebar Feed")
             case .switchRightSidebarToDock: return String(localized: "shortcut.switchRightSidebarToDock.label", defaultValue: "Show Sidebar Dock")
             case .triggerFlash: return String(localized: "shortcut.flashFocusedPanel.label", defaultValue: "Flash Focused Panel")

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -21,7 +21,7 @@ enum RightSidebarMode: String, CaseIterable {
         switch self {
         case .files: return String(localized: "rightSidebar.mode.files", defaultValue: "Files")
         case .find: return String(localized: "rightSidebar.mode.find", defaultValue: "Find")
-        case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Sessions")
+        case .sessions: return String(localized: "rightSidebar.mode.sessions", defaultValue: "Vault")
         case .feed: return String(localized: "rightSidebar.mode.feed", defaultValue: "Feed")
         case .dock: return String(localized: "rightSidebar.mode.dock", defaultValue: "Dock")
         }
@@ -31,7 +31,7 @@ enum RightSidebarMode: String, CaseIterable {
         switch self {
         case .files: return "folder"
         case .find: return "magnifyingglass"
-        case .sessions: return "bubble.left.and.text.bubble.right"
+        case .sessions: return "books.vertical"
         case .feed: return "dot.radiowaves.left.and.right"
         case .dock: return "dock.rectangle"
         }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -209,11 +209,11 @@ struct SessionEntry: Identifiable, Hashable {
                 return String(localized: "sessionIndex.localCommand", defaultValue: "Local command")
             }
             if Self.isClaudeSyntheticEnvelope(trimmed) {
-                return String(localized: "sessionIndex.untitled", defaultValue: "Untitled session")
+                return String(localized: "sessionIndex.untitled", defaultValue: "Untitled chat")
             }
         }
         if trimmed.isEmpty {
-            return String(localized: "sessionIndex.untitled", defaultValue: "Untitled session")
+            return String(localized: "sessionIndex.untitled", defaultValue: "Untitled chat")
         }
         return trimmed
     }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -87,7 +87,7 @@ struct SessionIndexView: View {
                     .font(.system(size: 10, weight: .medium))
             }
             .buttonStyle(.borderless)
-            .help(String(localized: "sessionIndex.reload.tooltip", defaultValue: "Reload sessions"))
+            .help(String(localized: "sessionIndex.reload.tooltip", defaultValue: "Reload Vault"))
             .disabled(store.isLoading)
         }
         .rightSidebarChromeBar()
@@ -98,7 +98,7 @@ struct SessionIndexView: View {
     private var loadingView: some View {
         VStack(spacing: 6) {
             ProgressView().controlSize(.small)
-            Text(String(localized: "sessionIndex.loading", defaultValue: "Scanning sessions…"))
+            Text(String(localized: "sessionIndex.loading", defaultValue: "Loading Vault…"))
                 .font(.system(size: 11))
                 .foregroundColor(.secondary)
         }
@@ -107,11 +107,11 @@ struct SessionIndexView: View {
 
     private var emptyView: some View {
         VStack(spacing: 4) {
-            Text(String(localized: "sessionIndex.empty.title", defaultValue: "No sessions found"))
+            Text(String(localized: "sessionIndex.empty.title", defaultValue: "Vault is empty"))
                 .font(.system(size: 12))
                 .foregroundColor(.secondary)
             Text(String(localized: "sessionIndex.empty.subtitle",
-                                   defaultValue: "Sessions from Claude Code, Codex, and OpenCode will appear here."))
+                                   defaultValue: "Claude Code, Codex, and OpenCode history will appear here."))
                 .font(.system(size: 11))
                 .foregroundColor(.secondary.opacity(0.7))
                 .multilineTextAlignment(.center)
@@ -1895,7 +1895,7 @@ private struct SectionPopoverView: View {
                     .foregroundColor(.secondary)
                 TextField(
                     String(localized: "sessionIndex.popover.searchPlaceholder",
-                           defaultValue: "Search sessions"),
+                           defaultValue: "Search Vault"),
                     text: $query
                 )
                 .textFieldStyle(.plain)


### PR DESCRIPTION
## Summary
- Rename the right sidebar Sessions mode and shortcut label to Vault.
- Replace the chat-bubble sidebar icon with the books-style `books.vertical` symbol.
- Update Vault panel empty/loading/search copy and localized strings.

## Testing
- `git diff --check`
- `python3 -m json.tool Resources/Localizable.xcstrings >/tmp/cmux-vault-xcstrings-lint.json`
- `./scripts/reload.sh --tag vault`
- `gh workflow run test-e2e.yml --repo manaflow-ai/cmux -f ref=task-rename-sessions-to-vault -f test_filter="RightSidebarChromeHeightUITests" -f record_video=true`, passed: https://github.com/manaflow-ai/cmux/actions/runs/25353000837

## Issues
- Task: Rename the right sidebar sessions feature to Vault.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated UI terminology from "sessions" to "vault" throughout the interface, including sidebar labels, section titles, empty states, and search placeholders.
  * Refreshed sidebar icon for visual consistency.
  * Changed default title from "Untitled session" to "Untitled chat".

<!-- end of auto-generated comment: release notes by coderabbit.ai -->