### PR TITLE
Fix Mark Workspace as Unread enablement

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1419,8 +1419,8 @@ struct ContentView: View {
         static let workspaceHasPeers = "workspace.hasPeers"
         static let workspaceHasAbove = "workspace.hasAbove"
         static let workspaceHasBelow = "workspace.hasBelow"
-        static let workspaceHasUnread = "workspace.hasUnread"
-        static let workspaceHasRead = "workspace.hasRead"
+        static let workspaceCanMarkRead = "workspace.canMarkRead"
+        static let workspaceCanMarkUnread = "workspace.canMarkUnread"
         static let sidebarMatchTerminalBackground = "sidebar.matchTerminalBackground"
         static let hasFocusedPanel = "panel.hasFocus"
         static let panelName = "panel.name"
@@ -6166,12 +6166,12 @@ struct ContentView: View {
                 (workspaceIndex ?? tabManager.tabs.count - 1) < tabManager.tabs.count - 1
             )
             snapshot.setBool(
-                CommandPaletteContextKeys.workspaceHasUnread,
-                notificationStore.notifications.contains { $0.tabId == workspace.id && !$0.isRead }
+                CommandPaletteContextKeys.workspaceCanMarkRead,
+                notificationStore.canMarkWorkspaceRead(forTabIds: [workspace.id])
             )
             snapshot.setBool(
-                CommandPaletteContextKeys.workspaceHasRead,
-                notificationStore.notifications.contains { $0.tabId == workspace.id && $0.isRead }
+                CommandPaletteContextKeys.workspaceCanMarkUnread,
+                notificationStore.canMarkWorkspaceUnread(forTabIds: [workspace.id])
             )
         }
 
