### PR TITLE
Fix activity feed layout and loading

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -67,8 +67,10 @@
 		3069F1D10000000000000005 /* CMUXPasteboardFidelity in Frameworks */ = {isa = PBXBuildFile; productRef = 3069F1D10000000000000006 /* CMUXPasteboardFidelity */; };
 		F53000A0A1B2C3D4E5F60718 /* CMUXRovoDevIndex in Frameworks */ = {isa = PBXBuildFile; productRef = F53000A2A1B2C3D4E5F60718 /* CMUXRovoDevIndex */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
+		FEED0000000000000000F013 /* FeedDisplayLabels.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F012 /* FeedDisplayLabels.swift */; };
 		FEED0000000000000000F005 /* FeedPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F004 /* FeedPanelView.swift */; };
 		FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F010 /* FeedPanelViewModel.swift */; };
+		FEED0000000000000000F015 /* FeedSecondaryFilterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F014 /* FeedSecondaryFilterButton.swift */; };
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
 		FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */; };
 		FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */; };
@@ -135,6 +137,7 @@
 		A5001093 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001090 /* AppDelegate.swift */; };
 		D7AB00000000000000000001 /* AppDelegate+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000002 /* AppDelegate+MoveTabToNewWorkspace.swift */; };
 		2907A0012907A0012907A001 /* AppDelegate+RecoverableMainWindowRoutes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2907A0022907A0022907A002 /* AppDelegate+RecoverableMainWindowRoutes.swift */; };
+		A500109A0000000000000001 /* AppDelegate+WorkstreamLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500109A0000000000000002 /* AppDelegate+WorkstreamLaunch.swift */; };
 		C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00020000000000000002 /* CloudVMActionLauncher.swift */; };
 		A5001094 /* NotificationsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001091 /* NotificationsPage.swift */; };
 		A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
@@ -423,8 +426,10 @@
 		3023B1013023B1013023B101 /* ConfigSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSettingsView.swift; sourceTree = "<group>"; };
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
+		FEED0000000000000000F012 /* FeedDisplayLabels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedDisplayLabels.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F010 /* FeedPanelViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelViewModel.swift; sourceTree = "<group>"; };
+		FEED0000000000000000F014 /* FeedSecondaryFilterButton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedSecondaryFilterButton.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00A /* FeedPreviewWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPreviewWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedButtonStyleDebugWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedTextEditorDebugWindowController.swift; sourceTree = "<group>"; };
@@ -535,6 +540,7 @@
 		C7A505000000000000000001 /* TerminalControllerTopSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalControllerTopSupport.swift; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+EqualizeSplitsShortcut.swift"; sourceTree = "<group>"; };
+		A500109A0000000000000002 /* AppDelegate+WorkstreamLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkstreamLaunch.swift"; sourceTree = "<group>"; };
 		C10D00020000000000000002 /* CloudVMActionLauncher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudVMActionLauncher.swift; sourceTree = "<group>"; };
 		D7AB00000000000000000002 /* AppDelegate+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		2907A0022907A0022907A002 /* AppDelegate+RecoverableMainWindowRoutes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+RecoverableMainWindowRoutes.swift"; sourceTree = "<group>"; };
@@ -818,8 +824,10 @@
 			isa = PBXGroup;
 			children = (
 				FEED0000000000000000F001 /* FeedCoordinator.swift */,
+				FEED0000000000000000F012 /* FeedDisplayLabels.swift */,
 				FEED0000000000000000F004 /* FeedPanelView.swift */,
 				FEED0000000000000000F010 /* FeedPanelViewModel.swift */,
+				FEED0000000000000000F014 /* FeedSecondaryFilterButton.swift */,
 				FEED0000000000000000F00A /* FeedPreviewWindowController.swift */,
 				FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */,
 				FEED0000000000000000F00E /* FeedTextEditorDebugWindowController.swift */,
@@ -990,6 +998,7 @@
 				D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */,
 				A5001090 /* AppDelegate.swift */,
 				E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */,
+				A500109A0000000000000002 /* AppDelegate+WorkstreamLaunch.swift */,
 				D7AB00000000000000000002 /* AppDelegate+MoveTabToNewWorkspace.swift */,
 				2907A0022907A0022907A002 /* AppDelegate+RecoverableMainWindowRoutes.swift */,
 				C10D00020000000000000002 /* CloudVMActionLauncher.swift */,
@@ -1528,6 +1537,7 @@
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				E3309A01 /* AppDelegate+EqualizeSplitsShortcut.swift in Sources */,
+				A500109A0000000000000001 /* AppDelegate+WorkstreamLaunch.swift in Sources */,
 				D7AB00000000000000000001 /* AppDelegate+MoveTabToNewWorkspace.swift in Sources */,
 				2907A0012907A0012907A001 /* AppDelegate+RecoverableMainWindowRoutes.swift in Sources */,
 				C10D00010000000000000001 /* CloudVMActionLauncher.swift in Sources */,
@@ -1605,8 +1615,10 @@
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
 				FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */,
+				FEED0000000000000000F013 /* FeedDisplayLabels.swift in Sources */,
 				FEED0000000000000000F005 /* FeedPanelView.swift in Sources */,
 				FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */,
+				FEED0000000000000000F015 /* FeedSecondaryFilterButton.swift in Sources */,
 				FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */,
 				FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */,
 				FEED0000000000000000F00F /* FeedTextEditorDebugWindowController.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -263,6 +263,7 @@
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
+		ABCDEF1234567890ABCDEF13 /* FeedActivityPaginationUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF1234567890ABCDEF12 /* FeedActivityPaginationUITests.swift */; };
 		B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
 		B9000018A1B2C3D4E5F60719 /* WindowDragHandleView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000017A1B2C3D4E5F60719 /* WindowDragHandleView.swift */; };
@@ -657,6 +658,7 @@
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
+		ABCDEF1234567890ABCDEF12 /* FeedActivityPaginationUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedActivityPaginationUITests.swift; sourceTree = "<group>"; };
 		B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
 		F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarScrollUITests.swift; sourceTree = "<group>"; };
@@ -831,6 +833,7 @@
 			children = (
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */,
 				FEED0000000000000000F008 /* FeedSidebarUITests.swift */,
+				ABCDEF1234567890ABCDEF12 /* FeedActivityPaginationUITests.swift */,
 				B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 				B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
 				B9000019A1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift */,
