### PR TITLE
Auto-preserve Vertex/Bedrock auth env when launching claude wrapper inside cmux

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -85,16 +85,53 @@ case "${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV:-}" in
 esac
 
 should_preserve_claude_auth_selection_key() {
-    [[ "$PRESERVE_CLAUDE_AUTH_SELECTION_ENV" == true ]] || return 1
+    if [[ "$PRESERVE_CLAUDE_AUTH_SELECTION_ENV" == true ]]; then
+        local configured_keys="${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}"
+        if [[ -z "$configured_keys" ]]; then
+            return 0
+        fi
+        configured_keys="${configured_keys//,/ }"
+        local configured_key
+        for configured_key in $configured_keys; do
+            [[ "$configured_key" == "$1" ]] && return 0
+        done
+    fi
 
-    local configured_keys="${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}"
-    [[ -n "$configured_keys" ]] || return 0
+    # Auto-preserve Vertex/Bedrock auth selection so users with valid
+    # CLAUDE_CODE_USE_VERTEX=1 / CLAUDE_CODE_USE_BEDROCK=1 setups in their
+    # shell rc authenticate inside cmux the same way they do in plain
+    # Terminal. Without this, the wrapper silently drops the selection
+    # signal and claude reports "not logged in".
+    # Refs: https://github.com/manaflow-ai/cmux/issues/3641 (Vertex)
+    #       https://github.com/manaflow-ai/cmux/issues/3638 (Bedrock)
+    local vertex_on=false bedrock_on=false
+    case "${CLAUDE_CODE_USE_VERTEX:-}" in
+        1|true|TRUE|yes|YES) vertex_on=true ;;
+    esac
+    case "${CLAUDE_CODE_USE_BEDROCK:-}" in
+        1|true|TRUE|yes|YES) bedrock_on=true ;;
+    esac
 
