### PR TITLE
fix: close all targeted tabs in pane right-click 'Close Other Tabs' (#3605)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -292,6 +292,7 @@
 		B900002FA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */; };
 		B9000035A1B2C3D4E5F60719 /* CMUXCLI+DocsSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000031A1B2C3D4E5F60719 /* CMUXCLI+DocsSettings.swift */; };
 		D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */; };
+		D7AB36050000000000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB36050000000000000002 /* WorkspaceCloseTabsContextMenuTests.swift */; };
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
@@ -722,6 +723,7 @@
 		B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+ThemeSupport.swift"; sourceTree = "<group>"; };
 		B9000031A1B2C3D4E5F60719 /* CMUXCLI+DocsSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+DocsSettings.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceAdjacentPaneMoveTests.swift; sourceTree = "<group>"; };
+		D7AB36050000000000000002 /* WorkspaceCloseTabsContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceCloseTabsContextMenuTests.swift; sourceTree = "<group>"; };
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
@@ -1244,6 +1246,7 @@
 					3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */,
 					D7AB34400000000000000004 /* GhosttyTerminalViewVisibilityPolicyTests.swift */,
 					D7AB00000000000000000012 /* WorkspaceAdjacentPaneMoveTests.swift */,
+					D7AB36050000000000000002 /* WorkspaceCloseTabsContextMenuTests.swift */,
 					D0B10009A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift */,
 					71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */,
 					71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */,
