### PR TITLE
Fix web lint errors and typed Bun test shim

### DIFF
--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -86,8 +86,23 @@ jobs:
                 ;;
             esac
             ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
+            ZIG_TAR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
+            ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
+            curl \
+              --fail \
+              --location \
+              --show-error \
+              --continue-at - \
+              --connect-timeout 30 \
+              --retry 8 \
+              --retry-all-errors \
+              --retry-delay 10 \
+              --retry-max-time 900 \
+              --speed-limit 1024 \
+              --speed-time 60 \
+              "$ZIG_URL" \
+              --output "$ZIG_TAR"
+            tar xf "$ZIG_TAR" -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
             sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
             sudo rm -rf /usr/local/lib/zig

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -70,59 +70,9 @@ jobs:
         run: ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          set -euo pipefail
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED}"
-            case "$(uname -m)" in
-              arm64) ZIG_ARCH="aarch64" ;;
-              x86_64) ZIG_ARCH="x86_64" ;;
-              *)
-                echo "Unsupported macOS runner architecture: $(uname -m)" >&2
-                exit 1
-                ;;
-            esac
-            ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-            ZIG_FILE="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
-            ZIG_TAR="/tmp/${ZIG_FILE}"
-            ZIG_URL="https://pkg.hexops.org/zig/${ZIG_FILE}"
-            ZIG_SIG="${ZIG_TAR}.minisig"
-            ZIG_SIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/${ZIG_FILE}.minisig"
-            ZIG_PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
-            curl \
-              --fail \
-              --location \
-              --show-error \
-              --continue-at - \
-              --connect-timeout 30 \
-              --retry 8 \
-              --retry-all-errors \
-              --retry-delay 10 \
-              --retry-max-time 900 \
-              --speed-limit 1024 \
-              --speed-time 60 \
-              "$ZIG_URL" \
-              --output "$ZIG_TAR"
-            if command -v minisign >/dev/null 2>&1; then
-              curl --fail --location --show-error --retry 8 --retry-all-errors --retry-delay 10 --retry-max-time 300 "$ZIG_SIG_URL" --output "$ZIG_SIG"
-              minisign -Vm "$ZIG_TAR" -P "$ZIG_PUBKEY"
-            else
-              ZIG_INDEX="/tmp/zig-download-index.json"
-              curl --fail --location --show-error --retry 8 --retry-all-errors --retry-delay 10 --retry-max-time 300 https://ziglang.org/download/index.json --output "$ZIG_INDEX"
-              ZIG_EXPECTED_SHA="$(/usr/bin/ruby -rjson -e 'data = JSON.parse(File.read(ARGV[0])); puts data.fetch(ARGV[1]).fetch(ARGV[2]).fetch("shasum")' "$ZIG_INDEX" "$ZIG_REQUIRED" "${ZIG_ARCH}-macos")"
-              echo "${ZIG_EXPECTED_SHA}  ${ZIG_TAR}" | shasum -a 256 --check -
-            fi
-            tar xf "$ZIG_TAR" -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-            sudo rm -rf /usr/local/lib/zig
-            sudo mkdir -p /usr/local/lib/zig
-            sudo cp -R "${ZIG_DIR}/lib/." /usr/local/lib/zig/
-            zig version
-          fi
+        uses: mlugg/setup-zig@d1434d08867e3ee9daa34448df10607b98908d29 # v2.2.1
+        with:
+          version: 0.15.2
 
       - name: Build tagged app
         run: ./scripts/reload.sh --tag "$PERF_TAG"

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -91,9 +91,6 @@ jobs:
             ZIG_SIG="${ZIG_TAR}.minisig"
             ZIG_SIG_URL="${ZIG_URL}.minisig"
             ZIG_PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
-            if ! command -v minisign >/dev/null 2>&1; then
-              HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install minisign
-            fi
             curl \
               --fail \
               --location \
@@ -108,17 +105,15 @@ jobs:
               --speed-time 60 \
               "$ZIG_URL" \
               --output "$ZIG_TAR"
-            curl \
-              --fail \
-              --location \
-              --show-error \
-              --retry 8 \
-              --retry-all-errors \
-              --retry-delay 10 \
-              --retry-max-time 300 \
-              "$ZIG_SIG_URL" \
-              --output "$ZIG_SIG"
-            minisign -Vm "$ZIG_TAR" -P "$ZIG_PUBKEY"
+            if command -v minisign >/dev/null 2>&1; then
+              curl --fail --location --show-error --retry 8 --retry-all-errors --retry-delay 10 --retry-max-time 300 "$ZIG_SIG_URL" --output "$ZIG_SIG"
+              minisign -Vm "$ZIG_TAR" -P "$ZIG_PUBKEY"
+            else
+              ZIG_INDEX="/tmp/zig-download-index.json"
+              curl --fail --location --show-error --retry 8 --retry-all-errors --retry-delay 10 --retry-max-time 300 https://ziglang.org/download/index.json --output "$ZIG_INDEX"
+              ZIG_EXPECTED_SHA="$(/usr/bin/ruby -rjson -e 'data = JSON.parse(File.read(ARGV[0])); puts data.fetch(ARGV[1]).fetch(ARGV[2]).fetch("shasum")' "$ZIG_INDEX" "$ZIG_REQUIRED" "${ZIG_ARCH}-macos")"
+              echo "${ZIG_EXPECTED_SHA}  ${ZIG_TAR}" | shasum -a 256 --check -
+            fi
             tar xf "$ZIG_TAR" -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
             sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -92,7 +92,7 @@ jobs:
             ZIG_SIG_URL="${ZIG_URL}.minisig"
             ZIG_PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
             if ! command -v minisign >/dev/null 2>&1; then
