### PR TITLE
Add DeepSeek-TUI hook and session support

### DIFF
--- a/Assets.xcassets/AgentIcons/DeepSeekTUI.imageset/Contents.json
+++ b/Assets.xcassets/AgentIcons/DeepSeekTUI.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "DeepSeekTUI.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Assets.xcassets/AgentIcons/DeepSeekTUI.imageset/DeepSeekTUI.svg
+++ b/Assets.xcassets/AgentIcons/DeepSeekTUI.imageset/DeepSeekTUI.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="128" height="128" viewBox="0 0 128 128">
+  <rect width="128" height="128" rx="28" fill="#0B6E69"/>
+  <path d="M32 39h28c18 0 31 12 31 25s-13 25-31 25H32V39zm18 15v20h10c8 0 13-4 13-10s-5-10-13-10H50z" fill="#F5FBFA"/>
+  <path d="M76 39h32v15H91v35H76V39z" fill="#B6F1EA"/>
+</svg>

--- a/CLI/CMUXCLI+DocsSettings.swift
+++ b/CLI/CMUXCLI+DocsSettings.swift
@@ -92,6 +92,7 @@ extension CMUXCLI {
             commands: [
                 "cmux codex install-hooks",
                 "cmux hooks opencode install",
+                "cmux hooks deepseek-tui install",
                 "cmux hooks setup",
             ]
         ),

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8398,7 +8398,7 @@ struct CMUXCLI {
             agent. Claude Code hooks are injected automatically by the cmux Claude wrapper.
 
             Agents:
-              codex, opencode, cursor, gemini, rovodev, copilot, codebuddy, factory, qoder
+              codex, opencode, cursor, gemini, rovodev, deepseek-tui, copilot, codebuddy, factory, qoder
 
             Hook targets:
               setup              Install hooks for all supported agents on PATH
@@ -14315,6 +14315,23 @@ struct CMUXCLI {
         )
     }
 
+    private func parseAgentHookInput(
+        def: AgentHookDef,
+        rawInput: String,
+        env: [String: String],
+        subcommand: String
+    ) -> ClaudeHookParsedInput {
+        guard def.name == "deepseek-tui",
+              rawInput.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return parseClaudeHookInput(rawInput: rawInput)
+        }
+        let hookEventName = DeepSeekTUIHookPayload.hookEventName(forSubcommand: subcommand)
+        return parseClaudeHookInput(rawInput: DeepSeekTUIHookPayload.jsonString(
+            hookEventName: hookEventName,
+            environment: env
+        ))
+    }
+
     private func compactClaudeHookObject(_ object: [String: Any]) -> [String: Any] {
         var compact: [String: Any] = [:]
 
@@ -15607,6 +15624,7 @@ struct CMUXCLI {
             case flat       // Cursor: {"hooks": {"event": [{"command": "..."}]}, "version": 1}
             case nested(timeoutMs: Int)  // Codex/Gemini: nested with type/command/timeout
             case rovoDevYAML
+            case deepSeekTUITOML
         }
 
         struct HookEvent {
@@ -15660,6 +15678,7 @@ struct CMUXCLI {
         "session-start": .sessionStart,
         "prompt-submit": .promptSubmit,
         "stop": .stop,
+        "on-error": .stop,
         "agent-response": .stop,
         "shell-exec": .promptSubmit,
         "shell-done": .noop,
@@ -15725,6 +15744,20 @@ struct CMUXCLI {
                 .init(agentEvent: "on_complete", cmuxSubcommand: "stop"),
                 .init(agentEvent: "on_error", cmuxSubcommand: "stop"),
                 .init(agentEvent: "on_tool_permission", cmuxSubcommand: "prompt-submit"),
+            ]
+        ),
+        AgentHookDef(
+            name: "deepseek-tui", displayName: "DeepSeek-TUI", statusKey: "deepseek-tui",
+            configDir: ".deepseek", configFile: "config.toml", binaryName: "deepseek",
+            sessionStoreSuffix: "deepseek-tui", disableEnvVar: "CMUX_DEEPSEEK_TUI_HOOKS_DISABLED",
+            hookMarker: "cmux hooks deepseek-tui", format: .deepSeekTUITOML,
+            events: [
+                .init(agentEvent: "session_start", cmuxSubcommand: "session-start"),
+                .init(agentEvent: "message_submit", cmuxSubcommand: "prompt-submit"),
+                .init(agentEvent: "tool_call_before", cmuxSubcommand: "pre-tool-use"),
+                .init(agentEvent: "tool_call_after", cmuxSubcommand: "post-tool-use"),
+                .init(agentEvent: "on_error", cmuxSubcommand: "on-error"),
+                .init(agentEvent: "session_end", cmuxSubcommand: "stop"),
             ]
         ),
         AgentHookDef(
@@ -15831,7 +15864,7 @@ struct CMUXCLI {
                     "hooks": [["type": "command", "command": cmd, "timeout": timeoutMs] as [String: Any]]
                 ] as [String: Any])
                 result[event.agentEvent] = groups
-            case .rovoDevYAML:
+            case .rovoDevYAML, .deepSeekTUITOML:
                 break
             }
         }
@@ -15852,7 +15885,7 @@ struct CMUXCLI {
                     "hooks": [["type": "command", "command": feedCmd, "timeout": feedTimeoutMs] as [String: Any]]
                 ] as [String: Any])
                 result[agentEvent] = groups
-            case .rovoDevYAML:
+            case .rovoDevYAML, .deepSeekTUITOML:
                 break
             }
         }
@@ -16163,6 +16196,25 @@ export default CMUXSessionRestore;
     }
 
     private func installRovoDevHooks(_ def: AgentHookDef) throws {
+        try installTextConfigHooks(def, content: rovoDevHooksContent)
+    }
+
+    private func uninstallRovoDevHooks(_ def: AgentHookDef) throws {
+        try uninstallTextConfigHooks(def, content: rovoDevHooksContent)
+    }
+
+    private func installDeepSeekTUIHooks(_ def: AgentHookDef) throws {
+        try installTextConfigHooks(def, content: deepSeekTUIHooksContent)
+    }
+
+    private func uninstallDeepSeekTUIHooks(_ def: AgentHookDef) throws {
+        try uninstallTextConfigHooks(def, content: deepSeekTUIHooksContent)
+    }
+
+    private func installTextConfigHooks(
+        _ def: AgentHookDef,
+        content: (String, AgentHookDef, Bool) throws -> String
+    ) throws {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
         let filePath = "\(configDir)/\(def.configFile)"
@@ -16174,8 +16226,8 @@ export default CMUXSessionRestore;
             return
         }
 
-        let oldString = try readRovoDevConfig(filePath: filePath, displayName: def.displayName)
-        let newString = try rovoDevHooksContent(existing: oldString, def: def, shouldInstall: true)
+        let oldString = try readTextHookConfig(filePath: filePath, displayName: def.displayName)
+        let newString = try content(oldString, def, true)
         if oldString == newString {
             print("\(def.displayName) hooks already up to date at \(filePath)")
             return
@@ -16198,7 +16250,10 @@ export default CMUXSessionRestore;
         print("\(def.displayName) hooks installed at \(filePath)")
     }
 
