### PR TITLE
Add remote file download to File Explorer

### DIFF
--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -403,11 +403,61 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
             return FileExplorerEntry(name: cleanName, path: fullPath, isDirectory: isDir)
         }
     }
+
+    func downloadToLocal(remotePath: String, isDirectory: Bool, localDestination: String, completion: @escaping (Result<Void, Error>) -> Void) {
+        let dest = destination
+        let p = port
+        let identity = identityFile
+        let opts = sshOptions
+        DispatchQueue.global(qos: .userInitiated).async {
+            do {
+                var args: [String] = ["-q", "-o", "ConnectTimeout=6", "-o", "BatchMode=yes"]
+                if isDirectory { args.append("-r") }
+                if let p { args += ["-P", String(p)] }
+                if let identity { args += ["-i", identity] }
+                for opt in opts { args += ["-o", opt] }
+                let scpSource = Self.scpPrefixedDestination(dest, path: remotePath)
+                args += [scpSource, localDestination]
+
+                let process = Process()
+                process.executableURL = URL(fileURLWithPath: "/usr/bin/scp")
+                process.arguments = args
+                let errPipe = Pipe()
+                process.standardError = errPipe
+                try process.run()
+                let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                process.waitUntilExit()
+
+                guard process.terminationStatus == 0 else {
+                    let detail = String(data: stderrData, encoding: .utf8) ?? "scp exited \(process.terminationStatus)"
+                    throw FileExplorerError.downloadFailed(detail)
+                }
+                DispatchQueue.main.async { completion(.success(())) }
+            } catch {
+                DispatchQueue.main.async { completion(.failure(error)) }
+            }
+        }
+    }
+
+    private static func scpPrefixedDestination(_ destination: String, path: String) -> String {
+        let trimmed = destination.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: "@", maxSplits: 1, omittingEmptySubsequences: false)
+        if parts.count == 2 {
+            let user = String(parts[0])
+            let host = String(parts[1])
+            let bracketed = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+            return "\(user)@\(bracketed):\(path)"
+        }
+        let host = trimmed
+        let bracketed = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
+        return "\(bracketed):\(path)"
+    }
 }
 
 enum FileExplorerError: LocalizedError {
     case providerUnavailable
     case sshCommandFailed(String)
+    case downloadFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -415,6 +465,8 @@ enum FileExplorerError: LocalizedError {
             return String(localized: "fileExplorer.error.unavailable", defaultValue: "File explorer is not available")
         case .sshCommandFailed(let detail):
             return String(localized: "fileExplorer.error.sshFailed", defaultValue: "SSH command failed: \(detail)")
+        case .downloadFailed(let detail):
+            return String(localized: "fileExplorer.error.downloadFailed", defaultValue: "Download failed: \(detail)")
         }
     }
 }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -525,6 +525,19 @@ struct FileExplorerPanelView: NSViewRepresentable {
                 menu.addItem(.separator())
             }
 
+            if !isLocal {
+                let downloadItem = NSMenuItem(
+                    title: String(localized: "fileExplorer.contextMenu.downloadToLocal", defaultValue: "Download to Local..."),
+                    action: #selector(contextMenuDownloadToLocal(_:)),
+                    keyEquivalent: ""
+                )
+                downloadItem.target = self
+                downloadItem.representedObject = node
+                menu.addItem(downloadItem)
+
+                menu.addItem(.separator())
+            }
+
             let copyPathItem = NSMenuItem(
                 title: String(localized: "fileExplorer.contextMenu.copyPath", defaultValue: "Copy Path"),
                 action: #selector(contextMenuCopyPath(_:)),
@@ -572,6 +585,38 @@ struct FileExplorerPanelView: NSViewRepresentable {
             }
             NSPasteboard.general.clearContents()
             NSPasteboard.general.setString(relativePath, forType: .string)
+        }
+
+        @objc private func contextMenuDownloadToLocal(_ sender: NSMenuItem) {
+            guard let node = sender.representedObject as? FileExplorerNode,
+                  let sshProvider = store.provider as? SSHFileExplorerProvider else { return }
+
+            let panel = NSSavePanel()
+            panel.title = String(localized: "fileExplorer.download.title", defaultValue: "Download from Remote")
+            panel.nameFieldStringValue = node.name
+            panel.directoryURL = FileManager.default.urls(for: .downloadsDirectory, in: .userDomainMask).first
+            panel.canCreateDirectories = true
+            if node.isDirectory {
+                panel.canSelectHiddenExtension = true
+            }
+            panel.begin { response in
+                guard response == .OK, let url = panel.url else { return }
+                sshProvider.downloadToLocal(
+                    remotePath: node.path,
+                    isDirectory: node.isDirectory,
+                    localDestination: url.path
+                ) { result in
+                    switch result {
+                    case .success:
+                        break
+                    case .failure(let error):
+                        let alert = NSAlert()
+                        alert.messageText = String(localized: "fileExplorer.download.failed", defaultValue: "Download Failed")
+                        alert.informativeText = error.localizedDescription
+                        alert.runModal()
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Closes #3637

Add "Download to Local..." context menu item for remote SSH files and directories in the File Explorer. Uses `scp` in reverse direction (remote→local) with the existing SSH connection config from `SSHFileExplorerProvider`.

### Changes
- **FileExplorerStore.swift**: Added `downloadToLocal()` method to `SSHFileExplorerProvider` with IPv6 bracket handling, plus `downloadFailed` error case
- **FileExplorerView.swift**: Added "Download to Local..." context menu item (shown only for remote files) with `NSSavePanel` for destination selection and error alert on failure

### How it works
1. Right-click a remote file/directory in File Explorer
2. Select "Download to Local..."
3. Choose save location (defaults to Downloads folder)
4. `scp` downloads the file in background, error alert shown on failure

## Test plan
- [ ] Open a workspace with an active SSH session
- [ ] Verify "Download to Local..." appears in context menu for remote files only
- [ ] Download a remote file — verify it lands at chosen location
- [ ] Download a remote directory — verify recursive download works
- [ ] Verify local files do NOT show the "Download to Local..." menu item
- [ ] Test download failure (e.g. permission denied) — verify error alert appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds “Download to Local...” to the File Explorer for SSH-backed files and folders. Downloads from remote to a chosen local path via `scp`, addressing Linear #3637.

- **New Features**
  - Context menu item appears for remote nodes only; opens a save dialog (defaults to Downloads) and supports files and directories.
  - Transfers via `/usr/bin/scp` using the active SSH config (port, identity, options) with IPv6-safe host formatting; errors surface through a new `downloadFailed` case and an alert.

<sup>Written for commit d6b43dcafa205fbda9c56b25ed38a212d157706d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SSH-based download capability for remote file systems, enabling you to download files and directories from remote servers directly to your local machine
  * Introduced a convenient "Download to Local" context menu option in the file explorer for non-local providers
  * Enhanced error handling with clearer messages to guide you when download operations fail

<!-- end of auto-generated comment: release notes by coderabbit.ai -->