### PR TITLE
Fix Finder image drops into Claude Code terminals

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		36CE99ED050785B5E96B72BB /* AuthCallbackRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A19A4145F034965110CF87 /* AuthCallbackRouter.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
 		46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */; };
+		C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C35610000000000000000002 /* FinderFileDropRegressionTests.swift */; };
 		51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */; };
 		C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
@@ -439,6 +440,7 @@
 
 /* Begin PBXFileReference section */
 		02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalAndGhosttyTests.swift; sourceTree = "<group>"; };
+		C35610000000000000000002 /* FinderFileDropRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FinderFileDropRegressionTests.swift; sourceTree = "<group>"; };
 		D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalTabDragRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWebViewDragRoutingTests.swift; sourceTree = "<group>"; };
 		D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropRoutingTests.swift; sourceTree = "<group>"; };
@@ -1218,6 +1220,7 @@
 				D0B1000DA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift */,
 					D0B1000FA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift */,
 					02FC74F2C27127CC565B3E8C /* TerminalAndGhosttyTests.swift */,
+					C35610000000000000000002 /* FinderFileDropRegressionTests.swift */,
 					3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */,
 					D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */,
 					D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */,
@@ -1826,6 +1829,7 @@
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,
 				D0B1000EA1B2C3D4E5F60001 /* BrowserPaneDropRoutingTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,
+				C35610000000000000000001 /* FinderFileDropRegressionTests.swift in Sources */,
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6313,16 +6313,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func servicePathURLs(from pasteboard: NSPasteboard) -> [URL] {
-        if let pathURLs = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL], !pathURLs.isEmpty {
+        let pathURLs = PasteboardFileURLReader.fileURLs(from: pasteboard)
+        if !pathURLs.isEmpty {
             return pathURLs
-        }
-
-        let filenamesType = NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")
-        if let paths = pasteboard.propertyList(forType: filenamesType) as? [String] {
-            let urls = paths.map { URL(fileURLWithPath: $0) }
-            if !urls.isEmpty {
-                return urls
-            }
         }
 
         if let raw = pasteboard.string(forType: .string), !raw.isEmpty {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -30,19 +30,24 @@ enum DragOverlayRoutingPolicy {
     }
 
     static func hasFileURL(_ pasteboardTypes: [NSPasteboard.PasteboardType]?) -> Bool {
-        guard let pasteboardTypes else { return false }
-        return pasteboardTypes.contains(.fileURL)
+        PasteboardFileURLReader.hasFileURLType(pasteboardTypes ?? [])
     }
 
     static func shouldCaptureFileDropDestination(
         pasteboardTypes: [NSPasteboard.PasteboardType]?,
         hasLocalDraggingSource: Bool
     ) -> Bool {
-        // File URL drops are routed at the Bonsplit pane layer so center/edge
-        // drop targets stay visible and the host can open previews or splits.
-        _ = hasLocalDraggingSource
+        // External Finder file drops need the stable root AppKit destination so
+        // terminal/browser panes receive their shared file insertion/upload path.
+        // Internal cmux drag payloads keep their dedicated pane routing.
         guard hasFileURL(pasteboardTypes) else { return false }
-        return false
+        guard !hasFilePreviewTransfer(pasteboardTypes),
+              !hasBonsplitTabTransfer(pasteboardTypes),
+              !hasSidebarTabReorder(pasteboardTypes) else {
+            return false
+        }
+        guard !hasLocalDraggingSource else { return false }
+        return true
     }
 
     static func shouldCaptureFileDropDestination(
@@ -148,7 +153,7 @@ final class FileDropOverlayView: NSView {
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        registerForDraggedTypes([.fileURL])
+        registerForDraggedTypes(Array(PasteboardFileURLReader.fileURLPasteboardTypes))
     }
 
     required init?(coder: NSCoder) { fatalError("init(coder:) not implemented") }
@@ -493,7 +498,7 @@ final class FileDropOverlayView: NSView {
 
         let interestingTypes = types.filter { type in
             let raw = type.rawValue
-            return raw == NSPasteboard.PasteboardType.fileURL.rawValue
+            return PasteboardFileURLReader.fileURLPasteboardTypes.contains(type)
                 || raw == DragOverlayRoutingPolicy.bonsplitTabTransferType.rawValue
                 || raw == DragOverlayRoutingPolicy.sidebarTabReorderType.rawValue
                 || raw.contains("public.text")
@@ -510,7 +515,7 @@ final class FileDropOverlayView: NSView {
 
     private func hasRelevantDragTypes(_ types: [NSPasteboard.PasteboardType]?) -> Bool {
         guard let types else { return false }
-        return types.contains(.fileURL)
+        return DragOverlayRoutingPolicy.hasFileURL(types)
             || types.contains(DragOverlayRoutingPolicy.bonsplitTabTransferType)
             || types.contains(DragOverlayRoutingPolicy.sidebarTabReorderType)
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5760,9 +5760,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case reject
     }
 
-    private static let dropTypes: Set<NSPasteboard.PasteboardType> = [
+    private static let dropTypes: Set<NSPasteboard.PasteboardType> = PasteboardFileURLReader.fileURLPasteboardTypes.union([
         .string,
-        .fileURL,
         .URL,
         .png,
         .tiff,
@@ -5770,7 +5769,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         NSPasteboard.PasteboardType(UTType.gif.identifier),
         NSPasteboard.PasteboardType(UTType.heic.identifier),
         NSPasteboard.PasteboardType(UTType.heif.identifier)
-    ]
+    ])
     private static let tabTransferPasteboardType = NSPasteboard.PasteboardType("com.splittabbar.tabtransfer")
     private static let sidebarTabReorderPasteboardType = NSPasteboard.PasteboardType("com.cmux.sidebar-tab-reorder")
 

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -28,6 +28,51 @@ enum TerminalImageTransferPreparedContent: Equatable {
     case reject
 }
 
+enum PasteboardFileURLReader {
+    static let legacyFilenamesPboardType = NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")
+    static let fileURLPasteboardTypes: Set<NSPasteboard.PasteboardType> = [
+        .fileURL,
+        legacyFilenamesPboardType
+    ]
+
+    static func hasFileURLType(_ pasteboardTypes: [NSPasteboard.PasteboardType]) -> Bool {
+        return pasteboardTypes.contains { fileURLPasteboardTypes.contains($0) }
+    }
+
+    static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
+        var fileURLs: [URL] = []
+
+        let objects = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) ?? []
+        for object in objects {
+            if let url = object as? URL, url.isFileURL {
+                fileURLs.append(url.standardizedFileURL)
+            }
+        }
+
+        if let paths = pasteboard.propertyList(forType: legacyFilenamesPboardType) as? [String] {
+            fileURLs.append(
+                contentsOf: paths
+                    .filter { !$0.isEmpty }
+                    .map { URL(fileURLWithPath: $0).standardizedFileURL }
+            )
+        }
+
+        if let rawFileURL = pasteboard.string(forType: .fileURL),
+           let url = URL(string: rawFileURL),
+           url.isFileURL {
+            fileURLs.append(url.standardizedFileURL)
+        }
+
+        var seen: Set<String> = []
+        return fileURLs.filter { url in
+            seen.insert(url.path).inserted
+        }
+    }
+}
+
 enum TerminalImageTransferExecutionError: Error {
     case cancelled
 }
@@ -313,10 +358,7 @@ enum TerminalImageTransferPlanner {
     }
 
     private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {
-        guard let urls = pasteboard.readObjects(forClasses: [NSURL.self]) as? [URL] else {
-            return []
-        }
-        return urls.filter(\.isFileURL)
+        PasteboardFileURLReader.fileURLs(from: pasteboard)
     }
 
     private static func finishUpload(

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -49,6 +49,13 @@ final class FinderFileDropRegressionTests: XCTestCase {
             ),
             "Bonsplit tab drags can also advertise file URLs and must not be hijacked by the file-drop overlay"
         )
+        XCTAssertFalse(
+            DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
+                pasteboardTypes: [.fileURL],
+                hasLocalDraggingSource: true
+            ),
+            "Unknown local file drags should stay off the root overlay unless they are proven external"
+        )
     }
 
     func testLegacyFinderFilenameDropPlanInsertsEscapedLocalPath() throws {

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class FinderFileDropRegressionTests: XCTestCase {
+    private func make1x1PNG(color: NSColor) throws -> Data {
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        color.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        image.unlockFocus()
+        let tiffData = try XCTUnwrap(image.tiffRepresentation)
+        let bitmap = try XCTUnwrap(NSBitmapImageRep(data: tiffData))
+        return try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
+    }
+
+    func testOverlayCapturesExternalFileDropsButNotInternalPreviewDrags() {
+        XCTAssertTrue(
+            DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
+                pasteboardTypes: [.fileURL],
+                hasLocalDraggingSource: false
+            ),
+            "Finder file drops should use the root AppKit overlay so terminal inputs receive the shared file-path insertion path"
+        )
+        XCTAssertTrue(
+            DragOverlayRoutingPolicy.shouldCaptureFileDropOverlay(
+                pasteboardTypes: [.fileURL],
+                eventType: .leftMouseDragged
+            )
+        )
+
+        XCTAssertFalse(
+            DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
+                pasteboardTypes: [.fileURL, DragOverlayRoutingPolicy.filePreviewTransferType],
+                hasLocalDraggingSource: true
+            ),
+            "Internal file-preview drags carry a dedicated cmux transfer type and should stay on pane/file-preview routing"
+        )
+        XCTAssertFalse(
+            DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
+                pasteboardTypes: [.fileURL, DragOverlayRoutingPolicy.bonsplitTabTransferType],
+                hasLocalDraggingSource: true
+            ),
+            "Bonsplit tab drags can also advertise file URLs and must not be hijacked by the file-drop overlay"
+        )
+    }
+
+    func testLegacyFinderFilenameDropPlanInsertsEscapedLocalPath() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("finder legacy \(UUID().uuidString)")
+            .appendingPathExtension("png")
+        try make1x1PNG(color: .systemBlue).write(to: fileURL)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
+        let pasteboard = NSPasteboard(name: .init("cmux-test-legacy-filename-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        pasteboard.setPropertyList(
+            [fileURL.path],
+            forType: NSPasteboard.PasteboardType(rawValue: "NSFilenamesPboardType")
+        )
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: false
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected local path insertion, got \(plan)")
+        }
+
+        XCTAssertEqual(text, TerminalImageTransferPlanner.escapeForShell(fileURL.path))
+    }
+}

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2518,7 +2518,7 @@ final class FileDropOverlayViewTests: XCTestCase {
         )
     }
 