@@ -1647,6 +1650,7 @@
 			files = (
 				B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,
+				ABCDEF1234567890ABCDEF13 /* FeedActivityPaginationUITests.swift in Sources */,
 				B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 				B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,
 				B900001BA1B2C3D4E5F60719 /* CloseWorkspacesConfirmDialogUITests.swift in Sources */,

--- a/Sources/AppDelegate+WorkstreamLaunch.swift
+++ b/Sources/AppDelegate+WorkstreamLaunch.swift
@@ -1,0 +1,113 @@
+import Foundation
+import CMUXWorkstream
+
+extension AppDelegate {
+    static func installWorkstreamStoreForLaunch(env: [String: String]) {
+        let fileURL = workstreamPersistenceFileURLForLaunch(env: env)
+#if DEBUG
+        seedFeedActivityPaginationUITestLogIfNeeded(env: env, fileURL: fileURL)
+#endif
+        FeedCoordinator.shared.install(
+            store: WorkstreamStore(
+                transport: NullWorkstreamTransport(),
+                persistence: WorkstreamPersistence(fileURL: fileURL),
+                initialLoadLimit: workstreamInitialLoadLimitForLaunch(env: env),
+                historyPageSize: workstreamHistoryPageSizeForLaunch(env: env)
+            )
+        )
+    }
+
+    static func workstreamPersistenceFileURLForLaunch(env: [String: String]) -> URL {
+#if DEBUG
+        if let path = env["CMUX_UI_TEST_WORKSTREAM_FILE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+#endif
+        return WorkstreamPersistence.defaultFileURL()
+    }
+
+    static func workstreamInitialLoadLimitForLaunch(env: [String: String]) -> Int {
+#if DEBUG
+        if let raw = env["CMUX_UI_TEST_WORKSTREAM_INITIAL_LOAD_LIMIT"],
+           let value = Int(raw),
+           value > 0 {
+            return value
+        }
+#endif
+        return WorkstreamDefaultInitialLoadLimit
+    }
+
+    static func workstreamHistoryPageSizeForLaunch(env: [String: String]) -> Int {
+#if DEBUG
+        if let raw = env["CMUX_UI_TEST_WORKSTREAM_HISTORY_PAGE_SIZE"],
+           let value = Int(raw),
+           value > 0 {
+            return value
+        }
+#endif
+        return WorkstreamDefaultHistoryPageSize
+    }
+
+#if DEBUG
+    static func seedFeedActivityPaginationUITestLogIfNeeded(
+        env: [String: String],
+        fileURL: URL
+    ) {
+        guard let rawCount = env["CMUX_UI_TEST_FEED_ACTIVITY_SEED_COUNT"],
+              let count = Int(rawCount),
+              count > 0 else {
+            return
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        var data = Data()
+        do {
+            for index in 0..<count {
+                let item = WorkstreamItem(
+                    workstreamId: "opencode-ui-page-\(index)",
+                    source: .opencode,
+                    kind: .todos,
+                    createdAt: baseDate.addingTimeInterval(TimeInterval(index)),
+                    cwd: "/tmp/cmux-feed-pagination",
+                    status: .telemetry,
+                    payload: .todos([]),
+                    context: WorkstreamContext(lastUserMessage: "activity pagination seed \(index)")
+                )
+                data.append(try encoder.encode(item))
+                data.append(0x0A)
+            }
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
+            ) { payload in
+                payload["seeded"] = "1"
+                payload["seedCount"] = "\(count)"
+                payload["seedPath"] = fileURL.path
+            }
+        } catch {
+            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
+            ) { payload in
+                payload["seeded"] = "0"
+                payload["seedError"] = "\(error)"
+                payload["seedPath"] = fileURL.path
+            }
+        }
+    }
+#else
+    static func seedFeedActivityPaginationUITestLogIfNeeded(
+        env: [String: String],
+        fileURL: URL
+    ) {
+        _ = env
+        _ = fileURL
+    }
+#endif
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -945,6 +945,92 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    private static func workstreamPersistenceFileURLForLaunch(env: [String: String]) -> URL {
+#if DEBUG
+        if let path = env["CMUX_UI_TEST_WORKSTREAM_FILE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !path.isEmpty {
+            return URL(fileURLWithPath: path)
+        }
+#endif
+        return WorkstreamPersistence.defaultFileURL()
+    }
+
+    private static func workstreamInitialLoadLimitForLaunch(env: [String: String]) -> Int {
+#if DEBUG
+        if let raw = env["CMUX_UI_TEST_WORKSTREAM_INITIAL_LOAD_LIMIT"],
+           let value = Int(raw),
+           value > 0 {
+            return value
+        }
+#endif
+        return WorkstreamDefaultInitialLoadLimit
+    }
+
+    private static func workstreamHistoryPageSizeForLaunch(env: [String: String]) -> Int {
+#if DEBUG
+        if let raw = env["CMUX_UI_TEST_WORKSTREAM_HISTORY_PAGE_SIZE"],
+           let value = Int(raw),
+           value > 0 {
+            return value
+        }
+#endif
+        return WorkstreamDefaultHistoryPageSize
+    }
+
+#if DEBUG
+    private static func seedFeedActivityPaginationUITestLogIfNeeded(
+        env: [String: String],
+        fileURL: URL
+    ) {
+        guard let rawCount = env["CMUX_UI_TEST_FEED_ACTIVITY_SEED_COUNT"],
+              let count = Int(rawCount),
+              count > 0 else {
+            return
+        }
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
+        var data = Data()
+        do {
+            for index in 0..<count {
+                let item = WorkstreamItem(
+                    workstreamId: "opencode-ui-page-\(index)",
+                    source: .opencode,
+                    kind: .todos,
+                    createdAt: baseDate.addingTimeInterval(TimeInterval(index)),
+                    cwd: "/tmp/cmux-feed-pagination",
+                    status: .telemetry,
+                    payload: .todos([]),
+                    context: WorkstreamContext(lastUserMessage: "activity pagination seed \(index)")
+                )
+                data.append(try encoder.encode(item))
+                data.append(0x0A)
+            }
+            try FileManager.default.createDirectory(
+                at: fileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: fileURL, options: .atomic)
+            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
+            ) { payload in
+                payload["seeded"] = "1"
+                payload["seedCount"] = "\(count)"
+                payload["seedPath"] = fileURL.path
+            }
+        } catch {
+            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
+            ) { payload in
+                payload["seeded"] = "0"
+                payload["seedError"] = "\(error)"
+                payload["seedPath"] = fileURL.path
+            }
+        }
+    }
+#endif
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
@@ -958,6 +1044,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         claimAuthCallbackURLSchemes()
 
+        let workstreamPersistenceURL = Self.workstreamPersistenceFileURLForLaunch(env: env)
+#if DEBUG
+        Self.seedFeedActivityPaginationUITestLogIfNeeded(
+            env: env,
+            fileURL: workstreamPersistenceURL
+        )
+#endif
+
         // Install the Feed (workstream) store. Separate from the transport
         // wiring: the store is a plain singleton here, and the socket
         // `feed.*` V2 verbs in `TerminalController` push into it directly
