### PR TITLE
Suppress permission notifications when hook auto-allows within grace period

### DIFF
--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -25,6 +25,14 @@ final class FeedCoordinator: @unchecked Sendable {
     /// handler signals the semaphore after filling the slot.
     private let waiterLock = NSLock()
     private var waiters: [String: PendingWaiter] = [:]
+    private var pendingNotifications: [String: DispatchWorkItem] = [:]
+
+    /// How long to wait before posting a native notification banner.
+    /// Overridden in tests to a small value so tests don't take 500 ms.
+    nonisolated(unsafe) var notificationGraceDelay: TimeInterval = 0.5
+
+    /// Overrides the notification posting function in unit tests.
+    nonisolated(unsafe) var notificationPosterForTesting: ((WorkstreamEvent, String) -> Void)?
 
     /// One kqueue-backed DispatchSource per distinct agent PID we've
     /// ever seen. The kernel fires `.exit` the instant the process
@@ -124,7 +132,10 @@ final class FeedCoordinator: @unchecked Sendable {
         // If this is a blocking actionable event and the app window isn't
         // focused, post a native notification banner with inline action
         // buttons so the user can respond without switching windows.
-        postFeedNotification(event: event, requestId: requestId)
+        let poster = notificationPosterForTesting ?? postFeedNotification
+        DispatchQueue.main.async {
+            poster(event, requestId)
+        }
 
         let deadline: DispatchTime = .now() + waitTimeout
         let waitResult = semaphore.wait(timeout: deadline)

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -132,16 +132,26 @@ final class FeedCoordinator: @unchecked Sendable {
         // If this is a blocking actionable event and the app window isn't
         // focused, post a native notification banner with inline action
         // buttons so the user can respond without switching windows.
+        // Delay by the grace period so that hooks that auto-resolve the
+        // request (e.g. a PermissionRequest hook that returns "allow"
+        // immediately) have a chance to call deliverReply and cancel the
+        // work item before the notification ever fires.
         let poster = notificationPosterForTesting ?? postFeedNotification
-        DispatchQueue.main.async {
+        let delay = notificationGraceDelay
+        let notifyWork = DispatchWorkItem {
             poster(event, requestId)
         }
+        waiterLock.lock()
+        pendingNotifications[requestId] = notifyWork
+        waiterLock.unlock()
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: notifyWork)
 
         let deadline: DispatchTime = .now() + waitTimeout
         let waitResult = semaphore.wait(timeout: deadline)
 
         waiterLock.lock()
         let w = waiters.removeValue(forKey: requestId)
+        pendingNotifications.removeValue(forKey: requestId)
         waiterLock.unlock()
 
         switch waitResult {
@@ -165,6 +175,7 @@ final class FeedCoordinator: @unchecked Sendable {
             waiter.decision = decision
             waiter.semaphore.signal()
         }
+        pendingNotifications.removeValue(forKey: requestId)?.cancel()
         waiterLock.unlock()
 
         let resolve: @Sendable () -> Void = { [requestId, decision] in

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -27,7 +27,12 @@ final class FeedCoordinator: @unchecked Sendable {
     private var waiters: [String: PendingWaiter] = [:]
     /// Request IDs whose notification should be suppressed when the grace-period
     /// timer fires — populated by deliverReply and the timeout-cleanup path.
-    private var suppressedNotificationIds: Set<String> = []
+    /// Generation counter per request ID. The asyncAfter closure captures its
+    /// generation at scheduling time and fires only when the entry still matches.
+    /// deliverReply and the timeout-cleanup path remove the entry to suppress the
+    /// notification. The dict is bounded: every entry is removed by whichever of
+    /// the three paths (timer, deliverReply, timeout) runs first.
+    private var notificationGenerations: [String: Int] = [:]
 
     private let notificationPoster: (WorkstreamEvent, String) -> Void
     private let notificationGraceDelay: TimeInterval
@@ -146,14 +151,17 @@ final class FeedCoordinator: @unchecked Sendable {
         // request (e.g. a PermissionRequest hook that returns "allow"
         // immediately) have a chance to call deliverReply and cancel the
         // work item before the notification ever fires.
+        waiterLock.lock()
+        let gen = (notificationGenerations[requestId] ?? 0) + 1
+        notificationGenerations[requestId] = gen
+        waiterLock.unlock()
         DispatchQueue.main.asyncAfter(deadline: .now() + notificationGraceDelay) { [weak self] in
             guard let self else { return }
             self.waiterLock.lock()
-            let suppressed = self.suppressedNotificationIds.remove(requestId) != nil
+            let shouldFire = self.notificationGenerations[requestId] == gen
+            if shouldFire { self.notificationGenerations.removeValue(forKey: requestId) }
             self.waiterLock.unlock()
-            if !suppressed {
-                self.notificationPoster(event, requestId)
-            }
+            if shouldFire { self.notificationPoster(event, requestId) }
         }
 
         let deadline: DispatchTime = .now() + waitTimeout
@@ -161,7 +169,7 @@ final class FeedCoordinator: @unchecked Sendable {
 
         waiterLock.lock()
         let w = waiters.removeValue(forKey: requestId)
-        suppressedNotificationIds.insert(requestId)
+        notificationGenerations.removeValue(forKey: requestId)
         waiterLock.unlock()
 
         switch waitResult {
@@ -185,7 +193,7 @@ final class FeedCoordinator: @unchecked Sendable {
             waiter.decision = decision
             waiter.semaphore.signal()
         }
-        suppressedNotificationIds.insert(requestId)
+        notificationGenerations.removeValue(forKey: requestId)
         waiterLock.unlock()
 
         let resolve: @Sendable () -> Void = { [requestId, decision] in

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -25,14 +25,12 @@ final class FeedCoordinator: @unchecked Sendable {
     /// handler signals the semaphore after filling the slot.
     private let waiterLock = NSLock()
     private var waiters: [String: PendingWaiter] = [:]
-    private var pendingNotifications: [String: DispatchWorkItem] = [:]
+    /// Request IDs whose notification should be suppressed when the grace-period
+    /// timer fires — populated by deliverReply and the timeout-cleanup path.
+    private var suppressedNotificationIds: Set<String> = []
 
-    /// How long to wait before posting a native notification banner.
-    /// Overridden in tests to a small value so tests don't take 500 ms.
-    nonisolated(unsafe) var notificationGraceDelay: TimeInterval = 0.5
-
-    /// Overrides the notification posting function in unit tests.
-    nonisolated(unsafe) var notificationPosterForTesting: ((WorkstreamEvent, String) -> Void)?
+    private let notificationPoster: (WorkstreamEvent, String) -> Void
+    private let notificationGraceDelay: TimeInterval
 
     /// One kqueue-backed DispatchSource per distinct agent PID we've
     /// ever seen. The kernel fires `.exit` the instant the process
@@ -45,7 +43,19 @@ final class FeedCoordinator: @unchecked Sendable {
         label: "cmux.feed.pidWatcher", qos: .utility
     )
 
-    private init() {}
+    private init() {
+        self.notificationPoster = postFeedNotification
+        self.notificationGraceDelay = 0.5
+    }
+
+    /// For tests: inject a custom poster and/or a shorter grace delay.
+    init(
+        notificationPoster: @escaping (WorkstreamEvent, String) -> Void,
+        notificationGraceDelay: TimeInterval = 0.5
+    ) {
+        self.notificationPoster = notificationPoster
+        self.notificationGraceDelay = notificationGraceDelay
+    }
 
     /// Must be called once at app launch to install the store.
     @MainActor
@@ -94,11 +104,11 @@ final class FeedCoordinator: @unchecked Sendable {
         waitTimeout: TimeInterval
     ) -> IngestBlockingResult {
         guard let requestId = event.requestId, waitTimeout > 0 else {
-            DispatchQueue.main.async {
-                MainActor.assumeIsolated {
-                    FeedCoordinator.shared.store.ingest(event)
+            DispatchQueue.main.async { [weak self] in
+                MainActor.assumeIsolated { [weak self] in
+                    self?.store.ingest(event)
                     if let ppid = event.ppid, ppid > 0 {
-                        FeedCoordinator.shared.armPidWatcher(ppid: ppid)
+                        self?.armPidWatcher(ppid: ppid)
                     }
                 }
             }
@@ -120,11 +130,11 @@ final class FeedCoordinator: @unchecked Sendable {
         // — no polling, no leaked cards when the agent is killed.
         let itemIdSlot = UnsafeItemIdSlot()
         DispatchQueue.main.sync {
-            MainActor.assumeIsolated {
-                FeedCoordinator.shared.store.ingest(event)
-                itemIdSlot.value = FeedCoordinator.shared.store.items.last?.id
+            MainActor.assumeIsolated { [self] in
+                self.store.ingest(event)
+                itemIdSlot.value = self.store.items.last?.id
                 if let ppid = event.ppid, ppid > 0 {
-                    FeedCoordinator.shared.armPidWatcher(ppid: ppid)
+                    self.armPidWatcher(ppid: ppid)
                 }
             }
         }
@@ -136,22 +146,22 @@ final class FeedCoordinator: @unchecked Sendable {
         // request (e.g. a PermissionRequest hook that returns "allow"
         // immediately) have a chance to call deliverReply and cancel the
         // work item before the notification ever fires.
-        let poster = notificationPosterForTesting ?? postFeedNotification
-        let delay = notificationGraceDelay
-        let notifyWork = DispatchWorkItem {
-            poster(event, requestId)
+        DispatchQueue.main.asyncAfter(deadline: .now() + notificationGraceDelay) { [weak self] in
+            guard let self else { return }
+            self.waiterLock.lock()
+            let suppressed = self.suppressedNotificationIds.remove(requestId) != nil
+            self.waiterLock.unlock()
+            if !suppressed {
+                self.notificationPoster(event, requestId)
+            }
         }
-        waiterLock.lock()
-        pendingNotifications[requestId] = notifyWork
-        waiterLock.unlock()
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: notifyWork)
 
         let deadline: DispatchTime = .now() + waitTimeout
         let waitResult = semaphore.wait(timeout: deadline)
 
         waiterLock.lock()
         let w = waiters.removeValue(forKey: requestId)
-        pendingNotifications.removeValue(forKey: requestId)
+        suppressedNotificationIds.insert(requestId)
         waiterLock.unlock()
 
         switch waitResult {
@@ -175,7 +185,7 @@ final class FeedCoordinator: @unchecked Sendable {
             waiter.decision = decision
             waiter.semaphore.signal()
         }
-        pendingNotifications.removeValue(forKey: requestId)?.cancel()
+        suppressedNotificationIds.insert(requestId)
         waiterLock.unlock()
 
         let resolve: @Sendable () -> Void = { [requestId, decision] in

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -196,10 +196,9 @@ final class FeedCoordinator: @unchecked Sendable {
         notificationGenerations.removeValue(forKey: requestId)
         waiterLock.unlock()
 
-        let resolve: @Sendable () -> Void = { [requestId, decision] in
+        let resolve: @Sendable () -> Void = { [weak self, requestId, decision] in
             MainActor.assumeIsolated {
-                let store = FeedCoordinator.shared.store
-                guard let store else { return }
+                guard let store = self?.store else { return }
                 if let itemId = Self.findItemId(for: requestId, in: store.items) {
                     store.markResolved(itemId, decision: decision)
                 }
@@ -233,9 +232,9 @@ final class FeedCoordinator: @unchecked Sendable {
 
     private func expireTimedOutItem(_ itemId: UUID?) {
         guard let itemId else { return }
-        let expire: @Sendable () -> Void = { [itemId] in
+        let expire: @Sendable () -> Void = { [weak self, itemId] in
             MainActor.assumeIsolated {
-                FeedCoordinator.shared.store?.markExpired(itemId)
+                self?.store?.markExpired(itemId)
             }
         }
         if Thread.isMainThread {
@@ -278,9 +277,9 @@ extension FeedCoordinator {
     /// the observable state (only if called off-main).
     func snapshot(pendingOnly: Bool) -> [WorkstreamItem] {
         let slot = SnapshotSlot()
-        let body: @Sendable () -> Void = { [slot] in
+        let body: @Sendable () -> Void = { [self, slot] in
             MainActor.assumeIsolated {
-                guard let store = FeedCoordinator.shared.store else { return }
+                guard let store = self.store else { return }
                 slot.value = pendingOnly ? store.pending : store.items
             }
         }

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -22,6 +22,90 @@ final class FeedCoordinatorTests: XCTestCase {
         XCTAssertFalse(FeedPermissionActionPolicy.supportsBypassPermissions(source: .hermesAgent))
     }
 
+    func testNotificationSuppressedWhenReplyArrivesFast() async {
+        await MainActor.run {
+            FeedCoordinator.shared.install(store: WorkstreamStore(ringCapacity: 10))
+        }
+
+        let notificationFired = DispatchSemaphore(value: 0)
+        FeedCoordinator.shared.notificationGraceDelay = 0.3
+        FeedCoordinator.shared.notificationPosterForTesting = { _, _ in
+            notificationFired.signal()
+        }
+        defer {
+            FeedCoordinator.shared.notificationPosterForTesting = nil
+            FeedCoordinator.shared.notificationGraceDelay = 0.5
+        }
+
+        let event = WorkstreamEvent(
+            sessionId: "notif-suppress-test",
+            hookEventName: .permissionRequest,
+            source: "claude",
+            cwd: "/tmp",
+            toolName: "Bash",
+            toolInputJSON: #"{"command":"true"}"#,
+            requestId: "notif-suppress-request"
+        )
+
+        let done = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = FeedCoordinator.shared.ingestBlocking(event: event, waitTimeout: 5)
+            done.signal()
+        }
+
+        // Reply well within the grace period — notification should be cancelled.
+        Thread.sleep(forTimeInterval: 0.05)
+        FeedCoordinator.shared.deliverReply(
+            requestId: "notif-suppress-request",
+            decision: .permission(.once)
+        )
+
+        XCTAssertEqual(done.wait(timeout: .now() + 2), .success)
+        // Notification must NOT have fired.
+        XCTAssertEqual(notificationFired.wait(timeout: .now() + 0.5), .timedOut,
+            "notification should be suppressed when reply arrives before grace period")
+    }
+
+    func testNotificationFiresWhenNoReplyArrives() async {
+        await MainActor.run {
+            FeedCoordinator.shared.install(store: WorkstreamStore(ringCapacity: 10))
+        }
+
+        let notificationFired = DispatchSemaphore(value: 0)
+        FeedCoordinator.shared.notificationGraceDelay = 0.1
+        FeedCoordinator.shared.notificationPosterForTesting = { _, _ in
+            notificationFired.signal()
+        }
+        defer {
+            FeedCoordinator.shared.notificationPosterForTesting = nil
+            FeedCoordinator.shared.notificationGraceDelay = 0.5
+        }
+
+        let event = WorkstreamEvent(
+            sessionId: "notif-fire-test",
+            hookEventName: .permissionRequest,
+            source: "claude",
+            cwd: "/tmp",
+            toolName: "Bash",
+            toolInputJSON: #"{"command":"true"}"#,
+            requestId: "notif-fire-request"
+        )
+
+        DispatchQueue.global(qos: .userInitiated).async {
+            _ = FeedCoordinator.shared.ingestBlocking(event: event, waitTimeout: 2)
+        }
+
+        // No reply — notification should fire after the grace period.
+        XCTAssertEqual(notificationFired.wait(timeout: .now() + 1), .success,
+            "notification should fire when no reply arrives within grace period")
+
+        // Clean up the pending waiter.
+        FeedCoordinator.shared.deliverReply(
+            requestId: "notif-fire-request",
+            decision: .permission(.once)
+        )
+    }
+
     func testBlockingIngestExpiresItemWhenHookTimesOut() async {
         await MainActor.run {
             let store = WorkstreamStore(ringCapacity: 10)

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -23,18 +23,13 @@ final class FeedCoordinatorTests: XCTestCase {
     }
 
     func testNotificationSuppressedWhenReplyArrivesFast() async {
-        await MainActor.run {
-            FeedCoordinator.shared.install(store: WorkstreamStore(ringCapacity: 10))
-        }
-
         let notificationFired = DispatchSemaphore(value: 0)
-        FeedCoordinator.shared.notificationGraceDelay = 0.3
-        FeedCoordinator.shared.notificationPosterForTesting = { _, _ in
-            notificationFired.signal()
-        }
-        defer {
-            FeedCoordinator.shared.notificationPosterForTesting = nil
-            FeedCoordinator.shared.notificationGraceDelay = 0.5
+        let coordinator = FeedCoordinator(
+            notificationPoster: { _, _ in notificationFired.signal() },
+            notificationGraceDelay: 0.3
+        )
+        await MainActor.run {
+            coordinator.install(store: WorkstreamStore(ringCapacity: 10))
         }
 
         let event = WorkstreamEvent(
@@ -49,36 +44,27 @@ final class FeedCoordinatorTests: XCTestCase {
 
         let done = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .userInitiated).async {
-            _ = FeedCoordinator.shared.ingestBlocking(event: event, waitTimeout: 5)
+            _ = coordinator.ingestBlocking(event: event, waitTimeout: 5)
             done.signal()
         }
 
-        // Reply well within the grace period — notification should be cancelled.
+        // Reply well within the grace period — notification should be suppressed.
         Thread.sleep(forTimeInterval: 0.05)
-        FeedCoordinator.shared.deliverReply(
-            requestId: "notif-suppress-request",
-            decision: .permission(.once)
-        )
+        coordinator.deliverReply(requestId: "notif-suppress-request", decision: .permission(.once))
 
         XCTAssertEqual(done.wait(timeout: .now() + 2), .success)
-        // Notification must NOT have fired.
         XCTAssertEqual(notificationFired.wait(timeout: .now() + 0.5), .timedOut,
             "notification should be suppressed when reply arrives before grace period")
     }
 
     func testNotificationFiresWhenNoReplyArrives() async {
-        await MainActor.run {
-            FeedCoordinator.shared.install(store: WorkstreamStore(ringCapacity: 10))
-        }
-
         let notificationFired = DispatchSemaphore(value: 0)
-        FeedCoordinator.shared.notificationGraceDelay = 0.1
-        FeedCoordinator.shared.notificationPosterForTesting = { _, _ in
-            notificationFired.signal()
-        }
-        defer {
-            FeedCoordinator.shared.notificationPosterForTesting = nil
-            FeedCoordinator.shared.notificationGraceDelay = 0.5
+        let coordinator = FeedCoordinator(
+            notificationPoster: { _, _ in notificationFired.signal() },
+            notificationGraceDelay: 0.1
+        )
+        await MainActor.run {
+            coordinator.install(store: WorkstreamStore(ringCapacity: 10))
         }
 
         let event = WorkstreamEvent(
@@ -92,7 +78,7 @@ final class FeedCoordinatorTests: XCTestCase {
         )
 
         DispatchQueue.global(qos: .userInitiated).async {
-            _ = FeedCoordinator.shared.ingestBlocking(event: event, waitTimeout: 2)
+            _ = coordinator.ingestBlocking(event: event, waitTimeout: 2)
         }
 
         // No reply — notification should fire after the grace period.
@@ -100,10 +86,7 @@ final class FeedCoordinatorTests: XCTestCase {
             "notification should fire when no reply arrives within grace period")
 
         // Clean up the pending waiter.
-        FeedCoordinator.shared.deliverReply(
-            requestId: "notif-fire-request",
-            decision: .permission(.once)
-        )
+        coordinator.deliverReply(requestId: "notif-fire-request", decision: .permission(.once))
     }
 
     func testBlockingIngestExpiresItemWhenHookTimesOut() async {

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -77,16 +77,19 @@ final class FeedCoordinatorTests: XCTestCase {
             requestId: "notif-fire-request"
         )
 
+        let done = DispatchSemaphore(value: 0)
         DispatchQueue.global(qos: .userInitiated).async {
             _ = coordinator.ingestBlocking(event: event, waitTimeout: 2)
+            done.signal()
         }
 
         // No reply — notification should fire after the grace period.
         XCTAssertEqual(notificationFired.wait(timeout: .now() + 1), .success,
             "notification should fire when no reply arrives within grace period")
 
-        // Clean up the pending waiter.
+        // Unblock ingestBlocking and wait for it to finish.
         coordinator.deliverReply(requestId: "notif-fire-request", decision: .permission(.once))
+        XCTAssertEqual(done.wait(timeout: .now() + 2), .success)
     }
 
     func testBlockingIngestExpiresItemWhenHookTimesOut() async {


### PR DESCRIPTION
## Summary

- Adds a 500 ms grace period before posting a native notification banner for `PermissionRequest` feed events
- If `deliverReply` fires before the timer fires, the request ID is added to a suppression set and the notification is skipped at fire time — no bubble appears
- `notificationPoster` and `notificationGraceDelay` are injected via the `FeedCoordinator` initializer; tests use a locally-created instance with a short delay and a spy poster

Fixes #3702

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed notifications now wait a configurable grace period (default 0.5s) before appearing.
  * Notifications are suppressed/cancelled if a reply or removal occurs during that window, reducing spurious alerts.
  * Notification behavior is test-configurable to allow precise timing control.

* **Tests**
  * Added async tests verifying notification timing, grace-delay behavior, and suppression when replies arrive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->