-    configured_keys="${configured_keys//,/ }"
-    local configured_key
-    for configured_key in $configured_keys; do
-        [[ "$configured_key" == "$1" ]] && return 0
-    done
+    case "$1" in
+        CLAUDE_CODE_USE_VERTEX)
+            [[ "$vertex_on" == true ]] && return 0
+            ;;
+        CLAUDE_CODE_USE_BEDROCK)
+            [[ "$bedrock_on" == true ]] && return 0
+            ;;
+        ANTHROPIC_MODEL|ANTHROPIC_SMALL_FAST_MODEL)
+            # Vertex and Bedrock require backend-specific full model ids
+            # (e.g. "claude-sonnet-4-5@20250929" for Vertex,
+            # "us.anthropic.claude-sonnet-4-5-20250929-v1:0" for Bedrock).
+            # Preserve the user's selection only when one of those
+            # backends is active; otherwise stale ids would leak into the
+            # default Anthropic API path.
+            if [[ "$vertex_on" == true || "$bedrock_on" == true ]]; then
+                return 0
+            fi
+            ;;
+    esac
+
     return 1
 }
 

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -95,6 +95,11 @@ should_preserve_claude_auth_selection_key() {
         for configured_key in $configured_keys; do
             [[ "$configured_key" == "$1" ]] && return 0
         done
+        # Key not in the explicit list: do NOT early-return — fall through to
+        # the Vertex/Bedrock auto-preserve below. CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS
+        # is an additive allow-list, not an exclusion list, so an operator
+        # who opts in with a narrower key list still gets Vertex/Bedrock
+        # selection signals preserved when those backends are active.
     fi
 
     # Auto-preserve Vertex/Bedrock auth selection so users with valid

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -259,11 +259,17 @@ keys=(
   ANTHROPIC_API_KEY
   ANTHROPIC_AUTH_TOKEN
   ANTHROPIC_BASE_URL
+  ANTHROPIC_BEDROCK_BASE_URL
   ANTHROPIC_MODEL
   ANTHROPIC_SMALL_FAST_MODEL
+  ANTHROPIC_VERTEX_BASE_URL
+  ANTHROPIC_VERTEX_PROJECT_ID
+  AWS_PROFILE
+  AWS_REGION
   CLAUDE_CODE_USE_BEDROCK
   CLAUDE_CODE_USE_VERTEX
   CLAUDE_CONFIG_DIR
+  CLOUD_ML_REGION
 )
 for key in "${keys[@]}"; do
   if [[ ${!key+x} ]]; then
@@ -508,6 +514,138 @@ def test_live_socket_preserves_only_listed_claude_auth_keys(failures: list[str])
     expect("--session-id" not in real_argv, f"listed auth env: expected no injected session id, got {real_argv}", failures)
 
 
+def test_live_socket_auto_preserves_vertex_auth_when_truthy(failures: list[str]) -> None:
+    # Regression for https://github.com/manaflow-ai/cmux/issues/3641.
+    inherited = {
+        "CLAUDE_CODE_USE_VERTEX": "1",
+        "ANTHROPIC_MODEL": "claude-sonnet-4-5@20250929",
+        "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5@20251001",
+        "ANTHROPIC_VERTEX_PROJECT_ID": "my-gcp-project",
+        "ANTHROPIC_VERTEX_BASE_URL": "https://us-east5-aiplatform.googleapis.com",
+        "CLOUD_ML_REGION": "us-east5",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"vertex auto-preserve: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_VERTEX") == "1",
+        f"vertex auto-preserve: expected CLAUDE_CODE_USE_VERTEX=1 preserved, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_MODEL") == "claude-sonnet-4-5@20250929",
+        f"vertex auto-preserve: expected Vertex ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "claude-haiku-4-5@20251001",
+        f"vertex auto-preserve: expected Vertex ANTHROPIC_SMALL_FAST_MODEL preserved, got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_VERTEX_PROJECT_ID") == "my-gcp-project",
+        f"vertex auto-preserve: expected ANTHROPIC_VERTEX_PROJECT_ID preserved, got {auth_env.get('ANTHROPIC_VERTEX_PROJECT_ID')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_VERTEX_BASE_URL") == "https://us-east5-aiplatform.googleapis.com",
+        f"vertex auto-preserve: expected ANTHROPIC_VERTEX_BASE_URL preserved, got {auth_env.get('ANTHROPIC_VERTEX_BASE_URL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("CLOUD_ML_REGION") == "us-east5",
+        f"vertex auto-preserve: expected CLOUD_ML_REGION preserved, got {auth_env.get('CLOUD_ML_REGION')!r}",
+        failures,
+    )
+    expect(
+        "--session-id" in real_argv,
+        f"vertex auto-preserve: expected session injection, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures: list[str]) -> None:
+    # Regression for https://github.com/manaflow-ai/cmux/issues/3638.
+    inherited = {
+        "CLAUDE_CODE_USE_BEDROCK": "1",
+        "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "ANTHROPIC_SMALL_FAST_MODEL": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock-runtime.us-west-2.amazonaws.com",
+        "AWS_REGION": "us-west-2",
+        "AWS_PROFILE": "bedrock-prod",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"bedrock auto-preserve: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "1",
+        f"bedrock auto-preserve: expected CLAUDE_CODE_USE_BEDROCK=1 preserved, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_MODEL") == "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        f"bedrock auto-preserve: expected Bedrock ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "us.anthropic.claude-haiku-4-5-20251001-v1:0",
+        f"bedrock auto-preserve: expected Bedrock ANTHROPIC_SMALL_FAST_MODEL preserved, got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_BEDROCK_BASE_URL") == "https://bedrock-runtime.us-west-2.amazonaws.com",
+        f"bedrock auto-preserve: expected ANTHROPIC_BEDROCK_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BEDROCK_BASE_URL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("AWS_REGION") == "us-west-2",
+        f"bedrock auto-preserve: expected AWS_REGION preserved, got {auth_env.get('AWS_REGION')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("AWS_PROFILE") == "bedrock-prod",
+        f"bedrock auto-preserve: expected AWS_PROFILE preserved, got {auth_env.get('AWS_PROFILE')!r}",
+        failures,
+    )
+    expect(
+        "--session-id" in real_argv,
+        f"bedrock auto-preserve: expected session injection, got {real_argv}",
+        failures,
+    )
+
+
+def test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy(failures: list[str]) -> None:
+    inherited = {
+        "CLAUDE_CODE_USE_VERTEX": "0",
+        "CLAUDE_CODE_USE_BEDROCK": "",
+        "ANTHROPIC_MODEL": "stale-model",
+    }
+    code, auth_env, _, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"falsy vertex: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_VERTEX") == "__UNSET__",
+        f"falsy vertex: expected CLAUDE_CODE_USE_VERTEX=0 to be cleared, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "__UNSET__",
+        f"falsy vertex: expected empty CLAUDE_CODE_USE_BEDROCK to be cleared, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
+        f"falsy vertex: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+
+
 def test_live_socket_enforces_heap_cap_for_space_separated_flag(failures: list[str]) -> None:
     existing = "--max-old-space-size 2048 --trace-warnings"
     restored = "--max-old-space-size=2048 --trace-warnings"
