### PR TITLE
Fix main macOS CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,39 +55,7 @@ commands:
           name: Install zig
           no_output_timeout: 35m
           command: |
-            ZIG_REQUIRED="0.15.2"
-            if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-              echo "zig ${ZIG_REQUIRED} already installed"
-              exit 0
-            fi
-
-            case "$(uname -m)" in
-              arm64) ZIG_ARCH="aarch64" ;;
-              x86_64) ZIG_ARCH="x86_64" ;;
-              *)
-                echo "Unsupported macOS architecture: $(uname -m)" >&2
-                exit 1
-                ;;
-            esac
-
-            if ! command -v minisign >/dev/null 2>&1; then
-              brew install minisign
-            fi
-
-            ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
-            ZIG_MINISIGN_PUBLIC_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
-
-            echo "Installing verified zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "$ZIG_URL" -o /tmp/zig.tar.xz
-            curl -fSL "${ZIG_URL}.minisig" -o /tmp/zig.tar.xz.minisig
-            minisign -Vm /tmp/zig.tar.xz -x /tmp/zig.tar.xz.minisig -P "$ZIG_MINISIGN_PUBLIC_KEY"
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo rm -rf /usr/local/lib/zig
-            sudo mkdir -p /usr/local/lib/zig
-            sudo cp -f "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/zig" /usr/local/bin/zig
-            sudo cp -Rf "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/lib/." /usr/local/lib/zig/
-            zig version
+            ./scripts/install-zig-ci.sh
 
   print-xcode:
     steps:

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -69,19 +69,7 @@ jobs:
         if: steps.check-release.outputs.exists == 'false'
         run: |
           set -euo pipefail
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
           cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Package xcframework

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -67,19 +67,7 @@ jobs:
       - name: Install zig
         if: ${{ !matrix.skip_zig }}
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Cache DerivedData
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,19 +190,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -367,19 +355,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -563,19 +539,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -646,19 +610,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,19 +153,7 @@ jobs:
       - name: Install build deps
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -71,30 +71,7 @@ jobs:
 
       - name: Install zig
         run: |
