### PR TITLE
Fix #3303: app icon reverts to light variant after quit in automatic mode

### DIFF
--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -121,10 +121,8 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         // The clear is gated on `hasClearedAutomaticOverride` so the redundant
         // workspace ops don't fire on every effectiveAppearance KVO callback.
         if mode == .automatic {
-            if shouldPersistBundleIcon && !hasClearedAutomaticOverride {
-                NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
-                NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
-                _ = LSRegisterURL(appBundleURL as CFURL, true)
+            if !hasClearedAutomaticOverride {
+                persistBundleIcon(nil, at: appBundleURL)
                 hasClearedAutomaticOverride = true
             }
             dockTile.showDefaultAppIcon()
@@ -137,21 +135,20 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
 
         guard let imageName = mode.imageName,
               let icon = appBundle?.image(forResource: imageName) else {
-            if shouldPersistBundleIcon {
-                NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
-                NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
-                _ = LSRegisterURL(appBundleURL as CFURL, true)
-            }
+            persistBundleIcon(nil, at: appBundleURL)
             dockTile.showDefaultAppIcon()
             return
         }
 
-        if shouldPersistBundleIcon {
-            NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
-            NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
-            _ = LSRegisterURL(appBundleURL as CFURL, true)
-        }
+        persistBundleIcon(icon, at: appBundleURL)
         dockTile.showIcon(icon)
+    }
+
+    private func persistBundleIcon(_ icon: NSImage?, at appBundleURL: URL) {
+        guard shouldPersistBundleIcon else { return }
+        NSWorkspace.shared.setIcon(icon, forFile: appBundleURL.path, options: [])
+        NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+        _ = LSRegisterURL(appBundleURL as CFURL, true)
     }
 
     private static func performOnMain(_ work: @escaping () -> Void) {

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -102,12 +102,31 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         Self.assertMainQueue()
 
         let mode = DockTileAppIconMode(defaultsValue: appDefaults?.string(forKey: cmuxAppIconModeKey))
-        let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let appBundleURL else {
             dockTile.showDefaultAppIcon()
             return
         }
 
+        // For automatic mode, defer to the bundle's AppIcon asset catalog,
+        // which carries `luminosity: dark` appearance variants for every size.
+        // The Dock plugin runs in the Dock process where NSApp.effectiveAppearance
+        // is not a reliable signal for the user's system dark/light setting, so
+        // picking AppIconDark/AppIconLight here and persisting it via
+        // NSWorkspace.setIcon would lock the bundle icon to whatever variant the
+        // Dock happened to detect at quit time (issue #3303). Clearing any
+        // previous custom override lets macOS reassert the asset catalog's
+        // adaptive icon and switch automatically with system appearance.
+        if mode == .automatic {
+            if shouldPersistBundleIcon {
+                NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
+                NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
+                _ = LSRegisterURL(appBundleURL as CFURL, true)
+            }
+            dockTile.showDefaultAppIcon()
+            return
+        }
+
+        let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
         guard let imageName = mode.imageName(isDarkAppearance: isDarkAppearance),
               let icon = appBundle?.image(forResource: imageName) else {
             if shouldPersistBundleIcon {

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -13,10 +13,10 @@ private enum DockTileAppIconMode: String {
         self = Self(rawValue: defaultsValue ?? "") ?? .automatic
     }
 
-    func imageName(isDarkAppearance: Bool) -> NSImage.Name? {
+    var imageName: NSImage.Name? {
         switch self {
         case .automatic:
-            return isDarkAppearance ? NSImage.Name("AppIconDark") : NSImage.Name("AppIconLight")
+            return nil
         case .light:
             return NSImage.Name("AppIconLight")
         case .dark:
@@ -31,6 +31,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     private let pluginBundle = Bundle(for: CmuxDockTilePlugin.self)
     private var iconChangeObserver: NSObjectProtocol?
     private var appearanceObservation: NSKeyValueObservation?
+    private var hasClearedAutomaticOverride = false
 
     deinit {
         if let iconChangeObserver {
@@ -54,6 +55,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         }
         appearanceObservation?.invalidate()
         appearanceObservation = nil
+        hasClearedAutomaticOverride = false
 
         guard let dockTile else { return }
         updateDockTile(dockTile)
@@ -116,18 +118,24 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         // Dock happened to detect at quit time (issue #3303). Clearing any
         // previous custom override lets macOS reassert the asset catalog's
         // adaptive icon and switch automatically with system appearance.
+        // The clear is gated on `hasClearedAutomaticOverride` so the redundant
+        // workspace ops don't fire on every effectiveAppearance KVO callback.
         if mode == .automatic {
-            if shouldPersistBundleIcon {
+            if shouldPersistBundleIcon && !hasClearedAutomaticOverride {
                 NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])
                 NSWorkspace.shared.noteFileSystemChanged(appBundleURL.path)
                 _ = LSRegisterURL(appBundleURL as CFURL, true)
+                hasClearedAutomaticOverride = true
             }
             dockTile.showDefaultAppIcon()
             return
         }
 
-        let isDarkAppearance = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
-        guard let imageName = mode.imageName(isDarkAppearance: isDarkAppearance),
+        // Manual mode is about to write a custom bundle icon, so any previously
+        // recorded "automatic override cleared" state no longer applies.
+        hasClearedAutomaticOverride = false
+
+        guard let imageName = mode.imageName,
               let icon = appBundle?.image(forResource: imageName) else {
             if shouldPersistBundleIcon {
                 NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])

--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -30,14 +30,12 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
     // Keep the state minimal and derive everything from the enclosing app bundle.
     private let pluginBundle = Bundle(for: CmuxDockTilePlugin.self)
     private var iconChangeObserver: NSObjectProtocol?
-    private var appearanceObservation: NSKeyValueObservation?
     private var hasClearedAutomaticOverride = false
 
     deinit {
         if let iconChangeObserver {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
         }
-        appearanceObservation?.invalidate()
     }
 
     func setDockTile(_ dockTile: NSDockTile?) {
@@ -53,8 +51,6 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
             DistributedNotificationCenter.default().removeObserver(iconChangeObserver)
             self.iconChangeObserver = nil
         }
-        appearanceObservation?.invalidate()
-        appearanceObservation = nil
         hasClearedAutomaticOverride = false
 
         guard let dockTile else { return }
@@ -67,15 +63,6 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         ) { [weak self] _ in
             guard let self else { return }
             self.updateDockTile(dockTile)
-        }
-
-        if let app = NSApp {
-            appearanceObservation = app.observe(\.effectiveAppearance, options: []) { [weak self] _, _ in
-                DispatchQueue.main.async {
-                    guard let self, self.appearanceObservation != nil else { return }
-                    self.updateDockTile(dockTile)
-                }
-            }
         }
     }
 
@@ -119,7 +106,7 @@ final class CmuxDockTilePlugin: NSObject, NSDockTilePlugIn {
         // previous custom override lets macOS reassert the asset catalog's
         // adaptive icon and switch automatically with system appearance.
         // The clear is gated on `hasClearedAutomaticOverride` so the redundant
-        // workspace ops don't fire on every effectiveAppearance KVO callback.
+        // workspace ops don't repeat while the plugin remains in automatic mode.
         if mode == .automatic {
             if !hasClearedAutomaticOverride {
                 persistBundleIcon(nil, at: appBundleURL)


### PR DESCRIPTION
## Summary

Fix [#3303](https://github.com/manaflow-ai/cmux/issues/3303). When **App Icon = system** (automatic) and the system was in dark mode, quitting cmux made the Dock and Finder icon revert to the **light** variant, even though the asset catalog ships proper `luminosity: dark` variants for `AppIcon`.

## Root cause

`CmuxDockTilePlugin` runs in the **Dock process**, not in cmux's process, so:

- While cmux is running, the Dock displays the in-memory `NSApp.applicationIconImage` set by `AppIconAppearanceObserver` — this is correct.
- When cmux quits, the Dock loads the plugin and `updateDockTile` runs. It read `NSApp?.effectiveAppearance` from the Dock process, but that signal is **not** a reliable proxy for the user's system dark/light setting (the Dock app's own appearance does not always track Appearance).
- In automatic mode the plugin would resolve a fixed `AppIconDark` / `AppIconLight` from that signal and persist it on the bundle via `NSWorkspace.setIcon`. Once a custom bundle icon is set, macOS uses it instead of the asset catalog's adaptive `luminosity: dark` variants — locking the icon to whatever the Dock happened to detect at quit time.

## Fix

In `updateDockTile`, when mode is `.automatic`:

1. Clear any previous custom icon override: `NSWorkspace.shared.setIcon(nil, forFile: appBundleURL.path, options: [])`
2. Refresh the icon cache (`noteFileSystemChanged` + `LSRegisterURL`).
3. Tell the dock tile to use the default representation (`dockTile.showDefaultAppIcon()`).

This lets macOS reassert the bundle's adaptive `AppIcon` asset catalog, which already carries `luminosity: dark` variants for every size (16, 32, 128, 256, 512 at 1x and 2x). The Dock and Finder switch automatically with system appearance — no per-process appearance detection needed.

Explicit `.light` and `.dark` modes keep the existing persist-fixed-variant behavior — that path was already correct.

## Verification

### Build

- ``./scripts/reload.sh --tag fix-3303-icon`` succeeds.
- `lsp_diagnostics` clean on `Sources/AppIconDockTilePlugin.swift`.

### Manual test plan (matches issue's exact repro)

> ⚠️ Reviewers, please run this — Dock-icon-after-quit is GUI behavior that can't be exercised by an automated test (see _Tests_ section).

**Setup:** macOS in dark mode. Build with `./scripts/reload.sh --tag fix-3303-icon`.

1. **Launch tagged Debug app**, open Settings → App Icon → select **Automatic** (system).
2. Verify the Dock icon is **dark** while the app is running. ✅
3. Right-click app in Dock → Options → **Keep in Dock**.
4. **Quit** cmux (Cmd+Q).
5. ⭐ Observe the Dock icon — should remain **dark**, no flash to light.
6. Switch macOS to **light** mode while cmux is closed → Dock icon should switch to **light** automatically.
7. Switch back to **dark** → Dock icon should switch to **dark** automatically.
8. Re-launch cmux → icon stays dark, no regression.

**Migration check (for users upgrading from a build with the bug):**

- A user who hit #3303 on a previous build may have a stale custom-icon override sitting on `cmux.app`. The first time the dock plugin runs after this PR with `automatic` mode, `setIcon(nil, ...)` clears that override and the asset catalog takes over. No manual cleanup required.

**Explicit modes (no regression expected):**

- Settings → App Icon → **Dark** → quit → Dock stays dark even if system is light. ✅
- Settings → App Icon → **Light** → quit → Dock stays light even if system is dark. ✅

## Tests

No automated regression test added. Per the project's [test quality policy](./AGENTS.md#test-quality-policy), tests must verify observable runtime behavior, not implementation shape. The user-visible behavior here (Dock icon variant after quit, with the Dock plugin running in a separate process and reading icon services state) cannot be exercised through an executable test path from the cmux test target — any feasible test would either:

- mock `NSWorkspace.setIcon` and assert call shape (implementation-detail testing — disallowed by policy), or
- read the asset catalog or `Info.plist` (metadata snapshot test — disallowed by policy).

The existing `AppIconAppearanceObserverTests` and `AppIconSettingsTests` cover the in-process appearance-observation path, which is unaffected by this change. Manual verification steps above cover the Dock/quit path.

## Files changed

- `Sources/AppIconDockTilePlugin.swift` — early-return `.automatic` branch in `updateDockTile`.

Closes #3303.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3303: the app icon no longer switches to the light variant after quit when App Icon is set to Automatic. Dock and Finder now keep using the adaptive bundle icon that follows system appearance.

- **Bug Fixes**
  - In the Dock tile plugin, Automatic mode clears any custom bundle icon once and shows the default `AppIcon`, letting macOS switch variants automatically.
  - Light/Dark modes still persist a fixed variant; behavior unchanged.

- **Refactors**
  - Removed Dock appearance KVO and related state.
  - Replaced `imageName(isDarkAppearance:)` with `imageName` and removed the `.automatic` arm; `.automatic` now early-returns.
  - Extracted `persistBundleIcon(_:at:)` to centralize `NSWorkspace.setIcon` + cache refresh calls.

<sup>Written for commit c607112518074f891ce573d72cc29f77227a6feb. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3716?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dock tile icon now displays more reliably, falling back to the default app icon when custom assets are missing or the app bundle cannot be resolved.
  * Automatic icon mode now clears previous custom icon overrides once per session and consistently restores the default icon.
  * Manual icon selection now consistently applies chosen icons and avoids reverting to stale automatic overrides.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->