@@ -662,6 +800,9 @@ def main() -> int:
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
+    test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
+    test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)
+    test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -305,6 +305,23 @@ exit 0
             env = os.environ.copy()
             env.pop("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV", None)
             env.pop("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS", None)
+            for ambient_key in (
+                "ANTHROPIC_API_KEY",
+                "ANTHROPIC_AUTH_TOKEN",
+                "ANTHROPIC_BASE_URL",
+                "ANTHROPIC_BEDROCK_BASE_URL",
+                "ANTHROPIC_MODEL",
+                "ANTHROPIC_SMALL_FAST_MODEL",
+                "ANTHROPIC_VERTEX_BASE_URL",
+                "ANTHROPIC_VERTEX_PROJECT_ID",
+                "AWS_PROFILE",
+                "AWS_REGION",
+                "CLAUDE_CODE_USE_BEDROCK",
+                "CLAUDE_CODE_USE_VERTEX",
+                "CLAUDE_CONFIG_DIR",
+                "CLOUD_ML_REGION",
+            ):
+                env.pop(ambient_key, None)
             env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
             env["CMUX_SURFACE_ID"] = "surface:test"
             env["CMUX_SOCKET_PATH"] = socket_path
@@ -516,6 +533,7 @@ def test_live_socket_auto_preserves_vertex_auth_when_truthy(failures: list[str])
     # Regression for https://github.com/manaflow-ai/cmux/issues/3641.
     inherited = {
         "CLAUDE_CODE_USE_VERTEX": "1",
+        "ANTHROPIC_API_KEY": "anthropic-key-must-be-scrubbed-on-vertex",
         "ANTHROPIC_MODEL": "claude-sonnet-4-5@20250929",
         "ANTHROPIC_SMALL_FAST_MODEL": "claude-haiku-4-5@20251001",
         "ANTHROPIC_VERTEX_PROJECT_ID": "my-gcp-project",
@@ -558,6 +576,11 @@ def test_live_socket_auto_preserves_vertex_auth_when_truthy(failures: list[str])
         failures,
     )
     expect(
+        auth_env.get("ANTHROPIC_API_KEY") == "__UNSET__",
+        f"vertex auto-preserve: expected ANTHROPIC_API_KEY cleared (Vertex does not consume it), got {auth_env.get('ANTHROPIC_API_KEY')!r}",
+        failures,
+    )
+    expect(
         "--session-id" in real_argv,
         f"vertex auto-preserve: expected session injection, got {real_argv}",
         failures,
@@ -568,6 +591,7 @@ def test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures: list[str]
     # Regression for https://github.com/manaflow-ai/cmux/issues/3638.
     inherited = {
         "CLAUDE_CODE_USE_BEDROCK": "1",
+        "ANTHROPIC_API_KEY": "anthropic-key-must-be-scrubbed-on-bedrock",
         "ANTHROPIC_MODEL": "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
         "ANTHROPIC_SMALL_FAST_MODEL": "us.anthropic.claude-haiku-4-5-20251001-v1:0",
         "ANTHROPIC_BEDROCK_BASE_URL": "https://bedrock-runtime.us-west-2.amazonaws.com",
@@ -610,13 +634,18 @@ def test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures: list[str]
         failures,
     )
     expect(
+        auth_env.get("ANTHROPIC_API_KEY") == "__UNSET__",
+        f"bedrock auto-preserve: expected ANTHROPIC_API_KEY cleared (Bedrock does not consume it), got {auth_env.get('ANTHROPIC_API_KEY')!r}",
+        failures,
+    )
+    expect(
         "--session-id" in real_argv,
         f"bedrock auto-preserve: expected session injection, got {real_argv}",
         failures,
     )
 
 
-def test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy(failures: list[str]) -> None:
+def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures: list[str]) -> None:
     inherited = {
         "CLAUDE_CODE_USE_VERTEX": "0",
         "CLAUDE_CODE_USE_BEDROCK": "",
@@ -626,20 +655,54 @@ def test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy(failures:
         argv=["hello"],
         inherited_env=inherited,
     )
-    expect(code == 0, f"falsy vertex: wrapper exited {code}: {stderr}", failures)
+    expect(code == 0, f"falsy backends: wrapper exited {code}: {stderr}", failures)
     expect(
         auth_env.get("CLAUDE_CODE_USE_VERTEX") == "__UNSET__",
-        f"falsy vertex: expected CLAUDE_CODE_USE_VERTEX=0 to be cleared, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
+        f"falsy backends: expected CLAUDE_CODE_USE_VERTEX=0 to be cleared, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
         failures,
     )
     expect(
         auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "__UNSET__",
-        f"falsy vertex: expected empty CLAUDE_CODE_USE_BEDROCK to be cleared, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
+        f"falsy backends: expected empty CLAUDE_CODE_USE_BEDROCK to be cleared, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
         failures,
     )
     expect(
         auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
-        f"falsy vertex: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        f"falsy backends: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+
+
+def test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures: list[str]) -> None:
+    # Pins the precedence between the explicit-opt-in key list
+    # (CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS) and the Vertex/Bedrock
+    # auto-preserve introduced for #3641 / #3638: the key list adds entries
+    # to preservation, it does NOT exclude keys from auto-preserve.
+    inherited = {
+        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV": "1",
+        "CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS": "ANTHROPIC_API_KEY",
+        "ANTHROPIC_API_KEY": "explicitly-listed-key-must-survive",
+        "CLAUDE_CODE_USE_VERTEX": "1",
+        "ANTHROPIC_MODEL": "claude-sonnet-4-5@20250929",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"additive list: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("ANTHROPIC_API_KEY") == "explicitly-listed-key-must-survive",
+        f"additive list: expected listed ANTHROPIC_API_KEY preserved, got {auth_env.get('ANTHROPIC_API_KEY')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_VERTEX") == "1",
+        f"additive list: expected CLAUDE_CODE_USE_VERTEX auto-preserved despite not being in the explicit list, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_MODEL") == "claude-sonnet-4-5@20250929",
+        f"additive list: expected ANTHROPIC_MODEL auto-preserved (Vertex truthy) despite not being in the explicit list, got {auth_env.get('ANTHROPIC_MODEL')!r}",
         failures,
     )
 
