### PR TITLE
Fix Cmd+, settings shortcut routing

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10575,6 +10575,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return true
     }
 
+    private func handleContextIndependentShortcut(event: NSEvent) -> Bool {
+        if matchConfiguredShortcut(event: event, action: .quit) {
+            return handleQuitShortcutWarning()
+        }
+
+        if matchConfiguredShortcut(event: event, action: .openSettings) {
+            openPreferencesWindow(debugSource: "shortcut.openSettings")
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .reloadConfiguration) {
+            GhosttyApp.shared.reloadConfiguration(source: "shortcut.reloadConfiguration")
+            return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .newWindow) {
+            openNewMainWindow(preferredWindow: mainWindowForShortcutEvent(event))
+            return true
+        }
+
+        return false
+    }
+
+    private var contextIndependentShortcutActions: [KeyboardShortcutSettings.Action] {
+        // Keep main-window lifecycle commands, such as Close Window, on the synchronized
+        // path because their AppKit delegates depend on the active terminal context.
+        [
+            .quit,
+            .openSettings,
+            .reloadConfiguration,
+            .newWindow,
+        ]
+    }
+
     private func handleCustomShortcut(event: NSEvent) -> Bool {
         guard event.type == .keyDown else {
             clearConfiguredShortcutChordState()
@@ -10946,6 +10980,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
+        if handleContextIndependentShortcut(event: event) {
+            return true
+        }
+
+        if activeConfiguredShortcutChordPrefixForCurrentEvent == nil,
+           armConfiguredShortcutChordIfNeeded(event: event, actions: contextIndependentShortcutActions) {
+            return true
+        }
+
         let hasEventWindowContext = shortcutEventHasAddressableWindow(event)
         let didSynchronizeShortcutContext = synchronizeShortcutRoutingContext(event: event)
         if hasEventWindowContext && !didSynchronizeShortcutContext {
@@ -11036,18 +11079,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if matchConfiguredShortcut(event: event, action: .quit) {
-            return handleQuitShortcutWarning()
-        }
-        if matchConfiguredShortcut(event: event, action: .openSettings) {
-            openPreferencesWindow(debugSource: "shortcut.openSettings")
-            return true
-        }
-        if matchConfiguredShortcut(event: event, action: .reloadConfiguration) {
-            GhosttyApp.shared.reloadConfiguration(source: "shortcut.reloadConfiguration")
-            return true
-        }
-
         if matchConfiguredShortcut(event: event, action: .toggleFullScreen) {
             guard let targetWindow = mainWindowForShortcutEvent(event) else {
                 return false
@@ -11075,15 +11106,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             cmuxDebugLog("shortcut.action name=newWorkspace \(debugShortcutRouteSnapshot(event: event))")
 #endif
             performNewWorkspaceAction(event: event, debugSource: "shortcut.cmdN")
-            return true
-        }
-
-        // New Window: Cmd+Shift+N
-        // Handled here instead of relying on SwiftUI's CommandGroup menu item because
-        // after a browser panel has been shown, SwiftUI's menu dispatch can silently
-        // consume the key equivalent without firing the action closure.
-        if matchConfiguredShortcut(event: event, action: .newWindow) {
-            openNewMainWindow(preferredWindow: mainWindowForShortcutEvent(event))
             return true
         }
 

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -2791,6 +2791,61 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(workspace.panels.count, panelCountBefore)
     }
 
+    func testCmdCommaOpensSettingsFromWindowWithoutTerminalShortcutContext() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        defer { closeWindow(withId: windowId) }
+
+        let auxiliaryWindow = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        auxiliaryWindow.isReleasedWhenClosed = false
+        auxiliaryWindow.identifier = NSUserInterfaceItemIdentifier("cmux.shortcut-routing-test")
+        auxiliaryWindow.makeKeyAndOrderFront(nil)
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        defer {
+            auxiliaryWindow.orderOut(nil)
+            auxiliaryWindow.close()
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+
+        var settingsOpenCount = 0
+#if DEBUG
+        SettingsWindowPresenter.resetForTests()
+        defer { SettingsWindowPresenter.resetForTests() }
+#endif
+        SettingsWindowPresenter.configure(openWindow: {
+            settingsOpenCount += 1
+        })
+
+        guard let event = makeKeyDownEvent(
+            key: ",",
+            modifiers: [.command],
+            keyCode: 43,
+            windowNumber: auxiliaryWindow.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+, event")
+            return
+        }
+
+#if DEBUG
+        XCTAssertTrue(
+            appDelegate.debugHandleCustomShortcut(event: event),
+            "Cmd+, should remain app-scoped when the key event comes from a non-terminal window"
+        )
+#else
+        XCTFail("debugHandleCustomShortcut is only available in DEBUG")
+#endif
+        XCTAssertEqual(settingsOpenCount, 1)
+    }
+
     func testCmdIStillTriggersShowNotificationsShortcut() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")


### PR DESCRIPTION
Summary:
- Route app-level shortcuts that do not need terminal context before the terminal routing sync gate.
- Add a regression test for Cmd+, from a cmux window without terminal shortcut context.
- Keep close-window shortcuts on the synchronized path because their AppKit delegates depend on active terminal context.

Tests:
- CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-cmdcomma-red test -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdCommaOpensSettingsFromWindowWithoutTerminalShortcutContext -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testCmdShiftNCreatesWindowFromEventWindowWithoutAddingWorkspace
- CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag cmdcomma

Notes:
- The first commit adds the failing regression test; the second commit applies the fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts keyboard shortcut routing order, which can change how global/app-level shortcuts are handled across different window contexts. Risk is limited to input/shortcut behavior but could cause regressions in chord handling or window-specific routing.
> 
> **Overview**
> Fixes shortcut routing so **app-scoped shortcuts** (notably Cmd+, settings) are handled even when the key event originates from a window that lacks terminal shortcut context, by routing a small set of context-independent actions (`quit`, `openSettings`, `reloadConfiguration`, `newWindow`) *before* the terminal-context synchronization gate.
> 
> Adds a regression test ensuring Cmd+, opens Settings from an auxiliary (non-terminal) window, and updates chord arming so these context-independent actions can still participate in configured shortcut chords without requiring terminal window context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2eea49ab92e3e85774f87537cbe86ed04b56ece4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Settings shortcut (Cmd+,) so it works from non-terminal windows by handling app-level shortcuts before terminal routing. App-scoped actions like Quit, Settings, Reload Config, and New Window now work from any window.

- **Bug Fixes**
  - Route context-independent shortcuts early (Quit, Settings, Reload Configuration, New Window).
  - Add regression test to ensure Cmd+, opens Settings from a non-terminal window.
  - Keep close-window shortcuts on the synchronized path due to AppKit delegate requirements.

<sup>Written for commit 2eea49ab92e3e85774f87537cbe86ed04b56ece4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved shortcut handling to ensure context-independent actions (quit, Settings, reload configuration, and new window) work consistently across all application contexts and windows.

* **Tests**
  * Added test coverage for shortcut routing behavior from non-terminal windows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->