### PR TITLE
Add fixed right sidebar toggle

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -92454,6 +92454,40 @@
         }
       }
     },
+    "titlebar.rightSidebar.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Right Sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバーの切り替え"
+          }
+        }
+      }
+    },
+    "titlebar.rightSidebar.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show or hide the right sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバーの表示/非表示"
+          }
+        }
+      }
+    },
     "titlebar.sidebar.accessibilityLabel": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6825,7 +6825,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // ContentView.onAppear eventually runs syncTrafficLightInset (#2737).
         let initialTabBarLeadingInset: CGFloat =
             (WorkspacePresentationModeSettings.isMinimal() && !sidebarState.isVisible)
-                ? 80
+                ? MinimalModeTitlebarDebugSettings.trafficLightTabBarLeadingInset()
                 : 0
         tabManager.syncWorkspaceTabBarLeadingInset(initialTabBarLeadingInset)
         let notificationStore = TerminalNotificationStore.shared

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2,6 +2,7 @@ import AppKit
 import Bonsplit
 import Combine
 import ImageIO
+import Observation
 import SwiftUI
 import ObjectiveC
 import UniformTypeIdentifiers
@@ -1021,7 +1022,6 @@ struct ContentView: View {
     @EnvironmentObject var cmuxConfigStore: CmuxConfigStore
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
-    @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
     @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
     @AppStorage(ShortcutHintDebugSettings.titlebarHintYKey) private var titlebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultTitlebarHintY
@@ -1043,7 +1043,7 @@ struct ContentView: View {
     @State private var isFullScreen: Bool = false
     @State private var observedWindow: NSWindow?
     @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
-    @StateObject private var rightSidebarToggleShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
+    @State private var rightSidebarToggleShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @StateObject private var fileExplorerStore = FileExplorerStore()
     @StateObject private var sessionIndexStore = SessionIndexStore()
     @StateObject private var selectedWorkspaceDirectoryObserver = SelectedWorkspaceDirectoryObserver()
@@ -1055,6 +1055,7 @@ struct ContentView: View {
     @State private var workspaceHandoffFallbackTask: Task<Void, Never>?
     @State private var didApplyUITestSidebarSelection = false
     @State private var titlebarThemeGeneration: UInt64 = 0
+    @State private var rightSidebarShortcutRefreshTick = 0
     @State private var sidebarDraggedTabId: UUID?
     @State private var titlebarTextUpdateCoalescer = NotificationBurstCoalescer(delay: 1.0 / 30.0)
     @State private var sidebarResizerCursorReleaseWorkItem: DispatchWorkItem?
@@ -2287,7 +2288,7 @@ struct ContentView: View {
 
     private var rightSidebarTitlebarToggle: some View {
         let config = titlebarControlsConfig
-        let _ = keyboardShortcutSettingsObserver.revision
+        let _ = rightSidebarShortcutRefreshTick
         let shortcut = KeyboardShortcutSettings.shortcut(for: .toggleFileExplorer)
         let showsShortcutHint = shortcut.command && (alwaysShowShortcutHints || rightSidebarToggleShortcutHintMonitor.isModifierPressed)
         return TitlebarControlButton(
@@ -2340,7 +2341,7 @@ struct ContentView: View {
         if config.buttonBackground {
             icon
                 .background(
-                    RoundedRectangle(cornerRadius: config.buttonCornerRadius, style: .continuous)
+                    RoundedRectangle(cornerRadius: config.buttonCornerRadius)
                         .fill(Color(nsColor: .controlBackgroundColor).opacity(0.7))
                 )
         } else {
@@ -3272,6 +3273,10 @@ struct ContentView: View {
 
         view = AnyView(view.onChange(of: titlebarDebugChromeSnapshot) { _, _ in
             applyTitlebarDebugChromeChange()
+        })
+
+        view = AnyView(view.onReceive(NotificationCenter.default.publisher(for: KeyboardShortcutSettings.didChangeNotification)) { _ in
+            rightSidebarShortcutRefreshTick &+= 1
         })
 
         view = AnyView(view.onChange(of: tabManager.tabs.map(\.id)) { _ in
@@ -9310,7 +9315,7 @@ struct VerticalTabsSidebar: View {
     @Binding var selection: SidebarSelection
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
-    @StateObject private var modifierKeyMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
+    @State private var modifierKeyMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @StateObject private var dragAutoScrollController = SidebarDragAutoScrollController()
     @StateObject private var dragFailsafeMonitor = SidebarDragFailsafeMonitor()
     @StateObject private var tabItemSettingsStore = SidebarTabItemSettingsStore()
@@ -10609,18 +10614,19 @@ enum ShortcutHintModifierActivation {
 }
 
 @MainActor
-final class WindowScopedShortcutHintModifierMonitor: ObservableObject {
-    @Published private(set) var isModifierPressed = false
+@Observable
+final class WindowScopedShortcutHintModifierMonitor {
+    private(set) var isModifierPressed = false
 
     private let activation: ShortcutHintModifierActivation
     private let allowsHintsForWindow: (NSWindow) -> Bool
-    private weak var hostWindow: NSWindow?
-    private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
-    private var hostWindowDidResignKeyObserver: NSObjectProtocol?
-    private var flagsMonitor: Any?
-    private var keyDownMonitor: Any?
-    private var appResignObserver: NSObjectProtocol?
-    private var pendingShowWorkItem: DispatchWorkItem?
+    @ObservationIgnored private weak var hostWindow: NSWindow?
+    @ObservationIgnored private var hostWindowDidBecomeKeyObserver: NSObjectProtocol?
+    @ObservationIgnored private var hostWindowDidResignKeyObserver: NSObjectProtocol?
+    @ObservationIgnored private var flagsMonitor: Any?
+    @ObservationIgnored private var keyDownMonitor: Any?
+    @ObservationIgnored private var appResignObserver: NSObjectProtocol?
+    @ObservationIgnored private var pendingShowWorkItem: DispatchWorkItem?
 
     init(
         activation: ShortcutHintModifierActivation = .commandOrControl,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1021,7 +1021,11 @@ struct ContentView: View {
     @EnvironmentObject var cmuxConfigStore: CmuxConfigStore
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
+    @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
+    @AppStorage(ShortcutHintDebugSettings.titlebarHintXKey) private var titlebarShortcutHintXOffset = ShortcutHintDebugSettings.defaultTitlebarHintX
+    @AppStorage(ShortcutHintDebugSettings.titlebarHintYKey) private var titlebarShortcutHintYOffset = ShortcutHintDebugSettings.defaultTitlebarHintY
+    @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey) private var alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey) private var leftTitlebarControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey) private var leftTitlebarControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
     @AppStorage(MinimalModeTitlebarDebugSettings.rightToggleTrailingInsetKey) private var rightTitlebarToggleTrailingInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTrailingInset
@@ -1039,6 +1043,7 @@ struct ContentView: View {
     @State private var isFullScreen: Bool = false
     @State private var observedWindow: NSWindow?
     @StateObject private var fullscreenControlsViewModel = TitlebarControlsViewModel()
+    @StateObject private var rightSidebarToggleShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @StateObject private var fileExplorerStore = FileExplorerStore()
     @StateObject private var sessionIndexStore = SessionIndexStore()
     @StateObject private var selectedWorkspaceDirectoryObserver = SelectedWorkspaceDirectoryObserver()
@@ -2282,6 +2287,9 @@ struct ContentView: View {
 
     private var rightSidebarTitlebarToggle: some View {
         let config = titlebarControlsConfig
+        let _ = keyboardShortcutSettingsObserver.revision
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .toggleFileExplorer)
+        let showsShortcutHint = shortcut.command && (alwaysShowShortcutHints || rightSidebarToggleShortcutHintMonitor.isModifierPressed)
         return TitlebarControlButton(
             config: config,
             accessibilityIdentifier: "titlebarControl.toggleRightSidebar",
@@ -2304,6 +2312,23 @@ struct ContentView: View {
             width: MinimalModeSidebarTitlebarControlsMetrics.singleButtonHostWidth,
             height: MinimalModeSidebarTitlebarControlsMetrics.hostHeight
         )
+        .overlay(alignment: .topTrailing) {
+            ZStack(alignment: .topTrailing) {
+                if showsShortcutHint {
+                    ShortcutHintPill(shortcut: shortcut, fontSize: max(8, config.iconSize - 5))
+                        .frame(minHeight: titlebarShortcutHintHeight(for: config))
+                        .offset(
+                            x: CGFloat(ShortcutHintDebugSettings.clamped(titlebarShortcutHintXOffset)),
+                            y: titlebarShortcutHintVerticalOffset(for: config)
+                                + CGFloat(ShortcutHintDebugSettings.clamped(titlebarShortcutHintYOffset))
+                        )
+                        .shortcutHintTransition()
+                        .accessibilityIdentifier("titlebarShortcutHint.toggleFileExplorer")
+                }
+            }
+            .allowsHitTesting(false)
+        }
+        .shortcutHintVisibilityAnimation(value: showsShortcutHint)
     }
 
     @ViewBuilder
@@ -2712,6 +2737,7 @@ struct ContentView: View {
         )
 
         view = AnyView(view.onAppear {
+            rightSidebarToggleShortcutHintMonitor.start()
             selectedWorkspaceDirectoryObserver.wire(tabManager: tabManager)
             tabManager.applyWindowBackgroundForSelectedTab()
             reconcileMountedWorkspaceIds()
@@ -3276,9 +3302,11 @@ struct ContentView: View {
                 sidebarDragStartWidth = nil
             }
             removeSidebarResizerPointerMonitor()
+            rightSidebarToggleShortcutHintMonitor.stop()
         })
 
         view = AnyView(view.background(WindowAccessor(refreshID: appearance.appKitWindowMutationID) { [appearance] window in
+            rightSidebarToggleShortcutHintMonitor.setHostWindow(window)
             window.identifier = NSUserInterfaceItemIdentifier(windowIdentifier)
             window.isRestorable = false
             setMinimalModeSidebarTitlebarControlsAvailable(sidebarState.isVisible, in: window)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1021,6 +1021,7 @@ struct ContentView: View {
     @EnvironmentObject var cmuxConfigStore: CmuxConfigStore
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
+    @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
     @State private var sidebarWidth: CGFloat = 200
     @State private var hoveredResizerHandles: Set<SidebarResizerHandle> = []
     @State private var isResizerDragging = false
@@ -2240,6 +2241,53 @@ struct ContentView: View {
         )
     }
 
+    private var titlebarControlsConfig: TitlebarControlsStyleConfig {
+        (TitlebarControlsStyle(rawValue: titlebarControlsStyleRawValue) ?? .classic).config
+    }
+
+    private var rightSidebarTitlebarToggle: some View {
+        let config = titlebarControlsConfig
+        return TitlebarControlButton(
+            config: config,
+            accessibilityIdentifier: "titlebarControl.toggleRightSidebar",
+            accessibilityLabel: String(localized: "titlebar.rightSidebar.accessibilityLabel", defaultValue: "Toggle Right Sidebar"),
+            action: {
+                #if DEBUG
+                cmuxDebugLog("titlebar.toggleRightSidebar")
+                #endif
+                _ = AppDelegate.shared?.toggleRightSidebarInActiveMainWindow(preferredWindow: observedWindow)
+            }
+        ) {
+            titlebarControlIcon(systemName: "sidebar.right", config: config)
+        }
+        .safeHelp(
+            KeyboardShortcutSettings.Action.toggleFileExplorer.tooltip(
+                String(localized: "titlebar.rightSidebar.tooltip", defaultValue: "Show or hide the right sidebar")
+            )
+        )
+        .frame(
+            width: MinimalModeSidebarTitlebarControlsMetrics.singleButtonHostWidth,
+            height: MinimalModeSidebarTitlebarControlsMetrics.hostHeight
+        )
+    }
+
+    @ViewBuilder
+    private func titlebarControlIcon(systemName: String, config: TitlebarControlsStyleConfig) -> some View {
+        let icon = Image(systemName: systemName)
+            .font(.system(size: config.iconSize, weight: .semibold))
+            .frame(width: config.buttonSize, height: config.buttonSize)
+
+        if config.buttonBackground {
+            icon
+                .background(
+                    RoundedRectangle(cornerRadius: config.buttonCornerRadius, style: .continuous)
+                        .fill(Color(nsColor: .controlBackgroundColor).opacity(0.7))
+                )
+        } else {
+            icon
+        }
+    }
+
     private func customTitlebar(appearance: WindowAppearanceSnapshot) -> some View {
         let titlebarContentHeight = max(1, WindowChromeMetrics.appTitlebarHeight - 2)
         return ZStack {
@@ -2590,6 +2638,11 @@ struct ContentView: View {
                             .padding(.leading, 10)
                             .padding(.top, 4)
                     }
+                }
+                .overlay(alignment: .topTrailing) {
+                    rightSidebarTitlebarToggle
+                        .padding(.top, MinimalModeSidebarTitlebarControlsMetrics.topInset)
+                        .padding(.trailing, MinimalModeSidebarTitlebarControlsMetrics.trailingInset)
                 }
                 .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
                 .background(Color.clear)
@@ -9450,7 +9503,7 @@ struct VerticalTabsSidebar: View {
                             onNewTab: onNewTab
                         )
                             .padding(.leading, MinimalModeSidebarTitlebarControlsMetrics.leadingInset)
-                            .padding(.top, 2)
+                            .padding(.top, MinimalModeSidebarTitlebarControlsMetrics.topInset)
                     }
                 }
                 .background(Color.clear)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1012,6 +1012,14 @@ private final class SelectedWorkspaceDirectoryObserver: ObservableObject {
     }
 }
 
+func titlebarShortcutHintShouldShow(
+    shortcut: StoredShortcut,
+    alwaysShowShortcutHints: Bool,
+    modifierPressed: Bool
+) -> Bool {
+    !shortcut.isUnbound && (alwaysShowShortcutHints || (shortcut.command && modifierPressed))
+}
+
 struct ContentView: View {
     @ObservedObject var updateViewModel: UpdateViewModel
     let windowId: UUID
@@ -2290,7 +2298,11 @@ struct ContentView: View {
         let config = titlebarControlsConfig
         let _ = rightSidebarShortcutRefreshTick
         let shortcut = KeyboardShortcutSettings.shortcut(for: .toggleFileExplorer)
-        let showsShortcutHint = shortcut.command && (alwaysShowShortcutHints || rightSidebarToggleShortcutHintMonitor.isModifierPressed)
+        let showsShortcutHint = titlebarShortcutHintShouldShow(
+            shortcut: shortcut,
+            alwaysShowShortcutHints: alwaysShowShortcutHints,
+            modifierPressed: rightSidebarToggleShortcutHintMonitor.isModifierPressed
+        )
         return TitlebarControlButton(
             config: config,
             accessibilityIdentifier: "titlebarControl.toggleRightSidebar",

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1022,6 +1022,12 @@ struct ContentView: View {
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey) private var leftTitlebarControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey) private var leftTitlebarControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.rightToggleTrailingInsetKey) private var rightTitlebarToggleTrailingInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTrailingInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.rightToggleTopInsetKey) private var rightTitlebarToggleTopInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTopInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.trafficLightsXOffsetKey) private var trafficLightsXOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsXOffset
+    @AppStorage(MinimalModeTitlebarDebugSettings.trafficLightsYOffsetKey) private var trafficLightsYOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsYOffset
     @State private var sidebarWidth: CGFloat = 200
     @State private var hoveredResizerHandles: Set<SidebarResizerHandle> = []
     @State private var isResizerDragging = false
@@ -2245,6 +2251,35 @@ struct ContentView: View {
         (TitlebarControlsStyle(rawValue: titlebarControlsStyleRawValue) ?? .classic).config
     }
 
+    private var titlebarDebugChromeSnapshot: MinimalModeTitlebarDebugSnapshot {
+        MinimalModeTitlebarDebugSnapshot(
+            leftControlsLeadingInset: MinimalModeTitlebarDebugSettings.clamped(
+                leftTitlebarControlsLeadingInset,
+                range: MinimalModeTitlebarDebugSettings.horizontalInsetRange
+            ),
+            leftControlsTopInset: MinimalModeTitlebarDebugSettings.clamped(
+                leftTitlebarControlsTopInset,
+                range: MinimalModeTitlebarDebugSettings.topInsetRange
+            ),
+            rightToggleTrailingInset: MinimalModeTitlebarDebugSettings.clamped(
+                rightTitlebarToggleTrailingInset,
+                range: MinimalModeTitlebarDebugSettings.horizontalInsetRange
+            ),
+            rightToggleTopInset: MinimalModeTitlebarDebugSettings.clamped(
+                rightTitlebarToggleTopInset,
+                range: MinimalModeTitlebarDebugSettings.topInsetRange
+            ),
+            trafficLightsXOffset: MinimalModeTitlebarDebugSettings.clamped(
+                trafficLightsXOffset,
+                range: MinimalModeTitlebarDebugSettings.trafficLightOffsetRange
+            ),
+            trafficLightsYOffset: MinimalModeTitlebarDebugSettings.clamped(
+                trafficLightsYOffset,
+                range: MinimalModeTitlebarDebugSettings.trafficLightYOffsetRange
+            )
+        )
+    }
+
     private var rightSidebarTitlebarToggle: some View {
         let config = titlebarControlsConfig
         return TitlebarControlButton(
@@ -2333,8 +2368,17 @@ struct ContentView: View {
     }
 
     private func syncTrafficLightInset() {
-        let inset: CGFloat = (isMinimalMode && !sidebarState.isVisible && !isFullScreen) ? 80 : 0
+        let inset: CGFloat = (isMinimalMode && !sidebarState.isVisible && !isFullScreen)
+            ? MinimalModeTitlebarDebugSettings.trafficLightTabBarLeadingInset()
+            : 0
         tabManager.syncWorkspaceTabBarLeadingInset(inset)
+    }
+
+    private func applyTitlebarDebugChromeChange() {
+        if let observedWindow {
+            AppDelegate.shared?.applyWindowDecorations(to: observedWindow)
+        }
+        syncTrafficLightInset()
     }
 
     private func schedulePortalGeometrySynchronize() {
@@ -2641,8 +2685,24 @@ struct ContentView: View {
                 }
                 .overlay(alignment: .topTrailing) {
                     rightSidebarTitlebarToggle
-                        .padding(.top, MinimalModeSidebarTitlebarControlsMetrics.topInset)
-                        .padding(.trailing, MinimalModeSidebarTitlebarControlsMetrics.trailingInset)
+                        .padding(
+                            .top,
+                            CGFloat(
+                                MinimalModeTitlebarDebugSettings.clamped(
+                                    rightTitlebarToggleTopInset,
+                                    range: MinimalModeTitlebarDebugSettings.topInsetRange
+                                )
+                            )
+                        )
+                        .padding(
+                            .trailing,
+                            CGFloat(
+                                MinimalModeTitlebarDebugSettings.clamped(
+                                    rightTitlebarToggleTrailingInset,
+                                    range: MinimalModeTitlebarDebugSettings.horizontalInsetRange
+                                )
+                            )
+                        )
                 }
                 .frame(minWidth: CGFloat(SessionPersistencePolicy.minimumWindowWidth), minHeight: CGFloat(SessionPersistencePolicy.minimumWindowHeight))
                 .background(Color.clear)
@@ -3182,6 +3242,10 @@ struct ContentView: View {
             schedulePortalGeometrySynchronize()
             updateSidebarResizerBandState()
             syncTrafficLightInset()
+        })
+
+        view = AnyView(view.onChange(of: titlebarDebugChromeSnapshot) { _, _ in
+            applyTitlebarDebugChromeChange()
         })
 
         view = AnyView(view.onChange(of: tabManager.tabs.map(\.id)) { _ in
@@ -9233,6 +9297,10 @@ struct VerticalTabsSidebar: View {
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage("sidebarMatchTerminalBackground")
     private var sidebarMatchTerminalBackground = false
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
+    private var leftTitlebarControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey)
+    private var leftTitlebarControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
 
     private let tabRowSpacing: CGFloat = 2
     private var sidebarTitlebarInteractionHeight: CGFloat {
@@ -9502,8 +9570,24 @@ struct VerticalTabsSidebar: View {
                             },
                             onNewTab: onNewTab
                         )
-                            .padding(.leading, MinimalModeSidebarTitlebarControlsMetrics.leadingInset)
-                            .padding(.top, MinimalModeSidebarTitlebarControlsMetrics.topInset)
+                            .padding(
+                                .leading,
+                                CGFloat(
+                                    MinimalModeTitlebarDebugSettings.clamped(
+                                        leftTitlebarControlsLeadingInset,
+                                        range: MinimalModeTitlebarDebugSettings.horizontalInsetRange
+                                    )
+                                )
+                            )
+                            .padding(
+                                .top,
+                                CGFloat(
+                                    MinimalModeTitlebarDebugSettings.clamped(
+                                        leftTitlebarControlsTopInset,
+                                        range: MinimalModeTitlebarDebugSettings.topInsetRange
+                                    )
+                                )
+                            )
                     }
                 }
                 .background(Color.clear)
@@ -15006,7 +15090,7 @@ private struct TitlebarLeadingInsetReader: NSViewRepresentable {
         DispatchQueue.main.async {
             guard let window = nsView.window else { return }
             // Start past the traffic lights
-            var leading: CGFloat = 78
+            var leading = MinimalModeTitlebarDebugSettings.trafficLightTitlebarLeadingInset()
             // Add width of all left-aligned titlebar accessories
             for accessory in window.titlebarAccessoryViewControllers
                 where accessory.layoutAttribute == .leading || accessory.layoutAttribute == .left {

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -149,11 +149,11 @@ struct RightSidebarPanelView: View {
     let onResumeSession: ((SessionEntry) -> Void)?
     let onOpenFilePreview: (String) -> Void
 
-    @StateObject private var modeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOrControl) { window in
+    @State private var modeShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOrControl) { window in
         guard let responder = window.firstResponder else { return false }
         return AppDelegate.shared?.isRightSidebarFocusResponder(responder, in: window) == true
     }
-    @StateObject private var focusShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
+    @State private var focusShortcutHintMonitor = WindowScopedShortcutHintModifierMonitor(activation: .commandOnly)
     @StateObject private var dockStore = DockControlsStore()
     @ObservedObject private var keyboardShortcutSettingsObserver = KeyboardShortcutSettingsObserver.shared
     @AppStorage(ShortcutHintDebugSettings.alwaysShowHintsKey)

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1464,7 +1464,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         }()
         let containerHeight = max(contentSize.height, titlebarHeight)
         let debugSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
-        let xOffset = CGFloat(debugSnapshot.leftControlsLeadingInset - MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset)
+        let xOffset = MinimalModeTitlebarDebugSettings.leftControlsXOffset(
+            leadingInset: debugSnapshot.leftControlsLeadingInset
+        )
         let yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
             + CGFloat(MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset - debugSnapshot.leftControlsTopInset)
         let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1374,7 +1374,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         containerView.wantsLayer = true
         containerView.layer?.masksToBounds = false
         hostingView.translatesAutoresizingMaskIntoConstraints = true
-        hostingView.autoresizingMask = [.width, .height]
+        hostingView.autoresizingMask = []
         containerView.addSubview(hostingView)
 
         userDefaultsObserver = NotificationCenter.default.addObserver(

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1295,6 +1295,7 @@ private final class TitlebarShortcutHintModifierMonitor: ObservableObject {
 struct TitlebarControlsLayoutSnapshot: Equatable {
     let contentSize: NSSize
     let containerHeight: CGFloat
+    let xOffset: CGFloat
     let yOffset: CGFloat
 }
 
@@ -1322,6 +1323,7 @@ func titlebarControlsShouldApplyLayout(
     return abs(previous.contentSize.width - next.contentSize.width) > tolerance
         || abs(previous.contentSize.height - next.contentSize.height) > tolerance
         || abs(previous.containerHeight - next.containerHeight) > tolerance
+        || abs(previous.xOffset - next.xOffset) > tolerance
         || abs(previous.yOffset - next.yOffset) > tolerance
 }
 
@@ -1383,6 +1385,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             self?.applyWorkspaceTitlebarVisibility()
             if self?.showsWorkspaceTitlebar == true {
                 self?.restoreSizeAfterMinimalMode()
+                self?.scheduleSizeUpdate()
             }
         }
 
@@ -1460,10 +1463,14 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             } ?? contentSize.height
         }()
         let containerHeight = max(contentSize.height, titlebarHeight)
+        let debugSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
+        let xOffset = CGFloat(debugSnapshot.leftControlsLeadingInset - MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset)
         let yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
+            + CGFloat(MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset - debugSnapshot.leftControlsTopInset)
         let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(
             contentSize: contentSize,
             containerHeight: containerHeight,
+            xOffset: xOffset,
             yOffset: yOffset
         )
         guard titlebarControlsShouldApplyLayout(
@@ -1473,9 +1480,10 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             return
         }
         lastAppliedLayoutSnapshot = nextLayoutSnapshot
-        preferredContentSize = NSSize(width: contentSize.width, height: containerHeight)
-        containerView.frame = NSRect(x: 0, y: 0, width: contentSize.width, height: containerHeight)
-        hostingView.frame = NSRect(x: 0, y: yOffset, width: contentSize.width, height: contentSize.height)
+        let containerWidth = contentSize.width + abs(xOffset)
+        preferredContentSize = NSSize(width: containerWidth, height: containerHeight)
+        containerView.frame = NSRect(x: 0, y: 0, width: containerWidth, height: containerHeight)
+        hostingView.frame = NSRect(x: xOffset, y: yOffset, width: contentSize.width, height: contentSize.height)
     }
 
     private func applyWorkspaceTitlebarVisibility() {

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -462,7 +462,7 @@ final class WindowDecorationsController {
                 button.setFrameOrigin(nextOrigin)
             }
             state.baseOrigin = baseOrigin
-            state.appliedFrame = button.frame
+            state.appliedFrame = NSRect(origin: nextOrigin, size: button.frame.size)
         }
     }
 

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -6,10 +6,12 @@ final class WindowDecorationsController {
     private var minimalModeSidebarChromeHoverMonitor: Any?
     private var lastMinimalModeTitlebarClick: MinimalModeTitlebarClickRecord?
     private var lastKnownPresentationMode = WorkspacePresentationModeSettings.mode()
+    private var lastKnownTitlebarDebugSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
     private let minimalModeSidebarTitlebarClickTargets = NSMapTable<NSWindow, MinimalModeSidebarControlActionView>(
         keyOptions: .weakMemory,
         valueOptions: .strongMemory
     )
+    private static var trafficLightDebugFrameStateKey: UInt8 = 0
 
     deinit {
         let center = NotificationCenter.default
@@ -42,6 +44,9 @@ final class WindowDecorationsController {
         }
         let shouldHideButtons = shouldHideTrafficLights(for: window)
         hideStandardButtons(on: window, hidden: shouldHideButtons)
+        if isMainWorkspaceWindow(window) {
+            applyTrafficLightDebugOffsets(to: window)
+        }
         applyMinimalModeSidebarTitlebarClickTarget(to: window)
     }
 
@@ -54,14 +59,16 @@ final class WindowDecorationsController {
         observers.append(center.addObserver(forName: NSWindow.didBecomeKeyNotification, object: nil, queue: .main, using: handler))
         observers.append(center.addObserver(forName: NSWindow.didBecomeMainNotification, object: nil, queue: .main, using: handler))
         observers.append(center.addObserver(forName: UserDefaults.didChangeNotification, object: nil, queue: .main) { [weak self] _ in
-            self?.applyPresentationModeChangeIfNeeded()
+            self?.applyDefaultsDrivenDecorationChangeIfNeeded()
         })
     }
 
-    private func applyPresentationModeChangeIfNeeded() {
+    private func applyDefaultsDrivenDecorationChangeIfNeeded() {
         let currentMode = WorkspacePresentationModeSettings.mode()
-        guard currentMode != lastKnownPresentationMode else { return }
+        let currentTitlebarSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
+        guard currentMode != lastKnownPresentationMode || currentTitlebarSnapshot != lastKnownTitlebarDebugSnapshot else { return }
         lastKnownPresentationMode = currentMode
+        lastKnownTitlebarDebugSnapshot = currentTitlebarSnapshot
         attachToExistingWindows()
     }
 
@@ -406,7 +413,10 @@ final class WindowDecorationsController {
 
         let hostHeight = MinimalModeSidebarTitlebarControlsMetrics.hostHeight
         let contentBounds = contentView.bounds
-        let targetY = contentView.isFlipped ? contentBounds.minY : max(0, contentBounds.maxY - hostHeight)
+        let topInset = MinimalModeSidebarTitlebarControlsMetrics.topInset
+        let targetY = contentView.isFlipped
+            ? contentBounds.minY + topInset
+            : max(0, contentBounds.maxY - hostHeight - topInset)
         target.frame = NSRect(
             x: MinimalModeSidebarTitlebarControlsMetrics.leadingInset,
             y: targetY,
@@ -432,6 +442,39 @@ final class WindowDecorationsController {
         minimalModeSidebarTitlebarClickTargets.removeObject(forKey: window)
     }
 
+    private func applyTrafficLightDebugOffsets(to window: NSWindow) {
+        let snapshot = MinimalModeTitlebarDebugSettings.snapshot()
+        let offset = NSPoint(
+            x: CGFloat(snapshot.trafficLightsXOffset),
+            y: CGFloat(snapshot.trafficLightsYOffset)
+        )
+        for buttonType in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
+            guard let button = window.standardWindowButton(buttonType) else { continue }
+            let state = trafficLightFrameState(for: button)
+            let baseOrigin: NSPoint
+            if state.currentFrameMatchesApplied(button.frame) {
+                baseOrigin = state.baseOrigin
+            } else {
+                baseOrigin = button.frame.origin
+            }
+            let nextOrigin = NSPoint(x: baseOrigin.x + offset.x, y: baseOrigin.y + offset.y)
+            if abs(button.frame.origin.x - nextOrigin.x) > 0.25 || abs(button.frame.origin.y - nextOrigin.y) > 0.25 {
+                button.setFrameOrigin(nextOrigin)
+            }
+            state.baseOrigin = baseOrigin
+            state.appliedFrame = button.frame
+        }
+    }
+
+    private func trafficLightFrameState(for button: NSButton) -> TrafficLightDebugFrameState {
+        if let state = objc_getAssociatedObject(button, &Self.trafficLightDebugFrameStateKey) as? TrafficLightDebugFrameState {
+            return state
+        }
+        let state = TrafficLightDebugFrameState(baseOrigin: button.frame.origin, appliedFrame: button.frame)
+        objc_setAssociatedObject(button, &Self.trafficLightDebugFrameStateKey, state, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return state
+    }
+
     private func shouldHideTrafficLights(for window: NSWindow) -> Bool {
         if window.isSheet {
             return true
@@ -443,5 +486,22 @@ final class WindowDecorationsController {
             return true
         }
         return false
+    }
+}
+
+private final class TrafficLightDebugFrameState {
+    var baseOrigin: NSPoint
+    var appliedFrame: NSRect
+
+    init(baseOrigin: NSPoint, appliedFrame: NSRect) {
+        self.baseOrigin = baseOrigin
+        self.appliedFrame = appliedFrame
+    }
+
+    func currentFrameMatchesApplied(_ frame: NSRect) -> Bool {
+        abs(frame.origin.x - appliedFrame.origin.x) < 0.25
+            && abs(frame.origin.y - appliedFrame.origin.y) < 0.25
+            && abs(frame.size.width - appliedFrame.size.width) < 0.25
+            && abs(frame.size.height - appliedFrame.size.height) < 0.25
     }
 }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -456,8 +456,11 @@ func isMinimalModeTitlebarControlHit(window: NSWindow, locationInWindow: NSPoint
 
 enum MinimalModeSidebarTitlebarControlsMetrics {
     static let leadingInset: CGFloat = 72
+    static let trailingInset: CGFloat = 8
+    static let topInset: CGFloat = 2
     static let hostWidth: CGFloat = 124
     static let hostHeight: CGFloat = 28
+    static let singleButtonHostWidth: CGFloat = hostHeight
 }
 
 enum MinimalModeSidebarControlActionSlot: Int {

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -475,6 +475,11 @@ enum MinimalModeTitlebarDebugSettings {
     static let topInsetRange: ClosedRange<Double> = -8...32
     static let trafficLightOffsetRange: ClosedRange<Double> = -48...96
     static let trafficLightYOffsetRange: ClosedRange<Double> = -24...24
+    static let leftControlsXOffsetRange: ClosedRange<Double> = (
+        horizontalInsetRange.lowerBound - defaultLeftControlsLeadingInset
+    )...(
+        horizontalInsetRange.upperBound - defaultLeftControlsLeadingInset
+    )
 
     static func clamped(_ value: Double, range: ClosedRange<Double>) -> Double {
         min(max(value, range.lowerBound), range.upperBound)
@@ -489,7 +494,8 @@ enum MinimalModeTitlebarDebugSettings {
         } else {
             rawValue = fallback
         }
-        return clamped(rawValue, range: range)
+        let finiteValue = rawValue.isFinite ? rawValue : fallback
+        return clamped(finiteValue, range: range)
     }
 
     static func trafficLightTabBarLeadingInset(defaults: UserDefaults = .standard) -> CGFloat {
@@ -530,6 +536,15 @@ enum MinimalModeTitlebarDebugSettings {
                 key: leftControlsTopInsetKey,
                 fallback: defaultLeftControlsTopInset,
                 range: topInsetRange
+            )
+        )
+    }
+
+    static func leftControlsXOffset(leadingInset: Double) -> CGFloat {
+        CGFloat(
+            clamped(
+                leadingInset - defaultLeftControlsLeadingInset,
+                range: leftControlsXOffsetRange
             )
         )
     }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -463,11 +463,11 @@ enum MinimalModeTitlebarDebugSettings {
     static let trafficLightsYOffsetKey = "debug.titlebar.trafficLightsYOffset"
 
     static let defaultLeftControlsLeadingInset = 72.0
-    static let defaultLeftControlsTopInset = 2.0
+    static let defaultLeftControlsTopInset = -0.3
     static let defaultRightToggleTrailingInset = 8.0
-    static let defaultRightToggleTopInset = 2.0
+    static let defaultRightToggleTopInset = -0.0
     static let defaultTrafficLightsXOffset = 0.0
-    static let defaultTrafficLightsYOffset = 0.0
+    static let defaultTrafficLightsYOffset = 1.7
     static let defaultTrafficLightTabBarInset = 80.0
     static let defaultTrafficLightTitlebarLeadingInset = 78.0
 

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -454,10 +454,124 @@ func isMinimalModeTitlebarControlHit(window: NSWindow, locationInWindow: NSPoint
     return MinimalModeTitlebarControlHitRegionRegistry.containsWindowPoint(locationInWindow, in: window)
 }
 
+enum MinimalModeTitlebarDebugSettings {
+    static let leftControlsLeadingInsetKey = "debug.titlebar.leftControlsLeadingInset"
+    static let leftControlsTopInsetKey = "debug.titlebar.leftControlsTopInset"
+    static let rightToggleTrailingInsetKey = "debug.titlebar.rightToggleTrailingInset"
+    static let rightToggleTopInsetKey = "debug.titlebar.rightToggleTopInset"
+    static let trafficLightsXOffsetKey = "debug.titlebar.trafficLightsXOffset"
+    static let trafficLightsYOffsetKey = "debug.titlebar.trafficLightsYOffset"
+
+    static let defaultLeftControlsLeadingInset = 72.0
+    static let defaultLeftControlsTopInset = 2.0
+    static let defaultRightToggleTrailingInset = 8.0
+    static let defaultRightToggleTopInset = 2.0
+    static let defaultTrafficLightsXOffset = 0.0
+    static let defaultTrafficLightsYOffset = 0.0
+    static let defaultTrafficLightTabBarInset = 80.0
+    static let defaultTrafficLightTitlebarLeadingInset = 78.0
+
+    static let horizontalInsetRange: ClosedRange<Double> = 0...180
+    static let topInsetRange: ClosedRange<Double> = -8...32
+    static let trafficLightOffsetRange: ClosedRange<Double> = -48...96
+    static let trafficLightYOffsetRange: ClosedRange<Double> = -24...24
+
+    static func clamped(_ value: Double, range: ClosedRange<Double>) -> Double {
+        min(max(value, range.lowerBound), range.upperBound)
+    }
+
+    static func doubleValue(defaults: UserDefaults = .standard, key: String, fallback: Double, range: ClosedRange<Double>) -> Double {
+        let rawValue: Double
+        if let value = defaults.object(forKey: key) as? NSNumber {
+            rawValue = value.doubleValue
+        } else if let text = defaults.string(forKey: key), let parsed = Double(text) {
+            rawValue = parsed
+        } else {
+            rawValue = fallback
+        }
+        return clamped(rawValue, range: range)
+    }
+
+    static func trafficLightTabBarLeadingInset(defaults: UserDefaults = .standard) -> CGFloat {
+        let offset = doubleValue(
+            defaults: defaults,
+            key: trafficLightsXOffsetKey,
+            fallback: defaultTrafficLightsXOffset,
+            range: trafficLightOffsetRange
+        )
+        return CGFloat(max(0, defaultTrafficLightTabBarInset + offset))
+    }
+
+    static func trafficLightTitlebarLeadingInset(defaults: UserDefaults = .standard) -> CGFloat {
+        let offset = doubleValue(
+            defaults: defaults,
+            key: trafficLightsXOffsetKey,
+            fallback: defaultTrafficLightsXOffset,
+            range: trafficLightOffsetRange
+        )
+        return CGFloat(max(0, defaultTrafficLightTitlebarLeadingInset + offset))
+    }
+
+    static func snapshot(defaults: UserDefaults = .standard) -> MinimalModeTitlebarDebugSnapshot {
+        MinimalModeTitlebarDebugSnapshot(
+            leftControlsLeadingInset: doubleValue(
+                defaults: defaults,
+                key: leftControlsLeadingInsetKey,
+                fallback: defaultLeftControlsLeadingInset,
+                range: horizontalInsetRange
+            ),
+            leftControlsTopInset: doubleValue(
+                defaults: defaults,
+                key: leftControlsTopInsetKey,
+                fallback: defaultLeftControlsTopInset,
+                range: topInsetRange
+            ),
+            rightToggleTrailingInset: doubleValue(
+                defaults: defaults,
+                key: rightToggleTrailingInsetKey,
+                fallback: defaultRightToggleTrailingInset,
+                range: horizontalInsetRange
+            ),
+            rightToggleTopInset: doubleValue(
+                defaults: defaults,
+                key: rightToggleTopInsetKey,
+                fallback: defaultRightToggleTopInset,
+                range: topInsetRange
+            ),
+            trafficLightsXOffset: doubleValue(
+                defaults: defaults,
+                key: trafficLightsXOffsetKey,
+                fallback: defaultTrafficLightsXOffset,
+                range: trafficLightOffsetRange
+            ),
+            trafficLightsYOffset: doubleValue(
+                defaults: defaults,
+                key: trafficLightsYOffsetKey,
+                fallback: defaultTrafficLightsYOffset,
+                range: trafficLightYOffsetRange
+            )
+        )
+    }
+}
+
+struct MinimalModeTitlebarDebugSnapshot: Equatable {
+    let leftControlsLeadingInset: Double
+    let leftControlsTopInset: Double
+    let rightToggleTrailingInset: Double
+    let rightToggleTopInset: Double
+    let trafficLightsXOffset: Double
+    let trafficLightsYOffset: Double
+}
+
 enum MinimalModeSidebarTitlebarControlsMetrics {
-    static let leadingInset: CGFloat = 72
-    static let trailingInset: CGFloat = 8
-    static let topInset: CGFloat = 2
+    static var leadingInset: CGFloat {
+        CGFloat(MinimalModeTitlebarDebugSettings.snapshot().leftControlsLeadingInset)
+    }
+
+    static var topInset: CGFloat {
+        CGFloat(MinimalModeTitlebarDebugSettings.snapshot().leftControlsTopInset)
+    }
+
     static let hostWidth: CGFloat = 124
     static let hostHeight: CGFloat = 28
     static let singleButtonHostWidth: CGFloat = hostHeight

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -512,6 +512,28 @@ enum MinimalModeTitlebarDebugSettings {
         return CGFloat(max(0, defaultTrafficLightTitlebarLeadingInset + offset))
     }
 
+    static func leftControlsLeadingInset(defaults: UserDefaults = .standard) -> CGFloat {
+        CGFloat(
+            doubleValue(
+                defaults: defaults,
+                key: leftControlsLeadingInsetKey,
+                fallback: defaultLeftControlsLeadingInset,
+                range: horizontalInsetRange
+            )
+        )
+    }
+
+    static func leftControlsTopInset(defaults: UserDefaults = .standard) -> CGFloat {
+        CGFloat(
+            doubleValue(
+                defaults: defaults,
+                key: leftControlsTopInsetKey,
+                fallback: defaultLeftControlsTopInset,
+                range: topInsetRange
+            )
+        )
+    }
+
     static func snapshot(defaults: UserDefaults = .standard) -> MinimalModeTitlebarDebugSnapshot {
         MinimalModeTitlebarDebugSnapshot(
             leftControlsLeadingInset: doubleValue(
@@ -565,11 +587,19 @@ struct MinimalModeTitlebarDebugSnapshot: Equatable {
 
 enum MinimalModeSidebarTitlebarControlsMetrics {
     static var leadingInset: CGFloat {
-        CGFloat(MinimalModeTitlebarDebugSettings.snapshot().leftControlsLeadingInset)
+        leadingInset()
     }
 
     static var topInset: CGFloat {
-        CGFloat(MinimalModeTitlebarDebugSettings.snapshot().leftControlsTopInset)
+        topInset()
+    }
+
+    static func leadingInset(defaults: UserDefaults = .standard) -> CGFloat {
+        MinimalModeTitlebarDebugSettings.leftControlsLeadingInset(defaults: defaults)
+    }
+
+    static func topInset(defaults: UserDefaults = .standard) -> CGFloat {
+        MinimalModeTitlebarDebugSettings.leftControlsTopInset(defaults: defaults)
     }
 
     static let hostWidth: CGFloat = 124
@@ -699,7 +729,7 @@ func isMinimalModeSidebarChromeHoverCandidate(
         topStripHeight: MinimalModeChromeMetrics.titlebarHeight
     ) else { return false }
 
-    let minX = MinimalModeSidebarTitlebarControlsMetrics.leadingInset
+    let minX = MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults)
     let maxX = minX + MinimalModeSidebarTitlebarControlsMetrics.hostWidth
     return locationInWindow.x >= minX && locationInWindow.x <= maxX
 }
@@ -744,8 +774,9 @@ func minimalModeSidebarControlActionSlot(
         topStripHeight: MinimalModeChromeMetrics.titlebarHeight
     ) else { return nil }
 
+    let leadingInset = MinimalModeSidebarTitlebarControlsMetrics.leadingInset(defaults: defaults)
     let localPoint = NSPoint(
-        x: locationInWindow.x - MinimalModeSidebarTitlebarControlsMetrics.leadingInset,
+        x: locationInWindow.x - leadingInset,
         y: MinimalModeSidebarTitlebarControlsMetrics.hostHeight / 2
     )
     return TitlebarControlsHitRegions.sidebarActionSlot(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1105,6 +1105,7 @@ struct cmuxApp: App {
 
 #if DEBUG
     private func openAllDebugWindows() {
+        DebugWindowControlsWindowController.shared.show()
         BrowserImportHintDebugWindowController.shared.show()
         BrowserProfilePopoverDebugWindowController.shared.show()
         AboutTitlebarDebugWindowController.shared.show()
@@ -1599,6 +1600,18 @@ private enum DebugWindowConfigSnapshot {
         shortcutHintShowOnControlHold=\(boolValue(defaults, key: ShortcutHintDebugSettings.showHintsOnControlHoldKey, fallback: ShortcutHintDebugSettings.defaultShowHintsOnControlHold))
         """
 
+        let titlebarChromePayload = """
+        titlebarLeftControlsLeadingInset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset)))
+        titlebarLeftControlsTopInset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset)))
+        titlebarRightToggleTrailingInset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.rightToggleTrailingInsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultRightToggleTrailingInset)))
+        titlebarRightToggleTopInset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.rightToggleTopInsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultRightToggleTopInset)))
+        titlebarTrafficLightsXOffset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.trafficLightsXOffsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultTrafficLightsXOffset)))
+        titlebarTrafficLightsYOffset=\(String(format: "%.1f", doubleValue(defaults, key: MinimalModeTitlebarDebugSettings.trafficLightsYOffsetKey, fallback: MinimalModeTitlebarDebugSettings.defaultTrafficLightsYOffset)))
+        titlebarTrafficLightTabBarInset=\(String(format: "%.1f", Double(MinimalModeTitlebarDebugSettings.trafficLightTabBarLeadingInset(defaults: defaults))))
+        titlebarTrafficLightTitleLeadingInset=\(String(format: "%.1f", Double(MinimalModeTitlebarDebugSettings.trafficLightTitlebarLeadingInset(defaults: defaults))))
+        titlebarLeadingExtra=\(String(format: "%.1f", doubleValue(defaults, key: "debugTitlebarLeadingExtra", fallback: 0.0)))
+        """
+
         let backgroundPayload = """
         bgGlassEnabled=\(boolValue(defaults, key: "bgGlassEnabled", fallback: false))
         bgGlassMaterial=\(stringValue(defaults, key: "bgGlassMaterial", fallback: "hudWindow"))
@@ -1612,6 +1625,9 @@ private enum DebugWindowConfigSnapshot {
         return """
         # Sidebar Debug
         \(sidebarPayload)
+
+        # Titlebar Chrome
+        \(titlebarChromePayload)
 
         # Background Debug
         \(backgroundPayload)
@@ -1690,6 +1706,18 @@ private struct DebugWindowControlsView: View {
     @AppStorage(SidebarActiveTabIndicatorSettings.styleKey)
     private var sidebarActiveTabIndicatorStyle = SidebarActiveTabIndicatorSettings.defaultStyle.rawValue
     @AppStorage("debugTitlebarLeadingExtra") private var titlebarLeadingExtra: Double = 0
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
+    private var leftControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey)
+    private var leftControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.rightToggleTrailingInsetKey)
+    private var rightToggleTrailingInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTrailingInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.rightToggleTopInsetKey)
+    private var rightToggleTopInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTopInset
+    @AppStorage(MinimalModeTitlebarDebugSettings.trafficLightsXOffsetKey)
+    private var trafficLightsXOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsXOffset
+    @AppStorage(MinimalModeTitlebarDebugSettings.trafficLightsYOffsetKey)
+    private var trafficLightsYOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsYOffset
     @AppStorage(BrowserDevToolsButtonDebugSettings.iconNameKey) private var browserDevToolsIconNameRaw = BrowserDevToolsButtonDebugSettings.defaultIcon.rawValue
     @AppStorage(BrowserDevToolsButtonDebugSettings.iconColorKey) private var browserDevToolsIconColorRaw = BrowserDevToolsButtonDebugSettings.defaultColor.rawValue
 
@@ -1789,6 +1817,7 @@ private struct DebugWindowControlsView: View {
                             FeedTextEditorDebugWindowController.shared.show()
                         }
                         Button("Open All Debug Windows") {
+                            DebugWindowControlsWindowController.shared.show()
                             BrowserImportHintDebugWindowController.shared.show()
                             BrowserProfilePopoverDebugWindowController.shared.show()
                             AboutTitlebarDebugWindowController.shared.show()
@@ -1856,18 +1885,54 @@ private struct DebugWindowControlsView: View {
                     .padding(.top, 2)
                 }
 
-                GroupBox("Titlebar Spacing") {
-                    VStack(alignment: .leading, spacing: 6) {
+                GroupBox("Titlebar Chrome") {
+                    VStack(alignment: .leading, spacing: 10) {
+                        chromeSliderSection(
+                            "Traffic lights",
+                            xLabel: "X offset",
+                            x: $trafficLightsXOffset,
+                            xRange: MinimalModeTitlebarDebugSettings.trafficLightOffsetRange,
+                            yLabel: "Y offset",
+                            y: $trafficLightsYOffset,
+                            yRange: MinimalModeTitlebarDebugSettings.trafficLightYOffsetRange
+                        )
+
+                        chromeSliderSection(
+                            "Left buttons",
+                            xLabel: "Leading",
+                            x: $leftControlsLeadingInset,
+                            xRange: MinimalModeTitlebarDebugSettings.horizontalInsetRange,
+                            yLabel: "Top",
+                            y: $leftControlsTopInset,
+                            yRange: MinimalModeTitlebarDebugSettings.topInsetRange
+                        )
+
+                        chromeSliderSection(
+                            "Right toggle",
+                            xLabel: "Trailing",
+                            x: $rightToggleTrailingInset,
+                            xRange: MinimalModeTitlebarDebugSettings.horizontalInsetRange,
+                            yLabel: "Top",
+                            y: $rightToggleTopInset,
+                            yRange: MinimalModeTitlebarDebugSettings.topInsetRange
+                        )
+
                         HStack(spacing: 8) {
-                            Text("Leading extra")
+                            Text("Title text leading")
                             Slider(value: $titlebarLeadingExtra, in: 0...40)
                             Text(String(format: "%.0f", titlebarLeadingExtra))
                                 .font(.caption)
                                 .monospacedDigit()
                                 .frame(width: 30, alignment: .trailing)
                         }
-                        Button("Reset (0)") {
-                            titlebarLeadingExtra = 0
+
+                        HStack(spacing: 12) {
+                            Button("Reset Chrome") {
+                                resetTitlebarChrome()
+                            }
+                            Button("Copy Chrome Config") {
+                                copyTitlebarChromeConfig()
+                            }
                         }
                     }
                     .padding(.top, 2)
@@ -1924,7 +1989,7 @@ private struct DebugWindowControlsView: View {
                         Button("Copy All Debug Config") {
                             DebugWindowConfigSnapshot.copyCombinedToPasteboard()
                         }
-                        Text("Copies sidebar, background, menu bar, and browser devtools settings as one payload.")
+                        Text("Copies sidebar, titlebar, background, menu bar, and browser devtools settings as one payload.")
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -1950,11 +2015,33 @@ private struct DebugWindowControlsView: View {
         }
     }
 
+    private func chromeSliderSection(
+        _ title: String,
+        xLabel: String,
+        x: Binding<Double>,
+        xRange: ClosedRange<Double>,
+        yLabel: String,
+        y: Binding<Double>,
+        yRange: ClosedRange<Double>
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+            sliderRow(xLabel, value: x, range: xRange)
+            sliderRow(yLabel, value: y, range: yRange)
+        }
+    }
+
     private func sliderRow(_ label: String, value: Binding<Double>) -> some View {
+        sliderRow(label, value: value, range: ShortcutHintDebugSettings.offsetRange)
+    }
+
+    private func sliderRow(_ label: String, value: Binding<Double>, range: ClosedRange<Double>) -> some View {
         HStack(spacing: 8) {
             Text(label)
-            Slider(value: value, in: ShortcutHintDebugSettings.offsetRange)
-            Text(String(format: "%.1f", ShortcutHintDebugSettings.clamped(value.wrappedValue)))
+            Slider(value: value, in: range)
+            Text(String(format: "%.1f", MinimalModeTitlebarDebugSettings.clamped(value.wrappedValue, range: range)))
                 .font(.caption)
                 .monospacedDigit()
                 .frame(width: 44, alignment: .trailing)
@@ -1969,6 +2056,33 @@ private struct DebugWindowControlsView: View {
         paneShortcutHintXOffset = ShortcutHintDebugSettings.defaultPaneHintX
         paneShortcutHintYOffset = ShortcutHintDebugSettings.defaultPaneHintY
         alwaysShowShortcutHints = ShortcutHintDebugSettings.defaultAlwaysShowHints
+    }
+
+    private func resetTitlebarChrome() {
+        leftControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
+        leftControlsTopInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset
+        rightToggleTrailingInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTrailingInset
+        rightToggleTopInset = MinimalModeTitlebarDebugSettings.defaultRightToggleTopInset
+        trafficLightsXOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsXOffset
+        trafficLightsYOffset = MinimalModeTitlebarDebugSettings.defaultTrafficLightsYOffset
+        titlebarLeadingExtra = 0
+    }
+
+    private func copyTitlebarChromeConfig() {
+        let payload = """
+        titlebarLeftControlsLeadingInset=\(String(format: "%.1f", leftControlsLeadingInset))
+        titlebarLeftControlsTopInset=\(String(format: "%.1f", leftControlsTopInset))
+        titlebarRightToggleTrailingInset=\(String(format: "%.1f", rightToggleTrailingInset))
+        titlebarRightToggleTopInset=\(String(format: "%.1f", rightToggleTopInset))
+        titlebarTrafficLightsXOffset=\(String(format: "%.1f", trafficLightsXOffset))
+        titlebarTrafficLightsYOffset=\(String(format: "%.1f", trafficLightsYOffset))
+        titlebarTrafficLightTabBarInset=\(String(format: "%.1f", Double(MinimalModeTitlebarDebugSettings.trafficLightTabBarLeadingInset())))
+        titlebarTrafficLightTitleLeadingInset=\(String(format: "%.1f", Double(MinimalModeTitlebarDebugSettings.trafficLightTitlebarLeadingInset())))
+        titlebarLeadingExtra=\(String(format: "%.1f", titlebarLeadingExtra))
+        """
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(payload, forType: .string)
     }
 
     private func copyShortcutHintConfig() {

--- a/cmuxTests/ShortcutAndCommandPaletteTests.swift
+++ b/cmuxTests/ShortcutAndCommandPaletteTests.swift
@@ -839,6 +839,40 @@ final class CommandPaletteSelectionScrollBehaviorTests: XCTestCase {
 
 
 final class ShortcutHintModifierPolicyTests: XCTestCase {
+    func testTitlebarShortcutHintAlwaysShowAllowsBoundNonCommandShortcut() {
+        let controlShortcut = StoredShortcut(key: "R", command: false, shift: false, option: false, control: true)
+        let commandShortcut = StoredShortcut(key: "R", command: true, shift: false, option: false, control: false)
+
+        XCTAssertTrue(
+            titlebarShortcutHintShouldShow(
+                shortcut: controlShortcut,
+                alwaysShowShortcutHints: true,
+                modifierPressed: false
+            )
+        )
+        XCTAssertFalse(
+            titlebarShortcutHintShouldShow(
+                shortcut: controlShortcut,
+                alwaysShowShortcutHints: false,
+                modifierPressed: true
+            )
+        )
+        XCTAssertTrue(
+            titlebarShortcutHintShouldShow(
+                shortcut: commandShortcut,
+                alwaysShowShortcutHints: false,
+                modifierPressed: true
+            )
+        )
+        XCTAssertFalse(
+            titlebarShortcutHintShouldShow(
+                shortcut: .unbound,
+                alwaysShowShortcutHints: true,
+                modifierPressed: true
+            )
+        )
+    }
+
     func testShortcutHintRequiresEnabledCommandOrControlOnlyModifier() {
         withDefaultsSuite { defaults in
             defaults.set(true, forKey: ShortcutHintDebugSettings.showHintsOnCommandHoldKey)

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -154,6 +154,7 @@ final class TitlebarControlsSizingPolicyTests: XCTestCase {
         let baseline = TitlebarControlsLayoutSnapshot(
             contentSize: NSSize(width: 128, height: 22),
             containerHeight: 28,
+            xOffset: 0,
             yOffset: 3
         )
         XCTAssertTrue(titlebarControlsShouldApplyLayout(previous: nil, next: baseline))
@@ -162,9 +163,18 @@ final class TitlebarControlsSizingPolicyTests: XCTestCase {
         let changed = TitlebarControlsLayoutSnapshot(
             contentSize: NSSize(width: 132, height: 22),
             containerHeight: 28,
+            xOffset: 0,
             yOffset: 3
         )
         XCTAssertTrue(titlebarControlsShouldApplyLayout(previous: baseline, next: changed))
+
+        let offsetChanged = TitlebarControlsLayoutSnapshot(
+            contentSize: NSSize(width: 128, height: 22),
+            containerHeight: 28,
+            xOffset: 1,
+            yOffset: 3
+        )
+        XCTAssertTrue(titlebarControlsShouldApplyLayout(previous: baseline, next: offsetChanged))
     }
 
     func testShortcutHintVerticalOffsetKeepsPillInsideButtonLane() {

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -737,6 +737,31 @@ final class WindowDragHandleHitTests: XCTestCase {
         )
     }
 
+    func testTitlebarDebugSettingsRejectNonFiniteValues() {
+        let suiteName = "WindowDragHandleHitTests.nonFiniteDebugSettings.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set("nan", forKey: MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
+        defaults.set("inf", forKey: MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let snapshot = MinimalModeTitlebarDebugSettings.snapshot(defaults: defaults)
+        XCTAssertEqual(
+            snapshot.leftControlsLeadingInset,
+            MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            snapshot.leftControlsTopInset,
+            MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset,
+            accuracy: 0.001
+        )
+        XCTAssertEqual(
+            MinimalModeTitlebarDebugSettings.leftControlsLeadingInset(defaults: defaults),
+            CGFloat(MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset),
+            accuracy: 0.001
+        )
+    }
+
     func testDragHandleIgnoresHiddenSiblingWhenResolvingHit() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 36))
         let dragHandle = NSView(frame: container.bounds)

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -693,6 +693,50 @@ final class WindowDragHandleHitTests: XCTestCase {
         )
     }
 
+    func testMinimalModeSidebarFallbackHitUsesProvidedDebugLeadingInset() {
+        let suiteName = "WindowDragHandleHitTests.debugLeadingInset.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.set(WorkspacePresentationModeSettings.Mode.minimal.rawValue, forKey: WorkspacePresentationModeSettings.modeKey)
+        defaults.set(TitlebarControlsStyle.classic.rawValue, forKey: "titlebarControlsStyle")
+        defaults.set(120.0, forKey: MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 120),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.test")
+        defer { window.orderOut(nil) }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let firstButtonX = TitlebarControlsHitRegions.buttonXRanges(config: TitlebarControlsStyle.classic.config)[0].lowerBound + 1
+        let titlebarY = contentView.bounds.maxY - 4
+        XCTAssertNil(
+            minimalModeSidebarControlActionSlot(
+                window: window,
+                locationInWindow: NSPoint(
+                    x: CGFloat(MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset) + firstButtonX,
+                    y: titlebarY
+                ),
+                defaults: defaults
+            ),
+            "Fallback hit testing should move away from the default leading inset when debug defaults override it."
+        )
+        XCTAssertEqual(
+            minimalModeSidebarControlActionSlot(
+                window: window,
+                locationInWindow: NSPoint(x: CGFloat(120) + firstButtonX, y: titlebarY),
+                defaults: defaults
+            ),
+            .toggleSidebar
+        )
+    }
+
     func testDragHandleIgnoresHiddenSiblingWhenResolvingHit() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 36))
         let dragHandle = NSView(frame: container.bounds)


### PR DESCRIPTION
Adds a top-right titlebar button for toggling the right sidebar. The button is anchored as a root-level top-trailing overlay and uses the same titlebar host metrics as the left sidebar toggle so its top position stays fixed while sidebars open, close, or resize.

Validation:
- jq empty Resources/Localizable.xcstrings
- git diff --check
- ./scripts/reload.sh --tag rs-toggle

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a fixed top-right titlebar button to toggle the right sidebar and live titlebar chrome debug controls. Traffic‑light X offsets now drive tab/title leading insets and windows update live when defaults change.

- **New Features**
  - Right sidebar toggle anchored as a root-level overlay; sized via `MinimalModeSidebarTitlebarControlsMetrics` (host/single-button widths) and positioned via `MinimalModeTitlebarDebugSettings` (top/trailing). Honors `TitlebarControlsStyle`, shows a Command-held shortcut hint, and includes localized label/tooltip (en/ja).
  - Titlebar chrome debug controls: sliders for left controls (leading/top), right toggle (trailing/top), and traffic lights (X/Y), with Reset and Copy Chrome Config. Traffic‑light offsets apply to standard window buttons; tab bar/title leading insets derive from the X offset and update on defaults change.
  - Shortcut-hint system now uses Observation (`@Observable`), refreshes on shortcut setting changes, and only shows hints for bound shortcuts (always-show or Command-held for Command-bound actions).

- **Bug Fixes**
  - Titlebar accessory layout accounts for horizontal `xOffset`, disables autoresizing, restores size on mode changes, and resizes when insets change; layout snapshot and tests updated.
  - Minimal-mode titlebar accessory/click-target placement respects configurable top/leading insets; hit testing uses the provided debug leading inset and rejects non-finite defaults. Reduced UserDefaults reads for titlebar hit testing.

<sup>Written for commit e8e5241f9caea9a88c207148588121b1d96bb7f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window chrome layout/hit-testing and standard button positioning in minimal mode, which can cause subtle UI regressions across window states (fullscreen/minimal/sidebar). Most behavior is gated by UserDefaults debug knobs and UI-only changes, limiting broader risk.
> 
> **Overview**
> Adds a fixed, top-right titlebar button to toggle the right sidebar, including localized accessibility label/tooltip and a command-held shortcut hint that refreshes when shortcut settings change.
> 
> Introduces `MinimalModeTitlebarDebugSettings` (UserDefaults-driven) to tune minimal-mode titlebar chrome (left controls insets, right toggle insets, and traffic-light X/Y offsets). These settings now drive tab/title leading insets, update window decorations live, adjust minimal-mode titlebar hit-testing/metrics, and extend the titlebar accessory layout snapshot to account for horizontal offsets.
> 
> Updates shortcut-hint modifier monitoring to use Swift Observation (`@Observable`) and adjusts related views/tests accordingly, plus adds tests for the new hint-visibility logic and debug-setting clamping/non-finite handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8e5241f9caea9a88c207148588121b1d96bb7f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added right sidebar toggle in the titlebar with a keyboard shortcut indicator
  * Added English and Japanese localization for sidebar controls

* **Improvements**
  * Better titlebar control positioning and layout for minimal mode
  * More robust window decoration and accessory layout, including improved hit testing
  * Debug UI now exposes titlebar chrome tuning controls

* **Tests**
  * Added unit tests for shortcut hint behavior and minimal-mode hit-testing/normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->