### PR TITLE
Fix arrow key navigation in IME candidate window during composition

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14182,6 +14182,14 @@ private extension NSWindow {
         }
 
         if let ghosttyView = firstResponderGhosttyView {
+            if ghosttyView.shouldRouteTextInputKeyEquivalentToKeyDown(event) {
+                ghosttyView.keyDown(with: event)
+#if DEBUG
+                cmuxDebugLog("  → terminal text-input key equivalent routed to keyDown")
+#endif
+                return true
+            }
+
             // If the IME is composing and the key has no Cmd modifier, don't intercept —
             // let it flow through normal AppKit event dispatch so the input method can
             // process it. Cmd-based shortcuts should still work during composition since

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -138,6 +138,20 @@ extension GhosttyNSView {
         }
     }
 
+    /// Returns true when a window-level key-equivalent probe should re-enter
+    /// the terminal's keyDown path so AppKit's text input context sees the key
+    /// before terminal bindings or cursor escape sequences do.
+    func shouldRouteTextInputKeyEquivalentToKeyDown(_ event: NSEvent) -> Bool {
+        shouldRouteTextInputKeyEquivalentToKeyDown(event, inputSourceId: nil)
+    }
+
+    func shouldRouteTextInputKeyEquivalentToKeyDown(_ event: NSEvent, inputSourceId: String?) -> Bool {
+        guard event.type == .keyDown else { return false }
+        guard shouldKeepIMECompositionCommandInsideTextInput(event) else { return false }
+        if hasMarkedText() { return true }
+        return isInputMethodSource(inputSourceId ?? KeyboardLayout.id)
+    }
+
     /// Returns true for active-composition command keys that belong to AppKit's
     /// text input manager even when marked text itself does not change.
     func shouldKeepIMECompositionCommandInsideTextInput(_ event: NSEvent) -> Bool {

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -61,7 +61,10 @@ extension GhosttyNSView {
             return true
         }
 
-        guard let event else { return false }
+        guard let event,
+              textInputHandledEvent || isInputMethodSource(inputSourceId) else {
+            return false
+        }
         return shouldKeepIMECompositionCommandInsideTextInput(event)
     }
 

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -83,6 +83,59 @@ extension GhosttyNSView {
         return flags == [.numericPad]
     }
 