@@ -800,7 +863,8 @@ def main() -> int:
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)
-    test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy(failures)
+    test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures)
+    test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)
     test_live_socket_preserves_explicit_bypass_availability_flag(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -305,6 +305,8 @@ exit 0
             env = os.environ.copy()
             env.pop("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV", None)
             env.pop("CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS", None)
+            for ambient_aws_key in [k for k in env if k.startswith("AWS_")]:
+                env.pop(ambient_aws_key, None)
             for ambient_key in (
                 "ANTHROPIC_API_KEY",
                 "ANTHROPIC_AUTH_TOKEN",
@@ -314,8 +316,6 @@ exit 0
                 "ANTHROPIC_SMALL_FAST_MODEL",
                 "ANTHROPIC_VERTEX_BASE_URL",
                 "ANTHROPIC_VERTEX_PROJECT_ID",
-                "AWS_PROFILE",
-                "AWS_REGION",
                 "CLAUDE_CODE_USE_BEDROCK",
                 "CLAUDE_CODE_USE_VERTEX",
                 "CLAUDE_CONFIG_DIR",
@@ -673,6 +673,28 @@ def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures
     )
 
 
+def test_live_socket_auto_preserve_accepts_all_documented_truthy_variants(failures: list[str]) -> None:
+    # The wrapper recognizes 1|true|TRUE|yes|YES as truthy (matching the
+    # existing CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV parser); the focused
+    # auto-preserve tests above only exercise "1". This loop pins all 5
+    # documented variants for both backends so a future "simplification"
+    # of the case statement cannot silently drop yes/YES/true/TRUE.
+    for backend_key in ("CLAUDE_CODE_USE_VERTEX", "CLAUDE_CODE_USE_BEDROCK"):
+        for variant in ("1", "true", "TRUE", "yes", "YES"):
+            inherited = {backend_key: variant}
+            code, auth_env, _, stderr = run_wrapper_auth_env(
+                argv=["hello"],
+                inherited_env=inherited,
+            )
+            label = f"{backend_key}={variant!r}"
+            expect(code == 0, f"truthy variants ({label}): wrapper exited {code}: {stderr}", failures)
+            expect(
+                auth_env.get(backend_key) == variant,
+                f"truthy variants ({label}): expected {backend_key} preserved, got {auth_env.get(backend_key)!r}",
+                failures,
+            )
+
+
 def test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures: list[str]) -> None:
     # Pins the precedence between the explicit-opt-in key list
     # (CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS) and the Vertex/Bedrock
