### PR TITLE
Fix OMX popup renderer tmux probes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11347,6 +11347,7 @@ struct CMUXCLI {
         let canonicalWorkspaceId = try resolveWorkspaceId(workspaceId, client: client)
         var context: [String: String] = [
             "session_name": "cmux",
+            "session_attached": "1",
             "window_id": "@\(canonicalWorkspaceId)",
             "window_uuid": canonicalWorkspaceId
         ]
@@ -11394,6 +11395,7 @@ struct CMUXCLI {
         if let resolvedPaneId {
             context["pane_id"] = "%\(resolvedPaneId)"
             context["pane_uuid"] = resolvedPaneId
+            context["pane_dead"] = "0"
             let panePayload = try client.sendV2(method: "pane.list", params: ["workspace_id": canonicalWorkspaceId])
             let panes = panePayload["panes"] as? [[String: Any]] ?? []
             if let pane = panes.first(where: { ($0["id"] as? String) == resolvedPaneId }),

--- a/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_compat.go
@@ -194,13 +194,14 @@ func tmuxFormatContext(rc *rpcContext, workspaceId string, paneId string, surfac
 	}
 
 	ctx := map[string]string{
-		"session_name":  "cmux",
-		"session_id":    "$0",
-		"window_id":     "@" + canonicalWsId,
-		"window_uuid":   canonicalWsId,
-		"window_active": "1",
-		"window_flags":  "*",
-		"pane_active":   "1",
+		"session_name":     "cmux",
+		"session_id":       "$0",
+		"session_attached": "1",
+		"window_id":        "@" + canonicalWsId,
+		"window_uuid":      canonicalWsId,
+		"window_active":    "1",
+		"window_flags":     "*",
+		"pane_active":      "1",
 	}
 
 	// Get workspace list for index/title
@@ -254,6 +255,7 @@ func tmuxFormatContext(rc *rpcContext, workspaceId string, paneId string, surfac
 	if resolvedPaneId != "" {
 		ctx["pane_id"] = "%" + resolvedPaneId
 		ctx["pane_uuid"] = resolvedPaneId
+		ctx["pane_dead"] = "0"
 
 		panePayload, err := rc.call("pane.list", map[string]any{"workspace_id": canonicalWsId})
 		if err == nil {

--- a/daemon/remote/cmd/cmuxd-remote/tmux_split_ref_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/tmux_split_ref_test.go
@@ -86,18 +86,43 @@ func startMockTmuxCompatSocket(t *testing.T) string {
 					}
 				case "pane.list":
 					panes := []map[string]any{{
-						"id":    "33333333-3333-4333-8333-333333333333",
-						"ref":   "pane:1",
-						"index": 1,
+						"id":             "33333333-3333-4333-8333-333333333333",
+						"ref":            "pane:1",
+						"index":          1,
+						"rows":           32,
+						"columns":        120,
+						"cell_height_px": 18,
+						"cell_width_px":  9,
 					}}
 					if splitCreated {
 						panes = append(panes, map[string]any{
-							"id":    "66666666-6666-4666-8666-666666666666",
-							"ref":   "pane:2",
-							"index": 2,
+							"id":             "66666666-6666-4666-8666-666666666666",
+							"ref":            "pane:2",
+							"index":          2,
+							"rows":           12,
+							"columns":        120,
+							"cell_height_px": 18,
+							"cell_width_px":  9,
 						})
 					}
 					resp["result"] = map[string]any{"panes": panes}
+				case "pane.surfaces":
+					switch paneId, _ := params["pane_id"].(string); paneId {
+					case "33333333-3333-4333-8333-333333333333":
+						resp["result"] = map[string]any{
+							"surfaces": []map[string]any{{"id": "44444444-4444-4444-8444-444444444444", "selected": true}},
+						}
+					case "66666666-6666-4666-8666-666666666666":
+						resp["result"] = map[string]any{
+							"surfaces": []map[string]any{{"id": "77777777-7777-4777-8777-777777777777", "selected": true}},
+						}
+					default:
+						resp["ok"] = false
+						resp["error"] = map[string]any{
+							"code":    "not_found",
+							"message": "Pane not found",
+						}
+					}
 				case "surface.split":
 					if got, _ := params["surface_id"].(string); got != "44444444-4444-4444-8444-444444444444" {
 						resp["ok"] = false
@@ -170,6 +195,83 @@ func TestTmuxSplitWindowCanonicalizesCallerSurfaceRefs(t *testing.T) {
 
 	if got := output; got != "%66666666-6666-4666-8666-666666666666\n" {
 		t.Fatalf("stdout = %q", got)
+	}
+}
+
+func TestTmuxQuestionRendererFormatProbes(t *testing.T) {
+	origHome := os.Getenv("HOME")
+	origWorkspace := os.Getenv("CMUX_WORKSPACE_ID")
+	origSurface := os.Getenv("CMUX_SURFACE_ID")
+	origPane := os.Getenv("TMUX_PANE")
+	os.Setenv("HOME", t.TempDir())
+	os.Setenv("CMUX_WORKSPACE_ID", "workspace:1")
+	os.Setenv("CMUX_SURFACE_ID", "surface:1")
+	os.Setenv("TMUX_PANE", "%pane:1")
+	defer func() {
+		os.Setenv("HOME", origHome)
+		if origWorkspace != "" {
+			os.Setenv("CMUX_WORKSPACE_ID", origWorkspace)
+		} else {
+			os.Unsetenv("CMUX_WORKSPACE_ID")
+		}
+		if origSurface != "" {
+			os.Setenv("CMUX_SURFACE_ID", origSurface)
+		} else {
+			os.Unsetenv("CMUX_SURFACE_ID")
+		}
+		if origPane != "" {
+			os.Setenv("TMUX_PANE", origPane)
+		} else {
+			os.Unsetenv("TMUX_PANE")
+		}
+	}()
+
+	sockPath := startMockTmuxCompatSocket(t)
+	rc := &rpcContext{socketPath: sockPath}
+
+	attached := captureStdout(t, func() {
+		if err := dispatchTmuxCommand(rc, "display-message", []string{"-p", "#{session_attached}"}); err != nil {
+			t.Fatalf("display-message session_attached: %v", err)
+		}
+	})
+	if attached != "1\n" {
+		t.Fatalf("session_attached stdout = %q, want 1\\n", attached)
+	}
+
+	targetedAttached := captureStdout(t, func() {
+		if err := dispatchTmuxCommand(rc, "display-message", []string{"-t", "%33333333-3333-4333-8333-333333333333", "-p", "#{session_attached}"}); err != nil {
+			t.Fatalf("targeted display-message session_attached: %v", err)
+		}
+	})
+	if targetedAttached != "1\n" {
+		t.Fatalf("targeted session_attached stdout = %q, want 1\\n", targetedAttached)
+	}
+
+	targetedPaneDead := captureStdout(t, func() {
+		if err := dispatchTmuxCommand(rc, "display-message", []string{"-t", "%33333333-3333-4333-8333-333333333333", "-p", "#{pane_dead}"}); err != nil {
+			t.Fatalf("targeted display-message pane_dead: %v", err)
+		}
+	})
+	if targetedPaneDead != "0\n" {
+		t.Fatalf("targeted pane_dead stdout = %q, want 0\\n", targetedPaneDead)
+	}
+
+	combined := captureStdout(t, func() {
+		if err := dispatchTmuxCommand(rc, "display-message", []string{"-t", "%33333333-3333-4333-8333-333333333333", "-p", "#{session_attached}:#{pane_height}"}); err != nil {
+			t.Fatalf("combined display-message: %v", err)
+		}
+	})
+	if combined != "1:32\n" {
+		t.Fatalf("combined stdout = %q, want 1:32\\n", combined)
+	}
+
+	panes := captureStdout(t, func() {
+		if err := dispatchTmuxCommand(rc, "list-panes", []string{"-t", "%33333333-3333-4333-8333-333333333333", "-F", "#{pane_dead}\t#{pane_id}"}); err != nil {
+			t.Fatalf("list-panes pane_dead: %v", err)
+		}
+	})
+	if panes != "0\t%33333333-3333-4333-8333-333333333333\n" {
+		t.Fatalf("pane_dead stdout = %q, want live leader pane", panes)
 	}
 }
 

--- a/tests/test_cli_omx_hud_tmux_split.py
+++ b/tests/test_cli_omx_hud_tmux_split.py
@@ -269,6 +269,141 @@ def assert_omx_hud_splits_down_with_compact_size(
         raise AssertionError(f"HUD command should not be typed into a shell: {state.sent_text!r}")
 
 
+def assert_omx_question_renderer_tmux_probes_are_supported(
+    cli_path: str,
+    socket_path: Path,
+    fake_home: Path,
+) -> None:
+    attached_proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        ["__tmux-compat", "display-message", "-p", "#{session_attached}"],
+    )
+    if attached_proc.returncode != 0:
+        raise AssertionError(
+            "question renderer attached probe returned non-zero\n"
+            f"stdout={attached_proc.stdout.strip()}\n"
+            f"stderr={attached_proc.stderr.strip()}"
+        )
+    if attached_proc.stdout.strip() != "1":
+        raise AssertionError(
+            f"expected session_attached probe to print 1, got {attached_proc.stdout!r}"
+        )
+
+    targeted_attached_proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "display-message",
+            "-t",
+            f"%{PANE_ID}",
+            "-p",
+            "#{session_attached}",
+        ],
+    )
+    if targeted_attached_proc.returncode != 0:
+        raise AssertionError(
+            "question renderer targeted attached probe returned non-zero\n"
+            f"stdout={targeted_attached_proc.stdout.strip()}\n"
+            f"stderr={targeted_attached_proc.stderr.strip()}"
+        )
+    if targeted_attached_proc.stdout.strip() != "1":
+        raise AssertionError(
+            "expected targeted session_attached probe to print 1, "
+            f"got {targeted_attached_proc.stdout!r}"
+        )
+
+    targeted_pane_dead_proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "display-message",
+            "-t",
+            f"%{PANE_ID}",
+            "-p",
+            "#{pane_dead}",
+        ],
+    )
+    if targeted_pane_dead_proc.returncode != 0:
+        raise AssertionError(
+            "question renderer targeted pane-alive display probe returned non-zero\n"
+            f"stdout={targeted_pane_dead_proc.stdout.strip()}\n"
+            f"stderr={targeted_pane_dead_proc.stderr.strip()}"
+        )
+    if targeted_pane_dead_proc.stdout.strip() != "0":
+        raise AssertionError(
+            "expected targeted pane_dead display probe to print 0, "
+            f"got {targeted_pane_dead_proc.stdout!r}"
+        )
+
+    combined_proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "display-message",
+            "-t",
+            f"%{PANE_ID}",
+            "-p",
+            "#{session_attached}:#{pane_height}",
+        ],
+    )
+    if combined_proc.returncode != 0:
+        raise AssertionError(
+            "question renderer combined attached/height probe returned non-zero\n"
+            f"stdout={combined_proc.stdout.strip()}\n"
+            f"stderr={combined_proc.stderr.strip()}"
+        )
+    combined_fields = combined_proc.stdout.strip().split(":")
+    if len(combined_fields) != 2 or combined_fields[0] != "1":
+        raise AssertionError(
+            "expected combined attached/height probe to start with 1:, "
+            f"got {combined_proc.stdout!r}"
+        )
+    try:
+        height = int(combined_fields[1])
+    except ValueError as exc:
+        raise AssertionError(
+            f"expected combined attached/height probe to include numeric height, got {combined_proc.stdout!r}"
+        ) from exc
+    if height <= 0:
+        raise AssertionError(
+            f"expected combined attached/height probe to include positive height, got {combined_proc.stdout!r}"
+        )
+
+    panes_proc = run_cli(
+        cli_path,
+        socket_path,
+        fake_home,
+        [
+            "__tmux-compat",
+            "list-panes",
+            "-t",
+            f"%{PANE_ID}",
+            "-F",
+            "#{pane_dead}\t#{pane_id}",
+        ],
+    )
+    if panes_proc.returncode != 0:
+        raise AssertionError(
+            "question renderer pane-alive probe returned non-zero\n"
+            f"stdout={panes_proc.stdout.strip()}\n"
+            f"stderr={panes_proc.stderr.strip()}"
+        )
+    lines = [line for line in panes_proc.stdout.splitlines() if line.strip()]
+    expected = f"0\t%{PANE_ID}"
+    if expected not in lines:
+        raise AssertionError(
+            f"expected pane-alive probe to include {expected!r}, got {lines!r}"
+        )
+
+
 def assert_omx_hud_is_visible_to_tmux_pane_formats(
     cli_path: str,
     socket_path: Path,
@@ -514,6 +649,11 @@ def main() -> int:
             try:
                 assert_omx_hud_feature_probe_is_supported(cli_path, socket_path, fake_home)
                 assert_omx_hud_unsupported_feature_probe_fails(cli_path, socket_path, fake_home)
+                assert_omx_question_renderer_tmux_probes_are_supported(
+                    cli_path,
+                    socket_path,
+                    fake_home,
+                )
                 assert_omx_hud_splits_down_with_compact_size(
                     cli_path,
                     socket_path,


### PR DESCRIPTION
## Summary
- Report `session_attached=1` from shared cmux tmux-format contexts.
- Report `pane_dead=0` for resolved live panes in local Swift and remote Go tmux compatibility.
- Add behavioral regressions for the display-message/list-panes probes used by the OMX popup renderer.

## Verification
- `git diff --check -- CLI/cmux.swift daemon/remote/cmd/cmuxd-remote/tmux_compat.go tests/test_cli_omx_hud_tmux_split.py daemon/remote/cmd/cmuxd-remote/tmux_split_ref_test.go`
- Architect verification approved during Ralph execution.
- `PATH=/tmp/zig-aarch64-macos-0.15.2:$PATH CMUX_ZIG=/tmp/zig-aarch64-macos-0.15.2/zig ./scripts/reload.sh --tag fix-omx-question-attached`

## Not run locally
- Python socket and Go remote regression tests; repo policy says tests run via CI/VM.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cmux panes look attached to tmux so the OMX question/popup renderer stops rejecting them. Ensures tmux probes like display-message and list-panes pass without a real attached tmux client.

- **Bug Fixes**
  - Always expose `session_attached=1` in shared tmux-format context for both local Swift (`CLI/cmux.swift`) and remote Go (`daemon/remote/cmd/cmuxd-remote/tmux_compat.go`).
  - Report `pane_dead=0` for resolved panes in the same shared context.
  - Add regression tests for the exact probes the OMX renderer uses: `display-message` (`#{session_attached}`, `#{pane_dead}`, combined with `#{pane_height}`) and `list-panes` (`#{pane_dead}\t#{pane_id}`) in Go and Python test suites.

<sup>Written for commit b08394898ef31f839595b455a6708692cc547709. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

