### PR TITLE
Add ripgrepBinaryPath setting + nix-darwin rg fallback paths (#3657)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -394,6 +394,8 @@
 		FE001102 /* FileExplorerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE001002 /* FileExplorerView.swift */; };
 		FE001103 /* FileExplorerSearchController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE001003 /* FileExplorerSearchController.swift */; };
 		FE001104 /* FileExplorerTerminalPathInsertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE001004 /* FileExplorerTerminalPathInsertion.swift */; };
+		FE004101 /* RipgrepResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE004001 /* RipgrepResolver.swift */; };
+		FE004102 /* RipgrepResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE004002 /* RipgrepResolverTests.swift */; };
 		FE002101 /* FileExplorerRootResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002001 /* FileExplorerRootResolverTests.swift */; };
 		FE002102 /* FileExplorerStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002002 /* FileExplorerStoreTests.swift */; };
 		FE002103 /* FileSearchRipgrepParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002003 /* FileSearchRipgrepParserTests.swift */; };
@@ -864,6 +866,8 @@
 		FE001002 /* FileExplorerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerView.swift; sourceTree = "<group>"; };
 		FE001003 /* FileExplorerSearchController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerSearchController.swift; sourceTree = "<group>"; };
 		FE001004 /* FileExplorerTerminalPathInsertion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerTerminalPathInsertion.swift; sourceTree = "<group>"; };
+		FE004001 /* RipgrepResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RipgrepResolver.swift; sourceTree = "<group>"; };
+		FE004002 /* RipgrepResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RipgrepResolverTests.swift; sourceTree = "<group>"; };
 		FE002001 /* FileExplorerRootResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerRootResolverTests.swift; sourceTree = "<group>"; };
 			FE002002 /* FileExplorerStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerStoreTests.swift; sourceTree = "<group>"; };
 			FE002003 /* FileSearchRipgrepParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileSearchRipgrepParserTests.swift; sourceTree = "<group>"; };
@@ -1236,6 +1240,7 @@
 				B37A0000000000000000000A /* FileExplorerState.swift */,
 				FE001003 /* FileExplorerSearchController.swift */,
 				FE001004 /* FileExplorerTerminalPathInsertion.swift */,
+				FE004001 /* RipgrepResolver.swift */,
 				FE001002 /* FileExplorerView.swift */,
 				FE003001 /* SessionIndexStore.swift */,
 				B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */,
@@ -1409,6 +1414,7 @@
 				FE002001 /* FileExplorerRootResolverTests.swift */,
 				FE002002 /* FileExplorerStoreTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
+				FE004002 /* RipgrepResolverTests.swift */,
 			);
 			path = cmuxTests;
 			sourceTree = "<group>";
@@ -1851,6 +1857,7 @@
 				B37A00000000000000000009 /* FileExplorerState.swift in Sources */,
 				FE001103 /* FileExplorerSearchController.swift in Sources */,
 				FE001104 /* FileExplorerTerminalPathInsertion.swift in Sources */,
+				FE004101 /* RipgrepResolver.swift in Sources */,
 				FE001102 /* FileExplorerView.swift in Sources */,
 				FE003101 /* SessionIndexStore.swift in Sources */,
 				B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */,
@@ -2064,6 +2071,7 @@
 				FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 				FE002102 /* FileExplorerStoreTests.swift in Sources */,
 				FE002103 /* FileSearchRipgrepParserTests.swift in Sources */,
