### PR TITLE
Keep AppKit image updates on the main thread

### DIFF
--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -40,6 +40,14 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     }
 
     func setDockTile(_ dockTile: NSDockTile?) {
+        Self.performOnMain { [self] in
+            setDockTileOnMain(dockTile)
+        }
+    }
+
+    private func setDockTileOnMain(_ dockTile: NSDockTile?) {
+        Self.assertMainQueue()
+
         if let iconChangeObserver {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
             self.iconChangeObserver = nil
@@ -53,7 +61,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         iconChangeObserver = DistributedNotificationCenter.default().addObserver(
             forName: cmuxAppIconDidChangeNotification,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] _ in
             guard let self else { return }
             self.updateDockTile(dockTile)
@@ -91,6 +99,15 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     }
 
     private func updateDockTile(_ dockTile: NSDockTile) {
+        Self.performOnMain { [weak self] in
+            guard let self else { return }
+            self.updateDockTileOnMain(dockTile)
+        }
+    }
+
+    private func updateDockTileOnMain(_ dockTile: NSDockTile) {
+        Self.assertMainQueue()
+
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
         let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
@@ -117,6 +134,20 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         dockTile.showIcon(icon)
     }
 
+    private static func performOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
+    }
+
+    fileprivate static func assertMainQueue() {
+        #if DEBUG
+        dispatchPrecondition(condition: .onQueue(.main))
+        #endif
+    }
+
     /// Determine the enclosing app bundle for the dock tile plugin bundle.
     static func appBundleURL(for pluginBundleURL: URL) -> URL? {
         var url = pluginBundleURL
@@ -137,20 +168,20 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
 private extension NSDockTile {
     func showDefaultAppIcon() {
-        DispatchQueue.main.async {
-            self.contentView = nil
-            self.display()
-        }
+        CmuxDockTilePlugin.assertMainQueue()
+
+        contentView = nil
+        display()
     }
 
     func showIcon(_ newIcon: NSImage) {
-        DispatchQueue.main.async {
-            let iconView = NSImageView(frame: CGRect(origin: .zero, size: self.size))
-            iconView.wantsLayer = true
-            iconView.image = newIcon
-            self.contentView = iconView
-            self.display()
-        }
+        CmuxDockTilePlugin.assertMainQueue()
+
+        let iconView = NSImageView(frame: CGRect(origin: .zero, size: size))
+        iconView.wantsLayer = true
+        iconView.image = newIcon
+        contentView = iconView
+        display()
     }
 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -15267,6 +15267,10 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     }
 
     func updateIcon() {
+        #if DEBUG
+        dispatchPrecondition(condition: .onQueue(.main))
+        #endif
+
         let icon = NSWorkspace.shared.icon(forFile: directory)
         icon.size = NSSize(width: 16, height: 16)
         imageView.image = icon

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1486,7 +1486,7 @@ final class FileExplorerHeaderView: NSView {
     }
 
     private func applyHeaderState() {
-        let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); let config = NSImage.SymbolConfiguration(pointSize: 11, weight: .regular)
         if let quickSearchQuery {
             iconView.image = NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)?
                 .withSymbolConfiguration(config)
@@ -1580,7 +1580,7 @@ final class FileExplorerCellView: NSTableCellView {
     }
 
     func configure(with node: FileExplorerNode, gitStatus: GitFileStatus? = nil) {
-        let style = FileExplorerStyle.current
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); let style = FileExplorerStyle.current
 
         nameLabel.stringValue = node.name
         nameLabel.font = style.nameFont

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4295,6 +4295,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
         additionalEnvironment: [String: String] = [:],
         focusPlacement: TerminalSurfaceFocusPlacement = .workspace
     ) {
+        #if DEBUG
+        dispatchPrecondition(condition: .onQueue(.main))
+        #endif
+
         self.id = UUID()
         self.tabId = tabId
         self.surfaceContext = context
@@ -9678,6 +9682,10 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     init(surfaceView: GhosttyNSView) {
+        #if DEBUG
+        dispatchPrecondition(condition: .onQueue(.main))
+        #endif
+
         self.surfaceView = surfaceView
         backgroundView = NSView(frame: .zero)
         scrollView = GhosttyScrollView()

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1904,7 +1904,7 @@ private final class FilePreviewPDFThumbnailItemView: NSView {
     }
 
     func configure(image: NSImage?, pageNumber: String) {
-        imageView.image = image
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); imageView.image = image
         pageLabel.stringValue = pageNumber
     }
 
@@ -3199,7 +3199,7 @@ private final class FilePreviewImageContainerView: NSView {
     }
 
     func setURL(_ url: URL) {
-        guard currentURL != url else { return }
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); guard currentURL != url else { return }
         currentURL = url
         documentView.imageView.image = nil
         imageSize = normalizedSize(.zero)
@@ -3220,7 +3220,7 @@ private final class FilePreviewImageContainerView: NSView {
     }
 
     private func applyLoadedImage(_ image: NSImage?) {
-        documentView.imageView.image = image
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); documentView.imageView.image = image
         imageSize = normalizedSize(image?.size ?? .zero)
         isFitMode = true
         rotationDegrees = 0
@@ -3727,7 +3727,7 @@ private final class FilePreviewMagnifyingImageView: NSImageView {
     }
 
     override func draw(_ dirtyRect: NSRect) {
-        guard let image, rotationDegrees != 0 else {
+        assert(Thread.isMainThread, "AppKit image updates must run on the main thread"); guard let image, rotationDegrees != 0 else {
             super.draw(dirtyRect)
             return
         }


### PR DESCRIPTION
## Summary
- route dock tile setup/update through the main queue before AppKit, NSWorkspace, LaunchServices, or NSDockTile mutations
- add DEBUG-only main-queue tripwires around nearby NSImageView image paths implicated by the crash audit

Fixes #3590

## Verification
- ./scripts/reload.sh --tag fix-3590-main-thread-image-views
- git diff --check

## Not tested
- deterministic crash repro, because issue #3590 has no known repro path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts thread/queue handling for Dock tile and several AppKit image update paths; while mostly wrappers and DEBUG assertions, incorrect dispatching could still affect UI timing or introduce missed updates.
> 
> **Overview**
> Routes Dock tile setup/update through the main queue before mutating `NSDockTile`, `NSWorkspace`, and LaunchServices, including switching the distributed icon-change observer to `queue: .main` and updating Dock tile content synchronously on main.
> 
> Adds DEBUG-only main-thread tripwires (`dispatchPrecondition`/`assert(Thread.isMainThread)`) around multiple `NSImageView`/AppKit image assignment and view init/draw paths (folder icon view, file explorer header/cells, terminal surface init, and file preview image/PDF thumbnail updates) to catch off-main UI work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2840e20b70a49cc9aa777bbf5427d3d9b68b5158. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep all AppKit image and Dock tile updates on the main thread to prevent off-main NSImageView layer commits and crashes. Fixes #3590.

- **Bug Fixes**
  - Route Dock tile setup and icon updates through a main-queue helper; add `performOnMain` and DEBUG-only `assertMainQueue`.
  - Register distributed icon-change observer on `.main`.
  - Enforce main-thread-only in `NSDockTile.showIcon` and `showDefaultAppIcon`; update content view synchronously.
  - Add DEBUG-only main-thread checks (`dispatchPrecondition`/`assert`) in ContentView, FileExplorer, Terminal, and FilePreview image paths.

<sup>Written for commit 2840e20b70a49cc9aa777bbf5427d3d9b68b5158. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by enforcing main-thread execution for all critical UI operations, preventing potential crashes from concurrent modifications. Affected areas include dock tile updates, terminal views, file explorer, and preview panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->