+    func isTraditionalZhuyinInputSource(_ sourceId: String?) -> Bool {
+        guard let sourceId else { return false }
+        return sourceId.localizedCaseInsensitiveContains("TCIM.Zhuyin")
+    }
+
+    func shouldOpenZhuyinCandidatesWithSyntheticSpace(
+        event: NSEvent,
+        inputSourceId: String?,
+        markedTextBefore: Bool,
+        before: (text: String, selection: NSRange),
+        after: (text: String, selection: NSRange),
+        accumulatedText: [String],
+        commandSelector: Selector?,
+        candidateOpenAlreadyRequested: Bool
+    ) -> Bool {
+        guard !candidateOpenAlreadyRequested,
+              markedTextBefore,
+              accumulatedText.isEmpty,
+              isTraditionalZhuyinInputSource(inputSourceId),
+              Int(event.keyCode) == kVK_DownArrow,
+              commandSelector == #selector(NSResponder.moveDown(_:)),
+              before.text == after.text,
+              before.selection == after.selection else {
+            return false
+        }
+        return true
+    }
+
+    func shouldRememberZhuyinCandidateInteraction(
+        event: NSEvent,
+        inputSourceId: String?,
+        markedTextBefore: Bool,
+        accumulatedText: [String]
+    ) -> Bool {
+        guard markedTextBefore,
+              accumulatedText.isEmpty,
+              isTraditionalZhuyinInputSource(inputSourceId) else {
+            return false
+        }
+
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        guard flags.isEmpty || flags == [.shift] else { return false }
+
+        switch Int(event.keyCode) {
+        case kVK_DownArrow, kVK_UpArrow, kVK_PageUp, kVK_PageDown, kVK_Space:
+            return true
+        default:
+            return false
+        }
+    }
+
     /// Returns true for active-composition command keys that belong to AppKit's
     /// text input manager even when marked text itself does not change.
     func shouldKeepIMECompositionCommandInsideTextInput(_ event: NSEvent) -> Bool {

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -61,8 +61,7 @@ extension GhosttyNSView {
             return true
         }
 
-        guard let event,
-              textInputHandledEvent || isInputMethodSource(inputSourceId) else {
+        guard let event, isInputMethodSource(inputSourceId) else {
             return false
         }
         return shouldKeepIMECompositionCommandInsideTextInput(event)

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -35,13 +35,23 @@ extension GhosttyNSView {
         before: (text: String, selection: NSRange),
         after: (text: String, selection: NSRange),
         accumulatedText: [String],
-        event: NSEvent? = nil
+        event: NSEvent? = nil,
+        textInputHandledEvent: Bool = false,
+        inputSourceId: String? = nil
     ) -> Bool {
         guard accumulatedText.isEmpty else { return false }
 
         let hadMarkedTextBefore = !before.text.isEmpty
         let hasMarkedTextAfter = !after.text.isEmpty
-        guard hadMarkedTextBefore || hasMarkedTextAfter else { return false }
+        guard hadMarkedTextBefore || hasMarkedTextAfter else {
+            // Some IMEs, including Traditional Chinese Zhuyin, can handle a
+            // command key against their private preedit buffer before they call
+            // setMarkedText on the client. Keep handled no-output input-method
+            // events out of the terminal so keys such as Down can open
+            // candidates instead of moving the shell cursor.
+            guard textInputHandledEvent, isInputMethodSource(inputSourceId) else { return false }
+            return !shouldAllowDeferredNumpadIMEFallback(event)
+        }
 
         if before.text != after.text {
             return true
@@ -53,6 +63,24 @@ extension GhosttyNSView {
 
         guard let event else { return false }
         return shouldKeepIMECompositionCommandInsideTextInput(event)
+    }
+
+    func isInputMethodSource(_ sourceId: String?) -> Bool {
+        guard let sourceId else { return false }
+        return sourceId.localizedCaseInsensitiveContains("inputmethod")
+    }
+
+    func shouldAllowDeferredNumpadIMEFallback(_ event: NSEvent?) -> Bool {
+        guard let event,
+              let text = event.characters,
+              !text.isEmpty,
+              text.allSatisfy(\.isNumber) else {
+            return false
+        }
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.function, .capsLock])
+        return flags == [.numericPad]
     }
 
     /// Returns true for active-composition command keys that belong to AppKit's
@@ -81,13 +109,17 @@ extension GhosttyNSView {
         markedTextAfter: String,
         markedSelectionAfter: NSRange,
         accumulatedText: [String],
-        event: NSEvent? = nil
+        event: NSEvent? = nil,
+        textInputHandledEvent: Bool = false,
+        inputSourceId: String? = nil
     ) -> Bool {
         shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
             before: (markedTextBefore, markedSelectionBefore),
             after: (markedTextAfter, markedSelectionAfter),
             accumulatedText: accumulatedText,
-            event: event
+            event: event,
+            textInputHandledEvent: textInputHandledEvent,
+            inputSourceId: inputSourceId
         )
     }
 #endif

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Carbon.HIToolbox
 
 extension GhosttyNSView {
     /// Clamps AppKit's marked-text selection into the active preedit buffer.
@@ -33,7 +34,8 @@ extension GhosttyNSView {
     func shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
         before: (text: String, selection: NSRange),
         after: (text: String, selection: NSRange),
-        accumulatedText: [String]
+        accumulatedText: [String],
+        event: NSEvent? = nil
     ) -> Bool {
         guard accumulatedText.isEmpty else { return false }
 
@@ -45,7 +47,31 @@ extension GhosttyNSView {
             return true
         }
 
-        return before.selection != after.selection
+        if before.selection != after.selection {
+            return true
+        }
+
+        guard let event else { return false }
+        return shouldKeepIMECompositionCommandInsideTextInput(event)
+    }
+
+    /// Returns true for active-composition command keys that belong to AppKit's
+    /// text input manager even when marked text itself does not change.
+    func shouldKeepIMECompositionCommandInsideTextInput(_ event: NSEvent) -> Bool {
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        guard flags.isEmpty || flags == [.shift] else { return false }
+
+        switch Int(event.keyCode) {
+        case kVK_LeftArrow, kVK_RightArrow, kVK_UpArrow, kVK_DownArrow,
+             kVK_PageUp, kVK_PageDown, kVK_Home, kVK_End,
+             kVK_Space, kVK_Return, kVK_ANSI_KeypadEnter, kVK_Escape,
+             kVK_Tab, kVK_Delete, kVK_ForwardDelete:
+            return true
+        default:
+            return false
+        }
     }
 
 #if DEBUG
@@ -54,12 +80,14 @@ extension GhosttyNSView {
         markedSelectionBefore: NSRange,
         markedTextAfter: String,
         markedSelectionAfter: NSRange,
-        accumulatedText: [String]
+        accumulatedText: [String],
+        event: NSEvent? = nil
     ) -> Bool {
         shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
             before: (markedTextBefore, markedSelectionBefore),
             after: (markedTextAfter, markedSelectionAfter),
-            accumulatedText: accumulatedText
+            accumulatedText: accumulatedText,
+            event: event
         )
     }
 #endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7045,6 +7045,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private(set) var externalCommittedTextDepth = 0
     var numpadIMECommitDeduplicator = NumpadIMECommitDeduplicator()
     private var imeSuppressedKeyUpKeyCodes: Set<UInt16> = []
+    private var textInputCommandSelectorDuringKeyDown: Selector?
+    private var zhuyinCandidateOpenRequested = false
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -7086,6 +7088,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     // Prevents NSBeep for unimplemented actions from interpretKeyEvents
     override func doCommand(by selector: Selector) {
+        textInputCommandSelectorDuringKeyDown = selector
+#if DEBUG
+        if hasMarkedText() {
+            cmuxDebugLog(
+                "ime.doCommand selector=\(NSStringFromSelector(selector)) " +
+                "markedLength=\(markedText.length)"
+            )
+        }
+#endif
         // Intentionally empty - prevents system beep on unhandled key commands
     }
 
@@ -7467,6 +7478,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Set up text accumulator for interpretKeyEvents
         keyTextAccumulator = []
         defer { keyTextAccumulator = nil }
+        textInputCommandSelectorDuringKeyDown = nil
 
         let markedTextBefore = markedText.length > 0
         let markedStateBefore = (markedText.string, markedSelectedRange)
@@ -7513,10 +7525,39 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         syncPreeditMs = (ProcessInfo.processInfo.systemUptime - syncPreeditStart) * 1000.0
 #endif
 
-        let accumulatedText = keyTextAccumulator ?? []
+        var accumulatedText = keyTextAccumulator ?? []
+        var markedStateAfter = (markedText.string, markedSelectedRange)
+        if shouldOpenZhuyinCandidatesWithSyntheticSpace(
+            event: translationEvent,
+            inputSourceId: keyboardIdBefore,
+            markedTextBefore: markedTextBefore,
+            before: markedStateBefore,
+            after: markedStateAfter,
+            accumulatedText: accumulatedText,
+            commandSelector: textInputCommandSelectorDuringKeyDown,
+            candidateOpenAlreadyRequested: zhuyinCandidateOpenRequested
+        ) {
+            imeSuppressedKeyUpKeyCodes.insert(event.keyCode)
+            zhuyinCandidateOpenRequested = true
+            textInputCommandSelectorDuringKeyDown = nil
+            _ = handleTextInputKeyEvent(zhuyinCandidateOpenSpaceEvent(from: translationEvent))
+            syncPreedit(clearIfNeeded: markedTextBefore)
+            accumulatedText = keyTextAccumulator ?? []
+            markedStateAfter = (markedText.string, markedSelectedRange)
+        } else if shouldRememberZhuyinCandidateInteraction(
+            event: translationEvent,
+            inputSourceId: keyboardIdBefore,
+            markedTextBefore: markedTextBefore,
+            accumulatedText: accumulatedText
+        ) {
+            zhuyinCandidateOpenRequested = true
+        } else if markedTextBefore, isTraditionalZhuyinInputSource(keyboardIdBefore) {
+            zhuyinCandidateOpenRequested = false
+        }
+
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
             before: markedStateBefore,
-            after: (markedText.string, markedSelectedRange),
+            after: markedStateAfter,
             accumulatedText: accumulatedText,
             event: translationEvent,
             textInputHandledEvent: textInputHandledEvent,
@@ -7722,6 +7763,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return false
         }
         return inputContext.handleEvent(event)
