### PR TITLE
Harden SSH LocalCommand fish reconnect regression

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4749,20 +4749,20 @@ struct CMUXCLI {
             remoteBootstrapScript: remoteTerminalBootstrapScript
         )
         let deferredRemoteReconnectToken = UUID().uuidString.lowercased()
-        let deferredRemoteReconnectCommand = deferredRemoteReconnectLocalCommand(
+        let deferredRemoteReconnectCommandScript = deferredRemoteReconnectLocalCommandScript(
             in: remoteSSHOptions,
             localCLIPath: resolvedExecutableURL()?.path,
             foregroundAuthToken: deferredRemoteReconnectToken
         )
-        let sshConnectionTimingCommand = sshConnectionTimingLocalCommand(
+        let sshConnectionTimingCommandScript = sshConnectionTimingLocalCommandScript(
             target: sshOptions.displayDestination,
             relayPort: sshOptions.remoteRelayPort
         )
         let combinedLocalCommandScript = combinedLocalShellScript([
-            deferredRemoteReconnectCommand,
-            sshConnectionTimingCommand,
+            deferredRemoteReconnectCommandScript,
+            sshConnectionTimingCommandScript,
         ])
-        let configuredForegroundAuthToken = deferredRemoteReconnectCommand == nil ? nil : deferredRemoteReconnectToken
+        let configuredForegroundAuthToken = deferredRemoteReconnectCommandScript == nil ? nil : deferredRemoteReconnectToken
         let startupInitialSSHCommand = buildSSHCommandText(
             sshOptions,
             localCommandScript: combinedLocalCommandScript
@@ -4854,7 +4854,7 @@ struct CMUXCLI {
             var configureParams: [String: Any] = [
                 "workspace_id": workspaceId,
                 "destination": sshOptions.displayDestination,
-                "auto_connect": deferredRemoteReconnectCommand == nil,
+                "auto_connect": deferredRemoteReconnectCommandScript == nil,
             ]
             if let configuredForegroundAuthToken {
                 configureParams["foreground_auth_token"] = configuredForegroundAuthToken
@@ -4883,7 +4883,7 @@ struct CMUXCLI {
                 "cli.ssh.remote.configure workspace=\(String(workspaceId.prefix(8))) " +
                 "target=\(sshOptions.displayDestination) relayPort=\(sshOptions.remoteRelayPort) " +
                 "controlPath=\(sshOptionValue(named: "ControlPath", in: remoteSSHOptions) ?? "nil") " +
-                "deferredReconnect=\(deferredRemoteReconnectCommand == nil ? 0 : 1) " +
+                "deferredReconnect=\(deferredRemoteReconnectCommandScript == nil ? 0 : 1) " +
                 "sshOptions=\(remoteSSHOptions.joined(separator: "|"))"
             )
             let configureStartedAt = Date()
@@ -6630,7 +6630,7 @@ struct CMUXCLI {
         return false
     }
 
-    private func deferredRemoteReconnectLocalCommand(
+    private func deferredRemoteReconnectLocalCommandScript(
         in options: [String],
         localCLIPath: String?,
         foregroundAuthToken: String
@@ -6658,7 +6658,7 @@ struct CMUXCLI {
         ].joined(separator: " ")
     }
 
-    private func sshConnectionTimingLocalCommand(target: String, relayPort: Int) -> String {
+    private func sshConnectionTimingLocalCommandScript(target: String, relayPort: Int) -> String {
         let escapedTarget = target
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")

--- a/cmuxTests/WorkspaceSSHFishShellTests.swift
+++ b/cmuxTests/WorkspaceSSHFishShellTests.swift
@@ -13,6 +13,7 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
     func testSSHBootstrapStartupCommandPassesRemoteInstallScriptAsSingleSSHCommand() throws {
         let cliPath = try bundledCLIPath()
         let python3Path = try requireExecutable(["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"], name: "python3")
+        let fishExecutable = try requireExecutable(["/opt/homebrew/bin/fish", "/usr/local/bin/fish", "/usr/bin/fish", "/bin/fish"], name: "fish")
         let socketPath = makeSocketPath("sshboot")
         let listenerFD = try bindUnixSocket(at: socketPath)
         let state = MockSocketServerState()
@@ -137,7 +138,7 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
 
         if local_command:
             local_command = local_command.replace("%%", "%")
-            subprocess.run(["/bin/sh", "-c", local_command], check=False, env=os.environ.copy())
+            subprocess.run([os.environ["CMUX_TEST_LOCAL_SHELL"], "-c", local_command], check=False, env=os.environ.copy())
         PY
         cat >/dev/null
         exit 0
@@ -150,6 +151,7 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
         startupEnvironment["PATH"] = "\(fakeBin.path):/usr/bin:/bin:/usr/sbin:/sbin"
         startupEnvironment["CMUX_FAKE_SSH_LOG"] = fakeSSHLog.path
         startupEnvironment["CMUX_TEST_PYTHON3"] = python3Path
+        startupEnvironment["CMUX_TEST_LOCAL_SHELL"] = fishExecutable
         startupEnvironment["CMUX_SOCKET_PATH"] = socketPath
         startupEnvironment["CMUX_WORKSPACE_ID"] = workspaceID
         startupEnvironment["CMUX_CLI_SENTRY_DISABLED"] = "1"
@@ -230,7 +232,6 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
             0,
             "Expected LocalCommand shell snippet to parse cleanly, stderr: \(localCommandSyntaxCheck.stderr)"
         )
-        let fishExecutable = try requireExecutable(["/opt/homebrew/bin/fish", "/usr/local/bin/fish", "/usr/bin/fish", "/bin/fish"], name: "fish")
         let fishLocalCommandCheck = runProcess(
             executablePath: fishExecutable,
             arguments: ["-n", "-c", localCommand],
@@ -254,7 +255,6 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
         XCTAssertTrue(remoteCommandArgs[0].contains("set -eu"), "Expected installer command body in \(remoteCommandArgs)")
         XCTAssertFalse(remoteCommandArgs.contains("sh"))
         XCTAssertFalse(remoteCommandArgs.contains("-c"))
-
         let secondInvocationData = try XCTUnwrap(logLines.dropFirst().first?.data(using: .utf8))
         let secondInvocation = try XCTUnwrap(
             JSONSerialization.jsonObject(with: secondInvocationData, options: []) as? [String]


### PR DESCRIPTION
Closes #3533.

## Summary
- run the SSH LocalCommand regression through fish to match OpenSSH local-login-shell execution
- rename reconnect/timing helpers to make clear they return POSIX script bodies, while `openSSHLocalCommandValue` owns the final `/bin/sh -c` wrapped LocalCommand

## Regression-test note
Current `main` already includes the centralized `/bin/sh -c` OpenSSH LocalCommand wrapper from #3506, so the new test-hardening commit cannot demonstrate a red-first CI proof window against this base. This PR closes the remaining coverage gap by making the fake OpenSSH harness execute LocalCommand through fish instead of `/bin/sh`.

## Verification
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`
- `swiftc -typecheck CLI command files`
- Plain SSH LocalCommand repro: forcing `SHELL=$(command -v fish)` with bare `cmux_localcommand_probe=ok` fails with `fish: Unsupported use of =`
- Plain SSH fixed-shape repro: forcing the same fish context with `/bin/sh -c 'cmux_localcommand_probe=ok; ...'` prints `local-command-ok`\n- Tagged dev app: `./scripts/reload.sh --tag issue-3533-ssh-localcommand-fish --launch`\n- Tagged dev CLI/socket: `CMUX_SOCKET_PATH=/tmp/cmux-debug-issue-3533-ssh-localcommand-fish.sock /tmp/cmux-cli ssh ... austinywang@Austins-MacBook-Pro`, then remote command returned `CMUX_DEV_SSH_OK user=austinywang host=Austins-MacBook-Pro.local shell=/bin/zsh`\n- Tagged dev log: `remote.bootstrap.ready`, `remote.tty.bootstrap.ready`, and `remote.proxy.ready`; no `fish: Unsupported use of =` or `cmux_reconnect_cli=` LocalCommand assignment errors\n\n## Not tested\n- Local XCTest suite per repo policy\n- CI still in progress; live dogfood was prioritized per latest request