-          set -euo pipefail
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED}"
-            case "$(uname -m)" in
-              arm64) ZIG_ARCH="aarch64" ;;
-              x86_64) ZIG_ARCH="x86_64" ;;
-              *)
-                echo "Unsupported macOS runner architecture: $(uname -m)" >&2
-                exit 1
-                ;;
-            esac
-            ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-            sudo rm -rf /usr/local/lib/zig
-            sudo mkdir -p /usr/local/lib/zig
-            sudo cp -R "${ZIG_DIR}/lib/." /usr/local/lib/zig/
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Build tagged app
         run: ./scripts/reload.sh --tag "$PERF_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,19 +111,7 @@ jobs:
       - name: Install build deps
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -85,19 +85,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Create virtual display
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -93,19 +93,7 @@ jobs:
 
       - name: Install zig
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh
 
       - name: Install Bun for Feed sidebar tests
         if: ${{ inputs.test_filter == 'FeedSidebarUITests' || startsWith(inputs.test_filter, 'FeedSidebarUITests/') }}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -935,6 +935,7 @@ final class SocketClient {
 
     private let path: String
     private var socketFD: Int32 = -1
+    private var lastConfiguredReceiveTimeout: TimeInterval?
     private var lastOperationTelemetry: CLISocketOperationTelemetry.State?
     private static let defaultResponseTimeoutSeconds: TimeInterval = 15.0
     private static let multilineResponseIdleTimeoutSeconds: TimeInterval = 0.12
@@ -1028,6 +1029,7 @@ final class SocketClient {
             Darwin.close(socketFD)
             socketFD = -1
         }
+        lastConfiguredReceiveTimeout = nil
     }
 
     func send(command: String, responseTimeout: TimeInterval? = nil) throws -> String {
@@ -1043,10 +1045,8 @@ final class SocketClient {
         }
 
         let initialResponseTimeout = responseTimeout ?? Self.responseTimeoutSeconds
-        var configuredReceiveTimeout = Self.responseTimeoutSeconds
-        if initialResponseTimeout != configuredReceiveTimeout {
+        if lastConfiguredReceiveTimeout != initialResponseTimeout {
             try configureReceiveTimeout(initialResponseTimeout)
-            configuredReceiveTimeout = initialResponseTimeout
         }
         var operation = CLISocketOperationTelemetry.State(
             name: CLISocketOperationTelemetry.operationName(for: command),
@@ -1073,9 +1073,8 @@ final class SocketClient {
             operation.sawNewline = sawNewline
             operation.timeout = currentTimeout
             recordOperation(operation)
-            if currentTimeout != configuredReceiveTimeout {
+            if lastConfiguredReceiveTimeout != currentTimeout {
                 try configureReceiveTimeout(currentTimeout)
-                configuredReceiveTimeout = currentTimeout
             }
 
             var buffer = [UInt8](repeating: 0, count: 8192)
@@ -1454,6 +1453,7 @@ final class SocketClient {
             let reason = String(cString: strerror(errorCode))
             throw CLIError(message: "Failed to configure socket receive timeout (\(reason), errno \(errorCode))")
         }
+        lastConfiguredReceiveTimeout = timeout
     }
 
     static func waitForConnectableSocket(path: String, timeout: TimeInterval) throws -> SocketClient {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1043,6 +1043,11 @@ final class SocketClient {
         }
 
         let initialResponseTimeout = responseTimeout ?? Self.responseTimeoutSeconds
+        var configuredReceiveTimeout = Self.responseTimeoutSeconds
+        if initialResponseTimeout != configuredReceiveTimeout {
+            try configureReceiveTimeout(initialResponseTimeout)
+            configuredReceiveTimeout = initialResponseTimeout
+        }
         var operation = CLISocketOperationTelemetry.State(
             name: CLISocketOperationTelemetry.operationName(for: command),
             timeout: initialResponseTimeout,
@@ -1068,7 +1073,10 @@ final class SocketClient {
             operation.sawNewline = sawNewline
             operation.timeout = currentTimeout
             recordOperation(operation)
-            try configureReceiveTimeout(currentTimeout)
+            if currentTimeout != configuredReceiveTimeout {
+                try configureReceiveTimeout(currentTimeout)
+                configuredReceiveTimeout = currentTimeout
+            }
 
             var buffer = [UInt8](repeating: 0, count: 8192)
             let count = Darwin.read(socketFD, &buffer, buffer.count)
@@ -1147,6 +1155,7 @@ final class SocketClient {
         }
         do {
             try configureSocketWriteSafety(Self.responseTimeoutSeconds)
+            try configureReceiveTimeout(Self.responseTimeoutSeconds)
         } catch {
             close()
             throw error
@@ -1441,7 +1450,9 @@ final class SocketClient {
             )
         }
         guard result == 0 else {
-            throw CLIError(message: "Failed to configure socket receive timeout")
+            let errorCode = errno
+            let reason = String(cString: strerror(errorCode))
+            throw CLIError(message: "Failed to configure socket receive timeout (\(reason), errno \(errorCode))")
         }
     }
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */; };
 		C34670020000000000000001 /* KeyboardShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670020000000000000002 /* KeyboardShortcutContextTests.swift */; };
 		C34670030000000000000001 /* KeyboardShortcutContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670030000000000000002 /* KeyboardShortcutContext.swift */; };
+		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
 		E3309A01 /* AppDelegate+EqualizeSplitsShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A02 /* AppDelegate+EqualizeSplitsShortcut.swift */; };
 		E3309A03 /* TabManager+EqualizeSplits.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A04 /* TabManager+EqualizeSplits.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
@@ -495,6 +496,7 @@
 		E3337002E3337002E3337002 /* KeyboardShortcutSettingsFileStoreStartupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsFileStoreStartupTests.swift; sourceTree = "<group>"; };
 		C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateRenameShortcutContextTests.swift; sourceTree = "<group>"; };
 		C34670020000000000000002 /* KeyboardShortcutContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutContextTests.swift; sourceTree = "<group>"; };
+		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		E3309A0C /* KeyboardShortcutSettingsEqualizeSplitsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsEqualizeSplitsTests.swift; sourceTree = "<group>"; };
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
 		7E7E6EF344A568AC7FEE3715 /* cmuxUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1221,6 +1223,7 @@
 					C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
 					17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */,
 				C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */,
+				C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */,
 				E3309A0A /* AppDelegateEqualizeSplitsShortcutTests.swift */,
 				F6001001A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift */,
 				F6100001A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift */,
@@ -1839,6 +1842,7 @@
 					C1713006C1713006C1713006 /* CommandPaletteShortcutCustomizationTests.swift in Sources */,
 					725746692D9647948561044D /* AppDelegateBareSpaceShortcutRoutingTests.swift in Sources */,
 				C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */,
+				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
 				E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */,
 				F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */,
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -131,9 +131,11 @@ extension AppDelegate {
     }
 
     private func shortcutFocusedBrowserPanel(in window: NSWindow?) -> BrowserPanel? {
-        if let window,
-           let context = mainWindowContexts[ObjectIdentifier(window)] ??
-               mainWindowContexts.values.first(where: { $0.window === window }) {
+        if let window {
+            guard let context = mainWindowContexts[ObjectIdentifier(window)] ??
+                mainWindowContexts.values.first(where: { $0.window === window }) else {
+                return nil
+            }
             return context.tabManager.focusedBrowserPanel
         }
 

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -123,7 +123,21 @@ extension AppDelegate {
             return shortcutBrowserPanel(webView: webView)
         }
 
+        if let panel = shortcutFocusedBrowserPanel(in: shortcutWindow) {
+            return panel
+        }
+
         return nil
+    }
+
+    private func shortcutFocusedBrowserPanel(in window: NSWindow?) -> BrowserPanel? {
+        if let window,
+           let context = mainWindowContexts[ObjectIdentifier(window)] ??
+               mainWindowContexts.values.first(where: { $0.window === window }) {
+            return context.tabManager.focusedBrowserPanel
+        }
+
+        return tabManager?.focusedBrowserPanel
     }
 
     private func shortcutWebInspectorFocusedBrowserPanel(in window: NSWindow?) -> BrowserPanel? {
@@ -133,10 +147,10 @@ extension AppDelegate {
         if let window,
            let context = mainWindowContexts[ObjectIdentifier(window)] ??
                mainWindowContexts.values.first(where: { $0.window === window }) {
-            return context.tabManager.focusedBrowserPanel
+            return shortcutFocusedBrowserPanel(in: context.window ?? window)
         }
 
-        return tabManager?.focusedBrowserPanel
+        return shortcutFocusedBrowserPanel(in: window)
     }
 
     private func shortcutResolvedEventWindow(_ event: NSEvent) -> NSWindow? {

--- a/cmuxTests/AppDelegateRenameShortcutContextTests.swift
+++ b/cmuxTests/AppDelegateRenameShortcutContextTests.swift
@@ -38,7 +38,6 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
     private var savedShortcutsByAction: [KeyboardShortcutSettings.Action: StoredShortcut] = [:]
     private var actionsWithPersistedShortcut: Set<KeyboardShortcutSettings.Action> = []
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
-    private var temporarySettingsDirectoryURL: URL?
 
     override func setUp() {
         super.setUp()
@@ -53,21 +52,7 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
                 (action, KeyboardShortcutSettings.shortcut(for: action))
             }
         )
-        originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
-        let settingsDirectoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-rename-shortcut-context-\(UUID().uuidString)", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
-        } catch {
-            XCTFail("Failed to create isolated settings directory: \(error)")
-        }
-        temporarySettingsDirectoryURL = settingsDirectoryURL
-        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
-            primaryPath: settingsDirectoryURL.appendingPathComponent("cmux.json", isDirectory: false).path,
-            fallbackPath: nil,
-            additionalFallbackPaths: [],
-            startWatching: false
-        )
+        originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(prefix: "cmux-rename-shortcut-context")
         KeyboardShortcutSettings.resetAll()
     }
 
@@ -81,10 +66,6 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
                 KeyboardShortcutSettings.resetShortcut(for: action)
             }
         }
