### PR TITLE
Follow SSH workspaces in the Files sidebar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -86038,6 +86038,74 @@
         }
       }
     },
+    "fileExplorer.status.sshHomeFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unable to resolve SSH home: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH のホームを解決できません: %@"
+          }
+        }
+      }
+    },
+    "fileExplorer.status.sshResolvingHome": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Resolving remote home..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "リモートのホームを解決中..."
+          }
+        }
+      }
+    },
+    "fileExplorer.status.sshUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH files unavailable"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH ファイルを利用できません"
+          }
+        }
+      }
+    },
+    "fileExplorer.status.sshUnavailableWithDetail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH files unavailable: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "SSH ファイルを利用できません: %@"
+          }
+        }
+      }
+    },
     "fileExplorer.search.empty": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1029,7 +1029,7 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                             remoteConnectionState,
                             remoteConnectionDetail
                         ) = values
-                        Snapshot(
+                        return Snapshot(
                             workspaceId: workspace.id,
                             currentDirectory: currentDirectory,
                             remoteConfiguration: remoteConfiguration,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2500,7 +2500,7 @@ struct ContentView: View {
                         sshOptions: config.sshOptions
                     ),
                     displayTarget: config.displayTarget,
-                    isAvailable: tab.remoteConnectionState != .error,
+                    isAvailable: tab.remoteConnectionState == .connected,
                     unavailableDetail: tab.remoteConnectionDetail ?? tab.remoteDaemonStatus.detail
                 )
             )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1015,22 +1015,27 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                     )
                     .eraseToAnyPublisher()
                 }
-                let signals: [AnyPublisher<Void, Never>] = [
-                    workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
-                    workspace.$remoteConfiguration.map { _ in () }.eraseToAnyPublisher(),
-                    workspace.$remoteConnectionState.map { _ in () }.eraseToAnyPublisher(),
-                    workspace.$remoteConnectionDetail.map { _ in () }.eraseToAnyPublisher(),
-                    workspace.$remoteDaemonStatus.map { _ in () }.eraseToAnyPublisher(),
-                ]
-                return Publishers.MergeMany(signals)
-                    .map {
+                return workspace.$currentDirectory
+                    .combineLatest(
+                        workspace.$remoteConfiguration,
+                        workspace.$remoteConnectionState,
+                        workspace.$remoteConnectionDetail
+                    )
+                    .combineLatest(workspace.$remoteDaemonStatus)
+                    .map { values, remoteDaemonStatus in
+                        let (
+                            currentDirectory,
+                            remoteConfiguration,
+                            remoteConnectionState,
+                            remoteConnectionDetail
+                        ) = values
                         Snapshot(
                             workspaceId: workspace.id,
-                            currentDirectory: workspace.currentDirectory,
-                            remoteConfiguration: workspace.remoteConfiguration,
-                            remoteConnectionState: workspace.remoteConnectionState,
-                            remoteConnectionDetail: workspace.remoteConnectionDetail,
-                            remoteDaemonStatus: workspace.remoteDaemonStatus
+                            currentDirectory: currentDirectory,
+                            remoteConfiguration: remoteConfiguration,
+                            remoteConnectionState: remoteConnectionState,
+                            remoteConnectionDetail: remoteConnectionDetail,
+                            remoteDaemonStatus: remoteDaemonStatus
                         )
                     }
                     .eraseToAnyPublisher()

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -996,14 +996,18 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                 guard let workspace else {
                     return Just<(UUID?, String?)>((nil, nil)).eraseToAnyPublisher()
                 }
-                return workspace.$currentDirectory
-                    .map { (Optional(workspace.id), Optional($0)) }
+                let signals: [AnyPublisher<Void, Never>] = [
+                    workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
+                    workspace.$remoteConfiguration.map { _ in () }.eraseToAnyPublisher(),
+                    workspace.$remoteConnectionState.map { _ in () }.eraseToAnyPublisher(),
+                    workspace.$remoteConnectionDetail.map { _ in () }.eraseToAnyPublisher(),
+                    workspace.$remoteDaemonStatus.map { _ in () }.eraseToAnyPublisher(),
+                ]
+                return Publishers.MergeMany(signals)
+                    .map { (Optional(workspace.id), Optional(workspace.currentDirectory)) }
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
-            .removeDuplicates { previous, next in
-                previous.0 == next.0 && previous.1 == next.1
-            }
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.directoryChangeGeneration &+= 1
@@ -2437,70 +2441,52 @@ struct ContentView: View {
             // No selection means we have no local cwd to scope by; clear so the
             // sessions panel doesn't keep filtering by a stale previous tab.
             sessionIndexStore.setCurrentDirectoryIfChanged(nil)
+            fileExplorerStore.applyWorkspaceRoot(.none)
+            return
+        }
+
+        fileExplorerStore.showHiddenFiles = true
+
+        if tab.isRemoteWorkspace {
+            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
+            guard let config = tab.remoteConfiguration, config.transport == .ssh else {
+                fileExplorerStore.applyWorkspaceRoot(.none)
+                return
+            }
+
+            #if DEBUG
+            cmuxDebugLog(
+                "fileExplorer.sync remote state=\(tab.remoteConnectionState.rawValue) " +
+                "dest=\(config.destination) target=\(config.displayTarget)"
+            )
+            #endif
+
+            fileExplorerStore.applyWorkspaceRoot(
+                .remoteSSH(
+                    workspaceId: tab.id,
+                    connection: SSHFileExplorerConnection(
+                        destination: config.destination,
+                        port: config.port,
+                        identityFile: config.identityFile,
+                        sshOptions: config.sshOptions
+                    ),
+                    displayTarget: config.displayTarget,
+                    isAvailable: tab.remoteConnectionState != .error,
+                    unavailableDetail: tab.remoteConnectionDetail ?? tab.remoteDaemonStatus.detail
+                )
+            )
             return
         }
 
         let dir = tab.currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !dir.isEmpty else {
             sessionIndexStore.setCurrentDirectoryIfChanged(nil)
+            fileExplorerStore.applyWorkspaceRoot(.none)
             return
         }
 
-        fileExplorerStore.showHiddenFiles = true
-        if !tab.isRemoteWorkspace {
-            sessionIndexStore.setCurrentDirectoryIfChanged(dir)
-        } else {
-            sessionIndexStore.setCurrentDirectoryIfChanged(nil)
-        }
-
-        if tab.isRemoteWorkspace {
-            let config = tab.remoteConfiguration
-            let remotePath = tab.remoteDaemonStatus.remotePath
-            let isReady = tab.remoteDaemonStatus.state == .ready
-            let homePath = remotePath.flatMap { path -> String? in
-                let components = dir.split(separator: "/")
-                if components.count >= 2, components[0] == "home" {
-                    return "/home/\(components[1])"
-                }
-                if dir.hasPrefix("/root") {
-                    return "/root"
-                }
-                return nil
-            } ?? ""
-
-            #if DEBUG
-            cmuxDebugLog("fileExplorer.sync remote dir=\(dir) ready=\(isReady) dest=\(config?.destination ?? "nil")")
-            #endif
-
-            if let existingProvider = fileExplorerStore.provider as? SSHFileExplorerProvider,
-               existingProvider.destination == config?.destination {
-                existingProvider.updateAvailability(isReady, homePath: isReady ? homePath : nil)
-                if isReady {
-                    // Only reload if the path actually changed
-                    let pathChanged = fileExplorerStore.rootPath != dir
-                    fileExplorerStore.setRootPath(dir)
-                    if pathChanged {
-                        fileExplorerStore.hydrateExpandedNodes()
-                    }
-                }
-            } else if let config {
-                let provider = SSHFileExplorerProvider(
-                    destination: config.destination,
-                    port: config.port,
-                    identityFile: config.identityFile,
-                    sshOptions: config.sshOptions,
-                    homePath: homePath,
-                    isAvailable: isReady
-                )
-                fileExplorerStore.setProvider(provider)
-                fileExplorerStore.setRootPath(dir)
-            }
-        } else {
-            if !(fileExplorerStore.provider is LocalFileExplorerProvider) {
-                fileExplorerStore.setProvider(LocalFileExplorerProvider())
-            }
-            fileExplorerStore.setRootPath(dir)
-        }
+        sessionIndexStore.setCurrentDirectoryIfChanged(dir)
+        fileExplorerStore.applyWorkspaceRoot(.local(path: dir))
     }
 
     private var focusedDirectory: String? {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2487,11 +2487,16 @@ struct ContentView: View {
                 fileExplorerStore.applyWorkspaceRoot(.none)
                 return
             }
+            let unavailableDetail = tab.remoteConnectionDetail ?? tab.remoteDaemonStatus.detail
 
             #if DEBUG
+            let hasUnavailableDetail = unavailableDetail?.isEmpty == false
             cmuxDebugLog(
                 "fileExplorer.sync remote state=\(tab.remoteConnectionState.rawValue) " +
-                "dest=\(config.destination) target=\(config.displayTarget)"
+                "hasDestination=\(config.destination.isEmpty ? 0 : 1) " +
+                "hasDisplayTarget=\(config.displayTarget.isEmpty ? 0 : 1) " +
+                "hasIdentityFile=\(config.identityFile == nil ? 0 : 1) " +
+                "hasDetail=\(hasUnavailableDetail ? 1 : 0)"
             )
             #endif
 
@@ -2506,7 +2511,7 @@ struct ContentView: View {
                     ),
                     displayTarget: config.displayTarget,
                     isAvailable: tab.remoteConnectionState == .connected,
-                    unavailableDetail: tab.remoteConnectionDetail ?? tab.remoteDaemonStatus.detail
+                    unavailableDetail: unavailableDetail
                 )
             )
             return

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -979,6 +979,15 @@ private func installFileDropOverlayWhenReady(
 
 @MainActor
 private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
+    private struct Snapshot: Equatable {
+        let workspaceId: UUID?
+        let currentDirectory: String?
+        let remoteConfiguration: WorkspaceRemoteConfiguration?
+        let remoteConnectionState: WorkspaceRemoteConnectionState?
+        let remoteConnectionDetail: String?
+        let remoteDaemonStatus: WorkspaceRemoteDaemonStatus?
+    }
+
     @Published private(set) var directoryChangeGeneration: UInt64 = 0
     private weak var tabManager: TabManager?
     private var cancellable: AnyCancellable?
@@ -992,9 +1001,19 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                 return tabManager.tabs.first(where: { $0.id == tabId })
             }
             .removeDuplicates(by: { $0?.id == $1?.id })
