### PR TITLE
Add Cloud VM default-provider stress check

### DIFF
--- a/web/app/[locale]/components/spacing-control.tsx
+++ b/web/app/[locale]/components/spacing-control.tsx
@@ -32,6 +32,14 @@ const defaults: DevValues = {
   docsPt: 8,
 };
 
+function initialPanelPosition() {
+  if (typeof window === "undefined") {
+    return { x: 0, y: 0 };
+  }
+
+  return { x: window.innerWidth - 340, y: window.innerHeight - 320 };
+}
+
 // Tiny external store (avoids setState-during-render)
 let snapshot = { ...defaults };
 const listeners = new Set<() => void>();
@@ -95,15 +103,11 @@ function applyToDOM(v: DevValues) {
 
 export function DevPanel() {
   const [visible, setVisible] = useState(false);
-  const [pos, setPos] = useState({ x: 0, y: 0 });
+  const [pos, setPos] = useState(initialPanelPosition);
   const [dragging, setDragging] = useState(false);
   const [copied, setCopied] = useState(false);
   const vals = useDevValues();
   const dragOffset = useRef({ x: 0, y: 0 });
-
-  useEffect(() => {
-    setPos({ x: window.innerWidth - 340, y: window.innerHeight - 320 });
-  }, []);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/web/app/[locale]/docs/notifications/page.tsx
+++ b/web/app/[locale]/docs/notifications/page.tsx
@@ -82,7 +82,7 @@ echo "$CMUX_NOTIFICATION_TITLE: $CMUX_NOTIFICATION_BODY" >> ~/notifications.log`
 
       <h2>{t("sending")}</h2>
 
-      <h3>{t("cli")}</h3>
+      <h3 id="cli-usage">{t("cli")}</h3>
       <CodeBlock lang="bash">{`cmux notify --title "Task Complete" --body "Your build finished"
 cmux notify --title "Claude Code" --subtitle "Waiting" --body "Agent needs input"`}</CodeBlock>
 
@@ -251,7 +251,7 @@ esac`}</CodeBlock>
   }
 }`}</CodeBlock>
 
-      <h2>{t("integrationExamples")}</h2>
+      <h2 id="integration-examples">{t("integrationExamples")}</h2>
 
       <h3>{t("notifyAfterLong")}</h3>
       <CodeBlock title="~/.zshrc" lang="bash">{`# Add to your shell config

--- a/web/app/[locale]/page.tsx
+++ b/web/app/[locale]/page.tsx
@@ -111,12 +111,12 @@ function HomeContent() {
                 <span className="text-muted">
                   {t.rich("feature.keyboardShortcutsDesc", {
                     link: (chunks) => (
-                      <a
+                      <Link
                         href="/docs/keyboard-shortcuts"
                         className={linkClass}
                       >
                         {chunks}
-                      </a>
+                      </Link>
                     ),
                   })}
                 </span>
@@ -176,14 +176,14 @@ function HomeContent() {
               <p className="text-muted">
                 {t.rich("faqNotificationsA", {
                   cliLink: (chunks) => (
-                    <a href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications#cli-usage" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                   hooksLink: (chunks) => (
-                    <a href="/docs/notifications" className={linkClass}>
+                    <Link href="/docs/notifications#integration-examples" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                 })}
               </p>
@@ -198,9 +198,9 @@ function HomeContent() {
                     </code>
                   ),
                   link: (chunks) => (
-                    <a href="/docs/keyboard-shortcuts" className={linkClass}>
+                    <Link href="/docs/keyboard-shortcuts" className={linkClass}>
                       {chunks}
-                    </a>
+                    </Link>
                   ),
                 })}
               </p>

--- a/web/package.json
+++ b/web/package.json
@@ -10,6 +10,7 @@
     "cloud-vm:migrate": "bun scripts/cloud-vm/migrate-vercel-aurora-iam.mjs",
     "cloud-vm:preflight": "bash scripts/cloud-vm/verify-migration-preflight.sh",
     "cloud-vm:smoke": "bun scripts/cloud-vm/smoke-vm-api.mjs",
+    "cloud-vm:stress": "bun scripts/cloud-vm/stress-vm-api.mjs",
     "db:check": "bunx drizzle-kit check --config drizzle.config.ts",
     "db:down": "bash scripts/db-local.sh down",
     "db:generate": "bunx drizzle-kit generate --config drizzle.config.ts",