-        if let temporarySettingsDirectoryURL {
-            try? FileManager.default.removeItem(at: temporarySettingsDirectoryURL)
-        }
-        temporarySettingsDirectoryURL = nil
         super.tearDown()
     }
 

--- a/cmuxTests/AppDelegateRenameShortcutContextTests.swift
+++ b/cmuxTests/AppDelegateRenameShortcutContextTests.swift
@@ -38,6 +38,7 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
     private var savedShortcutsByAction: [KeyboardShortcutSettings.Action: StoredShortcut] = [:]
     private var actionsWithPersistedShortcut: Set<KeyboardShortcutSettings.Action> = []
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
+    private var temporarySettingsDirectoryURL: URL?
 
     override func setUp() {
         super.setUp()
@@ -53,6 +54,20 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
             }
         )
         originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
+        let settingsDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rename-shortcut-context-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
+        } catch {
+            XCTFail("Failed to create isolated settings directory: \(error)")
+        }
+        temporarySettingsDirectoryURL = settingsDirectoryURL
+        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsDirectoryURL.appendingPathComponent("cmux.json", isDirectory: false).path,
+            fallbackPath: nil,
+            additionalFallbackPaths: [],
+            startWatching: false
+        )
         KeyboardShortcutSettings.resetAll()
     }
 
