### PR TITLE
fix: prevent cmux omo legacy plugin warning loop

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -11825,7 +11825,8 @@ struct CMUXCLI {
         }
     }
 
-    private static let omoPluginName = "oh-my-opencode"
+    private static let omoPluginName = "oh-my-openagent"
+    private static let legacyOmoPluginName = "oh-my-opencode"
     private static let openCodeSessionPluginConfigSpec = "./plugins/cmux-session.js"
 
     private func resolveExecutableInPath(_ name: String) -> String? {
@@ -11868,7 +11869,7 @@ struct CMUXCLI {
 
         // Keep the shadow package isolated from stale/yanked pins in the user's
         // opencode package.json. bun will update this manifest with the resolved
-        // oh-my-opencode version when installation succeeds.
+        // version when installation succeeds.
         let packageManifest: [String: Any] = [
             "dependencies": [
                 Self.omoPluginName: "latest"
@@ -12012,7 +12013,7 @@ struct CMUXCLI {
         return "4096"
     }
 
-    /// Creates a shadow config directory that layers oh-my-opencode on top of the user's
+    /// Creates a shadow config directory that layers the plugin on top of the user's
     /// existing opencode config without modifying the original. Sets OPENCODE_CONFIG_DIR
     /// to point at the shadow directory.
     private func omoEnsurePlugin() throws {
@@ -12037,7 +12038,8 @@ struct CMUXCLI {
         }
 
         var plugins = Self.openCodePluginListRemovingSessionPlugin((config["plugin"] as? [Any]) ?? [])
-        if !Self.openCodePluginListContains(plugins, spec: Self.omoPluginName, allowVersionSuffix: true) {
+        if !Self.openCodePluginListContains(plugins, spec: Self.omoPluginName, allowVersionSuffix: true)
+            && !Self.openCodePluginListContains(plugins, spec: Self.legacyOmoPluginName, allowVersionSuffix: true) {
             plugins.append(Self.omoPluginName)
         }
         config["plugin"] = plugins
@@ -12061,8 +12063,9 @@ struct CMUXCLI {
 
         try writeOpenCodeSessionPlugin(in: shadowDir)
 
-        // Copy oh-my-opencode plugin config (jsonc) if the user has one
-        for filename in ["oh-my-opencode.json", "oh-my-opencode.jsonc"] {
+        // Copy plugin config (jsonc) if the user has one — check both legacy and current names
+        for filename in ["oh-my-openagent.json", "oh-my-openagent.jsonc",
+                         "oh-my-opencode.json", "oh-my-opencode.jsonc"] {
             let userFile = userDir.appendingPathComponent(filename)
             let shadowFile = shadowDir.appendingPathComponent(filename)
             if fm.fileExists(atPath: userFile.path) && !fm.fileExists(atPath: shadowFile.path) {
@@ -12075,7 +12078,7 @@ struct CMUXCLI {
         if !fm.fileExists(atPath: pluginPackageDir.path) {
             let installDir = shadowDir
             if let bunPath = resolveExecutableInPath("bun") {
-                FileHandle.standardError.write("Installing oh-my-opencode plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
+                FileHandle.standardError.write("Installing \(Self.omoPluginName) plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
                 let installArguments = ["add", Self.omoPluginName]
                 let firstAttemptStatus = try omoRunPackageInstall(
                     executablePath: bunPath,
@@ -12083,7 +12086,7 @@ struct CMUXCLI {
                     currentDirectoryURL: installDir
                 )
                 if firstAttemptStatus != 0 {
-                    FileHandle.standardError.write("Retrying oh-my-opencode install with a clean shadow package state...\n".data(using: .utf8)!)
+                    FileHandle.standardError.write("Retrying \(Self.omoPluginName) install with a clean shadow package state...\n".data(using: .utf8)!)
                     try? fm.removeItem(at: shadowBunLockURL)
                     try? fm.removeItem(at: shadowNodeModules)
                     try omoEnsureShadowNodeModulesSymlink(shadowNodeModules: shadowNodeModules, userNodeModules: userNodeModules)
@@ -12093,39 +12096,56 @@ struct CMUXCLI {
                         currentDirectoryURL: installDir
                     )
                     if retryStatus != 0 {
-                        throw CLIError(message: "Failed to install oh-my-opencode. Try manually: npm install -g oh-my-opencode")
+                        throw CLIError(message: "Failed to install \(Self.omoPluginName). Try manually: npm install -g \(Self.omoPluginName)")
                     }
                 }
             } else if let npmPath = resolveExecutableInPath("npm") {
-                FileHandle.standardError.write("Installing oh-my-opencode plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
+                FileHandle.standardError.write("Installing \(Self.omoPluginName) plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
                 let status = try omoRunPackageInstall(
                     executablePath: npmPath,
                     arguments: ["install", Self.omoPluginName],
                     currentDirectoryURL: installDir
                 )
                 if status != 0 {
-                    throw CLIError(message: "Failed to install oh-my-opencode. Try manually: npm install -g oh-my-opencode")
+                    throw CLIError(message: "Failed to install \(Self.omoPluginName). Try manually: npm install -g \(Self.omoPluginName)")
                 }
             } else {
-                throw CLIError(message: "Neither bun nor npm found in PATH. Install oh-my-opencode manually: bunx oh-my-opencode install")
+                throw CLIError(message: "Neither bun nor npm found in PATH. Install \(Self.omoPluginName) manually: bunx \(Self.omoPluginName) install")
             }
-            FileHandle.standardError.write("oh-my-opencode plugin installed\n".data(using: .utf8)!)
+            FileHandle.standardError.write("\(Self.omoPluginName) plugin installed\n".data(using: .utf8)!)
         }
 
-        // Ensure tmux mode is enabled in oh-my-opencode config.
+        // Ensure tmux mode is enabled in the plugin config.
         // Without this, the TmuxSessionManager won't spawn visual panes even though
         // $TMUX is set (tmux.enabled defaults to false).
-        let omoConfigURL = shadowDir.appendingPathComponent("oh-my-opencode.json")
+        let omoConfigURL = shadowDir.appendingPathComponent("oh-my-openagent.json")
         var omoConfig: [String: Any]
         if let data = try? Data(contentsOf: omoConfigURL),
            let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
             omoConfig = existing
+        } else if let legacyURL = { () -> URL? in
+            let candidate = shadowDir.appendingPathComponent("oh-my-opencode.json")
+            return fm.fileExists(atPath: candidate.path) ? candidate : nil
+        }(),
+           let data = try? Data(contentsOf: legacyURL),
+           let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+            omoConfig = existing
         } else {
             // Check if user has a config we symlinked, read from source
-            let userOmoConfig = userDir.appendingPathComponent("oh-my-opencode.json")
-            if let data = try? Data(contentsOf: userOmoConfig),
-               let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
-                omoConfig = existing
+            let userOmoConfigURLs = [
+                userDir.appendingPathComponent("oh-my-openagent.json"),
+                userDir.appendingPathComponent("oh-my-opencode.json")
+            ]
+            var found: [String: Any]?
+            for url in userOmoConfigURLs {
+                if let data = try? Data(contentsOf: url),
+                   let existing = try? JSONSerialization.jsonObject(with: data) as? [String: Any] {
+                    found = existing
+                    break
+                }
+            }
+            if let found {
+                omoConfig = found
                 // Remove the symlink so we can write our own copy
                 try? fm.removeItem(at: omoConfigURL)
             } else {


### PR DESCRIPTION
Fixes an infinite warning loop where every 'cmux omo' run prints the legacy plugin migration warning.

## Root Cause

The omoPluginName constant in CLI/cmux.swift was 'oh-my-opencode' (old name). On every launch, omoEnsurePlugin() appends it to the shadow config plugin array since the user config uses 'oh-my-openagent' (new name). The plugin then auto-migrates it back, creating a loop.

## Fix

- Changed omoPluginName from 'oh-my-opencode' to 'oh-my-openagent'  
- Added legacyOmoPluginName for backward-compatible detection
- Updated plugin list check to skip append if either name is present
- Updated install messages and config file references

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the infinite legacy plugin warning loop in `cmux omo` by using the current plugin name and recognizing the old one. Users no longer see migration warnings on every run.

- **Bug Fixes**
  - Set `omoPluginName` to `oh-my-openagent`; added `legacyOmoPluginName` (`oh-my-opencode`).
  - Skip appending the plugin if either name exists in the config to stop the loop.
  - Updated install messages and errors to use the current package name.
  - Config lookup now supports both `oh-my-openagent.json(.c)` and `oh-my-opencode.json(.c)`, writing to the current name.

<sup>Written for commit a246017cffd3e915ec26910c4d68c4bf12e310a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated plugin installation and configuration file handling to support both current and legacy naming conventions, improving backward compatibility with existing setups and ensuring smoother transitions between naming formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->