### PR TITLE
fix: open links in MarkdownPanelView via explicit OpenURLAction

### DIFF
--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -61,12 +61,15 @@ struct MarkdownPanelView: View {
                 Markdown(panel.content)
                     .markdownTheme(cmuxMarkdownTheme)
                     .textSelection(.enabled)
-                    // Explicit handler: pointer-observer overlay + .textSelection
-                    // suppress SwiftUI Link's default activation, leaving links
-                    // styled but un-clickable without this.
+                    // Wire link activation through NSWorkspace explicitly.
+                    // SwiftUI's default Link path does not fire reliably
+                    // for the rendered Markdown in this panel; setting the
+                    // env action makes it deterministic. Surface failures
+                    // (no registered handler for the scheme, etc.) by
+                    // returning .systemAction so the click is not silently
+                    // swallowed.
                     .environment(\.openURL, OpenURLAction { url in
-                        NSWorkspace.shared.open(url)
-                        return .handled
+                        NSWorkspace.shared.open(url) ? .handled : .systemAction
                     })
                     .padding(.horizontal, 24)
                     .padding(.vertical, 16)

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -61,6 +61,13 @@ struct MarkdownPanelView: View {
                 Markdown(panel.content)
                     .markdownTheme(cmuxMarkdownTheme)
                     .textSelection(.enabled)
+                    // Explicit handler: pointer-observer overlay + .textSelection
+                    // suppress SwiftUI Link's default activation, leaving links
+                    // styled but un-clickable without this.
+                    .environment(\.openURL, OpenURLAction { url in
+                        NSWorkspace.shared.open(url)
+                        return .handled
+                    })
                     .padding(.horizontal, 24)
                     .padding(.vertical, 16)
             }


### PR DESCRIPTION
# Fix: links in `MarkdownPanelView` are styled but never opened on click

## Summary

- **What changed?** Added an explicit `OpenURLAction` to the `Markdown(panel.content)` view in `Sources/Panels/MarkdownPanelView.swift` so link clicks inside the rendered `.md` panel route through `NSWorkspace.shared.open(url)`.
- **Why?** Without it, links are visually rendered (color-styled via `.link { ForegroundColor(...) }`) but clicking them does nothing. The combination of `MarkdownPanelPointerObserver` (left-click overlay used for first-click panel focus + event forwarding) and `.textSelection(.enabled)` interferes with SwiftUI `Link`'s default activation path, so the `\.openURL` environment is never invoked. Setting it explicitly mirrors the existing `NSWorkspace.shared.open(url)` pattern used everywhere else in `Sources/` (e.g. `ContentView.swift`, `SessionIndexView.swift`, `GhosttyTerminalView.swift`, `AuthManager.swift`, etc. — see `git grep "NSWorkspace.shared.open"`).

Diff:

```diff
                 Markdown(panel.content)
                     .markdownTheme(cmuxMarkdownTheme)
                     .textSelection(.enabled)
+                    // Explicit handler: pointer-observer overlay + .textSelection
+                    // suppress SwiftUI Link's default activation, leaving links
+                    // styled but un-clickable without this.
+                    .environment(\.openURL, OpenURLAction { url in
+                        NSWorkspace.shared.open(url)
+                        return .handled
+                    })
                     .padding(.horizontal, 24)
                     .padding(.vertical, 16)
```

Net: 7 added lines, 1 file (`Sources/Panels/MarkdownPanelView.swift`). No new imports — `AppKit` and `SwiftUI` are already imported.

## Scope (what this does NOT fix)

This PR is intentionally narrow. It fixes only the rendered `.md` file viewer panel (`MarkdownPanel` opened via `Workspace.openOrFocusMarkdownSplit(...)`).

It does **not** touch:

- The Ghostty terminal panel's OSC 8 hyperlink / cmd-click handling (separate code path in `Sources/GhosttyTerminalView.swift`'s `GHOSTTY_ACTION_OPEN_URL` case).
- Any link-related routing settings (`BrowserLinkOpenSettings`, `CmdClickMarkdownRouteSettings`, `BrowserAvailabilitySettings`).
- The cmd-click → markdown viewer routing for `.md` paths in terminals (#1283).

Related issues that this PR does **not** claim to resolve but might tangentially help:

- #1283 — handles incoming cmd-click → markdown panel routing, but once the user is inside that panel, links inside the rendered markdown still need this fix to become clickable.

## Testing

- **Local compile:** could not run a full `xcodebuild` build locally — `GhosttyKit.xcframework` requires `zig` (per `CONTRIBUTING.md`'s `./scripts/setup.sh`) which isn't installed in my environment. SourceKit-LSP diagnostics on the changed file are clean.
- **What I verified manually:** read every existing `OpenURLAction` and `NSWorkspace.shared.open` call site in `Sources/` — the new code matches the project's existing pattern. The `OpenURLAction` API and `NSWorkspace.shared.open(_:)` are both stable AppKit/SwiftUI APIs (macOS 11+ / 10.x+ respectively), well below the project's deployment target.
- **CI is the source of truth** here — please run the full build via the standard pipeline.
- **No new tests added** intentionally. AGENTS.md `Test quality policy` says "Tests must verify observable runtime behavior through executable paths" and "Do not add tests that only verify source code text". A unit test that asserts `OpenURLAction` is wired would be exactly the AST-shape test that policy forbids. The behavioral test is "open a `.md` file with a link in cmux's markdown panel, click the link, expect default handler to open" — that requires the running app and is therefore appropriate for a manual / E2E check, not a unit test.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: _<to be added by submitter — open any `.md` file with an http/https/file link in cmux's markdown panel and click; before this PR, the click does nothing; after, the URL opens in the default handler>_

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally — _blocked on `zig` / xcframework setup; CI build expected to validate_
- [x] I added or updated tests for behavior changes — _N/A; behavioral test would violate `Test quality policy` (would only assert AST shape). Verification path is manual / E2E in the running app._
- [ ] I updated docs/changelog if needed — _no user-facing docs changed; CHANGELOG.md update intentionally deferred since `/release` flow regenerates it_
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Links in markdown panels now open using the system URL handler (e.g., the default browser), preserving their original visual styling. If opening externally fails, the app falls back to the system's default handling to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->