@@ -66,6 +81,10 @@ final class AppDelegateRenameShortcutContextTests: XCTestCase {
                 KeyboardShortcutSettings.resetShortcut(for: action)
             }
         }
+        if let temporarySettingsDirectoryURL {
+            try? FileManager.default.removeItem(at: temporarySettingsDirectoryURL)
+        }
+        temporarySettingsDirectoryURL = nil
         super.tearDown()
     }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -5,7 +5,6 @@ import XCTest
 #elseif canImport(cmux)
 @testable import cmux
 #endif
-
 private let appDelegateLastSurfaceCloseShortcutDefaultsKey = "closeWorkspaceOnLastSurfaceShortcut"
 private final class FakeWKInspectorContainerView: NSView {}
 private final class FocusableTestView: NSView {
@@ -13,7 +12,6 @@ private final class FocusableTestView: NSView {
 }
 private final class MenuActionProbe: NSObject {
     var callCount = 0
-
     @objc func perform(_ sender: Any?) {
         callCount += 1
     }
@@ -50,7 +48,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
     private var savedShortcutsByAction: [KeyboardShortcutSettings.Action: StoredShortcut] = [:]
     private var actionsWithPersistedShortcut: Set<KeyboardShortcutSettings.Action> = []
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
-    private var temporarySettingsDirectoryURL: URL?
 
     private func makeKeyEvent(
         modifierFlags: NSEvent.ModifierFlags,
@@ -89,21 +86,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 (action, KeyboardShortcutSettings.shortcut(for: action))
             }
         )
-        originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
-        let settingsDirectoryURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-shortcut-routing-\(UUID().uuidString)", isDirectory: true)
-        do {
-            try FileManager.default.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
-        } catch {
-            XCTFail("Failed to create isolated settings directory: \(error)")
-        }
-        temporarySettingsDirectoryURL = settingsDirectoryURL
-        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
-            primaryPath: settingsDirectoryURL.appendingPathComponent("cmux.json", isDirectory: false).path,
-            fallbackPath: nil,
-            additionalFallbackPaths: [],
-            startWatching: false
-        )
+        originalSettingsFileStore = KeyboardShortcutSettings.installIsolatedTestFileStore(prefix: "cmux-shortcut-routing")
         KeyboardShortcutSettings.resetAll()
     }
 