-    private func uninstallRovoDevHooks(_ def: AgentHookDef) throws {
+    private func uninstallTextConfigHooks(
+        _ def: AgentHookDef,
+        content: (String, AgentHookDef, Bool) throws -> String
+    ) throws {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
         let filePath = "\(configDir)/\(def.configFile)"
@@ -16206,17 +16261,17 @@ export default CMUXSessionRestore;
             print("No \(def.configFile) found at \(filePath)")
             return
         }
-        let oldString = try readRovoDevConfig(filePath: filePath, displayName: def.displayName)
-        let newString = try rovoDevHooksContent(existing: oldString, def: def, shouldInstall: false)
+        let oldString = try readTextHookConfig(filePath: filePath, displayName: def.displayName)
+        let newString = try content(oldString, def, false)
         guard oldString != newString else {
             print("Removed 0 cmux hook(s) from \(filePath)")
             return
         }
         try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
-        print("Removed Rovo Dev cmux hooks from \(filePath)")
+        print("Removed \(def.displayName) cmux hooks from \(filePath)")
     }
 
-    private func readRovoDevConfig(filePath: String, displayName: String) throws -> String {
+    private func readTextHookConfig(filePath: String, displayName: String) throws -> String {
         let fm = FileManager.default
         guard fm.fileExists(atPath: filePath) else { return "" }
         do {
@@ -16243,6 +16298,23 @@ export default CMUXSessionRestore;
         return RovoDevHookConfig.uninstalling(from: existing)
     }
 
+    private func deepSeekTUIHooksContent(
+        existing: String,
+        def: AgentHookDef,
+        shouldInstall: Bool
+    ) throws -> String {
+        let events = def.events.map { event in
+            DeepSeekTUIHookConfig.Event(
+                name: event.agentEvent,
+                command: hookCommand(for: def, event: event)
+            )
+        }
+        if shouldInstall {
+            return DeepSeekTUIHookConfig.installing(events: events, in: existing)
+        }
+        return DeepSeekTUIHookConfig.uninstalling(from: existing)
+    }
+
     private func installAgentHooks(_ def: AgentHookDef) throws {
         if def.name == "opencode" {
             try installOpenCodePluginHooks(def)
@@ -16250,6 +16322,10 @@ export default CMUXSessionRestore;
         }
         if def.name == "rovodev" {
             try installRovoDevHooks(def)
+            return
+        }
+        if def.name == "deepseek-tui" {
+            try installDeepSeekTUIHooks(def)
             return
         }
 
@@ -16309,7 +16385,7 @@ export default CMUXSessionRestore;
                     rewrittenGroups.append(group)
                 }
                 hooks[event] = rewrittenGroups.isEmpty ? nil : rewrittenGroups
-            case .rovoDevYAML:
+            case .rovoDevYAML, .deepSeekTUITOML:
                 break
             }
         }
@@ -16325,7 +16401,7 @@ export default CMUXSessionRestore;
                 var groups = hooks[event] as? [[String: Any]] ?? []
                 if let newGroups = value as? [[String: Any]] { groups.append(contentsOf: newGroups) }
                 hooks[event] = groups
-            case .rovoDevYAML:
+            case .rovoDevYAML, .deepSeekTUITOML:
                 break
             }
         }
@@ -16423,6 +16499,10 @@ export default CMUXSessionRestore;
             try uninstallRovoDevHooks(def)
             return
         }
+        if def.name == "deepseek-tui" {
+            try uninstallDeepSeekTUIHooks(def)
+            return
+        }
 
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
@@ -16465,7 +16545,7 @@ export default CMUXSessionRestore;
                     rewrittenGroups.append(group)
                 }
                 hooks[event] = rewrittenGroups.isEmpty ? nil : rewrittenGroups
-            case .rovoDevYAML:
+            case .rovoDevYAML, .deepSeekTUITOML:
                 break
             }
         }
@@ -16511,6 +16591,9 @@ export default CMUXSessionRestore;
         if def.name == "rovodev" {
             return RovoDevSessionResolver.inferredRovoDevSessionId(cwd: cwd, env: env) ?? ""
         }
+        if def.name == "deepseek-tui" {
+            return normalizedHookValue(env["DEEPSEEK_SESSION_ID"]) ?? ""
+        }
         return normalizedHookValue(env["CMUX_SURFACE_ID"]) ?? ""
     }
 
@@ -16531,7 +16614,7 @@ export default CMUXSessionRestore;
         let surfaceArg = optionValue(hookArgs, name: "--surface") ?? (hookWsFlag == nil ? env["CMUX_SURFACE_ID"] : nil)
 
         let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let input = parseClaudeHookInput(rawInput: rawInput)
+        let input = parseAgentHookInput(def: def, rawInput: rawInput, env: env, subcommand: subcommand)
 
         let store = ClaudeHookSessionStore(
             processEnv: env.merging(
@@ -18821,6 +18904,7 @@ export default CMUXSessionRestore;
             case "cursor":   envKey = "CMUX_CURSOR_PID"
             case "gemini":   envKey = "CMUX_GEMINI_PID"
             case "rovodev":  envKey = "CMUX_ROVODEV_PID"
+            case "deepseek-tui": envKey = "CMUX_DEEPSEEK_TUI_PID"
             case "copilot":  envKey = "CMUX_COPILOT_PID"
             default:         envKey = ""
             }

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -352,9 +352,11 @@
 		FE003105 /* RovoDevIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003005 /* RovoDevIndex.swift */; };
 		FE003106 /* SessionAgentPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003006 /* SessionAgentPresentation.swift */; };
 		FE003107 /* RovoDevTranscriptPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003007 /* RovoDevTranscriptPreview.swift */; };
+		FE003108 /* DeepSeekTUIIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003008 /* DeepSeekTUIIndex.swift */; };
 		F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */; };
 		F5300002A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */; };
 		F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */; };
+		F5320000A1B2C3D4E5F60718 /* DeepSeekTUISessionIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* DeepSeekTUISessionIndexTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -763,8 +765,10 @@
 		FE003005 /* RovoDevIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevIndex.swift; sourceTree = "<group>"; };
 		FE003006 /* SessionAgentPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionAgentPresentation.swift; sourceTree = "<group>"; };
 		FE003007 /* RovoDevTranscriptPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevTranscriptPreview.swift; sourceTree = "<group>"; };
+		FE003008 /* DeepSeekTUIIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepSeekTUIIndex.swift; sourceTree = "<group>"; };
 		F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevTranscriptPreviewTests.swift; sourceTree = "<group>"; };
 		F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RovoDevHookConfigTests.swift; sourceTree = "<group>"; };
+		F5320001A1B2C3D4E5F60718 /* DeepSeekTUISessionIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeepSeekTUISessionIndexTests.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -1094,6 +1098,7 @@
 				FE003001 /* SessionIndexStore.swift */,
 				FE003004 /* SessionIndexStore+CodexSQL.swift */,
 				FE003005 /* RovoDevIndex.swift */,
+				FE003008 /* DeepSeekTUIIndex.swift */,
 				FE003006 /* SessionAgentPresentation.swift */,
 				FE003007 /* RovoDevTranscriptPreview.swift */,
 				FE003002 /* SessionIndexView.swift */,
@@ -1159,6 +1164,7 @@
 					F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */,
 					F5410003A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift */,
 					F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