-            .map { workspace -> AnyPublisher<(UUID?, String?), Never> in
+            .map { workspace -> AnyPublisher<Snapshot, Never> in
                 guard let workspace else {
-                    return Just<(UUID?, String?)>((nil, nil)).eraseToAnyPublisher()
+                    return Just(
+                        Snapshot(
+                            workspaceId: nil,
+                            currentDirectory: nil,
+                            remoteConfiguration: nil,
+                            remoteConnectionState: nil,
+                            remoteConnectionDetail: nil,
+                            remoteDaemonStatus: nil
+                        )
+                    )
+                    .eraseToAnyPublisher()
                 }
                 let signals: [AnyPublisher<Void, Never>] = [
                     workspace.$currentDirectory.map { _ in () }.eraseToAnyPublisher(),
@@ -1004,10 +1023,20 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
                     workspace.$remoteDaemonStatus.map { _ in () }.eraseToAnyPublisher(),
                 ]
                 return Publishers.MergeMany(signals)
-                    .map { (Optional(workspace.id), Optional(workspace.currentDirectory)) }
+                    .map {
+                        Snapshot(
+                            workspaceId: workspace.id,
+                            currentDirectory: workspace.currentDirectory,
+                            remoteConfiguration: workspace.remoteConfiguration,
+                            remoteConnectionState: workspace.remoteConnectionState,
+                            remoteConnectionDetail: workspace.remoteConnectionDetail,
+                            remoteDaemonStatus: workspace.remoteDaemonStatus
+                        )
+                    }
                     .eraseToAnyPublisher()
             }
             .switchToLatest()
+            .removeDuplicates()
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
                 self?.directoryChangeGeneration &+= 1

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -391,7 +391,6 @@ final class SSHFileExplorerProvider: FileExplorerProvider, @unchecked Sendable {
             throw FileExplorerError.providerUnavailable
         }
         let home = try await transport.resolveHomePath(connection: connection)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
         guard !home.isEmpty else {
             throw FileExplorerError.sshCommandFailed("remote HOME was empty")
         }

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -1026,9 +1026,11 @@ final class FileExplorerStore: ObservableObject {
                     self.setRootPath(homePath)
                 }
             } catch {
-                await MainActor.run { [weak self] in
+                await MainActor.run { [weak self, weak sshProvider] in
                     guard let self,
-                          self.remoteHomeResolutionKey == resolutionKey else { return }
+                          let sshProvider,
+                          self.remoteHomeResolutionKey == resolutionKey,
+                          self.provider === sshProvider else { return }
                     self.remoteHomeResolutionKey = nil
                     self.remoteHomeResolutionTask = nil
                     self.setRootPath("")

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -878,6 +878,7 @@ final class FileExplorerStore: ObservableObject {
 
         do {
             let entries = try await provider.listDirectory(path: path, showHidden: showHiddenFiles)
+            try Task.checkCancellation()
             let children = entries.map { entry in
                 let node = FileExplorerNode(name: entry.name, path: entry.path, isDirectory: entry.isDirectory)
                 nodesByPath[entry.path] = node

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -392,13 +392,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     static let shared = ProcessSSHFileExplorerTransport()
 
     nonisolated func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
-        try await runOffMain {
-            let output = try Self.runSSHCommand(
-                connection: connection,
-                command: #"printf '%s\n' "$HOME""#
-            )
-            return output.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
+        let output = try await Self.runSSHCommand(
+            connection: connection,
+            command: #"printf '%s\n' "$HOME""#
+        )
+        return output.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     nonisolated func listDirectory(
@@ -406,38 +404,85 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         connection: SSHFileExplorerConnection,
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
-        try await runOffMain {
-            try Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
+        try await Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
+    }
+
+    private struct SSHCommandResult: Sendable {
+        let stdout: String
+        let stderr: String
+        let terminationStatus: Int32
+    }
+
+    // Keeps the child process reachable from the cancellation handler while
+    // the blocking wait runs on a detached thread.
+    private final class SSHCommandProcess: @unchecked Sendable {
+        private let process = Process()
+        private let outPipe = Pipe()
+        private let errPipe = Pipe()
+        private let lock = NSLock()
+        private var cancelled = false
+
+        init(connection: SSHFileExplorerConnection, command: String) {
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
+            process.arguments = ProcessSSHFileExplorerTransport.sshArguments(connection: connection, command: command)
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+        }
+
+        func run() throws -> SSHCommandResult {
+            lock.lock()
+            let wasCancelled = cancelled
+            lock.unlock()
+            if wasCancelled {
+                throw CancellationError()
+            }
+
+            try process.run()
+
+            lock.lock()
+            let shouldTerminate = cancelled && process.isRunning
+            lock.unlock()
+            if shouldTerminate {
+                process.terminate()
+            }
+
+            let data = outPipe.fileHandleForReading.readDataToEndOfFile()
+            let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
+            process.waitUntilExit()
+
+            return SSHCommandResult(
+                stdout: String(data: data, encoding: .utf8) ?? "",
+                stderr: String(data: stderrData, encoding: .utf8) ?? "",
+                terminationStatus: process.terminationStatus
+            )
+        }
+
+        func terminate() {
+            lock.lock()
+            cancelled = true
+            let isRunning = process.isRunning
+            lock.unlock()
+
+            if isRunning {
+                process.terminate()
+            }
         }
     }
 
-    private nonisolated func runOffMain<T: Sendable>(_ work: @escaping @Sendable () throws -> T) async throws -> T {
-        try await Task.detached(priority: .userInitiated) {
-            try work()
-        }.value
-    }
-
-    private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) throws -> String {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-        process.arguments = sshArguments(connection: connection, command: command)
-
-        let outPipe = Pipe()
-        let errPipe = Pipe()
-        process.standardOutput = outPipe
-        process.standardError = errPipe
-
-        try process.run()
-        // Read pipe data before waitUntilExit to avoid deadlock when pipe buffer fills
-        let data = outPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = errPipe.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
-
-        guard process.terminationStatus == 0 else {
-            let stderrStr = String(data: stderrData, encoding: .utf8) ?? ""
-            throw FileExplorerError.sshCommandFailed(stderrStr)
+    private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) async throws -> String {
+        let commandProcess = SSHCommandProcess(connection: connection, command: command)
+        let result = try await withTaskCancellationHandler {
+            try await Task.detached(priority: .userInitiated) {
+                try commandProcess.run()
+            }.value
+        } onCancel: {
+            commandProcess.terminate()
         }
-        return String(data: data, encoding: .utf8) ?? ""
+
+        guard result.terminationStatus == 0 else {
+            throw FileExplorerError.sshCommandFailed(result.stderr)
+        }
+        return result.stdout
     }
 
     private static func sshArguments(connection: SSHFileExplorerConnection, command: String) -> [String] {
@@ -461,11 +506,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         path: String,
         connection: SSHFileExplorerConnection,
         showHidden: Bool
-    ) throws -> [FileExplorerEntry] {
+    ) async throws -> [FileExplorerEntry] {
         // Escape single quotes in path for shell safety
         let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
         let lsFlags = showHidden ? "-1paFA" : "-1paF"
-        let output = try runSSHCommand(
+        let output = try await runSSHCommand(
             connection: connection,
             command: "ls \(lsFlags) '\(escapedPath)' 2>/dev/null"
         )
@@ -565,10 +610,10 @@ final class FileExplorerStore: ObservableObject {
     private var remoteHomeResolutionKey: String?
 
     var displayRootPath: String {
-        if let sshProvider = provider as? SSHFileExplorerProvider, rootPath.isEmpty {
-            return "ssh://\(sshProvider.displayTarget)"
-        }
         if let sshProvider = provider as? SSHFileExplorerProvider {
+            guard !rootPath.isEmpty else {
+                return "ssh://\(sshProvider.displayTarget)"
+            }
             return "ssh://\(sshProvider.displayTarget):\(rootPath)"
         }
         return FileExplorerRootResolver.displayPath(for: rootPath, homePath: provider?.homePath)
@@ -675,7 +720,7 @@ final class FileExplorerStore: ObservableObject {
         }
     }
 
-    func setProvider(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
+    private func setProvider(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
         #if DEBUG
         NSLog("[FileExplorer] setProvider: \(type(of: newProvider).self) available=\(newProvider?.isAvailable ?? false)")
         #endif
@@ -685,6 +730,12 @@ final class FileExplorerStore: ObservableObject {
             reload()
         }
     }
+
+    #if DEBUG
+    func setProviderForTesting(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
+        setProvider(newProvider, reloadIfAvailable: reloadIfAvailable)
+    }
+    #endif
 
     func reload() {
         #if DEBUG
@@ -829,7 +880,7 @@ final class FileExplorerStore: ObservableObject {
             } else {
                 rootNodes = children
                 isRootLoading = false
-                rootStatusMessage = nil
+                setRootStatusMessage(nil)
                 if selectedPath == nil {
                     selectedPath = children.first?.path
                     selectedPaths = selectedPath.map { Set([$0]) } ?? []
@@ -857,7 +908,7 @@ final class FileExplorerStore: ObservableObject {
                     parentNode.error = error.localizedDescription
                 } else {
                     isRootLoading = false
-                    rootStatusMessage = error.localizedDescription
+                    setRootStatusMessage(error.localizedDescription)
                 }
                 loadingPaths.remove(path)
                 loadTasks.removeValue(forKey: path)
@@ -915,11 +966,8 @@ final class FileExplorerStore: ObservableObject {
             if let detail, !detail.isEmpty {
                 setRootStatusMessage(
                     String(
-                        format: String(
-                            localized: "fileExplorer.status.sshUnavailableWithDetail",
-                            defaultValue: "SSH files unavailable: %@"
-                        ),
-                        detail
+                        localized: "fileExplorer.status.sshUnavailableWithDetail",
+                        defaultValue: "SSH files unavailable: \(detail)"
                     )
                 )
             } else {
@@ -986,11 +1034,8 @@ final class FileExplorerStore: ObservableObject {
                     self.setRootPath("")
                     self.setRootStatusMessage(
                         String(
-                            format: String(
-                                localized: "fileExplorer.status.sshHomeFailed",
-                                defaultValue: "Unable to resolve SSH home: %@"
-                            ),
-                            error.localizedDescription
+                            localized: "fileExplorer.status.sshHomeFailed",
+                            defaultValue: "Unable to resolve SSH home: \(error.localizedDescription)"
                         )
                     )
                 }

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -269,8 +269,8 @@ struct SSHFileExplorerConnection: Equatable, Sendable {
 }
 
 protocol SSHFileExplorerTransport: AnyObject {
-    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String
-    func listDirectory(
+    nonisolated func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String
+    nonisolated func listDirectory(
         path: String,
         connection: SSHFileExplorerConnection,
         showHidden: Bool

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -203,7 +203,7 @@ enum FileExplorerStyle: Int, CaseIterable {
 
 // MARK: - Models
 
-struct FileExplorerEntry {
+struct FileExplorerEntry: Sendable {
     let name: String
     let path: String
     let isDirectory: Bool
@@ -261,7 +261,7 @@ protocol FileExplorerProvider: AnyObject {
     var isAvailable: Bool { get }
 }
 
-struct SSHFileExplorerConnection: Equatable {
+struct SSHFileExplorerConnection: Equatable, Sendable {
     let destination: String
     let port: Int?
     let identityFile: String?
@@ -391,8 +391,8 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
 final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     static let shared = ProcessSSHFileExplorerTransport()
 
-    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
-        try await runOnBackground {
+    nonisolated func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
+        try await runOffMain {
             let output = try Self.runSSHCommand(
                 connection: connection,
                 command: #"printf '%s\n' "$HOME""#
@@ -401,27 +401,20 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
         }
     }
 
-    func listDirectory(
+    nonisolated func listDirectory(
         path: String,
         connection: SSHFileExplorerConnection,
         showHidden: Bool
     ) async throws -> [FileExplorerEntry] {
-        try await runOnBackground {
+        try await runOffMain {
             try Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
         }
     }
 
-    private func runOnBackground<T>(_ work: @escaping () throws -> T) async throws -> T {
-        return try await withCheckedThrowingContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                do {
-                    let result = try work()
-                    continuation.resume(returning: result)
-                } catch {
-                    continuation.resume(throwing: error)
-                }
-            }
-        }
+    private nonisolated func runOffMain<T: Sendable>(_ work: @escaping @Sendable () throws -> T) async throws -> T {
+        try await Task.detached(priority: .userInitiated) {
+            try work()
+        }.value
     }
 
     private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) throws -> String {

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -310,12 +310,30 @@ final class LocalFileExplorerProvider: FileExplorerProvider {
 
 // MARK: - SSH Provider
 
-final class SSHFileExplorerProvider: FileExplorerProvider {
+// Captured by async SSH tasks; mutable availability/root state is guarded by stateLock.
+final class SSHFileExplorerProvider: FileExplorerProvider, @unchecked Sendable {
+    private struct State: Sendable {
+        var homePath: String
+        var isAvailable: Bool
+    }
+
     let connection: SSHFileExplorerConnection
     let displayTarget: String
     private let transport: SSHFileExplorerTransport
-    private(set) var homePath: String
-    private(set) var isAvailable: Bool
+    private let stateLock = NSLock()
+    private var state: State
+
+    var homePath: String {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return state.homePath
+    }
+
+    var isAvailable: Bool {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        return state.isAvailable
+    }
 
     var destination: String { connection.destination }
     var port: Int? { connection.port }
@@ -343,8 +361,7 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
             return "\(destination):\(port)"
         }()
         self.transport = transport
-        self.homePath = homePath
-        self.isAvailable = isAvailable
+        self.state = State(homePath: homePath, isAvailable: isAvailable)
     }
 
     init(
@@ -357,14 +374,15 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
         self.connection = connection
         self.displayTarget = displayTarget
         self.transport = transport
-        self.homePath = homePath
-        self.isAvailable = isAvailable
+        self.state = State(homePath: homePath, isAvailable: isAvailable)
     }
 
     func updateAvailability(_ available: Bool, homePath: String?) {
-        self.isAvailable = available
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        state.isAvailable = available
         if let homePath {
-            self.homePath = homePath
+            state.homePath = homePath
         }
     }
 
@@ -978,9 +996,10 @@ final class FileExplorerStore: ObservableObject {
             return
         }
 
-        if !sshProvider.homePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+        let currentHomePath = sshProvider.homePath
+        if !currentHomePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             setRootStatusMessage(nil)
-            setRootPath(sshProvider.homePath)
+            setRootPath(currentHomePath)
             return
         }
 

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -578,7 +578,7 @@ final class FileExplorerStore: ObservableObject {
         if let sshProvider = provider as? SSHFileExplorerProvider {
             return "ssh://\(sshProvider.displayTarget):\(rootPath)"
         }
-        FileExplorerRootResolver.displayPath(for: rootPath, homePath: provider?.homePath)
+        return FileExplorerRootResolver.displayPath(for: rootPath, homePath: provider?.homePath)
     }
 
     // MARK: - Public API

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -261,6 +261,34 @@ protocol FileExplorerProvider: AnyObject {
     var isAvailable: Bool { get }
 }
 
+struct SSHFileExplorerConnection: Equatable {
+    let destination: String
+    let port: Int?
+    let identityFile: String?
+    let sshOptions: [String]
+}
+
+protocol SSHFileExplorerTransport: AnyObject {
+    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String
+    func listDirectory(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        showHidden: Bool
+    ) async throws -> [FileExplorerEntry]
+}
+
+enum FileExplorerWorkspaceRoot: Equatable {
+    case none
+    case local(path: String)
+    case remoteSSH(
+        workspaceId: UUID,
+        connection: SSHFileExplorerConnection,
+        displayTarget: String,
+        isAvailable: Bool,
+        unavailableDetail: String?
+    )
+}
+
 // MARK: - Local Provider
 
 final class LocalFileExplorerProvider: FileExplorerProvider {
@@ -283,25 +311,52 @@ final class LocalFileExplorerProvider: FileExplorerProvider {
 // MARK: - SSH Provider
 
 final class SSHFileExplorerProvider: FileExplorerProvider {
-    let destination: String
-    let port: Int?
-    let identityFile: String?
-    let sshOptions: [String]
+    let connection: SSHFileExplorerConnection
+    let displayTarget: String
+    private let transport: SSHFileExplorerTransport
     private(set) var homePath: String
     private(set) var isAvailable: Bool
+
+    var destination: String { connection.destination }
+    var port: Int? { connection.port }
+    var identityFile: String? { connection.identityFile }
+    var sshOptions: [String] { connection.sshOptions }
 
     init(
         destination: String,
         port: Int?,
         identityFile: String?,
         sshOptions: [String],
+        displayTarget: String? = nil,
         homePath: String,
-        isAvailable: Bool
+        isAvailable: Bool,
+        transport: SSHFileExplorerTransport = ProcessSSHFileExplorerTransport.shared
     ) {
-        self.destination = destination
-        self.port = port
-        self.identityFile = identityFile
-        self.sshOptions = sshOptions
+        self.connection = SSHFileExplorerConnection(
+            destination: destination,
+            port: port,
+            identityFile: identityFile,
+            sshOptions: sshOptions
+        )
+        self.displayTarget = displayTarget ?? {
+            guard let port else { return destination }
+            return "\(destination):\(port)"
+        }()
+        self.transport = transport
+        self.homePath = homePath
+        self.isAvailable = isAvailable
+    }
+
+    init(
+        connection: SSHFileExplorerConnection,
+        displayTarget: String,
+        homePath: String,
+        isAvailable: Bool,
+        transport: SSHFileExplorerTransport = ProcessSSHFileExplorerTransport.shared
+    ) {
+        self.connection = connection
+        self.displayTarget = displayTarget
+        self.transport = transport
         self.homePath = homePath
         self.isAvailable = isAvailable
     }
@@ -313,23 +368,54 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
         }
     }
 
+    func resolveHomePath() async throws -> String {
+        guard isAvailable else {
+            throw FileExplorerError.providerUnavailable
+        }
+        let home = try await transport.resolveHomePath(connection: connection)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !home.isEmpty else {
+            throw FileExplorerError.sshCommandFailed("remote HOME was empty")
+        }
+        return home
+    }
+
     func listDirectory(path: String, showHidden: Bool) async throws -> [FileExplorerEntry] {
         guard isAvailable else {
             throw FileExplorerError.providerUnavailable
         }
-        // Capture immutable config values for Sendable closure
-        let dest = destination
-        let p = port
-        let identity = identityFile
-        let opts = sshOptions
+        return try await transport.listDirectory(path: path, connection: connection, showHidden: showHidden)
+    }
+}
+
+final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
+    static let shared = ProcessSSHFileExplorerTransport()
+
+    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
+        try await runOnBackground {
+            let output = try Self.runSSHCommand(
+                connection: connection,
+                command: #"printf '%s\n' "$HOME""#
+            )
+            return output.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+    }
+
+    func listDirectory(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        showHidden: Bool
+    ) async throws -> [FileExplorerEntry] {
+        try await runOnBackground {
+            try Self.runSSHListCommand(path: path, connection: connection, showHidden: showHidden)
+        }
+    }
+
+    private func runOnBackground<T>(_ work: @escaping () throws -> T) async throws -> T {
         return try await withCheckedThrowingContinuation { continuation in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    let result = try SSHFileExplorerProvider.runSSHListCommand(
-                        path: path, destination: dest, port: p,
-                        identityFile: identity, sshOptions: opts,
-                        showHidden: showHidden
-                    )
+                    let result = try work()
                     continuation.resume(returning: result)
                 } catch {
                     continuation.resume(throwing: error)
@@ -338,32 +424,10 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
         }
     }
 
-    private static func runSSHListCommand(
-        path: String, destination: String, port: Int?,
-        identityFile: String?, sshOptions: [String],
-        showHidden: Bool
-    ) throws -> [FileExplorerEntry] {
+    private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) throws -> String {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/ssh")
-
-        var args: [String] = []
-        if let port {
-            args += ["-p", String(port)]
-        }
-        if let identityFile {
-            args += ["-i", identityFile]
-        }
-        for option in sshOptions {
-            args += ["-o", option]
-        }
-        // Batch mode, no TTY, connection timeout
-        args += ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "-T"]
-        // Escape single quotes in path for shell safety
-        let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
-        let lsFlags = showHidden ? "-1paFA" : "-1paF"
-        args += [destination, "ls \(lsFlags) '\(escapedPath)' 2>/dev/null"]
-
-        process.arguments = args
+        process.arguments = sshArguments(connection: connection, command: command)
 
         let outPipe = Pipe()
         let errPipe = Pipe()
@@ -380,9 +444,38 @@ final class SSHFileExplorerProvider: FileExplorerProvider {
             let stderrStr = String(data: stderrData, encoding: .utf8) ?? ""
             throw FileExplorerError.sshCommandFailed(stderrStr)
         }
-        guard let output = String(data: data, encoding: .utf8) else {
-            return []
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private static func sshArguments(connection: SSHFileExplorerConnection, command: String) -> [String] {
+        var args: [String] = []
+        if let port = connection.port {
+            args += ["-p", String(port)]
         }
+        if let identityFile = connection.identityFile {
+            args += ["-i", identityFile]
+        }
+        for option in connection.sshOptions {
+            args += ["-o", option]
+        }
+        // Batch mode, no TTY, connection timeout
+        args += ["-o", "BatchMode=yes", "-o", "ConnectTimeout=5", "-T"]
+        args += [connection.destination, command]
+        return args
+    }
+
+    private static func runSSHListCommand(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        showHidden: Bool
+    ) throws -> [FileExplorerEntry] {
+        // Escape single quotes in path for shell safety
+        let escapedPath = path.replacingOccurrences(of: "'", with: "'\\''")
+        let lsFlags = showHidden ? "-1paFA" : "-1paF"
+        let output = try runSSHCommand(
+            connection: connection,
+            command: "ls \(lsFlags) '\(escapedPath)' 2>/dev/null"
+        )
 
         let normalizedPath = path.hasSuffix("/") ? path : path + "/"
         return output.split(separator: "\n", omittingEmptySubsequences: true).compactMap { line in
@@ -441,6 +534,7 @@ final class FileExplorerStore: ObservableObject {
     @Published private(set) var isRootLoading: Bool = false
     @Published private(set) var gitStatusByPath: [String: GitFileStatus] = [:]
     @Published private(set) var contentRevision = 0
+    @Published private(set) var rootStatusMessage: String?
 
     var provider: FileExplorerProvider?
 
@@ -474,11 +568,54 @@ final class FileExplorerStore: ObservableObject {
     /// Prefetch debounce: path -> work item
     private var prefetchWorkItems: [String: DispatchWorkItem] = [:]
 
+    private var remoteHomeResolutionTask: Task<Void, Never>?
+    private var remoteHomeResolutionKey: String?
+
     var displayRootPath: String {
+        if let sshProvider = provider as? SSHFileExplorerProvider, rootPath.isEmpty {
+            return "ssh://\(sshProvider.displayTarget)"
+        }
+        if let sshProvider = provider as? SSHFileExplorerProvider {
+            return "ssh://\(sshProvider.displayTarget):\(rootPath)"
+        }
         FileExplorerRootResolver.displayPath(for: rootPath, homePath: provider?.homePath)
     }
 
     // MARK: - Public API
+
+    func applyWorkspaceRoot(
+        _ request: FileExplorerWorkspaceRoot,
+        sshTransport: SSHFileExplorerTransport = ProcessSSHFileExplorerTransport.shared
+    ) {
+        switch request {
+        case .none:
+            cancelRemoteHomeResolution()
+            setRootStatusMessage(nil)
+            if provider != nil {
+                setProvider(nil, reloadIfAvailable: false)
+            }
+            setRootPath("")
+
+        case .local(let path):
+            cancelRemoteHomeResolution()
+            setRootStatusMessage(nil)
+            if !(provider is LocalFileExplorerProvider) {
+                setRootPath("")
+                setProvider(LocalFileExplorerProvider(), reloadIfAvailable: false)
+            }
+            setRootPath(path)
+
+        case .remoteSSH(let workspaceId, let connection, let displayTarget, let isAvailable, let unavailableDetail):
+            applyRemoteSSHWorkspaceRoot(
+                workspaceId: workspaceId,
+                connection: connection,
+                displayTarget: displayTarget,
+                isAvailable: isAvailable,
+                unavailableDetail: unavailableDetail,
+                sshTransport: sshTransport
+            )
+        }
+    }
 
     func setRootPath(_ path: String) {
         guard path != rootPath else {
@@ -545,13 +682,13 @@ final class FileExplorerStore: ObservableObject {
         }
     }
 
-    func setProvider(_ newProvider: FileExplorerProvider?) {
+    func setProvider(_ newProvider: FileExplorerProvider?, reloadIfAvailable: Bool = true) {
         #if DEBUG
         NSLog("[FileExplorer] setProvider: \(type(of: newProvider).self) available=\(newProvider?.isAvailable ?? false)")
         #endif
         provider = newProvider
         // Re-expand previously expanded nodes if provider becomes available
-        if newProvider?.isAvailable == true {
+        if reloadIfAvailable, newProvider?.isAvailable == true {
             reload()
         }
     }
@@ -699,6 +836,7 @@ final class FileExplorerStore: ObservableObject {
             } else {
                 rootNodes = children
                 isRootLoading = false
+                rootStatusMessage = nil
                 if selectedPath == nil {
                     selectedPath = children.first?.path
                     selectedPaths = selectedPath.map { Set([$0]) } ?? []
@@ -726,6 +864,7 @@ final class FileExplorerStore: ObservableObject {
                     parentNode.error = error.localizedDescription
                 } else {
                     isRootLoading = false
+                    rootStatusMessage = error.localizedDescription
                 }
                 loadingPaths.remove(path)
                 loadTasks.removeValue(forKey: path)
@@ -748,12 +887,145 @@ final class FileExplorerStore: ObservableObject {
         isRootLoading = false
     }
 
+    private func applyRemoteSSHWorkspaceRoot(
+        workspaceId: UUID,
+        connection: SSHFileExplorerConnection,
+        displayTarget: String,
+        isAvailable: Bool,
+        unavailableDetail: String?,
+        sshTransport: SSHFileExplorerTransport
+    ) {
+        let existingProvider = provider as? SSHFileExplorerProvider
+        let sshProvider: SSHFileExplorerProvider
+        if let existingProvider,
+           existingProvider.connection == connection,
+           existingProvider.displayTarget == displayTarget {
+            sshProvider = existingProvider
+            sshProvider.updateAvailability(isAvailable, homePath: nil)
+        } else {
+            cancelRemoteHomeResolution()
+            setRootPath("")
+            sshProvider = SSHFileExplorerProvider(
+                connection: connection,
+                displayTarget: displayTarget,
+                homePath: "",
+                isAvailable: isAvailable,
+                transport: sshTransport
+            )
+            setProvider(sshProvider, reloadIfAvailable: false)
+        }
+
+        guard isAvailable else {
+            cancelRemoteHomeResolution()
+            setRootPath("")
+            let detail = unavailableDetail?.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let detail, !detail.isEmpty {
+                setRootStatusMessage(
+                    String(
+                        format: String(
+                            localized: "fileExplorer.status.sshUnavailableWithDetail",
+                            defaultValue: "SSH files unavailable: %@"
+                        ),
+                        detail
+                    )
+                )
+            } else {
+                setRootStatusMessage(
+                    String(localized: "fileExplorer.status.sshUnavailable", defaultValue: "SSH files unavailable")
+                )
+            }
+            return
+        }
+
+        if !sshProvider.homePath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            setRootStatusMessage(nil)
+            setRootPath(sshProvider.homePath)
+            return
+        }
+
+        resolveRemoteHome(
+            workspaceId: workspaceId,
+            provider: sshProvider,
+            connection: connection
+        )
+    }
+
+    private func resolveRemoteHome(
+        workspaceId: UUID,
+        provider sshProvider: SSHFileExplorerProvider,
+        connection: SSHFileExplorerConnection
+    ) {
+        let resolutionKey = [
+            workspaceId.uuidString,
+            connection.destination,
+            connection.port.map(String.init) ?? "",
+            connection.identityFile ?? "",
+            connection.sshOptions.joined(separator: "\u{1f}"),
+        ].joined(separator: "\u{1e}")
+
+        guard remoteHomeResolutionKey != resolutionKey else { return }
+        remoteHomeResolutionTask?.cancel()
+        remoteHomeResolutionKey = resolutionKey
+        setRootPath("")
+        setRootStatusMessage(String(localized: "fileExplorer.status.sshResolvingHome", defaultValue: "Resolving remote home..."))
+
+        remoteHomeResolutionTask = Task { [weak self, weak sshProvider] in
+            guard let sshProvider else { return }
+            do {
+                let homePath = try await sshProvider.resolveHomePath()
+                await MainActor.run { [weak self, weak sshProvider] in
+                    guard let self,
+                          let sshProvider,
+                          self.remoteHomeResolutionKey == resolutionKey,
+                          self.provider === sshProvider else { return }
+                    self.remoteHomeResolutionKey = nil
+                    self.remoteHomeResolutionTask = nil
+                    sshProvider.updateAvailability(true, homePath: homePath)
+                    self.setRootStatusMessage(nil)
+                    self.setRootPath(homePath)
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.remoteHomeResolutionKey == resolutionKey else { return }
+                    self.remoteHomeResolutionKey = nil
+                    self.remoteHomeResolutionTask = nil
+                    self.setRootPath("")
+                    self.setRootStatusMessage(
+                        String(
+                            format: String(
+                                localized: "fileExplorer.status.sshHomeFailed",
+                                defaultValue: "Unable to resolve SSH home: %@"
+                            ),
+                            error.localizedDescription
+                        )
+                    )
+                }
+            }
+        }
+    }
+
+    private func cancelRemoteHomeResolution() {
+        remoteHomeResolutionTask?.cancel()
+        remoteHomeResolutionTask = nil
+        remoteHomeResolutionKey = nil
+    }
+
+    private func setRootStatusMessage(_ message: String?) {
+        guard rootStatusMessage != message else { return }
+        rootStatusMessage = message
+    }
+
     private static func path(_ candidate: String, isContainedIn root: String) -> Bool {
         guard !root.isEmpty else { return false }
         if root == "/" {
             return candidate.hasPrefix("/")
         }
         return candidate == root || candidate.hasPrefix(root + "/")
+    }
+
+    deinit {
+        cancelRemoteHomeResolution()
     }
 }
 

--- a/Sources/FileExplorerStore.swift
+++ b/Sources/FileExplorerStore.swift
@@ -432,7 +432,7 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     }
 
     // Keeps the child process reachable from the cancellation handler while
-    // the blocking wait runs on a detached thread.
+    // the blocking wait runs off Swift's cooperative executor.
     private final class SSHCommandProcess: @unchecked Sendable {
         private let process = Process()
         private let outPipe = Pipe()
@@ -490,9 +490,11 @@ final class ProcessSSHFileExplorerTransport: SSHFileExplorerTransport {
     private static func runSSHCommand(connection: SSHFileExplorerConnection, command: String) async throws -> String {
         let commandProcess = SSHCommandProcess(connection: connection, command: command)
         let result = try await withTaskCancellationHandler {
-            try await Task.detached(priority: .userInitiated) {
-                try commandProcess.run()
-            }.value
+            try await withCheckedThrowingContinuation { continuation in
+                DispatchQueue.global(qos: .userInitiated).async {
+                    continuation.resume(with: Result { try commandProcess.run() })
+                }
+            }
         } onCancel: {
             commandProcess.terminate()
         }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -108,7 +108,11 @@ struct FileExplorerPanelView: NSViewRepresentable {
             guard let outlineView else { return }
 
             // Update empty state vs tree visibility
-            containerView?.updateVisibility(hasContent: !store.rootPath.isEmpty, isLoading: store.isRootLoading)
+            containerView?.updateVisibility(
+                hasContent: !store.rootPath.isEmpty,
+                isLoading: store.isRootLoading,
+                statusMessage: store.rootStatusMessage
+            )
 
             let newCount = store.rootNodes.count
             withProgrammaticOutlineUpdate {
@@ -880,11 +884,17 @@ final class FileExplorerContainerView: NSView {
         registerWithKeyboardFocusCoordinatorIfNeeded()
     }
 
-    func updateVisibility(hasContent: Bool, isLoading: Bool) {
-        headerView.isHidden = !hasContent
-        updateSearchLayout(hasContent: hasContent, isLoading: isLoading)
-        let searchCanShow = isSearchVisible && hasContent && !isLoading
-        emptyLabel.isHidden = hasContent || searchCanShow
+    func updateVisibility(hasContent: Bool, isLoading: Bool, statusMessage: String?) {
+        let normalizedStatus = statusMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasStatus = normalizedStatus?.isEmpty == false
+        let canShowTree = hasContent && !hasStatus
+        headerView.isHidden = !hasContent && !hasStatus
+        updateSearchLayout(hasContent: canShowTree, isLoading: isLoading)
+        let searchCanShow = isSearchVisible && canShowTree && !isLoading
+        emptyLabel.stringValue = hasStatus
+            ? normalizedStatus!
+            : String(localized: "fileExplorer.empty", defaultValue: "No folder open")
+        emptyLabel.isHidden = canShowTree || searchCanShow || isLoading
         loadingIndicator.isHidden = !isLoading
         if isLoading {
             loadingIndicator.startAnimation(nil)
@@ -1492,10 +1502,12 @@ final class FileExplorerHeaderView: NSView {
             iconView.image = NSImage(systemSymbolName: "magnifyingglass", accessibilityDescription: nil)?
                 .withSymbolConfiguration(config)
             pathLabel.stringValue = "/" + quickSearchQuery
+            pathLabel.toolTip = pathLabel.stringValue
         } else {
             iconView.image = NSImage(systemSymbolName: "folder.fill", accessibilityDescription: nil)?
                 .withSymbolConfiguration(config)
             pathLabel.stringValue = displayPath
+            pathLabel.toolTip = displayPath
         }
     }
 }

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -181,7 +181,7 @@ final class FileExplorerStoreTests: XCTestCase {
 
         XCTAssertTrue(store.provider is SSHFileExplorerProvider)
         XCTAssertEqual(store.rootPath, "/home/dev")
-        XCTAssertEqual(store.displayRootPath, "ssh://dev@ubuntu-host:2222~")
+        XCTAssertEqual(store.displayRootPath, "ssh://dev@ubuntu-host:2222:/home/dev")
         XCTAssertEqual(transport.resolvedHomeConnections, [connection])
         XCTAssertEqual(transport.listedPaths, ["/home/dev"])
     }

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -41,6 +41,34 @@ private final class MockFileExplorerProvider: FileExplorerProvider {
     }
 }
 
+private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
+    var homePath: Result<String, Error>
+    var listings: [String: Result<[FileExplorerEntry], Error>] = [:]
+    private(set) var resolvedHomeConnections: [SSHFileExplorerConnection] = []
+    private(set) var listedPaths: [String] = []
+
+    init(homePath: Result<String, Error> = .success("/home/dev")) {
+        self.homePath = homePath
+    }
+
+    func resolveHomePath(connection: SSHFileExplorerConnection) async throws -> String {
+        resolvedHomeConnections.append(connection)
+        return try homePath.get()
+    }
+
+    func listDirectory(
+        path: String,
+        connection: SSHFileExplorerConnection,
+        showHidden: Bool
+    ) async throws -> [FileExplorerEntry] {
+        listedPaths.append(path)
+        if let result = listings[path] {
+            return try result.get()
+        }
+        return []
+    }
+}
+
 // MARK: - Store Tests
 
 /// The store's `@Published` state is driven by unstructured `Task { ... }` calls that
@@ -117,6 +145,88 @@ final class FileExplorerStoreTests: XCTestCase {
         store.setProvider(provider)
         store.rootPath = "/home/user/project"
         XCTAssertEqual(store.displayRootPath, "~/project")
+    }
+
+    func testRemoteWorkspaceRootRequestResolvesSSHHomeInsteadOfKeepingLocalPath() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/home/dev"] = .success([
+            FileExplorerEntry(name: "project", path: "/home/dev/project", isDirectory: true),
+        ])
+        let connection = SSHFileExplorerConnection(
+            destination: "dev@ubuntu-host",
+            port: 2222,
+            identityFile: "/Users/alice/.ssh/id_ed25519",
+            sshOptions: ["ControlPath /tmp/cmux-ssh-%C"]
+        )
+
+        let store = FileExplorerStore()
+        store.setProvider(LocalFileExplorerProvider())
+        store.setRootPath("/Users/alice")
+
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: connection,
+                displayTarget: "dev@ubuntu-host:2222",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote home resolved and loaded") {
+            store.rootPath == "/home/dev" &&
+                store.rootNodes.map(\.name) == ["project"]
+        }
+
+        XCTAssertTrue(store.provider is SSHFileExplorerProvider)
+        XCTAssertEqual(store.rootPath, "/home/dev")
+        XCTAssertEqual(store.displayRootPath, "ssh://dev@ubuntu-host:2222~")
+        XCTAssertEqual(transport.resolvedHomeConnections, [connection])
+        XCTAssertEqual(transport.listedPaths, ["/home/dev"])
+    }
+
+    func testSwitchingFromLocalToRemoteRepointsTreeToRemoteHome() async throws {
+        let transport = MockSSHFileExplorerTransport(homePath: .success("/home/dev"))
+        transport.listings["/home/dev"] = .success([
+            FileExplorerEntry(name: ".ssh", path: "/home/dev/.ssh", isDirectory: true),
+        ])
+        let localProvider = MockFileExplorerProvider(homePath: "/Users/alice")
+        localProvider.listings["/Users/alice"] = .success([
+            FileExplorerEntry(name: "Desktop", path: "/Users/alice/Desktop", isDirectory: true),
+        ])
+
+        let store = FileExplorerStore()
+        store.setProvider(localProvider)
+        store.setRootPath("/Users/alice")
+        try await waitFor("local root loaded") {
+            store.rootPath == "/Users/alice" &&
+                store.rootNodes.map(\.name) == ["Desktop"]
+        }
+
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                isAvailable: true,
+                unavailableDetail: nil
+            ),
+            sshTransport: transport
+        )
+
+        try await waitFor("remote root replaces local root") {
+            store.rootPath == "/home/dev" &&
+                store.rootNodes.map(\.name) == [".ssh"]
+        }
+
+        XCTAssertTrue(store.provider is SSHFileExplorerProvider)
+        XCTAssertEqual(transport.resolvedHomeConnections.map(\.destination), ["dev@ubuntu-host"])
     }
 
     // MARK: - Expansion state persistence

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -69,6 +69,25 @@ private final class MockSSHFileExplorerTransport: SSHFileExplorerTransport {
     }
 }
 
+private final class DeferredListFileExplorerProvider: FileExplorerProvider {
+    var homePath = "/home/dev"
+    var isAvailable = true
+    private(set) var listCallPaths: [String] = []
+    private var continuation: CheckedContinuation<[FileExplorerEntry], Error>?
+
+    func listDirectory(path: String, showHidden: Bool) async throws -> [FileExplorerEntry] {
+        listCallPaths.append(path)
+        return try await withCheckedThrowingContinuation { continuation in
+            self.continuation = continuation
+        }
+    }
+
+    func resumeListing(returning entries: [FileExplorerEntry]) {
+        continuation?.resume(returning: entries)
+        continuation = nil
+    }
+}
+
 // MARK: - Store Tests
 
 /// The store's `@Published` state is driven by unstructured `Task { ... }` calls that
@@ -227,6 +246,48 @@ final class FileExplorerStoreTests: XCTestCase {
 
         XCTAssertTrue(store.provider is SSHFileExplorerProvider)
         XCTAssertEqual(transport.resolvedHomeConnections.map(\.destination), ["dev@ubuntu-host"])
+    }
+
+    func testCancelledRootLoadDoesNotClearRemoteUnavailableStatus() async throws {
+        let provider = DeferredListFileExplorerProvider()
+        let store = FileExplorerStore()
+        store.setProviderForTesting(provider)
+        store.setRootPath("/home/dev")
+
+        try await waitFor("root listing started") {
+            provider.listCallPaths == ["/home/dev"]
+        }
+
+        store.applyWorkspaceRoot(
+            .remoteSSH(
+                workspaceId: UUID(),
+                connection: SSHFileExplorerConnection(
+                    destination: "dev@ubuntu-host",
+                    port: nil,
+                    identityFile: nil,
+                    sshOptions: []
+                ),
+                displayTarget: "dev@ubuntu-host",
+                isAvailable: false,
+                unavailableDetail: nil
+            ),
+            sshTransport: MockSSHFileExplorerTransport()
+        )
+
+        let unavailableMessage = String(
+            localized: "fileExplorer.status.sshUnavailable",
+            defaultValue: "SSH files unavailable"
+        )
+        XCTAssertEqual(store.rootStatusMessage, unavailableMessage)
+
+        provider.resumeListing(returning: [
+            FileExplorerEntry(name: "stale", path: "/home/dev/stale", isDirectory: true),
+        ])
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+
+        XCTAssertEqual(store.rootStatusMessage, unavailableMessage)
+        XCTAssertTrue(store.rootNodes.isEmpty)
     }
 
     // MARK: - Expansion state persistence

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -127,7 +127,7 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         let store = FileExplorerStore()
-        store.setProvider(provider)
+        store.setProviderForTesting(provider)
         store.setRootPath("/home/user/project")
 
         try await waitFor("root nodes loaded") { store.rootNodes.count == 2 }
@@ -142,7 +142,7 @@ final class FileExplorerStoreTests: XCTestCase {
     func testDisplayRootPathUsesTilde() {
         let provider = MockFileExplorerProvider(homePath: "/home/user")
         let store = FileExplorerStore()
-        store.setProvider(provider)
+        store.setProviderForTesting(provider)
         store.rootPath = "/home/user/project"
         XCTAssertEqual(store.displayRootPath, "~/project")
     }
@@ -160,7 +160,7 @@ final class FileExplorerStoreTests: XCTestCase {
         )
 
         let store = FileExplorerStore()
-        store.setProvider(LocalFileExplorerProvider())
+        store.setProviderForTesting(LocalFileExplorerProvider())
         store.setRootPath("/Users/alice")
 
         store.applyWorkspaceRoot(
@@ -197,7 +197,7 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         let store = FileExplorerStore()
-        store.setProvider(localProvider)
+        store.setProviderForTesting(localProvider)
         store.setRootPath("/Users/alice")
         try await waitFor("local root loaded") {
             store.rootPath == "/Users/alice" &&
@@ -241,7 +241,7 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         let store = FileExplorerStore()
-        store.setProvider(provider1)
+        store.setProviderForTesting(provider1)
         store.setRootPath("/home/user/project")
         try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 
@@ -260,7 +260,7 @@ final class FileExplorerStoreTests: XCTestCase {
             FileExplorerEntry(name: "main.swift", path: "/home/user/project/src/main.swift", isDirectory: false),
             FileExplorerEntry(name: "lib.swift", path: "/home/user/project/src/lib.swift", isDirectory: false),
         ])
-        store.setProvider(provider2)
+        store.setProviderForTesting(provider2)
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/src"))
 
@@ -278,7 +278,7 @@ final class FileExplorerStoreTests: XCTestCase {
         let provider = MockFileExplorerProvider(isAvailable: false)
 
         let store = FileExplorerStore()
-        store.setProvider(provider)
+        store.setProviderForTesting(provider)
         store.setRootPath("/home/user/project")
         // Wait for the initial load attempt to actually reach the provider,
         // not just for `isRootLoading` to drop (which may already be false
@@ -323,7 +323,7 @@ final class FileExplorerStoreTests: XCTestCase {
         ])
 
         let store = FileExplorerStore()
-        store.setProvider(provider)
+        store.setProviderForTesting(provider)
         store.setRootPath("/home/user/project")
         try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "lib" } }
 
@@ -343,7 +343,7 @@ final class FileExplorerStoreTests: XCTestCase {
             FileExplorerEntry(name: "helpers.swift", path: "/home/user/project/lib/helpers.swift", isDirectory: false),
         ])
 
-        store.setProvider(newProvider)
+        store.setProviderForTesting(newProvider)
 
         XCTAssertTrue(store.expandedPaths.contains("/home/user/project/lib"))
         try await waitFor("lib re-hydrated with 2 children") {
@@ -363,7 +363,7 @@ final class FileExplorerStoreTests: XCTestCase {
         )
 
         let store = FileExplorerStore()
-        store.setProvider(provider)
+        store.setProviderForTesting(provider)
         store.setRootPath("/home/user/project")
         try await waitFor("root loaded") { store.rootNodes.contains { $0.name == "src" } }
 


### PR DESCRIPTION
Fixes #3719.

## Summary
- Add a regression-test commit proving an SSH workspace root resolves to the remote home instead of keeping a local macOS path.
- Route file explorer roots through a single workspace-root request so focused local workspaces use their local cwd and focused SSH workspaces resolve the remote `$HOME`.
- Show inline SSH status while the remote home is resolving or unavailable, with localized English/Japanese strings and an `ssh://` header/tooltip for the active target.

## Verification
- `git diff --cached --check`
- `jq empty Resources/Localizable.xcstrings`

## Not run locally
- XCTest/build/UI tests are deferred to GitHub Actions per workspace policy; no local `xcodebuild` was run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches file-explorer root selection and SSH subprocess execution/cancellation; bugs here can cause missing/incorrect file trees or stuck status messages, but changes are scoped and covered by new tests.
> 
> **Overview**
> The Files sidebar now routes all root changes through a single `applyWorkspaceRoot` API so **local tabs track their local cwd** while **SSH workspaces resolve and display the remote `$HOME`** (instead of reusing a stale macOS path).
> 
> SSH file browsing is refactored to use an injectable `SSHFileExplorerTransport` with cancellation-safe process handling, and the UI surfaces inline, localized status while SSH home is resolving or unavailable (including `ssh://` header display + tooltips). New unit tests cover remote-home resolution, switching local→remote behavior, and ensuring cancelled loads don’t clear an SSH-unavailable status.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367b9827d9cdfbec0969c291da939d94e2030f59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Files sidebar follow the focused SSH workspace by resolving the remote $HOME and only loading files when connected. Fixes #3719; clears stale local paths, shows clear status while resolving or unavailable, preserves status after cancelled loads, and syncs with recent sidebar UI changes from `main`.

- **New Features**
  - Route root changes through a single `applyWorkspaceRoot` API; resolve SSH roots via an injectable transport; clear the tree while pending/unavailable; show `ssh://<target>` (and `:/<path>` once resolved) in the header and tooltips.
  - Inline SSH status messages (“Resolving remote home…”, “SSH files unavailable”, with detail) localized in English/Japanese.

- **Bug Fixes**
  - Gate SSH listing until connected; cancel and terminate in‑flight SSH processes on root switches; make success paths cancellation-aware so stale results can’t clear an “unavailable” status.
  - Deduplicate/stabilize workspace‑root updates, validate provider identity on failures, make SSH provider state thread‑safe, and keep SSH subprocess work non‑blocking with cancellation‑safe termination.
  - Merge latest Files sidebar changes and retain the Find refresh path while preserving SSH status messaging in the empty state.

<sup>Written for commit 367b9827d9cdfbec0969c291da939d94e2030f59. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote SSH workspace support in the file explorer with live connection availability and resolved remote-home handling.
* **UI**
  * File explorer empty state, header, and search layout surface SSH status messages; path tooltip updated during search.
* **Localization**
  * Added English and Japanese SSH status strings for resolving, failure, and unavailable states.
* **Tests**
  * Added tests covering remote SSH workspace behavior and home resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->