@@ -122,10 +105,6 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 KeyboardShortcutSettings.resetShortcut(for: action)
             }
         }
-        if let temporarySettingsDirectoryURL {
-            try? FileManager.default.removeItem(at: temporarySettingsDirectoryURL)
-        }
-        temporarySettingsDirectoryURL = nil
         super.tearDown()
     }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -50,6 +50,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
     private var savedShortcutsByAction: [KeyboardShortcutSettings.Action: StoredShortcut] = [:]
     private var actionsWithPersistedShortcut: Set<KeyboardShortcutSettings.Action> = []
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
+    private var temporarySettingsDirectoryURL: URL?
 
     private func makeKeyEvent(
         modifierFlags: NSEvent.ModifierFlags,
@@ -89,6 +90,20 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             }
         )
         originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
+        let settingsDirectoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-shortcut-routing-\(UUID().uuidString)", isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: settingsDirectoryURL, withIntermediateDirectories: true)
+        } catch {
+            XCTFail("Failed to create isolated settings directory: \(error)")
+        }
+        temporarySettingsDirectoryURL = settingsDirectoryURL
+        KeyboardShortcutSettings.settingsFileStore = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsDirectoryURL.appendingPathComponent("cmux.json", isDirectory: false).path,
+            fallbackPath: nil,
+            additionalFallbackPaths: [],
+            startWatching: false
+        )
         KeyboardShortcutSettings.resetAll()
     }
 
@@ -107,6 +122,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
                 KeyboardShortcutSettings.resetShortcut(for: action)
             }
         }
+        if let temporarySettingsDirectoryURL {
+            try? FileManager.default.removeItem(at: temporarySettingsDirectoryURL)
+        }
+        temporarySettingsDirectoryURL = nil
         super.tearDown()
     }
 
@@ -2783,11 +2802,13 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             return
         }
 
+        withTemporaryShortcut(action: .openSettings, shortcut: .unbound) {
 #if DEBUG
-        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: event))
+            XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: event))
 #else
-        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+            XCTFail("debugHandleCustomShortcut is only available in DEBUG")
 #endif
+        }
         XCTAssertEqual(workspace.panels.count, panelCountBefore)
     }
 
@@ -3368,7 +3389,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(observedWorkspaceWindow?.windowNumber, window.windowNumber)
     }
 