@@ -864,6 +886,7 @@ def main() -> int:
     test_live_socket_auto_preserves_vertex_auth_when_truthy(failures)
     test_live_socket_auto_preserves_bedrock_auth_when_truthy(failures)
     test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures)
+    test_live_socket_auto_preserve_accepts_all_documented_truthy_variants(failures)
     test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failures)
     test_live_socket_enforces_heap_cap_for_space_separated_flag(failures)
     test_live_socket_tmpdir_failure_skips_node_options_injection(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -430,8 +430,6 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
         "ANTHROPIC_BASE_URL": "https://api.example.test",
         "ANTHROPIC_MODEL": "stale-model",
         "ANTHROPIC_SMALL_FAST_MODEL": "stale-small-model",
-        "CLAUDE_CODE_USE_BEDROCK": "1",
-        "CLAUDE_CODE_USE_VERTEX": "1",
     }
     code, auth_env, real_argv, stderr = run_wrapper_auth_env(
         argv=["hello"],

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -677,27 +677,6 @@ def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures
         f"falsy backends: expected ANTHROPIC_SMALL_FAST_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
         failures,
     )
-    expect(code == 0, f"falsy backends: wrapper exited {code}: {stderr}", failures)
-    expect(
-        auth_env.get("CLAUDE_CODE_USE_VERTEX") == "__UNSET__",
-        f"falsy backends: expected CLAUDE_CODE_USE_VERTEX=0 to be cleared, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
-        failures,
-    )
-    expect(
-        auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "__UNSET__",
-        f"falsy backends: expected empty CLAUDE_CODE_USE_BEDROCK to be cleared, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
-        failures,
-    )
-    expect(
-        auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
-        f"falsy backends: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
-        failures,
-    )
-    expect(
-        auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "__UNSET__",
-        f"falsy backends: expected ANTHROPIC_SMALL_FAST_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
-        failures,
-    )
 
 
 def test_live_socket_auto_preserve_accepts_all_documented_truthy_variants(failures: list[str]) -> None:

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -650,6 +650,7 @@ def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures
         "CLAUDE_CODE_USE_VERTEX": "0",
         "CLAUDE_CODE_USE_BEDROCK": "",
         "ANTHROPIC_MODEL": "stale-model",