@@ -1861,6 +1864,7 @@
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				D7AB00000000000000000011 /* WorkspaceAdjacentPaneMoveTests.swift in Sources */,
+				D7AB36050000000000000001 /* WorkspaceCloseTabsContextMenuTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
 					6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */,
 					6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4202,9 +4202,24 @@ class TabManager: ObservableObject {
 
         let count = plan.panelIds.count
         let titleLines = plan.titles.map { "• \($0)" }.joined(separator: "\n")
-        let message = "This is about to close \(count) tab\(count == 1 ? "" : "s") in this pane:\n\(titleLines)"
+        let title = String(localized: "dialog.closeOtherTabs.title", defaultValue: "Close other tabs?")
+        let messageFormat: String
+        if count == 1 {
+            messageFormat = String(
+                localized: "dialog.closeOtherTabs.message.one",
+                defaultValue: "This will close 1 tab in this pane:\n%@"
+            )
+        } else {
+            messageFormat = String(
+                localized: "dialog.closeOtherTabs.message.other",
+                defaultValue: "This will close %1$lld tabs in this pane:\n%2$@"
+            )
+        }
+        let message: String = (count == 1)
+            ? String(format: messageFormat, locale: .current, titleLines)
+            : String(format: messageFormat, locale: .current, Int64(count), titleLines)
         guard confirmClose(
-            title: "Close other tabs?",
+            title: title,
             message: message,
             acceptCmdD: false
         ) else { return }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12371,13 +12371,72 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     private func closeTabs(_ tabIds: [TabID], skipPinned: Bool = true) {
-        for tabId in tabIds {
+        let confirmManager = owningTabManager
+            ?? AppDelegate.shared?.tabManagerFor(tabId: id)
+            ?? AppDelegate.shared?.tabManager
+
+        if let confirmManager, confirmManager.isCloseConfirmationInFlight {
+            return
+        }
+
+        let candidates: [TabID] = tabIds.compactMap { tabId in
             if skipPinned,
                let panelId = panelIdFromSurfaceId(tabId),
                pinnedPanelIds.contains(panelId) {
-                continue
+                return nil
             }
-            _ = bonsplitController.closeTab(tabId)
+            return tabId
+        }
+        guard !candidates.isEmpty else { return }
+
+        let needsConfirm = candidates.contains { tabId in
+            guard let panelId = panelIdFromSurfaceId(tabId) else { return false }
+            return panelNeedsConfirmClose(panelId: panelId)
+        }
+
+        if needsConfirm {
+            guard let confirmManager else { return }
+            let titles = candidates.map { tabId -> String in
+                guard let panelId = panelIdFromSurfaceId(tabId) else {
+                    return String(localized: "tab.untitled", defaultValue: "Untitled Tab")
+                }
+                let raw = panelTitle(panelId: panelId)?
+                    .replacingOccurrences(of: "\n", with: " ")
+                    .replacingOccurrences(of: "\r", with: " ")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                if let raw, !raw.isEmpty {
+                    return raw
+                }
+                return String(localized: "tab.untitled", defaultValue: "Untitled Tab")
+            }
+            let count = candidates.count
+            let titleLines = titles.map { "• \($0)" }.joined(separator: "\n")
+            let title = String(localized: "dialog.closeOtherTabs.title", defaultValue: "Close other tabs?")
+            let messageFormat: String
+            if count == 1 {
+                messageFormat = String(
+                    localized: "dialog.closeOtherTabs.message.one",
+                    defaultValue: "This will close 1 tab in this pane:\n%@"
+                )
+            } else {
+                messageFormat = String(
+                    localized: "dialog.closeOtherTabs.message.other",
+                    defaultValue: "This will close %1$lld tabs in this pane:\n%2$@"
+                )
+            }
+            let message: String = (count == 1)
+                ? String(format: messageFormat, locale: .current, titleLines)
+                : String(format: messageFormat, locale: .current, Int64(count), titleLines)
+            guard confirmManager.confirmClose(title: title, message: message, acceptCmdD: false) else {
+                return
+            }
+        }
+
+        for tabId in candidates {
+            forceCloseTabIds.insert(tabId)
+            if !bonsplitController.closeTab(tabId) {
+                forceCloseTabIds.remove(tabId)
+            }
         }
     }
 

--- a/cmuxTests/WorkspaceCloseTabsContextMenuTests.swift
+++ b/cmuxTests/WorkspaceCloseTabsContextMenuTests.swift
@@ -1,0 +1,197 @@
+import XCTest
+import Bonsplit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for issue #3605:
+/// "REGRESSION: close other tab is broken".
+///
+/// Before commit a5a1cafb (PR #2989, "Fix close confirmation bypass when spamming close")
+/// the right-click context menu's "Close Other Tabs" / "Close Tabs to Left/Right" actions
+/// would prompt once per dirty tab and eventually close them all. After PR #2989, the new
+/// `Workspace.shouldCloseTab` guard on `TabManager.isCloseConfirmationInFlight` rejects every
+/// tab in the loop after the first, so only one of the targeted tabs ever closes.
+///
+/// These tests exercise the right-click context menu path (`splitTabBar(_:didRequestTabContextAction:)`)
+/// directly for `.closeOthers`, `.closeToLeft`, and `.closeToRight`, mirroring real user flows
+/// where every panel runs a shell that wants confirm-on-close.
+@MainActor
+final class WorkspaceCloseTabsContextMenuTests: XCTestCase {
+
+    // MARK: - .closeOthers
+
+    func testCloseOthersClosesAllNonAnchorTabsWhenAllNeedConfirmation() throws {
+        let (manager, workspace, paneId, anchorPanelId, otherPanelIds) = try makeWorkspaceWithThreeTerminalsInOnePane()
+
+        for panelId in [anchorPanelId] + otherPanelIds {
+            try markTerminalNeedsConfirmClose(workspace: workspace, panelId: panelId)
+        }
+
+        var promptCount = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            promptCount += 1
+            return true
+        }
+
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(anchorPanelId))
+        let anchorTab = try XCTUnwrap(workspace.bonsplitController.tab(anchorTabId))
+
+        XCTAssertEqual(workspace.bonsplitController.tabs(inPane: paneId).count, 3,
+            "Precondition: pane should have 3 tabs before closeOthers")
+
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestTabContextAction: .closeOthers,
+            for: anchorTab,
+            inPane: paneId
+        )
+
+        let remaining = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        XCTAssertEqual(
+            remaining, [anchorTabId],
+            "Expected only the anchor tab to remain after closeOthers, but got \(remaining.count) tabs"
+        )
+        for panelId in otherPanelIds {
+            XCTAssertNil(
+                workspace.surfaceIdFromPanelId(panelId),
+                "Expected panel \(panelId) to be removed from surface mapping"
+            )
+        }
+        XCTAssertEqual(promptCount, 1, "Expected exactly one batched confirmation prompt for the closeOthers action")
+    }
+
+    func testCloseOthersCancelledKeepsAllTabs() throws {
+        let (manager, workspace, paneId, anchorPanelId, otherPanelIds) = try makeWorkspaceWithThreeTerminalsInOnePane()
+
+        for panelId in [anchorPanelId] + otherPanelIds {
+            try markTerminalNeedsConfirmClose(workspace: workspace, panelId: panelId)
+        }
+
+        var promptCount = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            promptCount += 1
+            return false
+        }
+
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(anchorPanelId))
+        let anchorTab = try XCTUnwrap(workspace.bonsplitController.tab(anchorTabId))
+
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestTabContextAction: .closeOthers,
+            for: anchorTab,
+            inPane: paneId
+        )
+
+        XCTAssertEqual(
+            workspace.bonsplitController.tabs(inPane: paneId).count, 3,
+            "Cancelling the prompt must leave all tabs open"
+        )
+        XCTAssertEqual(promptCount, 1, "User should see exactly one prompt before cancelling")
+    }
+
+    func testCloseOthersWithoutConfirmNeededClosesAllImmediately() throws {
+        let (manager, workspace, paneId, anchorPanelId, otherPanelIds) = try makeWorkspaceWithThreeTerminalsInOnePane()
+
+        for panelId in [anchorPanelId] + otherPanelIds {
+            try markTerminalNeedsConfirmClose(workspace: workspace, panelId: panelId, value: false)
+        }
+
+        var promptCount = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            promptCount += 1
+            return true
+        }
+
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(anchorPanelId))
+        let anchorTab = try XCTUnwrap(workspace.bonsplitController.tab(anchorTabId))
+
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestTabContextAction: .closeOthers,
+            for: anchorTab,
+            inPane: paneId
+        )
+
+        XCTAssertEqual(
+            workspace.bonsplitController.tabs(inPane: paneId).map(\.id), [anchorTabId],
+            "All non-anchor tabs should close synchronously when no confirmation is needed"
+        )
+        XCTAssertEqual(promptCount, 0, "No confirmation prompt should fire when no panel needs confirm")
+    }
+
+    // MARK: - .closeToRight
+
+    func testCloseToRightClosesAllTabsRightOfAnchorWhenAllNeedConfirmation() throws {
+        let (manager, workspace, paneId, anchorPanelId, otherPanelIds) = try makeWorkspaceWithThreeTerminalsInOnePane()
+
+        for panelId in [anchorPanelId] + otherPanelIds {
+            try markTerminalNeedsConfirmClose(workspace: workspace, panelId: panelId)
+        }
+
+        var promptCount = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            promptCount += 1
+            return true
+        }
+
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(anchorPanelId))
+        let anchorTab = try XCTUnwrap(workspace.bonsplitController.tab(anchorTabId))
+
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestTabContextAction: .closeToRight,
+            for: anchorTab,
+            inPane: paneId
+        )
+
+        let remaining = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        XCTAssertEqual(
+            remaining, [anchorTabId],
+            "Expected only the anchor tab (leftmost) to remain after closeToRight"
+        )
+        XCTAssertEqual(promptCount, 1, "Expected one batched confirmation for the right-side close")
+    }
+
+    // MARK: - Helpers
+
+    @MainActor
+    private func makeWorkspaceWithThreeTerminalsInOnePane() throws -> (
+        manager: TabManager,
+        workspace: Workspace,
+        paneId: PaneID,
+        anchorPanelId: UUID,
+        otherPanelIds: [UUID]
+    ) {
+        let manager = TabManager()
+        let workspace = try XCTUnwrap(manager.tabs.first)
+        let anchorPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let paneId = try XCTUnwrap(workspace.paneId(forPanelId: anchorPanelId))
+
+        let secondPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
+        let thirdPanel = try XCTUnwrap(workspace.newTerminalSurface(inPane: paneId, focus: false))
+
+        // Re-select the anchor so the right-click menu's anchor matches the originally focused tab.
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(anchorPanelId))
+        workspace.bonsplitController.selectTab(anchorTabId)
+
+        return (manager, workspace, paneId, anchorPanelId, [secondPanel.id, thirdPanel.id])
+    }
+
+    @MainActor
+    private func markTerminalNeedsConfirmClose(
+        workspace: Workspace,
+        panelId: UUID,
+        value: Bool = true
+    ) throws {
+        let terminalPanel = try XCTUnwrap(
+            workspace.terminalPanel(for: panelId),
+            "Expected a TerminalPanel at \(panelId)"
+        )
+        terminalPanel.surface.setNeedsConfirmCloseOverrideForTesting(value)
+    }
+}

