### PR TITLE
Fix managed settings reapply for issue 3590

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -446,6 +446,7 @@ jobs:
           fi
 
           CMUX_ALLOW_UNTAGGED_CA_REGRESSION=1 \
+          CMUX_CA_ASSERT_HOLD_SECONDS=15 \
           CMUX_TAG="ci-ca-main-thread" \
           ./scripts/verify-main-thread-ca-transactions.sh "$APP"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -439,7 +439,12 @@ jobs:
       - name: Run CoreAnimation main-thread startup regression
         run: |
           set -euo pipefail
-          APP="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Debug/cmux DEV.app" -print -quit)"
+          APP="$(
+            find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Debug/cmux DEV.app" -exec stat -f '%m %N' {} \; \
+              | sort -nr \
+              | head -1 \
+              | cut -d' ' -f2-
+          )"
           if [ -z "${APP:-}" ] || [ ! -d "$APP" ]; then
             echo "cmux DEV.app not found in DerivedData" >&2
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -436,6 +436,19 @@ jobs:
       - name: Validate Swift warning budget
         run: python3 scripts/swift_warning_budget.py --log /tmp/cmux-build-output.txt
 
+      - name: Run CoreAnimation main-thread startup regression
+        run: |
+          set -euo pipefail
+          APP="$(find "$HOME/Library/Developer/Xcode/DerivedData" -path "*/Build/Products/Debug/cmux DEV.app" -print -quit)"
+          if [ -z "${APP:-}" ] || [ ! -d "$APP" ]; then
+            echo "cmux DEV.app not found in DerivedData" >&2
+            exit 1
+          fi
+
+          CMUX_ALLOW_UNTAGGED_CA_REGRESSION=1 \
+          CMUX_TAG="ci-ca-main-thread" \
+          ./scripts/verify-main-thread-ca-transactions.sh "$APP"
+
       - name: Create virtual display
         run: |
           set -euo pipefail

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -11,14 +11,8 @@ final class KeyboardShortcutSettingsObserver: ObservableObject {
     private var recorderCancellable: AnyCancellable?
 
     private init(notificationCenter: NotificationCenter = .default) {
-        settingsCancellable = notificationCenter.publisher(for: KeyboardShortcutSettings.didChangeNotification)
-            .sink { [weak self] _ in
-                self?.revision &+= 1
-            }
-        recorderCancellable = notificationCenter.publisher(for: KeyboardShortcutRecorderActivity.didChangeNotification)
-            .sink { [weak self] _ in
-                self?.revision &+= 1
-            }
+        settingsCancellable = notificationCenter.publisher(for: KeyboardShortcutSettings.didChangeNotification).receive(on: DispatchQueue.main).sink { [weak self] _ in self?.revision &+= 1 }
+        recorderCancellable = notificationCenter.publisher(for: KeyboardShortcutRecorderActivity.didChangeNotification).receive(on: DispatchQueue.main).sink { [weak self] _ in self?.revision &+= 1 }
     }
 }
 
@@ -176,15 +170,8 @@ final class CmuxSettingsFileStore {
             }
         }
 
-        defaultsCancellable = notificationCenter.publisher(for: UserDefaults.didChangeNotification)
-            .sink { [weak self] _ in
-                self?.reapplyManagedSettingsIfNeeded()
-            }
-        socketPasswordObserver = notificationCenter.addObserver(
-            forName: SocketControlPasswordStore.didChangeNotification,
-            object: nil,
-            queue: nil
-        ) { [weak self] _ in
+        defaultsCancellable = notificationCenter.publisher(for: UserDefaults.didChangeNotification).receive(on: DispatchQueue.main).sink { [weak self] _ in self?.reapplyManagedSettingsIfNeeded() }
+        socketPasswordObserver = notificationCenter.addObserver(forName: SocketControlPasswordStore.didChangeNotification, object: nil, queue: .main) { [weak self] _ in
             self?.reapplyManagedSettingsIfNeeded()
         }
     }
