### PR TITLE
Fix #3599 setAppearance main-thread crash

### DIFF
--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -40,6 +40,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     }
 
     func setDockTile(_ dockTile: NSDockTile?) {
+        dispatchPrecondition(condition: .onQueue(.main))
         if let iconChangeObserver {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
             self.iconChangeObserver = nil
@@ -53,7 +54,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         iconChangeObserver = DistributedNotificationCenter.default().addObserver(
             forName: cmuxAppIconDidChangeNotification,
             object: nil,
-            queue: nil
+            queue: .main
         ) { [weak self] _ in
             guard let self else { return }
             self.updateDockTile(dockTile)
@@ -91,6 +92,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     }
 
     private func updateDockTile(_ dockTile: NSDockTile) {
+        dispatchPrecondition(condition: .onQueue(.main))
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
         let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
@@ -137,20 +139,18 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
 private extension NSDockTile {
     func showDefaultAppIcon() {
-        DispatchQueue.main.async {
-            self.contentView = nil
-            self.display()
-        }
+        dispatchPrecondition(condition: .onQueue(.main))
+        contentView = nil
+        display()
     }
 
     func showIcon(_ newIcon: NSImage) {
-        DispatchQueue.main.async {
-            let iconView = NSImageView(frame: CGRect(origin: .zero, size: self.size))
-            iconView.wantsLayer = true
-            iconView.image = newIcon
-            self.contentView = iconView
-            self.display()
-        }
+        dispatchPrecondition(condition: .onQueue(.main))
+        let iconView = NSImageView(frame: CGRect(origin: .zero, size: size))
+        iconView.wantsLayer = true
+        iconView.image = newIcon
+        contentView = iconView
+        display()
     }
 }
 

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -36,9 +36,11 @@ enum AppearanceSettings {
         static var live: LiveApplyEnvironment {
             LiveApplyEnvironment(
                 setApplicationAppearance: { appearance in
+                    dispatchPrecondition(condition: .onQueue(.main))
                     NSApplication.shared.appearance = appearance
                 },
                 synchronizeTerminalThemeWithAppearance: { appearance, source in
+                    dispatchPrecondition(condition: .onQueue(.main))
                     GhosttyApp.shared.synchronizeThemeWithAppearance(appearance, source: source)
                 },
                 systemAppearance: {
@@ -164,14 +166,25 @@ enum AppearanceSettings {
         environment: LiveApplyEnvironment = .live
     ) -> AppearanceMode {
         let normalized = Self.mode(for: mode.rawValue)
-        let appearance = applicationAppearance(
-            for: normalized,
-            duringLaunch: duringLaunch,
-            environment: environment
-        )
-        environment.setApplicationAppearance(appearance)
-        if synchronizeTerminalTheme {
-            environment.synchronizeTerminalThemeWithAppearance(appearance, source)
+        let applySideEffects = {
+            dispatchPrecondition(condition: .onQueue(.main))
+            let appearance = applicationAppearance(
+                for: normalized,
+                duringLaunch: duringLaunch,
+                environment: environment
+            )
+            environment.setApplicationAppearance(appearance)
+            if synchronizeTerminalTheme {
+                environment.synchronizeTerminalThemeWithAppearance(appearance, source)
+            }
+        }
+
+        if Thread.isMainThread {
+            applySideEffects()
+        } else {
+            DispatchQueue.main.async {
+                applySideEffects()
+            }
         }
         return normalized
     }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -1096,6 +1096,7 @@ final class CmuxSettingsFileStore {
         let appearanceRawValue = shouldApplyAppearance ? UserDefaults.standard.string(forKey: defaultsKey) : nil
         let appIconMode = defaultsKey == AppIconSettings.modeKey ? AppIconSettings.resolvedMode() : nil
         let apply = {
+            dispatchPrecondition(condition: .onQueue(.main))
             if notifyScrollBar {
                 TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
             }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -213,8 +213,8 @@ enum BrowserThemeSettings {
 
         return defaultMode
     }
-
     static func apply(_ mode: BrowserThemeMode, to webView: WKWebView) {
+        dispatchPrecondition(condition: .onQueue(.main))
         switch mode {
         case .system:
             webView.appearance = nil

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1442,8 +1442,8 @@ final class TerminalNotificationStore: ObservableObject {
         focusedReadIndicatorByTabId.removeAll()
     }
 #endif
-
     private func refreshDockBadge() {
+        dispatchPrecondition(condition: .onQueue(.main))
         let label = Self.dockBadgeLabel(
             unreadCount: unreadCount,
             isEnabled: NotificationBadgeSettings.isDockBadgeEnabled(),

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4421,6 +4421,7 @@ private struct StartupAppearanceDebugView: View {
     }
 
     private func applyAppearance(_ mode: StartupAppearancePreviewMode) {
+        dispatchPrecondition(condition: .onQueue(.main))
         switch mode {
         case .stored:
             switch AppearanceSettings.resolvedMode() {
@@ -4657,6 +4658,7 @@ enum AppIconSettings {
                     return NSImage(named: imageName)
                 },
                 setApplicationIconImage: { icon in
+                    dispatchPrecondition(condition: .onQueue(.main))
                     NSApplication.shared.applicationIconImage = icon
                 },
                 startAppearanceObservation: {
@@ -4687,12 +4689,10 @@ enum AppIconSettings {
     }
 
     static func applyIcon(_ mode: AppIconMode, environment: Environment? = nil) {
+        guard Thread.isMainThread else { DispatchQueue.main.async { applyIcon(mode, environment: environment) }; return }
         let environment = environment ?? liveEnvironmentProvider()
-        // Tahoe can crash or wedge when app icon work runs during App.init(),
-        // so leave settings replay to update defaults only and let AppDelegate
-        // apply the resolved icon once didFinishLaunching begins.
+        // Avoid app icon work during App.init(); AppDelegate applies it after launch.
         guard environment.isApplicationFinishedLaunching() else { return }
-
         switch mode {
         case .automatic:
             environment.startAppearanceObservation()
@@ -4705,7 +4705,6 @@ enum AppIconSettings {
             guard let icon = environment.imageForMode(.dark) else { return }
             environment.setApplicationIconImage(icon)
         }
-
         environment.notifyDockTilePlugin()
     }
 
@@ -4767,6 +4766,7 @@ final class AppIconAppearanceObserver: NSObject {
                     NSImage(named: imageName)
                 },
                 setApplicationIconImage: { icon in
+                    dispatchPrecondition(condition: .onQueue(.main))
                     NSApplication.shared.applicationIconImage = icon
                 }
             )
@@ -4785,6 +4785,8 @@ final class AppIconAppearanceObserver: NSObject {
         super.init()
     }
     func startObserving() {
+        guard Thread.isMainThread else { DispatchQueue.main.async { [weak self] in self?.startObserving() }; return }
+        dispatchPrecondition(condition: .onQueue(.main))
         // Tahoe crashes if effectiveAppearance is touched during App.init(),
         // so defer the first automatic-icon apply until launch completes.
         if !environment.isApplicationFinishedLaunching() {
@@ -4802,6 +4804,8 @@ final class AppIconAppearanceObserver: NSObject {
     }
 
     func stopObserving() {
+        guard Thread.isMainThread else { DispatchQueue.main.async { [weak self] in self?.stopObserving() }; return }
+        dispatchPrecondition(condition: .onQueue(.main))
         observation?.invalidate()
         observation = nil
         lastAppliedImageName = nil
@@ -4818,12 +4822,14 @@ final class AppIconAppearanceObserver: NSObject {
     }
 
     private func cancelDeferredStart() {
+        dispatchPrecondition(condition: .onQueue(.main))
         hasDeferredStartPending = false
         guard let launchObserver else { return }
         environment.removeObserver(launchObserver)
         self.launchObserver = nil
     }
     private func applyIconForCurrentAppearance() {
+        dispatchPrecondition(condition: .onQueue(.main))
         guard environment.isApplicationFinishedLaunching() else { return }
         guard let isDark = environment.currentAppearanceIsDark() else { return }
         let imageName = isDark ? "AppIconDark" : "AppIconLight"

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -206,3 +206,78 @@ final class AppearanceSettingsTests: XCTestCase {
         }
     }
 }
+
+final class AppearanceSettingsThreadingTests: XCTestCase {
+    private final class LayoutTriggerView: NSView {
+        var onLayout: (() -> Void)?
+
+        override func layout() {
+            super.layout()
+            onLayout?()
+        }
+    }
+
+    func testRuntimeAppearanceApplyFromBackgroundDuringLayoutHopsToMainQueue() {
+        let suiteName = "AppearanceSettingsTests.BackgroundApply.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let layoutStarted = expectation(description: "main-thread layout started")
+        let backgroundApplyReturned = expectation(description: "background appearance apply returned")
+        let applicationAppearanceApplied = expectation(description: "application appearance applied on main")
+        let terminalThemeSynchronized = expectation(description: "terminal theme synchronized on main")
+        let backgroundQueue = DispatchQueue(label: "com.cmux.tests.appearance-background-apply")
+        let backgroundEntered = DispatchSemaphore(value: 0)
+
+        let environment = AppearanceSettings.LiveApplyEnvironment(
+            setApplicationAppearance: { _ in
+                dispatchPrecondition(condition: .onQueue(.main))
+                applicationAppearanceApplied.fulfill()
+            },
+            synchronizeTerminalThemeWithAppearance: { _, source in
+                dispatchPrecondition(condition: .onQueue(.main))
+                XCTAssertEqual(source, "cmuxConfig.applyManagedDefault")
+                terminalThemeSynchronized.fulfill()
+            },
+            systemAppearance: {
+                XCTFail("System mode should clear the runtime app override after launch")
+                return NSAppearance(named: .darkAqua)
+            }
+        )
+
+        DispatchQueue.main.async {
+            let root = LayoutTriggerView(frame: NSRect(x: 0, y: 0, width: 12, height: 12))
+            root.onLayout = {
+                layoutStarted.fulfill()
+                backgroundQueue.async {
+                    dispatchPrecondition(condition: .notOnQueue(.main))
+                    _ = AppearanceSettings.applyStoredMode(
+                        rawValue: AppearanceMode.system.rawValue,
+                        defaults: defaults,
+                        source: "cmuxConfig.applyManagedDefault",
+                        environment: environment
+                    )
+                    backgroundEntered.signal()
+                    backgroundApplyReturned.fulfill()
+                }
+                _ = backgroundEntered.wait(timeout: .now() + 2)
+            }
+
+            root.needsLayout = true
+            root.layoutSubtreeIfNeeded()
+        }
+
+        wait(
+            for: [
+                layoutStarted,
+                backgroundApplyReturned,
+                applicationAppearanceApplied,
+                terminalThemeSynchronized,
+            ],
+            timeout: 5
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Fixes #3599.

This locks runtime appearance application to the main queue instead of relying on the queue that triggered settings replay. The regression test reproduces the crash class by driving appearance application from a background queue during an AppKit layout pass and asserting the AppKit boundary runs on `DispatchQueue.main`.

## Architectural rationale

The durable boundary is the AppKit side-effect owner, not only `CmuxSettingsFileStore.applyManagedUserDefaultsValue(_:for:)`. `AppearanceSettings.applyLiveMode` now funnels `NSApplication.setAppearance` and terminal theme synchronization through the main queue with a main-queue precondition, so direct callers and settings replay share the same invariant. Related AppKit-mutating paths for app icons, dock tiles, browser appearance, and dock badges now assert the same main-queue contract.

## Verification

- `git diff --check`
- Local tests not run per repo/user instruction; CI is expected to validate the Swift test and build matrix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple AppKit-mutating paths (appearance, dock tile, app icon, web view theme, dock badge) to enforce main-thread execution, which can affect runtime behavior/timing but primarily reduces crash risk.
> 
> **Overview**
> Fixes a crash by ensuring runtime appearance changes and related AppKit side effects always run on `DispatchQueue.main`, regardless of which queue triggers settings replay.
> 
> `AppearanceSettings.applyLiveMode` now hops to the main queue when called off-main and asserts main-queue execution for `NSApplication.shared.appearance` and terminal theme synchronization. Similar main-thread contracts are enforced across app icon application/observation, dock tile plugin updates (including notification delivery on `.main`), browser `WKWebView` theme application, and dock badge refresh.
> 
> Adds a regression test that triggers appearance application from a background queue during an AppKit layout pass and asserts the work is executed on the main queue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d49e80816f8cacc79510f853c789c17ecf21dde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3599 by forcing all AppKit-facing appearance work onto the main thread and asserting it. Adds a regression test that applies from a background queue during layout and verifies the hop to main.

- **Bug Fixes**
  - Route `NSApplication.shared.appearance` and terminal theme sync through the main queue; add main-queue preconditions and hop when off-main.
  - Enforce main-thread updates for app icons and observers; guard/hop for apply/start/stop and assert in `setApplicationIconImage`; still defer icon apply until after launch.
  - Dock tile plugin observers run on `.main`; NSDockTile updates and view mutations now run synchronously on main with preconditions.
  - Require main-thread access for `WKWebView` theme apply, dock badge refresh, and the settings replay apply closure.

<sup>Written for commit 0d49e80816f8cacc79510f853c789c17ecf21dde. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