+					F5320001A1B2C3D4E5F60718 /* DeepSeekTUISessionIndexTests.swift */,
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
@@ -1653,6 +1659,7 @@
 				FE003101 /* SessionIndexStore.swift in Sources */,
 				FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */,
 				FE003105 /* RovoDevIndex.swift in Sources */,
+				FE003108 /* DeepSeekTUIIndex.swift in Sources */,
 				FE003106 /* SessionAgentPresentation.swift in Sources */,
 				FE003107 /* RovoDevTranscriptPreview.swift in Sources */,
 				FE003102 /* SessionIndexView.swift in Sources */,
@@ -1756,6 +1763,7 @@
 					F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */,
 					F5410002A1B2C3D4E5F60718 /* RestorableAgentNonInteractiveTests.swift in Sources */,
 					F5300000A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift in Sources */,
+					F5320000A1B2C3D4E5F60718 /* DeepSeekTUISessionIndexTests.swift in Sources */,
 				F5300002A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift in Sources */,
 				F5310000A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift in Sources */,
 				FA100000A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift in Sources */,

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -28,6 +28,7 @@ public enum AgentLaunchEnvironmentPolicy {
         "ANTHROPIC_MODEL",
         "CLAUDE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",
+        "CMUX_DEEPSEEK_TUI_SESSIONS_DIR",
         "CMUX_ROVODEV_SESSIONS_DIR",
         "CODEX_HOME",
         "CODEBUDDY_BASE_URL",

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -45,6 +45,9 @@ public enum AgentLaunchSanitizer {
         case "rovodev":
             guard let preserved = preservedArguments(kind: fallbackKind, args: tail) else { return nil }
             return [executable, "rovodev", "run"] + preserved
+        case "deepseek-tui":
+            guard let preserved = preservedArguments(kind: fallbackKind, args: tail) else { return nil }
+            return [executable] + preserved
         default:
             guard let preserved = preservedArguments(kind: fallbackKind, args: tail) else { return nil }
             return [executable] + preserved
@@ -81,6 +84,8 @@ public enum AgentLaunchSanitizer {
                 return nil
             }
             return preserveOptions(tail, policy: rovoDevPolicy)
+        case "deepseek-tui":
+            return preserveOptions(args, policy: deepSeekTUIPolicy)
         case "copilot":
             return preserveOptions(args, policy: copilotPolicy)
         case "codebuddy":

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerAdditionalPolicies.swift
@@ -385,4 +385,55 @@ extension AgentLaunchSanitizer {
             "-o"
         ]
     )
+
+    static let deepSeekTUIPolicy = Policy(
+        valueOptions: [
+            "--config",
+            "--max-subagents",
+            "--profile",
+            "--resume",
+            "-r",
+            "--workspace",
+            "-w"
+        ],
+        nonRestorableCommands: [
+            "apply",
+            "auth",
+            "completions",
+            "doctor",
+            "eval",
+            "exec",
+            "execpolicy",
+            "features",
+            "fork",
+            "help",
+            "init",
+            "login",
+            "logout",
+            "mcp",
+            "models",
+            "pr",
+            "responses-api-proxy",
+            "review",
+            "sandbox",
+            "serve",
+            "sessions",
+            "setup"
+        ],
+        droppedOptions: [
+            "--continue",
+            "-c",
+            "--resume",
+            "-r"
+        ],
+        droppedOptionPrefixes: [
+            "--resume=",
+            "-r="
+        ],
+        rejectOptions: [
+            "--prompt",
+            "-p"
+        ],
+        resumeSubcommand: "resume"
+    )
 }

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/DeepSeekTUIHookConfig.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/DeepSeekTUIHookConfig.swift
@@ -1,0 +1,243 @@
+import Foundation
+
+public enum DeepSeekTUIHookConfig {
+    public struct Event: Equatable {
+        public var name: String
+        public var command: String
+        public var timeoutSecs: Int
+
+        public init(name: String, command: String, timeoutSecs: Int = 5) {
+            self.name = name
+            self.command = command
+            self.timeoutSecs = timeoutSecs
+        }
+    }
+
+    private static let beginMarker = "# cmux hooks deepseek-tui begin"
+    private static let endMarker = "# cmux hooks deepseek-tui end"
+
+    public static func installing(events: [Event], in existing: String) -> String {
+        var lines = removingMarkedBlock(normalizedLines(existing))
+
+        if containsHooksTable(lines) {
+            lines = ensuringHooksEnabled(lines)
+        } else {
+            if !lines.isEmpty, lines.last?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+                lines.append("")
+            }
+            lines.append("[hooks]")
+            lines.append("enabled = true")
+        }
+
+        if !lines.isEmpty, lines.last?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            lines.append("")
+        }
+        lines.append(beginMarker)
+        for event in events {
+            lines.append("[[hooks.hooks]]")
+            lines.append("name = \(tomlBasicString("cmux-\(event.name)"))")
+            lines.append("event = \(tomlBasicString(event.name))")
+            lines.append("command = \(tomlBasicString(event.command))")
+            lines.append("timeout_secs = \(event.timeoutSecs)")
+            lines.append("")
+        }
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        lines.append(endMarker)
+
+        return serialized(lines)
+    }
+
+    public static func uninstalling(from existing: String) -> String {
+        serialized(removingMarkedBlock(normalizedLines(existing)))
+    }
+
+    private static func normalizedLines(_ content: String) -> [String] {
+        var lines = content
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func serialized(_ lines: [String]) -> String {
+        lines.isEmpty ? "" : lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func containsHooksTable(_ lines: [String]) -> Bool {
+        lines.contains { line in
+            line.trimmingCharacters(in: .whitespaces)
+                .range(of: #"^\[hooks\]\s*(#.*)?$"#, options: .regularExpression) != nil
+        }
+    }
+
+    private static func ensuringHooksEnabled(_ lines: [String]) -> [String] {
+        var result = lines
+        guard let tableIndex = result.firstIndex(where: { line in
+            line.trimmingCharacters(in: .whitespaces)
+                .range(of: #"^\[hooks\]\s*(#.*)?$"#, options: .regularExpression) != nil
+        }) else {
+            return result
+        }
+
+        var index = tableIndex + 1
+        while index < result.count {
+            let trimmed = result[index].trimmingCharacters(in: .whitespaces)
+            if trimmed.range(of: #"^enabled\s*="#, options: .regularExpression) != nil {
+                let indent = result[index].prefix { $0 == " " || $0 == "\t" }
+                result[index] = "\(indent)enabled = true"
+                return result
+            }
+            if trimmed.hasPrefix("[") {
+                break
+            }
+            index += 1
+        }
+
+        result.insert("enabled = true", at: tableIndex + 1)
+        return result
+    }
+
+    private static func removingMarkedBlock(_ lines: [String]) -> [String] {
+        var result = lines
+        var index = 0
+        while index < result.count {
+            guard result[index].trimmingCharacters(in: .whitespaces) == beginMarker else {
+                index += 1
+                continue
+            }
+
+            guard let endIndex = result[(index + 1)...].firstIndex(where: {
+                $0.trimmingCharacters(in: .whitespaces) == endMarker
+            }) else {
+                index += 1
+                continue
+            }
+
+            let removalStart = result.indices.contains(index - 1)
+                && result[index - 1].trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? index - 1
+                : index
+            result.removeSubrange(removalStart...endIndex)
+            index = removalStart
+        }
+        return result
+    }
+
+    private static func tomlBasicString(_ value: String) -> String {
+        var escaped = ""
+        escaped.reserveCapacity(value.count + 2)
+        for scalar in value.unicodeScalars {
+            switch scalar {
+            case "\\":
+                escaped += "\\\\"
+            case "\"":
+                escaped += "\\\""
+            case "\n":
+                escaped += "\\n"
+            case "\r":
+                escaped += "\\r"
+            case "\t":
+                escaped += "\\t"
+            default:
+                escaped.unicodeScalars.append(scalar)
+            }
+        }
+        return "\"\(escaped)\""
+    }
+}
+
+public enum DeepSeekTUIHookPayload {
+    public static func hookEventName(forSubcommand subcommand: String) -> String {
+        switch subcommand {
+        case "session-start":
+            return "session_start"
+        case "prompt-submit":
+            return "message_submit"
+        case "pre-tool-use":
+            return "tool_call_before"
+        case "post-tool-use":
+            return "tool_call_after"
+        case "on-error":
+            return "on_error"
+        case "stop":
+            return "session_end"
+        default:
+            return subcommand
+        }
+    }
+
+    public static func jsonObject(
+        hookEventName: String,
+        environment env: [String: String]
+    ) -> [String: Any] {
+        var object: [String: Any] = [
+            "event": hookEventName,
+            "hook_event_name": hookEventName,
+        ]
+
+        setString(&object, key: "session_id", value: env["DEEPSEEK_SESSION_ID"])
+        setString(&object, key: "cwd", value: env["DEEPSEEK_WORKSPACE"])
+        setString(&object, key: "message", value: env["DEEPSEEK_MESSAGE"])
+        setString(&object, key: "tool_name", value: env["DEEPSEEK_TOOL_NAME"])
+        setString(&object, key: "tool_result", value: env["DEEPSEEK_TOOL_RESULT"])
+        setString(&object, key: "mode", value: env["DEEPSEEK_MODE"])
+        setString(&object, key: "previous_mode", value: env["DEEPSEEK_PREVIOUS_MODE"])
+        setString(&object, key: "error", value: env["DEEPSEEK_ERROR"])
+        setString(&object, key: "model", value: env["DEEPSEEK_MODEL"])
+
+        if let toolArgs = normalized(env["DEEPSEEK_TOOL_ARGS"]) {
+            object["tool_input"] = decodedJSONValue(toolArgs) ?? toolArgs
+        }
+        if let exitCode = normalized(env["DEEPSEEK_TOOL_EXIT_CODE"]).flatMap(Int.init) {
+            object["tool_exit_code"] = exitCode
+        }
+        if let success = normalized(env["DEEPSEEK_TOOL_SUCCESS"]) {
+            object["tool_success"] = success == "true" || success == "1"
+        }
+        if let totalTokens = normalized(env["DEEPSEEK_TOTAL_TOKENS"]).flatMap(Int.init) {
+            object["total_tokens"] = totalTokens
+        }
+        if let sessionCost = normalized(env["DEEPSEEK_SESSION_COST"]).flatMap(Double.init) {
+            object["session_cost"] = sessionCost
+        }
+
+        return object
+    }
+
+    public static func jsonString(
+        hookEventName: String,
+        environment env: [String: String]
+    ) -> String {
+        let object = jsonObject(hookEventName: hookEventName, environment: env)
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+
+    private static func setString(_ object: inout [String: Any], key: String, value: String?) {
+        guard let value = normalized(value) else { return }
+        object[key] = value
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func decodedJSONValue(_ value: String) -> Any? {
+        guard let data = value.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed])
+    }
+}

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/DeepSeekTUISessionResolver.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/DeepSeekTUISessionResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+public enum DeepSeekTUISessionResolver {
+    public static func sessionsRoot(env: [String: String]) -> String {
+        if let override = normalized(env["CMUX_DEEPSEEK_TUI_SESSIONS_DIR"]) {
+            return expandedPath(override, env: env)
+        }
+        return (homeDirectory(env: env) as NSString)
+            .appendingPathComponent(".deepseek/sessions")
+    }
+
+    private static func normalized(_ raw: String?) -> String? {
+        let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func homeDirectory(env: [String: String]) -> String {
+        normalized(env["HOME"]) ?? NSHomeDirectory()
+    }
+
+    private static func expandedPath(_ path: String, env: [String: String]) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed == "~" || trimmed.hasPrefix("~/") else {
+            return NSString(string: trimmed).expandingTildeInPath
+        }
+        let home = homeDirectory(env: env)
+        guard trimmed != "~" else { return home }
+        return (home as NSString).appendingPathComponent(String(trimmed.dropFirst(2)))
+    }
+}

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -35,4 +35,32 @@ struct AgentLaunchSanitizerTests {
             ) == ["cursor-agent", "--model", "gpt-5.4", "--sandbox", "enabled"]
         )
     }
+
+    @Test("Preserves DeepSeek-TUI global options and drops resume selectors")
+    func preservesDeepSeekTUIGlobalOptionsAndDropsResumeSelectors() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "deepseek",
+                    "--config",
+                    "/tmp/deepseek.toml",
+                    "--workspace",
+                    "/tmp/repo",
+                    "--resume",
+                    "old-session",
+                    "--yolo",
+                    "initial prompt should not persist",
+                ],
+                launcher: "deepseek-tui",
+                fallbackKind: "deepseek-tui"
+            ) == [
+                "deepseek",
+                "--config",
+                "/tmp/deepseek.toml",
+                "--workspace",
+                "/tmp/repo",
+                "--yolo",
+            ]
+        )
+    }
 }

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/DeepSeekTUIHookConfigTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/DeepSeekTUIHookConfigTests.swift
@@ -1,0 +1,78 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+@Suite("DeepSeekTUIHookConfig")
+struct DeepSeekTUIHookConfigTests {
+    @Test("Installs hook array without duplicating an existing hooks table")
+    func installsHookArrayWithoutDuplicatingExistingHooksTable() {
+        let existing = """
+        default_text_model = "deepseek-v4"
+
+        [hooks]
+        enabled = true
+
+        [[hooks.hooks]]
+        event = "session_start"
+        command = "echo user"
+
+        """
+
+        let installed = DeepSeekTUIHookConfig.installing(
+            events: [
+                DeepSeekTUIHookConfig.Event(
+                    name: "message_submit",
+                    command: #"cmux hooks deepseek-tui prompt-submit --note "quoted""#
+                ),
+            ],
+            in: existing
+        )
+
+        #expect(installed.components(separatedBy: "[hooks]").count - 1 == 1)
+        #expect(installed.contains("# cmux hooks deepseek-tui begin"))
+        #expect(installed.contains(#"event = "message_submit""#))
+        #expect(installed.contains(#"command = "cmux hooks deepseek-tui prompt-submit --note \"quoted\"""#))
+        #expect(DeepSeekTUIHookConfig.uninstalling(from: installed) == existing)
+    }
+
+    @Test("Creates hooks table when missing and reinstalls idempotently")
+    func createsHooksTableWhenMissingAndReinstallsIdempotently() {
+        let events = [
+            DeepSeekTUIHookConfig.Event(
+                name: "session_start",
+                command: "cmux hooks deepseek-tui session-start"
+            ),
+        ]
+        let installed = DeepSeekTUIHookConfig.installing(events: events, in: "")
+        let reinstalled = DeepSeekTUIHookConfig.installing(events: events, in: installed)
+
+        #expect(installed == reinstalled)
+        #expect(installed.contains("[hooks]\nenabled = true"))
+        #expect(DeepSeekTUIHookConfig.uninstalling(from: installed) == "[hooks]\nenabled = true\n")
+    }
+
+    @Test("Enables an existing hooks table")
+    func enablesExistingHooksTable() {
+        let installed = DeepSeekTUIHookConfig.installing(
+            events: [
+                DeepSeekTUIHookConfig.Event(
+                    name: "session_end",
+                    command: "cmux hooks deepseek-tui stop"
+                ),
+            ],
+            in: """
+            [hooks]
+            enabled = false
+
+            [[hooks.hooks]]
+            event = "session_start"
+            command = "echo user"
+
+            """
+        )
+
+        #expect(installed.contains("[hooks]\nenabled = true"))
+        #expect(!installed.contains("enabled = false"))
+        #expect(installed.contains(#"event = "session_end""#))
+    }
+}

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamSource.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamSource.swift
@@ -10,6 +10,7 @@ public enum WorkstreamSource: String, Codable, Sendable, CaseIterable, Equatable
     case cursor
     case opencode
     case gemini
