### PR TITLE
fix(claude): preserve dev channel resume flag

### DIFF
--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -10,6 +10,7 @@ extension AgentLaunchSanitizer {
             "--allowed-tools",
             "--append-system-prompt",
             "--betas",
+            "--dangerously-load-development-channels",
             "--debug-file",
             "--disallowedTools",
             "--disallowed-tools",

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1758,6 +1758,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
                 executablePath: "/Users/lawrence/.local/bin/claude",
                 arguments: [
                     "/Users/lawrence/.local/bin/claude",
+                    "--dangerously-load-development-channels",
+                    "server:custom-dev-channel",
                     "--dangerously-skip-permissions"
                 ],
                 workingDirectory: "/Users/lawrence/fun",
@@ -1773,7 +1775,7 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         XCTAssertEqual(
             snapshot.resumeCommand,
-            "cd '/Users/lawrence/fun' && 'env' 'CLAUDE_CONFIG_DIR=/Users/lawrence/.codex-accounts/claude/_p1775010019397' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/Users/lawrence/.local/bin/claude' '--resume' '24ec0052-450c-4914-b1dd-2ee80d4bc84b' '--dangerously-skip-permissions'"
+            "cd '/Users/lawrence/fun' && 'env' 'CLAUDE_CONFIG_DIR=/Users/lawrence/.codex-accounts/claude/_p1775010019397' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1' 'CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR' '/Users/lawrence/.local/bin/claude' '--resume' '24ec0052-450c-4914-b1dd-2ee80d4bc84b' '--dangerously-load-development-channels' 'server:custom-dev-channel' '--dangerously-skip-permissions'"
         )
     }
 


### PR DESCRIPTION
## Summary
 
 - Preserves Claude’s `--dangerously-load-development-channels <channel>` launch argument when cmux rebuilds a recovery/resume command.
 - This flag is value-taking. Without listing it in Claude’s value-taking sanitizer policy, cmux preserved the flag but dropped the channel value, so 
`server:custom-dev-channel` was treated as a positional argument instead of part of the option.
 - This matters for Claude Code dev-channel workflows because Claude documents `server:<name>` as a supported development-channel entry for local channel 
testing.
 
 ## Testing
 
 - Ran whitespace validation:
   ```bash
   git diff --check HEAD~1..HEAD

 - Ran the targeted Claude resume regression: CMUX_SKIP_ZIG_BUILD=1 xcodebuild \
    -project GhosttyTabs.xcodeproj \
    -scheme cmux-unit \
    -configuration Debug \
    -destination 'platform=macOS' \
    -derivedDataPath /Users/cole/Library/Developer/Xcode/DerivedData/cmux-fix-claude-dev-channel-resume \
    -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testClaudeResumeCommandPreservesDangerouslySkipPermissionsAndObservedEnvironment \
    test
 - Verified the generated Claude resume command keeps:
  - --dangerously-load-development-channels server:custom-dev-channel
  - --dangerously-skip-permissions
 - Result: targeted test passed, 1 test, 0 failures.

Full local app build was not run. This machine is missing Xcode’s Metal Toolchain, so the targeted unit test used the repo-supported CMUX_SKIP_ZIG_BUILD=1 path
to skip the Ghostty CLI helper build.

References:

 - Claude Code CLI reference for --dangerously-load-development-channels: https://docs.anthropic.com/en/docs/claude-code/cli-reference
 - Claude Code channels reference for server:<name> dev-channel entries: 
https://docs.anthropic.com/en/docs/claude-code/channels-reference#test-during-the-research-preview

Demo:
non-UI resume-command generation fix.


Checklist

- [X]  I tested the change locally
- [X]  I added or updated tests for behavior changes
- [X]  I updated docs/changelog if needed
- [x]  I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x]  All code review bot comments are resolved
- [ ]  All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure `cmux` preserves Claude’s `--dangerously-load-development-channels <channel>` option and its value when rebuilding a resume command. Fixes dev-channel workflows where the channel was dropped and misread as a positional argument.

- **Bug Fixes**
  - Treat `--dangerously-load-development-channels` as value-taking in the sanitizer to keep the channel value during resume.
  - Extend the session persistence test to assert the resume command includes `--dangerously-load-development-channels server:custom-dev-channel` and `--dangerously-skip-permissions`.

<sup>Written for commit a18430890b8c72fd0e20879bdb9addea3d37dd2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced the `--dangerously-load-development-channels` CLI option to enable development channel loading.

* **Tests**
  * Enhanced test coverage to verify the new CLI option is properly preserved and applied in command generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->