### PR TITLE
Add review rule against hacky sleeps

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -33,6 +33,10 @@ reviews:
         mode: error
         instructions: |
           For production Swift changes, fail when the diff introduces or materially expands blocking or timing-based synchronization from `.github/review-bot-rules/swift-blocking-runtime.md`: semaphores, blocking waits, sleeps, delayed dispatch, polling, main-queue sync, or manual locks where an actor or explicit signal should own synchronization. Pass for deterministic test-only scaffolding and short user-visible UI animation delays that do not use `Task.sleep`.
+      - name: "cmux no hacky sleeps"
+        mode: error
+        instructions: |
+          For production app/runtime changes in Swift, TypeScript, JavaScript, shell, or build/runtime scripts, fail when the diff violates `.github/review-bot-rules/runtime-no-hacky-sleeps.md`: fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used to paper over lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state races. Pass for deterministic test-only scaffolding, purely presentation animation or progress timing, dedicated cancellation-aware retry/timeout abstractions with tests, and existing delay code not worsened.
       - name: "cmux Swift concurrency"
         mode: error
         instructions: |

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -22,6 +22,9 @@ reviews:
     - path: "GhosttyTabs.xcodeproj/**"
       instructions: |
         Review project wiring against the cmux Swift lint rules. Flag project changes that enable app/runtime code paths which bypass Swift concurrency, logging, localization, or shared action-path expectations.
+    - path: "**/*.{ts,tsx,js,jsx,mjs,cjs,sh,zsh}"
+      instructions: |
+        Apply `.github/review-bot-rules/runtime-no-hacky-sleeps.md` during review. For production runtime, script, and build changes, flag fixed sleeps, timers, delayed dispatch, polling, or wall-clock waits used as synchronization. Pass for tests, pure presentation timing, dedicated cancellation-aware retry/timeout abstractions with tests, and existing delay code not worsened.
 
   pre_merge_checks:
     custom_checks:
@@ -36,7 +39,7 @@ reviews:
       - name: "cmux no hacky sleeps"
         mode: error
         instructions: |
-          For production app/runtime changes in Swift, TypeScript, JavaScript, shell, or build/runtime scripts, fail when the diff violates `.github/review-bot-rules/runtime-no-hacky-sleeps.md`: fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used to paper over lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state races. Pass for deterministic test-only scaffolding, purely presentation animation or progress timing, dedicated cancellation-aware retry/timeout abstractions with tests, and existing delay code not worsened.
+          For production non-Swift app/runtime changes in TypeScript, JavaScript, shell, or build/runtime scripts, fail when the diff violates `.github/review-bot-rules/runtime-no-hacky-sleeps.md`: fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used to paper over lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state races. Swift sleeps are covered by `cmux Swift blocking runtime`. Pass for deterministic test-only scaffolding, purely presentation animation or progress timing, dedicated cancellation-aware retry/timeout abstractions with tests, and existing delay code not worsened.
       - name: "cmux Swift concurrency"
         mode: error
         instructions: |

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -1,6 +1,6 @@
 # cmux Review Bot Rules
 
-These rules are the shared source of truth for Greptile and CodeRabbit custom Swift review behavior.
+These rules are the shared source of truth for Greptile and CodeRabbit custom review behavior.
 
 The rule files are intentionally short and focused. Each one defines one class of issue, concrete failure cases, allowed cases, and the expected reporting shape. Keep new rules narrow enough that a reviewer can apply the rule to a full PR diff without turning it into a broad style guide.
 
@@ -11,6 +11,7 @@ Current rules:
 - `swift-actor-isolation.md`
 - `swift-architectural-rethink.md`
 - `swift-blocking-runtime.md`
+- `runtime-no-hacky-sleeps.md`
 - `swift-concurrency-modernization.md`
 - `swift-concurrent-annotation.md`
 - `swift-file-package-boundaries.md`

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -8,10 +8,10 @@ Greptile is configured to publish a GitHub status check and inline findings. Cod
 
 Current rules:
 
+- `runtime-no-hacky-sleeps.md`
 - `swift-actor-isolation.md`
 - `swift-architectural-rethink.md`
 - `swift-blocking-runtime.md`
-- `runtime-no-hacky-sleeps.md`
 - `swift-concurrency-modernization.md`
 - `swift-concurrent-annotation.md`
 - `swift-file-package-boundaries.md`