-    func testOverlayDoesNotCaptureFileDragLifecycleWhenPanePreviewDropsAreEnabled() {
+    func testOverlayForwardsExternalFileDragLifecycleToBrowserWebViews() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),
             styleMask: [.titled, .closable],
@@ -2566,15 +2566,15 @@ final class FileDropOverlayViewTests: XCTestCase {
             pasteboard: pasteboard
         )
 
-        XCTAssertEqual(overlay.draggingEntered(dragInfo), [])
-        XCTAssertFalse(overlay.prepareForDragOperation(dragInfo))
-        XCTAssertFalse(overlay.performDragOperation(dragInfo))
+        XCTAssertEqual(overlay.draggingEntered(dragInfo), .copy)
+        XCTAssertTrue(overlay.prepareForDragOperation(dragInfo))
+        XCTAssertTrue(overlay.performDragOperation(dragInfo))
         overlay.concludeDragOperation(dragInfo)
 
         XCTAssertEqual(
             webView.dragCalls,
-            [],
-            "Finder file drops should reach pane-level Bonsplit preview targets instead of the root overlay"
+            ["entered", "prepare", "perform", "conclude"],
+            "Finder file drops should keep browser uploads working while the root overlay owns the external file drag destination"
         )
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/3561.

## Summary
- restore the root AppKit file-drop overlay as the external Finder file URL destination
- keep internal cmux file-preview/tab/sidebar drag payloads on their existing pane routes
- share file URL pasteboard parsing across terminal paste/drop and macOS Services, including public.file-url and legacy NSFilenamesPboardType
- keep browser pane file uploads flowing through the overlay forwarding path

