### PR TITLE
Fix: Detect Chrome custom data directories from running processes

### DIFF
--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7180,6 +7180,7 @@ enum InstalledBrowserDetector {
             NSWorkspace.shared.urlForApplication(withBundleIdentifier: bundleIdentifier)
         }
         let appSearchDirectories = applicationSearchDirectories ?? defaultApplicationSearchDirectories(homeDirectoryURL: homeDirectoryURL)
+        let runningDataRoots = extractRunningUserDataDirectories()
 
         let candidates = allBrowserDescriptors.compactMap { descriptor -> InstalledBrowserCandidate? in
             let appDetection = detectApplication(
@@ -7189,10 +7190,25 @@ enum InstalledBrowserDetector {
                 fileManager: fileManager
             )
 
+            var candidateRunningRoots: [URL] = []
+            for bundleId in descriptor.bundleIdentifiers {
+                if let roots = runningDataRoots[bundleId] {
+                    candidateRunningRoots.append(contentsOf: roots)
+                }
+            }
+            if let appBundleId = appDetection.bundleIdentifier, let roots = runningDataRoots[appBundleId] {
+                for root in roots {
+                    if !candidateRunningRoots.contains(root) {
+                        candidateRunningRoots.append(root)
+                    }
+                }
+            }
+
             let dataDetection = detectData(
                 descriptor: descriptor,
                 homeDirectoryURL: homeDirectoryURL,
                 appBundleIdentifier: appDetection.bundleIdentifier,
+                runningDataRoots: candidateRunningRoots,
                 fileManager: fileManager
             )
 
@@ -7317,6 +7333,7 @@ enum InstalledBrowserDetector {
         descriptor: BrowserImportBrowserDescriptor,
         homeDirectoryURL: URL,
         appBundleIdentifier: String?,
+        runningDataRoots: [URL] = [],
         fileManager: FileManager
     ) -> (dataRootURL: URL?, family: BrowserImportEngineFamily, profiles: [InstalledBrowserProfile], artifactHits: [String]) {
         var bestRootURL: URL?
@@ -7328,8 +7345,12 @@ enum InstalledBrowserDetector {
             appBundleIdentifier: appBundleIdentifier
         )
 
+        var candidateURLs = runningDataRoots
         for relativePath in candidateRootPaths {
-            let rootURL = homeDirectoryURL.appendingPathComponent(relativePath, isDirectory: true)
+            candidateURLs.append(homeDirectoryURL.appendingPathComponent(relativePath, isDirectory: true))
+        }
+
+        for rootURL in candidateURLs {
             guard fileManager.fileExists(atPath: rootURL.path) else { continue }
 
             let detectedProfiles = detectProfiles(
@@ -7426,6 +7447,75 @@ enum InstalledBrowserDetector {
             }
             return lhs.0.rawValue > rhs.0.rawValue
         } ?? (descriptor.family, [])
+    }
+
+    private static func extractRunningUserDataDirectories() -> [String: [URL]] {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-xww", "-o", "command"]
+        let pipe = Pipe()
+        process.standardOutput = pipe
+        
+        var results: [String: [URL]] = [:]
+        
+        do {
+            try process.run()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            if let output = String(data: data, encoding: .utf8) {
+                let lines = output.components(separatedBy: .newlines)
+                for line in lines {
+                    guard let range = line.range(of: "--user-data-dir=") else { continue }
+                    
+                    var matchedBundle: String?
+                    if line.contains("Google Chrome") {
+                        matchedBundle = "com.google.Chrome"
+                    } else if line.contains("Brave") {
+                        matchedBundle = "com.brave.Browser"
+                    } else if line.contains("Chromium") {
+                        matchedBundle = "org.chromium.Chromium"
+                    } else if line.contains("Edge") {
+                        matchedBundle = "com.microsoft.edgemac"
+                    } else if line.contains("Arc") {
+                        matchedBundle = "company.thebrowser.Browser"
+                    } else if line.contains("Vivaldi") {
+                        matchedBundle = "com.vivaldi.Vivaldi"
+                    }
+                    
+                    guard let bundle = matchedBundle else { continue }
+                    
+                    let remainder = line[range.upperBound...]
+                    var path = ""
+                    if remainder.hasPrefix("\"") {
+                        if let endQuote = remainder.dropFirst().firstIndex(of: "\"") {
+                            path = String(remainder.dropFirst()[..<endQuote])
+                        }
+                    } else if remainder.hasPrefix("'") {
+                        if let endQuote = remainder.dropFirst().firstIndex(of: "'") {
+                            path = String(remainder.dropFirst()[..<endQuote])
+                        }
+                    } else {
+                        if let nextFlag = remainder.range(of: " --") {
+                            path = String(remainder[..<nextFlag.lowerBound]).trimmingCharacters(in: .whitespaces)
+                        } else {
+                            path = String(remainder).trimmingCharacters(in: .whitespaces)
+                        }
+                    }
+                    
+                    guard !path.isEmpty else { continue }
+                    
+                    let url = URL(fileURLWithPath: path)
+                    if results[bundle] == nil {
+                        results[bundle] = []
+                    }
+                    if !results[bundle]!.contains(url) {
+                        results[bundle]!.append(url)
+                    }
+                }
+            }
+        } catch {
+            // Silently ignore
+        }
+        return results
     }
 
     private static func bundleIdentifier(for appURL: URL) -> String? {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7504,16 +7504,12 @@ enum InstalledBrowserDetector {
                     guard !path.isEmpty else { continue }
                     
                     let url = URL(fileURLWithPath: path)
-                    if results[bundle] == nil {
-                        results[bundle] = []
-                    }
-                    if !results[bundle]!.contains(url) {
-                        results[bundle]!.append(url)
+                    if results[bundle]?.contains(url) != true {
+                        results[bundle, default: []].append(url)
                     }
                 }
             }
         } catch {
-            // Silently ignore
         }
         return results
     }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -7464,40 +7464,64 @@ enum InstalledBrowserDetector {
             if let output = String(data: data, encoding: .utf8) {
                 let lines = output.components(separatedBy: .newlines)
                 for line in lines {
-                    guard let range = line.range(of: "--user-data-dir=") else { continue }
+                    var execName: String
+                    if let flagRange = line.range(of: "--user-data-dir") {
+                        execName = String(line[..<flagRange.lowerBound])
+                    } else {
+                        continue
+                    }
                     
                     var matchedBundle: String?
-                    if line.contains("Google Chrome") {
+                    if execName.contains("Google Chrome") {
                         matchedBundle = "com.google.Chrome"
-                    } else if line.contains("Brave") {
+                    } else if execName.contains("Brave") {
                         matchedBundle = "com.brave.Browser"
-                    } else if line.contains("Chromium") {
+                    } else if execName.contains("Chromium") {
                         matchedBundle = "org.chromium.Chromium"
-                    } else if line.contains("Edge") {
+                    } else if execName.contains("Edge") {
                         matchedBundle = "com.microsoft.edgemac"
-                    } else if line.contains("Arc") {
+                    } else if execName.contains("Arc") {
                         matchedBundle = "company.thebrowser.Browser"
-                    } else if line.contains("Vivaldi") {
+                    } else if execName.contains("Vivaldi") {
                         matchedBundle = "com.vivaldi.Vivaldi"
                     }
                     
                     guard let bundle = matchedBundle else { continue }
                     
-                    let remainder = line[range.upperBound...]
                     var path = ""
-                    if remainder.hasPrefix("\"") {
-                        if let endQuote = remainder.dropFirst().firstIndex(of: "\"") {
-                            path = String(remainder.dropFirst()[..<endQuote])
-                        }
-                    } else if remainder.hasPrefix("'") {
-                        if let endQuote = remainder.dropFirst().firstIndex(of: "'") {
-                            path = String(remainder.dropFirst()[..<endQuote])
-                        }
-                    } else {
-                        if let nextFlag = remainder.range(of: " --") {
-                            path = String(remainder[..<nextFlag.lowerBound]).trimmingCharacters(in: .whitespaces)
+                    if let range = line.range(of: "--user-data-dir=") {
+                        let remainder = line[range.upperBound...]
+                        if remainder.hasPrefix("\"") {
+                            if let endQuote = remainder.dropFirst().firstIndex(of: "\"") {
+                                path = String(remainder.dropFirst()[..<endQuote])
+                            }
+                        } else if remainder.hasPrefix("'") {
+                            if let endQuote = remainder.dropFirst().firstIndex(of: "'") {
+                                path = String(remainder.dropFirst()[..<endQuote])
+                            }
                         } else {
-                            path = String(remainder).trimmingCharacters(in: .whitespaces)
+                            if let nextFlag = remainder.range(of: " --") {
+                                path = String(remainder[..<nextFlag.lowerBound]).trimmingCharacters(in: .whitespaces)
+                            } else {
+                                path = String(remainder).trimmingCharacters(in: .whitespaces)
+                            }
+                        }
+                    } else if let range = line.range(of: "--user-data-dir") {
+                        let remainder = line[range.upperBound...].trimmingCharacters(in: .whitespaces)
+                        if remainder.hasPrefix("\"") {
+                            if let endQuote = remainder.dropFirst().firstIndex(of: "\"") {
+                                path = String(remainder.dropFirst()[..<endQuote])
+                            }
+                        } else if remainder.hasPrefix("'") {
+                            if let endQuote = remainder.dropFirst().firstIndex(of: "'") {
+                                path = String(remainder.dropFirst()[..<endQuote])
+                            }
+                        } else {
+                            if let nextSpace = remainder.firstIndex(of: " ") {
+                                path = String(remainder[..<nextSpace])
+                            } else {
+                                path = String(remainder)
+                            }
                         }
                     }
                     

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -7397,7 +7397,12 @@ struct SettingsView: View {
     }
 
     private func refreshDetectedImportBrowsers() {
-        detectedImportBrowsers = InstalledBrowserDetector.detectInstalledBrowsers()
+        Task.detached(priority: .utility) {
+            let browsers = InstalledBrowserDetector.detectInstalledBrowsers()
+            await MainActor.run {
+                self.detectedImportBrowsers = browsers
+            }
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds logic to `InstalledBrowserDetector` to auto-detect custom `--user-data-dir` paths from running Chromium-based browser processes. This resolves issues where `cmux` fails to import browser data if Chrome was installed in a portable way or is pointing to an external drive.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Auto-detect custom `--user-data-dir` paths from running Chromium-based browsers and use them when scanning for profiles. Fixes imports for portable/external installs and avoids UI stalls during detection.

- **Bug Fixes**
  - Scan `ps -xww -o command` to extract `--user-data-dir` for Chrome, Brave, Chromium, Edge, Arc, and Vivaldi; handle both `--user-data-dir=<path>` and `--user-data-dir <path>` (quoted paths too) with tighter bundle matching.
  - Use detected directories as candidate data roots during profile detection; dedupe and keep existing search paths as fallback.
  - Run detection off the main thread and update UI on `MainActor` to prevent freezes in Settings.

<sup>Written for commit 841123835e7f9647c93127091a4a811c7bf9bbad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved browser import detection can discover profile/data directories from currently running browsers, increasing available import sources.
  * Merged running browser data roots yield more accurate selection of correct profile locations during import.
  * Background detection now runs asynchronously to keep the UI responsive while refreshing detected browsers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->