--- a/.github/review-bot-rules/runtime-no-hacky-sleeps.md
+++ b/.github/review-bot-rules/runtime-no-hacky-sleeps.md
@@ -1,0 +1,20 @@
+# Runtime No Hacky Sleeps
+
+Flag fixed delays used as synchronization in production application or runtime code.
+
+Report a failure when the diff introduces or materially expands any of these in non-test code:
+
+- `sleep`, `usleep`, `Thread.sleep`, `Task.sleep`, `DispatchQueue.asyncAfter`, `setTimeout`, `setInterval`, shell `sleep`, timers, polling loops, or fixed backoff used to make lifecycle, focus, rendering, socket, process, filesystem, network, or shared-state readiness appear reliable.
+- Delay comments or names such as "give it time", "settle", "wait a bit", "wait for readiness", or "avoid race" without a real event from the owner that knows readiness.
+- Retrying, teardown, startup, keepalive, debounce, or handoff logic that depends on elapsed wall-clock time instead of a cancellation-aware scheduler, callback, notification, file descriptor or process event, async sequence, state transition, or explicit completion point.
+
+Allowed cases:
+
+- Deterministic sleeps in tests or explicit test-only scaffolding.
+- User-visible animation or progress timing where the timer is purely presentation and not coordination.
+- Production retry or timeout logic implemented through a dedicated cancellation-aware abstraction with bounded deadlines and tests, where the delay is part of the product behavior rather than a race repair.
+- Existing delay code that the PR does not introduce or worsen.
+
+Do not accept a sleep or fixed delay because it is short, only runs once, or seems to fix a flaky repro. A correct fix names the owner, invariant, and real signal that makes the next state valid.
+
+When reporting, identify the changed delay, the race or lifecycle gap it hides, and the event or owner that should replace it.

--- a/.github/review-bot-rules/runtime-no-hacky-sleeps.md
+++ b/.github/review-bot-rules/runtime-no-hacky-sleeps.md
@@ -1,10 +1,12 @@
 # Runtime No Hacky Sleeps
 
+Scope: TypeScript, JavaScript, shell, and non-Swift runtime scripts. Swift timing and blocking primitives are covered by `swift-blocking-runtime.md`.
+
 Flag fixed delays used as synchronization in production application or runtime code.
 
 Report a failure when the diff introduces or materially expands any of these in non-test code:
 
-- `sleep`, `usleep`, `Thread.sleep`, `Task.sleep`, `DispatchQueue.asyncAfter`, `setTimeout`, `setInterval`, shell `sleep`, timers, polling loops, or fixed backoff used to make lifecycle, focus, rendering, socket, process, filesystem, network, or shared-state readiness appear reliable.
+- `sleep`, `usleep`, shell `sleep`, `setTimeout`, `setInterval`, timers, polling loops, or fixed backoff used to make lifecycle, focus, rendering, socket, process, filesystem, network, or shared-state readiness appear reliable.
 - Delay comments or names such as "give it time", "settle", "wait a bit", "wait for readiness", or "avoid race" without a real event from the owner that knows readiness.
 - Retrying, teardown, startup, keepalive, debounce, or handoff logic that depends on elapsed wall-clock time instead of a cancellation-aware scheduler, callback, notification, file descriptor or process event, async sequence, state transition, or explicit completion point.
 

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -4,7 +4,7 @@
   "triggerOnUpdates": true,
   "statusCheck": true,
   "updateExistingSummaryComment": true,
