### PR TITLE
Keep Claude launch env and bypass opt-in

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -18185,11 +18185,17 @@ export default CMUXSessionRestore;
         guard item.canResolve else { return "Resolved or informational item" }
         switch item.kind {
         case "permissionRequest":
-            if item.source == "codex" {
+            if !feedTUISourceSupportsPersistentPermissionModes(item.source) {
                 return "Permission: Enter/o once, d deny"
+            }
+            if !feedTUISourceSupportsBypassPermissions(item.source) {
+                return "Permission: Enter/o once, a always, l all tools, d deny"
             }
             return "Permission: Enter/o once, a always, l all tools, b bypass, d deny"
         case "exitPlan":
+            if !feedTUISourceSupportsBypassPermissions(item.source) {
+                return "Plan: Enter default, a auto, m manual, u ultraplan, f replan, d deny"
+            }
             return "Plan: Enter default, a auto, m manual, u ultraplan, b bypass, f replan, d deny"
         case "question":
             let questionCount = max(item.questions.count, 1)
@@ -18210,6 +18216,14 @@ export default CMUXSessionRestore;
         }
     }
 
+    private func feedTUISourceSupportsPersistentPermissionModes(_ source: String) -> Bool {
+        source != "codex"
+    }
+
+    private func feedTUISourceSupportsBypassPermissions(_ source: String) -> Bool {
+        source != "codex" && source != "claude"
+    }
+
     private func resolveFeedTUIItem(
         _ item: FeedTUIItem,
         key: FeedTUIKey,
@@ -18227,11 +18241,11 @@ export default CMUXSessionRestore;
             switch key {
             case .enter, .once:
                 mode = "once"
-            case .always where item.source != "codex":
+            case .always where feedTUISourceSupportsPersistentPermissionModes(item.source):
                 mode = "always"
-            case .all where item.source != "codex":
+            case .all where feedTUISourceSupportsPersistentPermissionModes(item.source):
                 mode = "all"
-            case .bypass where item.source != "codex":
+            case .bypass where feedTUISourceSupportsBypassPermissions(item.source):
                 mode = "bypass"
             case .deny:
                 mode = "deny"
@@ -18264,7 +18278,7 @@ export default CMUXSessionRestore;
                 mode = "manual"
             case .ultraplan:
                 mode = "ultraplan"
-            case .bypass:
+            case .bypass where feedTUISourceSupportsBypassPermissions(item.source):
                 mode = "bypassPermissions"
             case .deny:
                 mode = "deny"
@@ -19116,12 +19130,6 @@ export default CMUXSessionRestore;
                 var updatedPermissions: [[String: Any]]?
                 if mode == "always" || mode == "all" {
                     updatedPermissions = rawObject["permission_suggestions"] as? [[String: Any]]
-                } else if mode == "bypass" {
-                    updatedPermissions = [[
-                        "type": "setMode",
-                        "mode": "bypassPermissions",
-                        "destination": "session",
-                    ]]
                 }
                 return encode(permissionRequestHookDecision(
                     behavior: "allow",
@@ -19180,12 +19188,6 @@ export default CMUXSessionRestore;
                     updatedPermissions = [[
                         "type": "setMode",
                         "mode": "auto",
-                        "destination": "session",
-                    ]]
-                } else if mode == "bypassPermissions" {
-                    updatedPermissions = [[
-                        "type": "setMode",
-                        "mode": "bypassPermissions",
                         "destination": "session",
                     ]]
                 }

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -72,6 +72,7 @@
 		A5B00005A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
 		FEED0000000000000000F005 /* FeedPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F004 /* FeedPanelView.swift */; };
+		FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F012 /* FeedPermissionActionPolicy.swift */; };
 		FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F010 /* FeedPanelViewModel.swift */; };
 		FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00A /* FeedPreviewWindowController.swift */; };
 		FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */; };
@@ -453,6 +454,7 @@
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
+		FEED0000000000000000F012 /* FeedPermissionActionPolicy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPermissionActionPolicy.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F010 /* FeedPanelViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelViewModel.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00A /* FeedPreviewWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPreviewWindowController.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedButtonStyleDebugWindowController.swift; sourceTree = "<group>"; };
@@ -877,6 +879,7 @@
 			children = (
 				FEED0000000000000000F001 /* FeedCoordinator.swift */,
 				FEED0000000000000000F004 /* FeedPanelView.swift */,
