### PR TITLE
Add auxiliary window close shortcut review rule

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -64,3 +64,7 @@ reviews:
         mode: error
         instructions: |
           For Swift architecture changes, fail when the diff violates `.github/review-bot-rules/swift-architectural-rethink.md`: symptom patches using sleeps, delayed dispatch, polling, locks, observers, side channels, duplicate entrypoint wiring, or split UI lifecycle ownership that leaves bad state representable. Pass for small correctness fixes with clear owners and invariants, required platform bridges, and test-only synchronization.
+      - name: "cmux Swift auxiliary window close shortcuts"
+        mode: error
+        instructions: |
+          For Swift changes that add or materially change standalone cmux-owned windows, fail when the diff violates `.github/review-bot-rules/swift-auxiliary-window-close-shortcuts.md`: user-visible NSWindow, NSPanel, NSWindowController, SwiftUI Window, or WindowGroup code without a stable cmux.* identifier and shared close-shortcut ownership through cmuxAuxiliaryWindowIdentifiers. Pass for main workspace windows, terminal panes, tabs, sheets, popovers, menus, test-only fixtures, and existing unregistered windows not worsened by the PR. If the deterministic CI script already catches the literal assignment, mention scripts/lint_auxiliary_window_close_shortcuts.py; otherwise explain the broader review-only pattern.

--- a/.github/review-bot-rules/README.md
+++ b/.github/review-bot-rules/README.md
@@ -11,6 +11,7 @@ Current rules:
 - `runtime-no-hacky-sleeps.md`
 - `swift-actor-isolation.md`
 - `swift-architectural-rethink.md`
+- `swift-auxiliary-window-close-shortcuts.md`
 - `swift-blocking-runtime.md`
 - `swift-concurrency-modernization.md`
 - `swift-concurrent-annotation.md`

--- a/.github/review-bot-rules/swift-auxiliary-window-close-shortcuts.md
+++ b/.github/review-bot-rules/swift-auxiliary-window-close-shortcuts.md
@@ -1,0 +1,19 @@
+# Swift Auxiliary Window Close Shortcuts
+
+Standalone cmux-owned windows must have one close-shortcut owner so Cmd+W closes or hides the active window instead of falling through to workspace panel closing.
+
+Report a failure when the diff introduces or materially changes:
+
+- A user-visible `NSWindow`, `NSPanel`, `NSWindowController`, SwiftUI `Window`, or SwiftUI `WindowGroup` without a stable `cmux.*` window identifier.
+- A `cmux.*` window identifier assignment that is missing from `cmuxAuxiliaryWindowIdentifiers` in `Sources/cmuxApp.swift`.
+- A new standalone debug, settings, preview, task, editor, browser, file, import, config, or inspector window that can become key but is not covered by `cmuxWindowShouldOwnCloseShortcut`.
+- A custom Cmd+W, `performKeyEquivalent`, or close-menu workaround that bypasses the shared `cmuxWindowShouldOwnCloseShortcut` routing instead of registering the window identifier.
+
+Allowed cases:
+
+- Main workspace windows, terminal panes, tabs, sheets, popovers, menus, and views that are not standalone key windows.
+- Hidden bootstrap or internal windows explicitly documented in the script ignore list.
+- Test-only fixture windows.
+- Existing unregistered windows that the PR does not introduce or worsen, though mention them if they are adjacent to the changed window code.
+
+When reporting, include the window/controller/file, the missing identifier or owner registration, and the expected shared path: assign a stable `cmux.*` identifier and register user-closable windows in `cmuxAuxiliaryWindowIdentifiers`. If the hard CI lint already catches the exact literal assignment, point to `scripts/lint_auxiliary_window_close_shortcuts.py`; otherwise explain why the bot rule caught a more flexible pattern.


### PR DESCRIPTION
Summary:
- add a shared review-bot rule for standalone auxiliary window Cmd+W ownership
- wire it into CodeRabbit pre-merge checks
- keep the deterministic CI script as the hard gate for literal identifier assignments

Verification:
- ruby -e 'require "yaml"; YAML.load_file(".coderabbit.yaml"); puts "coderabbit yaml ok"'\n- git diff --check\n- python3 scripts/lint_auxiliary_window_close_shortcuts.py\n\n@coderabbitai review\n@greptile-apps review

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add a new review-bot rule and wire it into CodeRabbit pre-merge checks; no production runtime behavior is modified.
> 
> **Overview**
> Adds a new Swift review-bot rule to ensure standalone cmux-owned auxiliary windows have stable `cmux.*` identifiers and are registered for shared Cmd+W close-shortcut ownership.
> 
> Wires this rule into CodeRabbit `pre_merge_checks` and documents it in the review-bot rules README, with guidance to reference `scripts/lint_auxiliary_window_close_shortcuts.py` when the deterministic lint already covers a specific identifier assignment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ebac45986687d5c246f8db0b3a98a259d289f7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a review-bot rule that enforces Cmd+W ownership for standalone Swift auxiliary windows. This helps stop accidental workspace panel closes by requiring stable `cmux.*` identifiers and shared close-shortcut routing.

- **New Features**
  - Added `.github/review-bot-rules/swift-auxiliary-window-close-shortcuts.md` with checks and allowed cases.
  - Enabled the rule in `.coderabbit.yaml` as an error-mode pre-merge check.
  - Kept the deterministic CI guard in `scripts/lint_auxiliary_window_close_shortcuts.py`; the rule catches broader non-literal patterns.
  - Updated the rule index in `.github/review-bot-rules/README.md`.

<sup>Written for commit 0ebac45986687d5c246f8db0b3a98a259d289f7a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced code review tooling with a new quality assurance rule for Swift window management to ensure consistent behavior across the application.
  * Updated review documentation to reflect new automated checking procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->