### PR TITLE
fix: prevent recursive os_unfair_lock crash on cmd-clicked .md viewer route + drop fragment/query gate

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3829,6 +3829,11 @@ class GhosttyApp {
                             panelId: surfaceId,
                             preferredWorkspaceId: preferredWorkspaceId
                         )?.workspace ?? workspace
+                        // Re-apply the sync remote-surface gate; panel may have moved.
+                        guard !resolvedWorkspace.isRemoteTerminalSurface(surfaceId) else {
+                            NSWorkspace.shared.open(fileURL)
+                            return
+                        }
                         // TOCTOU re-check: file may have been removed/renamed
                         // since the synchronous gate. Fall through if so.
                         guard CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path) else {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3777,16 +3777,16 @@ class GhosttyApp {
                 return false
             }
             // Route markdown file URLs into the cmux viewer when the toggle is
-            // on AND the link is local + has no anchor/query. Anything else
-            // (toggle off, hosted file URL, #fragment, ?query, non-markdown,
-            // remote workspace, unreadable file, split creation failure) falls
-            // through to the existing NSWorkspace path below so the default-off
-            // behavior and URL semantics are preserved.
+            // on AND the link is local. URL fragments/queries are stripped (the
+            // panel only needs the file path), so links emitted by tools like
+            // Claude Code (`foo.md#L42`) still route into the viewer. Anything
+            // else (toggle off, hosted file URL, non-markdown, remote workspace,
+            // unreadable file, split creation failure) falls through to the
+            // existing NSWorkspace path below so the default-off behavior and
+            // URL semantics are preserved.
             let fileURLHost = target.url.host
             if CmdClickMarkdownRouteSettings.isEnabled(),
                target.url.isFileURL,
-               target.url.fragment == nil,
-               target.url.query == nil,
                fileURLHost == nil || fileURLHost?.isEmpty == true || fileURLHost == "localhost",
                CmdClickMarkdownRouteSettings.isMarkdownPath(target.url.path) {
                 let fileURL = target.url
@@ -3799,10 +3799,27 @@ class GhosttyApp {
                           CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path) else {
                         return false
                     }
-                    return workspace.openOrFocusMarkdownSplit(
-                        from: termSurface.id,
-                        filePath: fileURL.path
-                    ) != nil
+                    // Defer the split creation. Ghostty's Surface.openUrl holds
+                    // an internal lock when it dispatches into this Swift
+                    // handler; opening a new panel synchronously triggers
+                    // Surface.encodeKey on the focus path, which tries to
+                    // acquire the same lock and aborts (recursive os_unfair_lock
+                    // — see crash reports referenced in #3370). Running on the
+                    // next runloop tick lets Surface.openUrl return and release
+                    // the lock first.
+                    let surfaceId = termSurface.id
+                    DispatchQueue.main.async {
+                        guard workspace.openOrFocusMarkdownSplit(
+                            from: surfaceId,
+                            filePath: fileURL.path
+                        ) == nil else { return }
+                        // Async fallback: if the split could not be created
+                        // (e.g. the source pane disappeared between commit and
+                        // dispatch), surface the file through the system opener
+                        // so the click is not silently lost.
+                        NSWorkspace.shared.open(fileURL)
+                    }
+                    return true
                 }
                 if routed {
                     return true

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3800,13 +3800,24 @@ class GhosttyApp {
                         return false
                     }
                     // Defer the split creation. Ghostty's Surface.openUrl holds
-                    // an internal lock when it dispatches into this Swift
-                    // handler; opening a new panel synchronously triggers
+                    // an internal os_unfair_lock when it dispatches into this
+                    // Swift handler; opening a new panel synchronously triggers
                     // Surface.encodeKey on the focus path, which tries to
                     // acquire the same lock and aborts (recursive os_unfair_lock
-                    // — see crash reports referenced in #3370). Running on the
-                    // next runloop tick lets Surface.openUrl return and release
-                    // the lock first.
+                    // — see crash reports referenced in #3370).
+                    //
+                    // CAVEAT — timing-based mitigation: this works because the
+                    // Ghostty C side currently releases the surface lock within
+                    // the same runloop cycle that dispatches this callback,
+                    // which is an undocumented Ghostty implementation detail.
+                    // If a future Ghostty change moves the unlock to a later
+                    // tick, every Swift caller that re-enters Surface state
+                    // from inside performOnMain (not just this one) will
+                    // silently regress to the same crash. The structural fix
+                    // is to dispatch the OPEN_URL callback asynchronously from
+                    // C so the lock is always released before any Swift runs
+                    // — tracked in #3560. Until that lands, do NOT remove
+                    // this DispatchQueue.main.async.
                     let surfaceId = termSurface.id
                     DispatchQueue.main.async {
                         guard workspace.openOrFocusMarkdownSplit(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3818,16 +3818,30 @@ class GhosttyApp {
                     // C so the lock is always released before any Swift runs
                     // — tracked in #3560. Until that lands, do NOT remove
                     // this DispatchQueue.main.async.
+                    let preferredWorkspaceId = workspace.id
                     let surfaceId = termSurface.id
                     DispatchQueue.main.async {
-                        guard workspace.openOrFocusMarkdownSplit(
+                        // Re-resolve workspace at dispatch time: tabs can move
+                        // between workspaces in the runloop gap, so the
+                        // captured value may be stale. Mirrors the deferred
+                        // browser path's pattern.
+                        let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
+                            panelId: surfaceId,
+                            preferredWorkspaceId: preferredWorkspaceId
+                        ) ?? workspace
+                        // TOCTOU re-check: file may have been removed/renamed
+                        // since the synchronous gate. Fall through if so.
+                        guard CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path) else {
+                            NSWorkspace.shared.open(fileURL)
+                            return
+                        }
+                        guard resolvedWorkspace.openOrFocusMarkdownSplit(
                             from: surfaceId,
                             filePath: fileURL.path
                         ) == nil else { return }
-                        // Async fallback: if the split could not be created
-                        // (e.g. the source pane disappeared between commit and
-                        // dispatch), surface the file through the system opener
-                        // so the click is not silently lost.
+                        // Split creation failed (source pane gone between
+                        // commit and dispatch) — surface via system opener so
+                        // the click is not silently lost.
                         NSWorkspace.shared.open(fileURL)
                     }
                     return true

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3828,7 +3828,7 @@ class GhosttyApp {
                         let resolvedWorkspace = AppDelegate.shared?.workspaceContainingPanel(
                             panelId: surfaceId,
                             preferredWorkspaceId: preferredWorkspaceId
-                        ) ?? workspace
+                        )?.workspace ?? workspace
                         // TOCTOU re-check: file may have been removed/renamed
                         // since the synchronous gate. Fall through if so.
                         guard CmdClickMarkdownRouteSettings.shouldRoute(path: fileURL.path) else {


### PR DESCRIPTION
Closes #3370.
Extends partial coverage of #1283 (fragmented `.md` URLs now route through the viewer).

# Summary

- **What changed?** In `Sources/GhosttyTerminalView.swift`'s `GHOSTTY_ACTION_OPEN_URL` handler, the cmd-click `.md` viewer route (a) defers `Workspace.openOrFocusMarkdownSplit` to `DispatchQueue.main.async` instead of running synchronously inside `performOnMain`, and (b) no longer gates routing on `fragment == nil` / `query == nil`. An async `NSWorkspace.shared.open` fallback covers the rare case where deferred split creation fails.
- **Why?**
  1. **Crash fix (#3370).** With `openMarkdownInCmuxViewer: true`, cmd-clicking a real `.md` link inside a terminal pane crashes cmux on **stable 0.64.1** (reproduced) and on nightly per the original report. `Surface.openUrl` (Ghostty side) is holding an internal lock when it dispatches into the Swift handler; the synchronous `performOnMain` chain runs `openOrFocusMarkdownSplit -> newMarkdownSplit -> focusPanel -> applyTabSelectionNow -> Surface.encodeKey`, and `Surface.encodeKey` tries to re-acquire that same lock — \`BUG IN CLIENT OF LIBPLATFORM: Trying to recursively lock an os_unfair_lock\`, Abort Cause 259. Running the split creation on the next runloop tick lets \`Surface.openUrl\` return and release its lock first.
  2. **Routing coverage (#1283).** Tools like Claude Code routinely emit markdown links with line-anchor fragments (\`file:///abs/path/foo.md#L42\`). Under the previous \`fragment == nil\` / \`query == nil\` gate, those URLs fell through to \`NSWorkspace.shared.open\` and opened in the system editor (Xcode / VS Code / Typora) even when \`openMarkdownInCmuxViewer\` was on. The viewer's contract only consumes \`URL.path\` (which excludes fragment/query), so stripping happens automatically and the panel-state behavior is unchanged.

Net diff: 1 file, +28/-11 lines.

## Crash backtrace (cmux 0.64.1 stable, build 81, macOS 26.4.1, Apple Silicon)

\`\`\`
0  _os_unfair_lock_recursive_abort
1  _os_unfair_lock_lock_slow
2  Surface.encodeKey
3  Workspace.applyTabSelectionNow
4  Workspace.focusPanel
5  Workspace.newMarkdownSplit
6  Workspace.openOrFocusMarkdownSplit
7  closure #33 in GhosttyApp.handleAction
... performOnMain (synchronous, MainActor.assumeIsolated)
13 GhosttyApp.handleAction
14 @objc closure #2 in GhosttyApp.initializeGhostty
15 Surface.openUrl   ← holds the lock that frame 2 tries to re-acquire
16 @objc GhosttyNSView.mouseUp
... AppKit event delivery
\`\`\`

\`Surface.openUrl\` (Ghostty submodule) acquires the surface lock for the duration of the URL action callback. The Swift handler runs synchronously inside that window via \`performOnMain\` (\`@MainActor () -> T\`), so any panel/focus mutation that ends up in \`Surface.encodeKey\` deadlocks on the same \`os_unfair_lock\`. Deferring the panel mutation by one runloop tick is the smallest correct fix; it does not require Ghostty submodule changes.

## Why this also resolves the original #3370 stable report

The \`addisonlynch\` repro on 0.63.2 stable used a placeholder path (\`/any/path/to/file.md\`) that does not exist; \`CmdClickMarkdownRouteSettings.shouldRoute(path:)\` rejects unreadable paths, so on stable they hit the editor-fall-through branch and concluded "the setting is ignored." With a real \`.md\` file the same stable build hits the recursive-lock crash documented above (verified locally on 0.64.1 → identical commit as 0.63.2's mainline routing path). One bug, two reports.

## Scope (what this does NOT do)

- Does not touch \`Sources/GhosttyTerminalView.swift\`'s \`handleCommandClickRelease\` path (line 8526). That cmd-click-on-detected-path branch is not in the crash trace and is not entered through Ghostty's \`Surface.openUrl\` lock; touching it would risk regressions in a path that is currently working.
- Does not modify the markdown panel itself (\`MarkdownPanel.swift\` / \`MarkdownPanelView.swift\`).
- Does not address the broader feature request in #1283 to detect bare filenames at the terminal level — the existing OSC 8 / \`file://\` URL routing already handles those cases once toggled on. After this PR a wider class of \`file://\` URLs (those with anchors/queries) will reach that path.
- Does not change the default-off behavior. The gate still requires \`openMarkdownInCmuxViewer\` to be enabled.

## Testing

- **Manual reproduction:** with \`openMarkdownInCmuxViewer: true\` on stable 0.64.1, cmd-clicking a real \`.md\` link in a terminal pane reliably crashes the app with the trace above. See \`~/Library/Logs/DiagnosticReports/cmux-2026-05-06-010520.ips\` and \`cmux-2026-05-06-010546.ips\` (both produced during this investigation, both with identical recursive-lock signature).
- **Local compile:** could not run a full \`xcodebuild\` build locally — \`GhosttyKit.xcframework\` requires \`zig\` (per \`CONTRIBUTING.md\`'s \`./scripts/setup.sh\`) which isn't installed in my environment. SourceKit-LSP diagnostics on the changed file are clean. CI is the source of truth here.
- **No new tests added intentionally.** AGENTS.md \`Test quality policy\` says "Tests must verify observable runtime behavior through executable paths". A unit test that asserts \`DispatchQueue.main.async\` is wired would be exactly the AST-shape test that policy forbids. The behavioral test is "open a \`.md\` link with \`openMarkdownInCmuxViewer\` on and observe no crash" — that requires the running app and is appropriate for a manual / E2E check.

## Demo Video

For UI or behavior changes, include a short demo video.

- Video URL or attachment: _<to be added after a tagged-debug verification — the simplest demo is \`cmd+click\` on a \`.md\` link in a Claude Code chat pane: pre-PR the app crashes, post-PR the panel opens.>_

## Review Trigger (Copy/Paste as PR comment)

\`\`\`text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
\`\`\`

## Checklist

- [ ] I tested the change locally — _blocked on \`zig\` / xcframework setup; CI build expected to validate. The crash itself was verified on the user's stable 0.64.1 install (crash report attached above)._
- [x] I added or updated tests for behavior changes — _N/A; behavioral test would violate \`Test quality policy\` (would only assert AST shape). The verification path is manual / E2E in the running app._
- [ ] I updated docs/changelog if needed — _no user-facing docs changed; CHANGELOG.md update intentionally deferred since \`/release\` flow regenerates it._
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Local file:// Markdown links now route even if they include fragments or queries, and routing is limited to local hosts (empty or "localhost").
  * In-app Markdown split creation is deferred and re-validated before opening; if creating a split fails or validation changes, the file reliably opens in the system viewer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->