--- a/cmuxTests/WorkspaceCloseTabsContextMenuTests.swift
+++ b/cmuxTests/WorkspaceCloseTabsContextMenuTests.swift
@@ -157,6 +157,40 @@ final class WorkspaceCloseTabsContextMenuTests: XCTestCase {
         XCTAssertEqual(promptCount, 1, "Expected one batched confirmation for the right-side close")
     }
 
+    // MARK: - .closeToLeft
+
+    func testCloseToLeftClosesAllTabsLeftOfAnchorWhenAllNeedConfirmation() throws {
+        let (manager, workspace, paneId, anchorPanelId, otherPanelIds) = try makeWorkspaceWithThreeTerminalsInOnePane()
+        let rightmostPanelId = try XCTUnwrap(otherPanelIds.last)
+
+        for panelId in [anchorPanelId] + otherPanelIds {
+            try markTerminalNeedsConfirmClose(workspace: workspace, panelId: panelId)
+        }
+
+        var promptCount = 0
+        manager.confirmCloseHandler = { _, _, _ in
+            promptCount += 1
+            return true
+        }
+
+        let anchorTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(rightmostPanelId))
+        let anchorTab = try XCTUnwrap(workspace.bonsplitController.tab(anchorTabId))
+
+        workspace.splitTabBar(
+            workspace.bonsplitController,
+            didRequestTabContextAction: .closeToLeft,
+            for: anchorTab,
+            inPane: paneId
+        )
+
+        let remaining = workspace.bonsplitController.tabs(inPane: paneId).map(\.id)
+        XCTAssertEqual(
+            remaining, [anchorTabId],
+            "Expected only the anchor tab (rightmost) to remain after closeToLeft"
+        )
+        XCTAssertEqual(promptCount, 1, "Expected one batched confirmation for the left-side close")
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
## Summary