-              brew install minisign
+              HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 brew install minisign
             fi
             curl \
               --fail \

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -88,6 +88,12 @@ jobs:
             ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
             ZIG_TAR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
             ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
+            ZIG_SIG="${ZIG_TAR}.minisig"
+            ZIG_SIG_URL="${ZIG_URL}.minisig"
+            ZIG_PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
+            if ! command -v minisign >/dev/null 2>&1; then
+              brew install minisign
+            fi
             curl \
               --fail \
               --location \
@@ -102,6 +108,17 @@ jobs:
               --speed-time 60 \
               "$ZIG_URL" \
               --output "$ZIG_TAR"
+            curl \
+              --fail \
+              --location \
+              --show-error \
+              --retry 8 \
+              --retry-all-errors \
+              --retry-delay 10 \
+              --retry-max-time 300 \
+              "$ZIG_SIG_URL" \
+              --output "$ZIG_SIG"
+            minisign -Vm "$ZIG_TAR" -P "$ZIG_PUBKEY"
             tar xf "$ZIG_TAR" -C /tmp
             sudo mkdir -p /usr/local/bin /usr/local/lib
             sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -86,10 +86,11 @@ jobs:
                 ;;
             esac
             ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-            ZIG_TAR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
-            ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
+            ZIG_FILE="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
+            ZIG_TAR="/tmp/${ZIG_FILE}"
+            ZIG_URL="https://pkg.hexops.org/zig/${ZIG_FILE}"
             ZIG_SIG="${ZIG_TAR}.minisig"
