### PR TITLE
Markdown panel: copy buttons for path and content

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		E30760000000000000000002 /* TmuxWorkspacePaneOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
+		A5009002 /* MarkdownPanelTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5009001 /* MarkdownPanelTheme.swift */; };
 		A5001422 /* FilePreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001423 /* FilePreviewPanel.swift */; };
 		A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */; };
 		A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */; };
@@ -656,6 +657,7 @@
 		E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxWorkspacePaneOverlayView.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
+		A5009001 /* MarkdownPanelTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelTheme.swift; sourceTree = "<group>"; };
 		A5001423 /* FilePreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewPanel.swift; sourceTree = "<group>"; };
 		A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOpenSocketSupport.swift; sourceTree = "<group>"; };
 		A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewModeSupport.swift; sourceTree = "<group>"; };
@@ -1102,6 +1104,7 @@
 				A5007423 /* BrowserWebAuthnSupport.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
+				A5009001 /* MarkdownPanelTheme.swift */,
 				A5001423 /* FilePreviewPanel.swift */,
 				D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */,
 				A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */,
@@ -1681,6 +1684,7 @@
 				A5007422 /* BrowserWebAuthnSupport.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
+				A5009002 /* MarkdownPanelTheme.swift in Sources */,
 				A5001422 /* FilePreviewPanel.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
 				A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -101186,6 +101186,40 @@
         }
       }
     },
+    "markdown.content.copy.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy markdown content"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "Markdown本文をコピー"
+          }
+        }
+      }
+    },
+    "markdown.path.copy.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy file path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "new",
+            "value": "ファイルパスをコピー"
+          }
+        }
+      }
+    },
     "settings.section.sidebarAppearance": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/MarkdownPanelTheme.swift
+++ b/Sources/Panels/MarkdownPanelTheme.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+import MarkdownUI
+
+enum MarkdownPanelTheme {
+    static func make(colorScheme: ColorScheme) -> Theme {
+        let isDark = colorScheme == .dark
+
+        return Theme()
+            .text {
+                ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
+                FontSize(14)
+            }
+            .heading1 { configuration in
+                VStack(alignment: .leading, spacing: 8) {
+                    configuration.label
+                        .markdownTextStyle {
+                            FontWeight(.bold)
+                            FontSize(28)
+                            ForegroundColor(isDark ? .white : .primary)
+                        }
+                    Divider()
+                }
+                .markdownMargin(top: 24, bottom: 16)
+            }
+            .heading2 { configuration in
+                VStack(alignment: .leading, spacing: 6) {
+                    configuration.label
+                        .markdownTextStyle {
+                            FontWeight(.bold)
+                            FontSize(22)
+                            ForegroundColor(isDark ? .white : .primary)
+                        }
+                    Divider()
+                }
+                .markdownMargin(top: 20, bottom: 12)
+            }
+            .heading3 { configuration in
+                configuration.label
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(18)
+                        ForegroundColor(isDark ? .white : .primary)
+                    }
+                    .markdownMargin(top: 16, bottom: 8)
+            }
+            .heading4 { configuration in
+                configuration.label
+                    .markdownTextStyle {
+                        FontWeight(.semibold)
+                        FontSize(16)
+                        ForegroundColor(isDark ? .white : .primary)
+                    }
+                    .markdownMargin(top: 12, bottom: 6)
+            }
+            .heading5 { configuration in
+                configuration.label
+                    .markdownTextStyle {
+                        FontWeight(.medium)
+                        FontSize(14)
+                        ForegroundColor(isDark ? .white : .primary)
+                    }
+                    .markdownMargin(top: 10, bottom: 4)
+            }
+            .heading6 { configuration in
+                configuration.label
+                    .markdownTextStyle {
+                        FontWeight(.medium)
+                        FontSize(13)
+                        ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
+                    }
+                    .markdownMargin(top: 8, bottom: 4)
+            }
+            .codeBlock { configuration in
+                ScrollView(.horizontal, showsIndicators: true) {
+                    configuration.label
+                        .markdownTextStyle {
+                            FontFamilyVariant(.monospaced)
+                            FontSize(13)
+                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
+                        }
+                        .padding(12)
+                }
+                .background(isDark
+                    ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
+                    : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .markdownMargin(top: 8, bottom: 8)
+            }
+            .code {
+                FontFamilyVariant(.monospaced)
+                FontSize(13)
+                ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
+                BackgroundColor(isDark
+                    ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
+                    : Color(nsColor: NSColor(white: 0.92, alpha: 1.0)))
+            }
+            .blockquote { configuration in
+                HStack(spacing: 0) {
+                    RoundedRectangle(cornerRadius: 1.5)
+                        .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
+                        .frame(width: 3)
+                    configuration.label
+                        .markdownTextStyle {
+                            ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
+                            FontSize(14)
+                        }
+                        .padding(.leading, 12)
+                }
+                .markdownMargin(top: 8, bottom: 8)
+            }
+            .link {
+                ForegroundColor(Color.accentColor)
+            }
+            .strong {
+                FontWeight(.semibold)
+            }
+            .table { configuration in
+                configuration.label
+                    .markdownTableBorderStyle(.init(color: isDark ? .white.opacity(0.15) : .gray.opacity(0.3)))
+                    .markdownTableBackgroundStyle(
+                        .alternatingRows(
+                            isDark
+                                ? Color(nsColor: NSColor(white: 0.14, alpha: 1.0))
+                                : Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
+                            isDark
+                                ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
+                                : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
+                        )
+                    )
+                    .markdownMargin(top: 8, bottom: 8)
+            }
+            .thematicBreak {
+                Divider()
+                    .markdownMargin(top: 16, bottom: 16)
+            }
+            .listItem { configuration in
+                configuration.label
+                    .markdownMargin(top: 4, bottom: 4)
+            }
+            .paragraph { configuration in
+                configuration.label
+                    .markdownMargin(top: 4, bottom: 8)
+            }
+    }
+}

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -12,6 +12,8 @@ struct MarkdownPanelView: View {
 
     @State private var focusFlashOpacity: Double = 0.0
     @State private var focusFlashAnimationGeneration: Int = 0
+    @State private var pathCopied: Bool = false
+    @State private var contentCopied: Bool = false
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -87,7 +89,64 @@ struct MarkdownPanelView: View {
                 .foregroundColor(.secondary)
                 .lineLimit(1)
                 .truncationMode(.middle)
+                .textSelection(.enabled)
+                .help(panel.filePath)
+            copyPathButton
             Spacer()
+            copyContentButton
+        }
+    }
+
+    private var copyPathButton: some View {
+        let tooltip = String(
+            localized: "markdown.path.copy.tooltip",
+            defaultValue: "Copy file path"
+        )
+        return Button(action: copyFilePath) {
+            Image(systemName: pathCopied ? "checkmark" : "doc.on.doc")
+                .font(.system(size: 11))
+                .foregroundColor(pathCopied ? .green : .secondary)
+                .frame(width: 14, height: 14)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .help(tooltip)
+        .accessibilityLabel(tooltip)
+    }
+
+    private var copyContentButton: some View {
+        let tooltip = String(
+            localized: "markdown.content.copy.tooltip",
+            defaultValue: "Copy markdown content"
+        )
+        return Button(action: copyMarkdownContent) {
+            Image(systemName: contentCopied ? "checkmark" : "doc.plaintext")
+                .font(.system(size: 11))
+                .foregroundColor(contentCopied ? .green : .secondary)
+                .frame(width: 14, height: 14)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.borderless)
+        .disabled(panel.content.isEmpty)
+        .help(tooltip)
+        .accessibilityLabel(tooltip)
+    }
+
+    private func copyFilePath() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(panel.filePath, forType: .string)
+        pathCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            pathCopied = false
+        }
+    }
+
+    private func copyMarkdownContent() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(panel.content, forType: .string)
+        contentCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            contentCopied = false
         }
     }
 
@@ -99,13 +158,17 @@ struct MarkdownPanelView: View {
             Text(String(localized: "markdown.fileUnavailable.title", defaultValue: "File unavailable"))
                 .font(.headline)
                 .foregroundColor(.primary)
-            Text(panel.filePath)
-                .font(.system(size: 12, design: .monospaced))
-                .foregroundColor(.secondary)
-                .multilineTextAlignment(.center)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
-                .padding(.horizontal, 24)
+            HStack(spacing: 8) {
+                Text(panel.filePath)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundColor(.secondary)
+                    .multilineTextAlignment(.center)
+                    .textSelection(.enabled)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .help(panel.filePath)
+                copyPathButton
+            }
+            .padding(.horizontal, 24)
             Text(String(localized: "markdown.fileUnavailable.message", defaultValue: "The file may have been moved or deleted."))
                 .font(.caption)
                 .foregroundColor(.secondary)

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -14,6 +14,8 @@ struct MarkdownPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @State private var pathCopied: Bool = false
     @State private var contentCopied: Bool = false
+    @State private var pathCopyGeneration: Int = 0
+    @State private var contentCopyGeneration: Int = 0
     @Environment(\.colorScheme) private var colorScheme
 
     var body: some View {
@@ -61,7 +63,7 @@ struct MarkdownPanelView: View {
 
                 // Rendered markdown
                 Markdown(panel.content)
-                    .markdownTheme(cmuxMarkdownTheme)
+                    .markdownTheme(MarkdownPanelTheme.make(colorScheme: colorScheme))
                     .textSelection(.enabled)
                     // Wire link activation through NSWorkspace explicitly.
                     // SwiftUI's default Link path does not fire reliably
@@ -135,8 +137,11 @@ struct MarkdownPanelView: View {
     private func copyFilePath() {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(panel.filePath, forType: .string)
+        pathCopyGeneration &+= 1
+        let generation = pathCopyGeneration
         pathCopied = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            guard pathCopyGeneration == generation else { return }
             pathCopied = false
         }
     }
@@ -144,8 +149,11 @@ struct MarkdownPanelView: View {
     private func copyMarkdownContent() {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(panel.content, forType: .string)
+        contentCopyGeneration &+= 1
+        let generation = contentCopyGeneration
         contentCopied = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.2) {
+            guard contentCopyGeneration == generation else { return }
             contentCopied = false
         }
     }
@@ -182,158 +190,6 @@ struct MarkdownPanelView: View {
         colorScheme == .dark
             ? Color(nsColor: NSColor(white: 0.12, alpha: 1.0))
             : Color(nsColor: NSColor(white: 0.98, alpha: 1.0))
-    }
-
-    private var cmuxMarkdownTheme: Theme {
-        let isDark = colorScheme == .dark
-
-        return Theme()
-            // Text
-            .text {
-                ForegroundColor(isDark ? .white.opacity(0.9) : .primary)
-                FontSize(14)
-            }
-            // Headings
-            .heading1 { configuration in
-                VStack(alignment: .leading, spacing: 8) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(28)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 24, bottom: 16)
-            }
-            .heading2 { configuration in
-                VStack(alignment: .leading, spacing: 6) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontWeight(.bold)
-                            FontSize(22)
-                            ForegroundColor(isDark ? .white : .primary)
-                        }
-                    Divider()
-                }
-                .markdownMargin(top: 20, bottom: 12)
-            }
-            .heading3 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(18)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 16, bottom: 8)
-            }
-            .heading4 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.semibold)
-                        FontSize(16)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 12, bottom: 6)
-            }
-            .heading5 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(14)
-                        ForegroundColor(isDark ? .white : .primary)
-                    }
-                    .markdownMargin(top: 10, bottom: 4)
-            }
-            .heading6 { configuration in
-                configuration.label
-                    .markdownTextStyle {
-                        FontWeight(.medium)
-                        FontSize(13)
-                        ForegroundColor(isDark ? .white.opacity(0.7) : .secondary)
-                    }
-                    .markdownMargin(top: 8, bottom: 4)
-            }
-            // Code blocks
-            .codeBlock { configuration in
-                ScrollView(.horizontal, showsIndicators: true) {
-                    configuration.label
-                        .markdownTextStyle {
-                            FontFamilyVariant(.monospaced)
-                            FontSize(13)
-                            ForegroundColor(isDark ? Color(red: 0.9, green: 0.9, blue: 0.9) : Color(red: 0.2, green: 0.2, blue: 0.2))
-                        }
-                        .padding(12)
-                }
-                .background(isDark
-                    ? Color(nsColor: NSColor(white: 0.08, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.93, alpha: 1.0)))
-                .clipShape(RoundedRectangle(cornerRadius: 6))
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Inline code
-            .code {
-                FontFamilyVariant(.monospaced)
-                FontSize(13)
-                ForegroundColor(isDark ? Color(red: 0.85, green: 0.6, blue: 0.95) : Color(red: 0.6, green: 0.2, blue: 0.7))
-                BackgroundColor(isDark
-                    ? Color(nsColor: NSColor(white: 0.18, alpha: 1.0))
-                    : Color(nsColor: NSColor(white: 0.92, alpha: 1.0)))
-            }
-            // Block quotes
-            .blockquote { configuration in
-                HStack(spacing: 0) {
-                    RoundedRectangle(cornerRadius: 1.5)
-                        .fill(isDark ? Color.white.opacity(0.2) : Color.gray.opacity(0.4))
-                        .frame(width: 3)
-                    configuration.label
-                        .markdownTextStyle {
-                            ForegroundColor(isDark ? .white.opacity(0.6) : .secondary)
-                            FontSize(14)
-                        }
-                        .padding(.leading, 12)
-                }
-                .markdownMargin(top: 8, bottom: 8)
-            }
-            // Links
-            .link {
-                ForegroundColor(Color.accentColor)
-            }
-            // Strong
-            .strong {
-                FontWeight(.semibold)
-            }
-            // Tables
-            .table { configuration in
-                configuration.label
-                    .markdownTableBorderStyle(.init(color: isDark ? .white.opacity(0.15) : .gray.opacity(0.3)))
-                    .markdownTableBackgroundStyle(
-                        .alternatingRows(
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.14, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 0.96, alpha: 1.0)),
-                            isDark
-                                ? Color(nsColor: NSColor(white: 0.10, alpha: 1.0))
-                                : Color(nsColor: NSColor(white: 1.0, alpha: 1.0))
-                        )
-                    )
-                    .markdownMargin(top: 8, bottom: 8)
-            }
-            // Thematic break (horizontal rule)
-            .thematicBreak {
-                Divider()
-                    .markdownMargin(top: 16, bottom: 16)
-            }
-            // List items
-            .listItem { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 4)
-            }
-            // Paragraphs
-            .paragraph { configuration in
-                configuration.label
-                    .markdownMargin(top: 4, bottom: 8)
-            }
     }
 
     // MARK: - Focus Flash


### PR DESCRIPTION
## Summary

Add copy buttons to the markdown panel header — one for the file path, one for the markdown content. Path text is now selectable and shows the full path on hover.

## Screenshots


https://github.com/user-attachments/assets/ab4a2929-dbb6-4a5d-a821-92be4aff6585

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Copy markdown content and copy file path buttons added to the Markdown panel.
  * Immediate visual feedback (checkmark + green highlight) confirms successful copies.

* **UI Improvements**
  * Improved Markdown rendering theme for clearer, consistent styling and selectable file path text.

* **Localization**
  * Tooltips for the new copy controls added in English and Japanese.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->