@@ -6680,7 +6680,7 @@ struct ContentView: View {
                 subtitle: workspaceSubtitle,
                 keywords: ["workspace", "read", "notification", "inbox"],
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
-                enablement: { $0.bool(CommandPaletteContextKeys.workspaceHasUnread) }
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanMarkRead) }
             )
         )
         contributions.append(
@@ -6690,7 +6690,7 @@ struct ContentView: View {
                 subtitle: workspaceSubtitle,
                 keywords: ["workspace", "unread", "notification", "inbox"],
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
-                enablement: { $0.bool(CommandPaletteContextKeys.workspaceHasRead) }
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanMarkUnread) }
             )
         )
         appendIdentifierCopyCommandContributions(
@@ -13035,12 +13035,12 @@ private struct TabItemView: View, Equatable {
         Button(markReadLabel) {
             markTabsRead(targetIds)
         }
-        .disabled(!hasUnreadNotifications(in: targetIds))
+        .disabled(!notificationStore.canMarkWorkspaceRead(forTabIds: targetIds))
 
         Button(markUnreadLabel) {
             markTabsUnread(targetIds)
         }
-        .disabled(!hasReadNotifications(in: targetIds))
+        .disabled(!notificationStore.canMarkWorkspaceUnread(forTabIds: targetIds))
 
         Button(clearLatestNotificationLabel) {
             clearLatestNotifications(targetIds)
@@ -13204,16 +13204,6 @@ private struct TabItemView: View, Equatable {
         for id in targetIds {
             notificationStore.clearLatestNotification(forTabId: id)
         }
-    }
-
-    private func hasUnreadNotifications(in targetIds: [UUID]) -> Bool {
-        let targetSet = Set(targetIds)
-        return notificationStore.notifications.contains { targetSet.contains($0.tabId) && !$0.isRead }
-    }
-
-    private func hasReadNotifications(in targetIds: [UUID]) -> Bool {
-        let targetSet = Set(targetIds)
-        return notificationStore.notifications.contains { targetSet.contains($0.tabId) && $0.isRead }
     }
 
     private func hasLatestNotifications(in targetIds: [UUID]) -> Bool {

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -783,6 +783,8 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     var unreadCount: Int {
+        // Global badges count only notification-backed unread items. Per-workspace
+        // badges use unreadCount(forTabId:) and include manualUnreadWorkspaceIds.
         indexes.unreadCount
     }
 
@@ -895,6 +897,8 @@ final class TerminalNotificationStore: ObservableObject {
         manualUnreadWorkspaceIds = []
     }
 
+    // Per-workspace badges treat manualUnreadWorkspaceIds as "has unread
+    // activity"; summing these counts can exceed indexes.unreadCount.
     func unreadCount(forTabId tabId: UUID) -> Int {
         (indexes.unreadCountByTabId[tabId] ?? 0) + (manualUnreadWorkspaceIds.contains(tabId) ? 1 : 0)
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -878,6 +878,23 @@ final class TerminalNotificationStore: ObservableObject {
         refreshAuthorizationStatus()
     }
 
+    private func setWorkspaceManualUnread(_ isUnread: Bool, forTabId tabId: UUID) {
+        var nextIds = manualUnreadWorkspaceIds
+        let didChange: Bool
+        if isUnread {
+            didChange = nextIds.insert(tabId).inserted
+        } else {
+            didChange = nextIds.remove(tabId) != nil
+        }
+        guard didChange else { return }
+        manualUnreadWorkspaceIds = nextIds
+    }
+
+    private func clearWorkspaceManualUnread() {
+        guard !manualUnreadWorkspaceIds.isEmpty else { return }
+        manualUnreadWorkspaceIds = []
+    }
+
     func unreadCount(forTabId tabId: UUID) -> Int {
         (indexes.unreadCountByTabId[tabId] ?? 0) + (manualUnreadWorkspaceIds.contains(tabId) ? 1 : 0)
     }
@@ -977,7 +994,7 @@ final class TerminalNotificationStore: ObservableObject {
             isRead: false
         )
         updated.insert(notification, at: 0)
-        manualUnreadWorkspaceIds.remove(tabId)
+        setWorkspaceManualUnread(false, forTabId: tabId)
         notifications = updated
         if let cooldownKey, resolvedCooldownInterval != nil {
             lastNotificationDateByCooldownKey[cooldownKey] = now
@@ -1011,7 +1028,7 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
-        manualUnreadWorkspaceIds.remove(tabId)
+        setWorkspaceManualUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1029,6 +1046,7 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        setWorkspaceManualUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1046,10 +1064,10 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         if didChange {
-            manualUnreadWorkspaceIds.remove(tabId)
+            setWorkspaceManualUnread(false, forTabId: tabId)
             notifications = updated
         } else if !workspaceIsUnread(forTabId: tabId) {
-            manualUnreadWorkspaceIds.insert(tabId)
+            setWorkspaceManualUnread(true, forTabId: tabId)
         }
     }
 
@@ -1080,7 +1098,7 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
-        manualUnreadWorkspaceIds.removeAll()
+        clearWorkspaceManualUnread()
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1108,7 +1126,7 @@ final class TerminalNotificationStore: ObservableObject {
         guard !notifications.isEmpty || !focusedReadIndicatorByTabId.isEmpty || !manualUnreadWorkspaceIds.isEmpty else { return }
         let ids = notifications.map { $0.id.uuidString }
         replaceNotificationsForClear([])
-        manualUnreadWorkspaceIds.removeAll()
+        clearWorkspaceManualUnread()
         focusedReadIndicatorByTabId.removeAll()
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
@@ -1151,7 +1169,7 @@ final class TerminalNotificationStore: ObservableObject {
                 updated.append(notification)
             }
         }
-        manualUnreadWorkspaceIds.remove(tabId)
+        setWorkspaceManualUnread(false, forTabId: tabId)
         guard !idsToClear.isEmpty else { return }
         replaceNotificationsForClear(updated)
         clearFocusedReadIndicator(forTabId: tabId)
@@ -1461,7 +1479,7 @@ final class TerminalNotificationStore: ObservableObject {
     func replaceNotificationsForTesting(_ notifications: [TerminalNotification]) {
         TerminalMutationBus.shared.discardPendingNotifications()
         self.notifications = notifications
-        manualUnreadWorkspaceIds.removeAll()
+        clearWorkspaceManualUnread()
         focusedReadIndicatorByTabId.removeAll()
     }
 #endif

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -701,6 +701,8 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
     @Published private(set) var notificationMenuSnapshot = NotificationMenuSnapshotBuilder.make(notifications: [])
+    // Workspace-level manual unread drives sidebar workspace badges; pane-level
+    // manual unread remains owned by Workspace.manualUnreadPanelIds.
     @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -701,6 +701,7 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
     @Published private(set) var notificationMenuSnapshot = NotificationMenuSnapshotBuilder.make(notifications: [])
+    @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
     private var suppressNotificationDiffPublishing = false
@@ -876,7 +877,19 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func unreadCount(forTabId tabId: UUID) -> Int {
-        indexes.unreadCountByTabId[tabId] ?? 0
+        (indexes.unreadCountByTabId[tabId] ?? 0) + (manualUnreadWorkspaceIds.contains(tabId) ? 1 : 0)
+    }
+
+    func workspaceIsUnread(forTabId tabId: UUID) -> Bool {
+        unreadCount(forTabId: tabId) > 0
+    }
+
+    func canMarkWorkspaceRead(forTabIds tabIds: [UUID]) -> Bool {
+        tabIds.contains { workspaceIsUnread(forTabId: $0) }
+    }
+
+    func canMarkWorkspaceUnread(forTabIds tabIds: [UUID]) -> Bool {
+        tabIds.contains { !workspaceIsUnread(forTabId: $0) }
     }
 
     func hasUnreadNotification(forTabId tabId: UUID, surfaceId: UUID?) -> Bool {
@@ -962,6 +975,7 @@ final class TerminalNotificationStore: ObservableObject {
             isRead: false
         )
         updated.insert(notification, at: 0)
+        manualUnreadWorkspaceIds.remove(tabId)
         notifications = updated
         if let cooldownKey, resolvedCooldownInterval != nil {
             lastNotificationDateByCooldownKey[cooldownKey] = now
@@ -995,6 +1009,7 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        manualUnreadWorkspaceIds.remove(tabId)
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1029,7 +1044,10 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         if didChange {
+            manualUnreadWorkspaceIds.remove(tabId)
             notifications = updated
+        } else if !workspaceIsUnread(forTabId: tabId) {
+            manualUnreadWorkspaceIds.insert(tabId)
         }
     }
 
@@ -1060,6 +1078,7 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        manualUnreadWorkspaceIds.removeAll()
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1084,9 +1103,10 @@ final class TerminalNotificationStore: ObservableObject {
 
     func clearAll(discardQueuedNotifications: Bool = true) {
         if discardQueuedNotifications { TerminalMutationBus.shared.discardPendingNotifications() }
-        guard !notifications.isEmpty || !focusedReadIndicatorByTabId.isEmpty else { return }
+        guard !notifications.isEmpty || !focusedReadIndicatorByTabId.isEmpty || !manualUnreadWorkspaceIds.isEmpty else { return }
         let ids = notifications.map { $0.id.uuidString }
         replaceNotificationsForClear([])
+        manualUnreadWorkspaceIds.removeAll()
         focusedReadIndicatorByTabId.removeAll()
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
@@ -1129,6 +1149,7 @@ final class TerminalNotificationStore: ObservableObject {
                 updated.append(notification)
             }
         }
+        manualUnreadWorkspaceIds.remove(tabId)
         guard !idsToClear.isEmpty else { return }
         replaceNotificationsForClear(updated)
         clearFocusedReadIndicator(forTabId: tabId)
@@ -1438,6 +1459,7 @@ final class TerminalNotificationStore: ObservableObject {
     func replaceNotificationsForTesting(_ notifications: [TerminalNotification]) {
         TerminalMutationBus.shared.discardPendingNotifications()
         self.notifications = notifications
+        manualUnreadWorkspaceIds.removeAll()
         focusedReadIndicatorByTabId.removeAll()
     }
 #endif

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -953,14 +953,14 @@ struct cmuxApp: App {
         closeWorkspaceIds(workspaceIds, in: manager, allowPinned: true)
     }
 
-    private func selectedWorkspaceHasUnreadNotifications(in manager: TabManager) -> Bool {
+    private func selectedWorkspaceCanMarkRead(in manager: TabManager) -> Bool {
         guard let workspaceId = manager.selectedWorkspace?.id else { return false }
-        return notificationStore.notifications.contains { $0.tabId == workspaceId && !$0.isRead }
+        return notificationStore.canMarkWorkspaceRead(forTabIds: [workspaceId])
     }
 
-    private func selectedWorkspaceHasReadNotifications(in manager: TabManager) -> Bool {
+    private func selectedWorkspaceCanMarkUnread(in manager: TabManager) -> Bool {
         guard let workspaceId = manager.selectedWorkspace?.id else { return false }
-        return notificationStore.notifications.contains { $0.tabId == workspaceId && $0.isRead }
+        return notificationStore.canMarkWorkspaceUnread(forTabIds: [workspaceId])
     }
 
     private func markSelectedWorkspaceRead(in manager: TabManager) {
@@ -1064,12 +1064,12 @@ struct cmuxApp: App {
         Button(String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read")) {
             markSelectedWorkspaceRead(in: manager)
         }
-        .disabled(!selectedWorkspaceHasUnreadNotifications(in: manager))
+        .disabled(!selectedWorkspaceCanMarkRead(in: manager))
 
         Button(String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread")) {
             markSelectedWorkspaceUnread(in: manager)
         }
-        .disabled(!selectedWorkspaceHasReadNotifications(in: manager))
+        .disabled(!selectedWorkspaceCanMarkUnread(in: manager))
     }
 
     @ViewBuilder

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -21,10 +21,14 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         store.replaceNotificationsForTesting([])
 
         XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
+        XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
 
         store.markUnread(forTabId: workspaceId)
 
         XCTAssertGreaterThan(store.unreadCount(forTabId: workspaceId), 0)
+        XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
 
         store.markRead(forTabId: workspaceId)
 

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -30,6 +30,18 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
         XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
 
+        store.markRead(forTabId: workspaceId, surfaceId: UUID())
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
+        XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
+
+        store.markUnread(forTabId: workspaceId)
+
+        XCTAssertGreaterThan(store.unreadCount(forTabId: workspaceId), 0)
+        XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
+
         store.markRead(forTabId: workspaceId)
 
         XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -9,6 +9,28 @@ import AppKit
 
 @MainActor
 final class WorkspaceManualUnreadTests: XCTestCase {
+    override func tearDown() {
+        TerminalNotificationStore.shared.replaceNotificationsForTesting([])
+        super.tearDown()
+    }
+
+    func testMarkWorkspaceUnreadCreatesUnreadStateForReadWorkspaceWithoutRetainedNotification() {
+        let store = TerminalNotificationStore.shared
+        let workspaceId = UUID()
+
+        store.replaceNotificationsForTesting([])
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
+
+        store.markUnread(forTabId: workspaceId)
+
+        XCTAssertGreaterThan(store.unreadCount(forTabId: workspaceId), 0)
+
+        store.markRead(forTabId: workspaceId)
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
+    }
+
     func testShouldClearManualUnreadWhenFocusMovesToDifferentPanel() {
         let previousFocusedPanelId = UUID()
         let nextFocusedPanelId = UUID()

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -33,6 +33,8 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         store.markRead(forTabId: workspaceId)
 
         XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
+        XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
     }
 
     func testShouldClearManualUnreadWhenFocusMovesToDifferentPanel() {


### PR DESCRIPTION
Fixes #3725.

## Summary
- adds a regression test for marking a read workspace unread when no retained notification exists
- centralizes workspace read/unread capability in TerminalNotificationStore
- wires sidebar context menu, app Workspace menu, command palette, and socket action through the shared state owner

## Verification
- git diff --check
- local tests not run per repository policy; CI is the test runner

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unread state computation by introducing manual workspace-unread tracking and routes multiple UI surfaces through new eligibility helpers, which could affect badge counts and command enablement across the app.
> 
> **Overview**
> Fixes workspace **Mark as Read/Unread** enablement by centralizing the decision logic in `TerminalNotificationStore`.
> 
> Adds `manualUnreadWorkspaceIds` so a workspace can be treated as unread even when there are no retained unread notifications, and clears this state on relevant read/clear/new-notification paths. Updates the command palette context keys/enablement, sidebar context menu, and app workspace menu to use `canMarkWorkspaceRead`/`canMarkWorkspaceUnread` instead of scanning `notifications`, and adds a regression test covering the “mark unread with no retained notification” case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18805d2d126725c667d6b02b258ed660b53cd2d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3725. Centralizes workspace read/unread state in `TerminalNotificationStore` so “Mark Workspace as Read/Unread” enables based on true workspace state, even when no retained notification exists.

- **Bug Fixes**
  - Added a manual workspace unread marker; it shows in per-workspace badges via `unreadCount(forTabId:)`/`workspaceIsUnread` but not in global `unreadCount`; cleared on workspace- and surface-level reads, new notifications, clear-latest, and clear-all.
  - Introduced `notificationStore.canMarkWorkspaceRead`/`canMarkWorkspaceUnread` and switched the sidebar, app menu, and command palette to use them; renamed palette context keys to `workspace.canMarkRead`/`workspace.canMarkUnread`.
  - Extended tests to cover manual-unread without retained notifications and read/unread round-trips; clarified workspace vs pane manual-unread ownership.

<sup>Written for commit 18805d2d126725c667d6b02b258ed660b53cd2d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces can now be manually marked as unread; badges/indicators support a manual unread override.

* **Bug Fixes**
  * "Mark as Read/Unread" commands in the command palette and context menus now enable/disable based on improved eligibility checks, so actions are available only when applicable.

* **Tests**
  * Added a test covering manual-unread behavior and ensured test state is cleaned up between runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->