### PR TITLE
Trim 0.64.0 changelog to shipped features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,6 @@ All notable changes to cmux are documented here.
 - Show Codex TUI errors in the sidebar ([#3212](https://github.com/manaflow-ai/cmux/pull/3212))
 - Keep Cmd-Shift-N windows on the source display ([#3214](https://github.com/manaflow-ai/cmux/pull/3214))
 - Select find text on repeated Cmd+F ([#3314](https://github.com/manaflow-ai/cmux/pull/3314))
-- Search Codex rollout content from the sessions sidebar ([#3396](https://github.com/manaflow-ai/cmux/pull/3396))
 - Disable Claude OSC notifications in the cmux wrapper and gate Claude OSC suppression on integration setting ([#3418](https://github.com/manaflow-ai/cmux/pull/3418), [#3474](https://github.com/manaflow-ai/cmux/pull/3474))
 - Namespace agent hook CLI commands ([#3298](https://github.com/manaflow-ai/cmux/pull/3298))
 
@@ -111,7 +110,7 @@ All notable changes to cmux are documented here.
 - Fix close confirmation bypass when spamming close ([#2989](https://github.com/manaflow-ai/cmux/pull/2989))
 - Fix multi-workspace close confirmation modality ([#3153](https://github.com/manaflow-ai/cmux/pull/3153))
 - Fix Cmd/Ctrl shortcut hint parity ([#2994](https://github.com/manaflow-ai/cmux/pull/2994))
-- Fix Sessions panel CPU loop on nightly and cancel drag on Escape ([#2995](https://github.com/manaflow-ai/cmux/pull/2995), [#3013](https://github.com/manaflow-ai/cmux/pull/3013))
+- Cancel drag on Escape ([#3013](https://github.com/manaflow-ai/cmux/pull/3013))
 - Pin regular-weight Japanese auto-fallback face ([#3015](https://github.com/manaflow-ai/cmux/pull/3015))
 - Fix 100% CPU from ContentView publisher feedback loop ([#3028](https://github.com/manaflow-ai/cmux/pull/3028))
 - Fix `DebugEventLog` `NSFileHandle` ObjC exception crash ([#3034](https://github.com/manaflow-ai/cmux/pull/3034))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,18 +49,14 @@ All notable changes to cmux are documented here.
 ## [0.64.0] - 2026-05-05
 
 ### Added
-- Feed sidebar with `cmux feed-hook` and OpenCode plugin to surface permission requests, plan approvals, and agent questions inline ([#3057](https://github.com/manaflow-ai/cmux/pull/3057), [#3405](https://github.com/manaflow-ai/cmux/pull/3405), [#3457](https://github.com/manaflow-ai/cmux/pull/3457))
-- Sessions panel (renamed Vault) in the right sidebar with persistent session restore and agent resume across relaunch ([#2936](https://github.com/manaflow-ai/cmux/pull/2936), [#2978](https://github.com/manaflow-ai/cmux/pull/2978), [#3259](https://github.com/manaflow-ai/cmux/pull/3259), [#3419](https://github.com/manaflow-ai/cmux/pull/3419), [#3429](https://github.com/manaflow-ai/cmux/pull/3429), [#3487](https://github.com/manaflow-ai/cmux/pull/3487), [#3528](https://github.com/manaflow-ai/cmux/pull/3528))
+- Restore prior panes and resume Claude Code, Codex, OpenCode, Gemini, and Rovo Dev sessions across relaunch, including when you close the last window with the red X ([#2936](https://github.com/manaflow-ai/cmux/pull/2936), [#2978](https://github.com/manaflow-ai/cmux/pull/2978), [#3259](https://github.com/manaflow-ai/cmux/pull/3259), [#3419](https://github.com/manaflow-ai/cmux/pull/3419), [#3429](https://github.com/manaflow-ai/cmux/pull/3429), [#3487](https://github.com/manaflow-ai/cmux/pull/3487), [#3528](https://github.com/manaflow-ai/cmux/pull/3528), [#3530](https://github.com/manaflow-ai/cmux/pull/3530), [#3535](https://github.com/manaflow-ai/cmux/pull/3535))
 - Passkey, WebAuthn, and FIDO2 support in browser panes ([#2660](https://github.com/manaflow-ai/cmux/pull/2660), [#2727](https://github.com/manaflow-ai/cmux/pull/2727), [#2905](https://github.com/manaflow-ai/cmux/pull/2905), [#2908](https://github.com/manaflow-ai/cmux/pull/2908))
-- `cmux vm` CLI and Cloud VM backend for spawning Freestyle-backed cloud workspaces with `cmux vm new`, `cmux vm shell`, and `cmux vm attach` ([#3046](https://github.com/manaflow-ai/cmux/pull/3046), [#3185](https://github.com/manaflow-ai/cmux/pull/3185), [#3196](https://github.com/manaflow-ai/cmux/pull/3196), [#3219](https://github.com/manaflow-ai/cmux/pull/3219), [#3432](https://github.com/manaflow-ai/cmux/pull/3432), [#3437](https://github.com/manaflow-ai/cmux/pull/3437))
-- Dock right-sidebar TUI control surface with project and global config via `.cmux/dock.json` and `~/.config/cmux/dock.json` ([#3217](https://github.com/manaflow-ai/cmux/pull/3217), [#3366](https://github.com/manaflow-ai/cmux/pull/3366), [#3376](https://github.com/manaflow-ai/cmux/pull/3376), [#3393](https://github.com/manaflow-ai/cmux/pull/3393))
 - Task Manager window and `cmux top` CLI for window, workspace, pane, surface, and browser webview snapshots ([#3290](https://github.com/manaflow-ai/cmux/pull/3290), [#3471](https://github.com/manaflow-ai/cmux/pull/3471))
 - Finder-like file explorer sidebar with SSH support ([#1963](https://github.com/manaflow-ai/cmux/pull/1963))
 - File preview panels in the sidebar ([#3139](https://github.com/manaflow-ai/cmux/pull/3139))
 - Menu bar only mode ([#3181](https://github.com/manaflow-ai/cmux/pull/3181))
 - System-wide hotkey to show and hide cmux windows ([#2389](https://github.com/manaflow-ai/cmux/pull/2389))
 - Cursor and Gemini CLI agent integrations with `setup-hooks` ([#2717](https://github.com/manaflow-ai/cmux/pull/2717))
-- Gemini and Rovo Dev session hooks with sessions piped into Vault ([#3530](https://github.com/manaflow-ai/cmux/pull/3530), [#3535](https://github.com/manaflow-ai/cmux/pull/3535))
 - iMessage mode for agent prompts ([#3252](https://github.com/manaflow-ai/cmux/pull/3252))
 - Settings sidebar shell and unified config utility window with cmux, Ghostty, and synced tabs ([#3024](https://github.com/manaflow-ai/cmux/pull/3024), [#3244](https://github.com/manaflow-ai/cmux/pull/3244), [#3400](https://github.com/manaflow-ai/cmux/pull/3400))
 - Make `cmux.json` the canonical settings file with JSONC parsing and legacy `settings.json` fallback ([#3409](https://github.com/manaflow-ai/cmux/pull/3409), [#3424](https://github.com/manaflow-ai/cmux/pull/3424))
@@ -81,7 +77,6 @@ All notable changes to cmux are documented here.
 - Korean (ko) localization ([#2885](https://github.com/manaflow-ai/cmux/pull/2885)) -- thanks @say8425!
 - Opt-in setting to open Cmd-clicked Markdown files in the cmux Markdown viewer ([#2904](https://github.com/manaflow-ai/cmux/pull/2904)) -- thanks @SeongJaeSong!
 - cmux browser disable switch ([#3256](https://github.com/manaflow-ai/cmux/pull/3256))
-- Beta feature toggles for Feed and Dock ([#3537](https://github.com/manaflow-ai/cmux/pull/3537))
 - Markdown and plain-text variants for docs pages plus `/llms.txt` index for agent consumption ([#3410](https://github.com/manaflow-ai/cmux/pull/3410))
 
 ### Changed
@@ -102,7 +97,6 @@ All notable changes to cmux are documented here.
 - Select find text on repeated Cmd+F ([#3314](https://github.com/manaflow-ai/cmux/pull/3314))
 - Search Codex rollout content from the sessions sidebar ([#3396](https://github.com/manaflow-ai/cmux/pull/3396))
 - Disable Claude OSC notifications in the cmux wrapper and gate Claude OSC suppression on integration setting ([#3418](https://github.com/manaflow-ai/cmux/pull/3418), [#3474](https://github.com/manaflow-ai/cmux/pull/3474))
-- Route Codex permission approvals through Feed ([#3420](https://github.com/manaflow-ai/cmux/pull/3420))
 - Namespace agent hook CLI commands ([#3298](https://github.com/manaflow-ai/cmux/pull/3298))
 
 ### Fixed

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -24,12 +24,11 @@ Run this workflow to prepare and publish a cmux release.
 - Build a deduplicated list of all contributor `@handle`s.
 
 4. Update changelogs:
-- Update `CHANGELOG.md`.
-- Do not edit a separate docs changelog file; `web/app/docs/changelog/page.tsx` renders from `CHANGELOG.md`.
-- Use categories `Added`, `Changed`, `Fixed`, `Removed`.
+- `CHANGELOG.md` is the source of truth: `web/app/[locale]/docs/changelog/page.tsx` renders the per-version bullet lists directly from it.
+- Update `CHANGELOG.md` using categories `Added`, `Changed`, `Fixed`, `Removed`.
 - **Credit contributors inline** (see Contributor Credits below).
 - **Confirm shipped scope with the user before drafting user-facing entries.** A merged PR is not the same as a shipped feature: features can be behind beta toggles, internal flags, partially landed, reverted later, or otherwise not user-ready. Before writing the `Added`/`Changed` sections, list the candidate user-facing items and ask the user which are actually ready to ship in this version. Drop anything they say is not ready, plus any entries that depend on it. Re-confirm if the version, scope, or shipped surface changes mid-release.
-- Mirror the curated highlights in `web/app/[locale]/docs/changelog/changelog-media.ts` to the same shipped scope. If the user removes a feature here, also remove it from the version's `features` and update its `title`.
+- Mirror the curated highlights in `web/app/[locale]/docs/changelog/changelog-media.ts` to the same shipped scope. The docs changelog page reads its hero title and feature highlights from this file (bullets still come from `CHANGELOG.md`). If the user drops a feature, also remove it from the version's `features` and update its `title` so the highlights match the bullets.
 - If no user-facing changes exist, confirm with the user before continuing.
 
 5. Bump app version metadata:

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -28,6 +28,8 @@ Run this workflow to prepare and publish a cmux release.
 - Do not edit a separate docs changelog file; `web/app/docs/changelog/page.tsx` renders from `CHANGELOG.md`.
 - Use categories `Added`, `Changed`, `Fixed`, `Removed`.
 - **Credit contributors inline** (see Contributor Credits below).
+- **Confirm shipped scope with the user before drafting user-facing entries.** A merged PR is not the same as a shipped feature: features can be behind beta toggles, internal flags, partially landed, reverted later, or otherwise not user-ready. Before writing the `Added`/`Changed` sections, list the candidate user-facing items and ask the user which are actually ready to ship in this version. Drop anything they say is not ready, plus any entries that depend on it. Re-confirm if the version, scope, or shipped surface changes mid-release.
+- Mirror the curated highlights in `web/app/[locale]/docs/changelog/changelog-media.ts` to the same shipped scope. If the user removes a feature here, also remove it from the version's `features` and update its `title`.
 - If no user-facing changes exist, confirm with the user before continuing.
 
 5. Bump app version metadata:
@@ -65,7 +67,7 @@ Run this workflow to prepare and publish a cmux release.
 
 ## Changelog Rules
 
-- Include only user-visible changes.
+- Include only user-visible changes that actually ship in this version. A merged PR alone is not enough: confirm with the user that each candidate feature is shipped (not behind a beta toggle, not partially landed, not deferred). When in doubt, ask before listing it.
 - Exclude internal-only changes (CI, tests, docs-only edits, refactors without behavior changes).
 - Write concise user-facing bullets in present tense.
 

--- a/web/app/[locale]/docs/changelog/changelog-media.ts
+++ b/web/app/[locale]/docs/changelog/changelog-media.ts
@@ -27,27 +27,12 @@ export interface VersionMedia {
 
 export const changelogMedia: Record<string, VersionMedia> = {
   "0.64.0": {
-    title: "Feed, Vault, Cloud VMs, Dock, Passkeys, File Explorer",
+    title: "Session Restore on Quit, Passkeys, File Explorer, Task Manager",
     features: [
       {
-        title: "Feed",
+        title: "Session Restore on Quit",
         description:
-          "A new Feed mode in the right sidebar surfaces actionable agent events inline: permission requests, plan approvals, and questions land where you can answer them. Ships with cmux feed-hook and an OpenCode plugin so any agent plugs into the same flow.",
-      },
-      {
-        title: "Vault",
-        description:
-          "The Sessions panel (renamed Vault) restores prior panes and resumes Claude Code, Codex, OpenCode, Gemini, and Rovo Dev sessions across relaunch. Sessions also persist when you close the last window via the red X.",
-      },
-      {
-        title: "cmux Cloud VMs",
-        description:
-          "cmux vm new, cmux vm shell, and cmux vm attach spin up Freestyle-backed cloud workspaces from the terminal. The image bakes cmuxd-remote and a systemd-activated socket so connections come up clean.",
-      },
-      {
-        title: "Dock",
-        description:
-          "Mount any TUI as a right-sidebar control surface, configurable per project in .cmux/dock.json or globally in ~/.config/cmux/dock.json. Ships with the cmux feed TUI as the first built-in Dock control.",
+          "Closing the last window with the red X no longer drops your work. cmux restores prior panes on relaunch and resumes Claude Code, Codex, OpenCode, Gemini, and Rovo Dev sessions where you left off.",
       },
       {
         title: "Passkeys, WebAuthn, and FIDO2",


### PR DESCRIPTION
## Summary
- Drop Feed, Vault, Cloud VMs, and Dock from the 0.64.0 entry in `CHANGELOG.md` and from the docs highlights in `web/app/[locale]/docs/changelog/changelog-media.ts`. Those features are not ready to ship.
- Keep session restore on quit as a top-line 0.64.0 highlight (that part shipped). Reword the bullet so it stands on its own without the Vault branding, and roll the Gemini and Rovo Dev session-hook PRs into the same entry.
- Update the `release` skill to require explicit user confirmation that each user-facing item actually shipped before drafting the changelog, and to keep `changelog-media.ts` in sync with that scope.

## Testing
- No app/runtime changes. Vercel preview will render the trimmed docs changelog.

## Related
- Task: trim 0.64.0 changelog page so we don't preannounce Feed/Vault/Cloud VMs/Dock

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trims the 0.64.0 changelog/docs to only shipped features and promotes session restore on quit. Adds a release check to avoid preannouncing unshipped work and clarifies the docs vs. changelog split.

- **Docs and Release Process**
  - `CHANGELOG.md`: remove Feed, Vault, Cloud VMs, Dock and dependents (beta toggles, Feed routing, sessions sidebar search, Vault CPU loop fix); keep “Session Restore on Quit,” rewrite to stand alone, include Gemini and Rovo Dev, and note red X close restores panes/sessions.
  - `web/app/[locale]/docs/changelog/changelog-media.ts`: retitle 0.64.0 highlights, drop Feed/Vault/Cloud VMs/Dock, and keep “Session Restore on Quit” with the red X detail.
  - `skills/release/SKILL.md`: define the two-file split—`CHANGELOG.md` is the source for bullets; `changelog-media.ts` supplies the hero title and highlights—and require explicit user confirmation of shipped scope; keep both files in sync and include only shipped, user-visible changes.

<sup>Written for commit 83e6b41f174704f92214c1ee4c08f75157b17a7e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session restore on quit, browser-pane authentication (passkeys), Task Manager, cmux top CLI, Finder-like file explorer with previews, menu-bar-only mode, system-wide hotkey, and new agent/CLI integration hooks.

* **Documentation**
  * Updated 0.64.0 changelog and docs; added guidance for changelog creation and validation; introduced Markdown/plain-text docs variant.

* **Changed**
  * Consolidated PR polling, faster terminal paste, and UI theme/workspace visual refinements.

* **Chores**
  * Adjusted changelog/media entries to reflect shipped features.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->