## Verification
- Added a test-only commit first to prove external file drops must route to terminal input and legacy Finder filenames must insert an escaped local path.
- Ran  locally.
- Did not run local tests or builds per task policy; CI will verify before the required dev reload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AppKit drag-and-drop routing and pasteboard file URL parsing, which can impact multiple drop/paste entry points and internal drag payloads. Risk is mitigated by added regression coverage for external vs internal drags and legacy Finder filename drops.
> 
> **Overview**
> Fixes external Finder file/image drops by **routing external file URL drags to the root `FileDropOverlayView` destination** while explicitly excluding internal cmux drag payloads (file preview transfer, Bonsplit tab transfer, sidebar reorder) from being captured.
> 
> Introduces `PasteboardFileURLReader` to **normalize file URL extraction** (including legacy `NSFilenamesPboardType`) and reuses it across terminal drop/paste handling and macOS Services path resolution; updates drop type registration to include all supported file URL pasteboard types.
> 
> Adds regression tests (`FinderFileDropRegressionTests`) and updates `WindowAndDragTests` to assert the overlay **forwards the full drag lifecycle** to portal-hosted `WKWebView` targets so browser uploads still work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02627db249fba1d9b1be012eb7664045737d281f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores Finder image/file drops into Claude Code terminals by routing external file URLs to the root overlay and standardizing file URL parsing, while keeping browser uploads working. Fixes #3561.

- **Bug Fixes**
  - Route external Finder file URLs to the root AppKit overlay; insert a shell-escaped local path into terminal input.
  - Do not capture internal cmux drags (file preview, Bonsplit tab transfer, sidebar reorder).
  - Forward overlay drag lifecycle to `WKWebView` targets so browser pane uploads keep working.
  - Add regression coverage for overlay routing and legacy `NSFilenamesPboardType` drops inserting escaped paths.

- **Refactors**
  - Introduce `PasteboardFileURLReader` to normalize file URL parsing (supports `public.file-url` and `NSFilenamesPboardType`, de-duplicates and standardizes paths).
  - Use the shared reader across terminal paste/drop and macOS Services; update overlay and `GhosttyNSView` drop-type registration to include all supported file URL types.

<sup>Written for commit 02627db249fba1d9b1be012eb7664045737d281f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file drag-and-drop compatibility with support for both modern and legacy drop methods.
  * Enhanced detection and routing of external file drops to properly distinguish them from internal drag operations.

* **Tests**
  * Added regression tests for legacy file drop handling.
  * Updated drag-and-drop lifecycle tests to validate proper behavior during file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->