### PR TITLE
Fix split button opening local shell instead of remote in SSH workspaces

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -36,6 +36,11 @@ enum WorkspacePendingTerminalInputPolicy {
     }
 }
 
+// @unchecked Sendable safety: This type is only ever accessed on the MainActor
+// (created, mutated, and read exclusively from Workspace methods which run on main).
+// The Sendable conformance is needed because it's stored in a dictionary that crosses
+// an isolation boundary in the notification observer closure, but all actual access
+// is serialized on the main thread.
 private final class WorkspacePendingTerminalInputObserver: @unchecked Sendable {
     var observer: NSObjectProtocol?
 }
@@ -13597,8 +13602,15 @@ extension Workspace: BonsplitDelegate {
                     // Keep the existing placeholder tab identity and replace only the panel mapping.
                     // This avoids an extra create+close tab churn that can transiently render an
                     // empty pane during drag-to-split of a single-tab pane.
-                    let inheritedConfig = inheritedTerminalConfig(inPane: originalPane)
+                    var inheritedConfig = inheritedTerminalConfig(inPane: originalPane)
                     let remoteCommand = remoteTerminalStartupCommand()
+                    // Hold the PTY open after the remote session ends so the user sees
+                    // the exit message rather than a silently-respawned local login shell.
+                    if remoteCommand != nil {
+                        var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+                        template.waitAfterCommand = true
+                        inheritedConfig = template
+                    }
 
                     let replacementPanel = TerminalPanel(
                         workspaceId: id,
@@ -13667,10 +13679,17 @@ extension Workspace: BonsplitDelegate {
         )
 #endif
 
-        let inheritedConfig = inheritedTerminalConfig(
+        var inheritedConfig = inheritedTerminalConfig(
             preferredPanelId: sourcePanelId,
             inPane: originalPane
         )
+        // Hold the PTY open after the remote session ends so the user sees
+        // the exit message rather than a silently-respawned local login shell.
+        if remoteTerminalStartupCommand != nil {
+            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+            template.waitAfterCommand = true
+            inheritedConfig = template
+        }
 
         let newPanel = TerminalPanel(
             workspaceId: id,
@@ -13697,6 +13716,9 @@ extension Workspace: BonsplitDelegate {
         ) else {
             panels.removeValue(forKey: newPanel.id)
             panelTitles.removeValue(forKey: newPanel.id)
+            if remoteTerminalStartupCommand != nil {
+                untrackRemoteTerminalSurface(newPanel.id)
+            }
             terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
             return
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -805,7 +805,9 @@ extension Workspace {
 
         case .split(let split):
             guard split.children.count == 2 else {
+#if DEBUG
                 NSLog("[CmuxConfig] split node requires exactly 2 children, got %d", split.children.count)
+#endif
                 leaves.append((paneId: paneId, surfaces: []))
                 return
             }
@@ -1016,7 +1018,9 @@ extension Workspace {
                 }
 
                 self.removePendingTerminalInputObserver(registration, forPanelId: panelId)
+#if DEBUG
                 NSLog("[CmuxConfig] surface not ready after 3s, dropping command (%d chars)", text.count)
+#endif
             }
         }
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -13594,16 +13594,21 @@ extension Workspace: BonsplitDelegate {
                     // This avoids an extra create+close tab churn that can transiently render an
                     // empty pane during drag-to-split of a single-tab pane.
                     let inheritedConfig = inheritedTerminalConfig(inPane: originalPane)
+                    let remoteCommand = remoteTerminalStartupCommand()
 
                     let replacementPanel = TerminalPanel(
                         workspaceId: id,
                         context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
                         configTemplate: inheritedConfig,
-                        portOrdinal: portOrdinal
+                        portOrdinal: portOrdinal,
+                        initialCommand: remoteCommand
                     )
                     configureTerminalPanel(replacementPanel)
                     panels[replacementPanel.id] = replacementPanel
                     panelTitles[replacementPanel.id] = replacementPanel.displayTitle
+                    if remoteCommand != nil {
+                        trackRemoteTerminalSurface(replacementPanel.id)
+                    }
                     seedTerminalInheritanceFontPoints(panelId: replacementPanel.id, configTemplate: inheritedConfig)
                     surfaceIdToPanelId[replacementTab.id] = replacementPanel.id
 
@@ -13649,6 +13654,7 @@ extension Workspace: BonsplitDelegate {
         // (or fall back to defaults) instead of leaving an empty selector pane.
         let sourceTabId = controller.selectedTab(inPane: originalPane)?.id
         let sourcePanelId = sourceTabId.flatMap { panelIdFromSurfaceId($0) }
+        let remoteTerminalStartupCommand = remoteTerminalStartupCommand()
 
 #if DEBUG
         cmuxDebugLog(
@@ -13666,11 +13672,15 @@ extension Workspace: BonsplitDelegate {
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: inheritedConfig,
-            portOrdinal: portOrdinal
+            portOrdinal: portOrdinal,
+            initialCommand: remoteTerminalStartupCommand
         )
         configureTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
+        if remoteTerminalStartupCommand != nil {
+            trackRemoteTerminalSurface(newPanel.id)
+        }
         seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
 
         guard let newTabId = bonsplitController.createTab(


### PR DESCRIPTION
## Summary
- Split button (UI) in remote SSH workspaces now correctly connects to the remote host, matching Cmd+D behavior
- Also fixes the same issue in the drag-to-split placeholder repair path

## Root Cause
`splitTabBar(_:didSplitPane:)` created `TerminalPanel` without passing `initialCommand: remoteTerminalStartupCommand`, so new panes always spawned a local shell regardless of the workspace's remote configuration.

## Changes
- Pass `remoteTerminalStartupCommand()` as `initialCommand` in the `didSplitPane` auto-create path
- Call `trackRemoteTerminalSurface()` for new panels when the remote command is present
- Apply the same fix to the drag-to-split placeholder repair path

## Test plan
- [ ] `cmux ssh <host>` → click split-right button → new pane should SSH to remote
- [ ] `cmux ssh <host>` → click split-down button → same
- [ ] Drag a tab to split edge in remote workspace → replacement pane should also be remote
- [ ] Local workspace split still works normally (no regression)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split actions in SSH workspaces now open a remote shell instead of a local one. They also keep the PTY open after SSH exit to avoid respawning a local shell.

- **Bug Fixes**
  - Pass the remote startup command to new `TerminalPanel` via `initialCommand` in split and drag-to-split paths.
  - Track new panels as remote surfaces; untrack on `createTab` failure.
  - Set `waitAfterCommand=true` for remote splits so the PTY stays open after SSH exit.
  - Guard debug `NSLog` calls with `#if DEBUG` in layout tree build and pending input timeout.
  - Add a safety comment explaining `@unchecked Sendable` for the pending input observer.

<sup>Written for commit 0e9971e8305ff4204b41155c28c09a803e86ecad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure startup commands are passed to remote terminals during placeholder repair and auto-create flows so terminals initialize correctly.
  
* **Refactor**
  * Only track remote terminal surfaces when a startup command is present, and avoid tracking when none exists.
  
* **Chores**
  * Restrict debug logging to debug builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->