+    case deepseekTUI = "deepseek-tui"
     case copilot
     case codebuddy
     case factory

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -105489,6 +105489,29 @@
         }
       }
     },
+    "sessionIndex.agent.deepseekTUI": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DeepSeek-TUI"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DeepSeek-TUI"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DeepSeek-TUI"
+          }
+        }
+      }
+    },
     "sessionIndex.untitled": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/DeepSeekTUIIndex.swift
+++ b/Sources/DeepSeekTUIIndex.swift
@@ -1,0 +1,229 @@
+import CMUXAgentLaunch
+import Foundation
+
+struct DeepSeekTUIIndexedSession: Equatable, Sendable {
+    let sessionId: String
+    let title: String
+    let workspacePath: String?
+    let modified: Date
+    let sessionURL: URL
+}
+
+struct DeepSeekTUIIndexResult: Equatable, Sendable {
+    let sessions: [DeepSeekTUIIndexedSession]
+    let errors: [String]
+}
+
+private struct DeepSeekTUISessionEnvelope: Decodable {
+    let metadata: DeepSeekTUISessionMetadata
+}
+
+private struct DeepSeekTUISessionMetadata: Decodable {
+    let id: String
+    let title: String?
+    let updatedAt: Date
+    let workspace: String?
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case title
+        case updatedAt = "updated_at"
+        case workspace
+    }
+}
+
+private struct DeepSeekTUISessionCandidate: Sendable {
+    let url: URL
+    let mtime: Date
+}
+
+enum DeepSeekTUIIndex {
+    static func defaultSessionsRoot(
+        env: [String: String] = ProcessInfo.processInfo.environment
+    ) -> String {
+        DeepSeekTUISessionResolver.sessionsRoot(env: env)
+    }
+
+    static func loadSessions(
+        needle: String,
+        cwdFilter: String?,
+        offset: Int,
+        limit: Int,
+        sessionsRoot: String = Self.defaultSessionsRoot()
+    ) -> DeepSeekTUIIndexResult {
+        guard limit > 0 else { return DeepSeekTUIIndexResult(sessions: [], errors: []) }
+        guard offset >= 0 else { return DeepSeekTUIIndexResult(sessions: [], errors: []) }
+        let (target, overflow) = offset.addingReportingOverflow(limit)
+        guard !overflow else { return DeepSeekTUIIndexResult(sessions: [], errors: []) }
+
+        let rootURL = URL(fileURLWithPath: sessionsRoot, isDirectory: true)
+        let fileManager = FileManager.default
+        var isDirectory = ObjCBool(false)
+        guard fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return DeepSeekTUIIndexResult(sessions: [], errors: [])
+        }
+
+        let sessionURLs: [URL]
+        do {
+            sessionURLs = try fileManager.contentsOfDirectory(
+                at: rootURL,
+                includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey],
+                options: [.skipsHiddenFiles]
+            )
+        } catch {
+            return DeepSeekTUIIndexResult(
+                sessions: [],
+                errors: ["DeepSeek-TUI: cannot read sessions directory \(rootURL.path) (\(error.localizedDescription))"]
+            )
+        }
+
+        var errors: [String] = []
+        let candidates = sessionURLs.compactMap { url -> DeepSeekTUISessionCandidate? in
+            guard url.pathExtension == "json" else { return nil }
+            do {
+                let values = try url.resourceValues(forKeys: [.contentModificationDateKey, .isRegularFileKey])
+                guard values.isRegularFile == true else { return nil }
+                return DeepSeekTUISessionCandidate(
+                    url: url,
+                    mtime: values.contentModificationDate ?? .distantPast
+                )
+            } catch {
+                errors.append("DeepSeek-TUI: cannot inspect \(url.path) (\(error.localizedDescription))")
+                return nil
+            }
+        }.sorted { $0.mtime > $1.mtime }
+
+        var matchedCount = 0
+        var sessions: [DeepSeekTUIIndexedSession] = []
+        sessions.reserveCapacity(limit)
+        let normalizedNeedle = needle.lowercased()
+
+        for candidate in candidates {
+            if Task.isCancelled { break }
+            if matchedCount >= target { break }
+
+            let envelope: DeepSeekTUISessionEnvelope
+            do {
+                let data = try Data(contentsOf: candidate.url)
+                envelope = try Self.decoder.decode(DeepSeekTUISessionEnvelope.self, from: data)
+            } catch {
+                errors.append("DeepSeek-TUI: cannot read session \(candidate.url.path) (\(error.localizedDescription))")
+                continue
+            }
+
+            let metadata = envelope.metadata
+            let cwd = metadata.workspace
+            if let cwdFilter, cwd != cwdFilter {
+                continue
+            }
+            let title = metadata.title ?? ""
+            if !normalizedNeedle.isEmpty {
+                let haystack = [metadata.id, title, cwd ?? ""]
+                    .joined(separator: " ")
+                    .lowercased()
+                guard haystack.range(of: normalizedNeedle, options: [.literal]) != nil else {
+                    continue
+                }
+            }
+
+            if matchedCount >= offset {
+                sessions.append(DeepSeekTUIIndexedSession(
+                    sessionId: metadata.id,
+                    title: title,
+                    workspacePath: cwd,
+                    modified: metadata.updatedAt,
+                    sessionURL: candidate.url
+                ))
+            }
+            matchedCount += 1
+        }
+
+        return DeepSeekTUIIndexResult(sessions: sessions, errors: errors)
+    }
+
+    private static let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let raw = try container.decode(String.self)
+            if let date = fractionalISO8601.date(from: raw) ?? plainISO8601.date(from: raw) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO-8601 date: \(raw)"
+            )
+        }
+        return decoder
+    }()
+
+    private static let fractionalISO8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private static let plainISO8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}
+
+extension SessionIndexStore {
+    nonisolated static func loadDeepSeekTUIEntries(
+        needle: String,
+        cwdFilter: String?,
+        offset: Int,
+        limit: Int,
+        errorBag: ErrorBag,
+        sessionsRoot: String = DeepSeekTUIIndex.defaultSessionsRoot()
+    ) -> [SessionEntry] {
+        let result = DeepSeekTUIIndex.loadSessions(
+            needle: needle,
+            cwdFilter: cwdFilter,
+            offset: offset,
+            limit: limit,
+            sessionsRoot: sessionsRoot
+        )
+        for error in result.errors {
+            errorBag.add(error)
+        }
+        return result.sessions.map { session in
+            SessionEntry(
+                id: "deepseek-tui:" + session.sessionId,
+                agent: .deepseekTUI,
+                sessionId: session.sessionId,
+                title: session.title,
+                cwd: session.workspacePath,
+                gitBranch: nil,
+                pullRequest: nil,
+                modified: session.modified,
+                fileURL: session.sessionURL,
+                specifics: .deepseekTUI
+            )
+        }
+    }
+
+    #if DEBUG
+    nonisolated static func loadDeepSeekTUIEntriesForTesting(
+        sessionsRoot: String,
+        needle: String = "",
+        cwdFilter: String? = nil,
+        offset: Int = 0,
+        limit: Int = 100
+    ) -> SearchOutcome {
+        let bag = ErrorBag()
+        let entries = loadDeepSeekTUIEntries(
+            needle: needle,
+            cwdFilter: cwdFilter,
+            offset: offset,
+            limit: limit,
+            errorBag: bag,
+            sessionsRoot: sessionsRoot
+        )
+        return SearchOutcome(entries: entries, errors: bag.snapshot())
+    }
+    #endif
+}

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -1120,6 +1120,7 @@ struct FeedItemRow: View, Equatable {
         case .claude: return Color(red: 0.92, green: 0.54, blue: 0.29)
         case .codex: return .green
         case .opencode: return .blue
+        case .deepseekTUI: return .cyan
         case .cursor: return .purple
         default: return .secondary
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -143,6 +143,10 @@ enum AgentResumeCommandBuilder {
             let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "acli")
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "rovodev", args: original.tail) else { return nil }
             return [original.executable, "rovodev", "run", "--restore", sessionId] + preserved
