### PR TITLE
Fix sidebar workspace close hover state

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		9C1BEA3D2E6F49709A71C020 /* TerminalControllerSocketWriteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1BEA3D2E6F49709A71C021 /* TerminalControllerSocketWriteTests.swift */; };
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
 		988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */; };
+		D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */; };
 		A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB000000000000000001 /* AppearanceSettings.swift */; };
 		A5001001 /* cmuxApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001011 /* cmuxApp.swift */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
@@ -525,6 +526,7 @@
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
 		243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAppearanceSupport.swift; sourceTree = "<group>"; };
 		D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift; sourceTree = "<group>"; };
+		D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTracker.swift; sourceTree = "<group>"; };
 		610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/InternalTabDragConfiguration.swift; sourceTree = "<group>"; };
 		A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShortcutHintPill.swift; sourceTree = "<group>"; };
 		0B54144FA244A0B482D2903D /* WindowGlassEffect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowGlassEffect.swift; sourceTree = "<group>"; };
@@ -970,6 +972,7 @@
 				9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
+				D35450020000000000000002 /* SidebarWorkspaceRowHoverTracker.swift */,
 				C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */,
 				610008EA5E3744DDBE05C8E2 /* InternalTabDragConfiguration.swift */,
 				A080D1F6CCCBFBED8D95DD1D /* ShortcutHintPill.swift */,
@@ -1541,6 +1544,7 @@
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
 				211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */,
 				988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,
+				D35450010000000000000001 /* SidebarWorkspaceRowHoverTracker.swift in Sources */,
 				C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
 				125BAEF2FE3B454547B964D1 /* ShortcutHintPill.swift in Sources */,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12641,7 +12641,6 @@ struct SidebarWorkspaceSnapshotBuilder {
 }
 
 private final class SidebarTabItemContextMenuState: ObservableObject {
-    var isVisible = false
     var hasDeferredWorkspaceObservationInvalidation = false
     var pendingWorkspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot?
 }