+    }
+
+    private func zhuyinCandidateOpenSpaceEvent(from event: NSEvent) -> NSEvent {
+        NSEvent.keyEvent(
+            with: event.type,
+            location: event.locationInWindow,
+            modifierFlags: event.modifierFlags.subtracting([.shift, .numericPad, .function]),
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber,
+            context: nil,
+            characters: " ",
+            charactersIgnoringModifiers: " ",
+            isARepeat: event.isARepeat,
+            keyCode: UInt16(kVK_Space)
+        ) ?? event
     }
 
     @discardableResult
@@ -12807,6 +12863,7 @@ extension GhosttyNSView: NSTextInputClient {
         if markedText.length > 0 {
             markedText.mutableString.setString("")
             markedSelectedRange = NSRange(location: NSNotFound, length: 0)
+            zhuyinCandidateOpenRequested = false
             syncPreedit()
             invalidateTextInputCoordinates(selectionChanged: true)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12876,7 +12876,6 @@ extension GhosttyNSView: NSTextInputClient {
         markedText.mutableString.setString("")
         markedSelectedRange = NSRange(location: NSNotFound, length: 0)
         zhuyinCandidateOpenRequested = false
-        imeSuppressedKeyUpKeyCodes.removeAll()
 
         if hadMarkedText {
             syncPreedit()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7043,6 +7043,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var lastPerformKeyEvent: TimeInterval?
     private(set) var externalCommittedTextDepth = 0
     var numpadIMECommitDeduplicator = NumpadIMECommitDeduplicator()
+    private var imeSuppressedKeyUpKeyCodes: Set<UInt16> = []
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -7516,8 +7517,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         let accumulatedText = keyTextAccumulator ?? []
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
-            before: markedStateBefore, after: (markedText.string, markedSelectedRange), accumulatedText: accumulatedText
-        ) { return }
+            before: markedStateBefore,
+            after: (markedText.string, markedSelectedRange),
+            accumulatedText: accumulatedText,
+            event: translationEvent
+        ) {
+            imeSuppressedKeyUpKeyCodes.insert(event.keyCode)
+            return
+        }
 
         // Build the key event
         var keyEvent = ghostty_input_key_s()
@@ -7735,6 +7742,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #endif
 
     override func keyUp(with event: NSEvent) {
+        if imeSuppressedKeyUpKeyCodes.remove(event.keyCode) != nil {
+            return
+        }
+
         guard let surface = ensureSurfaceReadyForInput() else {
             super.keyUp(with: event)
             return

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7064,6 +7064,19 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var keyTextAccumulatorForTesting: [String]? {
         keyTextAccumulator
     }
+    func setIMETransientStateForTesting(
+        suppressedKeyUpKeyCodes: Set<UInt16>,
+        zhuyinCandidateOpenRequested: Bool
+    ) {
+        imeSuppressedKeyUpKeyCodes = suppressedKeyUpKeyCodes
+        self.zhuyinCandidateOpenRequested = zhuyinCandidateOpenRequested
+    }
+    var imeSuppressedKeyUpKeyCodesForTesting: Set<UInt16> {
+        imeSuppressedKeyUpKeyCodes
+    }
+    var zhuyinCandidateOpenRequestedForTesting: Bool {
+        zhuyinCandidateOpenRequested
+    }
     func shouldSuppressShiftSpaceFallbackTextForTesting(event: NSEvent, markedTextBefore: Bool) -> Bool {
         shouldSuppressShiftSpaceFallbackText(event: event, markedTextBefore: markedTextBefore)
     }
@@ -12849,8 +12862,8 @@ extension GhosttyNSView: NSTextInputClient {
     }
 
     func unmarkText() {
-#if DEBUG
         let hadMarkedText = markedText.length > 0
+#if DEBUG
         let typingTimingStart = CmuxTypingTiming.start()
         defer {
             CmuxTypingTiming.logDuration(
@@ -12860,10 +12873,12 @@ extension GhosttyNSView: NSTextInputClient {
             )
         }
 #endif
-        if markedText.length > 0 {
-            markedText.mutableString.setString("")
-            markedSelectedRange = NSRange(location: NSNotFound, length: 0)
-            zhuyinCandidateOpenRequested = false
+        markedText.mutableString.setString("")
+        markedSelectedRange = NSRange(location: NSNotFound, length: 0)
+        zhuyinCandidateOpenRequested = false
+        imeSuppressedKeyUpKeyCodes.removeAll()
+
+        if hadMarkedText {
             syncPreedit()
             invalidateTextInputCoordinates(selectionChanged: true)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7027,6 +7027,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             desiredFocus = false
             terminalSurface?.recordExternalFocusState(false)
             imeSuppressedKeyUpKeyCodes.removeAll()
+            zhuyinCandidateOpenRequested = false
         }
         if result, let surface = surface {
             let now = CACurrentMediaTime()
@@ -7537,7 +7538,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             commandSelector: textInputCommandSelectorDuringKeyDown,
             candidateOpenAlreadyRequested: zhuyinCandidateOpenRequested
         ) {
-            imeSuppressedKeyUpKeyCodes.insert(event.keyCode)
             zhuyinCandidateOpenRequested = true
             textInputCommandSelectorDuringKeyDown = nil
             _ = handleTextInputKeyEvent(zhuyinCandidateOpenSpaceEvent(from: translationEvent))

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7053,6 +7053,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
 #if DEBUG
     // Test-only accessors for keyTextAccumulator to verify CJK IME composition behavior.
+    static var debugTextInputEventHandler: ((GhosttyNSView, NSEvent) -> Bool)?
+
     func setKeyTextAccumulatorForTesting(_ value: [String]?) {
         keyTextAccumulator = value
     }
@@ -7471,19 +7473,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         // Capture the keyboard layout ID before interpretation so we can
         // detect if an IME changed it (e.g. toggling input methods).
-        // We only check when not already in a preedit state.
-        let keyboardIdBefore: String? = if (!markedTextBefore) {
-            KeyboardLayout.id
-        } else {
-            nil
-        }
+        let keyboardIdBefore = KeyboardLayout.id
 
         // Let the input system handle the event (for IME, dead keys, etc.)
 #if DEBUG
         let interpretTimingStart = CmuxTypingTiming.start()
         let interpretPhaseStart = ProcessInfo.processInfo.systemUptime
 #endif
-        interpretKeyEvents([translationEvent])
+        let textInputHandledEvent = handleTextInputKeyEvent(translationEvent)
 #if DEBUG
         interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
         CmuxTypingTiming.logDuration(
@@ -7521,7 +7518,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             before: markedStateBefore,
             after: (markedText.string, markedSelectedRange),
             accumulatedText: accumulatedText,
-            event: translationEvent
+            event: translationEvent,
+            textInputHandledEvent: textInputHandledEvent,
+            inputSourceId: keyboardIdBefore
         ) {
             imeSuppressedKeyUpKeyCodes.insert(event.keyCode)
             return
@@ -7709,6 +7708,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         // Rendering is driven by Ghostty's wakeups/renderer.
+    }
+
+    @discardableResult
+    private func handleTextInputKeyEvent(_ event: NSEvent) -> Bool {
+#if DEBUG
+        if let debugTextInputEventHandler = Self.debugTextInputEventHandler {
+            return debugTextInputEventHandler(self, event)
+        }
+#endif
+        guard let inputContext else {
+            interpretKeyEvents([event])
+            return false
+        }
+        return inputContext.handleEvent(event)
     }
 
     @discardableResult

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7026,6 +7026,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if result {
             desiredFocus = false
             terminalSurface?.recordExternalFocusState(false)
+            imeSuppressedKeyUpKeyCodes.removeAll()
         }
         if result, let surface = surface {
             let now = CACurrentMediaTime()

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -16,13 +16,6 @@ private var ghosttyPasteAsPlainTextActionSwizzled = false
 private var ghosttyPasteAsPlainTextActionHook: ((GhosttyNSView, Any?) -> Void)?
 
 private extension GhosttyNSView {
-    @objc func cmuxUnitTest_interpretKeyEvents(_ eventArray: [NSEvent]) {
-        if let hook = cjkIMEInterpretKeyEventsHook, hook(self, eventArray) {
-            return
-        }
-        cmuxUnitTest_interpretKeyEvents(eventArray)
-    }
-
     @objc func cmuxUnitTest_paste(_ sender: Any?) {
         ghosttyPasteActionHook?(self, sender)
         cmuxUnitTest_paste(sender)
@@ -37,30 +30,12 @@ private extension GhosttyNSView {
 func installCJKIMEInterpretKeyEventsSwizzle() {
     guard !cjkIMEInterpretKeyEventsSwizzled else { return }
 
-    let originalSelector = #selector(GhosttyNSView.interpretKeyEvents(_:))
-    let swizzledSelector = #selector(GhosttyNSView.cmuxUnitTest_interpretKeyEvents(_:))
-
-    guard let originalMethod = class_getInstanceMethod(GhosttyNSView.self, originalSelector),
-          let swizzledMethod = class_getInstanceMethod(GhosttyNSView.self, swizzledSelector) else {
-        fatalError("Unable to locate GhosttyNSView interpretKeyEvents methods for swizzling")
-    }
-
-    let didAddMethod = class_addMethod(
-        GhosttyNSView.self,
-        originalSelector,
-        method_getImplementation(swizzledMethod),
-        method_getTypeEncoding(swizzledMethod)
-    )
-
-    if didAddMethod {
-        class_replaceMethod(
-            GhosttyNSView.self,
-            swizzledSelector,
-            method_getImplementation(originalMethod),
-            method_getTypeEncoding(originalMethod)
-        )
-    } else {
-        method_exchangeImplementations(originalMethod, swizzledMethod)
+    GhosttyNSView.debugTextInputEventHandler = { candidateView, event in
+        if let hook = cjkIMEInterpretKeyEventsHook, hook(candidateView, [event]) {
+            return true
+        }
+        candidateView.interpretKeyEvents([event])
+        return false
     }
 
     cjkIMEInterpretKeyEventsSwizzled = true

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import Carbon.HIToolbox
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -55,11 +56,17 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
-    private func keyEvent(text: String, keyCode: UInt16, windowNumber: Int) throws -> NSEvent {
+    private func keyEvent(
+        type: NSEvent.EventType = .keyDown,
+        text: String,
+        keyCode: UInt16,
+        modifierFlags: NSEvent.ModifierFlags = [],
+        windowNumber: Int
+    ) throws -> NSEvent {
         try XCTUnwrap(NSEvent.keyEvent(
-            with: .keyDown,
+            with: type,
             location: .zero,
-            modifierFlags: [],
+            modifierFlags: modifierFlags,
             timestamp: ProcessInfo.processInfo.systemUptime,
             windowNumber: windowNumber,
             context: nil,
@@ -204,6 +211,175 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             forwardedPressCount,
             0,
             "AppKit-consumed Zhuyin marked-text changes must not forward a duplicate Ghostty key"
+        )
+    }
+
+    func testArrowNavigationStaysInsideZhuyinCandidateWindowDuringComposition() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        surfaceView.setMarkedText(
+            "ㄓㄨ",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertTrue(surfaceView.hasMarkedText(), "Candidate navigation should leave composition active")
+        XCTAssertEqual(
+            forwardedPressKeyCodes,
+            [],
+            "Arrow keys consumed by the Zhuyin candidate window must not move the terminal cursor"
+        )
+        XCTAssertEqual(
+            forwardedReleaseKeyCodes,
+            [],
+            "A suppressed IME arrow keyDown should not be followed by an unmatched Ghostty keyUp"
+        )
+    }
+
+    func testArrowStillForwardsToTerminalWhenNoCompositionIsActive() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedPressKeyCodes.append(keyEvent.keycode)
+        }
+
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertFalse(surfaceView.hasMarkedText())
+        XCTAssertEqual(
+            forwardedPressKeyCodes,
+            [UInt32(kVK_DownArrow)],
+            "Plain arrows should keep moving the terminal cursor when no IME composition is active"
+        )
+    }
+
+    func testNumberCandidateSelectionStillCommitsTextDuringZhuyinComposition() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        surfaceView.setMarkedText(
+            "ㄓㄨ",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            candidateView.insertText("注", replacementRange: NSRange(location: NSNotFound, length: 0))
+            return true
+        }
+
+        var forwardedText: [String] = []
+        var forwardedPressKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            if let text = keyEvent.text {
+                forwardedText.append(String(cString: text))
+            } else {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let event = try keyEvent(
+            text: "1",
+            keyCode: UInt16(kVK_ANSI_1),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertFalse(surfaceView.hasMarkedText(), "Number candidate selection should commit the chosen text")
+        XCTAssertEqual(forwardedText, ["注"])
+        XCTAssertEqual(
+            forwardedPressKeyCodes,
+            [],
+            "Candidate number selection should not also send the raw number key to the terminal"
         )
     }
 

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -573,6 +573,65 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testDoesNotSuppressNonInputMethodDeadKeyCommandWhenMarkedTextIsUnchanged() throws {
+        let view = GhosttyNSView(frame: .zero)
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: 0
+        )
+
+        XCTAssertFalse(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "`",
+                markedSelectionBefore: NSRange(location: 1, length: 0),
+                markedTextAfter: "`",
+                markedSelectionAfter: NSRange(location: 1, length: 0),
+                accumulatedText: [],
+                event: event,
+                textInputHandledEvent: false,
+                inputSourceId: "com.apple.keylayout.USInternational"
+            )
+        )
+    }
+
+    func testSuppressesInputMethodCommandWhenMarkedTextIsUnchanged() throws {
+        let view = GhosttyNSView(frame: .zero)
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: 0
+        )
+
+        XCTAssertTrue(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "ㄓㄨ",
+                markedSelectionBefore: NSRange(location: 2, length: 0),
+                markedTextAfter: "ㄓㄨ",
+                markedSelectionAfter: NSRange(location: 2, length: 0),
+                accumulatedText: [],
+                event: event,
+                textInputHandledEvent: false,
+                inputSourceId: "com.apple.inputmethod.TCIM.Zhuyin"
+            )
+        )
+    }
+
+    func testUnmarkTextClearsIMETransientStateWithoutMarkedText() {
+        let view = GhosttyNSView(frame: .zero)
+        view.setIMETransientStateForTesting(
+            suppressedKeyUpKeyCodes: [UInt16(kVK_DownArrow)],
+            zhuyinCandidateOpenRequested: true
+        )
+
+        view.unmarkText()
+
+        XCTAssertFalse(view.hasMarkedText())
+        XCTAssertEqual(view.markedRange(), NSRange(location: NSNotFound, length: 0))
+        XCTAssertEqual(view.imeSuppressedKeyUpKeyCodesForTesting, [])
+        XCTAssertFalse(view.zhuyinCandidateOpenRequestedForTesting)
+    }
+
     func testSuppressesInputMethodHandledKeyWithoutMarkedText() throws {
         let view = GhosttyNSView(frame: .zero)
         let event = try keyEvent(

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -390,6 +390,86 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testDownArrowRequestsZhuyinCandidatesViaSpaceCommandFallback() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        surfaceView.setMarkedText(
+            "ㄓㄨ",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var sawDownCommand = false
+        var syntheticSpaceCount = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, events in
+            guard candidateView === surfaceView, let event = events.first else { return false }
+            if Int(event.keyCode) == kVK_DownArrow {
+                sawDownCommand = true
+                candidateView.doCommand(by: #selector(NSResponder.moveDown(_:)))
+                return false
+            }
+            if Int(event.keyCode) == kVK_Space {
+                syntheticSpaceCount += 1
+                return true
+            }
+            return false
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertTrue(sawDownCommand)
+        XCTAssertEqual(
+            syntheticSpaceCount,
+            1,
+            "A Zhuyin Down command that AppKit does not otherwise resolve should ask the IME to open candidates"
+        )
+        XCTAssertTrue(surfaceView.hasMarkedText())
+        XCTAssertEqual(forwardedPressKeyCodes, [])
+        XCTAssertEqual(forwardedReleaseKeyCodes, [])
+    }
+
     func testNumberCandidateSelectionStillCommitsTextDuringZhuyinComposition() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -352,6 +352,84 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testWindowKeyEquivalentRoutesInputMethodArrowThroughKeyDownBeforeMarkedText() throws {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var sawDownInTextInput = false
+        cjkIMEInterpretKeyEventsHook = { candidateView, events in
+            guard candidateView === surfaceView, let event = events.first else { return false }
+            guard Int(event.keyCode) == kVK_DownArrow else { return false }
+            sawDownInTextInput = true
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            XCTAssertTrue(
+                window.performKeyEquivalent(with: keyDown),
+                "A window-level IME arrow key equivalent should be handled by routing it through terminal keyDown"
+            )
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertTrue(
+            sawDownInTextInput,
+            "The window key-equivalent path must deliver Bopomofo candidate arrows to NSTextInputContext"
+        )
+        XCTAssertEqual(
+            forwardedPressKeyCodes,
+            [],
+            "A Down arrow handled by the input method must not move the terminal cursor"
+        )
+        XCTAssertEqual(
+            forwardedReleaseKeyCodes,
+            [],
+            "A suppressed IME keyDown must also suppress the paired keyUp"
+        )
+    }
+
     func testArrowStillForwardsToTerminalWhenNoCompositionIsActive() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -695,7 +695,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
-    func testUnmarkTextClearsIMETransientStateWithoutMarkedText() {
+    func testUnmarkTextPreservesSuppressedKeyUpStateWithoutMarkedText() {
         let view = GhosttyNSView(frame: .zero)
         view.setIMETransientStateForTesting(
             suppressedKeyUpKeyCodes: [UInt16(kVK_DownArrow)],
@@ -706,7 +706,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
 
         XCTAssertFalse(view.hasMarkedText())
         XCTAssertEqual(view.markedRange(), NSRange(location: NSNotFound, length: 0))
-        XCTAssertEqual(view.imeSuppressedKeyUpKeyCodesForTesting, [])
+        XCTAssertEqual(view.imeSuppressedKeyUpKeyCodesForTesting, [UInt16(kVK_DownArrow)])
         XCTAssertFalse(view.zhuyinCandidateOpenRequestedForTesting)
     }
 

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -658,7 +658,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let view = GhosttyNSView(frame: .zero)
         let event = try keyEvent(
             text: "1",
-            keyCode: 83,
+            keyCode: UInt16(kVK_ANSI_Keypad1),
             modifierFlags: [.numericPad],
             windowNumber: 0
         )

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -589,7 +589,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
                 markedSelectionAfter: NSRange(location: 1, length: 0),
                 accumulatedText: [],
                 event: event,
-                textInputHandledEvent: false,
+                textInputHandledEvent: true,
                 inputSourceId: "com.apple.keylayout.USInternational"
             )
         )

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -284,6 +284,74 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testDownArrowCanOpenZhuyinCandidatesBeforeMarkedTextIsMirrored() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertFalse(
+            surfaceView.hasMarkedText(),
+            "Opening Zhuyin candidates can be handled by the IME before it mirrors marked text"
+        )
+        XCTAssertEqual(
+            forwardedPressKeyCodes,
+            [],
+            "A Zhuyin-handled Down arrow must stay with AppKit so it can open the candidate list"
+        )
+        XCTAssertEqual(
+            forwardedReleaseKeyCodes,
+            [],
+            "A Zhuyin-handled Down arrow keyUp must not leave an unmatched terminal release"
+        )
+    }
+
     func testArrowStillForwardsToTerminalWhenNoCompositionIsActive() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface
@@ -421,6 +489,51 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
                 markedTextAfter: "",
                 markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
                 accumulatedText: []
+            )
+        )
+    }
+
+    func testSuppressesInputMethodHandledKeyWithoutMarkedText() throws {
+        let view = GhosttyNSView(frame: .zero)
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: 0
+        )
+
+        XCTAssertTrue(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "",
+                markedSelectionBefore: NSRange(location: NSNotFound, length: 0),
+                markedTextAfter: "",
+                markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
+                accumulatedText: [],
+                event: event,
+                textInputHandledEvent: true,
+                inputSourceId: "com.apple.inputmethod.TCIM.Zhuyin"
+            )
+        )
+    }
+
+    func testAllowsDeferredNumpadFallbackWithoutMarkedText() throws {
+        let view = GhosttyNSView(frame: .zero)
+        let event = try keyEvent(
+            text: "1",
+            keyCode: 83,
+            modifierFlags: [.numericPad],
+            windowNumber: 0
+        )
+
+        XCTAssertFalse(
+            view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                markedTextBefore: "",
+                markedSelectionBefore: NSRange(location: NSNotFound, length: 0),
+                markedTextAfter: "",
+                markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
+                accumulatedText: [],
+                event: event,
+                textInputHandledEvent: true,
+                inputSourceId: "com.apple.inputmethod.TCIM.Pinyin"
             )
         )
     }


### PR DESCRIPTION
## Summary
- Keep active IME composition command keys inside AppKit text input when no committed text is produced
- Prevent suppressed IME command keyDown events from producing unmatched Ghostty keyUp events
- Add focused regression coverage for Zhuyin candidate arrow navigation, normal terminal arrow behavior, and number-key candidate commits

Fixes #3691.

## Validation
- git diff --check
- Local tests and direct xcodebuild intentionally not run per repo/user policy; CI will validate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes low-level macOS key routing for IME/text-input events (including window `performKeyEquivalent`), which can affect shortcut handling and terminal input behavior across layouts and IMEs.
> 
> **Overview**
> Fixes IME composition key handling so *command-style navigation keys* (e.g. arrows/page/home/end/space/return) stay within AppKit text input when an input method consumes them, preventing the terminal from receiving cursor-movement sequences during candidate navigation.
> 
> Adds paired suppression for keyUp when a keyDown was suppressed (avoiding unmatched releases), routes certain window-level key equivalents back through `keyDown`/`NSTextInputContext.handleEvent`, and introduces a Traditional Zhuyin fallback that synthesizes Space to open candidates when Down is handled as `moveDown:` without producing text.
> 
> Refactors IME test hooks away from method swizzling to a debug handler and adds regression tests covering Zhuyin candidate navigation (including pre-marked-text handling), normal arrow forwarding when not composing, numpad fallback, and number-key candidate commits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20954ec85393702a2091571fdd663a626ed0d8ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IME candidate-window navigation during composition by keeping arrow/page/home/end and related keys inside AppKit, including the window key-equivalent path. Suppresses paired keyUp correctly, preserves suppression across unmark, and adds a Zhuyin fallback so Down opens candidates instead of moving the terminal cursor.

- **Bug Fixes**
  - Keep composition command keys inside text input when handled by an input method; require an input‑method source so dead‑key layouts aren’t suppressed.
  - Route `keyDown` via `NSTextInputContext.handleEvent`, and route window key equivalents back through `keyDown`, so IME‑handled no‑output keys don’t reach the terminal; suppress the paired `keyUp` and keep that suppression across unmark, clearing it only on focus loss or on the matching `keyUp`.
  - Traditional Zhuyin: if Down is handled as `moveDown:` with no output, synthesize Space to open candidates; track candidate‑open interactions and clear the hint on unmark or focus loss.
  - Preserve deferred numpad fallback; arrows still forward when not composing; number‑key candidate selection commits text only.

<sup>Written for commit 20954ec85393702a2091571fdd663a626ed0d8ba. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved IME handling for CJK input so navigation and candidate selection no longer produce duplicate or stray key events; key-up suppression now respects composition state, recent event context, accumulated pending text, and is cleared on focus loss.

* **Refactor**
  * Centralized and simplified text-input routing and IME suppression into a clearer, testable handler and removed the prior swizzle approach.

* **Tests**
  * Expanded Zhuyin/CJK IME tests for arrow navigation, candidate selection, numpad fallback, and event-dependent suppression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->