### PR TITLE
Fix file drop on terminal, opening viewer instead of pasting path (#3729)

### DIFF
--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -145,6 +145,10 @@ extension FileDropOverlayView {
         if terminalUnderPoint(windowPoint) != nil {
             return .terminal
         }
+        if let paneTarget = paneDropTargetUnderPoint(windowPoint) as? PaneDropTargetView,
+           paneTarget.hostedView != nil {
+            return .terminal
+        }
         return nil
     }
 


### PR DESCRIPTION
## Summary
- `textDropDestinationKindUnderPoint` failed to detect terminals when
  `PaneDropTargetView` captured the hit-test before `GhosttyNSView`,
  causing `canDropAsText` to be false and routing all Finder file drops
  to the file preview panel instead of inserting shell-escaped paths.
- Adds a pane-target fallback: when `terminalUnderPoint` misses, check
  whether a `PaneDropTargetView` with a live `hostedView` exists at the
  drop point — if so, a terminal is present and text routing applies.

## Local testing
All verified manually on a tagged Debug build:
- ✅ Drag file from Finder onto terminal → pastes shell-escaped path
- ✅ Shift+drag file onto terminal → opens preview/split
- ✅ Drag image onto file preview panel → splits with two previews
- ✅ Drag file onto browser pane → no-op (same as before fix)
- ✅ Drag file to edge of terminal pane → pastes path, does not split
- ✅ Drag preview panel tab onto terminal → tab/split operation preserved
- ✅ Drag multiple files onto terminal → all paths pasted correctly
- ✅ Inverted setting in Settings → File Drop Behavior → confirmed opposite behavior applies

Fixes #3729

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a regression where dropping a file onto the terminal opened the preview viewer instead of inserting a shell-escaped path. Adds a pane-target fallback in hit testing so terminals are detected even when `PaneDropTargetView` captures the hit test.

- **Bug Fixes**
  - If `terminalUnderPoint` misses, treat a `PaneDropTargetView` with a non-nil `hostedView` as a terminal for text drops.
  - Restores expected behavior: file drops paste paths; Shift+drag still opens preview/split; non-terminal panes unchanged.

<sup>Written for commit 2d6082a648261f3f3d935818bb3bb9abd03bf3ca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file drop target detection for pane areas to ensure more accurate drop handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->