Right-click **Close Other Tabs** / **Close Tabs to Right** / **Close Tabs to Left** on a panel tab regressed: when every tab in the pane wants confirm-on-close (e.g. each runs a shell), only **one** of the targeted tabs ever closes. The user sees their confirmation, one tab disappears, and the rest silently stay open. Closes #3605.

The keyboard shortcut path (`Cmd+Option+T`, [`TabManager.closeOtherTabsInFocusedPaneWithConfirmation`](Sources/TabManager.swift)) was not affected.

## Root cause

`Workspace.closeTabs(_:)` iterated `tabIds` and called `bonsplitController.closeTab(tabId)` directly without setting `forceCloseTabIds`. The first call kicks off `Workspace.shouldCloseTab`'s async per-panel `beginSheetModal` confirmation, which sets `TabManager.isCloseConfirmationInFlight = true`.

PR #2989 (\`a5a1cafb\` — *Fix close confirmation bypass when spamming close*) added an early-return on that flag at the top of `shouldCloseTab` to fix close-spam. As a side effect, every subsequent call in the loop returned `false` synchronously and was never retried, so only the first tab closed after the user confirmed it.

## Fix

`Workspace.closeTabs(_:)` now matches the working keyboard-shortcut path:

1. Bail early if a confirmation is already on-screen, preserving the PR #2989 anti-spam guard for unrelated flows.
2. Filter pinned panels up front.
3. If any candidate panel needs confirmation, show **one** batched dialog listing every tab title — using the existing localized `dialog.closeOtherTabs.title` / `.message.one` / `.message.other` strings.
4. After the user confirms (or if no panel needs confirmation), insert each candidate into `forceCloseTabIds` and call `closeTab`. If `bonsplitController.closeTab` returns false, remove the stale entry so we never leak `forceCloseTabIds` bypass state.

