### PR TITLE
Fix v0.64.1 bundled CLI launch crash

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -184,7 +184,7 @@
 		A5001226 /* SocketControlSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001225 /* SocketControlSettings.swift */; };
 		A5001230 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = A5001231 /* Sparkle */; };
 		A5001240 /* WindowDecorationsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001241 /* WindowDecorationsController.swift */; };
-		A5001250 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A5001253 /* Sentry-Dynamic */; };
+		A5001250 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 		A5001270 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = A5001271 /* PostHog */; };
 		A5001290 /* MarkdownUI in Frameworks */ = {isa = PBXBuildFile; productRef = A5001291 /* MarkdownUI */; };
 		A50012F1 /* Backport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50012F0 /* Backport.swift */; };
@@ -296,7 +296,7 @@
 		B9000023A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */; };
 		B9000130A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */; };
 		F0F0A001A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */; };
-		B9000024A1B2C3D4E5F60719 /* Sentry-Dynamic in Frameworks */ = {isa = PBXBuildFile; productRef = A5001253 /* Sentry-Dynamic */; };
+		B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = A5001251 /* Sentry */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
 		B9000027A1B2C3D4E5F60719 /* RemoteRelayZshBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001641 /* RemoteRelayZshBootstrap.swift */; };
 		C0B4D9B0A1B2C3D4E5F60718 /* UpdatePillUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0B4D9B1A1B2C3D4E5F60718 /* UpdatePillUITests.swift */; };
@@ -801,7 +801,7 @@
 			files = (
 				A5001006 /* GhosttyKit.xcframework in Frameworks */,
 				A5001230 /* Sparkle in Frameworks */,
-				A5001250 /* Sentry-Dynamic in Frameworks */,
+				A5001250 /* Sentry in Frameworks */,
 				A5001270 /* PostHog in Frameworks */,
 				A5001290 /* MarkdownUI in Frameworks */,
 				5EDB6027B346C46521A93C74 /* CMUXAuthCore in Frameworks */,
@@ -824,7 +824,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B9000024A1B2C3D4E5F60719 /* Sentry-Dynamic in Frameworks */,
+				B9000024A1B2C3D4E5F60719 /* Sentry in Frameworks */,
 				A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1304,7 +1304,7 @@
 			name = GhosttyTabs;
 			packageProductDependencies = (
 				A5001231 /* Sparkle */,
-				A5001253 /* Sentry-Dynamic */,
+				A5001251 /* Sentry */,
 				A5001271 /* PostHog */,
 				A5001261 /* Bonsplit */,
 				A5001291 /* MarkdownUI */,
@@ -1333,7 +1333,7 @@
 			);
 			name = "cmux-cli";
 			packageProductDependencies = (
-				A5001253 /* Sentry-Dynamic */,
+				A5001251 /* Sentry */,
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 			);
 			productName = cmux;
@@ -2385,11 +2385,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
-		};
-		A5001253 /* Sentry-Dynamic */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = A5001252 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = "Sentry-Dynamic";
 		};
 		A5001261 /* Bonsplit */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
 		51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */; };
+		C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35530000000000000102 /* BundledCLILinkageTests.swift */; };
 		C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
 		C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A10000000000000002 /* CmuxConfigUI.swift */; };
@@ -593,6 +594,7 @@
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
 		A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRovoDevHookPersistenceTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
+		C0DE35530000000000000102 /* BundledCLILinkageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledCLILinkageTests.swift; sourceTree = "<group>"; };
 		A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeHookRegressionTests.swift; sourceTree = "<group>"; };
 		A5001101 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		A5001211 /* UpdateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/UpdateController.swift; sourceTree = "<group>"; };
@@ -1265,6 +1267,7 @@
 					A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */,
 					A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 					A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
+					C0DE35530000000000000102 /* BundledCLILinkageTests.swift */,
 					A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */,
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
@@ -1874,6 +1877,7 @@
 					A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
 					A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */,
 					A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
+					C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */,
 					A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
 				C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,

