### PR TITLE
Fix command palette arrow keys and no-match flash

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -92,6 +92,27 @@ func shouldDispatchBrowserArrowViaFirstResponderKeyDown(
     return normalizedFlags.isEmpty
 }
 
+func shouldDispatchCommandPaletteHorizontalArrowViaFirstResponderKeyDown(
+    keyCode: UInt16,
+    firstResponderIsCommandPaletteFieldEditor: Bool,
+    firstResponderHasMarkedText: Bool = false,
+    flags: NSEvent.ModifierFlags
+) -> Bool {
+    guard firstResponderIsCommandPaletteFieldEditor else { return false }
+    guard !firstResponderHasMarkedText else { return false }
+    guard keyCode == 123 || keyCode == 124 else { return false }
+
+    let normalizedFlags = flags
+        .intersection(.deviceIndependentFlagsMask)
+        .subtracting([.numericPad, .function, .capsLock])
+    switch normalizedFlags {
+    case [], [.shift], [.option], [.option, .shift], [.command], [.command, .shift]:
+        return true
+    default:
+        return false
+    }
+}
+
 func shouldToggleMainWindowFullScreenForCommandControlFShortcut(
     flags: NSEvent.ModifierFlags,
     chars: String,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13726,6 +13726,7 @@ private var cmuxFirstResponderGuardHitViewContext: NSView?
 private var cmuxFirstResponderGuardContextWindowNumber: Int?
 private var cmuxBrowserReturnForwardingDepth = 0
 private var cmuxBrowserArrowForwardingDepth = 0
+private var cmuxCommandPaletteArrowForwardingDepth = 0
 private var cmuxWindowFirstResponderBypassDepth = 0
 private var cmuxFieldEditorOwningWebViewAssociationKey: UInt8 = 0
 
@@ -13841,6 +13842,49 @@ private extension AppDelegate {
 }
 
 private extension NSWindow {
+    static func cmuxCommandPaletteOwnsFieldEditor(_ textView: NSTextView?, in window: NSWindow) -> Bool {
+        guard let textView,
+              textView.isFieldEditor,
+              textView.window === window else {
+            return false
+        }
+
+        if let ownerView = cmuxFieldEditorOwnerView(textView),
+           cmuxIsInsideCommandPaletteOverlay(ownerView) {
+            return true
+        }
+
+        guard let container = cmuxCommandPaletteOverlayContainer(in: window) else {
+            return false
+        }
+        return !container.isHidden && container.alphaValue > 0.001
+    }
+
+    private static func cmuxIsInsideCommandPaletteOverlay(_ view: NSView) -> Bool {
+        var current: NSView? = view
+        while let candidate = current {
+            if candidate.identifier == commandPaletteOverlayContainerIdentifier {
+                return true
+            }
+            current = candidate.superview
+        }
+        return false
+    }
+
+    private static func cmuxCommandPaletteOverlayContainer(in window: NSWindow) -> NSView? {
+        guard let searchRoot = window.contentView?.superview ?? window.contentView else {
+            return nil
+        }
+        var stack: [NSView] = [searchRoot]
+        while let candidate = stack.popLast() {
+            if candidate.identifier == commandPaletteOverlayContainerIdentifier {
+                return candidate
+            }
+            stack.append(contentsOf: candidate.subviews)
+        }
+        return nil
+    }
+
     @objc func cmux_makeFirstResponder(_ responder: NSResponder?) -> Bool {
         if cmuxIsWindowFirstResponderBypassActive() {
 #if DEBUG
@@ -14155,6 +14199,10 @@ private extension NSWindow {
             Self.cmuxOwningWebView(for: $0, in: self, event: event)
         }
         let firstResponderHasMarkedText = browserResponderHasMarkedText(self.firstResponder)
+        let firstResponderIsCommandPaletteFieldEditor = Self.cmuxCommandPaletteOwnsFieldEditor(
+            self.firstResponder as? NSTextView,
+            in: self
+        )
         if ShortcutRecorderEventRouter.dispatchActiveRecordingEvent(event, preferredWindow: self) {
             return true
         }
@@ -14215,6 +14263,21 @@ private extension NSWindow {
 #endif
                 return true
             }
+        }
+
+        if shouldDispatchCommandPaletteHorizontalArrowViaFirstResponderKeyDown(
+            keyCode: event.keyCode,
+            firstResponderIsCommandPaletteFieldEditor: firstResponderIsCommandPaletteFieldEditor,
+            firstResponderHasMarkedText: firstResponderHasMarkedText,
+            flags: event.modifierFlags
+        ) {
+            if cmuxCommandPaletteArrowForwardingDepth > 0 {
+                return false
+            }
+            cmuxCommandPaletteArrowForwardingDepth += 1
+            defer { cmuxCommandPaletteArrowForwardingDepth = max(0, cmuxCommandPaletteArrowForwardingDepth - 1) }
+            self.firstResponder?.keyDown(with: event)
+            return true
         }
 
         // Web forms rely on Return/Enter flowing through keyDown. If the original

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13849,9 +13849,8 @@ private extension NSWindow {
             return false
         }
 
-        if let ownerView = cmuxFieldEditorOwnerView(textView),
-           cmuxIsInsideCommandPaletteOverlay(ownerView) {
-            return true
+        if let ownerView = cmuxFieldEditorOwnerView(textView) {
+            return cmuxIsInsideCommandPaletteOverlay(ownerView)
         }
 
         guard let container = cmuxCommandPaletteOverlayContainer(in: window) else {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13850,24 +13850,32 @@ private extension NSWindow {
         }
 
         if let ownerView = cmuxFieldEditorOwnerView(textView) {
-            return cmuxIsInsideCommandPaletteOverlay(ownerView)
+            guard let container = cmuxCommandPaletteOverlayAncestor(of: ownerView) else {
+                return false
+            }
+            return cmuxCommandPaletteOverlayIsPresented(container)
         }
 
         guard let container = cmuxCommandPaletteOverlayContainer(in: window) else {
             return false
         }
-        return !container.isHidden && container.alphaValue > 0.001
+
+        return cmuxCommandPaletteOverlayIsPresented(container)
     }
 
-    private static func cmuxIsInsideCommandPaletteOverlay(_ view: NSView) -> Bool {
+    private static func cmuxCommandPaletteOverlayAncestor(of view: NSView) -> NSView? {
         var current: NSView? = view
         while let candidate = current {
             if candidate.identifier == commandPaletteOverlayContainerIdentifier {
-                return true
+                return candidate
             }
             current = candidate.superview
         }
-        return false
+        return nil
+    }
+
+    private static func cmuxCommandPaletteOverlayIsPresented(_ container: NSView) -> Bool {
+        !container.isHidden && container.alphaValue > 0.001
     }
 
     private static func cmuxCommandPaletteOverlayContainer(in window: NSWindow) -> NSView? {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -4435,7 +4435,8 @@ struct ContentView: View {
     private var commandPaletteCommandListView: some View {
         let visibleResults = commandPaletteVisibleResults
         let selectedIndex = commandPaletteSelectedIndex(resultCount: visibleResults.count)
-        let commandPaletteListIdentity = "\(commandPaletteListScope.rawValue):\(commandPaletteQuery)"
+        let commandPaletteListIdentity = Self.commandPaletteListIdentity(for: commandPaletteQuery)
+        let shouldShowEmptyState = commandPaletteShouldShowEmptyState
         let commandPaletteListMaxHeight: CGFloat = 450
         let commandPaletteRowHeight: CGFloat = 24
         let commandPaletteEmptyStateHeight: CGFloat = 44
@@ -4460,11 +4461,11 @@ struct ContentView: View {
             Divider()
 
             ScrollView {
-                // Rebuild the full results container on scope/query transitions so
+                // Rebuild the full results container on scope transitions so
                 // stale switcher rows cannot linger above command-mode results.
                 VStack(spacing: 0) {
                     if visibleResults.isEmpty {
-                        if commandPaletteShouldShowEmptyState {
+                        if shouldShowEmptyState {
                             Text(commandPaletteEmptyStateText)
                                 .font(.system(size: 13, weight: .regular))
                                 .foregroundStyle(.secondary)
@@ -5639,6 +5640,10 @@ struct ContentView: View {
         hasVisibleResults && commandPaletteListScope(for: oldQuery) != commandPaletteListScope(for: newQuery)
     }
 
+    nonisolated static func commandPaletteListIdentity(for query: String) -> String {
+        commandPaletteListScope(for: query).rawValue
+    }
+
     private var commandPaletteSwitcherIncludesSurfaceEntries: Bool {
         Self.commandPaletteSwitcherIncludesSurfaceEntries(
             searchAllSurfaces: commandPaletteSearchAllSurfaces,
@@ -6002,8 +6007,10 @@ struct ContentView: View {
             return false
         }
 
-        return currentMatchingQuery == resolvedMatchingQuery
-            || currentMatchingQuery.hasPrefix(resolvedMatchingQuery)
+        // The visible list is already empty at the call site. Keep the no-match
+        // message stable across any same-corpus pending query, including edits
+        // in the middle of the search text that are not prefix refinements.
+        return true
     }
 
     private func scheduleCommandPaletteResultsRefresh(
@@ -6086,14 +6093,16 @@ struct ContentView: View {
 
             await MainActor.run {
                 let currentScope = Self.commandPaletteListScope(for: commandPaletteQuery)
-                guard commandPaletteSearchRequestID == requestID,
-                      isCommandPalettePresented,
-                      currentScope == scope,
-                      Self.commandPaletteQueryForMatching(
-                          query: commandPaletteQuery,
-                          scope: currentScope
-                      ) == matchingQuery,
-                      cachedCommandPaletteFingerprint == fingerprint else {
+                let currentMatchingQuery = Self.commandPaletteQueryForMatching(
+                    query: commandPaletteQuery,
+                    scope: currentScope
+                )
+                let shouldApplyResults = commandPaletteSearchRequestID == requestID
+                    && isCommandPalettePresented
+                    && currentScope == scope
+                    && currentMatchingQuery == matchingQuery
+                    && cachedCommandPaletteFingerprint == fingerprint
+                guard shouldApplyResults else {
                     return
                 }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -5995,9 +5995,7 @@ struct ContentView: View {
         visibleResultsScopeMatches: Bool,
         resolvedSearchScopeMatches: Bool,
         resolvedSearchFingerprintMatches: Bool,
-        resolvedResultsAreEmpty: Bool,
-        currentMatchingQuery: String,
-        resolvedMatchingQuery: String
+        resolvedResultsAreEmpty: Bool
     ) -> Bool {
         guard isSearchPending,
               visibleResultsScopeMatches,
@@ -8541,9 +8539,7 @@ struct ContentView: View {
             visibleResultsScopeMatches: commandPaletteVisibleResultsScope == commandPaletteListScope,
             resolvedSearchScopeMatches: commandPaletteResolvedSearchScope == commandPaletteListScope,
             resolvedSearchFingerprintMatches: commandPaletteResolvedSearchFingerprint == commandPaletteVisibleResultsFingerprint,
-            resolvedResultsAreEmpty: cachedCommandPaletteResults.isEmpty,
-            currentMatchingQuery: commandPaletteQueryForMatching,
-            resolvedMatchingQuery: commandPaletteResolvedMatchingQuery
+            resolvedResultsAreEmpty: cachedCommandPaletteResults.isEmpty
         )
     }
 

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -485,15 +485,15 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testPendingEmptyStateIsNotPreservedWhileSearchIsStillPending() {
+    func testPendingEmptyStateIsNotPreservedWhenSearchIsNotPending() {
         XCTAssertFalse(
             ContentView.commandPaletteShouldPreserveEmptyStateWhileSearchPending(
-                isSearchPending: true,
+                isSearchPending: false,
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
                 resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzzz",
+                currentMatchingQuery: "zzzzzzzz",
                 resolvedMatchingQuery: "zzzzzzzz"
             )
         )
@@ -513,21 +513,43 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
         )
     }
 
-    func testPendingEmptyStateIsNotPreservedWhenQueryDoesNotRefineResolvedNoMatch() {
-        XCTAssertFalse(
+    func testPendingEmptyStateIsPreservedForSameScopeNoMatchInPlaceEdit() {
+        XCTAssertTrue(
             ContentView.commandPaletteShouldPreserveEmptyStateWhileSearchPending(
                 isSearchPending: true,
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
                 resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzza",
-                resolvedMatchingQuery: "zzzzb"
+                currentMatchingQuery: "aXbY",
+                resolvedMatchingQuery: "aXbc"
             )
         )
     }
 
     func testPendingEmptyStateIsNotPreservedWhenResolvedResultsMayBeStale() {
+        XCTAssertFalse(
+            ContentView.commandPaletteShouldPreserveEmptyStateWhileSearchPending(
+                isSearchPending: true,
+                visibleResultsScopeMatches: false,
+                resolvedSearchScopeMatches: true,
+                resolvedSearchFingerprintMatches: true,
+                resolvedResultsAreEmpty: true,
+                currentMatchingQuery: "zzzzzzzzz",
+                resolvedMatchingQuery: "zzzzzzzz"
+            )
+        )
+        XCTAssertFalse(
+            ContentView.commandPaletteShouldPreserveEmptyStateWhileSearchPending(
+                isSearchPending: true,
+                visibleResultsScopeMatches: true,
+                resolvedSearchScopeMatches: false,
+                resolvedSearchFingerprintMatches: true,
+                resolvedResultsAreEmpty: true,
+                currentMatchingQuery: "zzzzzzzzz",
+                resolvedMatchingQuery: "zzzzzzzz"
+            )
+        )
         XCTAssertFalse(
             ContentView.commandPaletteShouldPreserveEmptyStateWhileSearchPending(
                 isSearchPending: true,

--- a/cmuxTests/CommandPaletteSearchEngineTests.swift
+++ b/cmuxTests/CommandPaletteSearchEngineTests.swift
@@ -492,9 +492,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: true
             )
         )
     }
@@ -506,9 +504,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: true
             )
         )
     }
@@ -520,9 +516,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "aXbY",
-                resolvedMatchingQuery: "aXbc"
+                resolvedResultsAreEmpty: true
             )
         )
     }
@@ -534,9 +528,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: false,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: true
             )
         )
         XCTAssertFalse(
@@ -545,9 +537,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: false,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: true
             )
         )
         XCTAssertFalse(
@@ -556,9 +546,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: false,
-                resolvedResultsAreEmpty: true,
-                currentMatchingQuery: "zzzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: true
             )
         )
         XCTAssertFalse(
@@ -567,9 +555,7 @@ final class CommandPaletteSearchEngineTests: XCTestCase {
                 visibleResultsScopeMatches: true,
                 resolvedSearchScopeMatches: true,
                 resolvedSearchFingerprintMatches: true,
-                resolvedResultsAreEmpty: false,
-                currentMatchingQuery: "zzzzzzzzz",
-                resolvedMatchingQuery: "zzzzzzzz"
+                resolvedResultsAreEmpty: false
             )
         )
     }

--- a/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
+++ b/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
@@ -406,9 +406,77 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         }
     }
 
+    func testWindowPerformKeyEquivalentDoesNotStealHorizontalArrowsFromNonPaletteFieldEditor() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        guard let window = window(withId: windowId),
+              let contentView = window.contentView,
+              let searchRoot = contentView.superview ?? window.contentView else {
+            XCTFail("Expected test window")
+            return
+        }
+
+        let overlayContainer = NSView(frame: searchRoot.bounds)
+        overlayContainer.identifier = commandPaletteOverlayContainerIdentifier
+        overlayContainer.alphaValue = 1
+        overlayContainer.isHidden = false
+        searchRoot.addSubview(overlayContainer)
+        defer { overlayContainer.removeFromSuperview() }
+
+        let outsideOwnerView = NSView(frame: searchRoot.bounds)
+        searchRoot.addSubview(outsideOwnerView)
+        defer { outsideOwnerView.removeFromSuperview() }
+
+        let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+        fieldEditor.isFieldEditor = true
+        outsideOwnerView.addSubview(fieldEditor)
+        defer { fieldEditor.removeFromSuperview() }
+        XCTAssertTrue(window.makeFirstResponder(fieldEditor))
+        XCTAssertTrue(window.firstResponder === fieldEditor)
+        fieldEditor.nextResponder = outsideOwnerView
+        appDelegate.setCommandPaletteVisible(false, for: window)
+
+        guard let leftArrowEvent = makeKeyDownEvent(
+            key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+            modifiers: [],
+            keyCode: 123,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct horizontal arrow event")
+            return
+        }
+
+        XCTAssertFalse(window.performKeyEquivalent(with: leftArrowEvent))
+        XCTAssertEqual(fieldEditor.keyDownKeyCodes, [])
+    }
+
     private func withCommandPaletteFieldEditor(
         appDelegate: AppDelegate,
         _ body: (NSWindow, CommandPaletteShortcutFieldEditor) -> Void
+    ) {
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, overlayContainer in
+            let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+            fieldEditor.isFieldEditor = true
+            overlayContainer.addSubview(fieldEditor)
+            XCTAssertTrue(window.makeFirstResponder(fieldEditor))
+
+            defer {
+                fieldEditor.removeFromSuperview()
+            }
+
+            body(window, fieldEditor)
+        }
+    }
+
+    private func withVisibleCommandPaletteOverlay(
+        appDelegate: AppDelegate,
+        _ body: (NSWindow, NSView) -> Void
     ) {
         let windowId = appDelegate.createMainWindow()
         defer { closeWindow(withId: windowId) }
@@ -425,18 +493,12 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         overlayContainer.isHidden = false
         contentView.addSubview(overlayContainer)
 
-        let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-        fieldEditor.isFieldEditor = true
-        overlayContainer.addSubview(fieldEditor)
-        XCTAssertTrue(window.makeFirstResponder(fieldEditor))
-
         appDelegate.setCommandPaletteVisible(false, for: window)
         defer {
             overlayContainer.removeFromSuperview()
-            fieldEditor.removeFromSuperview()
         }
 
-        body(window, fieldEditor)
+        body(window, overlayContainer)
     }
 
     private func withTemporaryCommandPalettePreviousShortcut(_ body: () -> Void) {

--- a/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
+++ b/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
@@ -406,54 +406,76 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         }
     }
 
+    func testWindowPerformKeyEquivalentDoesNotRouteHorizontalArrowsWhenPaletteOverlayIsTransparent() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, overlayContainer in
+            let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+            fieldEditor.isFieldEditor = true
+            overlayContainer.addSubview(fieldEditor)
+            defer { fieldEditor.removeFromSuperview() }
+
+            XCTAssertTrue(window.makeFirstResponder(fieldEditor))
+            XCTAssertTrue(window.firstResponder === fieldEditor)
+
+            overlayContainer.alphaValue = 0
+
+            guard let leftArrowEvent = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 123,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct horizontal arrow event")
+                return
+            }
+
+            XCTAssertFalse(window.performKeyEquivalent(with: leftArrowEvent))
+            XCTAssertEqual(fieldEditor.keyDownKeyCodes, [])
+        }
+    }
+
     func testWindowPerformKeyEquivalentDoesNotStealHorizontalArrowsFromNonPaletteFieldEditor() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
         }
 
-        let windowId = appDelegate.createMainWindow()
-        defer { closeWindow(withId: windowId) }
+        withVisibleCommandPaletteOverlay(appDelegate: appDelegate) { window, _ in
+            guard let contentView = window.contentView else {
+                XCTFail("Expected test window content view")
+                return
+            }
 
-        guard let window = window(withId: windowId),
-              let contentView = window.contentView,
-              let searchRoot = contentView.superview ?? window.contentView else {
-            XCTFail("Expected test window")
-            return
+            let outsideOwnerView = NSView(frame: contentView.bounds)
+            contentView.addSubview(outsideOwnerView)
+            defer { outsideOwnerView.removeFromSuperview() }
+
+            let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
+            fieldEditor.isFieldEditor = true
+            outsideOwnerView.addSubview(fieldEditor)
+            defer { fieldEditor.removeFromSuperview() }
+
+            XCTAssertTrue(window.makeFirstResponder(fieldEditor))
+            XCTAssertTrue(window.firstResponder === fieldEditor)
+            fieldEditor.nextResponder = outsideOwnerView
+
+            guard let leftArrowEvent = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 123,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct horizontal arrow event")
+                return
+            }
+
+            XCTAssertFalse(window.performKeyEquivalent(with: leftArrowEvent))
+            XCTAssertEqual(fieldEditor.keyDownKeyCodes, [])
         }
-
-        let overlayContainer = NSView(frame: searchRoot.bounds)
-        overlayContainer.identifier = commandPaletteOverlayContainerIdentifier
-        overlayContainer.alphaValue = 1
-        overlayContainer.isHidden = false
-        searchRoot.addSubview(overlayContainer)
-        defer { overlayContainer.removeFromSuperview() }
-
-        let outsideOwnerView = NSView(frame: searchRoot.bounds)
-        searchRoot.addSubview(outsideOwnerView)
-        defer { outsideOwnerView.removeFromSuperview() }
-
-        let fieldEditor = CommandPaletteShortcutFieldEditor(frame: NSRect(x: 0, y: 0, width: 200, height: 24))
-        fieldEditor.isFieldEditor = true
-        outsideOwnerView.addSubview(fieldEditor)
-        defer { fieldEditor.removeFromSuperview() }
-        XCTAssertTrue(window.makeFirstResponder(fieldEditor))
-        XCTAssertTrue(window.firstResponder === fieldEditor)
-        fieldEditor.nextResponder = outsideOwnerView
-        appDelegate.setCommandPaletteVisible(false, for: window)
-
-        guard let leftArrowEvent = makeKeyDownEvent(
-            key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
-            modifiers: [],
-            keyCode: 123,
-            windowNumber: window.windowNumber
-        ) else {
-            XCTFail("Failed to construct horizontal arrow event")
-            return
-        }
-
-        XCTAssertFalse(window.performKeyEquivalent(with: leftArrowEvent))
-        XCTAssertEqual(fieldEditor.keyDownKeyCodes, [])
     }
 
     private func withCommandPaletteFieldEditor(
@@ -493,8 +515,8 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         overlayContainer.isHidden = false
         contentView.addSubview(overlayContainer)
 
-        appDelegate.setCommandPaletteVisible(false, for: window)
         defer {
+            appDelegate.setCommandPaletteVisible(false, for: window)
             overlayContainer.removeFromSuperview()
         }
 

--- a/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
+++ b/cmuxTests/CommandPaletteShortcutCustomizationTests.swift
@@ -211,7 +211,7 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
             return
         }
 
