### PR TITLE
Fix Rovo Dev transcript previews

### DIFF
--- a/Sources/RovoDevTranscriptPreview.swift
+++ b/Sources/RovoDevTranscriptPreview.swift
@@ -74,9 +74,8 @@ enum RovoDevTranscriptPreview {
     }
 
     private static func parseMessageObject(_ object: [String: Any]) -> [RovoDevTranscriptPreviewTurn] {
-        let partTurns = parseRovoDevParts(object)
-        if !partTurns.isEmpty {
-            return partTurns
+        if object["parts"] != nil {
+            return parseRovoDevParts(object)
         }
 
         for candidate in candidateMessages(from: object) {
@@ -149,7 +148,14 @@ enum RovoDevTranscriptPreview {
         ) ?? "event"
 
         return parts.compactMap { part in
-            guard let partObject = part as? [String: Any] else { return nil }
+            guard let partObject = part as? [String: Any] else {
+                let text = textFragments(from: part)
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n\n")
+                guard !text.isEmpty else { return nil }
+                return RovoDevTranscriptPreviewTurn(role: messageRole, text: text)
+            }
             return parseRovoDevPart(partObject, messageRole: messageRole)
         }
     }
@@ -223,10 +229,12 @@ enum RovoDevTranscriptPreview {
         }
 
         switch object["part_kind"] as? String {
-        case "text", "user-prompt", "retry-prompt", "system-prompt":
+        case "text", "user-prompt", "retry-prompt":
             if let text = object["content"] as? String ?? object["text"] as? String {
                 return [text]
             }
+        case "system-prompt":
+            return []
         case "tool-use", "tool_use", "tool-call", "tool_call":
             return toolCallFragments(from: object)
         case "tool-result", "tool_result", "tool-return", "tool_return":

--- a/Sources/RovoDevTranscriptPreview.swift
+++ b/Sources/RovoDevTranscriptPreview.swift
@@ -31,7 +31,7 @@ enum RovoDevTranscriptPreview {
         _ object: [String: Any],
         limit: Int
     ) -> [RovoDevTranscriptPreviewTurn]? {
-        for key in ["messages", "conversation", "turns", "entries"] {
+        for key in ["message_history", "messages", "conversation", "turns", "entries"] {
             if let turns = parseMessages(object[key], limit: limit) {
                 return turns
             }
@@ -49,11 +49,17 @@ enum RovoDevTranscriptPreview {
                 didHitLimit = true
                 break
             }
-            guard let object = message as? [String: Any],
-                  let turn = parseMessageObject(object) else {
+            guard let object = message as? [String: Any] else {
                 continue
             }
-            turns.append(turn)
+            let messageTurns = parseMessageObject(object)
+            for turn in messageTurns {
+                guard turns.count < limit else {
+                    didHitLimit = true
+                    break
+                }
+                turns.append(turn)
+            }
         }
         if didHitLimit {
             turns.append(RovoDevTranscriptPreviewTurn(
@@ -67,13 +73,18 @@ enum RovoDevTranscriptPreview {
         return turns
     }
 
-    private static func parseMessageObject(_ object: [String: Any]) -> RovoDevTranscriptPreviewTurn? {
+    private static func parseMessageObject(_ object: [String: Any]) -> [RovoDevTranscriptPreviewTurn] {
+        let partTurns = parseRovoDevParts(object)
+        if !partTurns.isEmpty {
+            return partTurns
+        }
+
         for candidate in candidateMessages(from: object) {
             if let turn = parseCandidate(candidate) {
-                return turn
+                return [turn]
             }
         }
-        return nil
+        return []
     }
 
     private static func candidateMessages(from object: [String: Any]) -> [[String: Any]] {
@@ -89,6 +100,7 @@ enum RovoDevTranscriptPreview {
     private static func parseCandidate(_ object: [String: Any]) -> RovoDevTranscriptPreviewTurn? {
         guard let role = normalizedRole(
             object["role"] as? String
+                ?? object["kind"] as? String
                 ?? object["speaker"] as? String
                 ?? object["sender"] as? String
                 ?? object["author"] as? String
@@ -115,9 +127,9 @@ enum RovoDevTranscriptPreview {
     private static func normalizedRole(_ raw: String?) -> String? {
         guard let raw else { return nil }
         switch raw.lowercased() {
-        case "user", "human":
+        case "user", "human", "request":
             return "user"
-        case "assistant", "ai", "agent":
+        case "assistant", "ai", "agent", "response":
             return "assistant"
         case "system", "developer":
             return "system"
@@ -126,6 +138,60 @@ enum RovoDevTranscriptPreview {
         default:
             return "event"
         }
+    }
+
+    private static func parseRovoDevParts(_ object: [String: Any]) -> [RovoDevTranscriptPreviewTurn] {
+        guard let parts = object["parts"] as? [Any] else { return [] }
+        let messageRole = normalizedRole(
+            object["role"] as? String
+                ?? object["kind"] as? String
+                ?? object["type"] as? String
+        ) ?? "event"
+
+        return parts.compactMap { part in
+            guard let partObject = part as? [String: Any] else { return nil }
+            return parseRovoDevPart(partObject, messageRole: messageRole)
+        }
+    }
+
+    private static func parseRovoDevPart(
+        _ object: [String: Any],
+        messageRole: String
+    ) -> RovoDevTranscriptPreviewTurn? {
+        let kind = (object["part_kind"] as? String ?? object["type"] as? String)?.lowercased()
+        let role: String
+        let fragments: [String]
+
+        switch kind {
+        case "text", "user-prompt", "retry-prompt":
+            role = messageRole == "event" && kind != "text" ? "user" : messageRole
+            fragments = textFragments(from: object["content"] ?? object["text"])
+        case "system-prompt":
+            return nil
+        case "tool-call", "tool_call", "tool-use", "tool_use", "function_call":
+            role = "tool"
+            fragments = toolCallFragments(from: object)
+        case "tool-result", "tool_result", "tool-return", "tool_return", "function_call_output":
+            role = "tool"
+            let primary = object["content"] ?? object["output"] ?? object["result"]
+            fragments = textFragments(from: primary)
+        default:
+            role = messageRole
+            fragments = textFragments(
+                from: object["content"]
+                    ?? object["text"]
+                    ?? object["message"]
+                    ?? object["output"]
+                    ?? object["result"]
+            )
+        }
+
+        let text = fragments
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n\n")
+        guard !text.isEmpty else { return nil }
+        return RovoDevTranscriptPreviewTurn(role: role, text: text)
     }
 
     private static func textFragments(from value: Any?) -> [String] {
@@ -142,12 +208,28 @@ enum RovoDevTranscriptPreview {
 
         switch object["type"] as? String {
         case "text", "input_text", "output_text":
-            if let text = object["text"] as? String {
+            if let text = object["text"] as? String ?? object["content"] as? String {
                 return [text]
             }
-        case "tool_use", "function_call":
+        case "tool_use", "tool-call", "tool_call", "function_call":
             return toolCallFragments(from: object)
-        case "tool_result", "function_call_output":
+        case "tool_result", "tool-result", "tool_return", "function_call_output":
+            let fragments = textFragments(from: object["content"] ?? object["output"] ?? object["result"])
+            if !fragments.isEmpty {
+                return fragments
+            }
+        default:
+            break
+        }
+
+        switch object["part_kind"] as? String {
+        case "text", "user-prompt", "retry-prompt", "system-prompt":
+            if let text = object["content"] as? String ?? object["text"] as? String {
+                return [text]
+            }
+        case "tool-use", "tool_use", "tool-call", "tool_call":
+            return toolCallFragments(from: object)
+        case "tool-result", "tool_result", "tool-return", "tool_return":
             let fragments = textFragments(from: object["content"] ?? object["output"] ?? object["result"])
             if !fragments.isEmpty {
                 return fragments
@@ -170,11 +252,28 @@ enum RovoDevTranscriptPreview {
         if let name = object["name"] as? String, !name.isEmpty {
             parts.append(name)
         }
-        if let input = object["input"] ?? object["arguments"],
+        if let toolName = object["tool_name"] as? String,
+           !toolName.isEmpty,
+           toolName != "unknown",
+           parts.isEmpty {
+            parts.append(toolName)
+        }
+        if let input = object["input"] ?? object["arguments"] ?? object["tool_input"],
+           !isEmptyJSONContainer(input),
            let rendered = renderedJSON(input) {
             parts.append(rendered)
         }
         return parts
+    }
+
+    private static func isEmptyJSONContainer(_ value: Any) -> Bool {
+        if let object = value as? [String: Any] {
+            return object.isEmpty
+        }
+        if let array = value as? [Any] {
+            return array.isEmpty
+        }
+        return false
     }
 
     private static func renderedJSON(_ value: Any) -> String? {

--- a/Sources/RovoDevTranscriptPreview.swift
+++ b/Sources/RovoDevTranscriptPreview.swift
@@ -257,16 +257,15 @@ enum RovoDevTranscriptPreview {
 
     private static func toolCallFragments(from object: [String: Any]) -> [String] {
         var parts: [String] = []
-        if let toolName = object["tool_name"] as? String,
-           toolName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "unknown" {
+        let name = trimmedToolName(object["name"] as? String)
+        let toolName = trimmedToolName(object["tool_name"] as? String)
+        if isUnknownToolName(name) || isUnknownToolName(toolName) {
             return []
         }
-        if let name = object["name"] as? String, !name.isEmpty {
+        if let name {
             parts.append(name)
         }
-        if let toolName = object["tool_name"] as? String,
-           !toolName.isEmpty,
-           parts.isEmpty {
+        if let toolName, parts.isEmpty {
             parts.append(toolName)
         }
         if let input = object["input"] ?? object["arguments"] ?? object["tool_input"],
@@ -275,6 +274,16 @@ enum RovoDevTranscriptPreview {
             parts.append(rendered)
         }
         return parts
+    }
+
+    private static func trimmedToolName(_ raw: String?) -> String? {
+        guard let raw else { return nil }
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func isUnknownToolName(_ name: String?) -> Bool {
+        name?.lowercased() == "unknown"
     }
 
     private static func isEmptyJSONContainer(_ value: Any) -> Bool {

--- a/Sources/RovoDevTranscriptPreview.swift
+++ b/Sources/RovoDevTranscriptPreview.swift
@@ -257,12 +257,15 @@ enum RovoDevTranscriptPreview {
 
     private static func toolCallFragments(from object: [String: Any]) -> [String] {
         var parts: [String] = []
+        if let toolName = object["tool_name"] as? String,
+           toolName.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "unknown" {
+            return []
+        }
         if let name = object["name"] as? String, !name.isEmpty {
             parts.append(name)
         }
         if let toolName = object["tool_name"] as? String,
            !toolName.isEmpty,
-           toolName != "unknown",
            parts.isEmpty {
             parts.append(toolName)
         }

--- a/cmuxTests/RovoDevTranscriptPreviewTests.swift
+++ b/cmuxTests/RovoDevTranscriptPreviewTests.swift
@@ -140,4 +140,38 @@ final class RovoDevTranscriptPreviewTests: XCTestCase {
             RovoDevTranscriptPreviewTurn(role: "assistant", text: "Readable assistant text"),
         ])
     }
+
+    func testDoesNotFallBackToSystemPromptParts() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "role": "user",
+              "parts": [
+                { "part_kind": "system-prompt", "content": "Internal instructions should stay hidden" }
+              ]
+            },
+            {
+              "role": "assistant",
+              "parts": [
+                { "part_kind": "text", "content": "Visible response" }
+              ]
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns, [
+            RovoDevTranscriptPreviewTurn(role: "assistant", text: "Visible response"),
+        ])
+    }
 }

--- a/cmuxTests/RovoDevTranscriptPreviewTests.swift
+++ b/cmuxTests/RovoDevTranscriptPreviewTests.swift
@@ -32,4 +32,112 @@ final class RovoDevTranscriptPreviewTests: XCTestCase {
             RovoDevTranscriptPreviewTurn(role: "assistant", text: "Done"),
         ])
     }
+
+    func testReadsRovoDevMessageHistoryParts() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "kind": "request",
+              "parts": [
+                { "part_kind": "system-prompt", "content": "Internal instructions" },
+                { "part_kind": "user-prompt", "content": "Render the Rovo preview" }
+              ],
+              "timestamp": "2026-01-15T10:00:00.000Z"
+            },
+            {
+              "kind": "response",
+              "parts": [
+                { "part_kind": "text", "content": "I'll inspect the transcript schema." },
+                {
+                  "part_kind": "tool_use",
+                  "tool_name": "read_file",
+                  "tool_input": { "path": "session_context.json" }
+                },
+                { "part_kind": "tool_result", "content": "message_history" },
+                { "part_kind": "text", "content": "The preview parser is updated." }
+              ],
+              "timestamp": "2026-01-15T10:00:05.000Z"
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns.map(\.role), ["user", "assistant", "tool", "tool", "assistant"])
+        XCTAssertEqual(turns[0].text, "Render the Rovo preview")
+        XCTAssertEqual(turns[1].text, "I'll inspect the transcript schema.")
+        XCTAssertTrue(turns[2].text.contains("read_file"))
+        XCTAssertTrue(turns[2].text.contains(#""path" : "session_context.json""#))
+        XCTAssertEqual(turns[3].text, "message_history")
+        XCTAssertEqual(turns[4].text, "The preview parser is updated.")
+    }
+
+    func testReadsRovoDevRoleBasedMessageHistory() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "role": "user",
+              "parts": [{ "part_kind": "text", "content": "Use the real Rovo schema" }]
+            },
+            {
+              "role": "assistant",
+              "parts": [{ "part_kind": "text", "content": "Parsed from message_history." }]
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns, [
+            RovoDevTranscriptPreviewTurn(role: "user", text: "Use the real Rovo schema"),
+            RovoDevTranscriptPreviewTurn(role: "assistant", text: "Parsed from message_history."),
+        ])
+    }
+
+    func testSkipsUnknownRovoDevToolWithEmptyInput() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "role": "assistant",
+              "parts": [
+                { "part_kind": "tool_use", "tool_name": "unknown", "tool_input": {} },
+                { "part_kind": "text", "content": "Readable assistant text" }
+              ]
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns, [
+            RovoDevTranscriptPreviewTurn(role: "assistant", text: "Readable assistant text"),
+        ])
+    }
 }

--- a/cmuxTests/RovoDevTranscriptPreviewTests.swift
+++ b/cmuxTests/RovoDevTranscriptPreviewTests.swift
@@ -141,6 +141,39 @@ final class RovoDevTranscriptPreviewTests: XCTestCase {
         ])
     }
 
+    func testSkipsUnknownRovoDevToolWithNonEmptyInput() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "role": "assistant",
+              "parts": [
+                {
+                  "part_kind": "tool_use",
+                  "tool_name": "unknown",
+                  "tool_input": { "path": "internal/session_context.json" }
+                },
+                { "part_kind": "text", "content": "Readable assistant text" }
+              ]
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns, [
+            RovoDevTranscriptPreviewTurn(role: "assistant", text: "Readable assistant text"),
+        ])
+    }
+
     func testDoesNotFallBackToSystemPromptParts() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/RovoDevTranscriptPreviewTests.swift
+++ b/cmuxTests/RovoDevTranscriptPreviewTests.swift
@@ -174,6 +174,39 @@ final class RovoDevTranscriptPreviewTests: XCTestCase {
         ])
     }
 
+    func testSkipsUnknownRovoDevToolNameFieldWithNonEmptyInput() throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let contextURL = tempDir.appendingPathComponent("session_context.json")
+        let context = """
+        {
+          "message_history": [
+            {
+              "role": "assistant",
+              "parts": [
+                {
+                  "part_kind": "tool_use",
+                  "name": "unknown",
+                  "input": { "path": "internal/session_context.json" }
+                },
+                { "part_kind": "text", "content": "Readable assistant text" }
+              ]
+            }
+          ]
+        }
+        """
+        try context.write(to: contextURL, atomically: true, encoding: .utf8)
+
+        let turns = try XCTUnwrap(RovoDevTranscriptPreview.load(from: contextURL, limit: 10))
+
+        XCTAssertEqual(turns, [
+            RovoDevTranscriptPreviewTurn(role: "assistant", text: "Readable assistant text"),
+        ])
+    }
+
     func testDoesNotFallBackToSystemPromptParts() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-rovodev-preview-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
Summary
- Parse Rovo Dev session_context.json through message_history before generic transcript keys.
- Render Rovo parts as preview turns, including text, tool calls, and tool results, while skipping system prompts and empty unknown tool calls.
- Add focused Rovo schema regression tests in a separate first commit.

Research
- Downloaded Atlassian CLI acli version 1.3.18-stable. Rovo Dev help and plugin download are gated behind Atlassian auth, and the Go module path is private.
- Cross-checked the schema against ai-session-bridge's Rovo reader at https://github.com/frknyldz/ai-session-bridge/blob/d3a5f958e127b34bd41d2fd9dceea92a8469a54e/src/ai_session_bridge/readers/rovodev.py#L167-L215 and tests at https://github.com/frknyldz/ai-session-bridge/blob/d3a5f958e127b34bd41d2fd9dceea92a8469a54e/tests/test_readers/test_rovodev.py#L25-L79.

Validation
- git diff --check origin/main..HEAD
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-rovopv-test -only-testing:cmuxTests/RovoDevTranscriptPreviewTests test
- ./scripts/reload.sh --tag rovopv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Rovo Dev transcript previews by preferring `message_history.parts`, splitting each part into its own turn, and filtering system prompts and unknown tools. Renders user/assistant text and tool calls/results with cleaner payloads.

- **Bug Fixes**
  - Prefer `message_history`; turn each `part` into its own preview turn.
  - Parse via `part_kind`/`type`: text, tool calls (`tool_use`/`tool-call`/`tool_call`/`function_call`), and results (`tool_result`/`tool-return`/`tool_return`).
  - Infer roles from `kind`/`role`/`type` (map `request`/`response` to user/assistant; tool content as tool).
  - Filter system prompts; skip tools named `unknown` in `tool_name` or `name`; include inputs from `tool_input`/`arguments`/`input`; avoid emitting empty JSON containers.
  - Add tests for `message_history.parts`, role mapping, system-prompt filtering, and skipping unknown tools (covering both `tool_name` and `name`).

<sup>Written for commit 0e59629ee8ca6c5f8d11655b44b3b87c193b377b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Transcript parsing now supports an additional top-level message container, produces multiple preview turns per message (with overall limit-aware truncation markers), understands part-based messages (text, system-prompt filtering, tool-call/result rendering), recognizes more role aliases (e.g., request→user, response→assistant), and suppresses empty JSON inputs and unknown tool-name placeholders.

* **Tests**
  * Added tests covering multi-turn message_history parsing, parts handling, role mapping, and tool-use/result behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->