### PR TITLE
Add Qoder agent notification and status hooks

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -15706,7 +15706,7 @@ struct CMUXCLI {
     }
 
     private enum AgentHookAction {
-        case sessionStart, promptSubmit, stop, sessionEnd, noop
+        case sessionStart, promptSubmit, stop, sessionEnd, notification, noop
     }
 
     private static let subcommandActions: [String: AgentHookAction] = [
@@ -15717,6 +15717,7 @@ struct CMUXCLI {
         "shell-exec": .promptSubmit,
         "shell-done": .noop,
         "session-end": .sessionEnd,
+        "notification": .notification,
     ]
 
     // MARK: Agent definitions
@@ -15852,8 +15853,10 @@ struct CMUXCLI {
                 .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start"),
                 .init(agentEvent: "Stop", cmuxSubcommand: "stop"),
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
+                .init(agentEvent: "Notification", cmuxSubcommand: "notification"),
+                .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit"),
             ],
-            feedHookEvents: ["PreToolUse"]
+            feedHookEvents: ["PreToolUse", "PermissionRequest"]
         ),
     ]
 
@@ -17024,6 +17027,22 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 sendAgentFeedTelemetry(workspaceId: mapped.workspaceId)
                 _ = try? sendV1Command("clear_status \(def.statusKey) --tab=\(mapped.workspaceId)", client: client)
                 _ = try? sendV1Command("clear_agent_pid \(pidKey) --tab=\(mapped.workspaceId)", client: client)
+            }
+
+        case .notification:
+            let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
+            let workspaceId = try resolvePreferredWorkspaceIdForClaudeHook(preferred: workspaceArg, fallback: mapped?.workspaceId, client: client)
+            sendAgentFeedTelemetry(workspaceId: workspaceId)
+            // If the notification carries a meaningful title, rename the workspace/tab.
+            // Skip generic notification labels that aren't session titles.
+            let genericTitles: Set<String> = ["Agent Result", "Permission Request", "Notification"]
+            if let title = input.object?["title"] as? String,
+               !title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               !genericTitles.contains(title.trimmingCharacters(in: .whitespacesAndNewlines)) {
+                _ = try? client.sendV2(method: "workspace.rename", params: [
+                    "workspace_id": workspaceId,
+                    "title": title.trimmingCharacters(in: .whitespacesAndNewlines),
+                ])
             }
 
         case .noop:
@@ -19900,7 +19919,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         print("cmux hooks \(isUninstall ? "uninstall" : "setup"): \(verb) agent hooks")
         if !isUninstall {
-            print("  (Claude Code hooks are injected automatically via the claude wrapper)")
+            print("  (Claude Code and Qoder hooks are injected automatically via their wrapper scripts)")
         }
         print("")
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -328,6 +328,7 @@
 		D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */; };
 		E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */; };
 		C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00001A1B2C3D4E5F719 /* claude */; };
+		C1ADE00004A1B2C3D4E5F719 /* qodercli in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE00003A1B2C3D4E5F719 /* qodercli */; };
 		C2577000A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
 		CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */; };
@@ -450,6 +451,7 @@
 			files = (
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE00002A1B2C3D4E5F719 /* claude in Copy CLI */,
+				C1ADE00004A1B2C3D4E5F719 /* qodercli in Copy CLI */,
 				D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 			);
 			name = "Copy CLI";
@@ -788,6 +790,7 @@
 		C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigTests.swift; sourceTree = "<group>"; };
 		E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigNamedColorTests.swift; sourceTree = "<group>"; };
 		C1ADE00001A1B2C3D4E5F719 /* claude */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/claude; sourceTree = SOURCE_ROOT; };
+		C1ADE00003A1B2C3D4E5F719 /* qodercli */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = Resources/bin/qodercli; sourceTree = SOURCE_ROOT; };
 		C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalCmdClickUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B1A1B2C3D4E5F60718 /* BrowserPaneNavigationKeybindUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneNavigationKeybindUITests.swift; sourceTree = "<group>"; };
 		D0E0F0B5A1B2C3D4E5F60718 /* FindSelectionShortcutUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FindSelectionShortcutUITests.swift; sourceTree = "<group>"; };
@@ -912,6 +915,7 @@
 				B2E7294509CC42FE9191870E /* xterm-ghostty */,
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 				C1ADE00001A1B2C3D4E5F719 /* claude */,
+				C1ADE00003A1B2C3D4E5F719 /* qodercli */,
 				DA7A10CA710E000000000001 /* Localizable.xcstrings */,
 				DA7A10CA710E000000000002 /* InfoPlist.xcstrings */,
 				FEED0000000000000000F006 /* opencode-plugin.js */,

