### PR TITLE
fix: filter terminal color responses from PTY input to prevent escape sequence leaks (#2636)

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -485,6 +485,7 @@ func pumpPTYToWebSocket(ctx context.Context, cancel context.CancelFunc, conn *we
 }
 
 func pumpWebSocketToPTY(ctx context.Context, conn *websocket.Conn, ptyFile *os.File, done <-chan struct{}) {
+	inputFilter := newPTYInputFilter()
 	for {
 		select {
 		case <-done:
@@ -498,7 +499,10 @@ func pumpWebSocketToPTY(ctx context.Context, conn *websocket.Conn, ptyFile *os.F
 		}
 		switch msgType {
 		case websocket.MessageBinary:
-			_, _ = ptyFile.Write(payload)
+			filtered := inputFilter.filter(payload)
+			if len(filtered) > 0 {
+				_, _ = ptyFile.Write(filtered)
+			}
 		case websocket.MessageText:
 			var control wsPTYControlFrame
 			if err := json.Unmarshal(payload, &control); err != nil {
@@ -517,6 +521,61 @@ func pumpWebSocketToPTY(ctx context.Context, conn *websocket.Conn, ptyFile *os.F
 			}
 		}
 	}
+}
+
+type ptyInputFilter struct {
+	pending []byte
+}
+
+func newPTYInputFilter() *ptyInputFilter {
+	return &ptyInputFilter{}
+}
+
+func (f *ptyInputFilter) filter(payload []byte) []byte {
+	if len(payload) == 0 && len(f.pending) == 0 {
+		return nil
+	}
+
+	data := append(f.pending, payload...)
+	f.pending = nil
+
+	out := make([]byte, 0, len(data))
+	for len(data) > 0 {
+		matchLen, partial := terminalResponsePrefix(data)
+		if matchLen > 0 {
+			data = data[matchLen:]
+			continue
+		}
+		if partial {
+			f.pending = append(f.pending[:0], data...)
+			break
+		}
+		out = append(out, data[0])
+		data = data[1:]
+	}
+	return out
+}
+
+func terminalResponsePrefix(data []byte) (int, bool) {
+	// These are terminal-generated answers for Ghostty color-scheme probing and
+	// the corresponding DECRQM form. They are not user keystrokes, and forwarding
+	// them into the PTY can leave literal ?997... text in the shell input buffer.
+	responses := [][]byte{
+		[]byte("\x1b[?997;1n"),
+		[]byte("\x1b[?997;2n"),
+		[]byte("\x1b[?997;0$y"),
+		[]byte("\x1b[?997;1$y"),
+		[]byte("\x1b[?997;2$y"),
+	}
+	for _, response := range responses {
+		if bytes.HasPrefix(data, response) {
+			return len(response), false
+		}
+		if len(data) >= len("\x1b[?9") && bytes.HasPrefix(response, data) {
+			return 0, true
+		}
+	}
+	return 0, false
 }
 
 func resolvePTYShell(explicit string) string {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -69,6 +69,17 @@ var (
 	wsLeaseMu           sync.Mutex
 )
 
+// Terminal-generated answers for Ghostty color-scheme probing and the
+// corresponding DECRQM form. They are not user keystrokes, and forwarding them
+// into the PTY can leave literal ?997... text in the shell input buffer.
+var terminalResponseValues = [][]byte{
+	[]byte("\x1b[?997;1n"),
+	[]byte("\x1b[?997;2n"),
+	[]byte("\x1b[?997;0$y"),
+	[]byte("\x1b[?997;1$y"),
+	[]byte("\x1b[?997;2$y"),
+}
+
 func runWebSocketPTYServer(ctx context.Context, cfg wsPTYServerConfig, stderr io.Writer) error {
 	addr := cfg.ListenAddr
 	if strings.TrimSpace(addr) == "" {
@@ -557,21 +568,11 @@ func (f *ptyInputFilter) filter(payload []byte) []byte {
 }
 
 func terminalResponsePrefix(data []byte) (int, bool) {
-	// These are terminal-generated answers for Ghostty color-scheme probing and
-	// the corresponding DECRQM form. They are not user keystrokes, and forwarding
-	// them into the PTY can leave literal ?997... text in the shell input buffer.
-	responses := [][]byte{
-		[]byte("\x1b[?997;1n"),
-		[]byte("\x1b[?997;2n"),
-		[]byte("\x1b[?997;0$y"),
-		[]byte("\x1b[?997;1$y"),
-		[]byte("\x1b[?997;2$y"),
-	}
-	for _, response := range responses {
+	for _, response := range terminalResponseValues {
 		if bytes.HasPrefix(data, response) {
 			return len(response), false
 		}
-		if len(data) >= len("\x1b[?9") && bytes.HasPrefix(response, data) {
+		if len(data) >= len("\x1b") && bytes.HasPrefix(response, data) {
 			return 0, true
 		}
 	}

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -572,7 +572,11 @@ func terminalResponsePrefix(data []byte) (int, bool) {
 		if bytes.HasPrefix(data, response) {
 			return len(response), false
 		}
-		if len(data) >= len("\x1b") && bytes.HasPrefix(response, data) {
+		// All filtered responses share the prefix "\x1b[?9", so only buffer
+		// once that prefix is confirmed. Shorter frames (lone ESC, "\x1b[",
+		// "\x1b[?") pass through immediately so a user pressing Escape in
+		// vim/neovim isn't held back waiting for the next frame.
+		if len(data) >= len("\x1b[?9") && bytes.HasPrefix(response, data) {
 			return 0, true
 		}
 	}


### PR DESCRIPTION
## Problem

When Claude Code (or any tool sending DECRPM/DECRQM queries) starts inside a cmux pane, it sends terminal capability probe queries like `CSI ? 997 $ p`. The terminal responses (`CSI ? 997 ; 1 n`, etc.) were forwarded directly into the PTY write stream, leaking as visible garbage text in the shell input buffer:

```
❯ ?997;1n?997;1n
```

This happens because cmux WebSocket-to-PTY pump treated all incoming binary frames as user keystrokes, without distinguishing terminal-generated responses from actual input.

## Solution

Added a `ptyInputFilter` that intercepts binary WebSocket frames before writing them to the PTY. It maintains a small state buffer to handle responses that may arrive split across multiple frames.

The filter strips known terminal response sequences:
- `CSI ? 997 ; 1 n` — DECRPM dark mode report (yes)
- `CSI ? 997 ; 2 n` — DECRPM dark mode report (no)
- `CSI ? 997 ; 0 $ y` — DECRQM negative device status
- `CSI ? 997 ; 1 $ y` — DECRQM positive device status (no)
- `CSI ? 997 ; 2 $ y` — DECRQM positive device status (yes)

These are the same sequences Ghostty filters internally during its color-scheme probing initialization.

## Changes

- `daemon/remote/cmd/cmuxd-remote/ws_pty.go`: Added `ptyInputFilter` struct with stateful prefix matching, integrated into `pumpWebSocketToPTY` for binary frames.

## Testing

- Launched Claude Code inside cmux — prompt appears clean, no leaked escape sequences
- Normal keystrokes and control sequences pass through unchanged
- Verified with fish, bash, and zsh shells

Closes #2636

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Filters terminal-generated response sequences in the WebSocket-to-PTY path to stop escape codes leaking into shell input, including short fragments. Fixes visible "?997;1n" garbage when tools probe terminal capabilities.

- Bug Fixes
  - Added stateful `ptyInputFilter` in `pumpWebSocketToPTY` to process binary frames before writing to the PTY.
  - Strips DECRPM/DECRQM responses: `CSI ? 997 ; 1 n`, `CSI ? 997 ; 2 n`, `CSI ? 997 ; 0 $ y`, `CSI ? 997 ; 1 $ y`, `CSI ? 997 ; 2 $ y`.
  - Buffers only when the 4-byte prefix `\x1b[?9` is present; lets lone `ESC`, `\x1b[`, and `\x1b[?` pass so editors don’t freeze.
  - Moved `terminalResponseValues` to package level to reduce allocations in the scan loop.
  - Verified with fish, bash, and zsh. Closes #2636.

<sup>Written for commit e8a0ec65a8842ab21808c19ff92609d5e7352eea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebSocket-to-terminal input handling by filtering and suppressing specific terminal probe responses before they reach the shell. This prevents spurious escape sequences from interrupting interactive sessions, correctly handles probe fragments split across network frames, and improves stability and compatibility of remote terminal connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->