This keeps the keyboard-shortcut path and the right-click context menu *semantically* aligned without unifying anchor calculation: the keyboard shortcut still closes everything except the focused/selected tab, while the context menu still closes relative to the right-clicked tab.

## Two-commit structure

Per AGENTS.md *Regression test commit policy*:

1. **\`9bfe2078\`** — Adds the failing regression test only. CI should go red.
2. **\`6362f8ff\`** — Adds the fix. CI should go green.

The new test (`cmuxTests/WorkspaceCloseTabsContextMenuTests.swift`) drives `splitTabBar(_:didRequestTabContextAction:for:inPane:)` directly for `.closeOthers` and `.closeToRight`, with three terminal panels in the same pane all marked \`setNeedsConfirmCloseOverrideForTesting(true)\`, and a `confirmCloseHandler` injected into the `TabManager`. Without the fix only the first panel ever leaves the pane (and only after async drain); with the fix all targeted panels close after a single batched confirmation.

## Manual repro

1. Open a workspace, open 3+ tabs in the same pane (each with a running shell).
2. Right-click any tab → *Close Other Tabs*.
3. Confirm.

Before this PR: only one of the other tabs closes.
After this PR: all other tabs close.

## Notes

- I'm running on a borrowed work tree where local Zig is `0.16.0` so `xcodebuild -scheme cmux-unit` can't link the Ghostty CLI helper here. Swift compilation of the changed files is clean (LSP) and the change is intentionally minimal Swift; I'm relying on CI to run `cmuxTests` end-to-end.
- The fix benefits all three context-menu actions (`.closeOthers`, `.closeToLeft`, `.closeToRight`) because they share `closeTabs(_:)`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where right‑clicking “Close Other Tabs” or “Close Tabs to Left/Right” only closed one tab when all tabs required confirm-on-close. Now a single, batched confirmation closes all targeted tabs, and both keyboard and context‑menu paths show the same localized dialog.

- **Bug Fixes**
  - Updated `Workspace.closeTabs(_:)`: bail if a confirmation is in flight, skip pinned tabs, show one batched dialog using `dialog.closeOtherTabs.*`, then force-close each tab with cleanup on failure.
  - Applies to `.closeOthers`, `.closeToLeft`, and `.closeToRight`; keyboard shortcut logic is unchanged, and `TabManager.closeOtherTabsInFocusedPaneWithConfirmation` now uses the same localized strings.
  - Added `WorkspaceCloseTabsContextMenuTests` covering all three actions and cancellation to prevent regressions.

<sup>Written for commit 721a17257f40e3501cba6ae6f69f2f3fb7ca9d4d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added user confirmation prompts when closing multiple tabs from context menus to reduce accidental closures.

* **Refactor**
  * Dialog text for tab-closing confirmations replaced with localized strings to support translations and pluralization.

* **Tests**
  * Added regression tests covering context-menu tab-closing actions, confirmation flows, and cancellation scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->