### PR TITLE
Surface auth sign-in errors in Settings (#3617)

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -110152,6 +110152,35 @@
         }
       }
     },
+    "settings.account.error.signInSessionFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Sign-in didn't complete. Please try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインを完了できませんでした。もう一度お試しください。"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Не вдалося завершити вхід. Спробуйте ще раз."
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "로그인을 완료하지 못했습니다. 다시 시도해 주세요."
+          }
+        }
+      }
+    },
     "remote.state.connected.vmNoProxy": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -31,10 +31,11 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
     }
 }
 
-enum AuthManagerError: LocalizedError {
+enum AuthManagerError: LocalizedError, Equatable {
     case invalidCallback
     case missingAccessToken
     case missingRefreshToken
+    case signInSessionFailed
 
     var errorDescription: String? {
         switch self {
@@ -52,6 +53,11 @@ enum AuthManagerError: LocalizedError {
             return String(
                 localized: "settings.account.error.missingRefreshToken",
                 defaultValue: "Account refresh token is unavailable."
+            )
+        case .signInSessionFailed:
+            return String(
+                localized: "settings.account.error.signInSessionFailed",
+                defaultValue: "Sign-in didn't complete. Please try again."
             )
         }
     }
@@ -128,6 +134,7 @@ final class AuthManager: ObservableObject {
     @Published private(set) var isLoading = false
     @Published private(set) var isRestoringSession = false
     @Published private(set) var didCompleteBrowserSignIn = false
+    @Published private(set) var lastSignInError: AuthManagerError?
     @Published var selectedTeamID: String? {
         didSet {
             guard selectedTeamID != oldValue else { return }
@@ -189,6 +196,7 @@ final class AuthManager: ObservableObject {
         loginPollTask?.cancel()
         webAuthSession?.cancel()
         webAuthSession = nil
+        lastSignInError = nil
         isLoading = true
 
         let signInURL = AuthEnvironment.signInURL()
@@ -206,6 +214,7 @@ final class AuthManager: ObservableObject {
                 }
                 if let error {
                     NSLog("auth.webauth failed: %@", "\(error)")
+                    self.recordSignInSessionError(error)
                     return
                 }
                 guard let callbackURL else { return }
@@ -223,8 +232,19 @@ final class AuthManager: ObservableObject {
             webAuthSession = session
         } else {
             NSLog("auth.webauth: session.start() returned false")
+            lastSignInError = .signInSessionFailed
             isLoading = false
         }
+    }
+
+    private func recordSignInSessionError(_ error: Error) {
+        // canceledLogin = explicit user cancel; surfacing an error there is
+        // hostile. Other codes (network, sandbox, etc.) surface to fix #3617.
+        if let asError = error as? ASWebAuthenticationSessionError,
+           asError.code == .canceledLogin {
+            return
+        }
+        lastSignInError = .signInSessionFailed
     }
 
     /// Starts the ASWebAuthenticationSession popup and awaits the user's
@@ -395,18 +415,25 @@ final class AuthManager: ObservableObject {
 
     func handleCallbackURL(_ url: URL) async throws {
         guard let payload = AuthCallbackRouter.callbackPayload(from: url) else {
+            lastSignInError = .invalidCallback
             throw AuthManagerError.invalidCallback
         }
 
         isLoading = true
         defer { isLoading = false }
 
-        await tokenStore.seed(
-            accessToken: payload.accessToken,
-            refreshToken: payload.refreshToken
-        )
-        try await refreshSession()
-        didCompleteBrowserSignIn = true
+        do {
+            await tokenStore.seed(
+                accessToken: payload.accessToken,
+                refreshToken: payload.refreshToken
+            )
+            try await refreshSession()
+            didCompleteBrowserSignIn = true
+            lastSignInError = nil
+        } catch {
+            lastSignInError = (error as? AuthManagerError) ?? .signInSessionFailed
+            throw error
+        }
     }
 
     func seedTokensFromCLI(refreshToken: String, accessToken: String?) async {

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -213,7 +213,7 @@ final class AuthManager: ObservableObject {
                     self.webAuthSession = nil
                 }
                 if let error {
-                    NSLog("auth.webauth failed: %@", "\(error)")
+                    Self.authLog("webauth failed: \(error)")
                     self.recordSignInSessionError(error)
                     return
                 }
@@ -221,7 +221,7 @@ final class AuthManager: ObservableObject {
                 do {
                     try await self.handleCallbackURL(callbackURL)
                 } catch {
-                    NSLog("auth.webauth callback failed: %@", "\(error)")
+                    Self.authLog("webauth callback failed: \(error)")
                 }
             }
         }
@@ -231,7 +231,7 @@ final class AuthManager: ObservableObject {
         if session.start() {
             webAuthSession = session
         } else {
-            NSLog("auth.webauth: session.start() returned false")
+            Self.authLog("webauth: session.start() returned false")
             lastSignInError = .signInSessionFailed
             isLoading = false
         }
@@ -460,6 +460,7 @@ final class AuthManager: ObservableObject {
         await tokenStore.setTokens(accessToken: resolvedAccess, refreshToken: refreshToken)
         do {
             try await refreshSession()
+            lastSignInError = nil
             authLog("seedTokensFromCLI: success user=\(currentUser?.primaryEmail ?? "nil")")
         } catch {
             authLog("seedTokensFromCLI: refreshSession failed: \(error)")
@@ -532,6 +533,7 @@ final class AuthManager: ObservableObject {
         isAuthenticated = true
         selectedTeamID = Self.resolveTeamID(selectedTeamID: selectedTeamID, teams: result.teams)
         didCompleteBrowserSignIn = true
+        lastSignInError = nil
         authLog("applySignInResult: user=\(result.email ?? "nil") teams=\(result.teams.count) teamID=\(selectedTeamID ?? "nil")")
     }
 
@@ -597,6 +599,7 @@ final class AuthManager: ObservableObject {
         selectedTeamID = Self.resolveTeamID(selectedTeamID: selectedTeamID, teams: teams)
         authLog("signInWithCredential: success user=\(user.primaryEmail ?? "nil") teams=\(teams.count) teamID=\(selectedTeamID ?? "nil")")
         didCompleteBrowserSignIn = true
+        lastSignInError = nil
     }
 
     func signOut() async {
@@ -723,6 +726,7 @@ final class AuthManager: ObservableObject {
         currentUser = nil
         isAuthenticated = false
         didCompleteBrowserSignIn = false
+        lastSignInError = nil
         if clearSelectedTeam {
             selectedTeamID = nil
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -7526,6 +7526,12 @@ private struct AuthSettingsRow: View {
                         .font(.system(size: 11))
                         .foregroundColor(.secondary)
                 }
+                if let errorMessage = errorText {
+                    Text(errorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(.red)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             Spacer(minLength: 12)
             if authManager.isLoading || authManager.isRestoringSession {
@@ -7565,6 +7571,10 @@ private struct AuthSettingsRow: View {
             localized: "settings.account.signedOut.subtitle",
             defaultValue: "Sign in with your cmux account to enable sync across devices."
         )
+    }
+
+    private var errorText: String? {
+        authManager.lastSignInError?.errorDescription
     }
 
     private var buttonTitle: String {

--- a/cmuxTests/AuthManagerSignInErrorVisibilityTests.swift
+++ b/cmuxTests/AuthManagerSignInErrorVisibilityTests.swift
@@ -35,7 +35,9 @@ final class AuthManagerSignInErrorVisibilityTests: XCTestCase {
         do {
             try await manager.handleCallbackURL(badCallbackURL)
             XCTFail("Expected handleCallbackURL to throw AuthManagerError.invalidCallback")
-        } catch is AuthManagerError {
+        } catch AuthManagerError.invalidCallback {
+        } catch let error as AuthManagerError {
+            XCTFail("Expected .invalidCallback, got AuthManagerError.\(error)")
         } catch {
             XCTFail("Expected AuthManagerError, got \(type(of: error)): \(error)")
         }
@@ -44,6 +46,30 @@ final class AuthManagerSignInErrorVisibilityTests: XCTestCase {
             manager.lastSignInError,
             AuthManagerError.invalidCallback,
             "After a failed sign-in callback, AuthManager.lastSignInError must be populated so AuthSettingsRow can render it"
+        )
+    }
+
+    func testSignOutClearsStaleLastSignInError() async throws {
+        let manager = AuthManager(
+            client: NoopAuthTestClient(),
+            tokenStore: InMemoryTestTokenStore()
+        )
+        await manager.awaitBootstrapped()
+
+        // Stale-error invariant: a prior failed sign-in leaves .invalidCallback
+        // published; signOut → clearSessionState must clear it.
+        do {
+            try await manager.handleCallbackURL(URL(string: "cmux://auth-callback")!)
+            XCTFail("Expected handleCallbackURL to throw")
+        } catch {
+        }
+        XCTAssertEqual(manager.lastSignInError, .invalidCallback)
+
+        await manager.signOut()
+
+        XCTAssertNil(
+            manager.lastSignInError,
+            "signOut() routes through clearSessionState which must clear lastSignInError so it doesn't survive across auth-state transitions"
         )
     }
 }

--- a/cmuxTests/AuthManagerSignInErrorVisibilityTests.swift
+++ b/cmuxTests/AuthManagerSignInErrorVisibilityTests.swift
@@ -1,0 +1,85 @@
+import CMUXAuthCore
+import StackAuth
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for #3617: failed sign-in callbacks were silently
+/// `NSLog`-ed and never surfaced to the UI. The fix exposes the failure as a
+/// published `lastSignInError`. Per AGENTS.md regression test policy this
+/// failing test ships in its own commit so CI proves it catches the bug.
+@MainActor
+final class AuthManagerSignInErrorVisibilityTests: XCTestCase {
+    func testInvalidCallbackURLPublishesLastSignInError() async throws {
+        let manager = AuthManager(
+            client: NoopAuthTestClient(),
+            tokenStore: InMemoryTestTokenStore()
+        )
+        await manager.awaitBootstrapped()
+
+        XCTAssertNil(
+            manager.lastSignInError,
+            "AuthManager should not surface an error before any sign-in attempt"
+        )
+
+        // No `stack_refresh` / `stack_access` query items: this is the exact
+        // shape that makes `AuthCallbackRouter.callbackPayload` return nil and
+        // forces `handleCallbackURL` to throw `.invalidCallback`. Do not
+        // "fix" the URL — that would defeat this regression.
+        let badCallbackURL = URL(string: "cmux://auth-callback")!
+
+        do {
+            try await manager.handleCallbackURL(badCallbackURL)
+            XCTFail("Expected handleCallbackURL to throw AuthManagerError.invalidCallback")
+        } catch is AuthManagerError {
+        } catch {
+            XCTFail("Expected AuthManagerError, got \(type(of: error)): \(error)")
+        }
+
+        XCTAssertEqual(
+            manager.lastSignInError,
+            AuthManagerError.invalidCallback,
+            "After a failed sign-in callback, AuthManager.lastSignInError must be populated so AuthSettingsRow can render it"
+        )
+    }
+}
+
+// MARK: - Test doubles
+
+private final class NoopAuthTestClient: AuthClientProtocol {
+    func currentUser() async throws -> CMUXAuthUser? { nil }
+    func listTeams() async throws -> [AuthTeamSummary] { [] }
+}
+
+private final actor InMemoryTestTokenStore: StackAuthTokenStoreProtocol {
+    private var accessToken: String?
+    private var refreshToken: String?
+
+    func getStoredAccessToken() async -> String? { accessToken }
+    func getStoredRefreshToken() async -> String? { refreshToken }
+
+    func setTokens(accessToken: String?, refreshToken: String?) async {
+        self.accessToken = accessToken
+        self.refreshToken = refreshToken
+    }
+
+    func clearTokens() async {
+        accessToken = nil
+        refreshToken = nil
+    }
+
+    func compareAndSet(
+        compareRefreshToken: String,
+        newRefreshToken: String?,
+        newAccessToken: String?
+    ) async {
+        if refreshToken == compareRefreshToken {
+            refreshToken = newRefreshToken
+            accessToken = newAccessToken
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #3617.

`AuthManager.beginSignIn` and `handleCallbackURL` previously swallowed every failure via `NSLog` only. A user clicking **Settings → Sign In…** who hit any of `ASWebAuthenticationSessionError` (canceled consent, sandbox/TCC, network unreachable…), `handleCallbackURL` throwing `.invalidCallback` because the after-sign-in handler emitted a malformed deep link, or `session.start()` returning false saw the auth sheet flash and close with no visible error and no way to debug. The app stayed at "Not signed in" silently.

This PR publishes the most recent failure as `AuthManager.lastSignInError` and renders it in red below the Account row subtitle in `AuthSettingsRow`, so the failure mode that motivated #3617 is no longer invisible — regardless of which underlying root cause hits in any given environment.

## What changed

- `Sources/Auth/AuthManager.swift`
  - `AuthManagerError` is now `Equatable` and gains a `signInSessionFailed` case for non-`AuthManagerError` failures (network, sandbox, etc.).
  - New `@Published private(set) var lastSignInError: AuthManagerError?` published so SwiftUI can render it.
  - `beginSignIn` clears `lastSignInError` on entry, sets `.signInSessionFailed` on `session.start()` failure, and routes the completion handler's `error` through a new `recordSignInSessionError(_:)` helper that suppresses the error for `ASWebAuthenticationSessionError.canceledLogin` (explicit user cancel) so the UX stays quiet when the user cancels themselves.
  - `handleCallbackURL` sets `lastSignInError = .invalidCallback` before the early throw and otherwise sets it to the typed `AuthManagerError` (or `.signInSessionFailed` fallback) on any throw from `tokenStore.seed` / `refreshSession`. Clears it on success.
- `Sources/cmuxApp.swift` — `AuthSettingsRow` reads `authManager.lastSignInError?.errorDescription` and renders it in red under the existing subtitle. No layout change when no error is set.
- `Resources/Localizable.xcstrings` — adds `settings.account.error.signInSessionFailed` with `en` / `ja` / `uk` / `ko` translations, matching the existing `settings.account.error.*` key pattern.

This deliberately doesn't try to fix the underlying root cause(s) hypothesized in #3617 (`canceledLogin` from a dismissed consent dialog, double-fire from view-body re-evaluation, sandbox denial, network failure). It makes those root causes diagnosable so the *next* PR can target the actual cause once a Console.app log is captured.

## Test plan

`AGENTS.md` regression test policy is two commits:

1. `e0cd032a` — adds the failing regression test `cmuxTests/AuthManagerSignInErrorVisibilityTests.swift`. The test references `AuthManager.lastSignInError`, which doesn't exist yet on this commit, so CI compile fails — proving the test catches the bug.
2. `0cbea3d8` — ships the fix. The test now compiles and asserts `lastSignInError == .invalidCallback` after `handleCallbackURL` throws on a payload-less `cmux://auth-callback` URL.

The CI signal across the two commits is the proof: red on commit 1, green on commit 2.

Manual verification (not run locally per `AGENTS.md` "Never run tests locally"):

- [ ] Settings → Sign In… on a build where the sheet flashes-and-closes now shows `Sign-in didn't complete. Please try again.` under the subtitle.
- [ ] Settings → Sign In…, dismiss the macOS consent dialog explicitly. No error is shown (we suppress `canceledLogin`).
- [ ] Successful sign-in clears any prior error message.
- [ ] Sign Out leaves no stale error message.

## Out of scope (follow-up issues)

- Actual root-cause fix for the sheet flashing-and-closing on Release v0.64.3 — needs a captured `auth.webauth failed: …` line from Console.app, then targeted fix per the canceledLogin / double-fire / sandbox / network branches in #3617.
- `web/app/handler/after-sign-in/OpenNativeClient.tsx` UX nit — auto-redirect to the deep link instead of relying on a manual click. Different reviewer (web), different PR.
- Double-fire guard on `AuthSettingsRow.buttonAction()` (`webAuthSession != nil` / `isLoading == true`). Different concern, separate PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaced sign-in errors in Settings so users see why auth failed instead of a silent close. Fixes #3617 by publishing the last sign-in error, showing it under Account, and clearing it on success and sign-out.

- **Bug Fixes**
  - AuthManager now publishes `lastSignInError`; `AuthManagerError` is `Equatable` with new `.signInSessionFailed`. Error is set on `session.start()` failure, invalid callback, and other throws; suppressed for `ASWebAuthenticationSessionError.canceledLogin`; cleared on successful flows and on sign-out to avoid stale messages.
  - Settings shows the error message in red under the Account subtitle; no change when there’s no error.
  - Added `settings.account.error.signInSessionFailed` with en/ja/uk/ko translations.
  - Tests: added regression for invalid callback populating the error and another asserting sign-out clears it; tightened error matching.

- **Refactors**
  - Replaced three `NSLog` calls in the sign-in flow with `authLog` (DEBUG-guarded).

<sup>Written for commit d48988d3375fd79a1f8fb98e5c03b36de85df5d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users now see clear sign-in error messages shown in the account/auth settings row when authentication fails.

* **Localization**
  * Added translations for the new sign-in error message in English, Japanese, Ukrainian, and Korean.

* **Tests**
  * Added regression tests to verify sign-in error visibility and lifecycle.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->