@@ -12707,7 +12706,7 @@ private struct TabItemView: View, Equatable {
     @Binding var frozenPresentation: SidebarTabItemPresentationSnapshot?
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
     @StateObject private var contextMenuState = SidebarTabItemContextMenuState()
-    @State private var isHovering = false
+    @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
     @State private var rowHeight: CGFloat = 1
 
     var isMultiSelected: Bool {
@@ -12833,7 +12832,10 @@ private struct TabItemView: View, Equatable {
     }
 
     private var showCloseButton: Bool {
-        isHovering && canCloseWorkspace && !(showsModifierShortcutHints || alwaysShowShortcutHints)
+        rowInteractionState.shouldShowCloseButton(
+            canCloseWorkspace: canCloseWorkspace,
+            shortcutHintModeActive: showsModifierShortcutHints || alwaysShowShortcutHints
+        )
     }
 
     private var workspaceShortcutLabel: String? {
@@ -13232,6 +13234,9 @@ private struct TabItemView: View, Equatable {
         .contentShape(Rectangle())
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay {
+            SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
+        }
+        .overlay {
             MiddleClickCapture {
                 #if DEBUG
                 cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=middleClick")
@@ -13318,10 +13323,6 @@ private struct TabItemView: View, Equatable {
         .onTapGesture {
             updateSelection()
         }
-        .onHover { hovering in
-            guard !contextMenuState.isVisible else { return }
-            isHovering = hovering
-        }
         .safeHelp(workspaceSnapshot.title)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Text(accessibilityTitle))
@@ -13335,17 +13336,14 @@ private struct TabItemView: View, Equatable {
         .contextMenu {
             workspaceContextMenu
                 .onAppear {
-                    contextMenuState.isVisible = true
+                    rowInteractionState.contextMenuDidAppear()
                     contextMenuState.hasDeferredWorkspaceObservationInvalidation = false
                     contextMenuState.pendingWorkspaceSnapshot = nil
                     frozenPresentation = livePresentation
                 }
                 .onDisappear {
-                    contextMenuState.isVisible = false
+                    rowInteractionState.contextMenuDidDisappear()
                     frozenPresentation = nil
-                    if isHovering {
-                        isHovering = false
-                    }
                     flushDeferredWorkspaceObservationInvalidation()
                 }
         }
@@ -13357,7 +13355,7 @@ private struct TabItemView: View, Equatable {
             current: workspaceSnapshotStorage,
             next: nextSnapshot,
             force: force,
-            contextMenuVisible: contextMenuState.isVisible
+            contextMenuVisible: rowInteractionState.contextMenuVisible
         )
 
         if workspaceSnapshotStorage != decision.workspaceSnapshotStorage {

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
@@ -1,0 +1,193 @@
+import AppKit
+import SwiftUI
+
+struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
+    @Binding var rowInteractionState: SidebarWorkspaceRowInteractionState
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(rowInteractionState: $rowInteractionState)
+    }
+
+    func makeNSView(context: Context) -> SidebarWorkspaceRowHoverTrackingView {
+        let view = SidebarWorkspaceRowHoverTrackingView()
+        let coordinator = context.coordinator
+        view.onPointerHoverChanged = { hovering in
+            coordinator.pointerHoverChanged(hovering)
+        }
+        view.onMenuTrackingChanged = { tracking in
+            coordinator.menuTrackingChanged(tracking)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: SidebarWorkspaceRowHoverTrackingView, context: Context) {
+        context.coordinator.rowInteractionState = $rowInteractionState
+    }
+
+    final class Coordinator {
+        var rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>
+
+        init(rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>) {
+            self.rowInteractionState = rowInteractionState
+        }
+
+        func pointerHoverChanged(_ hovering: Bool) {
+            rowInteractionState.wrappedValue.setPointerHovering(hovering)
+        }
+
+        func menuTrackingChanged(_ tracking: Bool) {
+            if tracking {
+                rowInteractionState.wrappedValue.contextMenuTrackingDidBegin()
+            } else {
+                rowInteractionState.wrappedValue.contextMenuTrackingDidEnd()
+            }
+        }
+    }
+}
+
+enum SidebarWorkspaceRowMenuTrackingScope {
+    static func shouldSuppressCloseButton(
+        pointerInsideRow: Bool,
+        eventType: NSEvent.EventType?,
+        modifierFlags: NSEvent.ModifierFlags
+    ) -> Bool {
+        guard pointerInsideRow else { return false }
+
+        switch eventType {
+        case .some(.rightMouseDown), .some(.rightMouseUp):
+            return true
+        case .some(.leftMouseDown), .some(.leftMouseUp):
+            return modifierFlags.contains(.control)
+        default:
+            return false
+        }
+    }
+}
+
+final class SidebarWorkspaceRowHoverTrackingView: NSView {
+    var onPointerHoverChanged: ((Bool) -> Void)?
+    var onMenuTrackingChanged: ((Bool) -> Void)?
+    private var trackingArea: NSTrackingArea?
+    private var menuBeginObserver: NSObjectProtocol?
+    private var menuEndObserver: NSObjectProtocol?
+    private var lastReportedHover: Bool?
+    private var isMenuTracking = false
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let nextTrackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(nextTrackingArea)
+        trackingArea = nextTrackingArea
+        reconcileCurrentPointerLocation()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        refreshMenuTrackingObservers()
+        reconcileCurrentPointerLocation()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        reconcileCurrentPointerLocation()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        reportPointerHovering(false)
+    }
+
+    deinit {
+        if let menuBeginObserver {
+            NotificationCenter.default.removeObserver(menuBeginObserver)
+        }
+        if let menuEndObserver {
+            NotificationCenter.default.removeObserver(menuEndObserver)
+        }
+    }
+
+    private func refreshMenuTrackingObservers() {
+        if window == nil {
+            if let menuBeginObserver {
+                NotificationCenter.default.removeObserver(menuBeginObserver)
+                self.menuBeginObserver = nil
+            }
+            if let menuEndObserver {
+                NotificationCenter.default.removeObserver(menuEndObserver)
+                self.menuEndObserver = nil
+            }
+            isMenuTracking = false
+            return
+        }
+        if menuBeginObserver == nil {
+            menuBeginObserver = NotificationCenter.default.addObserver(
+                forName: NSMenu.didBeginTrackingNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self else { return }
+                guard shouldSuppressHoverForMenuTracking() else { return }
+                isMenuTracking = true
+                onMenuTrackingChanged?(true)
+                reportPointerHovering(false)
+            }
+        }
+        if menuEndObserver == nil {
+            menuEndObserver = NotificationCenter.default.addObserver(
+                forName: NSMenu.didEndTrackingNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                guard let self else { return }
+                guard isMenuTracking else { return }
+                isMenuTracking = false
+                onMenuTrackingChanged?(false)
+                reconcileCurrentPointerLocation()
+            }
+        }
+    }
+
+    private func shouldSuppressHoverForMenuTracking() -> Bool {
+        let event = NSApp.currentEvent
+        return SidebarWorkspaceRowMenuTrackingScope.shouldSuppressCloseButton(
+            pointerInsideRow: isPointerInsideBounds(),
+            eventType: event?.type,
+            modifierFlags: event?.modifierFlags ?? []
+        )
+    }
+
+    private func reconcileCurrentPointerLocation() {
+        guard !isMenuTracking else {
+            reportPointerHovering(false)
+            return
+        }
+        guard window != nil else {
+            reportPointerHovering(false)
+            return
+        }
+        reportPointerHovering(isPointerInsideBounds())
+    }
+
+    private func isPointerInsideBounds() -> Bool {
+        guard let window else { return false }
+        let pointInWindow = window.mouseLocationOutsideOfEventStream
+        let pointInView = convert(pointInWindow, from: nil)
+        return bounds.contains(pointInView)
+    }
+
+    private func reportPointerHovering(_ hovering: Bool) {
+        guard lastReportedHover != hovering else { return }
+        lastReportedHover = hovering
+        onPointerHoverChanged?(hovering)
+    }
+}

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -75,3 +75,60 @@ struct SidebarWorkspaceSnapshotRefreshPolicy {
         )
     }
 }
+
+struct SidebarWorkspaceRowInteractionState: Equatable {
+    private(set) var isPointerHovering = false
+    private(set) var contextMenuVisible = false
+    private var contextMenuTrackingSuppressesCloseButton = false
+    private var deferredPointerHoveringWhileContextMenuTracking: Bool?
+
+    mutating func setPointerHovering(_ hovering: Bool) {
+        if contextMenuTrackingSuppressesCloseButton {
+            deferredPointerHoveringWhileContextMenuTracking = hovering
+            isPointerHovering = false
+            return
+        }
+        deferredPointerHoveringWhileContextMenuTracking = nil
+        isPointerHovering = hovering
+    }
+
+    mutating func contextMenuDidAppear() {
+        contextMenuVisible = true
+        contextMenuTrackingSuppressesCloseButton = true
+        deferredPointerHoveringWhileContextMenuTracking = nil
+        isPointerHovering = false
+    }
+
+    mutating func contextMenuDidDisappear() {
+        contextMenuVisible = false
+        contextMenuTrackingSuppressesCloseButton = false
+        applyDeferredPointerHovering()
+    }
+
+    mutating func contextMenuTrackingDidBegin() {
+        contextMenuTrackingSuppressesCloseButton = true
+        deferredPointerHoveringWhileContextMenuTracking = nil
+        isPointerHovering = false
+    }
+
+    mutating func contextMenuTrackingDidEnd() {
+        contextMenuTrackingSuppressesCloseButton = false
+        applyDeferredPointerHovering()
+    }
+
+    func shouldShowCloseButton(
+        canCloseWorkspace: Bool,
+        shortcutHintModeActive: Bool
+    ) -> Bool {
+        isPointerHovering
+            && !contextMenuTrackingSuppressesCloseButton
+            && canCloseWorkspace
+            && !shortcutHintModeActive
+    }
+
+    private mutating func applyDeferredPointerHovering() {
+        guard let deferredHover = deferredPointerHoveringWhileContextMenuTracking else { return }
+        self.deferredPointerHoveringWhileContextMenuTracking = nil
+        isPointerHovering = deferredHover
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -117,3 +117,20 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         )
     }
 }
+
+final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
+    func testHoverRevealIsIndependentFromStaleContextMenuVisibility() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.setPointerHovering(true)
+
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                showsWorkspaceShortcutHint: false
+            ),
+            "A stale context-menu lifecycle flag must not permanently suppress hover-only close affordances."
+        )
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -1,3 +1,5 @@
+import AppKit
+import SwiftUI
 import XCTest
 
 #if canImport(cmux_DEV)
@@ -123,14 +125,226 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
         var state = SidebarWorkspaceRowInteractionState()
 
         state.contextMenuDidAppear()
+        state.contextMenuTrackingDidEnd()
         state.setPointerHovering(true)
 
         XCTAssertTrue(
             state.shouldShowCloseButton(
                 canCloseWorkspace: true,
-                showsWorkspaceShortcutHint: false
+                shortcutHintModeActive: false
             ),
-            "A stale context-menu lifecycle flag must not permanently suppress hover-only close affordances."
+            "A stale SwiftUI context-menu lifecycle flag must not permanently suppress hover-only close affordances after AppKit menu tracking has ended."
+        )
+
+        state.setPointerHovering(false)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "The stale SwiftUI menu flag must not make the close affordance visible when the pointer is no longer hovering."
+        )
+    }
+
+    func testContextMenuTrackingBeginHidesExistingCloseButtonBeforeSwiftUIMenuAppears() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            )
+        )
+
+        state.contextMenuTrackingDidBegin()
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Right-click menu tracking must hide an already-visible close affordance even before SwiftUI reports the context menu appearance."
+        )
+    }
+
+    func testHoverDuringContextMenuTrackingStaysHiddenUntilTrackingEnds() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.setPointerHovering(true)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Pointer hover updates observed during context-menu tracking must not reveal the close affordance under the menu."
+        )
+
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Once AppKit menu tracking ends, the last reconciled pointer position may reveal the close affordance even if SwiftUI menu state is stale."
+        )
+    }
+
+    func testCoordinatorPreservesHoverExitWhileMenuTrackingSuppressesCloseButton() {
+        var state = SidebarWorkspaceRowInteractionState()
+        let binding = Binding<SidebarWorkspaceRowInteractionState>(
+            get: { state },
+            set: { state = $0 }
+        )
+        let coordinator = SidebarWorkspaceRowHoverTracker.Coordinator(
+            rowInteractionState: binding
+        )
+
+        coordinator.menuTrackingChanged(true)
+        coordinator.pointerHoverChanged(true)
+        coordinator.pointerHoverChanged(false)
+        coordinator.menuTrackingChanged(false)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "A pointer exit observed during menu tracking must overwrite any earlier deferred hover enter before the menu dismisses."
+        )
+    }
+
+    func testMenuTrackingSuppressionOnlyAppliesToPointerMenusInsideRow() {
+        XCTAssertTrue(
+            SidebarWorkspaceRowMenuTrackingScope.shouldSuppressCloseButton(
+                pointerInsideRow: true,
+                eventType: .rightMouseDown,
+                modifierFlags: []
+            )
+        )
+        XCTAssertTrue(
+            SidebarWorkspaceRowMenuTrackingScope.shouldSuppressCloseButton(
+                pointerInsideRow: true,
+                eventType: .leftMouseDown,
+                modifierFlags: .control
+            )
+        )
+        XCTAssertFalse(
+            SidebarWorkspaceRowMenuTrackingScope.shouldSuppressCloseButton(
+                pointerInsideRow: false,
+                eventType: .rightMouseDown,
+                modifierFlags: []
+            ),
+            "A menu opened outside this row must not suppress this row's hover state."
+        )
+        XCTAssertFalse(
+            SidebarWorkspaceRowMenuTrackingScope.shouldSuppressCloseButton(
+                pointerInsideRow: true,
+                eventType: .keyDown,
+                modifierFlags: []
+            ),
+            "Keyboard-driven or app-level menu tracking must not be treated like this row's pointer context menu."
+        )
+    }
+
+    func testPointerExitWhileContextMenuIsVisibleStaysHiddenAfterDismissal() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+        state.contextMenuDidAppear()
+        state.setPointerHovering(false)
+        state.contextMenuDidDisappear()
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Pointer exit remains authoritative even when it is observed during the context-menu lifecycle."
+        )
+    }
+
+    func testNoHoverDoesNotRevealCloseButtonWhileContextMenuIsVisible() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuDidAppear()
+        state.setPointerHovering(false)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "A visible context menu must not make the close affordance visible when the pointer is not hovering."
+        )
+    }
+
+    func testContextMenuAppearanceHidesExistingCloseButtonUntilPointerIsReconciled() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            )
+        )
+
+        state.contextMenuDidAppear()
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Opening a context menu must clear the row close affordance until tracking reports the pointer is still inside."
+        )
+    }
+
+    func testContextMenuDismissalCanRevealAfterPointerReconciliation() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+        state.contextMenuDidAppear()
+        state.contextMenuDidDisappear()
+        state.setPointerHovering(true)
+
+        XCTAssertTrue(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "Closing the context menu may reveal the close affordance again only after pointer tracking reconciles inside the row."
+        )
+    }
+
+    func testCloseButtonHiddenWhenWorkspaceCannotBeClosed() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: false,
+                shortcutHintModeActive: false
+            )
+        )
+    }
+
+    func testCloseButtonHiddenDuringShortcutHintMode() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.setPointerHovering(true)
+
+        XCTAssertFalse(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: true
+            )
         )
     }
 }


