### PR TITLE
Fix SSH image drops through terminal text route

### DIFF
--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -127,6 +127,25 @@ enum FileDropTextDropController {
         return true
     }
 
+    @discardableResult
+    static func performTerminalTextDrop(
+        workspace: Workspace,
+        panelId: UUID,
+        hostedView: GhosttySurfaceScrollView,
+        urls: [URL],
+        window: NSWindow?
+    ) -> Bool {
+        performPanelTextDrop(
+            workspace: workspace,
+            panelId: panelId,
+            focusIntent: .terminal(.surface),
+            window: window,
+            insert: {
+                hostedView.handleDroppedURLs(urls)
+            }
+        )
+    }
+
     static func focusPanelAfterSuccessfulTextDrop(
         workspace: Workspace,
         panelId: UUID,

--- a/Sources/DragOverlayRoutingPolicy.swift
+++ b/Sources/DragOverlayRoutingPolicy.swift
@@ -128,7 +128,7 @@ enum FileDropTextDropController {
     }
 
     @discardableResult
-    static func performTerminalTextDrop(
+    static func performTerminalFileDrop(
         workspace: Workspace,
         panelId: UUID,
         hostedView: GhosttySurfaceScrollView,
@@ -142,6 +142,31 @@ enum FileDropTextDropController {
             window: window,
             insert: {
                 hostedView.handleDroppedURLs(urls)
+            }
+        )
+    }
+
+    @discardableResult
+    static func performTerminalFileDrop(
+        terminal: GhosttyNSView,
+        urls: [URL]
+    ) -> Bool {
+        guard let workspaceId = terminal.tabId,
+              let terminalSurfaceId = terminal.terminalSurface?.id,
+              let workspace = AppDelegate.shared?.workspaceFor(tabId: workspaceId),
+              let panelId = panelIdForTerminalDropFocus(
+                terminalSurfaceId: terminalSurfaceId,
+                workspace: workspace
+              ) else {
+            return terminal.handleDroppedFileURLs(urls)
+        }
+        return performPanelTextDrop(
+            workspace: workspace,
+            panelId: panelId,
+            focusIntent: .terminal(.surface),
+            window: terminal.window,
+            insert: {
+                terminal.handleDroppedFileURLs(urls)
             }
         )
     }

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -168,11 +168,11 @@ extension FileDropOverlayView {
     func performFileDropAsText(_ sender: any NSDraggingInfo) -> Bool {
         let urls = DragOverlayRoutingPolicy.fileURLs(from: sender.draggingPasteboard)
         guard !urls.isEmpty else { return false }
-        let text = TerminalImageTransferPlanner.insertedText(forFileURLs: urls)
-        guard !text.isEmpty else { return false }
 
         let windowPoint = sender.draggingLocation
         if let textView = editableTextViewUnderPoint(windowPoint) {
+            let text = TerminalImageTransferPlanner.insertedText(forFileURLs: urls)
+            guard !text.isEmpty else { return false }
             return insert(text, into: textView)
         }
         if let terminal = terminalUnderPoint(windowPoint) {
@@ -214,7 +214,7 @@ extension FileDropOverlayView {
     }
 
     private func insert(_ urls: [URL], into terminal: GhosttyNSView) -> Bool {
-        let handled = terminal.handleDroppedFileURLsAsText(urls)
+        let handled = terminal.handleDroppedFileURLs(urls)
         guard handled,
               let workspaceId = terminal.tabId,
               let terminalSurfaceId = terminal.terminalSurface?.id,

--- a/Sources/FileDropOverlayViewHitTesting.swift
+++ b/Sources/FileDropOverlayViewHitTesting.swift
@@ -214,24 +214,10 @@ extension FileDropOverlayView {
     }
 
     private func insert(_ urls: [URL], into terminal: GhosttyNSView) -> Bool {
-        let handled = terminal.handleDroppedFileURLs(urls)
-        guard handled,
-              let workspaceId = terminal.tabId,
-              let terminalSurfaceId = terminal.terminalSurface?.id,
-              let workspace = AppDelegate.shared?.workspaceFor(tabId: workspaceId),
-              let panelId = FileDropTextDropController.panelIdForTerminalDropFocus(
-                terminalSurfaceId: terminalSurfaceId,
-                workspace: workspace
-              ) else {
-            return handled
-        }
-        FileDropTextDropController.focusPanelAfterSuccessfulTextDrop(
-            workspace: workspace,
-            panelId: panelId,
-            focusIntent: .terminal(.surface),
-            window: terminal.window
+        FileDropTextDropController.performTerminalFileDrop(
+            terminal: terminal,
+            urls: urls
         )
-        return true
     }
 
     /// Hit-tests the window to find a WKWebView (browser panel) under the cursor.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9334,7 +9334,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
     }
 
-    fileprivate func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
+    func handleDroppedFileURLs(_ urls: [URL]) -> Bool {
         executePreparedImageTransfer(
             .fileURLs(urls),
             onCancel: {}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9341,13 +9341,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
-    func handleDroppedFileURLsAsText(_ urls: [URL]) -> Bool {
-        let text = TerminalImageTransferPlanner.insertedText(forFileURLs: urls)
-        guard !text.isEmpty, let terminalSurface else { return false }
-        terminalSurface.sendText(text)
-        return true
-    }
-
     @discardableResult
     fileprivate func insertDroppedPasteboard(_ pasteboard: NSPasteboard) -> Bool {
         executePreparedImageTransfer(
@@ -11318,13 +11311,6 @@ final class GhosttySurfaceScrollView: NSView {
         cmuxDebugLog("terminal.swiftUIDrop surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") urls=\(urls.map(\.lastPathComponent))")
         #endif
         return surfaceView.handleDroppedFileURLs(urls)
-    }
-
-    func handleDroppedURLsAsText(_ urls: [URL]) -> Bool {
-        #if DEBUG
-        cmuxDebugLog("terminal.swiftUIDropAsText surface=\(surfaceView.terminalSurface?.id.uuidString.prefix(5) ?? "nil") urls=\(urls.map(\.lastPathComponent))")
-        #endif
-        return surfaceView.handleDroppedFileURLsAsText(urls)
     }
 
     func terminalViewForDrop(at point: NSPoint) -> GhosttyNSView? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12429,6 +12429,21 @@ class TerminalController {
         let route = (v2String(params, "route") ?? "text_destination")
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased()
+        enum TerminalFileDropSimulationRoute {
+            case terminal
+            case textDestination
+        }
+        let simulationRoute: TerminalFileDropSimulationRoute
+        switch route {
+        case "terminal", "direct":
+            simulationRoute = .terminal
+        case "text", "text_destination", "pane_text":
+            simulationRoute = .textDestination
+        default:
+            return .err(code: "invalid_params", message: "Unknown route", data: [
+                "route": route
+            ])
+        }
 
         var result: V2CallResult = .err(code: "not_found", message: "Terminal surface not found", data: [
             "surface_id": surfaceId
@@ -12438,13 +12453,13 @@ class TerminalController {
                 return
             }
 
-            switch route {
-            case "terminal", "direct":
+            switch simulationRoute {
+            case .terminal:
                 let handled = panel.hostedView.debugSimulateFileDrop(paths: paths)
                 result = handled
                     ? .ok(["handled": true, "route": "terminal"])
                     : .err(code: "internal_error", message: "Terminal drop simulation failed", data: nil)
-            case "text", "text_destination", "pane_text":
+            case .textDestination:
                 guard let workspace = tabManager.tabs.first(where: { $0.id == panel.workspaceId }) else {
                     result = .err(code: "not_found", message: "Workspace not found", data: [
                         "workspace_id": panel.workspaceId.uuidString
@@ -12462,10 +12477,6 @@ class TerminalController {
                 result = handled
                     ? .ok(["handled": true, "route": "text_destination"])
                     : .err(code: "internal_error", message: "Text destination drop simulation failed", data: nil)
-            default:
-                result = .err(code: "invalid_params", message: "Unknown route", data: [
-                    "route": route
-                ])
             }
         }
         return result

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2781,6 +2781,8 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugSidebarVisible(params: params))
         case "debug.terminal.is_focused":
             return v2Result(id: id, self.v2DebugIsTerminalFocused(params: params))
+        case "debug.terminal.simulate_file_drop":
+            return v2Result(id: id, self.v2DebugSimulateTerminalFileDrop(params: params))
         case "debug.terminal.read_text":
             return v2Result(id: id, self.v2DebugReadTerminalText(params: params))
         case "debug.terminal.render_stats":
@@ -3017,6 +3019,7 @@ class TerminalController {
             "debug.right_sidebar.focus",
             "debug.sidebar.visible",
             "debug.terminal.is_focused",
+            "debug.terminal.simulate_file_drop",
             "debug.terminal.read_text",
             "debug.terminal.render_stats",
             "debug.layout",
@@ -12399,6 +12402,69 @@ class TerminalController {
             return .err(code: "internal_error", message: resp, data: nil)
         }
         return .ok(["focused": resp.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"])
+    }
+
+    private func v2DebugSimulateTerminalFileDrop(params: [String: Any]) -> V2CallResult {
+        guard let tabManager else {
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        }
+        guard let surfaceId = v2String(params, "surface_id") else {
+            return .err(code: "invalid_params", message: "Missing surface_id", data: nil)
+        }
+        guard let rawPaths = params["paths"] as? [String] else {
+            return .err(code: "invalid_params", message: "Missing paths", data: nil)
+        }
+        let paths = rawPaths
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !paths.isEmpty else {
+            return .err(code: "invalid_params", message: "paths must not be empty", data: nil)
+        }
+
+        let route = (v2String(params, "route") ?? "text_destination")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        var result: V2CallResult = .err(code: "not_found", message: "Terminal surface not found", data: [
+            "surface_id": surfaceId
+        ])
+        v2MainSync {
+            guard let panel = resolveTerminalPanel(from: surfaceId, tabManager: tabManager) else {
+                return
+            }
+
+            switch route {
+            case "terminal", "direct":
+                let handled = panel.hostedView.debugSimulateFileDrop(paths: paths)
+                result = handled
+                    ? .ok(["handled": true, "route": "terminal"])
+                    : .err(code: "internal_error", message: "Terminal drop simulation failed", data: nil)
+            case "text", "text_destination", "pane_text":
+                guard let workspace = tabManager.tabs.first(where: { $0.id == panel.workspaceId }) else {
+                    result = .err(code: "not_found", message: "Workspace not found", data: [
+                        "workspace_id": panel.workspaceId.uuidString
+                    ])
+                    return
+                }
+                let urls = paths.map { URL(fileURLWithPath: $0).standardizedFileURL }
+                let handled = FileDropTextDropController.performPanelTextDrop(
+                    workspace: workspace,
+                    panelId: panel.id,
+                    focusIntent: .terminal(.surface),
+                    window: panel.hostedView.window
+                ) {
+                    panel.hostedView.handleDroppedURLsAsText(urls)
+                }
+                result = handled
+                    ? .ok(["handled": true, "route": "text_destination"])
+                    : .err(code: "internal_error", message: "Text destination drop simulation failed", data: nil)
+            default:
+                result = .err(code: "invalid_params", message: "Unknown route", data: [
+                    "route": route
+                ])
+            }
+        }
+        return result
     }
 
     private func v2DebugReadTerminalText(params: [String: Any]) -> V2CallResult {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3021,7 +3021,6 @@ class TerminalController {
             "debug.right_sidebar.focus",
             "debug.sidebar.visible",
             "debug.terminal.is_focused",
-            "debug.terminal.simulate_file_drop",
             "debug.terminal.read_text",
             "debug.terminal.render_stats",
             "debug.layout",
@@ -3039,6 +3038,9 @@ class TerminalController {
             "debug.session_snapshot_seed_scrollback",
             "debug.window.screenshot",
         ])
+#endif
+#if DEBUG
+        methods.append("debug.terminal.simulate_file_drop")
 #endif
 
         return [

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12447,14 +12447,13 @@ class TerminalController {
                     return
                 }
                 let urls = paths.map { URL(fileURLWithPath: $0).standardizedFileURL }
-                let handled = FileDropTextDropController.performPanelTextDrop(
+                let handled = FileDropTextDropController.performTerminalTextDrop(
                     workspace: workspace,
                     panelId: panel.id,
-                    focusIntent: .terminal(.surface),
+                    hostedView: panel.hostedView,
+                    urls: urls,
                     window: panel.hostedView.window
-                ) {
-                    panel.hostedView.handleDroppedURLsAsText(urls)
-                }
+                )
                 result = handled
                     ? .ok(["handled": true, "route": "text_destination"])
                     : .err(code: "internal_error", message: "Text destination drop simulation failed", data: nil)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2781,8 +2781,10 @@ class TerminalController {
             return v2Result(id: id, self.v2DebugSidebarVisible(params: params))
         case "debug.terminal.is_focused":
             return v2Result(id: id, self.v2DebugIsTerminalFocused(params: params))
+#if DEBUG
         case "debug.terminal.simulate_file_drop":
             return v2Result(id: id, self.v2DebugSimulateTerminalFileDrop(params: params))
+#endif
         case "debug.terminal.read_text":
             return v2Result(id: id, self.v2DebugReadTerminalText(params: params))
         case "debug.terminal.render_stats":
@@ -12404,6 +12406,7 @@ class TerminalController {
         return .ok(["focused": resp.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "true"])
     }
 
+#if DEBUG
     private func v2DebugSimulateTerminalFileDrop(params: [String: Any]) -> V2CallResult {
         guard let tabManager else {
             return .err(code: "unavailable", message: "TabManager not available", data: nil)
@@ -12447,7 +12450,7 @@ class TerminalController {
                     return
                 }
                 let urls = paths.map { URL(fileURLWithPath: $0).standardizedFileURL }
-                let handled = FileDropTextDropController.performTerminalTextDrop(
+                let handled = FileDropTextDropController.performTerminalFileDrop(
                     workspace: workspace,
                     panelId: panel.id,
                     hostedView: panel.hostedView,
@@ -12465,6 +12468,7 @@ class TerminalController {
         }
         return result
     }
+#endif
 
     private func v2DebugReadTerminalText(params: [String: Any]) -> V2CallResult {
         let surfaceArg = v2String(params, "surface_id") ?? ""

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -274,7 +274,7 @@ final class PaneDropTargetView: NSView {
         workspace: Workspace
     ) -> Bool {
         if let hostedView {
-            return FileDropTextDropController.performTerminalTextDrop(
+            return FileDropTextDropController.performTerminalFileDrop(
                 workspace: workspace,
                 panelId: context.panelId,
                 hostedView: hostedView,
@@ -289,7 +289,7 @@ final class PaneDropTargetView: NSView {
             return false
         }
         if let terminalPanel = panel as? TerminalPanel {
-            return FileDropTextDropController.performTerminalTextDrop(
+            return FileDropTextDropController.performTerminalFileDrop(
                 workspace: workspace,
                 panelId: panelId,
                 hostedView: terminalPanel.hostedView,

--- a/Sources/TerminalPaneDropTargetView.swift
+++ b/Sources/TerminalPaneDropTargetView.swift
@@ -274,14 +274,12 @@ final class PaneDropTargetView: NSView {
         workspace: Workspace
     ) -> Bool {
         if let hostedView {
-            return FileDropTextDropController.performPanelTextDrop(
+            return FileDropTextDropController.performTerminalTextDrop(
                 workspace: workspace,
                 panelId: context.panelId,
-                focusIntent: .terminal(.surface),
-                window: window,
-                insert: {
-                    hostedView.handleDroppedURLsAsText(urls)
-                }
+                hostedView: hostedView,
+                urls: urls,
+                window: window
             )
         }
 
@@ -291,14 +289,12 @@ final class PaneDropTargetView: NSView {
             return false
         }
         if let terminalPanel = panel as? TerminalPanel {
-            return FileDropTextDropController.performPanelTextDrop(
+            return FileDropTextDropController.performTerminalTextDrop(
                 workspace: workspace,
                 panelId: panelId,
-                focusIntent: .terminal(.surface),
-                window: window ?? terminalPanel.hostedView.window,
-                insert: {
-                    terminalPanel.hostedView.handleDroppedURLsAsText(urls)
-                }
+                hostedView: terminalPanel.hostedView,
+                urls: urls,
+                window: window ?? terminalPanel.hostedView.window
             )
         }
         if let filePreviewPanel = panel as? FilePreviewPanel {

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -980,6 +980,19 @@ class cmux:
         res = self._call("debug.terminal.is_focused", {"surface_id": sid}) or {}
         return bool(res.get("focused"))
 
+    def simulate_terminal_file_drop(
+        self,
+        panel: Union[str, int],
+        paths: list[str],
+        route: str = "text_destination",
+    ) -> None:
+        sid = self._resolve_surface_id(panel)
+        self._call(
+            "debug.terminal.simulate_file_drop",
+            {"surface_id": sid, "paths": [str(path) for path in paths], "route": route},
+            timeout_s=30.0,
+        )
+
     def read_terminal_text(self, panel: Union[str, int, None] = None) -> str:
         params: Dict[str, Any] = {}
         if panel is not None:

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -121,8 +121,8 @@ def _run_cli_json(cli: str, args: list[str]) -> dict:
         raise cmuxError(f"cmux {' '.join(args)} failed: {(proc.stdout + proc.stderr).strip()}")
     try:
         return json.loads(proc.stdout or "{}")
-    except Exception as exc:
-        raise cmuxError(f"Invalid JSON output for {' '.join(args)}: {proc.stdout!r} ({exc})")
+    except json.JSONDecodeError as exc:
+        raise cmuxError(f"Invalid JSON output for {' '.join(args)}: {proc.stdout!r} ({exc})") from exc
 
 
 def _resolve_workspace_id(client: cmux, payload: dict) -> str:

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -22,6 +22,8 @@ from cmux import cmux, cmuxError
 
 
 SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+DEFAULT_CMD_TIMEOUT = float(os.environ.get("CMUX_TEST_CMD_TIMEOUT", "60"))
+SLOW_CMD_TIMEOUT = float(os.environ.get("CMUX_TEST_SLOW_CMD_TIMEOUT", "300"))
 
 
 def _must(condition: bool, message: str) -> None:
@@ -29,8 +31,22 @@ def _must(condition: bool, message: str) -> None:
         raise cmuxError(message)
 
 
-def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
-    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+def _run(
+    cmd: list[str],
+    *,
+    check: bool = True,
+    timeout: float | None = DEFAULT_CMD_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise cmuxError(f"Command timed out after {timeout}s ({' '.join(cmd)})") from exc
     if check and proc.returncode != 0:
         merged = f"{proc.stdout}\n{proc.stderr}".strip()
         raise cmuxError(f"Command failed ({' '.join(cmd)}): {merged}")
@@ -65,7 +81,15 @@ def _shell_single_quote(value: str) -> str:
     return "'" + value.replace("'", "'\"'\"'") + "'"
 
 
-def _ssh_run(host: str, host_port: int, key_path: Path, script: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+def _ssh_run(
+    host: str,
+    host_port: int,
+    key_path: Path,
+    script: str,
+    *,
+    check: bool = True,
+    timeout: float | None = DEFAULT_CMD_TIMEOUT,
+) -> subprocess.CompletedProcess[str]:
     return _run(
         [
             "ssh",
@@ -78,13 +102,14 @@ def _ssh_run(host: str, host_port: int, key_path: Path, script: str, *, check: b
             f"sh -lc {_shell_single_quote(script)}",
         ],
         check=check,
+        timeout=timeout,
     )
 
 
 def _wait_for_ssh(host: str, host_port: int, key_path: Path, timeout: float = 20.0) -> None:
     deadline = time.time() + timeout
     while time.time() < deadline:
-        probe = _ssh_run(host, host_port, key_path, "echo ready", check=False)
+        probe = _ssh_run(host, host_port, key_path, "echo ready", check=False, timeout=10)
         if probe.returncode == 0 and "ready" in probe.stdout:
             return
         time.sleep(0.4)
@@ -104,19 +129,28 @@ def _wait_remote_ready(client: cmux, workspace_id: str, timeout: float = 45.0) -
     raise cmuxError(f"Remote did not become ready for {workspace_id}: {last_status}")
 
 
-def _run_cli_json(cli: str, args: list[str]) -> dict:
+def _run_cli_json(
+    cli: str,
+    args: list[str],
+    *,
+    timeout: float | None = DEFAULT_CMD_TIMEOUT,
+) -> dict:
     env = dict(os.environ)
     env.pop("CMUX_WORKSPACE_ID", None)
     env.pop("CMUX_SURFACE_ID", None)
     env.pop("CMUX_TAB_ID", None)
 
-    proc = subprocess.run(
-        [cli, "--socket", SOCKET_PATH, "--json", "--id-format", "both", *args],
-        capture_output=True,
-        text=True,
-        env=env,
-        check=False,
-    )
+    try:
+        proc = subprocess.run(
+            [cli, "--socket", SOCKET_PATH, "--json", "--id-format", "both", *args],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise cmuxError(f"cmux {' '.join(args)} timed out after {timeout}s") from exc
     if proc.returncode != 0:
         raise cmuxError(f"cmux {' '.join(args)} failed: {(proc.stdout + proc.stderr).strip()}")
     try:
@@ -183,7 +217,7 @@ def main() -> int:
         pubkey = key_path.with_suffix(".pub").read_text(encoding="utf-8").strip()
         _must(bool(pubkey), "Generated SSH public key was empty")
 
-        _run(["docker", "build", "-t", image_tag, str(fixture_dir)])
+        _run(["docker", "build", "-t", image_tag, str(fixture_dir)], timeout=SLOW_CMD_TIMEOUT)
         _run([
             "docker", "run", "-d", "--rm",
             "--name", container_name,
@@ -208,6 +242,7 @@ def main() -> int:
                     "--ssh-option", "UserKnownHostsFile=/dev/null",
                     "--ssh-option", "StrictHostKeyChecking=no",
                 ],
+                timeout=90,
             )
             workspace_id = _resolve_workspace_id(client, payload)
             _wait_remote_ready(client, workspace_id)

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Regression: image drops into cmux ssh terminals upload to the remote host."""
+
+from __future__ import annotations
+
+import base64
+import glob
+import hashlib
+import json
+import os
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+
+def _must(condition: bool, message: str) -> None:
+    if not condition:
+        raise cmuxError(message)
+
+
+def _run(cmd: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if check and proc.returncode != 0:
+        merged = f"{proc.stdout}\n{proc.stderr}".strip()
+        raise cmuxError(f"Command failed ({' '.join(cmd)}): {merged}")
+    return proc
+
+
+def _find_cli_binary() -> str:
+    env_cli = os.environ.get("CMUXTERM_CLI")
+    if env_cli and os.path.isfile(env_cli) and os.access(env_cli, os.X_OK):
+        return env_cli
+
+    fixed = os.path.expanduser("~/Library/Developer/Xcode/DerivedData/cmux-tests-v2/Build/Products/Debug/cmux")
+    if os.path.isfile(fixed) and os.access(fixed, os.X_OK):
+        return fixed
+
+    candidates = glob.glob(os.path.expanduser("~/Library/Developer/Xcode/DerivedData/**/Build/Products/Debug/cmux"), recursive=True)
+    candidates += glob.glob("/tmp/cmux-*/Build/Products/Debug/cmux")
+    candidates = [path for path in candidates if os.path.isfile(path) and os.access(path, os.X_OK)]
+    if not candidates:
+        raise cmuxError("Could not locate cmux CLI binary; set CMUXTERM_CLI")
+    candidates.sort(key=lambda path: os.path.getmtime(path), reverse=True)
+    return candidates[0]
+
+
+def _docker_available() -> bool:
+    if shutil.which("docker") is None:
+        return False
+    return _run(["docker", "info"], check=False).returncode == 0
+
+
+def _shell_single_quote(value: str) -> str:
+    return "'" + value.replace("'", "'\"'\"'") + "'"
+
+
+def _ssh_run(host: str, host_port: int, key_path: Path, script: str, *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return _run(
+        [
+            "ssh",
+            "-o", "UserKnownHostsFile=/dev/null",
+            "-o", "StrictHostKeyChecking=no",
+            "-o", "ConnectTimeout=5",
+            "-p", str(host_port),
+            "-i", str(key_path),
+            host,
+            f"sh -lc {_shell_single_quote(script)}",
+        ],
+        check=check,
+    )
+
+
+def _wait_for_ssh(host: str, host_port: int, key_path: Path, timeout: float = 20.0) -> None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        probe = _ssh_run(host, host_port, key_path, "echo ready", check=False)
+        if probe.returncode == 0 and "ready" in probe.stdout:
+            return
+        time.sleep(0.4)
+    raise cmuxError("Timed out waiting for SSH server in docker fixture")
+
+
+def _wait_remote_ready(client: cmux, workspace_id: str, timeout: float = 45.0) -> None:
+    deadline = time.time() + timeout
+    last_status = {}
+    while time.time() < deadline:
+        last_status = client._call("workspace.remote.status", {"workspace_id": workspace_id}) or {}
+        remote = last_status.get("remote") or {}
+        daemon = remote.get("daemon") or {}
+        if str(remote.get("state") or "") == "connected" and str(daemon.get("state") or "") == "ready":
+            return
+        time.sleep(0.25)
+    raise cmuxError(f"Remote did not become ready for {workspace_id}: {last_status}")
+
+
+def _run_cli_json(cli: str, args: list[str]) -> dict:
+    env = dict(os.environ)
+    env.pop("CMUX_WORKSPACE_ID", None)
+    env.pop("CMUX_SURFACE_ID", None)
+    env.pop("CMUX_TAB_ID", None)
+
+    proc = subprocess.run(
+        [cli, "--socket", SOCKET_PATH, "--json", "--id-format", "both", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise cmuxError(f"cmux {' '.join(args)} failed: {(proc.stdout + proc.stderr).strip()}")
+    try:
+        return json.loads(proc.stdout or "{}")
+    except Exception as exc:
+        raise cmuxError(f"Invalid JSON output for {' '.join(args)}: {proc.stdout!r} ({exc})")
+
+
+def _resolve_workspace_id(client: cmux, payload: dict) -> str:
+    workspace_id = str(payload.get("workspace_id") or "")
+    if workspace_id:
+        return workspace_id
+
+    workspace_ref = str(payload.get("workspace_ref") or "")
+    if workspace_ref.startswith("workspace:"):
+        listed = client._call("workspace.list", {}) or {}
+        for row in listed.get("workspaces") or []:
+            if str(row.get("ref") or "") == workspace_ref:
+                resolved = str(row.get("id") or "")
+                if resolved:
+                    return resolved
+
+    raise cmuxError(f"Unable to resolve workspace_id from payload: {payload}")
+
+
+def _focused_surface_id(client: cmux) -> str:
+    ident = client.identify()
+    surface_id = str((ident.get("focused") or {}).get("surface_id") or "")
+    _must(bool(surface_id), f"Missing focused surface in identify payload: {ident}")
+    return surface_id
+
+
+def _wait_for_remote_drop_path(client: cmux, surface_id: str, timeout: float = 20.0) -> str:
+    pattern = re.compile(r"/tmp/cmux-drop-[0-9a-f-]+\.png")
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        last = client.read_terminal_text(surface_id)
+        match = pattern.search(last)
+        if match:
+            return match.group(0)
+        time.sleep(0.25)
+    raise cmuxError(f"Timed out waiting for remote drop path in terminal text: {last[-1000:]!r}")
+
+
+def main() -> int:
+    if not _docker_available():
+        print("SKIP: docker is not available")
+        return 0
+
+    cli = _find_cli_binary()
+    repo_root = Path(__file__).resolve().parents[1]
+    fixture_dir = repo_root / "tests" / "fixtures" / "ssh-remote"
+    _must(fixture_dir.is_dir(), f"Missing docker fixture directory: {fixture_dir}")
+
+    temp_dir = Path(tempfile.mkdtemp(prefix="cmux-ssh-image-drop-"))
+    image_tag = f"cmux-ssh-image-drop:{secrets.token_hex(4)}"
+    container_name = f"cmux-ssh-image-drop-{secrets.token_hex(4)}"
+    workspace_id = ""
+
+    try:
+        key_path = temp_dir / "id_ed25519"
+        _run(["ssh-keygen", "-t", "ed25519", "-N", "", "-f", str(key_path)])
+        pubkey = key_path.with_suffix(".pub").read_text(encoding="utf-8").strip()
+        _must(bool(pubkey), "Generated SSH public key was empty")
+
+        _run(["docker", "build", "-t", image_tag, str(fixture_dir)])
+        _run([
+            "docker", "run", "-d", "--rm",
+            "--name", container_name,
+            "-e", f"AUTHORIZED_KEY={pubkey}",
+            "-p", "127.0.0.1::22",
+            image_tag,
+        ])
+
+        host_ssh_port = int(_run(["docker", "port", container_name, "22/tcp"]).stdout.strip().split(":")[-1])
+        host = "root@127.0.0.1"
+        _wait_for_ssh(host, host_ssh_port, key_path)
+
+        with cmux(SOCKET_PATH) as client:
+            payload = _run_cli_json(
+                cli,
+                [
+                    "ssh",
+                    host,
+                    "--name", f"ssh-image-drop-{secrets.token_hex(4)}",
+                    "--port", str(host_ssh_port),
+                    "--identity", str(key_path),
+                    "--ssh-option", "UserKnownHostsFile=/dev/null",
+                    "--ssh-option", "StrictHostKeyChecking=no",
+                ],
+            )
+            workspace_id = _resolve_workspace_id(client, payload)
+            _wait_remote_ready(client, workspace_id)
+            client.select_workspace(workspace_id)
+
+            image_path = temp_dir / "dragged-image.png"
+            image_path.write_bytes(base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lS2cWQAAAABJRU5ErkJggg=="
+            ))
+            local_sha = hashlib.sha256(image_path.read_bytes()).hexdigest()
+
+            surface_id = _focused_surface_id(client)
+            client.simulate_terminal_file_drop(surface_id, [str(image_path)], route="text_destination")
+            remote_path = _wait_for_remote_drop_path(client, surface_id)
+
+        remote_sha = _ssh_run(
+            host,
+            host_ssh_port,
+            key_path,
+            f"sha256sum {_shell_single_quote(remote_path)}",
+        ).stdout.split()[0]
+        _must(
+            remote_sha == local_sha,
+            f"Uploaded file hash mismatch local={local_sha} remote={remote_sha} path={remote_path}",
+        )
+        print(f"PASS: ssh image drop uploaded {remote_path}")
+        return 0
+    finally:
+        if workspace_id:
+            _run([cli, "--socket", SOCKET_PATH, "close-workspace", "--workspace", workspace_id], check=False)
+        _run(["docker", "rm", "-f", container_name], check=False)
+        _run(["docker", "rmi", "-f", image_tag], check=False)
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary
- Route terminal text file drops through the existing SSH-aware file-drop upload planner.
- Add a debug socket drop simulation and Docker SSH regression for cmux ssh image drops.

Verification
- ./scripts/reload.sh --tag sshfix --launch
- CMUX_SOCKET_PATH=/tmp/cmux-debug-sshfix.sock CMUXTERM_CLI=/tmp/cmux-cli python3 tests_v2/test_ssh_remote_image_drop_upload.py
- git diff --check HEAD~2..HEAD

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal file-drop routing and focus behavior, which could affect drag-and-drop handling across terminals/editors (especially for remote/SSH sessions). Added debug-only RPC and an end-to-end Docker-based regression test reduces but doesn’t eliminate behavioral risk.
> 
> **Overview**
> Fixes terminal *drop-as-text* handling by routing terminal file drops through the existing image/file transfer path (including the SSH-aware upload planner), instead of a separate “insert paths as text” shortcut.
> 
> Introduces `FileDropTextDropController.performTerminalFileDrop(...)` and updates overlay/pane drop hit-testing to use it, while removing the legacy `handleDropped*AsText` terminal APIs and exposing `GhosttyNSView.handleDroppedFileURLs` for shared use.
> 
> Adds a **debug-only** socket method `debug.terminal.simulate_file_drop` (with selectable routing) plus a Python client wrapper, and a new Docker-backed regression test that validates SSH image drops upload correctly by comparing remote vs local SHA-256.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c504525217fa067c19a66869fe48f9d2027214c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes image drag-and-drop into SSH terminals by routing all terminal drops through the SSH-aware upload planner. Adds a debug drop simulator and a Docker SSH regression test with bounded timeouts to avoid hangs.

- **Bug Fixes**
  - Terminal and pane drops now call `FileDropTextDropController.performTerminalFileDrop(...)` in both overlay hit-testing and pane drop handlers, so images dropped in SSH sessions upload to the remote host.
  - Exposed `GhosttyNSView.handleDroppedFileURLs(...)` and removed the legacy “as text” path for terminal surfaces.

- **New Features**
  - Added `debug.terminal.simulate_file_drop` RPC with `route` selection (`terminal`/`direct` or `text_destination`) and a Python wrapper in `tests_v2/cmux.py`; now validates params and returns clear errors.
  - Added `tests_v2/test_ssh_remote_image_drop_upload.py` which spins up a Docker SSH server and verifies the uploaded image hash on the remote, with bounded subprocess/CLI timeouts.

<sup>Written for commit 9c504525217fa067c19a66869fe48f9d2027214c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal-targeted file-drop routing and insertion for more reliable drops and focus handling.
  * Added a debug RPC to simulate terminal file drops for testing and automation.
  * Terminal drop handler made accessible to enable broader use.

* **Bug Fixes**
  * Delay computing text payload from dropped files until confirmed editable, avoiding unnecessary/empty inserts.

* **Tests**
  * New end-to-end SSH remote image-drop regression test and test-client helper to simulate terminal file drops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->