+				FE004102 /* RipgrepResolverTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -59974,10 +59974,79 @@
             "value": "Çalışma alanı başına port sayısı."
           }
         },
-        "uk": {
+         "uk": {
           "stringUnit": {
             "state": "translated",
             "value": "Кількість портів на робочу область."
+          }
+        }
+      }
+    },
+    "settings.automation.ripgrep.customPath": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ripgrep Binary Path"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ripgrepバイナリパス"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ripgrep 바이너리 경로"
+          }
+        }
+      }
+    },
+    "settings.automation.ripgrep.customPath.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "e.g. /opt/homebrew/bin/rg"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "例: /opt/homebrew/bin/rg"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "예: /opt/homebrew/bin/rg"
+          }
+        }
+      }
+    },
+    "settings.automation.ripgrep.customPath.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Custom path to the rg (ripgrep) binary used by Find. Leave empty to auto-detect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Findが使うrg（ripgrep）バイナリのカスタムパス。空欄の場合は自動検出します。"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Find가 사용하는 rg(ripgrep) 바이너리의 사용자 지정 경로입니다. 비워두면 자동 감지합니다."
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -76882,6 +76882,29 @@
             }
         }
     },
+    "settings.search.alias.setting.automation.ripgrep-path": {
+        "extractionState": "manual",
+        "localizations": {
+            "en": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.ripgrepBinaryPath ripgrep rg binary executable path find search nix custom"
+                }
+            },
+            "ja": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.ripgrepBinaryPath ripgrep rg binary executable path find search nix custom リップグレップ バイナリ 実行ファイル パス 検索 nix カスタム"
+                }
+            },
+            "ko": {
+                "stringUnit": {
+                    "state": "translated",
+                    "value": "automation.ripgrepBinaryPath ripgrep rg binary executable path find search nix custom 리그렙 바이너리 실행파일 경로 검색 nix 사용자지정"
+                }
+            }
+        }
+    },
     "settings.search.alias.setting.automation.cursor": {
         "extractionState": "manual",
         "localizations": {

--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -286,17 +286,7 @@ final class FileSearchController {
     }
 
     private static func ripgrepExecutable() -> RipgrepExecutable? {
-        let fileManager = FileManager.default
-        for path in ["/opt/homebrew/bin/rg", "/usr/local/bin/rg", "/usr/bin/rg"] where fileManager.isExecutableFile(atPath: path) {
-            return RipgrepExecutable(url: URL(fileURLWithPath: path), prefixArguments: [])
-        }
-        let pathValue = ProcessInfo.processInfo.environment["PATH"] ?? ""
-        for directory in pathValue.split(separator: ":", omittingEmptySubsequences: true) {
-            let path = URL(fileURLWithPath: String(directory)).appendingPathComponent("rg").path
-            if fileManager.isExecutableFile(atPath: path) {
-                return RipgrepExecutable(url: URL(fileURLWithPath: path), prefixArguments: [])
-            }
-        }
-        return nil
+        guard let path = RipgrepResolver.resolve() else { return nil }
+        return RipgrepExecutable(url: URL(fileURLWithPath: path), prefixArguments: [])
     }
 }

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -645,6 +645,9 @@ final class CmuxSettingsFileStore {
         if let raw = jsonString(section["claudeBinaryPath"]) {
             snapshot.managedUserDefaults[ClaudeCodeIntegrationSettings.customClaudePathKey] = .string(raw)
         }
+        if let raw = jsonString(section["ripgrepBinaryPath"]) {
+            snapshot.managedUserDefaults[RipgrepIntegrationSettings.customRipgrepPathKey] = .string(raw)
+        }
         if let value = jsonBool(section["cursorIntegration"]) {
             snapshot.managedUserDefaults[CursorIntegrationSettings.hooksEnabledKey] = .bool(value)
         }
@@ -1281,6 +1284,7 @@ final class CmuxSettingsFileStore {
                     "socketPassword": "",
                     "claudeCodeIntegration": ClaudeCodeIntegrationSettings.defaultHooksEnabled,
                     "claudeBinaryPath": "",
+                    "ripgrepBinaryPath": "",
                     "cursorIntegration": CursorIntegrationSettings.defaultHooksEnabled,
                     "geminiIntegration": GeminiIntegrationSettings.defaultHooksEnabled,
                     "portBase": 9100,

--- a/Sources/RipgrepResolver.swift
+++ b/Sources/RipgrepResolver.swift
@@ -15,7 +15,11 @@ enum RipgrepIntegrationSettings {
     }
 }
 
-private let ripgrepResolverLogger = Logger(
+// `nonisolated` is required for file-scoped state under MainActor-by-default
+// isolation (project rule `.github/review-bot-rules/swift-logging.md`); without
+// it, `RipgrepResolver.resolve()` — which is nonisolated — would cross the
+// actor boundary on every read.
+nonisolated private let ripgrepResolverLogger = Logger(
     subsystem: "com.cmuxterm.app",
     category: "RipgrepResolver"
 )
@@ -40,7 +44,7 @@ private final class InvalidPathLogTracker: @unchecked Sendable {
     }
 }
 
-private let ripgrepInvalidPathTracker = InvalidPathLogTracker()
+nonisolated private let ripgrepInvalidPathTracker = InvalidPathLogTracker()
 
 /// Resolves the absolute path to `rg`, honoring `automation.ripgrepBinaryPath`
 /// first, then a fallback list of common install locations, then `$PATH`.
@@ -69,7 +73,7 @@ enum RipgrepResolver {
         fileManager: FileManager = .default
     ) -> String? {
         if let customPath {
-            if fileManager.isExecutableFile(atPath: customPath) {
+            if isExecutableRegularFile(atPath: customPath, fileManager: fileManager) {
                 return customPath
             }
             // Configured-but-not-executable falls through to the common paths
@@ -81,18 +85,36 @@ enum RipgrepResolver {
                 )
             }
         }
-        for path in commonPaths where fileManager.isExecutableFile(atPath: path) {
+        for path in commonPaths where isExecutableRegularFile(atPath: path, fileManager: fileManager) {
             return path
         }
         if let pathValue = environment["PATH"] {
             for directory in pathValue.split(separator: ":", omittingEmptySubsequences: true) {
                 let candidate = String(directory) + "/rg"
-                if fileManager.isExecutableFile(atPath: candidate) {
+                if isExecutableRegularFile(atPath: candidate, fileManager: fileManager) {
                     return candidate
                 }
             }
         }
         return nil
+    }
+
+    /// `FileManager.isExecutableFile(atPath:)` returns true for directories with
+    /// the search/execute bit set (it's `access(X_OK)` under the hood). A user
+    /// could plausibly point `automation.ripgrepBinaryPath` at a directory named
+    /// `rg/`, or have one of the common locations expand to a directory in some
+    /// future install layout. Filter those out so the resolver returns only real
+    /// executable files.
+    private static func isExecutableRegularFile(
+        atPath path: String,
+        fileManager: FileManager
+    ) -> Bool {
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+              !isDirectory.boolValue else {
+            return false
+        }
+        return fileManager.isExecutableFile(atPath: path)
     }
 
     /// Reset the dedupe tracker. Tests use this to assert per-call logging

--- a/Sources/RipgrepResolver.swift
+++ b/Sources/RipgrepResolver.swift
@@ -1,0 +1,78 @@
+import Foundation
+
+/// Mirrors `ClaudeCodeIntegrationSettings.customClaudePath` for `rg`. Lets users
+/// on Nix / asdf / non-standard installs point cmux at their ripgrep directly,
+/// because Dock-launched macOS apps snapshot env at Dock-start time and don't
+/// reliably inherit `launchctl setenv PATH` (issue #3657).
+enum RipgrepIntegrationSettings {
+    static let customRipgrepPathKey = "ripgrepBinaryPath"
+
+    static func customRipgrepPath(defaults: UserDefaults = .standard) -> String? {
+        let value = defaults.string(forKey: customRipgrepPathKey)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return value.isEmpty ? nil : value
+    }
+}
+
+/// Resolves the absolute path to `rg`, honoring `automation.ripgrepBinaryPath`
+/// first, then a fallback list of common install locations, then `$PATH`.
+/// Re-evaluated on every call so a settings change takes effect without an
+/// app restart.
+enum RipgrepResolver {
+    /// Order matters: Homebrew/MacPorts/system precedence is preserved (existing
+    /// behavior), then Nix-darwin profile paths added for #3657. Touching this
+    /// order changes which `rg` users with multiple installs end up running.
+    static func defaultCommonPaths(userName: String = NSUserName()) -> [String] {
+        return [
+            "/opt/homebrew/bin/rg",
+            "/usr/local/bin/rg",
+            "/usr/bin/rg",
+            "/opt/local/bin/rg",
+            "/etc/profiles/per-user/\(userName)/bin/rg",
+            "/run/current-system/sw/bin/rg",
+            "/nix/var/nix/profiles/default/bin/rg",
+        ]
+    }
+
+    /// Resolve the rg binary, or `nil` if none is found.
+    ///
+    /// - Parameters:
+    ///   - customPath: Override for `automation.ripgrepBinaryPath`. Defaults to
+    ///     the value persisted in standard `UserDefaults`. Pass `nil` explicitly
+    ///     to bypass the setting (used by tests).
+    ///   - commonPaths: Override for the hardcoded fallback list (used by tests).
+    ///   - environment: Override for the process environment (used by tests).
+    ///   - fileManager: Override for the file manager (used by tests).
+    static func resolve(
+        customPath: String? = RipgrepIntegrationSettings.customRipgrepPath(),
+        commonPaths: [String] = RipgrepResolver.defaultCommonPaths(),
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        fileManager: FileManager = .default
+    ) -> String? {
+        if let customPath {
+            if fileManager.isExecutableFile(atPath: customPath) {
+                return customPath
+            }
+            // Configured but not executable. Log and fall through to the
+            // common paths so a stale/typo'd setting doesn't completely
+            // disable Find when a valid binary still exists in a default
+            // location.
+            NSLog(
+                "[RipgrepResolver] automation.ripgrepBinaryPath '%@' is not executable; falling back to common locations",
+                customPath
+            )
+        }
+        for path in commonPaths where fileManager.isExecutableFile(atPath: path) {
+            return path
+        }
+        if let pathValue = environment["PATH"] {
+            for directory in pathValue.split(separator: ":", omittingEmptySubsequences: true) {
+                let candidate = String(directory) + "/rg"
+                if fileManager.isExecutableFile(atPath: candidate) {
+                    return candidate
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/RipgrepResolver.swift
+++ b/Sources/RipgrepResolver.swift
@@ -1,4 +1,5 @@
 import Foundation
+import os
 
 /// Mirrors `ClaudeCodeIntegrationSettings.customClaudePath` for `rg`. Lets users
 /// on Nix / asdf / non-standard installs point cmux at their ripgrep directly,
@@ -13,6 +14,33 @@ enum RipgrepIntegrationSettings {
         return value.isEmpty ? nil : value
     }
 }
+
+private let ripgrepResolverLogger = Logger(
+    subsystem: "com.cmuxterm.app",
+    category: "RipgrepResolver"
+)
+
+/// Per-process dedupe so a stuck-misconfigured `automation.ripgrepBinaryPath`
+/// can't spam unified logging once per Find keystroke. Each unique invalid
+/// path is logged at most once per process launch.
+private final class InvalidPathLogTracker: @unchecked Sendable {
+    private let lock = NSLock()
+    private var loggedPaths: Set<String> = []
+
+    func recordIfFirstSeen(_ path: String) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return loggedPaths.insert(path).inserted
+    }
+
+    func reset() {
+        lock.lock()
+        defer { lock.unlock() }
+        loggedPaths.removeAll()
+    }
+}
+
+private let ripgrepInvalidPathTracker = InvalidPathLogTracker()
 
 /// Resolves the absolute path to `rg`, honoring `automation.ripgrepBinaryPath`
 /// first, then a fallback list of common install locations, then `$PATH`.
@@ -34,15 +62,6 @@ enum RipgrepResolver {
         ]
     }
 
-    /// Resolve the rg binary, or `nil` if none is found.
-    ///
-    /// - Parameters:
-    ///   - customPath: Override for `automation.ripgrepBinaryPath`. Defaults to
-    ///     the value persisted in standard `UserDefaults`. Pass `nil` explicitly
-    ///     to bypass the setting (used by tests).
-    ///   - commonPaths: Override for the hardcoded fallback list (used by tests).
-    ///   - environment: Override for the process environment (used by tests).
-    ///   - fileManager: Override for the file manager (used by tests).
     static func resolve(
         customPath: String? = RipgrepIntegrationSettings.customRipgrepPath(),
         commonPaths: [String] = RipgrepResolver.defaultCommonPaths(),
@@ -53,14 +72,14 @@ enum RipgrepResolver {
             if fileManager.isExecutableFile(atPath: customPath) {
                 return customPath
             }
-            // Configured but not executable. Log and fall through to the
-            // common paths so a stale/typo'd setting doesn't completely
-            // disable Find when a valid binary still exists in a default
-            // location.
-            NSLog(
-                "[RipgrepResolver] automation.ripgrepBinaryPath '%@' is not executable; falling back to common locations",
-                customPath
-            )
+            // Configured-but-not-executable falls through to the common paths
+            // so a stale/typo'd setting doesn't completely disable Find when a
+            // valid binary still exists in a default location.
+            if ripgrepInvalidPathTracker.recordIfFirstSeen(customPath) {
+                ripgrepResolverLogger.warning(
+                    "automation.ripgrepBinaryPath '\(customPath, privacy: .public)' is not executable; falling back to common locations"
+                )
+            }
         }
         for path in commonPaths where fileManager.isExecutableFile(atPath: path) {
             return path
@@ -74,5 +93,11 @@ enum RipgrepResolver {
             }
         }
         return nil
+    }
+
+    /// Reset the dedupe tracker. Tests use this to assert per-call logging
+    /// behavior; production callers don't need it.
+    static func resetInvalidPathLogTrackerForTesting() {
+        ripgrepInvalidPathTracker.reset()
     }
 }

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1210,7 +1210,7 @@ final class SessionIndexStore: ObservableObject {
     /// Re-resolves on each call so a change to `automation.ripgrepBinaryPath`
     /// takes effect without an app restart. nil when no rg binary is found —
     /// the search code falls back to the Foundation substring scan.
-    nonisolated private static var cachedRipgrepPath: String? {
+    nonisolated private static var resolvedRipgrepPath: String? {
         RipgrepResolver.resolve()
     }
 
@@ -1226,7 +1226,7 @@ final class SessionIndexStore: ObservableObject {
     nonisolated static func ripgrepMatchingPaths(
         needle: String, root: String, fileGlob: String
     ) async -> [URL]? {
-        guard let rg = cachedRipgrepPath else { return nil }
+        guard let rg = resolvedRipgrepPath else { return nil }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: rg)
         process.arguments = [

--- a/Sources/SessionIndexStore.swift
+++ b/Sources/SessionIndexStore.swift
@@ -1207,27 +1207,12 @@ final class SessionIndexStore: ObservableObject {
         }
     }
 
-    /// Path to `rg` (ripgrep), if installed. Resolved once. nil when not found —
+    /// Re-resolves on each call so a change to `automation.ripgrepBinaryPath`
+    /// takes effect without an app restart. nil when no rg binary is found —
     /// the search code falls back to the Foundation substring scan.
-    nonisolated private static let cachedRipgrepPath: String? = {
-        let fm = FileManager.default
-        let common = [
-            "/opt/homebrew/bin/rg",
-            "/usr/local/bin/rg",
-            "/usr/bin/rg",
-            "/opt/local/bin/rg",
-        ]
-        for path in common where fm.isExecutableFile(atPath: path) {
-            return path
-        }
-        if let pathEnv = ProcessInfo.processInfo.environment["PATH"] {
-            for dir in pathEnv.split(separator: ":") {
-                let full = String(dir) + "/rg"
-                if fm.isExecutableFile(atPath: full) { return full }
-            }
-        }
-        return nil
-    }()
+    nonisolated private static var cachedRipgrepPath: String? {
+        RipgrepResolver.resolve()
+    }
 
     /// Run `rg --files-with-matches --ignore-case --fixed-strings` for `needle`
     /// under `root`, restricted to `glob` (e.g. `*.jsonl`). Returns matched file

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -420,6 +420,7 @@ enum SettingsSearchIndex {
         "automation.socketPassword": settingID(for: .automation, idSuffix: "socket-password"),
         "automation.claudeCodeIntegration": settingID(for: .automation, idSuffix: "claude-code"),
         "automation.claudeBinaryPath": settingID(for: .automation, idSuffix: "claude-path"),
+        "automation.ripgrepBinaryPath": settingID(for: .automation, idSuffix: "ripgrep-path"),
         "automation.cursorIntegration": settingID(for: .automation, idSuffix: "cursor"),
         "automation.geminiIntegration": settingID(for: .automation, idSuffix: "gemini"),
         "automation.portBase": settingID(for: .automation, idSuffix: "port-base"),

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -334,6 +334,7 @@ enum SettingsSearchIndex {
         setting(.automation, "socket-password", String(localized: "settings.automation.socketPassword", defaultValue: "Socket Password"), "socket auth credential"),
         setting(.automation, "claude-code", String(localized: "settings.automation.claudeCode", defaultValue: "Claude Code Integration"), "agent hooks notifications"),
         setting(.automation, "claude-path", String(localized: "settings.automation.claudeCode.customPath", defaultValue: "Claude Binary Path"), "custom claude executable"),
+        setting(.automation, "ripgrep-path", String(localized: "settings.automation.ripgrep.customPath", defaultValue: "Ripgrep Binary Path"), "ripgrep rg find search executable nix custom"),
         setting(.automation, "cursor", String(localized: "settings.automation.cursor", defaultValue: "Cursor Integration"), "agent hooks notifications"),
         setting(.automation, "gemini", String(localized: "settings.automation.gemini", defaultValue: "Gemini CLI Integration"), "agent hooks notifications"),
         setting(.automation, "port-base", String(localized: "settings.automation.portBase", defaultValue: "Port Base"), "CMUX_PORT start"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -83,6 +83,7 @@ enum SettingsSearchAliasIndex {
         "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),
         "automation:claude-code": localized("settings.search.alias.setting.automation.claude-code", defaultValue: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),
         "automation:claude-path": localized("settings.search.alias.setting.automation.claude-path", defaultValue: "automation.claudeBinaryPath claude binary executable path cli command custom"),
+        "automation:ripgrep-path": localized("settings.search.alias.setting.automation.ripgrep-path", defaultValue: "automation.ripgrepBinaryPath ripgrep rg binary executable path find search nix custom"),
         "automation:cursor": localized("settings.search.alias.setting.automation.cursor", defaultValue: "automation.cursorIntegration cursor ide agent hooks notifications"),
         "automation:gemini": localized("settings.search.alias.setting.automation.gemini", defaultValue: "automation.geminiIntegration gemini cli google agent hooks notifications"),
         "automation:port-base": localized("settings.search.alias.setting.automation.port-base", defaultValue: "automation.portBase cmux_port start first base env environment variable"),

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5090,6 +5090,8 @@ struct SettingsView: View {
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
     @AppStorage(ClaudeCodeIntegrationSettings.customClaudePathKey)
     private var customClaudePath = ""
+    @AppStorage(RipgrepIntegrationSettings.customRipgrepPathKey)
+    private var customRipgrepPath = ""
     @AppStorage(CursorIntegrationSettings.hooksEnabledKey)
     private var cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
     @AppStorage(GeminiIntegrationSettings.hooksEnabledKey)
@@ -6525,6 +6527,21 @@ struct SettingsView: View {
 
                     SettingsCard {
                         SettingsCardRow(
+                            configurationReview: .json("automation.ripgrepBinaryPath"),
+                            String(localized: "settings.automation.ripgrep.customPath", defaultValue: "Ripgrep Binary Path"),
+                            subtitle: String(localized: "settings.automation.ripgrep.customPath.subtitle", defaultValue: "Custom path to the rg (ripgrep) binary used by Find. Leave empty to auto-detect.")
+                        ) {
+                            TextField(
+                                String(localized: "settings.automation.ripgrep.customPath.placeholder", defaultValue: "e.g. /opt/homebrew/bin/rg"),
+                                text: $customRipgrepPath
+                            )
+                            .textFieldStyle(.roundedBorder)
+                            .frame(width: 200)
+                        }
+                    }
+
+                    SettingsCard {
+                        SettingsCardRow(
                             configurationReview: .json("automation.cursorIntegration"),
                             String(localized: "settings.automation.cursor", defaultValue: "Cursor Integration"),
                             subtitle: cursorHooksEnabled
@@ -7320,6 +7337,7 @@ struct SettingsView: View {
         socketControlMode = SocketControlSettings.defaultMode.rawValue
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
         customClaudePath = ""
+        customRipgrepPath = ""
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled
         geminiHooksEnabled = GeminiIntegrationSettings.defaultHooksEnabled
         sendAnonymousTelemetry = TelemetrySettings.defaultSendAnonymousTelemetry

--- a/cmuxTests/RipgrepResolverTests.swift
+++ b/cmuxTests/RipgrepResolverTests.swift
@@ -1,0 +1,170 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class RipgrepResolverTests: XCTestCase {
+    private var tempDirectory: URL!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RipgrepResolverTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempDirectory,
+            withIntermediateDirectories: true
+        )
+    }
+
+    override func tearDownWithError() throws {
+        if let tempDirectory {
+            try? FileManager.default.removeItem(at: tempDirectory)
+        }
+        tempDirectory = nil
+        try super.tearDownWithError()
+    }
+
+    func testResolvePrefersCustomPathWhenExecutable() throws {
+        let custom = try makeExecutableStub(named: "rg-custom")
+        let resolved = RipgrepResolver.resolve(
+            customPath: custom.path,
+            commonPaths: [],
+            environment: [:]
+        )
+        XCTAssertEqual(resolved, custom.path)
+    }
+
+    func testResolveFallsThroughWhenCustomPathIsNotExecutable() throws {
+        let fallback = try makeExecutableStub(named: "rg-fallback")
+        let bogus = tempDirectory.appendingPathComponent("nonexistent-rg").path
+
+        let resolved = RipgrepResolver.resolve(
+            customPath: bogus,
+            commonPaths: [fallback.path],
+            environment: [:]
+        )
+
+        XCTAssertEqual(
+            resolved,
+            fallback.path,
+            "A configured-but-missing custom path must fall back to common paths so Find still works"
+        )
+    }
+
+    func testResolveUsesCommonPathsWhenNoCustomPathConfigured() throws {
+        let nixStyle = try makeExecutableStub(
+            named: "rg",
+            inSubdirectory: "etc/profiles/per-user/example/bin"
+        )
+
+        let resolved = RipgrepResolver.resolve(
+            customPath: nil,
+            commonPaths: [nixStyle.path],
+            environment: [:]
+        )
+
+        XCTAssertEqual(resolved, nixStyle.path)
+    }
+
+    func testResolveFallsBackToPathEnvironmentWhenCommonPathsMiss() throws {
+        let pathDir = tempDirectory.appendingPathComponent("custom-bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: pathDir, withIntermediateDirectories: true)
+        let stub = try makeExecutableStub(named: "rg", in: pathDir)
+
+        let resolved = RipgrepResolver.resolve(
+            customPath: nil,
+            commonPaths: [],
+            environment: ["PATH": pathDir.path]
+        )
+
+        XCTAssertEqual(resolved, stub.path)
+    }
+
+    func testResolveReturnsNilWhenNothingMatches() {
+        let resolved = RipgrepResolver.resolve(
+            customPath: nil,
+            commonPaths: [tempDirectory.appendingPathComponent("missing-rg").path],
+            environment: ["PATH": tempDirectory.appendingPathComponent("missing-bin").path]
+        )
+        XCTAssertNil(resolved)
+    }
+
+    func testDefaultCommonPathsIncludesNixDarwinProfilePaths() {
+        let paths = RipgrepResolver.defaultCommonPaths(userName: "alice")
+        XCTAssertTrue(
+            paths.contains("/etc/profiles/per-user/alice/bin/rg"),
+            "Per-user nix-darwin profile path must be present (#3657)"
+        )
+        XCTAssertTrue(
+            paths.contains("/run/current-system/sw/bin/rg"),
+            "nix-darwin system path must be present (#3657)"
+        )
+        XCTAssertTrue(
+            paths.contains("/nix/var/nix/profiles/default/bin/rg"),
+            "Single-user Nix profile path must be present (#3657)"
+        )
+    }
+
+    func testDefaultCommonPathsPreservesHomebrewPrecedenceBeforeNixPaths() {
+        let paths = RipgrepResolver.defaultCommonPaths(userName: "alice")
+        guard let homebrewIndex = paths.firstIndex(of: "/opt/homebrew/bin/rg"),
+              let nixUserIndex = paths.firstIndex(of: "/etc/profiles/per-user/alice/bin/rg") else {
+            XCTFail("Expected both Homebrew and nix-darwin paths in default list")
+            return
+        }
+        XCTAssertLessThan(
+            homebrewIndex,
+            nixUserIndex,
+            "Homebrew must keep precedence so existing users aren't silently switched to a nix rg"
+        )
+    }
+
+    func testCustomRipgrepPathSettingTrimsWhitespaceAndIgnoresEmpty() {
+        let suiteName = "RipgrepResolverTests.\(UUID().uuidString)"
+        guard let defaults = UserDefaults(suiteName: suiteName) else {
+            XCTFail("Failed to create isolated UserDefaults suite")
+            return
+        }
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set("   ", forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+        XCTAssertNil(RipgrepIntegrationSettings.customRipgrepPath(defaults: defaults))
+
+        defaults.set("  /opt/homebrew/bin/rg  ", forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+        XCTAssertEqual(
+            RipgrepIntegrationSettings.customRipgrepPath(defaults: defaults),
+            "/opt/homebrew/bin/rg"
+        )
+
+        defaults.removeObject(forKey: RipgrepIntegrationSettings.customRipgrepPathKey)
+        XCTAssertNil(RipgrepIntegrationSettings.customRipgrepPath(defaults: defaults))
+    }
+
+    private func makeExecutableStub(
+        named name: String,
+        inSubdirectory subdirectory: String? = nil,
+        in parent: URL? = nil
+    ) throws -> URL {
+        let baseDirectory = parent ?? tempDirectory!
+        let containingDirectory: URL
+        if let subdirectory {
+            containingDirectory = baseDirectory.appendingPathComponent(subdirectory, isDirectory: true)
+            try FileManager.default.createDirectory(
+                at: containingDirectory,
+                withIntermediateDirectories: true
+            )
+        } else {
+            containingDirectory = baseDirectory
+        }
+        let url = containingDirectory.appendingPathComponent(name, isDirectory: false)
+        FileManager.default.createFile(
+            atPath: url.path,
+            contents: Data("#!/bin/sh\nexit 0\n".utf8),
+            attributes: [.posixPermissions: 0o755]
+        )
+        return url
+    }
+}

--- a/cmuxTests/RipgrepResolverTests.swift
+++ b/cmuxTests/RipgrepResolverTests.swift
@@ -92,6 +92,28 @@ final class RipgrepResolverTests: XCTestCase {
         XCTAssertNil(resolved)
     }
 
+    func testResolveRejectsDirectoryWithExecuteBit() throws {
+        let directoryNamedRg = tempDirectory.appendingPathComponent("rg-dir-as-binary", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryNamedRg, withIntermediateDirectories: true)
+        XCTAssertTrue(
+            FileManager.default.isExecutableFile(atPath: directoryNamedRg.path),
+            "Sanity check: a freshly created directory has the search/execute bit set, so isExecutableFile returns true; the resolver must filter via fileExists(atPath:isDirectory:)"
+        )
+
+        let realBinary = try makeExecutableStub(named: "rg-real")
+        let resolved = RipgrepResolver.resolve(
+            customPath: directoryNamedRg.path,
+            commonPaths: [realBinary.path],
+            environment: [:]
+        )
+
+        XCTAssertEqual(
+            resolved,
+            realBinary.path,
+            "A directory at the configured path must be rejected so the resolver falls back to the real executable"
+        )
+    }
+
     func testDefaultCommonPathsIncludesNixDarwinProfilePaths() {
         let paths = RipgrepResolver.defaultCommonPaths(userName: "alice")
         XCTAssertTrue(

--- a/cmuxTests/SettingsSearchIndexTests.swift
+++ b/cmuxTests/SettingsSearchIndexTests.swift
@@ -16,6 +16,8 @@ final class SettingsSearchIndexTests: XCTestCase {
         assertSearch("disable browser", contains: SettingsSearchIndex.settingID(for: .browser, idSuffix: "enable-browser"))
         assertSearch("http allowlist", contains: SettingsSearchIndex.settingID(for: .browser, idSuffix: "http-allowlist"))
         assertSearch("claude executable", contains: SettingsSearchIndex.settingID(for: .automation, idSuffix: "claude-path"))
+        assertSearch("ripgrep nix", contains: SettingsSearchIndex.settingID(for: .automation, idSuffix: "ripgrep-path"))
+        assertSearch("rg binary", contains: SettingsSearchIndex.settingID(for: .automation, idSuffix: "ripgrep-path"))
         assertSearch("resume on reopen", contains: SettingsSearchIndex.settingID(for: .terminal, idSuffix: "agent-auto-resume"))
         assertSearch("claude sessions", contains: SettingsSearchIndex.settingID(for: .terminal, idSuffix: "agent-auto-resume"))
         assertSearch("opencode resume", contains: SettingsSearchIndex.settingID(for: .terminal, idSuffix: "agent-auto-resume"))
@@ -35,6 +37,13 @@ final class SettingsSearchIndexTests: XCTestCase {
         XCTAssertEqual(
             SettingsSearchIndex.anchorID(forSettingsPath: "terminal.autoResumeAgentSessions"),
             SettingsSearchIndex.settingID(for: .terminal, idSuffix: "agent-auto-resume")
+        )
+    }
+
+    func testSettingsPathAnchorIncludesRipgrepBinaryPath() {
+        XCTAssertEqual(
+            SettingsSearchIndex.anchorID(forSettingsPath: "automation.ripgrepBinaryPath"),
+            SettingsSearchIndex.settingID(for: .automation, idSuffix: "ripgrep-path")
         )
     }
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -595,6 +595,11 @@
           "default": "",
           "description": "Custom path to the claude binary."
         },
+        "ripgrepBinaryPath": {
+          "type": "string",
+          "default": "",
+          "description": "Custom path to the rg (ripgrep) binary used by Find. Leave empty to auto-detect from common install locations and PATH."
+        },
         "cursorIntegration": {
           "type": "boolean",
           "default": true,


### PR DESCRIPTION
Closes #3657.

## Summary

cmux's project-search ("Find") was failing on Nix-managed macOS installs because `rg` lives in a nix profile path that wasn't in cmux's hardcoded fallback list, and Dock-launched macOS apps don't reliably inherit `launchctl setenv PATH`. Picked up after the reporter mentioned PR intent.

## Changes

Two complementary fixes per the issue:

1. **New `automation.ripgrepBinaryPath` setting** — mirrors the existing `automation.claudeBinaryPath`. Editable from `Settings > Automation` and from `~/.config/cmux/cmux.json`. Highest-leverage fix for non-standard installs (Nix, asdf, custom locations).

2. **Extended hardcoded fallback list** with common nix-darwin profile paths so single-install Nix users work out of the box without touching settings:
   - `/etc/profiles/per-user/$USER/bin/rg`
   - `/run/current-system/sw/bin/rg`
   - `/nix/var/nix/profiles/default/bin/rg`

## Resolution order

`RipgrepResolver.resolve()` (new shared helper used by both `FileExplorerSearchController` and `SessionIndexStore`) checks in order:

1. `automation.ripgrepBinaryPath` setting, if configured and executable
2. Common install paths (Homebrew/MacPorts/system → nix-darwin profiles)
3. `\$PATH` lookup (best-effort)

Existing Homebrew/MacPorts/system precedence is preserved so users with multiple installs aren't silently switched to a different `rg`. A configured-but-not-executable custom path logs and falls through to the fallback list rather than hard-failing — a stale typo'd setting shouldn't completely break Find when a valid binary still exists in a default location.

The resolver re-evaluates on every call (replacing `SessionIndexStore.cachedRipgrepPath` which was a `static let` that locked to first resolution), so a settings change takes effect immediately without an app restart.

## Files

- **New:** `Sources/RipgrepResolver.swift` — shared resolver + `RipgrepIntegrationSettings` accessors
- **New:** `cmuxTests/RipgrepResolverTests.swift` — 8 unit tests covering custom path / fallback / env / nix path inclusion / Homebrew precedence / setting trim semantics
- **Modified:** `Sources/FileExplorerSearchController.swift`, `Sources/SessionIndexStore.swift` — both call sites now delegate to `RipgrepResolver.resolve()`
- **Modified:** `Sources/cmuxApp.swift` — new `SettingsCard` row, `@AppStorage`, reset binding
- **Modified:** `Sources/KeyboardShortcutSettingsFileStore.swift` — JSON parser, supported settings paths, default template
- **Modified:** `Sources/SettingsNavigation.swift`, `Sources/SettingsSearchAliases.swift` — settings discovery / search
- **Modified:** `web/data/cmux.schema.json` — schema entry
- **Modified:** `Resources/Localizable.xcstrings` — en/ja/ko translations for the 3 new UI strings

## Verification

- `xcodebuild -scheme cmux-unit -only-testing:cmuxTests/RipgrepResolverTests` — **8/8 passing locally** (covers custom path priority, fallthrough on bad path, common-paths fallback, \$PATH fallback, nil terminus, nix path inclusion, Homebrew precedence preservation, setting trim/empty handling)
- `./scripts/reload.sh --tag fix-ripgrep-binary-path-3657` — Debug app builds clean
- LSP diagnostics clean across all touched files
- JSON schema and Localizable.xcstrings parse cleanly

## Notes for reviewers

- Per cmux test policy, no source-text/grep-style tests were added; unit tests verify observable runtime behavior of the resolver via injected `customPath` / `commonPaths` / `environment` / `fileManager` overrides.
- Setting names match the issue's request exactly (`automation.ripgrepBinaryPath`).
- Reporter is on macOS Apple Silicon + ripgrep 15.1.0 via nix-darwin; would be ideal to have them validate the merged build.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new `automation.ripgrepBinaryPath` setting and a shared `RipgrepResolver` with nix-darwin fallback paths so Find works on Nix-managed macOS (fixes #3657). Tightens resolution to accept only executable files, dedupes invalid-path logging, and re-resolves on each call.

- **New Features**
  - Added `automation.ripgrepBinaryPath` (Settings > Automation and `~/.config/cmux/cmux.json`), searchable via Settings (en/ja/ko aliases).
  - Introduced `RipgrepResolver` used by Find: setting → common paths (Homebrew/MacPorts/system → nix-darwin) → `$PATH`, re-evaluated on each call.

- **Bug Fixes**
  - Rejects directories misidentified as executables; only returns a real executable file.
  - Invalid custom path now logs via `os.Logger` once per process and falls back to common locations/`$PATH` instead of failing.

<sup>Written for commit ffe884203967829512fda3395cdd6315270d40d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Automation setting to specify a custom ripgrep (rg) binary path, editable in Settings and cleared by "Reset All Settings".
  * Settings search and navigation now include a "Ripgrep Binary Path" entry.

* **Behavior**
  * Custom path takes effect immediately; app falls back to auto-detection when unset or invalid.

* **Localization**
  * Added English, Japanese, Korean, and Ukrainian strings for the new setting and search aliases.

* **Tests**
  * Added unit tests covering resolution precedence and settings behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->