-        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window in
+        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window, _ in
             withTemporaryCommandPalettePreviousShortcut {
                 let remappedPrevious = StoredShortcut(key: "u", command: false, shift: false, option: false, control: true)
                 KeyboardShortcutSettings.setShortcut(remappedPrevious, for: .commandPalettePrevious)
@@ -290,7 +290,7 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
             return
         }
 
-        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window in
+        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window, _ in
             withTemporaryCommandPalettePreviousShortcut {
                 KeyboardShortcutSettings.unbindShortcut(for: .commandPalettePrevious)
                 XCTAssertNil(KeyboardShortcutSettings.shortcutIfBound(for: .commandPalettePrevious))
@@ -338,7 +338,7 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
             return
         }
 
-        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window in
+        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window, _ in
             withTemporaryCommandPaletteShortcut(.commandPaletteNext) {
                 KeyboardShortcutSettings.setShortcut(
                     StoredShortcut(key: "b", command: false, shift: false, option: false, control: true, chordKey: "n"),
@@ -377,9 +377,38 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
         }
     }
 
+    func testWindowPerformKeyEquivalentRoutesHorizontalArrowsToCommandPaletteFieldEditor() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        withCommandPaletteFieldEditor(appDelegate: appDelegate) { window, fieldEditor in
+            guard let leftArrowEvent = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSLeftArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 123,
+                windowNumber: window.windowNumber
+            ),
+            let rightArrowEvent = makeKeyDownEvent(
+                key: String(UnicodeScalar(NSRightArrowFunctionKey)!),
+                modifiers: [],
+                keyCode: 124,
+                windowNumber: window.windowNumber
+            ) else {
+                XCTFail("Failed to construct horizontal arrow events")
+                return
+            }
+
+            XCTAssertTrue(window.performKeyEquivalent(with: leftArrowEvent))
+            XCTAssertTrue(window.performKeyEquivalent(with: rightArrowEvent))
+            XCTAssertEqual(fieldEditor.keyDownKeyCodes, [123, 124])
+        }
+    }
+
     private func withCommandPaletteFieldEditor(
         appDelegate: AppDelegate,
-        _ body: (NSWindow) -> Void
+        _ body: (NSWindow, CommandPaletteShortcutFieldEditor) -> Void
     ) {
         let windowId = appDelegate.createMainWindow()
         defer { closeWindow(withId: windowId) }
@@ -407,7 +436,7 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
             fieldEditor.removeFromSuperview()
         }
 