+        "ANTHROPIC_SMALL_FAST_MODEL": "stale-small-model",
     }
     code, auth_env, _, stderr = run_wrapper_auth_env(
         argv=["hello"],
@@ -669,6 +670,32 @@ def test_live_socket_does_not_auto_preserve_when_all_backends_are_falsy(failures
     expect(
         auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
         f"falsy backends: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "__UNSET__",
+        f"falsy backends: expected ANTHROPIC_SMALL_FAST_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
+        failures,
+    )
+    expect(code == 0, f"falsy backends: wrapper exited {code}: {stderr}", failures)
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_VERTEX") == "__UNSET__",
+        f"falsy backends: expected CLAUDE_CODE_USE_VERTEX=0 to be cleared, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "__UNSET__",
+        f"falsy backends: expected empty CLAUDE_CODE_USE_BEDROCK to be cleared, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_MODEL") == "__UNSET__",
+        f"falsy backends: expected ANTHROPIC_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_MODEL')!r}",
+        failures,
+    )
+    expect(
+        auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "__UNSET__",
+        f"falsy backends: expected ANTHROPIC_SMALL_FAST_MODEL cleared (no live Vertex/Bedrock backend), got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}",
         failures,
     )
 

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -685,7 +685,7 @@ def test_live_socket_explicit_key_list_is_additive_to_vertex_auto_preserve(failu
         "CLAUDE_CODE_USE_VERTEX": "1",
         "ANTHROPIC_MODEL": "claude-sonnet-4-5@20250929",
     }
-    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+    code, auth_env, _, stderr = run_wrapper_auth_env(
         argv=["hello"],
         inherited_env=inherited,
     )


### PR DESCRIPTION
## Summary

Closes #3641 and closes #3638.