-            ZIG_SIG_URL="${ZIG_URL}.minisig"
+            ZIG_SIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/${ZIG_FILE}.minisig"
             ZIG_PUBKEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
             curl \
               --fail \

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12517,6 +12517,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         let focusContext = shortcutEventFocusContext(event)
         for action in KeyboardShortcutSettings.Action.allCases {
+            guard action != .showHideAllWindows else { continue }
             if (action.shortcutContext.isAlwaysAvailable || action.shortcutContext.isAvailable(focusContext)),
                matchesKeyboardShortcutEvent(event, action: action, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
                 return true

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -12518,7 +12518,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let focusContext = shortcutEventFocusContext(event)
         for action in KeyboardShortcutSettings.Action.allCases {
             if (action.shortcutContext.isAlwaysAvailable || action.shortcutContext.isAvailable(focusContext)),
-               matches(KeyboardShortcutSettings.shortcut(for: action)) {
+               matchesKeyboardShortcutEvent(event, action: action, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
                 return true
             }
         }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -699,7 +699,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var pendingConfiguredShortcutChord: PendingConfiguredShortcutChord?
     var activeConfiguredShortcutChordPrefixForCurrentEvent: ShortcutStroke?
     var shortcutEventFocusContextCache: ShortcutEventFocusContextCache?
-    private var configuredShortcutChordActions: [KeyboardShortcutSettings.Action] = []
     private var ghosttyConfigObserver: NSObjectProtocol?
     private var ghosttyGotoSplitLeftShortcut: StoredShortcut?
     private var ghosttyGotoSplitRightShortcut: StoredShortcut?
@@ -10316,28 +10315,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func installShortcutDefaultsObserver() {
         guard shortcutDefaultsObserver == nil else { return }
-        refreshConfiguredShortcutChordActions()
         shortcutDefaultsObserver = NotificationCenter.default.addObserver(
             forName: KeyboardShortcutSettings.didChangeNotification,
             object: nil,
             queue: .main
         ) { [weak self] _ in
-            self?.refreshConfiguredShortcutChordActions()
             self?.clearConfiguredShortcutChordState()
             self?.scheduleSplitButtonTooltipRefreshAcrossWorkspaces()
-        }
-    }
-
-    private func refreshConfiguredShortcutChordActions() {
-        configuredShortcutChordActions = KeyboardShortcutSettings.Action.allCases.filter { action in
-            // showHideAllWindows is dispatched via Carbon RegisterEventHotKey
-            // (SystemWideHotkeyController) and never routed through AppKit's
-            // local key handler. If a managed cmux.json entry happened to
-            // store it as a chord, arming the prefix here would swallow the
-            // first stroke and leave the second one orphaned, breaking that
-            // keystroke for the focused terminal/browser input.
-            guard action != .showHideAllWindows else { return false }
-            return KeyboardShortcutSettings.shortcut(for: action).hasChord
         }
     }
 
@@ -11051,19 +11035,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if handleConfiguredCmuxShortcut(
-            event: event,
-            actions: configuredCmuxShortcutActions,
-            context: configuredCmuxShortcutContext
-        ) {
+        if handleConfiguredCmuxShortcut(event: event, actions: configuredCmuxShortcutActions, context: configuredCmuxShortcutContext) {
             return true
         }
 
         if activeConfiguredShortcutChordPrefixForCurrentEvent != nil,
-           shouldConsumeSingleStrokeShortcutAfterConfiguredChordMismatch(
-               event: event,
-               cmuxActions: configuredCmuxShortcutActions
-           ) {
+           shouldConsumeSingleStrokeShortcutAfterConfiguredChordMismatch(event: event, cmuxActions: configuredCmuxShortcutActions) {
             return true
         }
 
@@ -12436,11 +12413,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return matchShortcutStroke(event: event, stroke: shortcut.firstStroke)
     }
 
-    private func matchConfiguredSingleStrokeShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
-        guard !shortcut.isUnbound, !shortcut.hasChord else { return false }
-        return matchShortcutStroke(event: event, stroke: shortcut.firstStroke)
-    }
-
     private func matchConfiguredShortcut(event: NSEvent, action: KeyboardShortcutSettings.Action) -> Bool {
         if !action.shortcutContext.isAlwaysAvailable && !action.shortcutContext.isAvailable(shortcutEventFocusContext(event)) { return false }
         return matchConfiguredShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action))
@@ -12515,17 +12487,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         shortcuts: [StoredShortcut] = []
     ) -> Bool {
         var seen = Set<StoredShortcut>()
-        let actionShortcuts: [StoredShortcut]
-        if let actions {
-            actionShortcuts = actions.map { KeyboardShortcutSettings.shortcut(for: $0) }
-        } else {
-            actionShortcuts = KeyboardShortcutSettings.Action.allCases.compactMap { action in
+        let configuredShortcuts = (actions?.map { KeyboardShortcutSettings.shortcut(for: $0) }
+            ?? KeyboardShortcutSettings.Action.allCases.compactMap { action in
                 guard action != .showHideAllWindows else { return nil }
                 let shortcut = KeyboardShortcutSettings.shortcut(for: action)
                 return shortcut.hasChord ? shortcut : nil
-            }
-        }
-        let configuredShortcuts = actionShortcuts + shortcuts
+            }) + shortcuts
         for shortcut in configuredShortcuts {
             guard seen.insert(shortcut).inserted else { continue }
             guard shortcut.hasChord else { continue }
@@ -12544,21 +12511,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         event: NSEvent,
         cmuxActions: [CmuxResolvedConfigAction]
     ) -> Bool {
+        func matches(_ shortcut: StoredShortcut?) -> Bool {
+            guard let shortcut, !shortcut.isUnbound, !shortcut.hasChord else { return false }
+            return matchShortcutStroke(event: event, stroke: shortcut.firstStroke)
+        }
+        let focusContext = shortcutEventFocusContext(event)
         for action in KeyboardShortcutSettings.Action.allCases {
-            if !action.shortcutContext.isAlwaysAvailable && !action.shortcutContext.isAvailable(shortcutEventFocusContext(event)) {
-                continue
-            }
-            if matchConfiguredSingleStrokeShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
+            if (action.shortcutContext.isAlwaysAvailable || action.shortcutContext.isAvailable(focusContext)),
+               matches(KeyboardShortcutSettings.shortcut(for: action)) {
                 return true
             }
         }
-        for action in cmuxActions {
-            guard let shortcut = action.shortcut else { continue }
-            if matchConfiguredSingleStrokeShortcut(event: event, shortcut: shortcut) {
-                return true
-            }
-        }
-        return false
+        return cmuxActions.contains { matches($0.shortcut) }
     }
 
     func configuredCmuxShortcutActions(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11059,6 +11059,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        if activeConfiguredShortcutChordPrefixForCurrentEvent != nil,
+           shouldConsumeSingleStrokeShortcutAfterConfiguredChordMismatch(
+               event: event,
+               cmuxActions: configuredCmuxShortcutActions
+           ) {
+            return true
+        }
+
         // Primary UI shortcuts
         if matchConfiguredShortcut(event: event, action: .toggleSidebar) {
             _ = toggleSidebarInActiveMainWindow()
@@ -12428,6 +12436,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return matchShortcutStroke(event: event, stroke: shortcut.firstStroke)
     }
 
+    private func matchConfiguredSingleStrokeShortcut(event: NSEvent, shortcut: StoredShortcut) -> Bool {
+        guard !shortcut.isUnbound, !shortcut.hasChord else { return false }
+        return matchShortcutStroke(event: event, stroke: shortcut.firstStroke)
+    }
+
     private func matchConfiguredShortcut(event: NSEvent, action: KeyboardShortcutSettings.Action) -> Bool {
         if !action.shortcutContext.isAlwaysAvailable && !action.shortcutContext.isAvailable(shortcutEventFocusContext(event)) { return false }
         return matchConfiguredShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action))
@@ -12502,9 +12515,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         shortcuts: [StoredShortcut] = []
     ) -> Bool {
         var seen = Set<StoredShortcut>()
-        let configuredShortcuts = (actions ?? configuredShortcutChordActions).map {
-            KeyboardShortcutSettings.shortcut(for: $0)
-        } + shortcuts
+        let actionShortcuts: [StoredShortcut]
+        if let actions {
+            actionShortcuts = actions.map { KeyboardShortcutSettings.shortcut(for: $0) }
+        } else {
+            actionShortcuts = KeyboardShortcutSettings.Action.allCases.compactMap { action in
+                guard action != .showHideAllWindows else { return nil }
+                let shortcut = KeyboardShortcutSettings.shortcut(for: action)
+                return shortcut.hasChord ? shortcut : nil
+            }
+        }
+        let configuredShortcuts = actionShortcuts + shortcuts
         for shortcut in configuredShortcuts {
             guard seen.insert(shortcut).inserted else { continue }
             guard shortcut.hasChord else { continue }
@@ -12513,6 +12534,27 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     firstStroke: shortcut.firstStroke,
                     windowNumber: configuredShortcutChordWindowNumber(for: event)
                 )
+                return true
+            }
+        }
+        return false
+    }
+
+    private func shouldConsumeSingleStrokeShortcutAfterConfiguredChordMismatch(
+        event: NSEvent,
+        cmuxActions: [CmuxResolvedConfigAction]
+    ) -> Bool {
+        for action in KeyboardShortcutSettings.Action.allCases {
+            if !action.shortcutContext.isAlwaysAvailable && !action.shortcutContext.isAvailable(shortcutEventFocusContext(event)) {
+                continue
+            }
+            if matchConfiguredSingleStrokeShortcut(event: event, shortcut: KeyboardShortcutSettings.shortcut(for: action)) {
+                return true
+            }
+        }
+        for action in cmuxActions {
+            guard let shortcut = action.shortcut else { continue }
+            if matchConfiguredSingleStrokeShortcut(event: event, shortcut: shortcut) {
                 return true
             }
         }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -453,7 +453,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(manager.tabs.count, initialCount + 1, "Chord prefix should arm instead of firing Settings")
     }
 