+        case .deepseekTUI:
+            let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "deepseek")
+            guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "deepseek-tui", args: original.tail) else { return nil }
+            return [original.executable] + preserved + ["resume", sessionId]
         case .copilot:
             return resumeWithOption(
                 kind: "copilot",

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -7,6 +7,7 @@ enum RestorableAgentKind: String, Codable, CaseIterable, Sendable {
     case gemini
     case opencode
     case rovodev
+    case deepseekTUI = "deepseek-tui"
     case copilot
     case codebuddy
     case factory

--- a/Sources/SessionAgentPresentation.swift
+++ b/Sources/SessionAgentPresentation.swift
@@ -7,6 +7,7 @@ extension SessionAgent {
         case .codex: return String(localized: "sessionIndex.agent.codex", defaultValue: "Codex")
         case .opencode: return String(localized: "sessionIndex.agent.opencode", defaultValue: "OpenCode")
         case .rovodev: return String(localized: "sessionIndex.agent.rovodev", defaultValue: "Rovo Dev")
+        case .deepseekTUI: return String(localized: "sessionIndex.agent.deepseekTUI", defaultValue: "DeepSeek-TUI")
         }
     }
 
@@ -17,6 +18,7 @@ extension SessionAgent {
         case .codex: return "AgentIcons/Codex"
         case .opencode: return "AgentIcons/OpenCode"
         case .rovodev: return "AgentIcons/RovoDev"
+        case .deepseekTUI: return "AgentIcons/DeepSeekTUI"
         }
     }
 }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -12,6 +12,7 @@ enum SessionAgent: String, CaseIterable, Identifiable, Hashable, Codable, Sendab
     case codex
     case opencode
     case rovodev