@@ -1060,20 +1047,8 @@ final class CmuxSettingsFileStore {
             }
         }
 
-        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey, didMutateStoredValue {
-            TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
-        }
-
-        switch defaultsKey {
-        case LanguageSettings.languageKey:
-            let language = AppLanguage(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .system
-            LanguageSettings.apply(language)
-        case AppearanceSettings.appearanceModeKey:
-            AppearanceSettings.applyStoredMode(rawValue: UserDefaults.standard.string(forKey: defaultsKey), source: "cmuxConfig.applyManagedDefault")
-        case AppIconSettings.modeKey:
-            AppIconSettings.applyIcon(AppIconSettings.resolvedMode())
-        default:
-            break
+        if didMutateStoredValue {
+            applyManagedDefaultSideEffects(for: defaultsKey, notifyScrollBar: defaultsKey == TerminalScrollBarSettings.showScrollBarKey, source: "cmuxConfig.applyManagedDefault")
         }
     }
 
@@ -1091,37 +1066,53 @@ final class CmuxSettingsFileStore {
             return
         }
 
+        var didMutateStoredValue = false
         switch backup {
         case .absent:
-            defaults.removeObject(forKey: defaultsKey)
+            if defaults.object(forKey: defaultsKey) != nil { defaults.removeObject(forKey: defaultsKey); didMutateStoredValue = true }
         case .bool(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.object(forKey: defaultsKey) as? Bool != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         case .int(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.object(forKey: defaultsKey) as? Int != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         case .double(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.object(forKey: defaultsKey) as? Double != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         case .string(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.string(forKey: defaultsKey) != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         case .stringArray(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.array(forKey: defaultsKey) as? [String] != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         case .stringDictionary(let value):
-            defaults.set(value, forKey: defaultsKey)
+            if defaults.dictionary(forKey: defaultsKey) as? [String: String] != value { defaults.set(value, forKey: defaultsKey); didMutateStoredValue = true }
         }
 
-        if defaultsKey == TerminalScrollBarSettings.showScrollBarKey {
-            TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
+        if didMutateStoredValue {
+            applyManagedDefaultSideEffects(for: defaultsKey, notifyScrollBar: defaultsKey == TerminalScrollBarSettings.showScrollBarKey, source: "cmuxConfig.restoreUserDefault")
+        }
+    }
+
+    private func applyManagedDefaultSideEffects(for defaultsKey: String, notifyScrollBar: Bool, source: String) {
+        let notificationCenter = notificationCenter
+        let language = defaultsKey == LanguageSettings.languageKey ? AppLanguage(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .system : nil
+        let shouldApplyAppearance = defaultsKey == AppearanceSettings.appearanceModeKey
+        let appearanceRawValue = shouldApplyAppearance ? UserDefaults.standard.string(forKey: defaultsKey) : nil
+        let appIconMode = defaultsKey == AppIconSettings.modeKey ? AppIconSettings.resolvedMode() : nil
+        let apply = {
+            if notifyScrollBar {
+                TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
+            }
+
+            if let language {
+                LanguageSettings.apply(language)
+            } else if shouldApplyAppearance {
+                AppearanceSettings.applyStoredMode(rawValue: appearanceRawValue, source: source)
+            } else if let appIconMode {
+                AppIconSettings.applyIcon(appIconMode)
+            }
         }
 
-        switch defaultsKey {
-        case LanguageSettings.languageKey:
-            let language = AppLanguage(rawValue: UserDefaults.standard.string(forKey: defaultsKey) ?? "") ?? .system
-            LanguageSettings.apply(language)
-        case AppearanceSettings.appearanceModeKey:
-            AppearanceSettings.applyStoredMode(rawValue: UserDefaults.standard.string(forKey: defaultsKey), source: "cmuxConfig.restoreUserDefault")
-        case AppIconSettings.modeKey:
-            AppIconSettings.applyIcon(AppIconSettings.resolvedMode())
-        default:
-            break
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async { apply() }
         }
     }
 

--- a/scripts/verify-main-thread-ca-transactions.sh
+++ b/scripts/verify-main-thread-ca-transactions.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APP_PATH="${1:-${CMUX_APP_PATH:-}}"
+TAG="${CMUX_TAG:-ca-main-thread}"
+SOCKET_PATH="${CMUX_SOCKET_PATH:-/tmp/cmux-debug-${TAG}.sock}"
+LOG_PATH="${CMUX_CA_ASSERT_LOG:-/tmp/cmux-ca-main-thread-${TAG}.log}"
+HOLD_SECONDS="${CMUX_CA_ASSERT_HOLD_SECONDS:-8}"
+
+if [ -z "$APP_PATH" ]; then
+  echo "usage: CMUX_APP_PATH=/path/to/cmux.app $0" >&2
+  echo "   or: $0 /path/to/cmux.app" >&2
+  exit 2
+fi
+
+if [ ! -d "$APP_PATH" ]; then
+  echo "ERROR: app bundle not found: $APP_PATH" >&2
+  exit 2
+fi
+
+APP_BASENAME="$(basename "$APP_PATH")"
+if [ "$APP_BASENAME" = "cmux DEV.app" ] && [ "${CMUX_ALLOW_UNTAGGED_CA_REGRESSION:-0}" != "1" ]; then
+  echo "ERROR: refusing to launch untagged cmux DEV.app without CMUX_ALLOW_UNTAGGED_CA_REGRESSION=1" >&2
+  exit 2
+fi
+
+BINARY="$APP_PATH/Contents/MacOS/cmux DEV"
+if [ ! -x "$BINARY" ]; then
+  BINARY="$APP_PATH/Contents/MacOS/cmux"
+fi
+
+if [ ! -x "$BINARY" ]; then
+  echo "ERROR: cmux executable not found in $APP_PATH" >&2
+  exit 2
+fi
+
+APP_PID=""
+
+cleanup() {
+  if [ -n "$APP_PID" ]; then
+    kill "$APP_PID" >/dev/null 2>&1 || true
+  fi
+  pkill -f "$BINARY" >/dev/null 2>&1 || true
+  rm -f "$SOCKET_PATH"
+}
+trap cleanup EXIT
+
+pkill -f "$BINARY" >/dev/null 2>&1 || true
+rm -f "$SOCKET_PATH" "$LOG_PATH"
+
+CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1 \
+CA_DEBUG_TRANSACTIONS=1 \
+CMUX_UI_TEST_MODE=1 \
+CMUX_DISABLE_SESSION_RESTORE=1 \
+CMUX_TAG="$TAG" \
+CMUX_SOCKET_PATH="$SOCKET_PATH" \
+CMUX_ALLOW_SOCKET_OVERRIDE=1 \
+"$BINARY" >"$LOG_PATH" 2>&1 &
+APP_PID=$!
+
+deadline=$((SECONDS + HOLD_SECONDS))
+socket_ready=0
+while [ "$SECONDS" -lt "$deadline" ]; do
+  if ! kill -0 "$APP_PID" >/dev/null 2>&1; then
+    wait "$APP_PID" >/dev/null 2>&1 || true
+    echo "FAIL: cmux exited while CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1 was active" >&2
+    echo "--- app log tail ($LOG_PATH) ---" >&2
+    tail -80 "$LOG_PATH" >&2 2>/dev/null || true
+    exit 1
+  fi
+
+  if [ -S "$SOCKET_PATH" ]; then
+    socket_ready=1
+  fi
+  sleep 0.25
+done
+
+if [ "$socket_ready" -ne 1 ]; then
+  echo "FAIL: cmux stayed alive but did not create its socket at $SOCKET_PATH" >&2
+  echo "--- app log tail ($LOG_PATH) ---" >&2
+  tail -80 "$LOG_PATH" >&2 2>/dev/null || true
+  exit 1
+fi
+
+if grep -E "CA_ASSERT_MAIN_THREAD_TRANSACTIONS|uncommitted CATransaction|implicit transaction wasn't created" "$LOG_PATH" >/dev/null 2>&1; then
+  echo "FAIL: CoreAnimation reported a worker-thread transaction" >&2
+  echo "--- app log tail ($LOG_PATH) ---" >&2
+  tail -80 "$LOG_PATH" >&2 2>/dev/null || true
+  exit 1
+fi
+
+echo "PASS: cmux startup survived CoreAnimation main-thread transaction assertions"

--- a/scripts/verify-main-thread-ca-transactions.sh
+++ b/scripts/verify-main-thread-ca-transactions.sh
@@ -6,6 +6,7 @@ TAG="${CMUX_TAG:-ca-main-thread}"
 SOCKET_PATH="${CMUX_SOCKET_PATH:-/tmp/cmux-debug-${TAG}.sock}"
 LOG_PATH="${CMUX_CA_ASSERT_LOG:-/tmp/cmux-ca-main-thread-${TAG}.log}"
 HOLD_SECONDS="${CMUX_CA_ASSERT_HOLD_SECONDS:-8}"
+APP_PID_FILE="${CMUX_CA_ASSERT_PID_FILE:-/tmp/cmux-ca-main-thread-${TAG}.pid}"
 
 if [ -z "$APP_PATH" ]; then
   echo "usage: CMUX_APP_PATH=/path/to/cmux.app $0" >&2
@@ -36,27 +37,52 @@ fi
 
 APP_PID=""
 
+kill_recorded_app() {
+  if [ ! -f "$APP_PID_FILE" ]; then
+    return
+  fi
+
+  local recorded_pid
+  recorded_pid="$(cat "$APP_PID_FILE" 2>/dev/null || true)"
+  case "$recorded_pid" in
+    ""|*[!0-9]*)
+      rm -f "$APP_PID_FILE"
+      return
+      ;;
+  esac
+
+  local args
+  args="$(ps -p "$recorded_pid" -o args= 2>/dev/null || true)"
+  if [ -n "$args" ] && [[ "$args" == *"$BINARY"* ]]; then
+    kill "$recorded_pid" >/dev/null 2>&1 || true
+  fi
+  rm -f "$APP_PID_FILE"
+}
+
 cleanup() {
   if [ -n "$APP_PID" ]; then
     kill "$APP_PID" >/dev/null 2>&1 || true
+    wait "$APP_PID" >/dev/null 2>&1 || true
   fi
-  pkill -f "$BINARY" >/dev/null 2>&1 || true
-  rm -f "$SOCKET_PATH"
+  rm -f "$SOCKET_PATH" "$APP_PID_FILE"
 }
 trap cleanup EXIT
 
-pkill -f "$BINARY" >/dev/null 2>&1 || true
+kill_recorded_app
 rm -f "$SOCKET_PATH" "$LOG_PATH"
 
 CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1 \
 CA_DEBUG_TRANSACTIONS=1 \
 CMUX_UI_TEST_MODE=1 \
 CMUX_DISABLE_SESSION_RESTORE=1 \
+CMUX_SOCKET_ENABLE=1 \
+CMUX_SOCKET_MODE=automation \
 CMUX_TAG="$TAG" \
 CMUX_SOCKET_PATH="$SOCKET_PATH" \
 CMUX_ALLOW_SOCKET_OVERRIDE=1 \
 "$BINARY" >"$LOG_PATH" 2>&1 &
 APP_PID=$!
+echo "$APP_PID" >"$APP_PID_FILE"
 
 deadline=$((SECONDS + HOLD_SECONDS))
 socket_ready=0

--- a/scripts/verify-main-thread-ca-transactions.sh
+++ b/scripts/verify-main-thread-ca-transactions.sh
@@ -82,7 +82,7 @@ if [ "$socket_ready" -ne 1 ]; then
   exit 1
 fi
 
-if grep -E "CA_ASSERT_MAIN_THREAD_TRANSACTIONS|uncommitted CATransaction|implicit transaction wasn't created" "$LOG_PATH" >/dev/null 2>&1; then
+if grep -E "uncommitted CATransaction|implicit transaction wasn't created|CoreAnimation.*thread|CATransaction.*thread" "$LOG_PATH" >/dev/null 2>&1; then
   echo "FAIL: CoreAnimation reported a worker-thread transaction" >&2
   echo "--- app log tail ($LOG_PATH) ---" >&2
   tail -80 "$LOG_PATH" >&2 2>/dev/null || true


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/3590.

## Summary
- Add a runtime CI guard that launches the built app with `CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1`.
- Deliver managed settings/defaults/socket-password notifications on the main queue before reapplying managed settings.
- Keep managed default side effects that touch AppKit or SwiftUI behind a defensive main-thread hop.

## Root cause
`AppDelegate.persistSessionSnapshot` writes restored session/window geometry to `UserDefaults` from `com.cmuxterm.app.sessionPersistence` so persistence does not block the UI thread. `UserDefaults.standard.set(...)` posts `UserDefaults.didChangeNotification` synchronously on the posting thread.

`CmuxSettingsFileStore` subscribed to that notification without a delivery queue, so the Combine sink ran on the session persistence queue. When managed defaults were active, that sink called `reapplyManagedSettingsIfNeeded()`. Reapplying plain defaults is safe, but some managed defaults have UI side effects. The reproduced crash re-applied `app.appearance`, entered `AppearanceSettings.applyStoredMode`, and assigned `NSApplication.shared.appearance` off-main. That left CoreAnimation work attached to a worker thread; the original `NSImageView` stack was the layer/display victim of that off-main transaction, not the initiating cause.

## Changed files
- `.github/workflows/ci.yml`
- `scripts/verify-main-thread-ca-transactions.sh`
- `Sources/KeyboardShortcutSettingsFileStore.swift`

No `.md` files are changed in this PR.

## Reproduction
- Reproduced on `origin/main` with a tagged Debug app under `CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1`.
- The red regression commit fails on the baseline with `FAIL: cmux exited while CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1 was active`.

## Verification
- `git diff --check`
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv`
- `./scripts/reload.sh --tag issue-3590-ca-regression`
- `CMUX_TAG=issue-3590-ca-regression CMUX_CA_ASSERT_HOLD_SECONDS=8 ./scripts/verify-main-thread-ca-transactions.sh <tagged app path>`
- `./scripts/test-unit.sh -derivedDataPath /tmp/cmux-unit-issue-3590 -only-testing:cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure & Testing**
  * Replaced a CI validation step with a new CI check that verifies CoreAnimation main-thread behavior during app startup.

* **New Tools**
  * Added a development script to automate startup verification, capture failure logs, and validate UI-thread CoreAnimation transactions.

* **Bug Fixes**
  * Ensured settings change notifications and all related UI updates are applied on the main thread for consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches managed-settings reapplication and UI side effects (appearance/language/app icon), where threading mistakes can cause crashes or subtle UI issues; also adds a new CI runtime regression step that could introduce flakiness on macOS runners.
> 
> **Overview**
> Prevents managed settings reapplication from running off-main by delivering `UserDefaults` / socket-password / shortcut-change notifications on the main queue and by defensively hopping to the main thread for managed-default side effects (appearance, language, app icon, scroll bar notifications).
> 
> Adds a CI runtime regression that launches the built macOS app with `CA_ASSERT_MAIN_THREAD_TRANSACTIONS=1` and drives a small CLI mutation to detect CoreAnimation worker-thread transactions, implemented via the new `scripts/verify-main-thread-ca-transactions.sh`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9674bede3ca20e3dee20499c0f44342cacdea54d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->