### PR TITLE
Fix terminal top-row click routing

### DIFF
--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -217,7 +217,20 @@ final class WindowTerminalHostView: NSView {
             in: self,
             eventType: eventType
         ) else { return false }
-        return decision.result
+        guard decision.result else { return false }
+        return hostedTerminalHitView(at: point) == nil
+    }
+
+    private func hostedTerminalHitView(at point: NSPoint) -> NSView? {
+        for subview in subviews.reversed() {
+            guard let hostedView = subview as? GhosttySurfaceScrollView,
+                  !hostedView.isHidden,
+                  hostedView.alphaValue > 0,
+                  hostedView.frame.contains(point) else { continue }
+
+            return hostedView.hitTest(point) ?? hostedView
+        }
+        return nil
     }
 
     private func shouldPassThroughToChrome(at point: NSPoint, eventType: NSEvent.EventType?) -> Bool {

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2257,6 +2257,54 @@ final class WindowTerminalHostViewTests: XCTestCase {
         )
     }
 
+    func testHostViewKeepsTerminalTopRowClickableWhenTabStripRegionOverlapsContent() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView,
+              let container = contentView.superview else {
+            XCTFail("Expected window content container")
+            return
+        }
+
+        let hostFrame = container.convert(contentView.bounds, from: contentView)
+        let host = WindowTerminalHostView(frame: hostFrame)
+        host.autoresizingMask = [.width, .height]
+
+        let terminalFrame = host.bounds.insetBy(dx: 0, dy: 32)
+        let hostedView = makeHostedTerminalView(frame: terminalFrame)
+        host.addSubview(hostedView)
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+
+        let tabStripOverlap: CGFloat = 2
+        let terminalTopInContent = contentView.convert(hostedView.frame, from: host).maxY
+        let tabStrip = FakeTabBarBackgroundNSView(
+            frame: NSRect(
+                x: 0,
+                y: terminalTopInContent - tabStripOverlap,
+                width: contentView.bounds.width,
+                height: 44
+            )
+        )
+        tabStrip.autoresizingMask = [.width, .minYMargin]
+        contentView.addSubview(tabStrip)
+
+        let pointInHostedView = NSPoint(x: hostedView.bounds.midX, y: hostedView.bounds.maxY - 0.5)
+        let pointInWindow = hostedView.convert(pointInHostedView, to: nil)
+        let pointInHost = host.convert(pointInWindow, from: nil)
+        let event = makeMouseDownEvent(at: pointInWindow, window: window)
+
+        assertHitFallsInsideHostedTerminal(
+            host.performHitTest(at: pointInHost, currentEvent: event),
+            hostedView: hostedView,
+            message: "The absolute top row of terminal content should own mouse-down hit-testing even if chrome hit regions overlap it"
+        )
+    }
+
     func testHostViewPassesThroughWhenNoTerminalSubviewIsHit() {
         let host = WindowTerminalHostView(frame: NSRect(x: 0, y: 0, width: 200, height: 120))
 


### PR DESCRIPTION
## Summary
- add a regression covering terminal top-row hit ownership when tab-strip chrome regions overlap terminal pixels
- keep Bonsplit tab-strip pass-through from swallowing hits that resolve inside a visible hosted terminal surface

## Testing
- Not run locally: xcodebuild-based test execution is intentionally skipped per repo policy; CI should run the test matrix.

Fixes #3709

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pointer hit-testing/routing in `WindowTerminalHostView`, which can subtly affect mouse interactions across chrome/terminal boundaries. Scoped change with targeted regression coverage lowers the risk but UI event routing regressions are still possible.
> 
> **Overview**
> Fixes click routing when the Bonsplit tab strip’s pass-through region overlaps terminal pixels by **only passing through to the pane tab bar if no visible `GhosttySurfaceScrollView` is hit**.
> 
> Adds a regression test ensuring a mouse-down on the terminal’s absolute top row is delivered to the hosted terminal even when a fake tab strip overlaps that area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c829a2e8a39e0fab171ea11b7f327b2221f05d08. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the terminal’s top row clickable even when tab-strip hit regions overlap terminal pixels. Fixes #3709 by routing hits to the visible hosted terminal before any chrome pass-through.

- **Bug Fixes**
  - In WindowTerminalHostView, only pass through to chrome when the point does not hit a visible hosted terminal view (GhosttySurfaceScrollView).
  - Keep Bonsplit tab-strip pass-through for real chrome, but it no longer swallows terminal-surface hits.
  - Added a unit regression that models a small tab-strip overlap and asserts the terminal’s absolute top row owns mouse-down events.

<sup>Written for commit c829a2e8a39e0fab171ea11b7f327b2221f05d08. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where clicks could incorrectly pass through overlapping UI chrome into terminal content; terminal top-row and other click areas remain interactive when UI elements overlap.

* **Tests**
  * Added a regression test to ensure hit-testing keeps terminal content clickable when the tab-strip region overlaps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->