### PR TITLE
Retry Zig downloads in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,34 +60,7 @@ commands:
               echo "zig ${ZIG_REQUIRED} already installed"
               exit 0
             fi
-
-            case "$(uname -m)" in
-              arm64) ZIG_ARCH="aarch64" ;;
-              x86_64) ZIG_ARCH="x86_64" ;;
-              *)
-                echo "Unsupported macOS architecture: $(uname -m)" >&2
-                exit 1
-                ;;
-            esac
-
-            if ! command -v minisign >/dev/null 2>&1; then
-              brew install minisign
-            fi
-
-            ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz"
-            ZIG_MINISIGN_PUBLIC_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
-
-            echo "Installing verified zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "$ZIG_URL" -o /tmp/zig.tar.xz
-            curl -fSL "${ZIG_URL}.minisig" -o /tmp/zig.tar.xz.minisig
-            minisign -Vm /tmp/zig.tar.xz -x /tmp/zig.tar.xz.minisig -P "$ZIG_MINISIGN_PUBLIC_KEY"
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo rm -rf /usr/local/lib/zig
-            sudo mkdir -p /usr/local/lib/zig
-            sudo cp -f "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/zig" /usr/local/bin/zig
-            sudo cp -Rf "/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}/lib/." /usr/local/lib/zig/
-            zig version
+            ./scripts/install-zig-ci.sh "$ZIG_REQUIRED"
 
   print-xcode:
     steps:

--- a/.github/workflows/build-ghosttykit.yml
+++ b/.github/workflows/build-ghosttykit.yml
@@ -69,19 +69,7 @@ jobs:
         if: steps.check-release.outputs.exists == 'false'
         run: |
           set -euo pipefail
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh 0.15.2
           cd ghostty && zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
 
       - name: Package xcframework

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -66,20 +66,7 @@ jobs:
 
       - name: Install zig
         if: ${{ !matrix.skip_zig }}
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Cache DerivedData
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,20 +189,7 @@ jobs:
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -366,20 +353,7 @@ jobs:
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -562,20 +536,7 @@ jobs:
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
@@ -645,20 +606,7 @@ jobs:
         run: ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Cache Zig packages
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -153,19 +153,7 @@ jobs:
       - name: Install build deps
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh 0.15.2
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/perf-activation.yml
+++ b/.github/workflows/perf-activation.yml
@@ -70,31 +70,7 @@ jobs:
         run: ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Install zig
-        run: |
-          set -euo pipefail
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED}"
-            case "$(uname -m)" in
-              arm64) ZIG_ARCH="aarch64" ;;
-              x86_64) ZIG_ARCH="x86_64" ;;
-              *)
-                echo "Unsupported macOS runner architecture: $(uname -m)" >&2
-                exit 1
-                ;;
-            esac
-            ZIG_DIR="/tmp/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-${ZIG_ARCH}-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f "${ZIG_DIR}/zig" /usr/local/bin/zig
-            sudo rm -rf /usr/local/lib/zig
-            sudo mkdir -p /usr/local/lib/zig
-            sudo cp -R "${ZIG_DIR}/lib/." /usr/local/lib/zig/
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Build tagged app
         run: ./scripts/reload.sh --tag "$PERF_TAG"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,19 +111,7 @@ jobs:
       - name: Install build deps
         if: steps.guard_release_assets.outputs.skip_all != 'true'
         run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+          ./scripts/install-zig-ci.sh 0.15.2
           npm install --global "create-dmg@${CREATE_DMG_VERSION}"
 
       - name: Download pre-built GhosttyKit.xcframework

--- a/.github/workflows/test-depot.yml
+++ b/.github/workflows/test-depot.yml
@@ -84,20 +84,7 @@ jobs:
           test -d GhosttyKit.xcframework
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Create virtual display
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -92,20 +92,7 @@ jobs:
           test -d GhosttyKit.xcframework
 
       - name: Install zig
-        run: |
-          ZIG_REQUIRED="0.15.2"
-          if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
-            echo "zig ${ZIG_REQUIRED} already installed"
-          else
-            echo "Installing zig ${ZIG_REQUIRED} from tarball"
-            curl -fSL "https://ziglang.org/download/${ZIG_REQUIRED}/zig-aarch64-macos-${ZIG_REQUIRED}.tar.xz" -o /tmp/zig.tar.xz
-            tar xf /tmp/zig.tar.xz -C /tmp
-            sudo mkdir -p /usr/local/bin /usr/local/lib
-            sudo cp -f /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/zig /usr/local/bin/zig
-            sudo cp -rf /tmp/zig-aarch64-macos-${ZIG_REQUIRED}/lib /usr/local/lib/zig
-            export PATH="/usr/local/bin:$PATH"
-            zig version
-          fi
+        run: ./scripts/install-zig-ci.sh 0.15.2
 
       - name: Install Bun for Feed sidebar tests
         if: ${{ inputs.test_filter == 'FeedSidebarUITests' || startsWith(inputs.test_filter, 'FeedSidebarUITests/') }}