+    case deepseekTUI = "deepseek-tui"
 
     var id: String { rawValue }
 }
@@ -82,6 +83,7 @@ enum AgentSpecifics: Hashable {
     case codex(model: String?, approvalPolicy: String?, sandboxMode: String?, effort: String?)
     case opencode(providerModel: String?, agentName: String?)
     case rovodev
+    case deepseekTUI
 }
 
 struct SessionEntry: Identifiable, Hashable {
@@ -139,6 +141,8 @@ struct SessionEntry: Identifiable, Hashable {
             return parts.joined(separator: " ")
         case .rovodev:
             return "acli rovodev run --restore \(Self.shellQuote(sessionId))"
+        case .deepseekTUI:
+            return "deepseek resume \(Self.shellQuote(sessionId))"
         }
     }
 
@@ -797,7 +801,8 @@ final class SessionIndexStore: ObservableObject {
         async let codex = loadCodexEntries(needle: "", cwdFilter: nil, offset: 0, limit: perAgentLimit, errorBag: bag)
         async let opencode = loadOpenCodeEntries(needle: "", cwdFilter: nil, offset: 0, limit: perAgentLimit, errorBag: bag)
         async let rovodev = loadRovoDevEntries(needle: "", cwdFilter: nil, offset: 0, limit: perAgentLimit, errorBag: bag)
-        let combined = await claude + codex + opencode + rovodev
+        async let deepseekTUI = loadDeepSeekTUIEntries(needle: "", cwdFilter: nil, offset: 0, limit: perAgentLimit, errorBag: bag)
+        let combined = await claude + codex + opencode + rovodev + deepseekTUI
         return combined.sorted { $0.modified > $1.modified }
     }
 
@@ -1309,7 +1314,11 @@ final class SessionIndexStore: ObservableObject {
                 needle: needle, agent: .rovodev, cwdFilter: cwdFilter,
                 offset: 0, limit: target, errorBag: bag
             )
-            let merged = (await c) + (await x) + (await o) + (await r)
+            async let d = Self.timedAgent(
+                needle: needle, agent: .deepseekTUI, cwdFilter: cwdFilter,
+                offset: 0, limit: target, errorBag: bag
+            )
+            let merged = (await c) + (await x) + (await o) + (await r) + (await d)
             let sorted = merged.sorted { $0.modified > $1.modified }
             entries = Array(sorted.dropFirst(offset).prefix(limit))
         }
@@ -1340,6 +1349,7 @@ final class SessionIndexStore: ObservableObject {
         case .codex: return await loadCodexEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         case .opencode: return loadOpenCodeEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         case .rovodev: return loadRovoDevEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
+        case .deepseekTUI: return loadDeepSeekTUIEntries(needle: needle, cwdFilter: cwdFilter, offset: offset, limit: limit, errorBag: errorBag)
         }
     }
 

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1104,6 +1104,9 @@ private enum SessionTranscriptLoader {
                 return SessionTranscriptTurn(id: index, role: role, text: truncatedText(turn.text, role: role))
             })
         }
+        if agent == .deepseekTUI {
+            return try loadDeepSeekTUISynchronously(from: url)
+        }
 
         let handle = try FileHandle(forReadingFrom: url)
         defer { try? handle.close() }