The cmux Claude wrapper (`Resources/bin/claude`) silently `unset`s `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_USE_BEDROCK`, `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, and `ANTHROPIC_API_KEY` when running inside a cmux terminal so cmux can manage which Claude account is in use. That worked for users on the default Anthropic backend, but **users who configure Vertex AI or Bedrock in their shell rc had no account-management surface in cmux to opt back in** — they just saw `not logged in` with no warning. The undocumented opt-in env var (`CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1`) existed but neither bug reporter could discover it.

This PR makes `should_preserve_claude_auth_selection_key()` automatically preserve the Vertex/Bedrock selection signals (and the matching model id) when the user has clearly configured one of those backends.

## What changed

`should_preserve_claude_auth_selection_key()` now returns true (in addition to the existing explicit opt-in path) when:

- key is `CLAUDE_CODE_USE_VERTEX` and its value is truthy (`1` / `true` / `TRUE` / `yes` / `YES`)
- key is `CLAUDE_CODE_USE_BEDROCK` and its value is truthy
- key is `ANTHROPIC_MODEL` or `ANTHROPIC_SMALL_FAST_MODEL` AND `CLAUDE_CODE_USE_VERTEX` or `CLAUDE_CODE_USE_BEDROCK` is truthy
  - Vertex requires backend-specific full ids like `claude-sonnet-4-5@20250929`
  - Bedrock requires Bedrock-specific ids like `us.anthropic.claude-sonnet-4-5-20250929-v1:0`
  - The default Anthropic backend cannot use either form, so the model selectors are meaningless without an active Vertex/Bedrock signal — that's why preservation is conditional rather than unconditional.

Falsy values (`CLAUDE_CODE_USE_VERTEX=0`, empty string) explicitly do **not** trigger preservation; the third regression test pins this so a future fix cannot over-preserve.

The Vertex/Bedrock supporting vars (`ANTHROPIC_VERTEX_PROJECT_ID`, `CLOUD_ML_REGION`, `ANTHROPIC_VERTEX_BASE_URL`, `ANTHROPIC_BEDROCK_BASE_URL`, `AWS_*`) are not in `CLAUDE_AUTH_SELECTION_ENV_KEYS` so they were already preserved; the regression tests now assert that explicitly so a future change cannot accidentally add them to the unset list.

## Backwards compatibility

- `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV` opt-in path is unchanged.
- Users on the default Anthropic backend continue to have selection vars scrubbed (no behavior change).
- Auto-preservation only triggers on truthy Vertex/Bedrock values, so users who have those env vars set to `0` / empty still get the scrub behavior.

## Tests

Per the [AGENTS.md regression-test commit policy](https://github.com/manaflow-ai/cmux/blob/main/AGENTS.md#regression-test-commit-policy), this PR is structured as two commits so CI proves the test catches the bug:

1. **f112b18d** `Add failing regression tests for Vertex/Bedrock auth env preservation` — tests only, CI goes red on the new tests:
   - `test_live_socket_auto_preserves_vertex_auth_when_truthy` — Vertex case (#3641)
   - `test_live_socket_auto_preserves_bedrock_auth_when_truthy` — Bedrock case (#3638)
   - `test_live_socket_does_not_auto_preserve_when_vertex_value_is_falsy` — negative case (already green; pins behavior so the fix can't over-preserve)

2. **76e04414** `Auto-preserve Vertex/Bedrock auth env in claude wrapper` — ships the wrapper fix and tightens `test_live_socket_preserves_third_party_claude_auth_for_fresh_launch`, which previously conflated "no Vertex/Bedrock signal" with "asserts they get cleared" by setting `CLAUDE_CODE_USE_VERTEX=1, CLAUDE_CODE_USE_BEDROCK=1` in the inherited env. The dedicated auto-preserve tests now own the truthy case.

The new tests exercise the wrapper through `subprocess` and inspect the env that survives into the spawned binary, per [AGENTS.md test policy](https://github.com/manaflow-ai/cmux/blob/main/AGENTS.md#test-quality-policy) (verify observable runtime behavior, not source text).

Run locally:

```bash
bash -n Resources/bin/claude
python3 Tests/test_claude_wrapper_hooks.py
# PASS: claude wrapper restores child NODE_OPTIONS while injecting supported hooks
```

13 tests, all green.

## Out of scope

- The `cmux.json` configurable preservation list suggested in the comment on #3638 by @markthebest12 — useful follow-up, but a larger surface change. This PR ships the minimum-correct fix that closes both issues today.
- Documenting `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV`. With auto-preservation in place, the original motivation (Vertex/Bedrock users having to discover the opt-in) is gone. The env var still works as an escape hatch for users who want to preserve other selection keys.

## Manual verification (suggested for reviewer)

```bash
# In a plain Terminal (not cmux):
export CLAUDE_CODE_USE_VERTEX=1
export ANTHROPIC_VERTEX_PROJECT_ID=<project>
export CLOUD_ML_REGION=us-east5

# Launch the tagged Debug app from this Terminal, then inside a cmux pane:
echo $CLAUDE_CODE_USE_VERTEX   # → 1 (already true on main)
which claude                   # → bundled wrapper
claude                         # → attempts Vertex auth instead of "not logged in"
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Expanded auth-env preservation: automatically preserves backend-specific environment variables for Vertex and Bedrock when those backends are enabled, avoids leaking stale backend-specific model identifiers into Anthropic paths, and keeps explicit preservation lists additive.

* **Tests**
  * Added live-socket regression tests covering auto-preserve behavior, truthy-var handling, explicit preserve-list interactions, session-id injection, and cleanup across backend configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->