### PR TITLE
fix: always show "Show more" for low-activity folder sections

### DIFF
--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -394,6 +394,7 @@ struct IndexSection: Identifiable, Equatable {
     let title: String
     let icon: SectionIcon
     let entries: [SessionEntry]
+    let mayHaveMoreOnDisk: Bool
 
     var id: SectionKey { key }
 }
@@ -509,7 +510,8 @@ final class SessionIndexStore: ObservableObject {
                     key: .agent(agent),
                     title: agent.displayName,
                     icon: .agent(agent),
-                    entries: entries
+                    entries: entries,
+                    mayHaveMoreOnDisk: false
                 )
             }
         case .directory:
@@ -536,7 +538,8 @@ final class SessionIndexStore: ObservableObject {
                         key: .directory(path.isEmpty ? nil : path),
                         title: directoryDisplayName(path),
                         icon: .folder,
-                        entries: buckets[path] ?? []
+                        entries: buckets[path] ?? [],
+                        mayHaveMoreOnDisk: true
                     )
                 }
         }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -317,7 +317,7 @@ private struct IndexSectionView: View, Equatable {
                         .equatable()
                         .id(entry.id)
                 }
-                if section.entries.count > rowLimit || section.icon == .folder {
+                if section.entries.count > rowLimit || section.mayHaveMoreOnDisk {
                     showMoreButton
                 }
                 Spacer(minLength: 2)

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -317,7 +317,7 @@ private struct IndexSectionView: View, Equatable {
                         .equatable()
                         .id(entry.id)
                 }
-                if section.entries.count > rowLimit {
+                if section.entries.count > rowLimit || section.icon == .folder {
                     showMoreButton
                 }
                 Spacer(minLength: 2)


### PR DESCRIPTION
## Problem

`SessionIndexView.swift:320` only renders the "Show more" button when `section.entries.count > rowLimit` (rowLimit = 5). But `section.entries` is populated by `scanAll()`, which loads only the **30 most-recently-modified conversations globally**. A folder with few recent conversations may contribute only 1–2 entries to that global top-30, so the condition never fires — even if the folder has many older conversations on disk.

Example: a project directory with 16 conversations on disk but only 2 modified recently enough to appear in the top-30. `2 > 5` → false → no button → older conversations are unreachable from the sidebar.

## Fix

Add `|| section.icon == .folder` to the condition on line 320:

```swift
// Before
if section.entries.count > rowLimit {

// After
if section.entries.count > rowLimit || section.icon == .folder {
```

Folder sections always show "Show more" because there could always be more entries on disk than the global top-30 captured. Agent sections keep their original behavior unchanged.

The `loadDirectorySnapshot` popover already correctly fetches all conversations for a directory — this change just ensures there's always a UI trigger to open it for folder sections.

**Tradeoff:** A folder that genuinely has ≤5 total conversations will show "Show more" unnecessarily. Clicking it opens the popover showing the same entries. Minor noise, no breakage.

## Test plan

- [ ] Open a project folder that has more than 5 conversations on disk but few recent ones — confirm "Show more" now appears
- [ ] Click "Show more" — confirm the popover loads all conversations for that directory
- [ ] Verify agent sections still only show "Show more" when they have > 5 entries in the index

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always show the "Show more" button for folder sections in the sidebar so older conversations beyond the global top-30 scan remain reachable. This now uses an explicit `mayHaveMoreOnDisk` flag (true for directories, false for agents) to drive the button, leaving agent sections unchanged.

- **Refactors**
  - Added `mayHaveMoreOnDisk` to `IndexSection` and updated the view condition to `entries.count > rowLimit || section.mayHaveMoreOnDisk`.

<sup>Written for commit a695ebe0bbef733c8f3990772fb8295ade67791d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved logic for displaying the "Show more" button: folder/directory sections now show the button when additional entries may exist on disk even if the visible entry count is below the collapsed limit, ensuring users can access more results reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->