@@ -1187,6 +1190,28 @@ private enum SessionTranscriptLoader {
             appendTurnLimitMarker(to: &turns, id: lineIndex)
         }
 
+        return coalesce(turns)
+    }
+
+    private static func loadDeepSeekTUISynchronously(from url: URL) throws -> [SessionTranscriptTurn] {
+        let data = try Data(contentsOf: url)
+        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let messages = object["messages"] as? [[String: Any]] else {
+            throw SessionTranscriptLoadError.missingFile
+        }
+
+        var turns: [SessionTranscriptTurn] = []
+        turns.reserveCapacity(min(messages.count, maxPreviewTurns))
+        for (index, message) in messages.enumerated() {
+            guard turns.count < maxPreviewTurns else {
+                appendTurnLimitMarker(to: &turns, id: index)
+                break
+            }
+            guard let turn = parseGenericMessage(message, agent: .deepseekTUI, id: index) else {
+                continue
+            }
+            turns.append(turn)
+        }
         return coalesce(turns)
     }
 
@@ -1305,7 +1330,7 @@ private enum SessionTranscriptLoader {
             return parseClaudeLine(object, id: id)
         case .codex:
             return parseCodexLine(object, id: id)
-        case .opencode, .rovodev:
+        case .opencode, .rovodev, .deepseekTUI:
             return parseGenericLine(object, agent: agent, id: id)
         }
     }
@@ -1585,7 +1610,7 @@ private enum SessionTranscriptLoader {
         case .codex:
             return containsAny(data, needles: codexResponseItemNeedles)
                 && containsAny(data, needles: codexPreviewNeedles)
-        case .opencode, .rovodev:
+        case .opencode, .rovodev, .deepseekTUI:
             return containsAny(data, needles: genericRoleNeedles)
         }
     }
