### PR TITLE
Fix tmux compat show-options to return safe defaults instead of erroring

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13017,8 +13017,9 @@ struct CMUXCLI {
             let optionName = parsed.positional.last ?? ""
             // Tolerant defaults so external probes (Codex's extended-keys
             // check, etc.) don't error: known options return tmux-compatible
-            // values; unknown options fall through to "" (matching real
-            // tmux's -q behavior). See #3239.
+            // values; unknown or unnamed options emit no output at all
+            // (matching real tmux's -q behavior — not even a trailing
+            // newline). See #3239.
             let defaults: [String: String] = [
                 "extended-keys": "on",
                 "extended-keys-format": "csi-u",
@@ -13028,11 +13029,12 @@ struct CMUXCLI {
                 "mode-keys": "emacs",
                 "prefix": "C-b",
             ]
-            let value = defaults[optionName] ?? ""
-            if parsed.hasFlag("-v") {
-                print(value)
-            } else if !optionName.isEmpty {
-                print("\(optionName) \(value)")
+            if !optionName.isEmpty, let value = defaults[optionName] {
+                if parsed.hasFlag("-v") {
+                    print(value)
+                } else {
+                    print("\(optionName) \(value)")
+                }
             }
 
         case "save-buffer", "saveb":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13015,13 +13015,23 @@ struct CMUXCLI {
                 boolFlags: ["-g", "-q", "-s", "-v", "-w"]
             )
             let optionName = parsed.positional.last ?? ""
-            guard optionName == "extended-keys" else {
-                throw CLIError(message: "Unsupported tmux compatibility command: \(command) \(optionName)")
-            }
-            let value = "on"
+            // Tolerant defaults so external probes (Codex's extended-keys
+            // check, etc.) don't error: known options return tmux-compatible
+            // values; unknown options fall through to "" (matching real
+            // tmux's -q behavior). See #3239.
+            let defaults: [String: String] = [
+                "extended-keys": "on",
+                "extended-keys-format": "csi-u",
+                "default-terminal": "tmux-256color",
+                "mouse": "off",
+                "status": "off",
+                "mode-keys": "emacs",
+                "prefix": "C-b",
+            ]
+            let value = defaults[optionName] ?? ""
             if parsed.hasFlag("-v") {
                 print(value)
-            } else {
+            } else if !optionName.isEmpty {
                 print("\(optionName) \(value)")
             }
 

--- a/tests_v2/test_tmux_compat_show_options.py
+++ b/tests_v2/test_tmux_compat_show_options.py
@@ -62,7 +62,14 @@ def _run_tmux_compat(cli: str, args: List[str]) -> subprocess.CompletedProcess:
     env.pop("CMUX_SURFACE_ID", None)
     env["CMUX_SOCKET_PATH"] = SOCKET_PATH
     cmd = [cli, "--socket", SOCKET_PATH, "__tmux-compat"] + args
-    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+    return subprocess.run(
+        cmd,
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=10,
+    )
 
 
 def _expect_value(
@@ -144,6 +151,9 @@ def test_unknown_option_returns_empty(cli: str) -> None:
     Real tmux returns empty for unset options under ``-q``; tools that probe
     expect non-failure. Pre-fix this throws ``Unsupported tmux compatibility
     command: show-options some-future-option``.
+
+    The assertion is exact (``proc.stdout == ""``, not ``.strip()``) so a
+    regression that prints a stray blank line is caught.
     """
     print("  test_unknown_option_returns_empty ... ", end="", flush=True)
     proc = _run_tmux_compat(cli, ["show-options", "-sv", "some-future-option"])
@@ -153,12 +163,34 @@ def test_unknown_option_returns_empty(cli: str) -> None:
         f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
     )
     _must(
-        proc.stdout.strip() == "",
+        proc.stdout == "",
         f"unknown-option -sv: expected empty stdout, got {proc.stdout!r}",
     )
     _must(
         "Unsupported tmux compatibility command" not in proc.stderr,
         f"unknown-option -sv: stderr should not say Unsupported, got {proc.stderr!r}",
+    )
+    print("PASS")
+
+
+def test_unknown_option_no_v_prints_nothing(cli: str) -> None:
+    """Unknown option without ``-v`` must also print nothing (no trailing space).
+
+    Locks in the contract caught in code review: a previous draft printed
+    ``"<name> "`` (key + space + newline) for unknown options because the
+    fallback emitted ``defaults[name] ?? ""`` unconditionally. Real tmux ``-q``
+    prints nothing for unknown options regardless of ``-v``.
+    """
+    print("  test_unknown_option_no_v_prints_nothing ... ", end="", flush=True)
+    proc = _run_tmux_compat(cli, ["show-options", "some-future-option"])
+    _must(
+        proc.returncode == 0,
+        f"unknown-option no -v: expected exit 0, got {proc.returncode}\n"
+        f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+    )
+    _must(
+        proc.stdout == "",
+        f"unknown-option no -v: expected empty stdout, got {proc.stdout!r}",
     )
     print("PASS")
 
@@ -228,6 +260,7 @@ def main() -> int:
             ("test_extended_keys_format_value_only", lambda: test_extended_keys_format_value_only(cli)),
             ("test_status_off_value_only", lambda: test_status_off_value_only(cli)),
             ("test_unknown_option_returns_empty", lambda: test_unknown_option_returns_empty(cli)),
+            ("test_unknown_option_no_v_prints_nothing", lambda: test_unknown_option_no_v_prints_nothing(cli)),
             ("test_show_alias_works", lambda: test_show_alias_works(cli)),
             ("test_global_flag_does_not_break", lambda: test_global_flag_does_not_break(cli)),
             ("test_issue_3239_exact_repro", lambda: test_issue_3239_exact_repro(cli)),

--- a/tests_v2/test_tmux_compat_show_options.py
+++ b/tests_v2/test_tmux_compat_show_options.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Regression: tmux-compat ``show-options`` returns safe defaults instead of erroring.
+
+Background: GitHub issue #3239 reports that ``cmux omx`` startup fails because
+Codex v0.125.0 probes::
+
+    tmux show-options -sv extended-keys
+
+and any variation that lands at ``cmux __tmux-compat show-options ...`` for an
+option other than ``extended-keys`` would throw
+``Error: Unsupported tmux compatibility command: show-options``. Real tmux is
+tolerant of unset options when ``-q`` is set and returns a default for known
+options, so the cmux compat shim should match that to keep external tools
+working.
+
+These tests exercise the handler directly via the CLI. They follow the
+``tests_v2`` runner contract (a tagged ``cmux DEV`` instance is launched and
+``CMUX_SOCKET_PATH`` is set by ``scripts/run-tests-v2.sh``). The show-options
+handler does not touch the v2 socket API, but the dispatcher resolves the
+socket before reaching the handler, so the test still requires a running
+instance.
+"""
+
+import glob
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+
+def _must(cond: bool, msg: str) -> None:
+    if not cond:
+        raise cmuxError(msg)
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    candidates = glob.glob(os.path.expanduser(
+        "~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"
+    ), recursive=True)
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    candidates = [p for p in candidates if os.path.isfile(p) and os.access(p, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
+    candidates.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+    return candidates[0]
+
+
+def _run_tmux_compat(cli: str, args: List[str]) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_SURFACE_ID", None)
+    env["CMUX_SOCKET_PATH"] = SOCKET_PATH
+    cmd = [cli, "--socket", SOCKET_PATH, "__tmux-compat"] + args
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+def _expect_value(
+    cli: str,
+    args: List[str],
+    expected_stdout: Optional[str],
+    *,
+    label: str,
+) -> None:
+    proc = _run_tmux_compat(cli, args)
+    _must(
+        proc.returncode == 0,
+        f"{label}: expected exit 0, got {proc.returncode}\n"
+        f"  args: {args}\n  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+    )
+    if expected_stdout is not None:
+        actual = proc.stdout.rstrip("\n")
+        _must(
+            actual == expected_stdout,
+            f"{label}: expected stdout {expected_stdout!r}, got {actual!r}\n"
+            f"  args: {args}\n  full stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+        )
+
+
+def test_extended_keys_value_only(cli: str) -> None:
+    """Regression for the original bug repro: ``show-options -sv extended-keys``.
+
+    This already worked before the fix (it was the only supported option), but
+    locks in the behavior so the safe-default refactor doesn't regress it.
+    """
+    print("  test_extended_keys_value_only ... ", end="", flush=True)
+    _expect_value(cli, ["show-options", "-sv", "extended-keys"], "on", label="extended-keys -sv")
+    print("PASS")
+
+
+def test_extended_keys_full_form(cli: str) -> None:
+    print("  test_extended_keys_full_form ... ", end="", flush=True)
+    _expect_value(cli, ["show-options", "extended-keys"], "extended-keys on", label="extended-keys (no -v)")
+    print("PASS")
+
+
+def test_default_terminal_value_only(cli: str) -> None:
+    """``show-options -sv default-terminal`` returns a tmux-compatible value.
+
+    Pre-fix this throws ``Unsupported tmux compatibility command: show-options
+    default-terminal`` and exits non-zero.
+    """
+    print("  test_default_terminal_value_only ... ", end="", flush=True)
+    _expect_value(
+        cli, ["show-options", "-sv", "default-terminal"], "tmux-256color",
+        label="default-terminal -sv",
+    )
+    print("PASS")
+
+
+def test_extended_keys_format_value_only(cli: str) -> None:
+    """``extended-keys-format`` is the second probe Codex/the issue mentions.
+
+    Real tmux's default is ``csi-u``. Pre-fix this throws.
+    """
+    print("  test_extended_keys_format_value_only ... ", end="", flush=True)
+    _expect_value(
+        cli, ["show-options", "-sv", "extended-keys-format"], "csi-u",
+        label="extended-keys-format -sv",
+    )
+    print("PASS")
+
+
+def test_status_off_value_only(cli: str) -> None:
+    """``status`` defaults to ``off`` in our shim (cmux has no tmux status line)."""
+    print("  test_status_off_value_only ... ", end="", flush=True)
+    _expect_value(cli, ["show-options", "-sv", "status"], "off", label="status -sv")
+    print("PASS")
+
+
+def test_unknown_option_returns_empty(cli: str) -> None:
+    """Unknown options must return empty + exit 0, never throw.
+
+    Real tmux returns empty for unset options under ``-q``; tools that probe
+    expect non-failure. Pre-fix this throws ``Unsupported tmux compatibility
+    command: show-options some-future-option``.
+    """
+    print("  test_unknown_option_returns_empty ... ", end="", flush=True)
+    proc = _run_tmux_compat(cli, ["show-options", "-sv", "some-future-option"])
+    _must(
+        proc.returncode == 0,
+        f"unknown-option -sv: expected exit 0, got {proc.returncode}\n"
+        f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+    )
+    _must(
+        proc.stdout.strip() == "",
+        f"unknown-option -sv: expected empty stdout, got {proc.stdout!r}",
+    )
+    _must(
+        "Unsupported tmux compatibility command" not in proc.stderr,
+        f"unknown-option -sv: stderr should not say Unsupported, got {proc.stderr!r}",
+    )
+    print("PASS")
+
+
+def test_show_alias_works(cli: str) -> None:
+    print("  test_show_alias_works ... ", end="", flush=True)
+    _expect_value(cli, ["show", "-sv", "extended-keys"], "on", label="show alias")
+    _expect_value(cli, ["show-option", "-sv", "extended-keys"], "on", label="show-option alias")
+    print("PASS")
+
+
+def test_global_flag_does_not_break(cli: str) -> None:
+    print("  test_global_flag_does_not_break ... ", end="", flush=True)
+    _expect_value(
+        cli, ["show-options", "-gv", "default-terminal"], "tmux-256color",
+        label="default-terminal -gv",
+    )
+    print("PASS")
+
+
+def test_issue_3239_exact_repro(cli: str) -> None:
+    """Locks in the exact command from issue #3239.
+
+    Issue body, "Steps to reproduce" section 4 and "Direct command output":
+        $ cmux __tmux-compat show-options -sv extended-keys
+        Error: Unsupported tmux compatibility command: show-options
+
+    After the fix, the same invocation must exit 0 and print ``on``.
+    """
+    print("  test_issue_3239_exact_repro ... ", end="", flush=True)
+    proc = _run_tmux_compat(cli, ["show-options", "-sv", "extended-keys"])
+    _must(
+        proc.returncode == 0,
+        f"issue #3239 repro: expected exit 0, got {proc.returncode}\n"
+        f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+    )
+    _must(
+        "Unsupported tmux compatibility command" not in proc.stdout
+        and "Unsupported tmux compatibility command" not in proc.stderr,
+        f"issue #3239 repro: must not print Unsupported error\n"
+        f"  stdout: {proc.stdout!r}\n  stderr: {proc.stderr!r}",
+    )
+    _must(
+        proc.stdout.rstrip("\n") == "on",
+        f"issue #3239 repro: stdout should be 'on', got {proc.stdout!r}",
+    )
+    print("PASS")
+
+
+def main() -> int:
+    cli = _find_cli_binary()
+    print(f"Using CLI: {cli}")
+    print(f"Socket: {SOCKET_PATH}")
+
+    passed = 0
+    failed = 0
+    errors: List = []
+
+    # Connect to assert the cmux instance is up before issuing CLI probes.
+    # The handler under test does not touch the v2 socket API, but the
+    # ``__tmux-compat`` dispatcher resolves the socket first.
+    with cmux(SOCKET_PATH):
+        tests = [
+            ("test_extended_keys_value_only", lambda: test_extended_keys_value_only(cli)),
+            ("test_extended_keys_full_form", lambda: test_extended_keys_full_form(cli)),
+            ("test_default_terminal_value_only", lambda: test_default_terminal_value_only(cli)),
+            ("test_extended_keys_format_value_only", lambda: test_extended_keys_format_value_only(cli)),
+            ("test_status_off_value_only", lambda: test_status_off_value_only(cli)),
+            ("test_unknown_option_returns_empty", lambda: test_unknown_option_returns_empty(cli)),
+            ("test_show_alias_works", lambda: test_show_alias_works(cli)),
+            ("test_global_flag_does_not_break", lambda: test_global_flag_does_not_break(cli)),
+            ("test_issue_3239_exact_repro", lambda: test_issue_3239_exact_repro(cli)),
+        ]
+
+        for name, test_fn in tests:
+            try:
+                test_fn()
+                passed += 1
+            except Exception as e:
+                failed += 1
+                errors.append((name, str(e)))
+                print(f"FAIL: {e}")
+
+    print(f"\n{'=' * 60}")
+    print(f"Results: {passed} passed, {failed} failed, {passed + failed} total")
+    if errors:
+        print("\nFailures:")
+        for name, err in errors:
+            print(f"  {name}: {err}")
+    return 0 if failed == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #3239.

`cmux __tmux-compat show-options` (and its `show-option`/`show` aliases) currently throws `Error: Unsupported tmux compatibility command: show-options <name>` for every option name except `extended-keys`. Codex v0.125.0 probes `tmux show-options -sv extended-keys` at startup, plus other read-only options, so `cmux omx` users see the error in their startup log.

This PR replaces the single-option `guard` in [`CLI/cmux.swift`](https://github.com/manaflow-ai/cmux/blob/fix/3239-tmux-show-options-default/CLI/cmux.swift#L13011-L13036) with a small defaults table and a tolerant fallback so:

- Known options return tmux-compatible defaults.
- Unknown options fall through to `""` and exit 0, matching real tmux's `-q` behavior for unset options.
- Existing `extended-keys -> on` behavior is preserved.

| Option | Returned value |
|---|---|
| `extended-keys` | `on` |
| `extended-keys-format` | `csi-u` |
| `default-terminal` | `tmux-256color` |
| `mouse` | `off` |
| `status` | `off` |
| `mode-keys` | `emacs` |
| `prefix` | `C-b` |
| _anything else_ | `""` (no throw, exit 0) |

The handler is shared by the OMO, OMC, and OMX shims, so the fix benefits all three flows. The OMX bash shim already short-circuits `extended-keys` before delegating to `cmux __tmux-compat`; that fast path is left in place to keep this change minimal.

## Test plan

Per the AGENTS.md regression-test commit policy, the PR is split into two commits so CI proves the test catches the bug:

1. `Add failing test for tmux-compat show-options safe defaults` — adds [`tests_v2/test_tmux_compat_show_options.py`](https://github.com/manaflow-ai/cmux/blob/fix/3239-tmux-show-options-default/tests_v2/test_tmux_compat_show_options.py) (9 cases). Without the fix this test goes red.
2. `Fix tmux-compat show-options to return safe defaults` — applies the implementation. Test goes green.

Verified locally with a tagged debug build (`./scripts/reload.sh --tag fix-3239-tmux`) by stash-rebuilding both states:

| Build | `tests_v2/test_tmux_compat_show_options.py` |
|---|---|
| pre-fix (test commit only) | 4 passed, **5 failed** with the issue's exact `Error: Unsupported tmux compatibility command: show-options ...` message |
| post-fix | 9 passed, 0 failed |

Manual CLI checks against the freshly-built binary:

```text
$ cmux __tmux-compat show-options -sv extended-keys
on
$ cmux __tmux-compat show-options -sv default-terminal
tmux-256color
$ cmux __tmux-compat show-options -sv made-up-option
        # empty stdout, exit 0
$ cmux __tmux-compat show-options default-terminal
default-terminal tmux-256color
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `__tmux-compat show-options` return tmux-compatible defaults and avoid errors on probes. Fixes Codex startup checks and precisely matches tmux’s `-q` behavior. Closes #3239.

- **Bug Fixes**
  - Replace the single-option guard with a small defaults map (e.g., `extended-keys=on`, `extended-keys-format=csi-u`, `default-terminal=tmux-256color`, `mouse=off`, `status=off`, `mode-keys=emacs`, `prefix=C-b`).
  - Only print for known options; unknown or unnamed options emit no output and exit 0.
  - Preserve `-v` output and aliases (`show`, `show-option`).
  - Applies to OMO, OMC, and OMX shims.

<sup>Written for commit 0cfa1222ee7d60a6b3e686f94f32a9348e38b0ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple tmux compatibility options (`extended-keys`, `extended-keys-format`, `default-terminal`, `mouse`, `status`, `mode-keys`, `prefix`)

* **Bug Fixes**
  * Unsupported tmux options no longer trigger errors; instead produce graceful empty output

* **Tests**
  * Added comprehensive regression test suite for tmux compatibility option handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->