### PR TITLE
Add sticky top-right button for toggling right sidebar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -92692,6 +92692,40 @@
         }
       }
     },
+    "titlebar.rightSidebar.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Right Sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバーの切り替え"
+          }
+        }
+      }
+    },
+    "titlebar.rightSidebar.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show or hide the right sidebar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "右サイドバーの表示/非表示"
+          }
+        }
+      }
+    },
     "update.available.short": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1779,7 +1779,9 @@ final class UpdateTitlebarAccessoryController {
     private var pendingAttachRetries: [ObjectIdentifier: Int] = [:]
     private var startupScanWorkItems: [DispatchWorkItem] = []
     private let controlsIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarControls")
+    private let rightToggleIdentifier = NSUserInterfaceItemIdentifier("cmux.rightSidebarToggle")
     private let controlsControllers = NSHashTable<TitlebarControlsAccessoryViewController>.weakObjects()
+    private let rightToggleControllers = NSHashTable<RightSidebarToggleAccessoryViewController>.weakObjects()
     private var lastKnownPresentationMode: WorkspacePresentationModeSettings.Mode = WorkspacePresentationModeSettings.mode()
     private var detachedNotificationsPopover: NSPopover?
     private var detachedNotificationsPopoverDelegate: DetachedNotificationsPopoverDelegate?
@@ -1932,6 +1934,14 @@ final class UpdateTitlebarAccessoryController {
             controlsControllers.add(controls)
         }
 
+        if !window.titlebarAccessoryViewControllers.contains(where: { $0.view.identifier == rightToggleIdentifier }) {
+            let rightToggle = RightSidebarToggleAccessoryViewController()
+            rightToggle.layoutAttribute = .right
+            rightToggle.view.identifier = rightToggleIdentifier
+            window.addTitlebarAccessoryViewController(rightToggle)
+            rightToggleControllers.add(rightToggle)
+        }
+
         attachedWindows.add(window)
         applyAccessoryVisibility(for: window)
 
@@ -1953,7 +1963,7 @@ final class UpdateTitlebarAccessoryController {
         let shouldHide = WorkspacePresentationModeSettings.mode() == .minimal
             || window.styleMask.contains(.fullScreen)
         for accessory in window.titlebarAccessoryViewControllers
-            where accessory.view.identifier == controlsIdentifier {
+            where accessory.view.identifier == controlsIdentifier || accessory.view.identifier == rightToggleIdentifier {
             accessory.isHidden = shouldHide
             accessory.view.isHidden = shouldHide
             accessory.view.alphaValue = shouldHide ? 0 : 1
@@ -1968,7 +1978,7 @@ final class UpdateTitlebarAccessoryController {
         }
         let matchingIndices = window.titlebarAccessoryViewControllers.indices.reversed().filter { index in
             let id = window.titlebarAccessoryViewControllers[index].view.identifier
-            return id == controlsIdentifier
+            return id == controlsIdentifier || id == rightToggleIdentifier
         }
         guard !matchingIndices.isEmpty || attachedWindows.contains(window) else { return }
 
@@ -2149,5 +2159,137 @@ final class UpdateTitlebarAccessoryController {
             return
         }
         target.toggleNotificationsPopover(animated: animated)
+    }
+}
+
+// MARK: - Right Sidebar Toggle
+
+private struct RightSidebarToggleView: View {
+    @AppStorage("titlebarControlsStyle") private var styleRawValue = TitlebarControlsStyle.classic.rawValue
+    let onToggle: () -> Void
+
+    var body: some View {
+        let style = TitlebarControlsStyle(rawValue: styleRawValue) ?? .classic
+        let config = style.config
+        TitlebarControlButton(
+            config: config,
+            accessibilityIdentifier: "titlebarControl.toggleRightSidebar",
+            accessibilityLabel: String(localized: "titlebar.rightSidebar.accessibilityLabel", defaultValue: "Toggle Right Sidebar"),
+            action: onToggle
+        ) {
+            Image(systemName: "sidebar.right")
+                .font(.system(size: config.iconSize, weight: .semibold))
+                .frame(width: config.buttonSize, height: config.buttonSize)
+        }
+        .safeHelp(KeyboardShortcutSettings.Action.toggleFileExplorer.tooltip(String(localized: "titlebar.rightSidebar.tooltip", defaultValue: "Show or hide the right sidebar")))
+    }
+}
+
+final class RightSidebarToggleAccessoryViewController: NSTitlebarAccessoryViewController {
+    private let hostingView: NonDraggableHostingView<RightSidebarToggleView>
+    private let containerView: NSView
+    private var pendingSizeUpdate = false
+    private var fittingSizeNeedsRefresh = true
+    private var cachedFittingSize: NSSize?
+    private var lastObservedViewSize: NSSize = .zero
+    private var lastAppliedLayoutSnapshot: TitlebarControlsLayoutSnapshot?
+
+    init() {
+        let containerView = NSView()
+        self.containerView = containerView
+        hostingView = NonDraggableHostingView(
+            rootView: RightSidebarToggleView(
+                onToggle: { [weak containerView] in
+                    _ = AppDelegate.shared?.toggleRightSidebarInActiveMainWindow(preferredWindow: containerView?.window)
+                }
+            )
+        )
+
+        super.init(nibName: nil, bundle: nil)
+
+        view = containerView
+        containerView.translatesAutoresizingMaskIntoConstraints = true
+        containerView.wantsLayer = true
+        containerView.layer?.masksToBounds = false
+        hostingView.translatesAutoresizingMaskIntoConstraints = true
+        hostingView.autoresizingMask = [.width, .height]
+        containerView.addSubview(hostingView)
+
+        scheduleSizeUpdate(invalidateFittingSize: true)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidAppear() {
+        super.viewDidAppear()
+        scheduleSizeUpdate(invalidateFittingSize: true)
+    }
+
+    override func viewDidLayout() {
+        super.viewDidLayout()
+        let currentViewSize = view.bounds.size
+        guard titlebarControlsShouldScheduleForViewSizeChange(
+            previous: lastObservedViewSize,
+            current: currentViewSize
+        ) else {
+            return
+        }
+        lastObservedViewSize = currentViewSize
+        scheduleSizeUpdate(invalidateFittingSize: true)
+    }
+
+    private func scheduleSizeUpdate(invalidateFittingSize: Bool = false) {
+        if invalidateFittingSize {
+            fittingSizeNeedsRefresh = true
+        }
+        guard !pendingSizeUpdate else { return }
+        pendingSizeUpdate = true
+        DispatchQueue.main.async { [weak self] in
+            self?.pendingSizeUpdate = false
+            self?.updateSize()
+        }
+    }
+
+    private func updateSize() {
+        let contentSize: NSSize
+        if fittingSizeNeedsRefresh || cachedFittingSize == nil {
+            hostingView.invalidateIntrinsicContentSize()
+            hostingView.layoutSubtreeIfNeeded()
+            cachedFittingSize = hostingView.fittingSize
+            fittingSizeNeedsRefresh = false
+        }
+        contentSize = cachedFittingSize ?? .zero
+
+        guard contentSize.width > 0, contentSize.height > 0 else { return }
+        let titlebarHeight: CGFloat = {
+            if let window = view.window,
+               let closeButton = window.standardWindowButton(.closeButton),
+               let titlebarView = closeButton.superview,
+               titlebarView.frame.height > 0 {
+                return titlebarView.frame.height
+            }
+            return view.window.map { window in
+                window.frame.height - window.contentLayoutRect.height
+            } ?? contentSize.height
+        }()
+        let containerHeight = max(contentSize.height, titlebarHeight)
+        let yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
+        let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(
+            contentSize: contentSize,
+            containerHeight: containerHeight,
+            yOffset: yOffset
+        )
+        guard titlebarControlsShouldApplyLayout(
+            previous: lastAppliedLayoutSnapshot,
+            next: nextLayoutSnapshot
+        ) else {
+            return
+        }
+        lastAppliedLayoutSnapshot = nextLayoutSnapshot
+        preferredContentSize = NSSize(width: contentSize.width, height: containerHeight)
+        containerView.frame = NSRect(x: 0, y: 0, width: contentSize.width, height: containerHeight)
+        hostingView.frame = NSRect(x: 0, y: yOffset, width: contentSize.width, height: contentSize.height)
     }
 }


### PR DESCRIPTION
## Summary
- Add a sticky top-right button that toggles the right sidebar visibility
- Button uses the same style and vertical positioning as the left sidebar toggle
- Implemented as a separate NSTitlebarAccessoryViewController with layoutAttribute = .right
- Added localization strings for accessibility label and tooltip

## Testing
- Built successfully with ./scripts/reload.sh --tag feat-right-sidebar-toggle-btn

## Issues
- Closes https://github.com/manaflow-ai/cmux/issues/new (plain-text task)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adds a new titlebar accessory and related layout/visibility logic; main risk is minor regressions in titlebar sizing/visibility across fullscreen/minimal modes.
> 
> **Overview**
> Adds a new *top-right* titlebar button to toggle the right sidebar, implemented as a separate `NSTitlebarAccessoryViewController` (`RightSidebarToggleAccessoryViewController`) with matching sizing/vertical alignment behavior to the existing titlebar controls.
> 
> Updates `UpdateTitlebarAccessoryController` to attach/detach and hide/show this new accessory alongside the existing left-side controls (including minimal mode and fullscreen handling), and adds new localized strings for the button’s accessibility label and tooltip.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3521753179bc42642933af690cd81826ffea90b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a sticky top-right titlebar button to show or hide the right sidebar, matching the left sidebar toggle. Includes localized accessibility label and tooltip (EN/JA).

- **New Features**
  - Adds `RightSidebarToggleAccessoryViewController` anchored to `.right`, with identifier `cmux.rightSidebarToggle`; hides in minimal mode and full screen.
  - Uses existing `TitlebarControlButton` style with SF Symbol `sidebar.right`; calls `AppDelegate.toggleRightSidebarInActiveMainWindow(...)`.
  - Adds localization keys `titlebar.rightSidebar.accessibilityLabel` and `titlebar.rightSidebar.tooltip` (EN/JA).

<sup>Written for commit e3521753179bc42642933af690cd81826ffea90b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new sidebar toggle control in the titlebar, positioned on the right side of the window header, providing quick access to show or hide the right sidebar on demand.
  * Implemented comprehensive localization for the new control with accessibility labels and helpful tooltips available in English and Japanese to ensure usability across different language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->