@@ -1599,7 +1624,7 @@ private enum SessionTranscriptLoader {
             if containsAny(data, needles: [Data(#""type":"user""#.utf8), Data(#""type": "user""#.utf8)]) {
                 return .user
             }
-        case .codex, .opencode, .rovodev:
+        case .codex, .opencode, .rovodev, .deepseekTUI:
             if containsAny(data, needles: [Data(#""role":"assistant""#.utf8), Data(#""role": "assistant""#.utf8)]) {
                 return .assistant
             }

--- a/cmuxTests/DeepSeekTUISessionIndexTests.swift
+++ b/cmuxTests/DeepSeekTUISessionIndexTests.swift
@@ -1,0 +1,136 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class DeepSeekTUISessionIndexTests: XCTestCase {
+    func testDeepSeekTUISessionIndexReadsMetadataAndResumeCommand() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        try writeSession(
+            in: fixture.sessionsRoot,
+            id: "older-session",
+            title: "Unrelated chat",
+            workspace: "/tmp/other repo",
+            updatedAt: Date(timeIntervalSince1970: 100)
+        )
+        try writeSession(
+            in: fixture.sessionsRoot,
+            id: "session with space",
+            title: "Ship DeepSeek-TUI support",
+            workspace: "/tmp/deepseek repo",
+            updatedAt: Date(timeIntervalSince1970: 200)
+        )
+
+        let outcome = SessionIndexStore.loadDeepSeekTUIEntriesForTesting(
+            sessionsRoot: fixture.sessionsRoot.path,
+            needle: "deepseek",
+            cwdFilter: "/tmp/deepseek repo"
+        )
+
+        XCTAssertEqual(outcome.errors, [])
+        let entry = try XCTUnwrap(outcome.entries.first)
+        XCTAssertEqual(outcome.entries.count, 1)
+        XCTAssertEqual(entry.agent, .deepseekTUI)
+        XCTAssertEqual(entry.sessionId, "session with space")
+        XCTAssertEqual(entry.title, "Ship DeepSeek-TUI support")
+        XCTAssertEqual(entry.cwd, "/tmp/deepseek repo")
+        XCTAssertEqual(entry.fileURL?.lastPathComponent, "session with space.json")
+        XCTAssertEqual(entry.resumeCommand, "deepseek resume 'session with space'")
+        XCTAssertEqual(
+            entry.resumeCommandWithCwd,
+            "cd '/tmp/deepseek repo' && deepseek resume 'session with space'"
+        )
+    }
+
+    func testDeepSeekTUISessionIndexReportsMalformedMetadata() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        let sessionURL = fixture.sessionsRoot.appendingPathComponent("broken-session.json")
+        try Data("{".utf8).write(to: sessionURL)
+
+        let outcome = SessionIndexStore.loadDeepSeekTUIEntriesForTesting(
+            sessionsRoot: fixture.sessionsRoot.path
+        )
+
+        XCTAssertEqual(outcome.entries, [])
+        XCTAssertEqual(outcome.errors.count, 1)
+        XCTAssertTrue(outcome.errors[0].contains("DeepSeek-TUI: cannot read session"))
+        XCTAssertTrue(outcome.errors[0].contains("broken-session.json"))
+    }
+
+    func testDeepSeekTUISessionIndexMissingRootIsEmptyWithoutError() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.tempDir) }
+
+        let missingRoot = fixture.tempDir.appendingPathComponent("missing", isDirectory: true)
+        let outcome = SessionIndexStore.loadDeepSeekTUIEntriesForTesting(
+            sessionsRoot: missingRoot.path
+        )
+
+        XCTAssertEqual(outcome.entries, [])
+        XCTAssertEqual(outcome.errors, [])
+    }
+
+    private func makeFixture() throws -> (tempDir: URL, sessionsRoot: URL) {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-deepseek-tui-session-index-\(UUID().uuidString)", isDirectory: true)
+        let sessionsRoot = tempDir.appendingPathComponent("sessions", isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionsRoot, withIntermediateDirectories: true)
+        return (tempDir, sessionsRoot)
+    }
+
+    private func writeSession(
+        in sessionsRoot: URL,
+        id: String,
+        title: String,
+        workspace: String,
+        updatedAt: Date
+    ) throws {
+        let sessionURL = sessionsRoot.appendingPathComponent("\(id).json")
+        let dateString = Self.iso8601.string(from: updatedAt)
+        let data = try JSONSerialization.data(
+            withJSONObject: [
+                "metadata": [
+                    "id": id,
+                    "title": title,
+                    "created_at": dateString,
+                    "updated_at": dateString,
+                    "message_count": 2,
+                    "total_tokens": 42,
+                    "model": "deepseek-chat",
+                    "workspace": workspace,
+                    "mode": "agent",
+                ],
+                "messages": [
+                    [
+                        "role": "user",
+                        "content": [
+                            [
+                                "type": "text",
+                                "text": "hello",
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+            options: [.sortedKeys]
+        )
+        try data.write(to: sessionURL)
+        try FileManager.default.setAttributes(
+            [.modificationDate: updatedAt],
+            ofItemAtPath: sessionURL.path
+        )
+    }
+
+    private static let iso8601: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+}

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -77,6 +77,41 @@ extension SocketListenerAcceptPolicyTests {
         )
     }
 
+    func testDeepSeekTUIResumeCommandUsesResumeSubcommandAndPreservesGlobals() {
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .deepseekTUI,
+            sessionId: "deepseek-session-123",
+            workingDirectory: "/tmp/deepseek repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "deepseek-tui",
+                executablePath: "/opt/homebrew/bin/deepseek",
+                arguments: [
+                    "/opt/homebrew/bin/deepseek",
+                    "--config",
+                    "/tmp/deepseek.toml",
+                    "--workspace",
+                    "/tmp/deepseek repo",
+                    "resume",
+                    "old-session",
+                    "--yolo",
+                    "initial prompt should not replay"
+                ],
+                workingDirectory: "/tmp/deepseek repo",
+                environment: [
+                    "DEEPSEEK_API_KEY": "secret",
+                    "CMUX_DEEPSEEK_TUI_SESSIONS_DIR": "/tmp/deepseek sessions"
+                ],
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        XCTAssertEqual(
+            snapshot.resumeCommand,
+            "cd '/tmp/deepseek repo' && 'env' 'CMUX_DEEPSEEK_TUI_SESSIONS_DIR=/tmp/deepseek sessions' '/opt/homebrew/bin/deepseek' '--config' '/tmp/deepseek.toml' '--workspace' '/tmp/deepseek repo' '--yolo' 'resume' 'deepseek-session-123'"
+        )
+    }
+
     func testAdditionalHookAgentResumeCommandsUseVerifiedCLIResumeFlags() {
         let cursor = SessionRestorableAgentSnapshot(
             kind: .cursor,
@@ -335,6 +370,27 @@ extension SocketListenerAcceptPolicyTests {
                 launcher: "rovodev",
                 fallbackKind: "rovodev"
             )
+        )
+        XCTAssertEqual(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "/opt/homebrew/bin/deepseek",
+                    "--config",
+                    "/tmp/deepseek.toml",
+                    "resume",
+                    "old-session",
+                    "--yolo",
+                    "initial prompt should not replay"
+                ],
+                launcher: "deepseek-tui",
+                fallbackKind: "deepseek-tui"
+            ),
+            [
+                "/opt/homebrew/bin/deepseek",
+                "--config",
+                "/tmp/deepseek.toml",
+                "--yolo"
+            ]
         )
     }
 

--- a/cmuxTests/RestorableAgentNonInteractiveTests.swift
+++ b/cmuxTests/RestorableAgentNonInteractiveTests.swift
@@ -115,6 +115,20 @@ final class RestorableAgentNonInteractiveTests: XCTestCase {
                 source: nil
             )
         )
+        let deepSeekExec = SessionRestorableAgentSnapshot(
+            kind: .deepseekTUI,
+            sessionId: "deepseek-session-123",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "deepseek-tui",
+                executablePath: "deepseek",
+                arguments: ["deepseek", "exec", "fix this"],
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: nil,
+                source: nil
+            )
+        )
         let cursorPrint = SessionRestorableAgentSnapshot(
             kind: .cursor,
             sessionId: "cursor-session-123",
@@ -193,6 +207,7 @@ final class RestorableAgentNonInteractiveTests: XCTestCase {
         XCTAssertNil(opencodePR.resumeCommand)
         XCTAssertNil(geminiPrompt.resumeCommand)
         XCTAssertNil(rovoDevAuth.resumeCommand)
+        XCTAssertNil(deepSeekExec.resumeCommand)
         XCTAssertNil(cursorPrint.resumeCommand)
         XCTAssertNil(copilotPrompt.resumeCommand)
         XCTAssertNil(codeBuddyPrint.resumeCommand)

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1173,6 +1173,14 @@ final class SessionPersistenceTests: XCTestCase {
                 ]
             ),
             (
+                .deepseekTUI,
+                [
+                    "/usr/local/bin/deepseek",
+                    "--config",
+                    "/tmp/deepseek.toml",
+                ]
+            ),
+            (
                 .copilot,
                 [
                     "/usr/local/bin/copilot",
@@ -1328,6 +1336,8 @@ final class SessionPersistenceTests: XCTestCase {
                 resolvedEnvironment = ["OPENCODE_CONFIG_DIR": "/tmp/opencode"]
             case .rovodev:
                 resolvedEnvironment = [:]
+            case .deepseekTUI:
+                resolvedEnvironment = ["CMUX_DEEPSEEK_TUI_SESSIONS_DIR": "/tmp/deepseek sessions"]
             case .copilot:
                 resolvedEnvironment = ["COPILOT_HOME": "/tmp/copilot"]
             case .codebuddy:


### PR DESCRIPTION
## Summary
- Add `cmux hooks deepseek-tui` install and uninstall support for DeepSeek-TUI TOML hooks.
- Persist DeepSeek-TUI hook sessions and show saved `~/.deepseek/sessions` entries in the session index with `deepseek resume <session_id>` commands.
- Add DeepSeek-TUI launch sanitization, Feed source tagging, localized presentation, and focused tests.

## Notes
- DeepSeek-TUI hooks are observer hooks. `tool_call_before` does not block, approve, or deny tool calls based on hook output, so cmux support records status and sessions rather than enforcing permission decisions.
- Upstream inspected at https://github.com/Hmbown/DeepSeek-TUI/tree/2d809225be73c91ed1fbb3bd6c1f5b89c5a16da3.

## Testing
- `swift test --package-path Packages/CMUXAgentLaunch`
- `xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-dstui-tests -only-testing:cmuxTests/DeepSeekTUISessionIndexTests -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testDeepSeekTUIResumeCommandUsesResumeSubcommandAndPreservesGlobals -only-testing:cmuxTests/RestorableAgentNonInteractiveTests/testNonInteractiveAgentLaunchesAreNotAutoRestored`
- `./scripts/reload.sh --tag dstui`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds DeepSeek-TUI hook installation and session indexing so users can install TOML hooks for `deepseek`, see saved sessions from `~/.deepseek/sessions`, and resume them with one click. Also adds launch sanitization and localized UI with icon and color.

- New Features
  - `cmux hooks deepseek-tui install`/`uninstall` inject/remove marked TOML hooks in `~/.deepseek/config.toml`, enabling `[hooks]`.
  - Observer hooks with event mapping; JSON payload built from `DEEPSEEK_*` env for each event.
  - Index and preview `~/.deepseek/sessions/*.json`; entries show in the Session Index and resume via `deepseek resume <id>`.
  - Launch sanitization and resume: keep `--config`/`--workspace`, drop prompt/resume selectors, use the `resume` subcommand; support `CMUX_DEEPSEEK_TUI_SESSIONS_DIR` to locate sessions.
  - UI: adds DeepSeek-TUI agent label, icon, color, and feed source tagging.

- Migration
  - Run `cmux hooks deepseek-tui install` to enable hooks.
  - Optionally set `CMUX_DEEPSEEK_TUI_SESSIONS_DIR` to override the sessions directory.

<sup>Written for commit aef86120ae24d25be0792234ffbe001f46e0a0bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for DeepSeek-TUI as an integrated agent with full session discovery, search, and restoration capabilities.
  * Implemented hook configuration system for DeepSeek-TUI events with configurable timeouts and payloads.
  * Added multi-language localization support for DeepSeek-TUI.

* **Tests**
  * Added comprehensive test coverage for DeepSeek-TUI session indexing, restoration, and hook configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->