--- a/scripts/install-zig-ci.sh
+++ b/scripts/install-zig-ci.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ZIG_REQUIRED="${1:-0.15.2}"
+INSTALL_PREFIX="${INSTALL_PREFIX:-/usr/local}"
+ZIG_MINISIGN_PUBLIC_KEY="RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U"
+
+if command -v zig >/dev/null 2>&1 && zig version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
+  echo "zig ${ZIG_REQUIRED} already installed"
+  exit 0
+fi
+
+case "$(uname -s)" in
+  Darwin) ZIG_OS="macos" ;;
+  Linux) ZIG_OS="linux" ;;
+  *)
+    echo "Unsupported OS for Zig install: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  arm64 | aarch64) ZIG_ARCH="aarch64" ;;
+  x86_64 | amd64) ZIG_ARCH="x86_64" ;;
+  *)
+    echo "Unsupported architecture for Zig install: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+install_from_homebrew() {
+  if [ "$ZIG_OS" != "macos" ] || [ "$ZIG_REQUIRED" != "0.15.2" ] || ! command -v brew >/dev/null 2>&1; then
+    return 1
+  fi
+
+  echo "Installing zig ${ZIG_REQUIRED} from Homebrew zig@0.15 bottle"
+  if ! brew info --formula zig@0.15 >/dev/null 2>&1; then
+    echo "Updating Homebrew metadata for zig@0.15"
+    HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ENV_HINTS=1 brew update --quiet
+  fi
+
+  HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ENV_HINTS=1 brew install zig@0.15
+
+  local brew_prefix
+  brew_prefix="$(brew --prefix zig@0.15)"
+  if ! "${brew_prefix}/bin/zig" version 2>/dev/null | grep -q "^${ZIG_REQUIRED}"; then
+    echo "Homebrew zig@0.15 did not provide zig ${ZIG_REQUIRED}" >&2
+    return 1
+  fi
+
+  sudo mkdir -p "${INSTALL_PREFIX}/bin" "${INSTALL_PREFIX}/lib/zig"
+  sudo rm -rf "${INSTALL_PREFIX}/lib/zig"
+  sudo mkdir -p "${INSTALL_PREFIX}/lib/zig"
+  sudo cp -f "${brew_prefix}/bin/zig" "${INSTALL_PREFIX}/bin/zig"
+  sudo cp -Rf "${brew_prefix}/lib/zig/." "${INSTALL_PREFIX}/lib/zig/"
+
+  export PATH="${INSTALL_PREFIX}/bin:${PATH}"
+  zig version
+}
+
+if install_from_homebrew; then
+  exit 0
+fi
+
+if ! command -v minisign >/dev/null 2>&1; then
+  if command -v brew >/dev/null 2>&1; then
+    HOMEBREW_NO_AUTO_UPDATE=1 HOMEBREW_NO_INSTALL_CLEANUP=1 HOMEBREW_NO_ENV_HINTS=1 brew install minisign
+  else
+    echo "minisign is required to verify Zig downloads" >&2
+    exit 1
+  fi
+fi
+
+download_with_retries() {
+  local url="$1"
+  local output="$2"
+  local attempt
+  local max_attempts=5
+
+  rm -f "$output"
+  for attempt in $(seq 1 "$max_attempts"); do
+    echo "Downloading ${url} (attempt ${attempt}/${max_attempts})"
+    if curl --fail --location --show-error --silent --connect-timeout 20 --speed-limit 65536 --speed-time 20 --max-time 120 "$url" --output "$output"; then
+      return 0
+    fi
+
+    rm -f "$output"
+    if [ "$attempt" -lt "$max_attempts" ]; then
+      sleep $((attempt * 2))
+    fi
+  done
+
+  return 1
+}
+
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "$tmpdir"' EXIT
+
+ZIG_BASE="zig-${ZIG_ARCH}-${ZIG_OS}-${ZIG_REQUIRED}"
+ZIG_URL="https://ziglang.org/download/${ZIG_REQUIRED}/${ZIG_BASE}.tar.xz"
+archive="$tmpdir/zig.tar.xz"
+signature="$tmpdir/zig.tar.xz.minisig"
+
+echo "Installing verified zig ${ZIG_REQUIRED} from tarball"
+download_with_retries "$ZIG_URL" "$archive"
+download_with_retries "${ZIG_URL}.minisig" "$signature"
+minisign -Vm "$archive" -x "$signature" -P "$ZIG_MINISIGN_PUBLIC_KEY"
+
+tar xf "$archive" -C "$tmpdir"
+sudo mkdir -p "${INSTALL_PREFIX}/bin" "${INSTALL_PREFIX}/lib/zig"
+sudo rm -rf "${INSTALL_PREFIX}/lib/zig"
+sudo mkdir -p "${INSTALL_PREFIX}/lib/zig"
+sudo cp -f "${tmpdir}/${ZIG_BASE}/zig" "${INSTALL_PREFIX}/bin/zig"
+sudo cp -Rf "${tmpdir}/${ZIG_BASE}/lib/." "${INSTALL_PREFIX}/lib/zig/"
+
+export PATH="${INSTALL_PREFIX}/bin:${PATH}"
+zig version


### PR DESCRIPTION
## Summary
- add one verified Zig installer script with retries and stall detection for transient ziglang.org failures
- switch CircleCI, activation, iOS/e2e, release, nightly, and GhosttyKit workflows to use it

## Verification
- `git diff --check`
- `bash -n scripts/install-zig-ci.sh`
- `./scripts/install-zig-ci.sh 0.15.2`
- YAML parse for `.github/workflows/*.yml` and `.circleci/config.yml`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Consolidated the Zig tool installation across CI/CD workflows into a single, reusable installer to reduce duplicated pipeline logic.
  * Added verified installation with signature checks to improve supply-chain security for build tooling.
  * Simplified CI steps for Zig setup, enhancing workflow reliability and easing future maintenance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->