@@ -965,7 +1059,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         FeedCoordinator.shared.install(
             store: WorkstreamStore(
                 transport: NullWorkstreamTransport(),
-                persistence: WorkstreamPersistence(fileURL: WorkstreamPersistence.defaultFileURL())
+                persistence: WorkstreamPersistence(fileURL: workstreamPersistenceURL),
+                initialLoadLimit: Self.workstreamInitialLoadLimitForLaunch(env: env),
+                historyPageSize: Self.workstreamHistoryPageSizeForLaunch(env: env)
             )
         )
         Task { @MainActor in

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -945,92 +945,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
-    private static func workstreamPersistenceFileURLForLaunch(env: [String: String]) -> URL {
-#if DEBUG
-        if let path = env["CMUX_UI_TEST_WORKSTREAM_FILE"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !path.isEmpty {
-            return URL(fileURLWithPath: path)
-        }
-#endif
-        return WorkstreamPersistence.defaultFileURL()
-    }
-
-    private static func workstreamInitialLoadLimitForLaunch(env: [String: String]) -> Int {
-#if DEBUG
-        if let raw = env["CMUX_UI_TEST_WORKSTREAM_INITIAL_LOAD_LIMIT"],
-           let value = Int(raw),
-           value > 0 {
-            return value
-        }
-#endif
-        return WorkstreamDefaultInitialLoadLimit
-    }
-
-    private static func workstreamHistoryPageSizeForLaunch(env: [String: String]) -> Int {
-#if DEBUG
-        if let raw = env["CMUX_UI_TEST_WORKSTREAM_HISTORY_PAGE_SIZE"],
-           let value = Int(raw),
-           value > 0 {
-            return value
-        }
-#endif
-        return WorkstreamDefaultHistoryPageSize
-    }
-
-#if DEBUG
-    private static func seedFeedActivityPaginationUITestLogIfNeeded(
-        env: [String: String],
-        fileURL: URL
-    ) {
-        guard let rawCount = env["CMUX_UI_TEST_FEED_ACTIVITY_SEED_COUNT"],
-              let count = Int(rawCount),
-              count > 0 else {
-            return
-        }
-
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        let baseDate = Date(timeIntervalSince1970: 1_700_000_000)
-        var data = Data()
-        do {
-            for index in 0..<count {
-                let item = WorkstreamItem(
-                    workstreamId: "opencode-ui-page-\(index)",
-                    source: .opencode,
-                    kind: .todos,
-                    createdAt: baseDate.addingTimeInterval(TimeInterval(index)),
-                    cwd: "/tmp/cmux-feed-pagination",
-                    status: .telemetry,
-                    payload: .todos([]),
-                    context: WorkstreamContext(lastUserMessage: "activity pagination seed \(index)")
-                )
-                data.append(try encoder.encode(item))
-                data.append(0x0A)
-            }
-            try FileManager.default.createDirectory(
-                at: fileURL.deletingLastPathComponent(),
-                withIntermediateDirectories: true
-            )
-            try data.write(to: fileURL, options: .atomic)
-            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
-                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
-            ) { payload in
-                payload["seeded"] = "1"
-                payload["seedCount"] = "\(count)"
-                payload["seedPath"] = fileURL.path
-            }
-        } catch {
-            _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
-                envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
-            ) { payload in
-                payload["seeded"] = "0"
-                payload["seedError"] = "\(error)"
-                payload["seedPath"] = fileURL.path
-            }
-        }
-    }
-#endif
-
     func applicationDidFinishLaunching(_ notification: Notification) {
         let env = ProcessInfo.processInfo.environment
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
@@ -1044,26 +958,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         claimAuthCallbackURLSchemes()
 
-        let workstreamPersistenceURL = Self.workstreamPersistenceFileURLForLaunch(env: env)
-#if DEBUG
-        Self.seedFeedActivityPaginationUITestLogIfNeeded(
-            env: env,
-            fileURL: workstreamPersistenceURL
-        )
-#endif
-
         // Install the Feed (workstream) store. Separate from the transport
         // wiring: the store is a plain singleton here, and the socket
         // `feed.*` V2 verbs in `TerminalController` push into it directly
         // via `FeedCoordinator`.
-        FeedCoordinator.shared.install(
-            store: WorkstreamStore(
-                transport: NullWorkstreamTransport(),
-                persistence: WorkstreamPersistence(fileURL: workstreamPersistenceURL),
-                initialLoadLimit: Self.workstreamInitialLoadLimitForLaunch(env: env),
-                historyPageSize: Self.workstreamHistoryPageSizeForLaunch(env: env)
-            )
-        )
+        Self.installWorkstreamStoreForLaunch(env: env)
         Task { @MainActor in
             await FeedCoordinator.shared.store?.start()
 #if DEBUG

--- a/Sources/Feed/FeedDisplayLabels.swift
+++ b/Sources/Feed/FeedDisplayLabels.swift
@@ -1,0 +1,47 @@
+import CMUXWorkstream
+import Foundation
+
+extension WorkstreamPermissionMode {
+    var displayLabel: String {
+        switch self {
+        case .once:
+            return String(localized: "feed.permission.mode.once", defaultValue: "once")
+        case .always:
+            return String(localized: "feed.permission.mode.always", defaultValue: "always")
+        case .all:
+            return String(localized: "feed.permission.mode.all", defaultValue: "all tools")
+        case .bypass:
+            return String(localized: "feed.permission.mode.bypass", defaultValue: "bypass")
+        case .deny:
+            return String(localized: "feed.permission.mode.deny", defaultValue: "denied")
+        }
+    }
+}
+
+extension WorkstreamExitPlanMode {
+    var displayLabel: String {
+        switch self {
+        case .ultraplan:
+            return String(localized: "feed.exitplan.mode.ultraplan", defaultValue: "ultraplan")
+        case .bypassPermissions:
+            return String(localized: "feed.exitplan.mode.bypass", defaultValue: "bypass")
+        case .autoAccept:
+            return String(localized: "feed.exitplan.mode.autoAccept", defaultValue: "auto")
+        case .manual:
+            return String(localized: "feed.exitplan.mode.manual", defaultValue: "manual")
+        case .deny:
+            return String(localized: "feed.exitplan.mode.deny", defaultValue: "denied")
+        }
+    }
+}
+
+extension WorkstreamSource {
+    var feedDisplayName: String {
+        switch self {
+        case .opencode:
+            return String(localized: "sessionIndex.agent.opencode", defaultValue: "OpenCode")
+        default:
+            return rawValue.capitalized
+        }
+    }
+}

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -44,6 +44,17 @@ private extension WorkstreamExitPlanMode {
     }
 }
 
+private extension WorkstreamSource {
+    var feedDisplayName: String {
+        switch self {
+        case .opencode:
+            return String(localized: "sessionIndex.agent.opencode", defaultValue: "OpenCode")
+        default:
+            return rawValue.capitalized
+        }
+    }
+}
+
 /// Right-sidebar Feed view. Matches the Sessions page visual language:
 /// compact rows with SF Symbol + 13pt title + secondary metadata,
 /// full-width hover backgrounds, and control-bar pill buttons styled
@@ -396,16 +407,30 @@ private struct FeedListView: View {
 
     private func visibleSnapshots(_ items: [WorkstreamItem]) -> [FeedItemSnapshot] {
         let lastPromptByWorkstream = Self.lastPromptByWorkstream(items)
+        let latestStopIds = Self.latestStopIdsByWorkstream(items)
         return filtered(items).map { item in
             FeedItemSnapshot(
                 item: item,
-                userPromptEcho: lastPromptByWorkstream[item.workstreamId]
+                userPromptEcho: lastPromptByWorkstream[item.workstreamId],
+                isLatestStopInWorkstream: latestStopIds[item.workstreamId] == item.id
             )
         }
     }
 
+    private static func latestStopIdsByWorkstream(_ items: [WorkstreamItem]) -> [String: UUID] {
+        var latestItems: [String: WorkstreamItem] = [:]
+        for item in items {
+            latestItems[item.workstreamId] = item
+        }
+        var out: [String: UUID] = [:]
+        for (workstreamId, item) in latestItems where item.kind == .stop {
+            out[workstreamId] = item.id
+        }
+        return out
+    }
+
     private func prefersStableSurface(_ snapshot: FeedItemSnapshot) -> Bool {
-        snapshot.status.isPending || snapshot.kind == .stop
+        snapshot.status.isPending || snapshot.isLatestStopInWorkstream
     }
 
     private var shouldShowActivityHistoryLoader: Bool {
@@ -861,8 +886,15 @@ struct FeedItemSnapshot: Equatable {
     /// by the list view so every card can show a "You: …" echo for
     /// context, even when the agent payload doesn't carry it directly.
     let userPromptEcho: String?
+    /// Stop events are frequent. Only the latest one per workstream
+    /// should show the inline reply controls; older stops stay compact.
+    let isLatestStopInWorkstream: Bool
 
-    init(item: WorkstreamItem, userPromptEcho: String? = nil) {
+    init(
+        item: WorkstreamItem,
+        userPromptEcho: String? = nil,
+        isLatestStopInWorkstream: Bool = false
+    ) {
         self.id = item.id
         self.workstreamId = item.workstreamId
         self.source = item.source
@@ -874,6 +906,7 @@ struct FeedItemSnapshot: Equatable {
         self.payload = item.payload
         self.context = item.context
         self.userPromptEcho = userPromptEcho
+        self.isLatestStopInWorkstream = isLatestStopInWorkstream
     }
 }
 
@@ -1040,7 +1073,7 @@ struct FeedItemRow: View, Equatable {
             Spacer(minLength: 4)
             HStack(spacing: 4) {
                 chip(
-                    text: snapshot.source.rawValue.capitalized,
+                    text: snapshot.source.feedDisplayName,
                     fg: sourceChipForeground,
                     bg: sourceChipBackground
                 )
@@ -1107,6 +1140,8 @@ struct FeedItemRow: View, Equatable {
                   ? .system(size: 10, weight: .medium).monospacedDigit()
                   : .system(size: 10, weight: .medium))
             .foregroundColor(fg)
+            .lineLimit(1)
+            .fixedSize(horizontal: true, vertical: false)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(
@@ -1212,13 +1247,17 @@ struct FeedItemRow: View, Equatable {
                 }
             )
         case .stop:
-            StopActionArea(
-                workstreamId: snapshot.workstreamId,
-                isRowSelected: isSelected,
-                onFocusRow: onControlFocus,
-                onBlurRow: onControlBlur,
-                onSend: { text in actions.sendText(snapshot.workstreamId, text) }
-            )
+            if snapshot.isLatestStopInWorkstream {
+                StopActionArea(
+                    workstreamId: snapshot.workstreamId,
+                    isRowSelected: isSelected,
+                    onFocusRow: onControlFocus,
+                    onBlurRow: onControlBlur,
+                    onSend: { text in actions.sendText(snapshot.workstreamId, text) }
+                )
+            } else {
+                TelemetryActionArea(snapshot: snapshot)
+            }
         default:
             TelemetryActionArea(snapshot: snapshot)
         }
@@ -1227,16 +1266,16 @@ struct FeedItemRow: View, Equatable {
     private var primaryTitle: String {
         switch snapshot.payload {
         case .permissionRequest(_, let toolName, _, _):
-            return "\(snapshot.source.rawValue.capitalized) · \(toolName)"
+            return "\(snapshot.source.feedDisplayName) · \(toolName)"
         case .exitPlan:
-            return "\(snapshot.source.rawValue.capitalized) · \(String(localized: "feed.kind.exitPlan", defaultValue: "Exit plan"))"
+            return "\(snapshot.source.feedDisplayName) · \(String(localized: "feed.kind.exitPlan", defaultValue: "Exit plan"))"
         case .question:
-            return "\(snapshot.source.rawValue.capitalized) · \(String(localized: "feed.kind.question", defaultValue: "Question"))"
+            return "\(snapshot.source.feedDisplayName) · \(String(localized: "feed.kind.question", defaultValue: "Question"))"
         default:
             if let title = snapshot.title, !title.isEmpty {
-                return "\(snapshot.source.rawValue.capitalized) · \(title)"
+                return "\(snapshot.source.feedDisplayName) · \(title)"
             }
-            return snapshot.source.rawValue.capitalized
+            return snapshot.source.feedDisplayName
         }
     }
 
@@ -1335,7 +1374,7 @@ private struct FeedContextBlock: View {
     }
 
     private var agentLabel: String {
-        "\(source.rawValue.capitalized):"
+        "\(source.feedDisplayName):"
     }
 }
 
@@ -1345,26 +1384,32 @@ private struct FeedLabeledTextRow: View {
     let labelColor: Color
     let textColor: Color
     var rendersMarkdown: Bool = false
+    var lineLimit: Int = 1
 
     var body: some View {
         HStack(alignment: .firstTextBaseline, spacing: 6) {
             Text(label)
                 .font(.system(size: 10, weight: .semibold))
                 .foregroundColor(labelColor)
-                .frame(width: 48, alignment: .leading)
+                .lineLimit(1)
+                .fixedSize(horizontal: true, vertical: false)
+                .frame(width: 62, alignment: .leading)
             if rendersMarkdown {
                 FeedMarkdownInlineText(
                     text: text,
                     fontSize: 11,
-                    foregroundColor: textColor
+                    foregroundColor: textColor,
+                    lineLimit: lineLimit
                 )
             } else {
                 Text(text)
                     .font(.system(size: 11))
                     .foregroundColor(textColor)
-                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(lineLimit)
+                    .truncationMode(.tail)
             }
         }
+        .help(text)
     }
 }
 
@@ -2335,17 +2380,20 @@ private struct FeedMarkdownInlineText: View {
     let fontSize: CGFloat
     let weight: Font.Weight?
     let foregroundColor: Color
+    let lineLimit: Int?
 
     init(
         text: String,
         fontSize: CGFloat,
         weight: Font.Weight? = nil,
-        foregroundColor: Color
+        foregroundColor: Color,
+        lineLimit: Int? = nil
     ) {
         self.text = text
         self.fontSize = fontSize
         self.weight = weight
         self.foregroundColor = foregroundColor
+        self.lineLimit = lineLimit
     }
 
     var body: some View {
@@ -2360,6 +2408,8 @@ private struct FeedMarkdownInlineText: View {
         Text(parsed)
             .font(font)
             .foregroundColor(foregroundColor)
+            .lineLimit(lineLimit)
+            .truncationMode(.tail)
             .fixedSize(horizontal: false, vertical: true)
     }
 }
@@ -2592,7 +2642,7 @@ private struct QuestionActionArea: View {
     }
 
     private var agentLabel: String {
-        "\(source.rawValue.capitalized):"
+        "\(source.feedDisplayName):"
     }
 
     /// Long-form rendering: single question with rich options. Each
@@ -2607,7 +2657,8 @@ private struct QuestionActionArea: View {
                     label: agentLabel,
                     text: question.prompt,
                     labelColor: .secondary,
-                    textColor: .primary.opacity(0.95)
+                    textColor: .primary.opacity(0.95),
+                    lineLimit: 3
                 )
             }
             ForEach(Array(question.options.enumerated()), id: \.offset) { idx, option in

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -85,7 +85,7 @@ struct FeedPanelView: View {
     }
 
     @State private var filter: Filter = .actionable
-    @StateObject private var viewModel = FeedPanelViewModel()
+    @State private var viewModel = FeedPanelViewModel()
 
     var body: some View {
         VStack(spacing: 0) {
@@ -95,8 +95,19 @@ struct FeedPanelView: View {
                 items: viewModel.items,
                 hasMorePersistedItems: viewModel.hasMorePersistedItems,
                 isLoadingOlderItems: viewModel.isLoadingOlderItems,
-                onLoadOlderItems: viewModel.loadOlderItems
+                onLoadOlderItems: viewModel.loadOlderItems,
+                onActivityViewportHeightChange: viewModel.noteActivityViewportHeight,
+                onActivityContentHeightChange: viewModel.noteActivityContentHeight
             )
+        }
+        .onAppear {
+            viewModel.setActivityAutoPaginationActive(filter == .activity)
+        }
+        .onDisappear {
+            viewModel.setActivityAutoPaginationActive(false)
+        }
+        .onChange(of: filter) { _, newFilter in
+            viewModel.setActivityAutoPaginationActive(newFilter == .activity)
         }
     }
 
@@ -170,6 +181,8 @@ private struct FeedListView: View {
     let hasMorePersistedItems: Bool
     let isLoadingOlderItems: Bool
     let onLoadOlderItems: () -> Void
+    let onActivityViewportHeightChange: (CGFloat) -> Void
+    let onActivityContentHeightChange: (CGFloat) -> Void
 
     @State private var focusSnapshot = FeedFocusSnapshot()
     @State private var scrollRequest: FeedScrollRequest?
@@ -306,34 +319,30 @@ private struct FeedListView: View {
         actions: FeedRowActions,
         showsLoadMore: Bool
     ) -> some View {
-        List {
-            // Single chronological history stream. The plain List keeps
-            // virtualization for older feed rows while active decision
-            // surfaces live above it in a stable stack.
-            ForEach(Array(snapshots.enumerated()), id: \.element.id) { idx, snapshot in
-                rowSurface(
-                    snapshot: snapshot,
-                    actions: actions,
-                    showsDivider: idx < snapshots.count - 1
-                )
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
+        ScrollView(.vertical) {
+            // Single chronological history stream. LazyVStack keeps
+            // history rows lazy while giving the view model an explicit
+            // content-height signal for bounded auto-pagination.
+            LazyVStack(spacing: 0) {
+                ForEach(Array(snapshots.enumerated()), id: \.element.id) { idx, snapshot in
+                    rowSurface(
+                        snapshot: snapshot,
+                        actions: actions,
+                        showsDivider: idx < snapshots.count - 1
+                    )
+                }
+                if showsLoadMore {
+                    FeedHistoryLoadMoreRow(
+                        isLoading: isLoadingOlderItems,
+                        action: onLoadOlderItems
+                    )
+                }
             }
-            if showsLoadMore {
-                FeedHistoryLoadMoreRow(
-                    isLoading: isLoadingOlderItems,
-                    action: onLoadOlderItems
-                )
-                .listRowInsets(EdgeInsets())
-                .listRowSeparator(.hidden)
-                .listRowBackground(Color.clear)
-            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .feedReportHeight(onActivityContentHeightChange)
         }
-        .listStyle(.plain)
-        .scrollContentBackground(.hidden)
         .feedZeroScrollContentMargins()
-        .environment(\.defaultMinListRowHeight, 0)
+        .feedReportHeight(onActivityViewportHeightChange)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -680,6 +689,14 @@ private extension View {
             contentMargins(.all, 0, for: .scrollContent)
         } else {
             self
+        }
+    }
+
+    func feedReportHeight(_ action: @escaping (CGFloat) -> Void) -> some View {
+        onGeometryChange(for: CGFloat.self, of: { proxy in
+            proxy.size.height
+        }) { height in
+            action(height)
         }
     }
 }

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -168,6 +168,7 @@ private struct FeedSecondaryFilterButton: View {
         .buttonStyle(.plain)
         .onHover { isHovered = $0 }
         .help(filter.label)
+        .accessibilityIdentifier("FeedFilterButton.\(filter.rawValue)")
     }
 }
 
@@ -343,6 +344,7 @@ private struct FeedListView: View {
         }
         .feedZeroScrollContentMargins()
         .feedReportHeight(onActivityViewportHeightChange)
+        .accessibilityIdentifier("FeedHistoryList")
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
@@ -651,6 +653,8 @@ private struct FeedRowSurface: View {
                 isHovered = hovering
             }
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("FeedRow.\(snapshot.workstreamId)")
     }
 
     private var rowBackgroundFill: Color {
@@ -696,7 +700,9 @@ private extension View {
         onGeometryChange(for: CGFloat.self, of: { proxy in
             proxy.size.height
         }) { height in
-            action(height)
+            Task { @MainActor in
+                action(height)
+            }
         }
     }
 }

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -10,51 +10,6 @@ private func feedDebugResponderSummary(_ responder: NSResponder?) -> String {
 }
 #endif
 
-private extension WorkstreamPermissionMode {
-    var displayLabel: String {
-        switch self {
-        case .once:
-            return String(localized: "feed.permission.mode.once", defaultValue: "once")
-        case .always:
-            return String(localized: "feed.permission.mode.always", defaultValue: "always")
-        case .all:
-            return String(localized: "feed.permission.mode.all", defaultValue: "all tools")
-        case .bypass:
-            return String(localized: "feed.permission.mode.bypass", defaultValue: "bypass")
-        case .deny:
-            return String(localized: "feed.permission.mode.deny", defaultValue: "denied")
-        }
-    }
-}
-
-private extension WorkstreamExitPlanMode {
-    var displayLabel: String {
-        switch self {
-        case .ultraplan:
-            return String(localized: "feed.exitplan.mode.ultraplan", defaultValue: "ultraplan")
-        case .bypassPermissions:
-            return String(localized: "feed.exitplan.mode.bypass", defaultValue: "bypass")
-        case .autoAccept:
-            return String(localized: "feed.exitplan.mode.autoAccept", defaultValue: "auto")
-        case .manual:
-            return String(localized: "feed.exitplan.mode.manual", defaultValue: "manual")
-        case .deny:
-            return String(localized: "feed.exitplan.mode.deny", defaultValue: "denied")
-        }
-    }
-}
-
-private extension WorkstreamSource {
-    var feedDisplayName: String {
-        switch self {
-        case .opencode:
-            return String(localized: "sessionIndex.agent.opencode", defaultValue: "OpenCode")
-        default:
-            return rawValue.capitalized
-        }
-    }
-}
-
 /// Right-sidebar Feed view. Matches the Sessions page visual language:
 /// compact rows with SF Symbol + 13pt title + secondary metadata,
 /// full-width hover backgrounds, and control-bar pill buttons styled
@@ -152,33 +107,6 @@ struct FeedPanelView: View {
         }
 #endif
         return .actionable
-    }
-}
-
-private struct FeedSecondaryFilterButton: View {
-    let filter: FeedPanelView.Filter
-    let isSelected: Bool
-    let action: () -> Void
-    @State private var isHovered = false
-
-    var body: some View {
-        Button(action: action) {
-            HStack(spacing: 3) {
-                Image(systemName: filter.symbolName)
-                    .font(.system(size: 10, weight: .medium))
-                Text(filter.label)
-                    .font(.system(size: 11, weight: .medium))
-            }
-            .rightSidebarChromePill(
-                isSelected: isSelected,
-                isHovered: isHovered,
-                geometryKeyPrefix: "rightSidebarSecondaryControl_feed_\(filter.rawValue)"
-            )
-        }
-        .buttonStyle(.plain)
-        .onHover { isHovered = $0 }
-        .help(filter.label)
-        .accessibilityIdentifier("FeedFilterButton.\(filter.rawValue)")
     }
 }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -84,7 +84,7 @@ struct FeedPanelView: View {
         }
     }
 
-    @State private var filter: Filter = .actionable
+    @State private var filter: Filter = Self.initialFilter()
     @State private var viewModel = FeedPanelViewModel()
 
     var body: some View {
@@ -142,6 +142,16 @@ struct FeedPanelView: View {
             }
             Spacer(minLength: 4)
         }
+    }
+
+    private static func initialFilter() -> Filter {
+#if DEBUG
+        let rawValue = ProcessInfo.processInfo.environment["CMUX_UI_TEST_FEED_INITIAL_FILTER"]
+        if rawValue == Filter.activity.rawValue {
+            return .activity
+        }
+#endif
+        return .actionable
     }
 }
 

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -57,8 +57,6 @@ struct FeedHistoryLoadMoreRow: View {
     let isLoading: Bool
     let action: () -> Void
 
-    @State private var isVisible = false
-
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
@@ -77,17 +75,6 @@ struct FeedHistoryLoadMoreRow: View {
         }
         .buttonStyle(.plain)
         .disabled(isLoading)
-        .onAppear {
-            isVisible = true
-            requestLoadIfVisible()
-        }
-        .onDisappear {
-            isVisible = false
-        }
-        .onChange(of: isLoading) { _, loading in
-            guard !loading else { return }
-            requestLoadIfVisible()
-        }
     }
 
     private var label: String {
@@ -97,8 +84,4 @@ struct FeedHistoryLoadMoreRow: View {
         return String(localized: "feed.history.loadOlder", defaultValue: "Load older activity")
     }
 
-    private func requestLoadIfVisible() {
-        guard isVisible, !isLoading else { return }
-        action()
-    }
 }

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -3,15 +3,76 @@ import Foundation
 import Observation
 import SwiftUI
 
-/// Bridges the `@Observable` WorkstreamStore to a Combine `@Published`
-/// snapshot so SwiftUI reliably re-renders the Feed panel on every
-/// mutation.
+struct FeedActivityPaginationMetrics: Equatable {
+    var viewportHeight: CGFloat = 0
+    var contentHeight: CGFloat = 0
+
+    var normalized: FeedActivityPaginationMetrics {
+        FeedActivityPaginationMetrics(
+            viewportHeight: ceil(max(0, viewportHeight)),
+            contentHeight: ceil(max(0, contentHeight))
+        )
+    }
+}
+
+struct FeedActivityAutoPaginationState: Equatable {
+    var isActive = false
+    var automaticPagesRequested = 0
+    var lastRequestedMetrics: FeedActivityPaginationMetrics?
+
+    mutating func setActive(_ active: Bool) {
+        guard isActive != active else { return }
+        isActive = active
+        automaticPagesRequested = 0
+        lastRequestedMetrics = nil
+    }
+
+    mutating func recordRequest(metrics: FeedActivityPaginationMetrics) {
+        automaticPagesRequested += 1
+        lastRequestedMetrics = metrics
+    }
+}
+
+enum FeedActivityAutoPaginationPolicy {
+    static let preloadPadding: CGFloat = 80
+    static let maxAutomaticPagesPerActivation = 3
+
+    static func shouldRequestPage(
+        metrics rawMetrics: FeedActivityPaginationMetrics,
+        state: FeedActivityAutoPaginationState,
+        hasMorePersistedItems: Bool,
+        isLoadingOlderItems: Bool
+    ) -> Bool {
+        guard state.isActive,
+              hasMorePersistedItems,
+              !isLoadingOlderItems,
+              state.automaticPagesRequested < maxAutomaticPagesPerActivation
+        else { return false }
+
+        let metrics = rawMetrics.normalized
+        guard metrics.viewportHeight > 0, metrics.contentHeight > 0 else { return false }
+        guard state.lastRequestedMetrics != metrics else { return false }
+        return metrics.contentHeight <= metrics.viewportHeight + preloadPadding
+    }
+}
+
+/// Bridges the `@Observable` WorkstreamStore to a UI-facing snapshot so
+/// SwiftUI reliably re-renders the Feed panel on every mutation.
 @MainActor
-final class FeedPanelViewModel: ObservableObject {
-    @Published private(set) var items: [WorkstreamItem] = []
-    @Published private(set) var hasMorePersistedItems = false
-    @Published private(set) var isLoadingOlderItems = false
+@Observable
+final class FeedPanelViewModel {
+    private(set) var items: [WorkstreamItem] = []
+    private(set) var hasMorePersistedItems = false
+    private(set) var isLoadingOlderItems = false
+
+    @ObservationIgnored
     private var storeInstalledObserver: NSObjectProtocol?
+    @ObservationIgnored
+    private var activityPaginationState = FeedActivityAutoPaginationState()
+    @ObservationIgnored
+    private var activityPaginationMetrics = FeedActivityPaginationMetrics()
+    @ObservationIgnored
+    private var automaticLoadTask: Task<Void, Never>?
 
     init() {
         storeInstalledObserver = NotificationCenter.default.addObserver(
@@ -30,6 +91,7 @@ final class FeedPanelViewModel: ObservableObject {
         if let storeInstalledObserver {
             NotificationCenter.default.removeObserver(storeInstalledObserver)
         }
+        automaticLoadTask?.cancel()
     }
 
     private func arm() {
@@ -43,13 +105,74 @@ final class FeedPanelViewModel: ObservableObject {
                 self?.arm()
             }
         }
+        requestAutomaticActivityPageIfNeeded()
     }
 
     nonisolated func loadOlderItems() {
         Task { @MainActor [weak self] in
-            guard let self, !self.isLoadingOlderItems, self.hasMorePersistedItems else { return }
-            await FeedCoordinator.shared.store?.loadOlderItems()
+            await self?.loadOlderItemsIfPossible()
         }
+    }
+
+    func setActivityAutoPaginationActive(_ active: Bool) {
+        activityPaginationState.setActive(active)
+        if !active {
+            automaticLoadTask?.cancel()
+            automaticLoadTask = nil
+            return
+        }
+        requestAutomaticActivityPageIfNeeded()
+    }
+
+    func noteActivityViewportHeight(_ height: CGFloat) {
+        let next = FeedActivityPaginationMetrics(
+            viewportHeight: height,
+            contentHeight: activityPaginationMetrics.contentHeight
+        ).normalized
+        guard next != activityPaginationMetrics else { return }
+        activityPaginationMetrics = next
+        requestAutomaticActivityPageIfNeeded()
+    }
+
+    func noteActivityContentHeight(_ height: CGFloat) {
+        let next = FeedActivityPaginationMetrics(
+            viewportHeight: activityPaginationMetrics.viewportHeight,
+            contentHeight: height
+        ).normalized
+        guard next != activityPaginationMetrics else { return }
+        activityPaginationMetrics = next
+        requestAutomaticActivityPageIfNeeded()
+    }
+
+    func waitForActivityAutoPaginationIdleForTesting() async {
+        while let task = automaticLoadTask {
+            await task.value
+        }
+    }
+
+    private func requestAutomaticActivityPageIfNeeded() {
+        guard automaticLoadTask == nil else { return }
+        let metrics = activityPaginationMetrics.normalized
+        guard FeedActivityAutoPaginationPolicy.shouldRequestPage(
+            metrics: metrics,
+            state: activityPaginationState,
+            hasMorePersistedItems: hasMorePersistedItems,
+            isLoadingOlderItems: isLoadingOlderItems
+        ) else { return }
+
+        activityPaginationState.recordRequest(metrics: metrics)
+        automaticLoadTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.loadOlderItemsIfPossible()
+            self.automaticLoadTask = nil
+            self.requestAutomaticActivityPageIfNeeded()
+        }
+    }
+
+    private func loadOlderItemsIfPossible() async {
+        guard !isLoadingOlderItems, hasMorePersistedItems else { return }
+        await FeedCoordinator.shared.store?.loadOlderItems()
+        arm()
     }
 }
 

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -105,6 +105,9 @@ final class FeedPanelViewModel {
                 self?.arm()
             }
         }
+#if DEBUG
+        recordActivityPaginationUITest(stage: "arm")
+#endif
         requestAutomaticActivityPageIfNeeded()
     }
 
@@ -161,10 +164,16 @@ final class FeedPanelViewModel {
         ) else { return }
 
         activityPaginationState.recordRequest(metrics: metrics)
+#if DEBUG
+        recordActivityPaginationUITest(stage: "auto.request")
+#endif
         automaticLoadTask = Task { @MainActor [weak self] in
             guard let self else { return }
             await self.loadOlderItemsIfPossible()
             self.automaticLoadTask = nil
+#if DEBUG
+            self.recordActivityPaginationUITest(stage: "auto.idle")
+#endif
             self.requestAutomaticActivityPageIfNeeded()
         }
     }
@@ -174,6 +183,24 @@ final class FeedPanelViewModel {
         await FeedCoordinator.shared.store?.loadOlderItems()
         arm()
     }
+
+#if DEBUG
+    private func recordActivityPaginationUITest(stage: String) {
+        _ = CmuxUITestCapture.mutateJSONObjectIfConfigured(
+            envKey: "CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"
+        ) { payload in
+            let metrics = activityPaginationMetrics.normalized
+            payload["stage"] = stage
+            payload["itemsCount"] = "\(items.count)"
+            payload["hasMorePersistedItems"] = hasMorePersistedItems ? "1" : "0"
+            payload["isLoadingOlderItems"] = isLoadingOlderItems ? "1" : "0"
+            payload["activityAutoPaginationActive"] = activityPaginationState.isActive ? "1" : "0"
+            payload["activityAutoPagesRequested"] = "\(activityPaginationState.automaticPagesRequested)"
+            payload["activityViewportHeight"] = "\(Int(metrics.viewportHeight.rounded()))"
+            payload["activityContentHeight"] = "\(Int(metrics.contentHeight.rounded()))"
+        }
+    }
+#endif
 }
 
 struct FeedHistoryLoadMoreRow: View {
@@ -198,6 +225,7 @@ struct FeedHistoryLoadMoreRow: View {
         }
         .buttonStyle(.plain)
         .disabled(isLoading)
+        .accessibilityIdentifier("FeedHistoryLoadMoreButton")
     }
 
     private var label: String {

--- a/Sources/Feed/FeedSecondaryFilterButton.swift
+++ b/Sources/Feed/FeedSecondaryFilterButton.swift
@@ -1,0 +1,28 @@
+import SwiftUI
+
+struct FeedSecondaryFilterButton: View {
+    let filter: FeedPanelView.Filter
+    let isSelected: Bool
+    let action: () -> Void
+    @State private var isHovered = false
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 3) {
+                Image(systemName: filter.symbolName)
+                    .font(.system(size: 10, weight: .medium))
+                Text(filter.label)
+                    .font(.system(size: 11, weight: .medium))
+            }
+            .rightSidebarChromePill(
+                isSelected: isSelected,
+                isHovered: isHovered,
+                geometryKeyPrefix: "rightSidebarSecondaryControl_feed_\(filter.rawValue)"
+            )
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help(filter.label)
+        .accessibilityIdentifier("FeedFilterButton.\(filter.rawValue)")
+    }
+}

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -8,6 +8,64 @@ import CMUXWorkstream
 #endif
 
 final class FeedCoordinatorTests: XCTestCase {
+    @MainActor
+    func testActivityAutoPaginationLoadsOnePagePerUnderfilledViewportMeasurement() async throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-feed-auto-page-\(UUID().uuidString).jsonl")
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let persistence = WorkstreamPersistence(fileURL: tmp)
+        for i in 0..<7 {
+            try await persistence.append(WorkstreamItem(
+                workstreamId: "opencode-auto-page-\(i)",
+                source: .opencode,
+                kind: .stop,
+                payload: .stop(reason: "done \(i)")
+            ))
+        }
+
+        let store = WorkstreamStore(
+            persistence: persistence,
+            ringCapacity: 20,
+            initialLoadLimit: 1,
+            historyPageSize: 2
+        )
+        await store.start()
+        FeedCoordinator.shared.install(store: store)
+
+        let model = FeedPanelViewModel()
+        model.setActivityAutoPaginationActive(true)
+        model.noteActivityViewportHeight(360)
+        model.noteActivityContentHeight(40)
+        await model.waitForActivityAutoPaginationIdleForTesting()
+
+        XCTAssertEqual(model.items.map(\.workstreamId), [
+            "opencode-auto-page-4",
+            "opencode-auto-page-5",
+            "opencode-auto-page-6",
+        ])
+        XCTAssertTrue(model.hasMorePersistedItems)
+
+        model.noteActivityContentHeight(40)
+        await model.waitForActivityAutoPaginationIdleForTesting()
+        XCTAssertEqual(model.items.count, 3, "Same geometry must not auto-load the next page again")
+
+        model.noteActivityContentHeight(220)
+        await model.waitForActivityAutoPaginationIdleForTesting()
+        XCTAssertEqual(model.items.map(\.workstreamId), [
+            "opencode-auto-page-2",
+            "opencode-auto-page-3",
+            "opencode-auto-page-4",
+            "opencode-auto-page-5",
+            "opencode-auto-page-6",
+        ])
+        XCTAssertTrue(model.hasMorePersistedItems)
+
+        model.noteActivityContentHeight(520)
+        await model.waitForActivityAutoPaginationIdleForTesting()
+        XCTAssertEqual(model.items.count, 5, "Filled viewport must leave remaining history for manual pagination")
+    }
+
     func testBlockingIngestExpiresItemWhenHookTimesOut() async {
         await MainActor.run {
             let store = WorkstreamStore(ringCapacity: 10)

--- a/cmuxUITests/FeedActivityPaginationUITests.swift
+++ b/cmuxUITests/FeedActivityPaginationUITests.swift
@@ -35,6 +35,7 @@ final class FeedActivityPaginationUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_WORKSTREAM_HISTORY_PAGE_SIZE"] = "2"
         app.launchEnvironment["CMUX_UI_TEST_FEED_ACTIVITY_SEED_COUNT"] = "30"
         app.launchEnvironment["CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"] = paginationPath
+        app.launchEnvironment["CMUX_UI_TEST_FEED_INITIAL_FILTER"] = "activity"
 
         launchAndEnsureUsable(app)
         defer { app.terminate() }
@@ -51,10 +52,6 @@ final class FeedActivityPaginationUITests: XCTestCase {
         let feedButton = app.buttons["RightSidebarModeButton.feed"].firstMatch
         XCTAssertTrue(feedButton.waitForExistence(timeout: 8), "Feed mode button did not appear")
         feedButton.click()
-
-        let activityButton = app.buttons["FeedFilterButton.activity"].firstMatch
-        XCTAssertTrue(activityButton.waitForExistence(timeout: 8), "Activity filter did not appear")
-        activityButton.click()
 
         let newestRow = app.descendants(matching: .any)["FeedRow.opencode-ui-page-29"].firstMatch
         XCTAssertTrue(newestRow.waitForExistence(timeout: 8), "Newest seeded activity row did not render")

--- a/cmuxUITests/FeedActivityPaginationUITests.swift
+++ b/cmuxUITests/FeedActivityPaginationUITests.swift
@@ -98,7 +98,6 @@ final class FeedActivityPaginationUITests: XCTestCase {
         waitForJSON(atPath: paginationPath, timeout: timeout) { data in
             guard data["activityAutoPaginationActive"] == "1",
                   data["isLoadingOlderItems"] == "0",
-                  data["stage"] == "auto.idle",
                   let itemsCount = Int(data["itemsCount"] ?? ""),
                   let autoPages = Int(data["activityAutoPagesRequested"] ?? "") else {
                 return false

--- a/cmuxUITests/FeedActivityPaginationUITests.swift
+++ b/cmuxUITests/FeedActivityPaginationUITests.swift
@@ -1,0 +1,148 @@
+import XCTest
+import Foundation
+
+final class FeedActivityPaginationUITests: XCTestCase {
+    private var chromePath = ""
+    private var paginationPath = ""
+    private var workstreamPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        chromePath = "/tmp/cmux-feed-activity-chrome-\(UUID().uuidString).json"
+        paginationPath = "/tmp/cmux-feed-activity-pagination-\(UUID().uuidString).json"
+        workstreamPath = "/tmp/cmux-feed-activity-workstream-\(UUID().uuidString).jsonl"
+        try? FileManager.default.removeItem(atPath: chromePath)
+        try? FileManager.default.removeItem(atPath: paginationPath)
+        try? FileManager.default.removeItem(atPath: workstreamPath)
+    }
+
+    func testActivityAutoLoadsBoundedPagesFromPersistedHistory() {
+        let app = XCUIApplication()
+        app.launchArguments += [
+            "-workspacePresentationMode", "minimal",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
+        app.launchEnvironment["CMUX_TAG"] = "ui-feed-page"
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = chromePath
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_WINDOW_SIZE"] = "1120x900"
+        app.launchEnvironment["CMUX_UI_TEST_WORKSTREAM_FILE"] = workstreamPath
+        app.launchEnvironment["CMUX_UI_TEST_WORKSTREAM_INITIAL_LOAD_LIMIT"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_WORKSTREAM_HISTORY_PAGE_SIZE"] = "2"
+        app.launchEnvironment["CMUX_UI_TEST_FEED_ACTIVITY_SEED_COUNT"] = "30"
+        app.launchEnvironment["CMUX_UI_TEST_FEED_ACTIVITY_PAGINATION_PATH"] = paginationPath
+
+        launchAndEnsureUsable(app)
+        defer { app.terminate() }
+
+        guard let setup = waitForJSONKey("ready", equals: "1", atPath: chromePath, timeout: 25) else {
+            XCTFail("Timed out waiting for right-sidebar test setup. data=\(loadJSON(atPath: chromePath) ?? [:])")
+            return
+        }
+        if let setupError = setup["setupError"], !setupError.isEmpty {
+            XCTFail("Right-sidebar test setup failed: \(setupError)")
+            return
+        }
+
+        let feedButton = app.buttons["RightSidebarModeButton.feed"].firstMatch
+        XCTAssertTrue(feedButton.waitForExistence(timeout: 8), "Feed mode button did not appear")
+        feedButton.click()
+
+        let activityButton = app.buttons["FeedFilterButton.activity"].firstMatch
+        XCTAssertTrue(activityButton.waitForExistence(timeout: 8), "Activity filter did not appear")
+        activityButton.click()
+
+        let newestRow = app.descendants(matching: .any)["FeedRow.opencode-ui-page-29"].firstMatch
+        XCTAssertTrue(newestRow.waitForExistence(timeout: 8), "Newest seeded activity row did not render")
+
+        guard let state = waitForPaginationIdleAfterAutoLoad(timeout: 12) else {
+            XCTFail("Timed out waiting for Activity auto-pagination. data=\(loadJSON(atPath: paginationPath) ?? [:])")
+            return
+        }
+
+        let itemsCount = Int(state["itemsCount"] ?? "") ?? 0
+        let autoPages = Int(state["activityAutoPagesRequested"] ?? "") ?? 0
+        XCTAssertEqual(state["seeded"], "1", "Expected seeded workstream history. state=\(state)")
+        XCTAssertGreaterThan(itemsCount, 1, "Activity should auto-load older rows on open. state=\(state)")
+        XCTAssertLessThanOrEqual(itemsCount, 7, "Activity should keep auto-load bounded to three pages. state=\(state)")
+        XCTAssertGreaterThanOrEqual(autoPages, 1, "Expected at least one automatic page request. state=\(state)")
+        XCTAssertLessThanOrEqual(autoPages, 3, "Expected automatic pagination budget to cap at three pages. state=\(state)")
+        XCTAssertEqual(state["hasMorePersistedItems"], "1", "Manual pagination should remain available. state=\(state)")
+
+        let olderRow = app.descendants(matching: .any)["FeedRow.opencode-ui-page-28"].firstMatch
+        XCTAssertTrue(olderRow.waitForExistence(timeout: 3), "First older auto-loaded row did not render")
+        XCTAssertTrue(app.buttons["FeedHistoryLoadMoreButton"].firstMatch.exists, "Load-more row should remain for manual pagination")
+    }
+
+    private func launchAndEnsureUsable(_ app: XCUIApplication) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground {
+            return
+        }
+        if app.state == .runningBackground {
+            app.activate()
+        }
+        XCTAssertTrue(
+            app.wait(for: .runningForeground, timeout: 20) || app.windows.firstMatch.waitForExistence(timeout: 6),
+            "cmux failed to launch for Activity pagination UI test. state=\(app.state.rawValue)"
+        )
+    }
+
+    private func waitForPaginationIdleAfterAutoLoad(timeout: TimeInterval) -> [String: String]? {
+        waitForJSON(atPath: paginationPath, timeout: timeout) { data in
+            guard data["activityAutoPaginationActive"] == "1",
+                  data["isLoadingOlderItems"] == "0",
+                  data["stage"] == "auto.idle",
+                  let itemsCount = Int(data["itemsCount"] ?? ""),
+                  let autoPages = Int(data["activityAutoPagesRequested"] ?? "") else {
+                return false
+            }
+            return itemsCount > 1 && autoPages > 0
+        }
+    }
+
+    private func waitForJSONKey(
+        _ key: String,
+        equals expected: String,
+        atPath path: String,
+        timeout: TimeInterval
+    ) -> [String: String]? {
+        waitForJSON(atPath: path, timeout: timeout) { data in
+            data[key] == expected
+        }
+    }
+
+    private func waitForJSON(
+        atPath path: String,
+        timeout: TimeInterval,
+        matching predicate: ([String: String]) -> Bool
+    ) -> [String: String]? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let data = loadJSON(atPath: path), predicate(data) {
+                return data
+            }
+            RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+        }
+        return loadJSON(atPath: path).flatMap { predicate($0) ? $0 : nil }
+    }
+
+    private func loadJSON(atPath path: String) -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return nil
+        }
+        return object.reduce(into: [String: String]()) { result, pair in
+            result[pair.key] = "\(pair.value)"
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- keep OpenCode feed labels on one line and use the existing OpenCode display name
- keep only the current stop row interactive, while older stop rows render compactly
- stop auto-loading older activity pages when the history button appears

## Testing
- ./scripts/reload.sh --tag actfix

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Activity feed layout and adds bounded, geometry-driven auto-pagination only in Activity. Chips and labels are single-line with the correct “OpenCode” name, and only the newest stop per workstream is interactive.

- **New Features**
  - Activity: Auto-pagination loads up to 3 pages when content ≤ viewport + 80px; only active in Activity; manual “Load older activity” remains.
  - Infra: Switched to ScrollView/LazyVStack with viewport/content height reporting; added accessibility identifiers for filters, rows, list, and load-more; split launch helpers into `AppDelegate+WorkstreamLaunch` with UI-test seeding and env overrides for initial filter, file path, load limit, and page size.
  - Tests: Added UI test for bounded auto-pagination and a unit test for one-page-per-measurement and 3-page cap.

- **Bug Fixes**
  - Loading: Removed row-based auto-load; history no longer auto-loads on row visibility.

<sup>Written for commit 896927e321d76652afe7738573e6635cb9857dcb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic activity auto-pagination that loads additional feed pages based on viewport/content size and activation state.

* **Improvements**
  * History stream now uses a lazy scrolling layout for smoother, more efficient browsing.
  * Localized feed source names shown in chips and labels.
  * Only the newest stop shows primary actions; older stops show secondary telemetry actions.
  * Added accessibility identifiers for filter buttons, feed rows, and the history list container.

* **Tests**
  * New unit and UI tests validating bounded auto-pagination and persisted-history loading.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->