-    func testConfiguredChordPrefixBlocksUnrelatedSingleStrokeShortcutOnSecondKey() throws {
+    func testConfiguredChordPrefixBlocksUnrelatedSingleStrokeShortcutOnSecondKey() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -474,42 +474,35 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         let initialWorkspaceCount = manager.tabs.count
         let initialPanelCount = workspace.panels.count
-        let shortcut = StoredShortcut(
-            key: "b",
-            command: false,
-            shift: false,
-            option: false,
-            control: true,
-            chordKey: "d"
-        )
+        let shortcut = StoredShortcut(key: "b", command: false, shift: false, option: false, control: true, chordKey: "d")
+        let showHideShortcut = StoredShortcut(key: "h", command: true, shift: false, option: false, control: false)
+        func requiredEvent(_ key: String, _ modifiers: NSEvent.ModifierFlags, _ keyCode: UInt16, _ description: String) -> NSEvent? {
+            guard let event = makeKeyDownEvent(key: key, modifiers: modifiers, keyCode: keyCode, windowNumber: window.windowNumber) else {
+                XCTFail("Failed to construct \(description) event")
+                return nil
+            }
+            return event
+        }
 
-        try withTemporaryShortcut(action: .splitRight, shortcut: shortcut) {
-            let prefixEvent = try XCTUnwrap(makeKeyDownEvent(
-                key: "b",
-                modifiers: [.control],
-                keyCode: 11,
-                windowNumber: window.windowNumber
-            ))
-            let conflictingSingleStrokeEvent = try XCTUnwrap(makeKeyDownEvent(
-                key: "n",
-                modifiers: [.command],
-                keyCode: 45,
-                windowNumber: window.windowNumber
-            ))
-            let numberedSingleStrokeEvent = try XCTUnwrap(makeKeyDownEvent(
-                key: "2",
-                modifiers: [.command],
-                keyCode: 19,
-                windowNumber: window.windowNumber
-            ))
+        withTemporaryShortcut(action: .splitRight, shortcut: shortcut) {
+            withTemporaryShortcut(action: .showHideAllWindows, shortcut: showHideShortcut) {
+                guard let prefixEvent = requiredEvent("b", [.control], 11, "chord prefix"),
+                      let conflictingSingleStrokeEvent = requiredEvent("n", [.command], 45, "Cmd+N"),
+                      let numberedSingleStrokeEvent = requiredEvent("2", [.command], 19, "Cmd+2"),
+                      let showHideSingleStrokeEvent = requiredEvent("h", [.command], 4, "Cmd+H") else {
+                    return
+                }
 #if DEBUG
-            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
-            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: conflictingSingleStrokeEvent))
-            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
-            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: numberedSingleStrokeEvent))
+                XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
+                XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: conflictingSingleStrokeEvent))
+                XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
+                XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: numberedSingleStrokeEvent))
+                XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
+                XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: showHideSingleStrokeEvent))
 #else