-    func testCmdShiftERequestsEditWorkspaceDescriptionInCommandPalette() {
+    func testCmdOptionERequestsEditWorkspaceDescriptionInCommandPalette() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -3399,7 +3420,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
         defer { NotificationCenter.default.removeObserver(descriptionToken) }
 
-        let renameWorkspaceExpectation = expectation(description: "Rename workspace notification should not fire for Cmd+Shift+E")
+        let renameWorkspaceExpectation = expectation(description: "Rename workspace notification should not fire for Cmd+Option+E")
         renameWorkspaceExpectation.isInverted = true
         let renameWorkspaceToken = NotificationCenter.default.addObserver(
             forName: .commandPaletteRenameWorkspaceRequested,
@@ -3412,11 +3433,11 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         guard let event = makeKeyDownEvent(
             key: "e",
-            modifiers: [.command, .shift],
+            modifiers: [.command, .option],
             keyCode: 14, // kVK_ANSI_E
             windowNumber: window.windowNumber
         ) else {
-            XCTFail("Failed to construct Cmd+Shift+E event")
+            XCTFail("Failed to construct Cmd+Option+E event")
             return
         }
 

--- a/cmuxTests/KeyboardShortcutTestSettingsIsolation.swift
+++ b/cmuxTests/KeyboardShortcutTestSettingsIsolation.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+extension KeyboardShortcutSettings {
+    static func installIsolatedTestFileStore(prefix: String) -> KeyboardShortcutSettingsFileStore {
+        let original = settingsFileStore
+        let settingsFileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("\(prefix)-\(UUID().uuidString).json", isDirectory: false)
+        settingsFileStore = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            additionalFallbackPaths: [],
+            startWatching: false
+        )
+        return original
+    }
+}

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZIG_REQUIRED="${ZIG_REQUIRED:-0.15.2}"
+ZIG_MINISIGN_PUBLIC_KEY="${ZIG_MINISIGN_PUBLIC_KEY:-RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U}"
+
+if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
+  echo "zig ${ZIG_REQUIRED} already installed"
+  exit 0
+fi
+
+case "$(uname -m)" in
+  arm64 | aarch64) ZIG_ARCH="aarch64" ;;
+  x86_64) ZIG_ARCH="x86_64" ;;
+  *)
+    echo "Unsupported macOS architecture: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+if ! command -v minisign >/dev/null 2>&1; then
+  if command -v brew >/dev/null 2>&1; then
+    brew install minisign
+  else
+    echo "minisign is required to verify Zig downloads" >&2
+    exit 1
+  fi
+fi
+
+ZIG_NAME="zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
+ZIG_TAR="/tmp/${ZIG_NAME}.tar.xz"
+ZIG_SIG="${ZIG_TAR}.minisig"
+ZIG_DIR="/tmp/${ZIG_NAME}"
+ZIG_OFFICIAL_URL="https://ziglang.org/download/${ZIG_REQUIRED}/${ZIG_NAME}.tar.xz"
+ZIG_MIRROR_URL="${ZIG_MIRROR_URL:-https://zigmirror.hryx.net/zig/${ZIG_NAME}.tar.xz}"
+
+download_file() {
+  local url="$1"
+  local output="$2"
+  curl \
+    --fail \
+    --location \
+    --show-error \
+    --connect-timeout 20 \
+    --max-time 300 \
+    --retry 8 \
+    --retry-all-errors \
+    --retry-delay 10 \
+    --retry-max-time 300 \
+    "$url" \
+    --output "$output"
+}
+
+echo "Installing verified zig ${ZIG_REQUIRED}"
+rm -f "$ZIG_TAR" "$ZIG_SIG"
+if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
+  echo "Mirror download failed; retrying from ${ZIG_OFFICIAL_URL}" >&2
+  download_file "$ZIG_OFFICIAL_URL" "$ZIG_TAR"
+fi
+download_file "${ZIG_OFFICIAL_URL}.minisig" "$ZIG_SIG"
+minisign -Vm "$ZIG_TAR" -x "$ZIG_SIG" -P "$ZIG_MINISIGN_PUBLIC_KEY"
+
+rm -rf "$ZIG_DIR"
+tar xf "$ZIG_TAR" -C /tmp
+sudo mkdir -p /usr/local/bin /usr/local/lib
+sudo rm -rf /usr/local/lib/zig
+sudo mkdir -p /usr/local/lib/zig
+sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
+sudo cp -Rf "${ZIG_DIR}/lib/." /usr/local/lib/zig/
+zig version

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -4,9 +4,12 @@ set -euo pipefail
 ZIG_REQUIRED="${ZIG_REQUIRED:-0.15.2}"
 ZIG_MINISIGN_PUBLIC_KEY="${ZIG_MINISIGN_PUBLIC_KEY:-RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U}"
 