-        body(window)
+        body(window, fieldEditor)
     }
 
     private func withTemporaryCommandPalettePreviousShortcut(_ body: () -> Void) {
@@ -463,7 +492,13 @@ final class CommandPaletteShortcutCustomizationTests: XCTestCase {
 }
 
 private final class CommandPaletteShortcutFieldEditor: NSTextView {
+    var keyDownKeyCodes: [UInt16] = []
+
     override func hasMarkedText() -> Bool {
         false
+    }
+
+    override func keyDown(with event: NSEvent) {
+        keyDownKeyCodes.append(event.keyCode)
     }
 }


### PR DESCRIPTION
Summary
- Route horizontal arrow keys back to the command palette field editor before app shortcut routing consumes them.
- Keep the command palette no-match empty state stable while a same-corpus search is pending.
- Add regression tests for both the arrow handling and in-place no-match edit flash.

Verification
- Red check on test-only commit: selected command palette tests failed as expected.
- Green check: xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-palette-green-check -only-testing:cmuxTests/CommandPaletteShortcutCustomizationTests/testWindowPerformKeyEquivalentRoutesHorizontalArrowsToCommandPaletteFieldEditor -only-testing:cmuxTests/CommandPaletteSearchEngineTests/testPendingEmptyStateIsNotPreservedWhenSearchIsNotPending -only-testing:cmuxTests/CommandPaletteSearchEngineTests/testPendingEmptyStateIsPreservedForSameResolvedNoMatchQuery -only-testing:cmuxTests/CommandPaletteSearchEngineTests/testPendingEmptyStateIsPreservedForSameScopeNoMatchInPlaceEdit -only-testing:cmuxTests/CommandPaletteSearchEngineTests/testPendingEmptyStateIsNotPreservedWhenResolvedResultsMayBeStale test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS `performKeyEquivalent` routing and command palette search/empty-state behavior, which could affect global keyboard handling and UI responsiveness if edge cases are missed.
> 
> **Overview**
> Fixes command palette keyboard routing so **left/right arrow keys** are forwarded to the palette’s focused field editor (when the visible overlay actually owns the field editor and there’s no IME marked text), preventing app-level shortcut routing from swallowing them.
> 
> Stabilizes command palette results rendering and the *no-match* empty state by rebuilding the results container on **scope-only** transitions and keeping the empty-state message pinned while a same-scope search is pending; also tightens async search result application guards to avoid stale updates.
> 
> Adds regression tests covering horizontal arrow forwarding/ownership guards and the pending no-match empty-state behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59c9f2bb0dd36b49c3c1599359c6126e7c8a7a79. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes command palette horizontal arrow routing and removes the empty‑state flicker. Arrows only reach the palette when its overlay is presented, and results stay stable during same‑scope pending searches.

- **Bug Fixes**
  - Route left/right arrows (with allowed modifiers) to the command palette field editor when it’s first responder and not in IME; require the editor to belong to a presented overlay (not hidden/transparent) so non‑palette editors aren’t affected.
  - Keep the “no match” message steady for any same‑scope pending search, including in‑place edits; results list identity is now scope‑only to prevent stale rows and flicker.
  - Apply results only when the request, scope, matching query, and fingerprint still match to avoid stale updates.
  - Added regression tests for horizontal arrow routing, transparent overlay ownership, non‑palette arrow ownership, and same‑scope empty‑state preservation.

<sup>Written for commit 59c9f2bb0dd36b49c3c1599359c6126e7c8a7a79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Command palette keyboard handling: left/right arrows now behave correctly while editing, respect palette visibility, and won’t interfere with other text fields
  * More stable handling of empty search results and fewer unnecessary result-list rebuilds during scope/query changes

* **Tests**
  * Expanded tests validating command-palette arrow routing, visibility cases, and search-result state transitions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->