### PR TITLE
Redirect /changelog to /docs/changelog (307)

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -18,6 +18,14 @@ export default function middleware(request: NextRequest) {
 
   const { pathname } = request.nextUrl;
 
+  // Temporary redirect: /changelog → /docs/changelog, preserving any locale prefix.
+  const changelogMatch = pathname.match(/^(\/[a-z]{2}(?:-[A-Z]{2})?)?\/changelog\/?$/);
+  if (changelogMatch) {
+    const url = request.nextUrl.clone();
+    url.pathname = `${changelogMatch[1] ?? ""}/docs/changelog`;
+    return NextResponse.redirect(url, 307);
+  }
+
   if (isAgentPageVariantPath(pathname)) {
     const url = request.nextUrl.clone();
     url.pathname = "/agent-page-variant";


### PR DESCRIPTION
## Summary
- Add a 307 (temporary) redirect in `web/proxy.ts` so `/changelog` and `/<locale>/changelog` (with or without trailing slash) land on `/docs/changelog`.
- Locale prefix is preserved when present, so non-default locales keep their language.

## Testing
- Local middleware regex match check (manual): `/changelog`, `/changelog/`, `/ja/changelog`, `/pt-BR/changelog/` all match; `/changelog/foo`, `/changelogs`, `/docs/changelog` do not.
- Vercel preview will exercise the real redirect end-to-end.

## Related
- Task: keep cmux.com/changelog working as a shortcut to the docs changelog page

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a temporary 307 redirect so `/changelog` and `/<locale>/changelog` (with or without trailing slash) go to `/docs/changelog`, preserving the locale when present. This keeps cmux.com/changelog working as a docs shortcut without a permanent rewrite.

<sup>Written for commit 287ac83c1cd262c3adf0f4aa23d4a2f0911a12a3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved changelog URL routing to automatically direct users to their localized documentation version. Accessing the changelog now preserves your language preference throughout the navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->