-if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-  echo "zig ${ZIG_REQUIRED} already installed"
-  exit 0
+if command -v zig >/dev/null 2>&1; then
+  INSTALLED_ZIG_VERSION="$(zig version 2>/dev/null || true)"
+  if [ "$INSTALLED_ZIG_VERSION" = "$ZIG_REQUIRED" ]; then
+    echo "zig ${ZIG_REQUIRED} already installed"
+    exit 0
+  fi
 fi
 
 case "$(uname -m)" in
@@ -57,7 +60,10 @@ if ! download_file "$ZIG_MIRROR_URL" "$ZIG_TAR"; then
   echo "Mirror download failed; retrying from ${ZIG_OFFICIAL_URL}" >&2
   download_file "$ZIG_OFFICIAL_URL" "$ZIG_TAR"
 fi
-download_file "${ZIG_OFFICIAL_URL}.minisig" "$ZIG_SIG"
+if ! download_file "${ZIG_MIRROR_URL}.minisig" "$ZIG_SIG"; then
+  echo "Mirror signature download failed; retrying from ${ZIG_OFFICIAL_URL}.minisig" >&2
+  download_file "${ZIG_OFFICIAL_URL}.minisig" "$ZIG_SIG"
+fi
 minisign -Vm "$ZIG_TAR" -x "$ZIG_SIG" -P "$ZIG_MINISIGN_PUBLIC_KEY"
 
 rm -rf "$ZIG_DIR"


### PR DESCRIPTION
Fixes the current red main macOS CI lanes at commit `65706d036f138628d5337188ca51f5f34acb566c`.

Changes:
- add a verified Zig installer script with retrying mirror fallback, then use it from CircleCI and GitHub workflows
- make CLI socket receive timeouts deterministic for fast closed-peer cases
- isolate shortcut routing tests from the developer `cmux.json`
- route browser-focused shortcuts through the focused browser panel before rename-tab/workspace defaults

Local verification:
- `bash -n scripts/install-zig-ci.sh`
- workflow YAML parse for `.circleci/config.yml` and `.github/workflows/*.yml`
- `./tests/test_ci_self_hosted_guard.sh`
- `./tests/test_ci_create_dmg_pinned.sh`
- `bash tests/test_ci_unit_test_spm_retry.sh`
- `bash tests/test_ci_ghosttykit_checksum_verification.sh`
- `bash tests/test_ci_ghosttykit_checksum_present.sh`
- CLI contract tests: version memory guard, help contract, layout focus contract, socket operation deadline
- targeted `AppDelegateShortcutRoutingTests` and `AppDelegateRenameShortcutContextTests`
- CircleCI release reproduction: universal Release build with explicit `/tmp/cmux-mainci-release` derived data

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failing macOS CI by introducing a verified Zig installer with mirror fallback and using it across all workflows. Also stabilizes CLI socket timeouts and tightens shortcut routing and tests to reduce flakes.

- **Bug Fixes**
  - macOS CI: replace inline Zig install steps with `scripts/install-zig-ci.sh` (minisign verification, retrying mirror fallback, arch autodetect) across CircleCI and all GitHub workflows.
  - CLI: make receive timeouts deterministic by configuring on connect and only when changed; avoid redundant `setsockopt` calls; include errno and reason in errors.
  - Shortcuts/tests: prioritize the focused browser panel during routing; add `KeyboardShortcutTestSettingsIsolation.installIsolatedTestFileStore` to isolate settings in tests; update keybinding expectation to Cmd+Option+E and wrap debug shortcut test with a temporary unbind to prevent flakes.

<sup>Written for commit 618d619b49e923d7bce34c01cddce79a0651d966. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Better keyboard shortcut focus resolution to prioritize the active browser panel
  * Improved CLI socket timeout handling and clearer error reporting

* **Tests**
  * Added isolation for keyboard shortcut settings in tests to reduce flakiness
  * Included a new test helper to support isolated test stores

* **Chores**
  * Centralized Zig toolchain installation into a dedicated CI script used across workflows for more consistent builds
<!-- end of auto-generated comment: release notes by coderabbit.ai -->