+				FEED0000000000000000F012 /* FeedPermissionActionPolicy.swift */,
 				FEED0000000000000000F010 /* FeedPanelViewModel.swift */,
 				FEED0000000000000000F00A /* FeedPreviewWindowController.swift */,
 				FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */,
@@ -1709,6 +1712,7 @@
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
 				FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */,
 				FEED0000000000000000F005 /* FeedPanelView.swift in Sources */,
+				FEED0000000000000000F013 /* FeedPermissionActionPolicy.swift in Sources */,
 				FEED0000000000000000F011 /* FeedPanelViewModel.swift in Sources */,
 				FEED0000000000000000F00B /* FeedPreviewWindowController.swift in Sources */,
 				FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */,

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -25,6 +25,7 @@ public enum ClaudeConfigDirectoryPath {
 
 public enum AgentLaunchEnvironmentPolicy {
     private static let safeEnvironmentKeys: Set<String> = [
+        "ANTHROPIC_BASE_URL",
         "ANTHROPIC_MODEL",
         "CLAUDE_CONFIG_DIR",
         "CMUX_CUSTOM_CLAUDE_PATH",

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -73,8 +73,6 @@ resolve_hook_cmux_bin() {
 
 CLAUDE_AUTH_SELECTION_ENV_KEYS=(
     ANTHROPIC_API_KEY
-    ANTHROPIC_AUTH_TOKEN
-    ANTHROPIC_BASE_URL
     ANTHROPIC_MODEL
     ANTHROPIC_SMALL_FAST_MODEL
     CLAUDE_CODE_USE_BEDROCK
@@ -288,20 +286,6 @@ for arg in "$@"; do
     esac
 done
 
-# Claude only honors a PermissionRequest `setMode` update to
-# `bypassPermissions` when bypass has been made available at launch.
-# This flag exposes bypass as an option without enabling it by default,
-# so the Feed Bypass button can switch modes later in the session.
-CMUX_BYPASS_AVAILABILITY_ARGS=(--allow-dangerously-skip-permissions)
-for arg in "$@"; do
-    case "$arg" in
-        --allow-dangerously-skip-permissions|--dangerously-skip-permissions)
-            CMUX_BYPASS_AVAILABILITY_ARGS=()
-            break
-            ;;
-    esac
-done
-
 # Export the wrapper's PID. Because we exec claude below, this PID becomes
 # the actual claude process PID, which hooks use for stale-session detection.
 export CMUX_CLAUDE_PID=$$
@@ -336,8 +320,8 @@ fi
 HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
-    exec "$REAL_CLAUDE" "${CMUX_BYPASS_AVAILABILITY_ARGS[@]}" --settings "$HOOKS_JSON" "$@"
+    exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-    exec "$REAL_CLAUDE" "${CMUX_BYPASS_AVAILABILITY_ARGS[@]}" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
 fi

--- a/Resources/feed-tui/index.ts
+++ b/Resources/feed-tui/index.ts
@@ -669,11 +669,17 @@ class FeedApp {
     }
     switch (item.kind) {
       case "permissionRequest":
-        if (item.source === "codex") {
+        if (!sourceSupportsPersistentPermissionModes(item.source)) {
           return "Enter once | d deny";
+        }
+        if (!sourceSupportsBypassPermissions(item.source)) {
+          return "Enter once | a always | l all | d deny";
         }
         return "Enter once | a always | l all | b bypass | d deny";
       case "exitPlan":
+        if (!sourceSupportsBypassPermissions(item.source)) {
+          return "Enter default | a auto | m manual | u ultra | f replan | d deny";
+        }
         return "Enter default | a auto | m manual | u ultra | b bypass | f replan | d deny";
       case "question":
         if (item.questionOptions.length === 0) {
@@ -714,14 +720,20 @@ class FeedApp {
     }
     switch (item.kind) {
       case "permissionRequest":
-        if (item.source === "codex") {
+        if (!sourceSupportsPersistentPermissionModes(item.source)) {
           // Codex PermissionRequest hooks only accept allow/deny for this
-          // invocation. Persistent allow/bypass modes are Claude/OpenCode-only.
+          // invocation. Persistent permission modes are agent-specific.
           return ["deny"].includes(action);
         }
-        return ["deny", "always", "all", "bypass"].includes(action);
+        return (
+          ["deny", "always", "all"].includes(action) ||
+          (action === "bypass" && sourceSupportsBypassPermissions(item.source))
+        );
       case "exitPlan":
-        return ["deny", "always", "manual", "ultraplan", "bypass"].includes(action);
+        return (
+          ["deny", "always", "manual", "ultraplan"].includes(action) ||
+          (action === "bypass" && sourceSupportsBypassPermissions(item.source))
+        );
       case "question":
         return action === "default" || action.startsWith("option:");
       default:
@@ -1055,6 +1067,14 @@ function isKey(key: KeyEvent, ...names: string[]): boolean {
 
 function isCtrlC(key: KeyEvent): boolean {
   return (key.ctrl && isKey(key, "c")) || key.sequence === "\u0003" || key.raw === "\u0003";
+}
+
+function sourceSupportsPersistentPermissionModes(source: string): boolean {
+  return source !== "codex";
+}
+
+function sourceSupportsBypassPermissions(source: string): boolean {
+  return source !== "codex" && source !== "claude";
 }
 
 function actionForKey(key: KeyEvent): string | undefined {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -2,7 +2,6 @@ import AppKit
 import Bonsplit
 import CMUXWorkstream
 import SwiftUI
-
 #if DEBUG
 private func feedDebugResponderSummary(_ responder: NSResponder?) -> String {
     guard let responder else { return "nil" }
@@ -43,17 +42,6 @@ private extension WorkstreamExitPlanMode {
         }
     }
 }
-
-enum FeedPermissionActionPolicy {
-    static func supportsPersistentPermissionModes(source: WorkstreamSource) -> Bool {
-        source != .codex
-    }
-
-    static func supportsBypassPermissions(source: WorkstreamSource) -> Bool {
-        source != .codex && source != .claude
-    }
-}
-
 /// Right-sidebar Feed view. Matches the Sessions page visual language:
 /// compact rows with SF Symbol + 13pt title + secondary metadata,
 /// full-width hover backgrounds, and control-bar pill buttons styled

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -44,6 +44,16 @@ private extension WorkstreamExitPlanMode {
     }
 }
 
+enum FeedPermissionActionPolicy {
+    static func supportsPersistentPermissionModes(source: WorkstreamSource) -> Bool {
+        source != .codex
+    }
+
+    static func supportsBypassPermissions(source: WorkstreamSource) -> Bool {
+        source != .codex && source != .claude
+    }
+}
+
 /// Right-sidebar Feed view. Matches the Sessions page visual language:
 /// compact rows with SF Symbol + 13pt title + secondary metadata,
 /// full-width hover backgrounds, and control-bar pill buttons styled
@@ -1387,10 +1397,12 @@ private struct PermissionActionArea: View {
                     FeedButton(label: String(localized: "feed.permission.once", defaultValue: "Allow Once"),
                                kind: .light, size: .medium, fullWidth: true) { onApprove(.once) }
                         .accessibilityIdentifier("FeedPermissionAllowOnceButton")
-                    if source != .codex {
+                    if FeedPermissionActionPolicy.supportsPersistentPermissionModes(source: source) {
                         FeedButton(label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
                                    kind: .primary, size: .medium, fullWidth: true) { onApprove(.always) }
                             .accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
+                    }
+                    if FeedPermissionActionPolicy.supportsBypassPermissions(source: source) {
                         FeedButton(label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
                                    kind: .destructive, size: .medium, fullWidth: true) { onApprove(.bypass) }
                             .accessibilityIdentifier("FeedPermissionBypassButton")

--- a/Sources/Feed/FeedPermissionActionPolicy.swift
+++ b/Sources/Feed/FeedPermissionActionPolicy.swift
@@ -1,0 +1,11 @@
+import CMUXWorkstream
+
+enum FeedPermissionActionPolicy {
+    static func supportsPersistentPermissionModes(source: WorkstreamSource) -> Bool {
+        source != .codex
+    }
+
+    static func supportsBypassPermissions(source: WorkstreamSource) -> Bool {
+        source != .codex && source != .claude
+    }
+}

--- a/Sources/TerminalStartupEnvironment.swift
+++ b/Sources/TerminalStartupEnvironment.swift
@@ -8,8 +8,6 @@ extension TerminalSurface {
 
     private static let inheritedClaudeAuthSelectionEnvironmentKeys: Set<String> = [
         "ANTHROPIC_API_KEY",
-        "ANTHROPIC_AUTH_TOKEN",
-        "ANTHROPIC_BASE_URL",
         "ANTHROPIC_MODEL",
         "ANTHROPIC_SMALL_FAST_MODEL",
         "CLAUDE_CODE_USE_BEDROCK",

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -8,6 +8,17 @@ import CMUXWorkstream
 #endif
 
 final class FeedCoordinatorTests: XCTestCase {
+    func testClaudePermissionActionPolicyKeepsBypassUserOwned() {
+        XCTAssertTrue(FeedPermissionActionPolicy.supportsPersistentPermissionModes(source: .claude))
+        XCTAssertFalse(FeedPermissionActionPolicy.supportsBypassPermissions(source: .claude))
+
+        XCTAssertFalse(FeedPermissionActionPolicy.supportsPersistentPermissionModes(source: .codex))
+        XCTAssertFalse(FeedPermissionActionPolicy.supportsBypassPermissions(source: .codex))
+
+        XCTAssertTrue(FeedPermissionActionPolicy.supportsPersistentPermissionModes(source: .opencode))
+        XCTAssertTrue(FeedPermissionActionPolicy.supportsBypassPermissions(source: .opencode))
+    }
+
     func testBlockingIngestExpiresItemWhenHookTimesOut() async {
         await MainActor.run {
             let store = WorkstreamStore(ringCapacity: 10)

--- a/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
+++ b/cmuxTests/GhosttyTerminalStartupEnvironmentTests.swift
@@ -102,12 +102,12 @@ final class GhosttyTerminalStartupEnvironmentTests: XCTestCase {
         XCTAssertEqual(merged["TERM_PROGRAM"], TerminalSurface.managedTerminalProgram)
     }
 
-    func testMergedStartupEnvironmentNeutralizesInheritedClaudeApiAuthSelection() {
+    func testMergedStartupEnvironmentPreservesThirdPartyClaudeApiEnvironment() {
         let merged = TerminalSurface.mergedStartupEnvironment(
             base: [
                 "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
                 "ANTHROPIC_API_KEY": "stale-api-key",
-                "ANTHROPIC_AUTH_TOKEN": "stale-auth-token",
+                "ANTHROPIC_AUTH_TOKEN": "third-party-auth-token",
                 "ANTHROPIC_BASE_URL": "https://api.example.test",
                 "ANTHROPIC_MODEL": "stale-model",
                 "CUSTOM_FLAG": "1"
@@ -119,13 +119,13 @@ final class GhosttyTerminalStartupEnvironmentTests: XCTestCase {
 
         XCTAssertEqual(merged["CLAUDE_CONFIG_DIR"], "/tmp/claude-config")
         XCTAssertEqual(merged["ANTHROPIC_API_KEY"], "")
-        XCTAssertEqual(merged["ANTHROPIC_AUTH_TOKEN"], "")
-        XCTAssertEqual(merged["ANTHROPIC_BASE_URL"], "")
+        XCTAssertEqual(merged["ANTHROPIC_AUTH_TOKEN"], "third-party-auth-token")
+        XCTAssertEqual(merged["ANTHROPIC_BASE_URL"], "https://api.example.test")
         XCTAssertEqual(merged["ANTHROPIC_MODEL"], "")
         XCTAssertEqual(merged["CUSTOM_FLAG"], "1")
     }
 
-    func testMergedStartupEnvironmentNeutralizesAmbientClaudeApiAuthSelection() {
+    func testMergedStartupEnvironmentDoesNotMaskAmbientThirdPartyClaudeApiEnvironment() {
         let merged = TerminalSurface.mergedStartupEnvironment(
             base: [
                 "CUSTOM_FLAG": "1"
@@ -144,8 +144,8 @@ final class GhosttyTerminalStartupEnvironmentTests: XCTestCase {
 
         XCTAssertNil(merged["CLAUDE_CONFIG_DIR"])
         XCTAssertEqual(merged["ANTHROPIC_API_KEY"], "")
-        XCTAssertEqual(merged["ANTHROPIC_AUTH_TOKEN"], "")
-        XCTAssertEqual(merged["ANTHROPIC_BASE_URL"], "")
+        XCTAssertNil(merged["ANTHROPIC_AUTH_TOKEN"])
+        XCTAssertNil(merged["ANTHROPIC_BASE_URL"])
         XCTAssertEqual(merged["ANTHROPIC_MODEL"], "")
         XCTAssertEqual(merged["CUSTOM_FLAG"], "1")
     }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1893,6 +1893,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
                 arguments: ["claude"],
                 workingDirectory: nil,
                 environment: [
+                    "ANTHROPIC_AUTH_TOKEN": "third-party-auth-token",
+                    "ANTHROPIC_BASE_URL": "https://api.example.test",
                     "ANTHROPIC_MODEL": "",
                     "PATH": " /tmp/bin ",
                     "UNSAFE_TOKEN": "secret"
@@ -1904,8 +1906,9 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "'env' 'ANTHROPIC_MODEL=' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=ANTHROPIC_MODEL' 'claude' '--resume' 'claude-session-env'"
+            "'env' 'ANTHROPIC_BASE_URL=https://api.example.test' 'ANTHROPIC_MODEL=' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=ANTHROPIC_BASE_URL,ANTHROPIC_MODEL' 'claude' '--resume' 'claude-session-env'"
         )
+        XCTAssertFalse(snapshot.resumeCommand?.contains("ANTHROPIC_AUTH_TOKEN") ?? true)
     }
 
     func testClaudeResumeCommandStripsStaleCmuxNodeOptionsRestoreModule() {

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -323,7 +323,7 @@ exit 0
         return proc.returncode, auth_env, read_lines(args_log), proc.stderr.strip()
 
 
-def test_live_socket_injects_supported_hooks(failures: list[str]) -> None:
+def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="live",
         argv=["hello"],
@@ -331,11 +331,12 @@ def test_live_socket_injects_supported_hooks(failures: list[str]) -> None:
     expect(code == 0, f"live socket: wrapper exited {code}: {stderr}", failures)
     expect("--settings" in real_argv, f"live socket: missing --settings in args: {real_argv}", failures)
     expect("--session-id" in real_argv, f"live socket: missing --session-id in args: {real_argv}", failures)
-    expect(
-        "--allow-dangerously-skip-permissions" in real_argv,
-        f"live socket: missing bypass availability flag in args: {real_argv}",
-        failures,
-    )
+    for flag in ("--allow-dangerously-skip-permissions", "--dangerously-skip-permissions"):
+        expect(
+            flag not in real_argv,
+            f"live socket: wrapper should not unlock bypass permissions via {flag}: {real_argv}",
+            failures,
+        )
     expect(real_argv[-1] == "hello", f"live socket: expected original arg to pass through, got {real_argv}", failures)
     expect(any(" ping" in line for line in cmux_log), f"live socket: expected cmux ping, got {cmux_log}", failures)
     expect(
@@ -415,11 +416,11 @@ def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> 
     expect(argv[0].endswith("/real-bin/claude"), f"plain claude: expected real claude executable, got {argv}", failures)
 
 
-def test_live_socket_clears_inherited_claude_auth_for_fresh_launch(failures: list[str]) -> None:
+def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures: list[str]) -> None:
     inherited = {
         "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
         "ANTHROPIC_API_KEY": "stale-api-key",
-        "ANTHROPIC_AUTH_TOKEN": "stale-auth-token",
+        "ANTHROPIC_AUTH_TOKEN": "third-party-auth-token",
         "ANTHROPIC_BASE_URL": "https://api.example.test",
         "ANTHROPIC_MODEL": "stale-model",
         "ANTHROPIC_SMALL_FAST_MODEL": "stale-small-model",
@@ -427,14 +428,20 @@ def test_live_socket_clears_inherited_claude_auth_for_fresh_launch(failures: lis
         "CLAUDE_CODE_USE_VERTEX": "1",
     }
     code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["--dangerously-skip-permissions"],
+        argv=["hello"],
         inherited_env=inherited,
     )
     expect(code == 0, f"fresh auth env: wrapper exited {code}: {stderr}", failures)
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == "/tmp/claude-config", f"fresh auth env: expected CLAUDE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
-    for key in inherited:
-        if key == "CLAUDE_CONFIG_DIR":
-            continue
+    expect(auth_env.get("ANTHROPIC_AUTH_TOKEN") == "third-party-auth-token", f"fresh auth env: expected ANTHROPIC_AUTH_TOKEN preserved, got {auth_env.get('ANTHROPIC_AUTH_TOKEN')!r}", failures)
+    expect(auth_env.get("ANTHROPIC_BASE_URL") == "https://api.example.test", f"fresh auth env: expected ANTHROPIC_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BASE_URL')!r}", failures)
+    for key in [
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_MODEL",
+        "ANTHROPIC_SMALL_FAST_MODEL",
+        "CLAUDE_CODE_USE_BEDROCK",
+        "CLAUDE_CODE_USE_VERTEX",
+    ]:
         expect(auth_env.get(key) == "__UNSET__", f"fresh auth env: expected {key} unset, got {auth_env.get(key)!r}", failures)
     expect("--session-id" in real_argv, f"fresh auth env: expected session injection, got {real_argv}", failures)
 
@@ -545,14 +552,25 @@ def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[
     expect(child_node_options == "__UNSET__", f"tmpdir failure: expected child NODE_OPTIONS passthrough, got {child_node_options!r}", failures)
 
 
-def test_live_socket_does_not_duplicate_bypass_availability_flag(failures: list[str]) -> None:
-    code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
-        socket_state="live",
-        argv=["--allow-dangerously-skip-permissions", "hello"],
-    )
-    expect(code == 0, f"bypass flag dedupe: wrapper exited {code}: {stderr}", failures)
-    count = real_argv.count("--allow-dangerously-skip-permissions")
-    expect(count == 1, f"bypass flag dedupe: expected one allow flag, got {count} in {real_argv}", failures)
+def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[str]) -> None:
+    cases = [
+        ("allow/plain", ["--allow-dangerously-skip-permissions", "hello"], True, "--allow-dangerously-skip-permissions"),
+        ("allow/resume", ["--allow-dangerously-skip-permissions", "--resume", "some-session-id"], False, "--allow-dangerously-skip-permissions"),
+        ("short/plain", ["--dangerously-skip-permissions", "hello"], True, "--dangerously-skip-permissions"),
+        ("short/resume", ["--dangerously-skip-permissions", "--resume", "some-session-id"], False, "--dangerously-skip-permissions"),
+    ]
+    for label, argv, expects_session_id, expected_flag in cases:
+        code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=argv,
+        )
+        expect(code == 0, f"explicit bypass flag ({label}): wrapper exited {code}: {stderr}", failures)
+        count = real_argv.count(expected_flag)
+        expect(count == 1, f"explicit bypass flag ({label}): expected one {expected_flag}, got {count} in {real_argv}", failures)
+        if expects_session_id:
+            expect("--session-id" in real_argv, f"explicit bypass flag ({label}): expected injected session id, got {real_argv}", failures)
+        else:
+            expect("--session-id" not in real_argv, f"explicit bypass flag ({label}): expected no injected session id, got {real_argv}", failures)
 
 
 def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> None:
@@ -638,15 +656,15 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
 
 def main() -> int:
     failures: list[str] = []
-    test_live_socket_injects_supported_hooks(failures)
+    test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
-    test_live_socket_clears_inherited_claude_auth_for_fresh_launch(failures)
+    test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
-    test_live_socket_does_not_duplicate_bypass_availability_flag(failures)
+    test_live_socket_preserves_explicit_bypass_availability_flag(failures)
     test_live_socket_stale_mktemp_literal_does_not_warn(failures)
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)


### PR DESCRIPTION
## Summary
- Keep cmux's Claude wrapper from adding bypass-permissions flags to plain hooked `claude` launches.
- Preserve user-provided `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` through fresh terminal startup and the live wrapper exec path.
- Keep `ANTHROPIC_AUTH_TOKEN` out of persisted/resume metadata while allowing non-secret `ANTHROPIC_BASE_URL` to restore.
- Gate Feed/TUI bypass controls for Claude so cmux does not offer a mid-session bypass path that Claude cannot honor without explicit launch opt-in.
- Keep the NODE_OPTIONS restore shim, hook injection, session tracking, and stale Claude selector cleanup intact.

## Root Cause
Two launch-contract changes in the same regression window mutated Claude inputs that cmux should not own. The wrapper exposed bypass permission availability by default, which made normal `claude` starts trip Claude's dangerous-mode path. Separately, Claude auth-selection cleanup treated third-party endpoint credentials as stale inherited state, causing cmux to mask `ANTHROPIC_BASE_URL` and `ANTHROPIC_AUTH_TOKEN` before Claude Code started.

## Test Plan
- `python3 -m py_compile tests/test_claude_wrapper_hooks.py`
- `bash -n Resources/bin/claude`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`
- `plutil -lint GhosttyTabs.xcodeproj/project.pbxproj`
- `git diff --check`
- Local regression/unit tests were not executed per repo policy; CI should run them.

Closes #3547
Closes #3548