### PR TITLE
Support Pi session restoration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -320,6 +320,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_socket_operation_deadline.py
           python3 tests/test_claude_wrapper_hooks.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_claude_hook_stop_last_assistant.py
+          CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_pi_extension_install.py
 
   tests-build-and-lag:
     # Build the full cmux scheme and run the lag regression on WarpBuild.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,9 @@ jobs:
           CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
             ./tests/test_bundled_ghostty_theme_picker_helper.sh
 
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
       - name: Run CLI no-socket regressions
         run: |
           set -euo pipefail

--- a/CLI/CMUXCLI+DocsSettings.swift
+++ b/CLI/CMUXCLI+DocsSettings.swift
@@ -84,16 +84,17 @@ extension CMUXCLI {
         DocsReference(
             topic: "agents",
             aliases: ["integrations", "agent-integrations"],
-            summary: "Codex, Claude Code, OpenCode, and agent workflow integrations.",
+            summary: "Agent hook integrations, Feed approvals, notifications, and session restore.",
             webURL: "https://cmux.com/docs/agent-integrations/oh-my-codex",
             rawResources: [
+                DocsResource(label: "agent hook docs", url: "https://raw.githubusercontent.com/manaflow-ai/cmux/main/docs/agent-hooks.md"),
                 DocsResource(label: "feed docs", url: "https://raw.githubusercontent.com/manaflow-ai/cmux/main/docs/feed.md"),
                 DocsResource(label: "notifications docs", url: "https://raw.githubusercontent.com/manaflow-ai/cmux/main/docs/notifications.md"),
             ],
             commands: [
-                "cmux codex install-hooks",
-                "cmux hooks opencode install",
                 "cmux hooks setup",
+                "cmux hooks setup <agent>",
+                "cmux hooks <agent> uninstall",
             ]
         ),
         DocsReference(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8456,9 +8456,11 @@ struct CMUXCLI {
               <agent> <event>    Internal hook entrypoint used by generated configs
               feed               Internal Feed decision bridge
 
-            OpenCode files:
+            Generated files:
               ~/.config/opencode/plugins/cmux-session.js
               ~/.config/opencode/plugins/cmux-feed.js
+              ~/.pi/agent/extensions/cmux-session.ts
+              See docs/agent-hooks.md for the full integration matrix.
 
             Examples:
               cmux hooks setup

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8427,7 +8427,7 @@ struct CMUXCLI {
             agent. Claude Code hooks are injected automatically by the cmux Claude wrapper.
 
             Agents:
-              codex, opencode, cursor, gemini, rovodev, copilot, codebuddy, factory, qoder
+              codex, opencode, pi, cursor, gemini, rovodev, copilot, codebuddy, factory, qoder
 
             Hook targets:
               setup              Install hooks for all supported agents on PATH
@@ -15719,6 +15719,13 @@ struct CMUXCLI {
             events: []
         ),
         AgentHookDef(
+            name: "pi", displayName: "Pi", statusKey: "pi",
+            configDir: ".pi/agent", configFile: "extensions/cmux-session.ts", configDirEnvOverride: "PI_CODING_AGENT_DIR",
+            sessionStoreSuffix: "pi", disableEnvVar: "CMUX_PI_HOOKS_DISABLED",
+            hookMarker: "cmux hooks pi", format: .flat,
+            events: []
+        ),
+        AgentHookDef(
             name: "cursor", displayName: "Cursor", statusKey: "cursor",
             configDir: ".cursor", configFile: "hooks.json", binaryName: "cursor-agent",
             sessionStoreSuffix: "cursor", disableEnvVar: "CMUX_CURSOR_HOOKS_DISABLED",
@@ -16191,6 +16198,220 @@ export default CMUXSessionRestore;
         print("Removed OpenCode cmux plugin from \(pluginURL.path)")
     }
 
+    private static let piExtensionMarker = "cmux-pi-session-extension-marker"
+    private static let piExtensionFilename = "cmux-session.ts"
+    private static let piExtensionSource = #"""
+// cmux-pi-session-extension-marker v1
+// Bridges Pi session lifecycle events into cmux's restorable session store.
+// Installed by `cmux hooks pi install` or `cmux hooks setup`.
+// DO NOT EDIT MANUALLY. cmux upgrades this file in place.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import type { AgentEndEvent, ExtensionAPI, ExtensionContext } from "@mariozechner/pi-coding-agent";
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function resolveExecutable(name: string): string {
+  const pathEnv = process.env.PATH || "";
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {}
+  }
+  return name;
+}
+
+function looksLikePiExecutable(value: string): boolean {
+  const base = path.basename(value).toLowerCase();
+  return base === "pi" || base === "pi-coding-agent";
+}
+
+function looksLikePiScript(value: string): boolean {
+  const normalized = value.replaceAll("\\", "/");
+  const base = path.basename(normalized).toLowerCase();
+  return (
+    normalized.includes("/@mariozechner/pi-coding-agent/") ||
+    normalized.includes("/packages/coding-agent/") ||
+    (base === "cli.js" && normalized.includes("pi-coding-agent")) ||
+    (base === "cli.ts" && normalized.includes("coding-agent"))
+  );
+}
+
+function normalizedLaunchArgv(): string[] {
+  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
+  if (raw.length === 0) return [resolveExecutable("pi")];
+  if (looksLikePiExecutable(raw[0])) return raw;
+  if (raw.length > 1 && looksLikePiScript(raw[1])) {
+    return [resolveExecutable("pi"), ...raw.slice(2)];
+  }
+  return [resolveExecutable("pi"), ...raw.slice(1)];
+}
+
+function base64NulSeparated(values: string[]): string {
+  const bytes: Buffer[] = [];
+  for (const value of values) {
+    bytes.push(Buffer.from(String(value), "utf8"));
+    bytes.push(Buffer.from([0]));
+  }
+  return Buffer.concat(bytes).toString("base64");
+}
+
+function hookEnvironment(cwd: string): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...process.env };
+  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
+    const argv = normalizedLaunchArgv();
+    env.CMUX_AGENT_LAUNCH_KIND = "pi";
+    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("pi");
+    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
+    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
+  }
+  return env;
+}
+
+function eventName(subcommand: string): string {
+  switch (subcommand) {
+    case "session-start":
+      return "SessionStart";
+    case "prompt-submit":
+      return "UserPromptSubmit";
+    case "stop":
+      return "Stop";
+    default:
+      return subcommand;
+  }
+}
+
+function textFromContent(content: unknown): string | null {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return null;
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== "object") continue;
+    const typed = block as { type?: unknown; text?: unknown };
+    if (typed.type === "text" && typeof typed.text === "string") parts.push(typed.text);
+  }
+  return parts.join("\n") || null;
+}
+
+function lastAssistantMessage(event: AgentEndEvent): string | undefined {
+  for (let index = event.messages.length - 1; index >= 0; index -= 1) {
+    const message = event.messages[index];
+    if (!message || typeof message !== "object") continue;
+    const typed = message as { role?: unknown; content?: unknown };
+    if (typed.role !== "assistant") continue;
+    const text = firstString(textFromContent(typed.content));
+    if (text) return text;
+  }
+  return undefined;
+}
+
+function sendHook(subcommand: string, ctx: ExtensionContext, extra: Record<string, unknown> = {}): void {
+  if (process.env.CMUX_PI_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+
+  const sessionId = firstString(ctx.sessionManager.getSessionId());
+  if (!sessionId) return;
+
+  const cwd = firstString(ctx.cwd, process.cwd()) || process.cwd();
+  const payload: Record<string, unknown> = {
+    session_id: sessionId,
+    cwd,
+    hook_event_name: eventName(subcommand),
+    event: eventName(subcommand),
+    ...extra,
+  };
+  const cmux = process.env.CMUX_PI_CMUX_BIN || "cmux";
+  try {
+    spawnSync(cmux, ["hooks", "pi", subcommand], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      env: hookEnvironment(cwd),
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: 5000,
+    });
+  } catch (_) {}
+}
+
+export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
+  pi.on("session_start", async (_event, ctx) => {
+    sendHook("session-start", ctx);
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    sendHook("prompt-submit", ctx, { prompt: event.prompt });
+  });
+
+  pi.on("agent_end", async (event, ctx) => {
+    sendHook("stop", ctx, { last_assistant_message: lastAssistantMessage(event) });
+  });
+}
+"""#
+
+    private func piExtensionURL(for def: AgentHookDef) -> URL {
+        URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent("extensions", isDirectory: true)
+            .appendingPathComponent(Self.piExtensionFilename, isDirectory: false)
+    }
+
+    private func installPiExtensionHooks(_ def: AgentHookDef) throws {
+        let extensionURL = piExtensionURL(for: def)
+        let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
+            || ProcessInfo.processInfo.arguments.contains("-y")
+        let existing = (try? String(contentsOf: extensionURL, encoding: .utf8)) ?? ""
+        if existing == Self.piExtensionSource {
+            print("Pi hooks already up to date at \(extensionURL.path)")
+            return
+        }
+        if !existing.isEmpty, !existing.contains(Self.piExtensionMarker) {
+            throw CLIError(message: "\(extensionURL.path) exists and is not a cmux extension; leaving it alone")
+        }
+        if !skipConfirm {
+            Self.printInstallPreview(
+                path: extensionURL.path,
+                oldContent: existing,
+                newContent: Self.piExtensionSource,
+                fallbackContent: Self.piExtensionSource
+            )
+            print("\nProceed? [y/N] ", terminator: "")
+            guard readLine()?.lowercased().hasPrefix("y") == true else {
+                print("Aborted.")
+                return
+            }
+        }
+        try FileManager.default.createDirectory(
+            at: extensionURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try Self.piExtensionSource.write(to: extensionURL, atomically: true, encoding: .utf8)
+        print("Pi hooks installed at \(extensionURL.path)")
+    }
+
+    private func uninstallPiExtensionHooks(_ def: AgentHookDef) throws {
+        let extensionURL = piExtensionURL(for: def)
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: extensionURL.path) else {
+            print("No Pi cmux extension found at \(extensionURL.path)")
+            return
+        }
+        let existing = (try? String(contentsOf: extensionURL, encoding: .utf8)) ?? ""
+        guard existing.contains(Self.piExtensionMarker) else {
+            print("Refusing to remove \(extensionURL.path): missing cmux marker")
+            return
+        }
+        try fm.removeItem(at: extensionURL)
+        print("Removed Pi cmux extension from \(extensionURL.path)")
+    }
+
     private func installRovoDevHooks(_ def: AgentHookDef) throws {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
@@ -16275,6 +16496,10 @@ export default CMUXSessionRestore;
     private func installAgentHooks(_ def: AgentHookDef) throws {
         if def.name == "opencode" {
             try installOpenCodePluginHooks(def)
+            return
+        }
+        if def.name == "pi" {
+            try installPiExtensionHooks(def)
             return
         }
         if def.name == "rovodev" {
@@ -16446,6 +16671,10 @@ export default CMUXSessionRestore;
     private func uninstallAgentHooks(_ def: AgentHookDef) throws {
         if def.name == "opencode" {
             try uninstallOpenCodePluginHooks(def)
+            return
+        }
+        if def.name == "pi" {
+            try uninstallPiExtensionHooks(def)
             return
         }
         if def.name == "rovodev" {
@@ -19521,7 +19750,7 @@ export default CMUXSessionRestore;
         for def in Self.agentDefs {
             if let filter = agentFilter, filter.lowercased() != def.name { continue }
             let configDir = def.resolvedConfigDir()
-            if def.name != "opencode", !fm.fileExists(atPath: configDir) {
+            if def.name != "opencode", def.name != "pi", !fm.fileExists(atPath: configDir) {
                 print("  \(def.name): skipped (config dir not found)")
                 skipped += 1
                 continue

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchEnvironmentPolicy.swift
@@ -52,6 +52,12 @@ public enum AgentLaunchEnvironmentPolicy {
         "GH_HOST",
         "NODE_OPTIONS",
         "OPENCODE_CONFIG_DIR",
+        "PI_CACHE_RETENTION",
+        "PI_CODING_AGENT_DIR",
+        "PI_CODING_AGENT_SESSION_DIR",
+        "PI_OFFLINE",
+        "PI_PACKAGE_DIR",
+        "PI_SKIP_VERSION_CHECK",
         "QODER_CONFIG_DIR",
         "USE_BUILTIN_RIPGREP"
     ]

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -57,6 +57,8 @@ public enum AgentLaunchSanitizer {
             return preserveOptions(args, policy: claudePolicy)
         case "codex":
             return preserveOptions(args, policy: codexPolicy)
+        case "pi":
+            return preserveOptions(args, policy: piPolicy)
         case "cursor":
             var tail = args
             if tail.first == "agent" {

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -156,6 +156,66 @@ extension AgentLaunchSanitizer {
         resumeSubcommand: "resume"
     )
 
+    static let piPolicy = Policy(
+        valueOptions: [
+            "--append-system-prompt",
+            "--api-key",
+            "--extension",
+            "--fork",
+            "--model",
+            "--models",
+            "--prompt-template",
+            "--provider",
+            "--resume",
+            "--session",
+            "--session-dir",
+            "--skill",
+            "--system-prompt",
+            "--theme",
+            "--thinking",
+            "--tools",
+            "-e",
+            "-t"
+        ],
+        nonRestorableCommands: [
+            "config",
+            "help",
+            "install",
+            "list",
+            "login",
+            "logout",
+            "remove",
+            "uninstall",
+            "update"
+        ],
+        droppedOptions: [
+            "--api-key",
+            "--continue",
+            "--fork",
+            "--resume",
+            "--session",
+            "-c",
+            "-r"
+        ],
+        droppedOptionPrefixes: [
+            "--api-key=",
+            "--fork=",
+            "--resume=",
+            "--session="
+        ],
+        rejectOptions: [
+            "--export",
+            "--list-models",
+            "--mode",
+            "--no-session",
+            "--print",
+            "--version",
+            "-h",
+            "-p",
+            "-v"
+        ]
+    )
+
     static let geminiPolicy = Policy(
         valueOptions: [
             "--model",

--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -209,6 +209,7 @@ extension AgentLaunchSanitizer {
             "--mode",
             "--no-session",
             "--print",
+            "--prompt",
             "--version",
             "-h",
             "-p",

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -50,6 +50,23 @@ struct AgentLaunchSanitizerTests {
         )
     }
 
+    @Test("Preserves repeated Pi extension and skill flags without replaying prompt")
+    func preservesRepeatedPiExtensionAndSkillFlags() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "pi", "--extension", "a.ts", "--extension", "b.ts",
+                    "--skill", "review", "--skill", "swift", "initial prompt"
+                ],
+                launcher: "pi",
+                fallbackKind: "pi"
+            ) == [
+                "pi", "--extension", "a.ts", "--extension", "b.ts",
+                "--skill", "review", "--skill", "swift"
+            ]
+        )
+    }
+
     @Test("Rejects noninteractive Pi launches")
     func rejectsNoninteractivePiLaunches() {
         #expect(

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -59,5 +59,12 @@ struct AgentLaunchSanitizerTests {
                 fallbackKind: "pi"
             ) == nil
         )
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["pi", "--prompt", "summarize"],
+                launcher: "pi",
+                fallbackKind: "pi"
+            ) == nil
+        )
     }
 }

--- a/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
+++ b/Packages/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentLaunchSanitizerTests.swift
@@ -35,4 +35,29 @@ struct AgentLaunchSanitizerTests {
             ) == ["cursor-agent", "--model", "gpt-5.4", "--sandbox", "enabled"]
         )
     }
+
+    @Test("Drops Pi session selectors and prompt while preserving configuration")
+    func dropsPiSessionSelectorsAndPrompt() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                [
+                    "pi", "--session", "old-session", "--model", "anthropic/claude-sonnet-4-5",
+                    "--thinking", "high", "--api-key", "secret", "implement this"
+                ],
+                launcher: "pi",
+                fallbackKind: "pi"
+            ) == ["pi", "--model", "anthropic/claude-sonnet-4-5", "--thinking", "high"]
+        )
+    }
+
+    @Test("Rejects noninteractive Pi launches")
+    func rejectsNoninteractivePiLaunches() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["pi", "--print", "summarize"],
+                launcher: "pi",
+                fallbackKind: "pi"
+            ) == nil
+        )
+    }
 }

--- a/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamSource.swift
+++ b/Packages/CMUXWorkstream/Sources/CMUXWorkstream/WorkstreamSource.swift
@@ -7,6 +7,7 @@ import Foundation
 public enum WorkstreamSource: String, Codable, Sendable, CaseIterable, Equatable {
     case claude
     case codex
+    case pi
     case cursor
     case opencode
     case gemini

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -119,6 +119,14 @@ enum AgentResumeCommandBuilder {
             let original = commandParts(launchCommand: launchCommand, fallbackExecutable: "codex")
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex", args: original.tail) else { return nil }
             return [original.executable, "resume"] + preserved + [sessionId]
+        case .pi:
+            return resumeWithOption(
+                kind: "pi",
+                launchCommand: launchCommand,
+                fallbackExecutable: "pi",
+                option: "--session",
+                sessionId: sessionId
+            )
         case .cursor:
             return resumeWithOption(
                 kind: "cursor",

--- a/Sources/RestorableAgentTypes.swift
+++ b/Sources/RestorableAgentTypes.swift
@@ -3,6 +3,7 @@ import Foundation
 enum RestorableAgentKind: String, Codable, CaseIterable, Sendable {
     case claude
     case codex
+    case pi
     case cursor
     case gemini
     case opencode

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -211,6 +211,14 @@ extension SocketListenerAcceptPolicyTests {
                 source: "process"
             )
         )
+        let pi = SessionRestorableAgentSnapshot(
+            kind: .pi, sessionId: "pi-session-123", workingDirectory: "/tmp/pi repo",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "pi", executablePath: "/Users/example/.bun/bin/pi",
+                arguments: ["/Users/example/.bun/bin/pi", "--model", "anthropic/claude-sonnet-4-5", "--session", "old-session", "--thinking", "high", "initial prompt should not replay"],
+                workingDirectory: "/tmp/pi repo", environment: ["PI_CODING_AGENT_DIR": "/tmp/pi home", "OPENAI_API_KEY": "secret"], capturedAt: 123, source: "process"
+            )
+        )
 
         XCTAssertEqual(
             cursor.resumeCommand,
@@ -232,6 +240,7 @@ extension SocketListenerAcceptPolicyTests {
             qoder.resumeCommand,
             "cd '/tmp/qoder repo' && 'env' 'QODER_CONFIG_DIR=/tmp/qoder config' '/Users/example/.npm/bin/qodercli' '--resume' 'qoder-session-123' '--model' 'gemini-2.5-pro' '--permission-mode' 'plan' '--workspace' '/tmp/qoder repo'"
         )
+        XCTAssertEqual(pi.resumeCommand, "cd '/tmp/pi repo' && 'env' 'PI_CODING_AGENT_DIR=/tmp/pi home' '/Users/example/.bun/bin/pi' '--session' 'pi-session-123' '--model' 'anthropic/claude-sonnet-4-5' '--thinking' 'high'")
     }
 
     func testAgentLaunchSanitizerMatchesGeminiAndRovoResumePolicies() {

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1167,6 +1167,14 @@ final class SessionPersistenceTests: XCTestCase {
                 ]
             ),
             (
+                .pi,
+                [
+                    "/usr/local/bin/pi",
+                    "--model",
+                    "anthropic/claude-sonnet-4-5",
+                ]
+            ),
+            (
                 .cursor,
                 [
                     "/usr/local/bin/cursor-agent",

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1347,6 +1347,8 @@ final class SessionPersistenceTests: XCTestCase {
                 resolvedEnvironment = ["CLAUDE_CONFIG_DIR": "/tmp/claude"]
             case .codex:
                 resolvedEnvironment = ["CODEX_HOME": "/tmp/codex"]
+            case .pi:
+                resolvedEnvironment = ["PI_CODING_AGENT_DIR": "/tmp/pi"]
             case .cursor:
                 resolvedEnvironment = [:]
             case .gemini:

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -1,0 +1,69 @@
+# Agent hook integrations
+
+cmux uses agent hooks to show running state, Feed approvals, notifications, and to restore agent sessions after a normal app relaunch.
+
+Claude Code is handled by the cmux Claude wrapper when Claude Code integration is enabled in Settings. Other agents are installed with:
+
+```bash
+cmux hooks setup
+cmux hooks setup <agent>
+cmux hooks setup --agent <agent>
+cmux hooks uninstall <agent>
+```
+
+Supported agent names are `codex`, `opencode`, `pi`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
+
+## Integrations
+
+| Agent | Binary checked | Installed file | Session restore | Feed bridge |
+| --- | --- | --- | --- | --- |
+| Claude Code | `claude` through wrapper | wrapper-injected settings | `claude --resume <id>` | PermissionRequest |
+| Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest |
+| OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
+| Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | none |
+| Cursor CLI | `cursor-agent` | `~/.cursor/hooks.json` | `cursor-agent --resume <id>` | beforeShellExecution |
+| Gemini | `gemini` | `~/.gemini/settings.json` | `gemini --resume <id>` | PreToolUse |
+| Rovo Dev | `acli` | `~/.rovodev/config.yml` | `acli rovodev run --restore <id>` | none |
+| Copilot | `copilot` | `~/.copilot/config.json` | `copilot --resume <id>` | PreToolUse |
+| CodeBuddy | `codebuddy` | `~/.codebuddy/settings.json` | `codebuddy --resume <id>` | PreToolUse |
+| Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
+| Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
+
+OpenCode also supports project-local Feed installation:
+
+```bash
+cmux hooks opencode install --project
+```
+
+That writes `.opencode/plugins/cmux-feed.js` in the current directory.
+
+## What the hooks record
+
+Session hooks write `~/.cmuxterm/<agent>-hook-sessions.json`. Each entry stores the agent session ID, cmux workspace ID, surface ID, cwd, process ID when available, and a sanitized launch command. On app relaunch, cmux rebuilds each workspace and runs the agent's native resume command with the saved session ID.
+
+The sanitizer preserves model, sandbox, config, and cwd-related flags. It drops prompts, credentials, old session selectors, and noninteractive commands so relaunch resumes the session instead of starting a new task or leaking secrets.
+
+## Environment overrides
+
+| Agent | Config directory override | Disable cmux hooks for one process |
+| --- | --- | --- |
+| Codex | `CODEX_HOME` | `CMUX_CODEX_HOOKS_DISABLED=1` |
+| OpenCode | `OPENCODE_CONFIG_DIR` | `CMUX_OPENCODE_HOOKS_DISABLED=1` |
+| Pi | `PI_CODING_AGENT_DIR` | `CMUX_PI_HOOKS_DISABLED=1` |
+| Cursor CLI | none | `CMUX_CURSOR_HOOKS_DISABLED=1` |
+| Gemini | none | `CMUX_GEMINI_HOOKS_DISABLED=1` |
+| Rovo Dev | none | `CMUX_ROVODEV_HOOKS_DISABLED=1` |
+| Copilot | `COPILOT_HOME` | `CMUX_COPILOT_HOOKS_DISABLED=1` |
+| CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
+| Factory | none | `CMUX_FACTORY_HOOKS_DISABLED=1` |
+| Qoder | `QODER_CONFIG_DIR` | `CMUX_QODER_HOOKS_DISABLED=1` |
+
+Pi uses Pi's extension system, not the legacy Pi hooks API. The installed extension is auto-discovered from `~/.pi/agent/extensions/` or `$PI_CODING_AGENT_DIR/extensions/`.
+
+## Troubleshooting
+
+Run `cmux hooks <agent> install --yes` to reinstall one integration. Run `cmux hooks <agent> uninstall --yes` before editing generated files by hand.
+
+If Feed shows nothing, confirm the terminal has `CMUX_SURFACE_ID` and the hook file contains a `cmux hooks feed --source <agent>` command or OpenCode feed plugin. Pi and Rovo Dev currently provide lifecycle and restore hooks only, so they do not create Feed approval cards.
+
+If relaunch does not resume an agent, check `~/.cmuxterm/<agent>-hook-sessions.json` for the saved session and verify the agent's resume command still works outside cmux.

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -269,7 +269,7 @@ Hook subcommands:
 | `hooks claude <event>` | Handle Claude Code hook events. `claude-hook <event>` remains as the main-compatibility alias. |
 | `hooks codex <event>` | Handle Codex hook events. `codex install-hooks` remains as the main-compatibility installer alias. |
 | `hooks feed --source <agent>` | Convert agent hook events into Feed context. |
-| `hooks <agent> <event>` | Generic hook surface for `opencode`, `cursor`, `gemini`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
+| `hooks <agent> <event>` | Generic hook surface for `opencode`, `pi`, `cursor`, `gemini`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
 
 Docs topics:
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -59,19 +59,21 @@ cmux hooks uninstall
 cmux hooks uninstall rovo
 ```
 
-Installs Feed-relevant hooks for every supported CLI whose binary is on `PATH`:
+Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook integrations](agent-hooks.md) for the complete session restore and Feed support matrix.
 
 | Agent        | Config                                    | Feed trigger             |
 |--------------|-------------------------------------------|--------------------------|
 | Claude Code  | wrapper-injected                          | PermissionRequest        |
 | Codex        | `~/.codex/hooks.json`                     | PermissionRequest        |
+| OpenCode     | `~/.config/opencode/plugins/cmux-feed.js` | plugin event bus         |
 | Cursor CLI   | `~/.cursor/hooks.json`                    | beforeShellExecution     |
 | Gemini       | `~/.gemini/settings.json`                 | PreToolUse               |
 | Copilot      | `~/.copilot/config.json`                  | PreToolUse               |
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
-| OpenCode     | `~/.config/opencode/plugins/cmux-feed.js` | plugin event bus         |
+| Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | lifecycle only           |
+| Rovo Dev     | `~/.rovodev/config.yml`                   | lifecycle only           |
 
 Individual agents:
 

--- a/tests/test_pi_extension_install.py
+++ b/tests/test_pi_extension_install.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""
+Regression test: the generated Pi extension is importable and emits cmux hook calls.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+from claude_teams_test_utils import resolve_cmux_cli
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> int:
+    bun = shutil.which("bun")
+    if bun is None:
+        print("SKIP: bun not found")
+        return 0
+
+    try:
+        cli_path = resolve_cmux_cli()
+    except Exception as exc:
+        print(f"FAIL: {exc}")
+        return 1
+
+    with tempfile.TemporaryDirectory(prefix="cmux-pi-extension-") as td:
+        root = Path(td)
+        config_dir = root / "pi-agent"
+        env = os.environ.copy()
+        env["PI_CODING_AGENT_DIR"] = str(config_dir)
+
+        install = subprocess.run(
+            [cli_path, "hooks", "pi", "install", "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if install.returncode != 0:
+            print("FAIL: pi extension install failed")
+            print(f"exit={install.returncode}")
+            print(f"stdout={install.stdout.strip()}")
+            print(f"stderr={install.stderr.strip()}")
+            return 1
+
+        extension_path = config_dir / "extensions" / "cmux-session.ts"
+        if not extension_path.exists():
+            print(f"FAIL: expected extension at {extension_path}")
+            return 1
+        extension_text = extension_path.read_text(encoding="utf-8")
+        if "cmux-pi-session-extension-marker" not in extension_text:
+            print(f"FAIL: expected cmux marker in {extension_path}")
+            return 1
+
+        fake_cmux = root / "fake-cmux"
+        fake_args_log = root / "fake-cmux-args.log"
+        fake_stdin_log = root / "fake-cmux-stdin.log"
+        fake_env_log = root / "fake-cmux-env.log"
+        make_executable(
+            fake_cmux,
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$FAKE_CMUX_ARGS_LOG"
+cat >> "$FAKE_CMUX_STDIN_LOG"
+printf '\n---\n' >> "$FAKE_CMUX_STDIN_LOG"
+{
+  printf 'kind=%s\n' "${CMUX_AGENT_LAUNCH_KIND-}"
+  printf 'cwd=%s\n' "${CMUX_AGENT_LAUNCH_CWD-}"
+  printf 'argv=%s\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-}"
+} >> "$FAKE_CMUX_ENV_LOG"
+""",
+        )
+
+        check_env = env.copy()
+        check_env["CMUX_TEST_PI_EXTENSION_PATH"] = str(extension_path)
+        check_env["CMUX_SURFACE_ID"] = "surface-pi-test"
+        check_env["CMUX_PI_CMUX_BIN"] = str(fake_cmux)
+        check_env["FAKE_CMUX_ARGS_LOG"] = str(fake_args_log)
+        check_env["FAKE_CMUX_STDIN_LOG"] = str(fake_stdin_log)
+        check_env["FAKE_CMUX_ENV_LOG"] = str(fake_env_log)
+        check_source = """
+const extensionPath = process.env.CMUX_TEST_PI_EXTENSION_PATH;
+const mod = await import(extensionPath);
+if (typeof mod.default !== "function") throw new Error("missing default export");
+const handlers = new Map();
+mod.default({
+  on(name, handler) {
+    handlers.set(name, handler);
+  }
+});
+for (const name of ["session_start", "before_agent_start", "agent_end"]) {
+  if (typeof handlers.get(name) !== "function") throw new Error(`missing ${name}`);
+}
+process.argv.splice(
+  0,
+  process.argv.length,
+  "/Users/example/.bun/bin/pi",
+  "--model",
+  "anthropic/claude-sonnet-4-5"
+);
+const ctx = {
+  cwd: "/tmp/pi-project",
+  sessionManager: {
+    getSessionId() { return "pi-session-test"; }
+  }
+};
+await handlers.get("session_start")({}, ctx);
+await handlers.get("before_agent_start")({ prompt: "hello pi" }, ctx);
+await handlers.get("agent_end")({
+  messages: [
+    { role: "user", content: "hello pi" },
+    { role: "assistant", content: [{ type: "text", text: "done" }] }
+  ],
+  stopReason: "completed"
+}, ctx);
+"""
+        check = subprocess.run(
+            [bun, "--eval", check_source],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            env=check_env,
+            timeout=20,
+        )
+        if check.returncode != 0:
+            print("FAIL: generated Pi extension is not importable")
+            print(f"exit={check.returncode}")
+            print(f"stdout={check.stdout.strip()}")
+            print(f"stderr={check.stderr.strip()}")
+            return 1
+
+        args_log = fake_args_log.read_text(encoding="utf-8") if fake_args_log.exists() else ""
+        stdin_log = fake_stdin_log.read_text(encoding="utf-8") if fake_stdin_log.exists() else ""
+        env_log = fake_env_log.read_text(encoding="utf-8") if fake_env_log.exists() else ""
+        for expected in [
+            "hooks pi session-start",
+            "hooks pi prompt-submit",
+            "hooks pi stop",
+        ]:
+            if expected not in args_log:
+                print(f"FAIL: extension did not invoke {expected}, got {args_log!r}")
+                return 1
+        if '"session_id":"pi-session-test"' not in stdin_log:
+            print(f"FAIL: extension did not pass session id, got {stdin_log!r}")
+            return 1
+        if '"prompt":"hello pi"' not in stdin_log or '"last_assistant_message":"done"' not in stdin_log:
+            print(f"FAIL: extension did not pass prompt/assistant payload, got {stdin_log!r}")
+            return 1
+        if "kind=pi" not in env_log or "cwd=/tmp/pi-project" not in env_log or "argv=" not in env_log:
+            print(f"FAIL: extension did not pass launch metadata environment, got {env_log!r}")
+            return 1
+        argv_line = next((line for line in env_log.splitlines() if line.startswith("argv=")), "")
+        try:
+            decoded_argv = [
+                value
+                for value in base64.b64decode(argv_line.removeprefix("argv=")).decode("utf-8").split("\0")
+                if value
+            ]
+        except Exception as exc:
+            print(f"FAIL: extension launch argv was not valid base64 NUL data: {exc}; env={env_log!r}")
+            return 1
+        expected_argv = [
+            "/Users/example/.bun/bin/pi",
+            "--model",
+            "anthropic/claude-sonnet-4-5",
+        ]
+        if decoded_argv != expected_argv:
+            print(f"FAIL: extension captured wrong Pi launch argv; expected {expected_argv!r}, got {decoded_argv!r}")
+            return 1
+
+    print("PASS: generated Pi extension installs and emits cmux hooks")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_session_relaunch_resumes_agent_sessions.py
+++ b/tests/test_session_relaunch_resumes_agent_sessions.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """
-Regression: normal relaunch should resume saved Claude/Codex/OpenCode sessions.
+Regression: normal relaunch should resume saved Claude/Codex/OpenCode/Pi sessions.
 
 Repro for issue #2923:
-1) Launch cmux and seed workspaces with tracked Claude/Codex/OpenCode sessions.
+1) Launch cmux and seed workspaces with tracked Claude/Codex/OpenCode/Pi sessions.
 2) Quit the app normally so the session snapshot is saved.
 3) Relaunch cmux the next day.
 4) Verify the restored panels automatically run the saved resume commands.
@@ -201,6 +201,7 @@ def main() -> int:
         "--dangerously-skip-permissions"
     )
     opencode_expected = "CMUX_FAKE_OPENCODE_RESUME:--session opencode-session-relaunch-2923"
+    pi_expected = "CMUX_FAKE_PI_RESUME:--session pi-session-relaunch-2923"
 
     failures: list[str] = []
 
@@ -210,9 +211,11 @@ def main() -> int:
         claude_hook_state = hook_state_dir / "claude-hook-sessions.json"
         codex_hook_state = hook_state_dir / "codex-hook-sessions.json"
         opencode_hook_state = hook_state_dir / "opencode-hook-sessions.json"
+        pi_hook_state = hook_state_dir / "pi-hook-sessions.json"
         _write_fake_agent(fake_bin_dir, "codex", "CMUX_FAKE_CODEX_RESUME")
         _write_fake_agent(fake_bin_dir, "claude", "CMUX_FAKE_CLAUDE_RESUME")
         _write_fake_agent(fake_bin_dir, "opencode", "CMUX_FAKE_OPENCODE_RESUME")
+        _write_fake_agent(fake_bin_dir, "pi", "CMUX_FAKE_PI_RESUME")
         launch_path = f"{fake_bin_dir}:{os.environ.get('PATH', '')}"
         app_env = {
             "PATH": launch_path,
@@ -225,6 +228,7 @@ def main() -> int:
         claude_hook_state.unlink(missing_ok=True)
         codex_hook_state.unlink(missing_ok=True)
         opencode_hook_state.unlink(missing_ok=True)
+        pi_hook_state.unlink(missing_ok=True)
 
         try:
             _launch(app_path, socket_path, env_overrides=app_env)
@@ -300,6 +304,24 @@ def main() -> int:
                         },
                     )
 
+                pi_workspace_id = client.new_workspace()
+                time.sleep(0.4)
+                client.select_workspace(pi_workspace_id)
+                time.sleep(0.4)
+                pi_surfaces = client.list_surfaces()
+                if not pi_surfaces:
+                    failures.append("expected a Pi workspace surface during setup")
+                else:
+                    _write_hook_state(
+                        pi_hook_state,
+                        session_id="pi-session-relaunch-2923",
+                        workspace_id=pi_workspace_id,
+                        surface_id=pi_surfaces[0][1],
+                        cwd=os.getcwd(),
+                        launcher="pi",
+                        executable_path=fake_bin_dir / "pi",
+                    )
+
                 client.select_workspace(codex_workspace_id)
                 time.sleep(0.4)
             finally:
@@ -310,13 +332,14 @@ def main() -> int:
             claude_hook_state.unlink(missing_ok=True)
             codex_hook_state.unlink(missing_ok=True)
             opencode_hook_state.unlink(missing_ok=True)
+            pi_hook_state.unlink(missing_ok=True)
 
             _launch(app_path, socket_path, env_overrides=app_env)
             client = _connect(socket_path)
             try:
                 workspaces = client.list_workspaces()
-                if len(workspaces) < 3:
-                    failures.append(f"expected >=3 restored workspaces after relaunch, got {len(workspaces)}")
+                if len(workspaces) < 4:
+                    failures.append(f"expected >=4 restored workspaces after relaunch, got {len(workspaces)}")
 
                 def workspace_contains(index: int, expected: str) -> bool:
                     if len(client.list_workspaces()) <= index:
@@ -347,6 +370,14 @@ def main() -> int:
                         "normal relaunch did not resume the saved OpenCode session; "
                         f"tail:\n{scrollback_tail}"
                     )
+
+                if not _wait_for_condition(12.0, lambda: workspace_contains(3, pi_expected)):
+                    client.select_workspace(3)
+                    scrollback_tail = "\n".join(_read_scrollback(client).splitlines()[-20:])
+                    failures.append(
+                        "normal relaunch did not resume the saved Pi session; "
+                        f"tail:\n{scrollback_tail}"
+                    )
             finally:
                 client.close()
             _quit(bundle_id, socket_path)
@@ -358,6 +389,7 @@ def main() -> int:
             claude_hook_state.unlink(missing_ok=True)
             codex_hook_state.unlink(missing_ok=True)
             opencode_hook_state.unlink(missing_ok=True)
+            pi_hook_state.unlink(missing_ok=True)
 
     if failures:
         print("FAIL:")
@@ -365,7 +397,7 @@ def main() -> int:
             print(f"- {failure}")
         return 1
 
-    print("PASS: normal relaunch resumes saved Claude, Codex, and OpenCode sessions")
+    print("PASS: normal relaunch resumes saved Claude, Codex, OpenCode, and Pi sessions")
     return 0
 
 


### PR DESCRIPTION
Adds Pi to cmux agent hooks and session restoration using Pi extensions.

Checks:
- ./scripts/reload.sh --tag pihook
- python3 tests/test_pi_extension_install.py
- swift test in Packages/CMUXAgentLaunch

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Pi session restoration via a generated Pi extension that bridges lifecycle events to cmux. On app relaunch, Pi sessions resume safely by sanitizing launch args and rejecting noninteractive runs.

- New Features
  - Added Pi to agent hooks with install/uninstall via `cmux hooks pi install`/`cmux hooks pi uninstall`, included in `cmux hooks setup`, and linked in CLI docs to `docs/agent-hooks.md`.
  - Generates a Pi extension at `~/.pi/agent/extensions/cmux-session.ts` that listens to `@mariozechner/pi-coding-agent` and calls `cmux hooks pi session-start|prompt-submit|stop`, passing normalized launch metadata (argv, cwd) via `CMUX_AGENT_LAUNCH_*`.
  - Restores Pi sessions on relaunch via `RestorableAgentKind.pi`; resume runs `pi --session <id>` with preserved configuration flags.
  - Sanitizes Pi launches: keeps model/config options, drops session selectors and prompt text, rejects noninteractive flags (`--prompt`, `--print`), and whitelists key `PI_*` env vars for pass-through.
  - UI recognizes Pi workstreams.

- Migration
  - Run `cmux hooks pi install` (or `cmux hooks setup`) to install the extension. Set `PI_CODING_AGENT_DIR` if you use a non-default config dir.

<sup>Written for commit 9e8b57a8148aabc0093472c636b9ad8af1ef9ff2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Pi agent support: installable hooks, per-agent hook commands, and session restore for Pi.

* **Documentation**
  * New agent hooks guide and updated CLI/feed docs to include Pi and additional agents.

* **Tests**
  * New regression and session-relaunch tests validating Pi extension installation, hook invocation, and session resume.

* **Chores**
  * CI updated to run the Pi extension installation regression test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->