### PR TITLE
Pause Swift file length budget CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,14 @@ jobs:
       - name: Validate CircleCI auto approval
         run: python3 tests/test_circleci_auto_approve.py
 
-      - name: Validate Swift file length budget
-        run: python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
+      # Paused: stale-base merge races (two PRs each fitting the budget can
+      # overshoot when merged back-to-back without rebasing). CodeRabbit and
+      # Greptile already flag large-file growth on PRs. Re-enable by uncommenting
+      # this step (and refresh the budget tsv first):
+      #   python3 scripts/swift_file_length_budget.py \
+      #     --budget .github/swift-file-length-budget.tsv --write-budget
+      # - name: Validate Swift file length budget
+      #   run: python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv
 
   remote-daemon-tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Comment out the `Validate Swift file length budget` step in `.github/workflows/ci.yml`. Main is currently red because two PRs that each fit the budget were merged 34 seconds apart without rebasing (https://github.com/manaflow-ai/cmux/pull/3616 +5 lines, https://github.com/manaflow-ai/cmux/pull/3574 +18 lines), pushing `Sources/GhosttyTerminalView.swift` 12 lines over.
- The hard gate is the wrong tradeoff right now: a merge queue or required-up-to-date branches solve this but add real friction to the dev loop. CodeRabbit and Greptile already flag large-file growth, which is enough as a soft signal.
- Script and tsv stay checked in. Re-enabling is one uncomment after refreshing the tsv.

## Test plan
- [ ] CI on this PR completes without the budget step
- [ ] After merge, the next push to main goes green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5f2d494211d2d9dd47cab438f13299bae7ecebfa. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Paused the Swift file length budget CI check to prevent red builds from stale-base merge races. The step is commented out in `.github/workflows/ci.yml`, and CodeRabbit/Greptile remain as soft signals for large-file growth.

- **Bug Fixes**
  - Stops main from failing when two PRs that each meet the budget combine to exceed it after back-to-back merges.
  - Script and budget TSV stay in repo; re-enable by refreshing the TSV and uncommenting the step in `.github/workflows/ci.yml`.

<sup>Written for commit 5f2d494211d2d9dd47cab438f13299bae7ecebfa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Temporarily disabled an automated validation check in the CI workflow pending resolution of merge-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->