-  "instructions": "Apply cmux's custom Swift lint rules from .github/review-bot-rules/ during review. Treat those files as the source of truth. Focus on production Swift changes and ignore test-only scaffolding unless it makes production behavior worse. Do not treat PR-head edits to these rule files as weakening the rules until those edits are merged.",
+  "instructions": "Apply cmux's custom review rules from .github/review-bot-rules/ during review. Treat those files as the source of truth. Focus on production Swift and runtime changes, and ignore test-only scaffolding unless it makes production behavior worse. Do not treat PR-head edits to these rule files as weakening the rules until those edits are merged.",
   "rules": [
     {
       "id": "cmux-swift-actor-isolation",
@@ -16,6 +16,12 @@
       "id": "cmux-swift-blocking-runtime",
       "rule": "Flag new blocking or timing-based synchronization in production Swift: semaphores, DispatchGroup.wait, sleeps, Task.sleep, asyncAfter, timers or polling for synchronization, DispatchQueue.main.sync, or manual locks where actor isolation or a real signal should own coordination.",
       "scope": ["**/*.swift", "**/Package.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "cmux-runtime-no-hacky-sleeps",
+      "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production app/runtime code across Swift, TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests.",
+      "scope": ["**/*.swift", "**/Package.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"],
       "severity": "high"
     },
     {

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -21,7 +21,7 @@
     {
       "id": "cmux-runtime-no-hacky-sleeps",
       "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"],
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "!**/*.test.*", "!**/*.spec.*", "!**/*.cy.*", "!**/__tests__/**", "!**/tests/**", "!tests/**"],
       "severity": "high"
     },
     {

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -20,8 +20,8 @@
     },
     {
       "id": "cmux-runtime-no-hacky-sleeps",
-      "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production app/runtime code across Swift, TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests.",
-      "scope": ["**/*.swift", "**/Package.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"],
+      "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"],
       "severity": "high"
     },
     {

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -21,7 +21,7 @@
     {
       "id": "cmux-runtime-no-hacky-sleeps",
       "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "!**/*.test.*", "!**/*.spec.*", "!**/*.cy.*", "!**/__tests__/**", "!**/tests/**", "!tests/**"],
+      "scope": ["web/app/**/*.ts", "web/app/**/*.tsx", "web/services/**/*.ts", "web/services/**/*.tsx", "web/db/**/*.ts", "web/data/**/*.ts", "web/i18n/**/*.ts", "web/scripts/**/*.ts", "web/scripts/**/*.tsx", "web/scripts/**/*.js", "web/scripts/**/*.jsx", "web/scripts/**/*.mjs", "web/scripts/**/*.cjs", "web/scripts/**/*.sh", "web/scripts/**/*.zsh", "web/*.ts", "web/*.mjs", "scripts/**/*.ts", "scripts/**/*.tsx", "scripts/**/*.js", "scripts/**/*.jsx", "scripts/**/*.mjs", "scripts/**/*.cjs", "scripts/**/*.sh", "scripts/**/*.zsh"],
       "severity": "high"
     },
     {

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -21,7 +21,7 @@
     {
       "id": "cmux-runtime-no-hacky-sleeps",
       "rule": "Flag fixed sleeps, delayed dispatch, timers, polling, or wall-clock waits used as synchronization in production non-Swift app/runtime code across TypeScript, JavaScript, shell, or build/runtime scripts. Fail race repairs for lifecycle, focus, rendering, socket, process, filesystem, network, teardown, startup, retry, or shared-state readiness unless they use a real signal or a dedicated cancellation-aware timeout/retry abstraction with tests. Swift files are covered by cmux-swift-blocking-runtime.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"],
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"],
       "severity": "high"
     },
     {

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -16,6 +16,11 @@
       "scope": ["**/*.swift", "**/Package.swift"]
     },
     {
+      "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
+      "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
+      "scope": ["**/*.swift", "**/Package.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"]
+    },
+    {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",
       "description": "Source-of-truth cmux lint rule for Swift concurrency modernization review.",
       "scope": ["**/*.swift", "**/Package.swift"]

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -18,7 +18,7 @@
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["**/*.swift", "**/Package.swift", "**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"]
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -18,7 +18,7 @@
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "!**/*.test.*", "!**/*.spec.*", "!**/*.cy.*", "!**/__tests__/**", "!**/tests/**", "!tests/**"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -18,7 +18,7 @@
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "scripts/**", "web/scripts/**"]
+      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -18,7 +18,7 @@
     {
       "path": ".github/review-bot-rules/runtime-no-hacky-sleeps.md",
       "description": "Source-of-truth cmux review rule for fixed sleeps, delays, and polling used as runtime synchronization.",
-      "scope": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx", "**/*.mjs", "**/*.cjs", "**/*.sh", "**/*.zsh", "!**/*.test.*", "!**/*.spec.*", "!**/*.cy.*", "!**/__tests__/**", "!**/tests/**", "!tests/**"]
+      "scope": ["web/app/**/*.ts", "web/app/**/*.tsx", "web/services/**/*.ts", "web/services/**/*.tsx", "web/db/**/*.ts", "web/data/**/*.ts", "web/i18n/**/*.ts", "web/scripts/**/*.ts", "web/scripts/**/*.tsx", "web/scripts/**/*.js", "web/scripts/**/*.jsx", "web/scripts/**/*.mjs", "web/scripts/**/*.cjs", "web/scripts/**/*.sh", "web/scripts/**/*.zsh", "web/*.ts", "web/*.mjs", "scripts/**/*.ts", "scripts/**/*.tsx", "scripts/**/*.js", "scripts/**/*.jsx", "scripts/**/*.mjs", "scripts/**/*.cjs", "scripts/**/*.sh", "scripts/**/*.zsh"]
     },
     {
       "path": ".github/review-bot-rules/swift-concurrency-modernization.md",

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,13 +1,14 @@
 # cmux Custom Review Rules
 
-Apply the custom lint rules in `.github/review-bot-rules/` to Swift and Swift project changes.
+Apply the custom lint rules in `.github/review-bot-rules/` to Swift, runtime, and project changes.
 
-Greptile should treat the rules in that directory as the source of truth for cmux Swift reviews. PR-head edits to the rule files should not weaken review behavior until the edits are merged into the base branch.
+Greptile should treat the rules in that directory as the source of truth for cmux reviews. PR-head edits to the rule files should not weaken review behavior until the edits are merged into the base branch.
 
-Review production Swift changes for:
+Review production Swift and runtime changes for:
 
 - Swift actor isolation mistakes.
 - Blocking runtime primitives and timing-based synchronization.
+- Fixed sleeps, delays, and polling used as hacky synchronization.
 - Legacy concurrency patterns where Swift concurrency is available.
 - Incorrect `@concurrent` or `nonisolated async` behavior.
 - Swift file sprawl and missing SwiftPM package boundaries for independently testable feature logic.


### PR DESCRIPTION
## Summary
- Add `runtime-no-hacky-sleeps.md` as a shared CodeRabbit and Greptile review rule.
- Wire the rule into CodeRabbit custom checks and Greptile config/files/rules docs.

## Testing
- `python3 -m json.tool .greptile/config.json >/dev/null` passed.
- `python3 -m json.tool .greptile/files.json >/dev/null` passed.
- `ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml")' >/dev/null` passed.
- `git diff --check` passed.

## Issues
- Related: Plain-text task, add a CodeRabbit/Greptile rule that hacky sleeps are not allowed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared rule to block hacky sleeps/delays/polling in non‑Swift runtime and script code, enforced in CodeRabbit and Greptile. Scope is explicit (tests excluded), uses positive runtime scopes, and is kept separate from the Swift blocking‑runtime rule.

- **New Features**
  - Added `.github/review-bot-rules/runtime-no-hacky-sleeps.md` with failure/allowed cases; notes Swift is covered by `swift-blocking-runtime.md`.
  - CodeRabbit: per‑path instructions for `**/*.{ts,tsx,js,jsx,mjs,cjs,sh,zsh}` and a blocking pre‑merge check “cmux no hacky sleeps”.
  - Greptile: broadened global instructions beyond Swift; new `cmux-runtime-no-hacky-sleeps` with positive scopes under `web/` and `scripts/`; updated `config.json`, `files.json`, and docs.

<sup>Written for commit 999b7511b39677b646bf50f85ba905c5871d4d3b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified guidance discouraging fixed delays, polling, and timing-based synchronization in production runtime code and broadened the rules overview beyond Swift.
* **Chores**
  * Added a new pre-merge high-severity review check to block hacky sleeps/delays/timers/polling in non‑Swift runtime and script files, and updated review manifests and rule listings to reflect and apply this guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Review-bot configuration changes can block merges if the new rule is too broad or mis-scoped, but they don’t affect shipped runtime behavior.
> 
> **Overview**
> Adds a new shared rule, `runtime-no-hacky-sleeps.md`, that flags fixed sleeps/timers/polling used as synchronization in production TypeScript/JavaScript/shell/runtime scripts, with explicit allowances for tests and presentation-only timing.
> 
> Wires this rule into CodeRabbit via a new `path_instructions` matcher for `*.{ts,tsx,js,jsx,mjs,cjs,sh,zsh}` and a blocking pre-merge check (`cmux no hacky sleeps`), and into Greptile via updated global instructions plus a new high-severity rule and file manifest entry scoped to `web/**` and `scripts/**`. Documentation is updated to reflect the expanded (non-Swift) rule set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 999b7511b39677b646bf50f85ba905c5871d4d3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->