--- a/web/scripts/cloud-vm/stress-vm-api.mjs
+++ b/web/scripts/cloud-vm/stress-vm-api.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+import { randomBytes } from "node:crypto";
+import { createRequire } from "node:module";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import WebSocket from "ws";
+import {
+  loadTargetEnv,
+  optionValue,
+  parseWebDirAndTarget,
+  requireEnvKeys,
+} from "./projects.mjs";
+
+const usage = "Usage: stress-vm-api.mjs [web-dir] <staging|production> [--count N] [--concurrency N] [--provider e2b|freestyle|default]";
+const { webDir, target, project, rest } = parseWebDirAndTarget(process.argv.slice(2), usage);
+const count = positiveInteger(optionValue(rest, "--count") ?? "8", "--count");
+const concurrency = Math.min(positiveInteger(optionValue(rest, "--concurrency") ?? "4", "--concurrency"), count);
+const provider = optionValue(rest, "--provider") ?? "default";
+if (!["default", "e2b", "freestyle"].includes(provider)) {
+  console.error("--provider must be default, e2b, or freestyle");
+  process.exit(2);
+}
+
+const requireFromWeb = createRequire(path.join(webDir, "package.json"));
+const stackModule = await import(pathToFileURL(requireFromWeb.resolve("@stackframe/js")).href);
+const { StackServerApp } = stackModule;
+
+const env = loadTargetEnv(project);
+requireEnvKeys(env, [
+  "NEXT_PUBLIC_STACK_PROJECT_ID",
+  "NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY",
+  "STACK_SECRET_SERVER_KEY",
+], `${project.projectName} stress`);
+
+const stack = new StackServerApp({
+  projectId: env.NEXT_PUBLIC_STACK_PROJECT_ID,
+  publishableClientKey: env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
+  secretServerKey: env.STACK_SECRET_SERVER_KEY,
+});
+
+const startedAt = Date.now();
+const results = [];
+const inFlightCleanups = new Set();
+let nextIndex = 0;
+let interruptedSignal = "";
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    if (interruptedSignal) return;
+    interruptedSignal = signal;
+    console.error(`received ${signal}; waiting for ${inFlightCleanups.size} in-flight case(s) to clean up`);
+  });
+}
+
+await Promise.all(Array.from({ length: concurrency }, async () => {
+  while (true) {
+    if (interruptedSignal) return;
+    const index = nextIndex;
+    nextIndex += 1;
+    if (index >= count) return;
+    results[index] = await runCase(index);
+  }
+}));
+if (interruptedSignal) await drainInFlight(interruptedSignal);
+
+const attempted = results.filter(Boolean);
+const successes = attempted.filter((result) => result.ok);
+const failures = attempted.filter((result) => !result.ok);
+const providerCounts = countBy(successes.map((result) => result.provider ?? "unknown"));
+const imageVersionCounts = countBy(successes.map((result) => result.imageVersion ?? "unknown"));
+const cleanupSummary = {
+  vmDeleted: results.filter((result) => result.cleanup?.vmDeleted).length,
+  userDeleted: results.filter((result) => result.cleanup?.userDeleted).length,
+  vmDeleteErrors: results.filter((result) => result.cleanup?.vmDeleteError).length,
+  userDeleteErrors: results.filter((result) => result.cleanup?.userDeleteError).length,
+};
+console.log(JSON.stringify({
+  ok: failures.length === 0,
+  target,
+  project: project.projectName,
+  provider,
+  count,
+  concurrency,
+  attempted: attempted.length,
+  interruptedSignal: interruptedSignal || undefined,
+  durationMs: Date.now() - startedAt,
+  successes: successes.length,
+  providerCounts,
+  imageVersionCounts,
+  cleanup: cleanupSummary,
+  failures,
+}, null, 2));
+if (interruptedSignal) process.exit(130);
+if (failures.length > 0) process.exit(1);
+
+async function runCase(index) {
+  const suffix = `${Date.now()}-${index}-${randomBytes(3).toString("hex")}`;
+  let user;
+  let vmId;
+  let authHeaders;
+  const cleanup = { vmDeleted: false, userDeleted: false };
+  let cleanupPromise;
+  const cleanupCase = () => {
+    cleanupPromise ??= cleanupRun({ getVmId: () => vmId, getAuthHeaders: () => authHeaders, getUser: () => user, cleanup });
+    return cleanupPromise;
+  };
+  inFlightCleanups.add(cleanupCase);
+  const started = Date.now();
+  try {
+    user = await stack.createUser({
+      primaryEmail: `cmux-${project.stackLabel}-stress+${suffix}@manaflow.dev`,
+      primaryEmailVerified: true,
+      primaryEmailAuthEnabled: true,
+      password: randomBytes(24).toString("base64url"),
+      displayName: `cmux ${project.stackLabel} stress ${index}`,
+    });
+    throwIfInterrupted();
+    const session = await user.createSession({ expiresInMillis: 20 * 60 * 1000, isImpersonation: true });
+    throwIfInterrupted();
+    const tokens = await session.getTokens();
+    throwIfInterrupted();
+    if (!tokens.accessToken || !tokens.refreshToken) {
+      throw new Error("Stack did not return stress session tokens");
+    }
+    authHeaders = {
+      authorization: `Bearer ${tokens.accessToken}`,
+      "x-stack-refresh-token": tokens.refreshToken,
+    };
+
+    const createBody = provider === "default" ? {} : { provider };
+    const create = await fetchWithTimeout(`${project.url}/api/vm`, {
+      method: "POST",
+      headers: {
+        ...authHeaders,
+        "content-type": "application/json",
+        "idempotency-key": `stress-${suffix}`,
+      },
+      body: JSON.stringify(createBody),
+    }, 90_000);
+    const createText = await create.text();
+    if (create.status !== 200) throw new Error(`POST /api/vm expected 200, got ${create.status}: ${createText}`);
+    const created = JSON.parse(createText);
+    if (!created.id) throw new Error("create response missing id");
+    vmId = created.id;
+    throwIfInterrupted();
+
+    const attach = await fetchWithTimeout(`${project.url}/api/vm/${encodeURIComponent(vmId)}/attach-endpoint`, {
+      method: "POST",
+      headers: { ...authHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ requireDaemon: true }),
+    }, 45_000);
+    const attachText = await attach.text();
+    if (attach.status !== 200) throw new Error(`POST attach-endpoint expected 200, got ${attach.status}: ${attachText}`);
+    const attached = JSON.parse(attachText);
+    if (attached.transport !== "websocket") throw new Error(`expected websocket attach, got ${attached.transport}`);
+    if (!attached.daemon?.url || !attached.daemon?.token || !attached.daemon?.sessionId) {
+      throw new Error("attach response missing daemon RPC endpoint");
+    }
+    throwIfInterrupted();
+
+    const rpc = await rpcProxyHealthz(attached.daemon.url, attached.daemon.token, attached.daemon.sessionId);
+    throwIfInterrupted();
+    return {
+      ok: true,
+      index,
+      provider: created.provider,
+      imageVersion: created.imageVersion,
+      attachTransport: attached.transport,
+      rpcCapabilities: rpc.capabilities,
+      durationMs: Date.now() - started,
+      cleanup,
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      index,
+      message: error instanceof Error ? error.message : String(error),
+      vmIdSet: !!vmId,
+      durationMs: Date.now() - started,
+      cleanup,
+    };
+  } finally {
+    await cleanupCase();
+    inFlightCleanups.delete(cleanupCase);
+  }
+}
+
+async function cleanupRun({ getVmId, getAuthHeaders, getUser, cleanup }) {
+  const vmId = getVmId();
+  const authHeaders = getAuthHeaders();
+  const user = getUser();
+
+  if (vmId && authHeaders) {
+    try {
+      const destroy = await fetchWithTimeout(`${project.url}/api/vm/${encodeURIComponent(vmId)}`, {
+        method: "DELETE",
+        headers: authHeaders,
+      }, 45_000);
+      cleanup.vmDeleted = destroy.status === 200;
+      if (!cleanup.vmDeleted) {
+        const body = await destroy.text().catch(() => "");
+        const detail = [destroy.status, destroy.statusText, body.slice(0, 200)].filter(Boolean).join(" ");
+        cleanup.vmDeleteError = `DELETE /api/vm/${vmId} expected 200, got ${detail}`;
+      }
+    } catch (error) {
+      cleanup.vmDeleteError = error instanceof Error ? error.message : String(error);
+    }
+  }
+
+  if (user && (!vmId || cleanup.vmDeleted)) {
+    try {
+      await user.delete();
+      cleanup.userDeleted = true;
+    } catch (error) {
+      cleanup.userDeleteError = error instanceof Error ? error.message : String(error);
+    }
+  } else if (user) {
+    cleanup.userDeleteError ??= "skipped user deletion because VM cleanup did not succeed";
+  }
+}
+
+async function drainInFlight(signal) {
+  const cleanups = Array.from(inFlightCleanups);
+  if (cleanups.length === 0) return;
+  console.error(`received ${signal}; running ${cleanups.length} registered cleanup(s) before exit`);
+  const settled = await Promise.allSettled(cleanups.map((cleanupCase) => cleanupCase()));
+  const rejected = settled.filter((result) => result.status === "rejected");
+  if (rejected.length > 0) {
+    console.error(`${rejected.length} cleanup callback(s) failed during ${signal} shutdown`);
+  }
+}
+
+function throwIfInterrupted() {
+  if (interruptedSignal) throw new Error(`interrupted by ${interruptedSignal}`);
+}
+
+async function fetchWithTimeout(url, init, timeoutMs) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function rpcProxyHealthz(url, token, sessionId) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const chunks = [];
+    let streamId = "";
+    let capabilities = [];
+    let settled = false;
+    let timer;
+    const fail = (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(error);
+    };
+    const succeed = (value) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(value);
+    };
+    timer = setTimeout(() => {
+      ws.terminate();
+      fail(new Error("rpc proxy timeout"));
+    }, 30_000);
+    ws.on("error", (error) => {
+      fail(error);
+    });
+    ws.on("close", () => {
+      fail(new Error("rpc proxy connection closed unexpectedly"));
+    });
+    ws.on("open", () => {
+      ws.send(JSON.stringify({ type: "auth", token, session_id: sessionId }));
+    });
+    ws.on("message", (data, isBinary) => {
+      try {
+        if (isBinary) return;
+        const msg = JSON.parse(data.toString());
+        if (msg.error || msg.type === "error") {
+          throw new Error(`rpc error message: ${describeRpcMessage(msg, streamId, chunks)}`);
+        }
+        if (msg.type === "ready") {
+          ws.send(JSON.stringify({ id: 1, method: "hello", params: {} }));
+          return;
+        }
+        if (msg.id === 1) {
+          if (msg.ok !== true) throw new Error(`hello failed: ${JSON.stringify(msg)}`);
+          capabilities = msg.result?.capabilities ?? [];
+          ws.send(JSON.stringify({ id: 2, method: "proxy.open", params: { host: "127.0.0.1", port: 7777 } }));
+          return;
+        }
+        if (msg.id === 2) {
+          if (msg.ok !== true) throw new Error(`proxy.open failed: ${JSON.stringify(msg)}`);
+          streamId = msg.result?.stream_id;
+          if (!streamId) throw new Error(`proxy.open missing stream_id: ${JSON.stringify(msg)}`);
+          ws.send(JSON.stringify({ id: 3, method: "proxy.stream.subscribe", params: { stream_id: streamId } }));
+          return;
+        }
+        if (msg.id === 3) {
+          if (msg.ok !== true) throw new Error(`proxy.stream.subscribe failed: ${JSON.stringify(msg)}`);
+          const request = Buffer
+            .from("GET /healthz HTTP/1.1\r\nHost: 127.0.0.1\r\nConnection: close\r\n\r\n")
+            .toString("base64");
+          ws.send(JSON.stringify({
+            id: 4,
+            method: "proxy.write",
+            params: { stream_id: streamId, data_base64: request },
+          }));
+          return;
+        }
+        if (msg.id === 4) {
+          if (msg.ok !== true) throw new Error(`proxy.write failed: ${JSON.stringify(msg)}`);
+          return;
+        }
+        if (msg.event === "proxy.stream.data" && msg.data_base64) {
+          chunks.push(Buffer.from(msg.data_base64, "base64"));
+          return;
+        }
+        if (msg.event === "proxy.stream.eof") {
+          const response = Buffer.concat(chunks).toString();
+          if (!response.includes("HTTP/1.1 200 OK") || !response.includes('"ok":true')) {
+            fail(new Error(`unexpected proxied healthz response: ${response.slice(0, 200)}`));
+          } else {
+            succeed({ capabilities });
+          }
+          ws.close();
+          return;
+        }
+        if (msg.event === "proxy.stream.error") throw new Error(`proxy.stream.error: ${JSON.stringify(msg)}`);
+        throw new Error(`unexpected rpc message: ${describeRpcMessage(msg, streamId, chunks)}`);
+      } catch (error) {
+        ws.terminate();
+        fail(error);
+      }
+    });
+  });
+}
+
+function describeRpcMessage(msg, streamId, chunks) {
+  const body = JSON.stringify(msg).slice(0, 500);
+  const chunkBytes = chunks.reduce((total, chunk) => total + chunk.length, 0);
+  return `${body} (streamId=${streamId || "unset"}, chunks=${chunks.length}, bytes=${chunkBytes})`;
+}
+
+function positiveInteger(raw, label) {
+  const value = String(raw).trim();
+  if (!/^\d+$/.test(value)) throw new Error(`${label} must be a positive integer`);
+  const parsed = Number(value);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) throw new Error(`${label} must be a positive integer`);
+  return parsed;
+}
+
+function countBy(values) {
+  return values.reduce((acc, value) => {
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}

--- a/web/scripts/cloud-vm/stress-vm-api.mjs
+++ b/web/scripts/cloud-vm/stress-vm-api.mjs
@@ -75,7 +75,7 @@ const cleanupSummary = {
   userDeleteErrors: results.filter((result) => result.cleanup?.userDeleteError).length,
 };
 console.log(JSON.stringify({
-  ok: failures.length === 0,
+  ok: !interruptedSignal && failures.length === 0,
   target,
   project: project.projectName,
   provider,

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -227,7 +227,7 @@ The dev Postgres port is `CMUX_PORT + 10000`, so `CMUX_PORT=10180` maps to `loca
 
 E2B interactive paths require a cmuxd WebSocket PTY image. The backend writes only a hash of attach tokens to Postgres; raw tokens are returned once to the Mac client.
 
-Operational note: Freestyle is enabled and is the default provider in staging and production. The active snapshot is `sh-6ch5p9k23xrcx24056n8` (`freestyle-rpclease-20260502a`), which has passed WebSocket PTY, reusable daemon RPC lease, and browser proxy smoke. Keep E2B enabled as the rollback provider.
+Operational note: Freestyle is the intended default when `CMUX_VM_DEFAULT_PROVIDER=freestyle`. Before rollout or rollback, verify the deployed `CMUX_VM_DEFAULT_PROVIDER`, `CMUX_VM_FREESTYLE_ENABLED`, and `FREESTYLE_SANDBOX_SNAPSHOT` env values with `bun run cloud-vm:env:audit -- <target> --strict`, then confirm WebSocket PTY, reusable daemon RPC lease, and browser proxy health with `bun run cloud-vm:stress -- <target> --provider default`. Keep E2B enabled as the rollback provider.
 
 ## Usage, limits, and pricing
 

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -172,6 +172,13 @@ Staging may run a real create/destroy smoke with tiny quotas:
 bun run cloud-vm:smoke -- staging --create --provider e2b
 ```
 
+Run default-provider stress before changing provider defaults or after provider incidents:
+
+```bash
+bun run cloud-vm:stress -- staging --count 8 --concurrency 4 --provider default
+bun run cloud-vm:stress -- production --count 12 --concurrency 4 --provider default
+```
+
 ## GitHub operations
 
 Cloud VM migrations and smoke checks are exposed as manual GitHub Actions:
@@ -220,7 +227,7 @@ The dev Postgres port is `CMUX_PORT + 10000`, so `CMUX_PORT=10180` maps to `loca
 
 E2B interactive paths require a cmuxd WebSocket PTY image. The backend writes only a hash of attach tokens to Postgres; raw tokens are returned once to the Mac client.
 
-Operational note: Freestyle creates are currently disabled in staging and production while the active Freestyle snapshot lacks the cmuxd RPC lease path required for browser proxy. Keep `CMUX_VM_DEFAULT_PROVIDER=e2b` and `CMUX_VM_FREESTYLE_ENABLED=0` until a new Freestyle snapshot passes WebSocket PTY and browser proxy smoke.
+Operational note: Freestyle is enabled and is the default provider in staging and production. The active snapshot is `sh-6ch5p9k23xrcx24056n8` (`freestyle-rpclease-20260502a`), which has passed WebSocket PTY, reusable daemon RPC lease, and browser proxy smoke. Keep E2B enabled as the rollback provider.
 
 ## Usage, limits, and pricing
 

--- a/web/tests/bun-test.d.ts
+++ b/web/tests/bun-test.d.ts
@@ -1,10 +1,38 @@
 declare module "bun:test" {
-  export const afterAll: any;
-  export const afterEach: any;
-  export const beforeAll: any;
-  export const beforeEach: any;
-  export const describe: any;
-  export const expect: any;
-  export const mock: any;
-  export const test: any;
+  type TestCallback = () => unknown | Promise<unknown>;
+  type LifecycleHook = (fn: TestCallback, timeout?: number) => void;
+  type TestFunction = {
+    (name: string, fn: TestCallback, timeout?: number): void;
+    only: TestFunction;
+    skip: TestFunction;
+    todo: (name: string) => void;
+  };
+  type MatcherFunction = (...args: unknown[]) => unknown;
+  type Matchers = Record<string, MatcherFunction> & {
+    not: Matchers;
+    rejects: Matchers;
+    resolves: Matchers;
+  };
+  type MockFunction<T extends (...args: unknown[]) => unknown> = T & {
+    mockClear: () => void;
+    mockResolvedValue: (value: unknown) => void;
+  };
+  type Mock = {
+    <T extends (...args: unknown[]) => unknown>(
+      implementation?: T,
+    ): MockFunction<T>;
+    module: (specifier: string, factory: () => unknown) => void;
+  };
+
+  export const afterAll: LifecycleHook;
+  export const afterEach: LifecycleHook;
+  export const beforeAll: LifecycleHook;
+  export const beforeEach: LifecycleHook;
+  export const describe: TestFunction;
+  export const expect: {
+    (actual: unknown): Matchers;
+    objectContaining: (value: unknown) => unknown;
+  };
+  export const mock: Mock;
+  export const test: TestFunction;
 }


### PR DESCRIPTION
## Summary
- add a deployed Cloud VM stress script that creates, attaches, browser-proxy-smokes, and cleans up test VMs/users
- document Freestyle as the current staging/production default with E2B kept as rollback
- fix existing web lint blockers so production readiness checks pass

## Verification
- bun run lint
- bun run cloud-vm:preflight -- --schema-only .
- bun run test
- bun run build
- bun run cloud-vm:stress -- staging --count 8 --concurrency 4 --provider default
- bun run cloud-vm:stress -- production --count 12 --concurrency 4 --provider default

## Live checks
- staging default provider is Freestyle on https://cmux-staging.vercel.app
- production default provider is Freestyle on https://cmux.com
- staging and production stress runs cleaned up all created VMs and Stack test users

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new operator-facing stress runner that creates and destroys real VMs/users against staging/production APIs, so misconfiguration or cleanup failures could consume quota or leave resources behind. Other changes are low-risk doc/link/typing fixes.
> 
> **Overview**
> Adds a new `cloud-vm:stress` command that repeatedly provisions Cloud VMs via `POST /api/vm`, attaches via WebSocket daemon RPC, browser-proxies a `/healthz` request, then attempts best-effort VM + Stack test-user cleanup and emits a JSON result summary/exit code.
> 
> Docs are updated to recommend running this stress check before provider default rollouts/rollbacks and to clarify Freestyle default-provider operational guidance. Separately fixes a couple of production/lint blockers: SSR-safe DevPanel positioning, anchorable docs sections + internal links migrated to Next `Link`, and stronger `bun:test` TypeScript declarations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 898fd7b5da8784542844dd6f6af0dfbfb8f6a3b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Cloud VM default‑provider stress check and documents Freestyle as the default in staging/production (E2B kept as rollback). Also improves SSR safety and docs anchors, and tightens test types.

- **New Features**
  - Added `cloud-vm:stress` (`scripts/cloud-vm/stress-vm-api.mjs`) to create VMs, attach via daemon RPC, proxy `/healthz`, then clean up; supports `--count`, `--concurrency`, `--provider (default|e2b|freestyle)`, timeouts, and graceful SIGINT/SIGTERM cleanup; outputs a JSON summary with provider/image counts and cleanup stats. Uses `@stackframe/js` and `ws`.
  - Updated ops docs to recommend running the default‑provider stress check and to note Freestyle as the staging/production default with E2B as rollback.

- **Bug Fixes**
  - Made DevPanel position SSR‑safe with a lazy initializer; switched internal links to Next `Link` and added anchor IDs to docs for deep links.
  - Expanded `bun:test` TypeScript types (lifecycle hooks, focused/skipped tests, matchers, mocks) to clear lint/type errors.

<sup>Written for commit 898fd7b5da8784542844dd6f6af0dfbfb8f6a3b6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DevPanel now initializes its on-screen position correctly on first render.

* **Chores**
  * Added a VM stress-test tool and a script to run it.

* **Documentation**
  * Internal docs links updated to use improved routing components.
  * FAQ/notifications docs updated with anchored headings for CLI and integration sections and operational guidance for VM stress testing.

* **Tests**
  * Strengthened TypeScript typings for the test framework.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->