### PR DESCRIPTION
## Summary
- Adds a regression contract for workspace-row close hover visibility when context-menu lifecycle state is stale.
- Separates pointer hover state from context-menu snapshot-freeze state so stale menu state cannot suppress the close affordance.
- Replaces SwiftUI row `.onHover` with an AppKit row hover tracker that reconciles actual pointer position when menu tracking ends and hides the close button during right-click menu tracking.

## Demo Video
Not recorded. This PR changes a narrow hover/context-menu interaction in the native macOS sidebar; regression coverage and CI are the validation surface for the fix.

## Testing
- Not run locally per repository policy; GitHub Actions and CircleCI are the validation surface for this PR.
- CI must pass before the dev build is launched.

## Checklist
- [x] Regression coverage added for stale context-menu state and close-button hover visibility.
- [x] Right-click menu tracking case covered so the close button does not stay visible during menu presentation.
- [x] Current CodeRabbit implementation comments addressed on the latest head.
- [x] No local `xcodebuild` or local tests run.

Fixes #3545

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sidebar row hover and context-menu tracking by bridging to AppKit and adding new state logic, which could affect close-button visibility and pointer interaction edge cases.
> 
> **Overview**
> Fixes a sidebar regression where the workspace-row close button could stay hidden or incorrectly visible due to stale SwiftUI context-menu/hover state.
> 
> This replaces the row’s SwiftUI `.onHover` handling with an AppKit-backed `SidebarWorkspaceRowHoverTracker` and introduces `SidebarWorkspaceRowInteractionState` to separate pointer hover from context-menu visibility/tracking, ensuring hover is reconciled when menu tracking ends and suppressed during right-click tracking. Adds focused unit tests covering stale menu lifecycle and hover/close-button visibility behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27526fe5d091afe2246dbf3e41ef2bf84c83dc9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->