### PR TITLE
Fix sidebar scroller visibility

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9783,10 +9783,6 @@ struct VerticalTabsSidebar: View {
     private var sidebarMatchTerminalBackground = false
 
     private let tabRowSpacing: CGFloat = 2
-    private var workspaceScrollTopVisibilityInset: CGFloat {
-        SidebarWorkspaceListMetrics.scrollTopInset
-    }
-
     private var sidebarTitlebarInteractionHeight: CGFloat {
         MinimalModeChromeMetrics.titlebarHeight
     }
@@ -9983,12 +9979,16 @@ struct VerticalTabsSidebar: View {
     }
 
     private func workspaceScrollArea(renderContext: WorkspaceListRenderContext) -> some View {
-        GeometryReader { geometryProxy in
+        let scrollInsets = SidebarWorkspaceScrollInsets.workspaceList
+        return GeometryReader { geometryProxy in
             ScrollViewReader { scrollProxy in
                 ScrollView {
                     workspaceScrollContent(
                         renderContext: renderContext,
-                        minHeight: geometryProxy.size.height
+                        minHeight: SidebarWorkspaceScrollLayout.contentMinHeight(
+                            viewportHeight: geometryProxy.size.height,
+                            insets: scrollInsets
+                        )
                     )
                 }
                 .background(
@@ -9998,11 +9998,11 @@ struct VerticalTabsSidebar: View {
                     .frame(width: 0, height: 0)
                 )
                 .safeAreaInset(edge: .top, spacing: 0) {
-                    Color.clear.frame(height: workspaceScrollTopVisibilityInset)
+                    Color.clear.frame(height: scrollInsets.top)
                         .allowsHitTesting(false)
                 }
                 .safeAreaInset(edge: .bottom, spacing: 0) {
-                    Color.clear.frame(height: sidebarBottomScrimHeight)
+                    Color.clear.frame(height: scrollInsets.bottom)
                         .allowsHitTesting(false)
                 }
                 .overlay(alignment: .top) {
@@ -10024,7 +10024,7 @@ struct VerticalTabsSidebar: View {
                     if draggedTabId != nil, let firstWorkspaceId = renderContext.workspaceIds.first {
                         Color.clear
                             .contentShape(Rectangle())
-                            .frame(height: workspaceScrollTopVisibilityInset + 8)
+                            .frame(height: scrollInsets.top + 8)
                             .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: SidebarTabDropDelegate(
                                 targetTabId: firstWorkspaceId,
                                 tabManager: tabManager,

--- a/Sources/WindowChromeMetrics.swift
+++ b/Sources/WindowChromeMetrics.swift
@@ -38,3 +38,26 @@ enum SidebarWorkspaceListMetrics {
         max(0, firstRowTopOffset - rowVerticalPadding)
     }
 }
+
+struct SidebarWorkspaceScrollInsets: Equatable {
+    static let workspaceList = SidebarWorkspaceScrollInsets(
+        top: SidebarWorkspaceListMetrics.scrollTopInset,
+        bottom: SidebarWorkspaceListMetrics.bottomScrimHeight
+    )
+
+    let top: CGFloat
+    let bottom: CGFloat
+
+    nonisolated var total: CGFloat {
+        top + bottom
+    }
+}
+
+enum SidebarWorkspaceScrollLayout {
+    nonisolated static func contentMinHeight(
+        viewportHeight: CGFloat,
+        insets: SidebarWorkspaceScrollInsets
+    ) -> CGFloat {
+        max(0, viewportHeight - insets.total)
+    }
+}

--- a/cmuxUITests/WorkspaceSidebarScrollUITests.swift
+++ b/cmuxUITests/WorkspaceSidebarScrollUITests.swift
@@ -43,6 +43,40 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
         )
     }
 
+    func testSidebarScrollerVisibilityFollowsWorkspaceOverflow() {
+        let app = XCUIApplication()
+        configureLaunch(app)
+        launchAndEnsureRunning(app)
+        XCTAssertTrue(waitForWindowCount(atLeast: 1, app: app, timeout: 8.0), "Expected a main window")
+        XCTAssertTrue(
+            waitForWorkspaceRowHittable(index: 1, count: 1, app: app, timeout: 8.0),
+            "Expected the initial workspace row to be visible"
+        )
+
+        let sidebar = app.descendants(matching: .any)["Sidebar"].firstMatch
+        XCTAssertTrue(sidebar.waitForExistence(timeout: 5.0), "Expected the workspace sidebar to exist")
+        XCTAssertTrue(
+            waitForSidebarVerticalScrollerHidden(app: app, sidebar: sidebar, timeout: 4.0),
+            "Expected the sidebar scroller to hide when the workspace content fits"
+        )
+
+        let workspaceCount = 20
+        for expectedCount in 2...workspaceCount {
+            app.typeKey("n", modifierFlags: [.command])
+            XCTAssertTrue(
+                waitForWorkspaceRowHittable(index: expectedCount, count: expectedCount, app: app, timeout: 6.0),
+                "Expected the newly selected workspace \(expectedCount) to be visible"
+            )
+        }
+
+        sidebar.coordinate(withNormalizedOffset: CGVector(dx: 0.97, dy: 0.5)).hover()
+        sidebar.swipeUp()
+        XCTAssertTrue(
+            waitForSidebarVerticalScrollerVisible(app: app, sidebar: sidebar, timeout: 4.0),
+            "Expected the sidebar scroller to appear when the workspace content overflows"
+        )
+    }
+
     private func configureLaunch(_ app: XCUIApplication) {
         app.launchArguments += ["-newWorkspacePlacement", "end"]
         app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
@@ -86,6 +120,43 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
     private func waitForWindowCount(atLeast count: Int, app: XCUIApplication, timeout: TimeInterval) -> Bool {
         pollUntil(timeout: timeout) {
             app.windows.count >= count
+        }
+    }
+
+    private func waitForSidebarVerticalScrollerHidden(
+        app: XCUIApplication,
+        sidebar: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        pollUntil(timeout: timeout) {
+            visibleSidebarVerticalScrollers(app: app, sidebar: sidebar).isEmpty
+        }
+    }
+
+    private func waitForSidebarVerticalScrollerVisible(
+        app: XCUIApplication,
+        sidebar: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        pollUntil(timeout: timeout) {
+            !visibleSidebarVerticalScrollers(app: app, sidebar: sidebar).isEmpty
+        }
+    }
+
+    private func visibleSidebarVerticalScrollers(
+        app: XCUIApplication,
+        sidebar: XCUIElement
+    ) -> [XCUIElement] {
+        guard sidebar.exists else { return [] }
+        let sidebarFrame = sidebar.frame
+        return app.descendants(matching: .scrollBar).allElementsBoundByIndex.filter { scroller in
+            guard scroller.exists, scroller.isHittable else { return false }
+            let frame = scroller.frame
+            guard frame.width > 0, frame.height > frame.width else { return false }
+            return frame.midX >= sidebarFrame.minX
+                && frame.midX <= sidebarFrame.maxX
+                && frame.maxY > sidebarFrame.minY
+                && frame.minY < sidebarFrame.maxY
         }
     }
 

--- a/cmuxUITests/WorkspaceSidebarScrollUITests.swift
+++ b/cmuxUITests/WorkspaceSidebarScrollUITests.swift
@@ -2,6 +2,7 @@ import XCTest
 
 final class WorkspaceSidebarScrollUITests: XCTestCase {
     private let topTitlebarWorkspaceClearance: CGFloat = 32
+    private let maxSidebarOverflowWorkspaceCount = 80
 
     override func setUp() {
         super.setUp()
@@ -60,20 +61,25 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
             "Expected the sidebar scroller to hide when the workspace content fits"
         )
 
-        let workspaceCount = 20
-        for expectedCount in 2...workspaceCount {
+        let overflowProbeStartCount = sidebarOverflowProbeStartCount(app: app, sidebar: sidebar)
+        var overflowReached = false
+        for expectedCount in 2...maxSidebarOverflowWorkspaceCount {
             app.typeKey("n", modifierFlags: [.command])
             XCTAssertTrue(
                 waitForWorkspaceRowHittable(index: expectedCount, count: expectedCount, app: app, timeout: 6.0),
                 "Expected the newly selected workspace \(expectedCount) to be visible"
             )
+
+            guard expectedCount >= overflowProbeStartCount else { continue }
+            if revealSidebarVerticalScroller(app: app, sidebar: sidebar, timeout: 1.0) {
+                overflowReached = true
+                break
+            }
         }
 
-        sidebar.coordinate(withNormalizedOffset: CGVector(dx: 0.97, dy: 0.5)).hover()
-        sidebar.swipeUp()
         XCTAssertTrue(
-            waitForSidebarVerticalScrollerVisible(app: app, sidebar: sidebar, timeout: 4.0),
-            "Expected the sidebar scroller to appear when the workspace content overflows"
+            overflowReached,
+            "Expected the sidebar scroller to appear before creating \(maxSidebarOverflowWorkspaceCount) workspaces"
         )
     }
 
@@ -117,6 +123,15 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
             .firstMatch
     }
 
+    private func sidebarOverflowProbeStartCount(app: XCUIApplication, sidebar: XCUIElement) -> Int {
+        let firstRow = workspaceRow(index: 1, count: 1, app: app)
+        guard sidebar.exists, firstRow.exists else { return 8 }
+
+        let rowHeight = max(firstRow.frame.height, 1)
+        let visibleRows = Int(ceil(sidebar.frame.height / rowHeight))
+        return min(maxSidebarOverflowWorkspaceCount, max(3, visibleRows + 1))
+    }
+
     private func waitForWindowCount(atLeast count: Int, app: XCUIApplication, timeout: TimeInterval) -> Bool {
         pollUntil(timeout: timeout) {
             app.windows.count >= count
@@ -141,6 +156,19 @@ final class WorkspaceSidebarScrollUITests: XCTestCase {
         pollUntil(timeout: timeout) {
             !visibleSidebarVerticalScrollers(app: app, sidebar: sidebar).isEmpty
         }
+    }
+
+    private func revealSidebarVerticalScroller(
+        app: XCUIApplication,
+        sidebar: XCUIElement,
+        timeout: TimeInterval
+    ) -> Bool {
+        sidebar.coordinate(withNormalizedOffset: CGVector(dx: 0.97, dy: 0.5)).hover()
+        if waitForSidebarVerticalScrollerVisible(app: app, sidebar: sidebar, timeout: min(0.25, timeout)) {
+            return true
+        }
+        sidebar.swipeUp()
+        return waitForSidebarVerticalScrollerVisible(app: app, sidebar: sidebar, timeout: timeout)
     }
 
     private func visibleSidebarVerticalScrollers(


### PR DESCRIPTION
Fixes #3555.

## Summary
- Restores sidebar scroller visibility to the real overflow state instead of decorative sidebar chrome.
- Centralizes workspace sidebar scroll insets and content min-height arithmetic in Swift-5-compatible value types with member-level nonisolated accessors.
- Adds regression UI coverage for fit-versus-overflow sidebar scroller behavior.

## Commit Structure
1. `b31e8199` adds the failing regression test proving the sidebar scroller must hide when workspace content fits and appear after overflow.
2. `b7b416b6` fixes the scroll container invariant and makes the overflow portion of the regression test probe only after a measured dynamic threshold.

## Verification
- Remote-only per task instruction; no local tests were run.
- PR CI and review feedback are being handled through the iterate-pr loop before the required final tagged launch verification.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined workspace sidebar scrolling layout, spacing, and min-height calculation to better handle varying viewport sizes and safe-area insets.
  * Adjusted top/bottom safe-area and drag-indicator spacing for more consistent visual alignment and scrolling behavior.
* **Tests**
  * Added a UI test that verifies the workspace sidebar scrollbar appears as the workspace list grows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts sidebar scroll insets/min-height calculations that affect workspace list overflow and drag/drop hit areas, so regressions could impact scrolling or drop targets across window sizes. Adds UI coverage to reduce risk but behavior is still UI-layout sensitive.
> 
> **Overview**
> Restores workspace sidebar scrollbar visibility to track *real list overflow* by centralizing top/bottom scroll insets and using them when computing the scroll content minimum height (instead of implicitly including decorative chrome).
> 
> Refactors `ContentView.workspaceScrollArea` to use the new `SidebarWorkspaceScrollInsets`/`SidebarWorkspaceScrollLayout` helpers for safe-area insets and the top drag/drop drop-zone height.
> 
> Adds `WorkspaceSidebarScrollUITests.testSidebarScrollerVisibilityFollowsWorkspaceOverflow` to assert the scroller is hidden when content fits and becomes visible once enough workspaces are created, using a dynamic probe threshold to reduce flakiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acf7eacc431cb2e6d686671799a80d6e969767f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->