-            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+                XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
+            }
         }
 
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -453,7 +453,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(manager.tabs.count, initialCount + 1, "Chord prefix should arm instead of firing Settings")
     }
 
-    func testConfiguredChordPrefixBlocksUnrelatedSingleStrokeShortcutOnSecondKey() {
+    func testConfiguredChordPrefixBlocksUnrelatedSingleStrokeShortcutOnSecondKey() throws {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -483,30 +483,30 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             chordKey: "d"
         )
 
-        withTemporaryShortcut(action: .splitRight, shortcut: shortcut) {
-            guard let prefixEvent = makeKeyDownEvent(
+        try withTemporaryShortcut(action: .splitRight, shortcut: shortcut) {
+            let prefixEvent = try XCTUnwrap(makeKeyDownEvent(
                 key: "b",
                 modifiers: [.control],
                 keyCode: 11,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Ctrl+B prefix event")
-                return
-            }
-
-            guard let conflictingSingleStrokeEvent = makeKeyDownEvent(
+            ))
+            let conflictingSingleStrokeEvent = try XCTUnwrap(makeKeyDownEvent(
                 key: "n",
                 modifiers: [.command],
                 keyCode: 45,
                 windowNumber: window.windowNumber
-            ) else {
-                XCTFail("Failed to construct Cmd+N event")
-                return
-            }
-
+            ))
+            let numberedSingleStrokeEvent = try XCTUnwrap(makeKeyDownEvent(
+                key: "2",
+                modifiers: [.command],
+                keyCode: 19,
+                windowNumber: window.windowNumber
+            ))
 #if DEBUG
             XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
             XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: conflictingSingleStrokeEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: numberedSingleStrokeEvent))
 #else
             XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
@@ -5407,8 +5407,8 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
     private func withTemporaryShortcut(
         action: KeyboardShortcutSettings.Action,
         shortcut: StoredShortcut? = nil,
-        _ body: () -> Void
-    ) {
+        _ body: () throws -> Void
+    ) rethrows {
         let hadPersistedShortcut = UserDefaults.standard.object(forKey: action.defaultsKey) != nil
         let originalShortcut = KeyboardShortcutSettings.shortcut(for: action)
         defer {
@@ -5419,7 +5419,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             }
         }
         KeyboardShortcutSettings.setShortcut(shortcut ?? action.defaultShortcut, for: action)
-        body()
+        try body()
     }
 
     private func assertEscapeKeyUpIsConsumedAfterCommandPaletteOpenRequest(

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -506,7 +506,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
 #if DEBUG
             XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: prefixEvent))
-            XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: conflictingSingleStrokeEvent))
+            XCTAssertTrue(appDelegate.debugHandleCustomShortcut(event: conflictingSingleStrokeEvent))
 #else
             XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif

--- a/web/app/[locale]/components/fade-image.tsx
+++ b/web/app/[locale]/components/fade-image.tsx
@@ -9,6 +9,7 @@ export function FadeImage(props: ImageProps) {
   return (
     <Image
       {...props}
+      alt={props.alt}
       placeholder={undefined}
       className={`${props.className ?? ""} transition-opacity duration-700 ${loaded ? "opacity-100" : "opacity-0"}`}
       onLoad={() => setLoaded(true)}

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTranslations } from "next-intl";
+import Image from "next/image";
 import { Link } from "../../../i18n/navigation";
 import { NavLinks } from "./nav-links";
 import { DownloadButton } from "./download-button";
@@ -32,7 +33,7 @@ export function SiteHeader({
             {!hideLogo && (
               <>
                 <Link href="/" className="flex items-center gap-2.5">
-                  <img
+                  <Image
                     src="/logo.png"
                     alt="cmux"
                     width={24}

--- a/web/app/[locale]/components/spacing-control.tsx
+++ b/web/app/[locale]/components/spacing-control.tsx
@@ -100,22 +100,30 @@ function applyToDOM(v: DevValues) {
 
 export function DevPanel() {
   const [visible, setVisible] = useState(false);
-  const [pos, setPos] = useState(initialPanelPosition);
+  const [pos, setPos] = useState({ x: 0, y: 0 });
   const [dragging, setDragging] = useState(false);
   const [copied, setCopied] = useState(false);
   const vals = useDevValues();
   const dragOffset = useRef({ x: 0, y: 0 });
+  const visibleRef = useRef(false);
+
+  const toggleVisible = useCallback(() => {
+    const nextVisible = !visibleRef.current;
+    visibleRef.current = nextVisible;
+    if (nextVisible) setPos(initialPanelPosition());
+    setVisible(nextVisible);
+  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (e.metaKey && e.key === ".") {
         e.preventDefault();
-        setVisible((v) => !v);
+        toggleVisible();
       }
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, []);
+  }, [toggleVisible]);
 
   const update = useCallback((patch: Partial<DevValues>) => {
     setStore(patch);

--- a/web/app/[locale]/components/spacing-control.tsx
+++ b/web/app/[locale]/components/spacing-control.tsx
@@ -49,6 +49,11 @@ function subscribe(cb: () => void) {
   return () => { listeners.delete(cb); };
 }
 
+function initialPanelPosition() {
+  if (typeof window === "undefined") return { x: 0, y: 0 };
+  return { x: window.innerWidth - 340, y: window.innerHeight - 320 };
+}
+
 export function useDevValues() {
   return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 }
@@ -95,15 +100,11 @@ function applyToDOM(v: DevValues) {
 
 export function DevPanel() {
   const [visible, setVisible] = useState(false);
-  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [pos, setPos] = useState(initialPanelPosition);
   const [dragging, setDragging] = useState(false);
   const [copied, setCopied] = useState(false);
   const vals = useDevValues();
   const dragOffset = useRef({ x: 0, y: 0 });
-
-  useEffect(() => {
-    setPos({ x: window.innerWidth - 340, y: window.innerHeight - 320 });
-  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/web/app/[locale]/docs/notifications/page.tsx
+++ b/web/app/[locale]/docs/notifications/page.tsx
@@ -82,7 +82,7 @@ echo "$CMUX_NOTIFICATION_TITLE: $CMUX_NOTIFICATION_BODY" >> ~/notifications.log`
 
       <h2>{t("sending")}</h2>
 
-      <h3>{t("cli")}</h3>
+      <h3 id="cli">{t("cli")}</h3>
       <CodeBlock lang="bash">{`cmux notify --title "Task Complete" --body "Your build finished"
 cmux notify --title "Claude Code" --subtitle "Waiting" --body "Agent needs input"`}</CodeBlock>
 
@@ -145,7 +145,7 @@ printf '\\e]99;i=1;e=1;d=1;p=body:All tests passed\\e\\\\'`}</CodeBlock>
         {t("comparisonCallout")}
       </Callout>
 
-      <h2>{t("claudeCodeHooks")}</h2>
+      <h2 id="claude-code-hooks">{t("claudeCodeHooks")}</h2>
       <p>
         {t.rich("claudeCodeHooksDesc", {
           link: (chunks) => (

--- a/web/app/[locale]/nightly/page.tsx
+++ b/web/app/[locale]/nightly/page.tsx
@@ -1,5 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
+import Image from "next/image";
 import { buildAlternates } from "../../../i18n/seo";
 import { SiteHeader } from "../components/site-header";
 
@@ -29,7 +30,7 @@ export default function NightlyPage() {
       <main className="w-full max-w-2xl mx-auto px-6 py-10">
         {/* Header */}
         <div className="flex items-center gap-4 mb-6">
-          <img
+          <Image
             src="/logo-nightly.png"
             alt="cmux NIGHTLY icon"
             width={48}

--- a/web/app/[locale]/opengraph-image.tsx
+++ b/web/app/[locale]/opengraph-image.tsx
@@ -56,7 +56,11 @@ export default async function Image() {
               position: "relative",
             }}
           >
-            <img src={screenshotSrc} width={size.width * S} />
+            <img
+              src={screenshotSrc}
+              alt="cmux terminal app screenshot"
+              width={size.width * S}
+            />
             <div
               style={{
                 position: "absolute",
@@ -88,6 +92,7 @@ export default async function Image() {
             >
               <img
                 src={logoSrc}
+                alt="cmux icon"
                 width={112 * S}
                 height={112 * S}
                 style={{ borderRadius: 20 * S }}

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -1,4 +1,5 @@
 import { useTranslations, useLocale } from "next-intl";
+import Image from "next/image";
 import { FadeImage } from "./components/fade-image";
 import Balancer from "react-wrap-balancer";
 import landingImage from "./assets/landing-image.png";
@@ -29,7 +30,7 @@ function HomeContent() {
       <main className="w-full max-w-2xl mx-auto px-6 py-16 sm:py-24">
         {/* Header */}
         <div className="flex items-center gap-4 mb-10" data-dev="header">
-          <img
+          <Image
             src="/logo.png"
             alt="cmux icon"
             width={48}
@@ -111,12 +112,12 @@ function HomeContent() {
                 <span className="text-muted">
                   {t.rich("feature.keyboardShortcutsDesc", {
                     link: (chunks) => (
-                      <a
+                      <Link
                         href="/docs/keyboard-shortcuts"
                         className={linkClass}
                       >
                         {chunks}
-                      </a>
+                      </Link>
                     ),
                   })}
                 </span>
@@ -176,14 +177,14 @@ function HomeContent() {
               <p className="text-muted">
                 {t.rich("faqNotificationsA", {
                   cliLink: (chunks) => (
-                    <a href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                   hooksLink: (chunks) => (
-                    <a href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                 })}
               </p>
@@ -198,9 +199,9 @@ function HomeContent() {
                     </code>
                   ),
                   link: (chunks) => (
-                    <a href="/docs/keyboard-shortcuts" className={linkClass}>
+                    <Link href="/docs/keyboard-shortcuts" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                 })}
               </p>
@@ -271,7 +272,7 @@ function HomeContent() {
                   >
                     —
                     {item.avatar && (
-                      <img
+                      <Image
                         src={item.avatar}
                         alt={item.name}
                         width={16}

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -177,12 +177,12 @@ function HomeContent() {
               <p className="text-muted">
                 {t.rich("faqNotificationsA", {
                   cliLink: (chunks) => (
-                    <Link href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications#cli" className={linkClass}>
                       {chunks}
                     </Link>
                   ),
                   hooksLink: (chunks) => (
-                    <Link href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications#claude-code-hooks" className={linkClass}>
                       {chunks}
                     </Link>
                   ),

--- a/web/app/[locale]/testimonials.tsx
+++ b/web/app/[locale]/testimonials.tsx
@@ -1,3 +1,5 @@
+import Image from "next/image";
+
 export const testimonials = [
   {
     key: "mitchellh",
@@ -282,7 +284,7 @@ export function TestimonialCard({
     >
       <div className="flex items-center gap-3 mb-3">
         {testimonial.avatar ? (
-          <img
+          <Image
             src={testimonial.avatar}
             alt={testimonial.name}
             width={40}

--- a/web/app/[locale]/typing.tsx
+++ b/web/app/[locale]/typing.tsx
@@ -29,7 +29,7 @@ export function TypingTagline() {
   useEffect(() => {
     const phrase = phrases[phraseIndex];
 
-    if (!deleting && charIndex === phrase.length) {
+    if (!deleting && charIndex >= phrase.length) {
       const timeout = setTimeout(() => setDeleting(true), 2000);
       return () => clearTimeout(timeout);
     }

--- a/web/app/[locale]/typing.tsx
+++ b/web/app/[locale]/typing.tsx
@@ -1,19 +1,22 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useTranslations } from "next-intl";
 import { useDevValues } from "./components/spacing-control";
 
 function usePhrases() {
   const t = useTranslations("home");
-  return [
-    t("typingCodingAgents"),
-    t("typingMultitasking"),
-    "Claude Code",
-    "Codex",
-    "OpenCode",
-    "Gemini CLI",
-  ];
+  return useMemo(
+    () => [
+      t("typingCodingAgents"),
+      t("typingMultitasking"),
+      "Claude Code",
+      "Codex",
+      "OpenCode",
+      "Gemini CLI",
+    ],
+    [t],
+  );
 }
 
 export function TypingTagline() {
@@ -45,7 +48,7 @@ export function TypingTagline() {
     }, speed);
 
     return () => clearTimeout(timeout);
-  }, [charIndex, deleting, phraseIndex]);
+  }, [charIndex, deleting, phraseIndex, phrases]);
 
   const phrase = phrases[phraseIndex];
   const displayed = phrase.slice(0, charIndex);

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -1,7 +1,11 @@
 declare module "bun:test" {
   type TestCallback = () => unknown | Promise<unknown>;
   type Lifecycle = (fn: TestCallback, timeout?: number) => void;
-  type NamedTest = (name: string, fn: TestCallback, timeout?: number) => void;
+  type NamedTest = {
+    (name: string, fn: TestCallback, timeout?: number): void;
+    readonly only: NamedTest;
+    readonly skip: NamedTest;
+  };
 
   type Matchers = {
     readonly not: Matchers;
@@ -23,6 +27,7 @@ declare module "bun:test" {
 
   type MockControls = {
     mockClear(): void;
+    mockResolvedValue(value: unknown): void;
   };
 
   type MockModule = {
@@ -35,7 +40,10 @@ declare module "bun:test" {
   export const beforeAll: Lifecycle;
   export const beforeEach: Lifecycle;
   export const describe: NamedTest;
-  export const expect: (actual: unknown) => Matchers;
+  export const expect: {
+    (actual: unknown): Matchers;
+    objectContaining(expected: unknown): unknown;
+  };
   export const mock: MockModule;
   export const test: NamedTest;
 }

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -1,5 +1,5 @@
 declare module "bun:test" {
-  type TestCallback = () => unknown | Promise<unknown>;
+  type TestCallback = () => void | Promise<void>;
   type Lifecycle = (fn: TestCallback, timeout?: number) => void;
   type NamedTest = {
     (name: string, fn: TestCallback, timeout?: number): void;
@@ -26,13 +26,13 @@ declare module "bun:test" {
   };
 
   type MockControls = {
-    mockClear(): void;
-    mockResolvedValue(value: unknown): void;
+    mockClear(): MockControls;
+    mockResolvedValue(value: unknown): MockControls;
   };
 
   type MockModule = {
     <T extends (...args: never[]) => unknown>(fn: T): T & MockControls;
-    module(moduleName: string, factory: () => unknown): void;
+    module(moduleName: string, factory: () => unknown | Promise<unknown>): void | Promise<void>;
   };
 
   export const afterAll: Lifecycle;

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -1,10 +1,41 @@
 declare module "bun:test" {
-  export const afterAll: any;
-  export const afterEach: any;
-  export const beforeAll: any;
-  export const beforeEach: any;
-  export const describe: any;
-  export const expect: any;
-  export const mock: any;
-  export const test: any;
+  type TestCallback = () => unknown | Promise<unknown>;
+  type Lifecycle = (fn: TestCallback, timeout?: number) => void;
+  type NamedTest = (name: string, fn: TestCallback, timeout?: number) => void;
+
+  type Matchers = {
+    readonly not: Matchers;
+    readonly resolves: Matchers;
+    readonly rejects: Matchers;
+    toBe(expected: unknown): void;
+    toBeInstanceOf(expected: unknown): void;
+    toBeNull(): void;
+    toContain(expected: unknown): void;
+    toEqual(expected: unknown): void;
+    toHaveBeenCalled(): void;
+    toHaveBeenCalledWith(...expected: unknown[]): void;
+    toHaveLength(expected: number): void;
+    toHaveProperty(key: string): void;
+    toMatchObject(expected: unknown): void;
+    toStartWith(expected: string): void;
+    toThrow(expected?: unknown): void;
+  };
+
+  type MockControls = {
+    mockClear(): void;
+  };
+
+  type MockModule = {
+    <T extends (...args: never[]) => unknown>(fn: T): T & MockControls;
+    module(moduleName: string, factory: () => unknown): void;
+  };
+
+  export const afterAll: Lifecycle;
+  export const afterEach: Lifecycle;
+  export const beforeAll: Lifecycle;
+  export const beforeEach: Lifecycle;
+  export const describe: NamedTest;
+  export const expect: (actual: unknown) => Matchers;
+  export const mock: MockModule;
+  export const test: NamedTest;
 }


### PR DESCRIPTION
## Summary
- clear the current `bun run lint` errors and warnings in the web package
- replace local marketing images with `next/image` and internal docs anchors with localized `Link`
- add a minimal typed Bun test shim without `any`

## Verification
- bun run lint
- bun test
- bun run cloud-vm:preflight -- --schema-only .
- bun run build with valid local Stack env and placeholder feedback env

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes all `web` lint errors, standardizes images/links for production, and refines shortcut routing to avoid accidental triggers while staying within budget. Also switches perf-activation to the signed, pinned `mlugg/setup-zig` action and adds a typed `bun:test` shim.

- **Bug Fixes**
  - Replaced `<img>` with `next/image` for logos/avatars in header, homepage, nightly, and testimonials.
  - Swapped docs anchors for localized `Link`; added `id` anchors; homepage links to `#cli` and `#claude-code-hooks`.
  - Forwarded `alt` in `FadeImage`; added alt text to Open Graph images.
  - Made the dev panel SSR-safe; set position on open; fixed Meta+`.` during SSR.
  - Memoized typing phrases; fixed effect deps to avoid stale values.
  - Typed `bun:test`: named tests (`only`/`skip`), `not`/`resolves`/`rejects`, common matchers, mock controls, `mock.module`, `expect.objectContaining`.
  - Kept shortcut routing under budget and precise: compute chords on demand, respect focus context, consume single-stroke shortcuts—including numbered—after a chord mismatch, but never consume Show/Hide All Windows; updated routing tests.
  - Perf activation: use signed, pinned `mlugg/setup-zig` to install Zig 0.15.2.

<sup>Written for commit 6c0a19b38c1bca3cb182bc68614baaad9d37a6d8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Modernized image rendering across the site for improved loading and visuals.

* **Accessibility**
  * Added alt text to images and anchor IDs for better screen-reader support and in-page linking.

* **Performance**
  * Faster navigation via client-side routing and fewer re-renders in typing/phrase display.

* **Bug Fixes**
  * SSR-safe developer panel positioning and improved keyboard shortcut handling around chorded shortcuts.

* **Tests**
  * Stronger test typings and additional shortcut routing tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->