--- a/Resources/bin/qodercli
+++ b/Resources/bin/qodercli
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# cmux qodercli wrapper - injects hooks and session tracking
+#
+# When running inside a cmux terminal (CMUX_SURFACE_ID is set), this wrapper
+# intercepts `qodercli` invocations to inject --session-id and --settings flags
+# so that qodercli hooks fire back into cmux for notifications/status.
+# Outside cmux, it passes through to the real qodercli binary unchanged.
+
+# Find the real qodercli binary, skipping our own directory.
+find_real_qodercli() {
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        [[ -x "$d/qodercli" ]] && printf '%s' "$d/qodercli" && return 0
+    done
+    return 1
+}
+
+# Return 0 only when CMUX_SOCKET_PATH points to a live cmux socket.
+cmux_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local self_dir cmux_bin
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    cmux_bin="$self_dir/cmux"
+    [[ -x "$cmux_bin" ]] || cmux_bin="$(command -v cmux || true)"
+    [[ -n "$cmux_bin" ]] || return 1
+
+    # Keep stale/hung socket checks bounded so qodercli startup does not block
+    # behind the CLI default timeout (15s).
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+resolve_hook_cmux_bin() {
+    local self_dir bundled_cli
+    bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
+    if [[ -n "$bundled_cli" && -x "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    bundled_cli="$self_dir/cmux"
+    if [[ -x "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    bundled_cli="$(command -v cmux || true)"
+    if [[ -n "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    printf '%s' "cmux"
+}
+
+encode_launch_argv() {
+    {
+        printf '%s\0' "$REAL_QODERCLI"
+        if (( $# > 0 )); then
+            printf '%s\0' "$@"
+        fi
+    } | base64 | tr -d '\n'
+}
+
+# Pass through if not in a cmux terminal, hooks are disabled, or the cmux
+# socket is unavailable (stale env / app not running).
+if [[ -z "$CMUX_SURFACE_ID" || "$CMUX_QODER_HOOKS_DISABLED" == "1" ]] || ! cmux_socket_available; then
+    REAL_QODERCLI="$(find_real_qodercli)" || { echo "Error: qodercli not found in PATH" >&2; exit 127; }
+    exec "$REAL_QODERCLI" "$@"
+fi
+
+# Find real qodercli.
+REAL_QODERCLI="$(find_real_qodercli)" || { echo "Error: qodercli not found in PATH" >&2; exit 127; }
+
+# Pass through subcommands that don't support session/hook flags.
+case "${1:-}" in
+    mcp|install|update|feedback|endpoint|machineinfo|jobs|commit|status|internal)
+        exec "$REAL_QODERCLI" "$@"
+        ;;
+esac
+
+# Check if the user already specified a session/resume flag.
+# If so, don't inject our own --session-id (it would conflict).
+SKIP_SESSION_ID=false
+for arg in "$@"; do
+    case "$arg" in
+        --resume|--resume=*|-r|--session-id|--session-id=*|--continue|-c|--fork-session)
+            SKIP_SESSION_ID=true
+            break
+            ;;
+    esac
+done
+
+# Export the wrapper's PID. Because we exec qodercli below, this PID becomes
+# the actual qodercli process PID, which hooks use for stale-session detection.
+export CMUX_QODER_PID=$$
+export CMUX_QODER_HOOK_CMUX_BIN="$(resolve_hook_cmux_bin)"
+export CMUX_AGENT_LAUNCH_KIND="qoder"
+export CMUX_AGENT_LAUNCH_EXECUTABLE="$REAL_QODERCLI"
+export CMUX_AGENT_LAUNCH_ARGV_B64="$(encode_launch_argv "$@")"
+export CMUX_AGENT_LAUNCH_CWD="$PWD"
+
+# Build qodercli settings JSON.
+# qodercli merges --settings additively with the user's own settings.json.
+# - SessionStart/Stop/Notification: lifecycle hooks
+# - SessionEnd: cleanup when qodercli exits (covers Ctrl+C where Stop doesn't fire)
+# - UserPromptSubmit: clears "Needs input" and sets "Running" on new prompt
+# - PreToolUse: clears "Needs input" and captures tool use for status (async)
+# - PermissionRequest: cmux hooks feed. SYNC with a 125s timeout.
+HOOKS_JSON='{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks feed --source qoder","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks qoder pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_QODER_HOOK_CMUX_BIN:-cmux}\" hooks feed --source qoder","timeout":125}]}]}}'
+
+if [[ "$SKIP_SESSION_ID" == true ]]; then
+    exec "$REAL_QODERCLI" --settings "$HOOKS_JSON" "$@"
+else
+    SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+    exec "$REAL_QODERCLI" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+fi


### PR DESCRIPTION
## Summary

Adds hook support for [Qoder CLI](https://qoder.com/cli) agent integration:

- Add `notification` hook handler to the generic agent hook system, enabling workspace rename when a notification carries a meaningful title
- Register `UserPromptSubmit` and `PermissionRequest` hooks for the Qoder agent (status/feed parity with Claude Code)
- Add `Resources/bin/qodercli` wrapper script that injects hooks and session tracking (same pattern as the existing `claude` wrapper)

## Test plan

- [x] Run Qoder CLI agent inside cmux, verify status transitions (Running → Idle) on each turn
- [ ] Verify notification hook fires and renames workspace when payload contains a non-generic title
- [ ] Verify PermissionRequest events appear in the feed panel
- [ ] Verify `--resume` / `--session-id` flags are not double-injected when user specifies them