--- a/cmuxTests/BundledCLILinkageTests.swift
+++ b/cmuxTests/BundledCLILinkageTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 
 final class BundledCLILinkageTests: XCTestCase {
+    deinit {}
+
     func testBundledCLIDoesNotDependOnPrivateRPathFrameworks() throws {
         let cliURL = try bundledCLIURL()
         let linkedLibraries = try linkedLibraries(for: cliURL)
@@ -37,21 +39,20 @@ final class BundledCLILinkageTests: XCTestCase {
 
     private func linkedLibraries(for executableURL: URL) throws -> [String] {
         let process = Process()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
+        let outputPipe = Pipe()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/otool")
         process.arguments = ["-L", executableURL.path]
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
 
         try process.run()
+        let outputData = outputPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
 
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        XCTAssertEqual(process.terminationStatus, 0, "otool failed: \(stderr)")
+        let output = String(data: outputData, encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "otool failed: \(output)")
 
-        return stdout
+        return output
             .split(separator: "\n")
             .dropFirst()
             .compactMap { line -> String? in

--- a/cmuxTests/BundledCLILinkageTests.swift
+++ b/cmuxTests/BundledCLILinkageTests.swift
@@ -1,0 +1,64 @@
+import XCTest
+
+final class BundledCLILinkageTests: XCTestCase {
+    func testBundledCLIDoesNotDependOnPrivateRPathFrameworks() throws {
+        let cliURL = try bundledCLIURL()
+        let linkedLibraries = try linkedLibraries(for: cliURL)
+        let privateRPathFrameworks = linkedLibraries.filter {
+            $0.hasPrefix("@rpath/") && $0.contains(".framework/")
+        }
+
+        XCTAssertEqual(
+            privateRPathFrameworks,
+            [],
+            "The bundled cmux CLI is copied into Contents/Resources/bin as a standalone helper. Private @rpath framework dependencies abort in dyld before CLI code can run."
+        )
+    }
+
+    private func bundledCLIURL() throws -> URL {
+        let fileManager = FileManager.default
+        let appBundleURL = Bundle(for: Self.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+
+        while let item = enumerator?.nextObject() as? URL {
+            guard item.lastPathComponent == "cmux",
+                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
+                continue
+            }
+            return item
+        }
+
+        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+    }
+
+    private func linkedLibraries(for executableURL: URL) throws -> [String] {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/otool")
+        process.arguments = ["-L", executableURL.path]
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        XCTAssertEqual(process.terminationStatus, 0, "otool failed: \(stderr)")
+
+        return stdout
+            .split(separator: "\n")
+            .dropFirst()
+            .compactMap { line -> String? in
+                line.trimmingCharacters(in: .whitespacesAndNewlines)
+                    .split(separator: " ")
+                    .first
+                    .map(String.init)
+            }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/3553

## Summary
- Pinpointed the launch crash from recent macOS DiagnosticReports: `EXC_CRASH/SIGABRT` in DYLD before Swift code runs, with `Library not loaded: @rpath/Sentry.framework/Versions/A/Sentry` referenced from `Contents/Resources/bin/cmux`.
- Restored the project to the single static `Sentry` package product so the copied bundled CLI helper is self-contained again. This avoids both the launch-time missing framework and Xcode's duplicate `Sentry.framework` output when static and dynamic Sentry products are mixed.
- Added an artifact-level regression test that fails if the bundled `Resources/bin/cmux` helper has private `@rpath/*.framework` dependencies.

## Verification
- `git diff --check`
- `plutil -lint GhosttyTabs.xcodeproj/project.pbxproj`
- Local XCTest/build not run per repo/user policy; CI should exercise the new regression.

## Notes
- Reporter environment: cmux v0.64.1 on macOS 26.4.1 Apple Silicon M1, immediate crash after update.
- Local evidence was from cmux DiagnosticReports on May 5, 2026 with the same launch-time DYLD missing-library signature.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Xcode package product linkage for Sentry across app/CLI targets, which can affect build outputs and runtime loading of the shipped CLI helper. Adds a new binary-inspection XCTest that may be sensitive to build/package layout changes.
> 
> **Overview**
> Prevents the bundled `Contents/Resources/bin/cmux` helper from crashing at launch by updating the Xcode project to use the `Sentry` Swift Package product (removing `Sentry-Dynamic`) for both the app and `cmux-cli` targets.
> 
> Adds `BundledCLILinkageTests` which locates the bundled CLI binary and uses `otool -L` to assert it has **no** private `@rpath/*.framework` dependencies, skipping if the helper isn’t present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a83c6751dc408e75d874be5ad1edd8400dc562b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a test that verifies the bundled CLI binary’s linked libraries to guard against unintended private framework dependencies; it skips if the helper is missing and fails on unexpected linkage or tool errors.

* **Chores**
  * Updated Xcode project wiring and build configuration, and adjusted Swift package integration across targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->