### PR TITLE
Fix auth sign-in session race

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1700,6 +1700,18 @@ struct CMUXCLI {
         }
     }
 
+    private static func manualSignInURL(from response: [String: Any]) -> String? {
+        guard let value = response["sign_in_url"] as? String else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private static func printManualSignInFallback(_ url: String?) {
+        guard let url else { return }
+        print("If it does not open, paste this URL in your browser:")
+        print(url)
+    }
+
     private struct VMCreateIdempotencyStore: Codable {
         var records: [String: VMCreateIdempotencyRecord] = [:]
     }
@@ -2347,18 +2359,23 @@ struct CMUXCLI {
                     print("Already signed in\(email.map { " as \($0)" } ?? ""). Use `cmux auth logout` to sign out first.")
                     break
                 }
+                let statusSignInURL = Self.manualSignInURL(from: statusBefore)
                 print("Opening sign-in popup on the cmux web app.")
+                Self.printManualSignInFallback(statusSignInURL)
                 // auth.begin_sign_in blocks on the server side until the
                 // popup completes (or 5min timeout). The response is the
                 // callback — no polling.
                 let result = try client.sendV2(method: "auth.begin_sign_in", responseTimeout: 305)
+                let resultSignInURL = Self.manualSignInURL(from: result) ?? statusSignInURL
                 if (result["signed_in"] as? Bool) == true {
                     let email = (result["user"] as? [String: Any])?["email"] as? String
                     print("Signed in\(email.map { " as \($0)" } ?? "").")
                 } else if (result["timed_out"] as? Bool) == true {
-                    print("Timed out waiting for sign-in. Run `cmux auth status` once you've finished in the popup.")
+                    print("Timed out waiting for sign-in. Run `cmux auth status` once you've finished in the browser.")
+                    Self.printManualSignInFallback(resultSignInURL)
                 } else {
                     print("Sign-in did not complete. Run `cmux auth status` to check.")
+                    Self.printManualSignInFallback(resultSignInURL)
                 }
 
             case "logout":

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2367,15 +2367,16 @@ struct CMUXCLI {
                 // popup completes (or 5min timeout). The response is the
                 // callback — no polling.
                 let result = try client.sendV2(method: "auth.begin_sign_in", responseTimeout: 305)
-                let resultSignInURL = Self.manualSignInURL(from: result) ?? statusSignInURL
                 if (result["signed_in"] as? Bool) == true {
                     let email = (result["user"] as? [String: Any])?["email"] as? String
                     print("Signed in\(email.map { " as \($0)" } ?? "").")
                 } else if (result["timed_out"] as? Bool) == true {
                     print("Timed out waiting for sign-in. Run `cmux auth status` once you've finished in the browser.")
+                    let resultSignInURL = Self.manualSignInURL(from: result) ?? statusSignInURL
                     Self.printManualSignInFallback(resultSignInURL)
                 } else {
                     print("Sign-in did not complete. Run `cmux auth status` to check.")
+                    let resultSignInURL = Self.manualSignInURL(from: result) ?? statusSignInURL
                     Self.printManualSignInFallback(resultSignInURL)
                 }
 

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -36,20 +36,49 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
             window.orderFront(nil)
         }
         if !NSApp.isActive {
-            var activationEvents = NotificationCenter.default
-                .notifications(named: NSApplication.didBecomeActiveNotification, object: NSApp)
-                .makeAsyncIterator()
-            let didRequestActivation = NSRunningApplication.current.activate(
-                options: [.activateAllWindows, .activateIgnoringOtherApps]
-            )
-            if didRequestActivation, !NSApp.isActive {
-                _ = await activationEvents.next()
-            }
+            await requestApplicationActivation()
         }
         window.makeKeyAndOrderFront(nil)
         cmuxDebugLog(
             "auth.webauth.prepare active=\(NSApp.isActive ? 1 : 0) visible=\(window.isVisible ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
         )
+    }
+
+    @MainActor
+    private static func requestApplicationActivation() async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            var observer: NSObjectProtocol?
+            var didResume = false
+
+            func resumeOnce() {
+                guard !didResume else { return }
+                didResume = true
+                if let observer {
+                    NotificationCenter.default.removeObserver(observer)
+                }
+                continuation.resume()
+            }
+
+            observer = NotificationCenter.default.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: NSApp,
+                queue: .main
+            ) { _ in
+                resumeOnce()
+            }
+
+            let didRequestActivation = NSRunningApplication.current.activate(
+                options: [.activateAllWindows, .activateIgnoringOtherApps]
+            )
+            if !didRequestActivation || NSApp.isActive {
+                resumeOnce()
+                return
+            }
+
+            DispatchQueue.main.async {
+                resumeOnce()
+            }
+        }
     }
 
     @MainActor
@@ -264,7 +293,7 @@ final class AuthManager: ObservableObject {
         }
 
         loginPollTask?.cancel()
-        cancelActiveWebAuthSession(setLoading: false)
+        cancelActiveWebAuthSession(clearLoading: false)
         isLoading = true
 
         let signInURL = AuthEnvironment.signInURL()
@@ -338,7 +367,7 @@ final class AuthManager: ObservableObject {
         }
         let result = await waitForSignInSettled(timeout: timeout)
         if result == .timedOut, attempt.startedNewSession, let sessionID = attempt.sessionID {
-            cancelActiveWebAuthSession(sessionID: sessionID, setLoading: true)
+            cancelActiveWebAuthSession(sessionID: sessionID, clearLoading: true)
         }
         return result
     }
@@ -384,7 +413,7 @@ final class AuthManager: ObservableObject {
         }
     }
 
-    private func cancelActiveWebAuthSession(sessionID: UUID? = nil, setLoading: Bool) {
+    private func cancelActiveWebAuthSession(sessionID: UUID? = nil, clearLoading: Bool) {
         if let sessionID, webAuthSessionID != sessionID {
             return
         }
@@ -392,7 +421,7 @@ final class AuthManager: ObservableObject {
         webAuthSession = nil
         webAuthSessionID = nil
         webAuthSignInURL = nil
-        if setLoading {
+        if clearLoading {
             isLoading = false
         }
         session?.cancel()

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -9,6 +9,7 @@ import Security
 
 private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
     static let shared = AuthPresentationContext()
+    @MainActor private static var fallbackAnchor: NSWindow?
 
     func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
         // ASWebAuthenticationSession invokes this on whichever thread called
@@ -18,16 +19,64 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
         if Thread.isMainThread {
             return Self.currentAnchor()
         }
-        var result: ASPresentationAnchor = NSWindow()
+        var result: ASPresentationAnchor?
         DispatchQueue.main.sync {
             result = Self.currentAnchor()
         }
-        return result
+        return result!
+    }
+
+    @MainActor
+    static func prepareForPresentation() async {
+        let window = currentAnchor()
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        if !window.isVisible {
+            window.orderFront(nil)
+        }
+        if !NSApp.isActive {
+            var activationEvents = NotificationCenter.default
+                .notifications(named: NSApplication.didBecomeActiveNotification, object: NSApp)
+                .makeAsyncIterator()
+            let didRequestActivation = NSRunningApplication.current.activate(
+                options: [.activateAllWindows, .activateIgnoringOtherApps]
+            )
+            if didRequestActivation, !NSApp.isActive {
+                _ = await activationEvents.next()
+            }
+        }
+        window.makeKeyAndOrderFront(nil)
+        cmuxDebugLog(
+            "auth.webauth.prepare active=\(NSApp.isActive ? 1 : 0) visible=\(window.isVisible ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
+        )
     }
 
     @MainActor
     private static func currentAnchor() -> ASPresentationAnchor {
-        NSApp.keyWindow ?? NSApp.mainWindow ?? (NSApp.windows.first ?? NSWindow())
+        if let keyWindow = NSApp.keyWindow {
+            return keyWindow
+        }
+        if let mainWindow = NSApp.mainWindow {
+            return mainWindow
+        }
+        if let visibleWindow = NSApp.windows.first(where: { $0.isVisible && !$0.isMiniaturized }) {
+            return visibleWindow
+        }
+        if let window = NSApp.windows.first {
+            return window
+        }
+        if let fallbackAnchor {
+            return fallbackAnchor
+        }
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1, height: 1),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        fallbackAnchor = window
+        return window
     }
 }
 
@@ -61,6 +110,11 @@ enum AuthSignInAwaitResult: Equatable, Sendable {
     case signedIn
     case cancelled
     case timedOut
+}
+
+private struct AuthSignInAttempt {
+    let sessionID: UUID?
+    let startedNewSession: Bool
 }
 
 protocol StackAuthTokenStoreProtocol: TokenStoreProtocol, Sendable {
@@ -191,10 +245,22 @@ final class AuthManager: ObservableObject {
     private var loginPollTask: Task<Void, Never>?
     private var webAuthSession: ASWebAuthenticationSession?
     private var webAuthSessionID: UUID?
+    private var webAuthSignInURL: URL?
+
+    var currentSignInURL: URL? {
+        if isAuthenticated { return nil }
+        return webAuthSignInURL ?? AuthEnvironment.signInURL()
+    }
 
     func beginSignIn() {
-        if isLoading, webAuthSession != nil {
-            return
+        Task { @MainActor in
+            _ = await startOrAttachSignIn()
+        }
+    }
+
+    private func startOrAttachSignIn() async -> AuthSignInAttempt {
+        if let activeSessionID = webAuthSessionID, webAuthSession != nil {
+            return AuthSignInAttempt(sessionID: activeSessionID, startedNewSession: false)
         }
 
         loginPollTask?.cancel()
@@ -205,6 +271,7 @@ final class AuthManager: ObservableObject {
         let callbackScheme = AuthEnvironment.callbackScheme
         let sessionID = UUID()
         webAuthSessionID = sessionID
+        webAuthSignInURL = signInURL
 
         let session = ASWebAuthenticationSession(
             url: signInURL,
@@ -218,9 +285,11 @@ final class AuthManager: ObservableObject {
                         self.isLoading = false
                         self.webAuthSession = nil
                         self.webAuthSessionID = nil
+                        self.webAuthSignInURL = nil
                     }
                 }
                 if let error {
+                    cmuxDebugLog("auth.webauth.failed session=\(sessionID.uuidString.prefix(8)) error=\(error)")
                     NSLog("auth.webauth failed: %@", "\(error)")
                     return
                 }
@@ -235,15 +304,24 @@ final class AuthManager: ObservableObject {
         session.presentationContextProvider = AuthPresentationContext.shared
         session.prefersEphemeralWebBrowserSession = false
 
+        await AuthPresentationContext.prepareForPresentation()
+        cmuxDebugLog(
+            "auth.webauth.start session=\(sessionID.uuidString.prefix(8)) scheme=\(callbackScheme) active=\(NSApp.isActive ? 1 : 0)"
+        )
         if session.start() {
             webAuthSession = session
+            cmuxDebugLog("auth.webauth.started session=\(sessionID.uuidString.prefix(8))")
+            return AuthSignInAttempt(sessionID: sessionID, startedNewSession: true)
         } else {
+            cmuxDebugLog("auth.webauth.startFailed session=\(sessionID.uuidString.prefix(8))")
             NSLog("auth.webauth: session.start() returned false")
             if webAuthSessionID == sessionID {
                 isLoading = false
                 webAuthSession = nil
                 webAuthSessionID = nil
+                webAuthSignInURL = nil
             }
+            return AuthSignInAttempt(sessionID: nil, startedNewSession: false)
         }
     }
 
@@ -254,12 +332,13 @@ final class AuthManager: ObservableObject {
     /// — the $isAuthenticated / $isLoading AsyncPublishers drive the wait.
     func beginSignInAndAwait(timeout: TimeInterval) async -> AuthSignInAwaitResult {
         if isAuthenticated { return .signedIn }
-        if !isLoading || webAuthSession == nil {
-            beginSignIn()
+        let attempt = await startOrAttachSignIn()
+        if attempt.sessionID == nil, !isLoading {
+            return isAuthenticated ? .signedIn : .cancelled
         }
         let result = await waitForSignInSettled(timeout: timeout)
-        if result == .timedOut {
-            cancelActiveWebAuthSession(setLoading: true)
+        if result == .timedOut, attempt.startedNewSession, let sessionID = attempt.sessionID {
+            cancelActiveWebAuthSession(sessionID: sessionID, setLoading: true)
         }
         return result
     }
@@ -305,10 +384,14 @@ final class AuthManager: ObservableObject {
         }
     }
 
-    private func cancelActiveWebAuthSession(setLoading: Bool) {
+    private func cancelActiveWebAuthSession(sessionID: UUID? = nil, setLoading: Bool) {
+        if let sessionID, webAuthSessionID != sessionID {
+            return
+        }
         let session = webAuthSession
         webAuthSession = nil
         webAuthSessionID = nil
+        webAuthSignInURL = nil
         if setLoading {
             isLoading = false
         }

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -68,7 +68,7 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
             }
 
             let didRequestActivation = NSRunningApplication.current.activate(
-                options: [.activateAllWindows, .activateIgnoringOtherApps]
+                options: [.activateAllWindows]
             )
             if !didRequestActivation || NSApp.isActive {
                 resumeOnce()

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -57,6 +57,12 @@ enum AuthManagerError: LocalizedError {
     }
 }
 
+enum AuthSignInAwaitResult: Equatable, Sendable {
+    case signedIn
+    case cancelled
+    case timedOut
+}
+
 protocol StackAuthTokenStoreProtocol: TokenStoreProtocol, Sendable {
     func seed(accessToken: String, refreshToken: String) async
     func clear() async
@@ -184,25 +190,35 @@ final class AuthManager: ObservableObject {
 
     private var loginPollTask: Task<Void, Never>?
     private var webAuthSession: ASWebAuthenticationSession?
+    private var webAuthSessionID: UUID?
 
     func beginSignIn() {
+        if isLoading, webAuthSession != nil {
+            return
+        }
+
         loginPollTask?.cancel()
-        webAuthSession?.cancel()
-        webAuthSession = nil
+        cancelActiveWebAuthSession(setLoading: false)
         isLoading = true
 
         let signInURL = AuthEnvironment.signInURL()
         let callbackScheme = AuthEnvironment.callbackScheme
+        let sessionID = UUID()
+        webAuthSessionID = sessionID
 
         let session = ASWebAuthenticationSession(
             url: signInURL,
             callbackURLScheme: callbackScheme
-        ) { [weak self] callbackURL, error in
+        ) { [weak self, sessionID] callbackURL, error in
             Task { @MainActor [weak self] in
                 guard let self else { return }
+                guard self.webAuthSessionID == sessionID else { return }
                 defer {
-                    self.isLoading = false
-                    self.webAuthSession = nil
+                    if self.webAuthSessionID == sessionID {
+                        self.isLoading = false
+                        self.webAuthSession = nil
+                        self.webAuthSessionID = nil
+                    }
                 }
                 if let error {
                     NSLog("auth.webauth failed: %@", "\(error)")
@@ -223,7 +239,11 @@ final class AuthManager: ObservableObject {
             webAuthSession = session
         } else {
             NSLog("auth.webauth: session.start() returned false")
-            isLoading = false
+            if webAuthSessionID == sessionID {
+                isLoading = false
+                webAuthSession = nil
+                webAuthSessionID = nil
+            }
         }
     }
 
@@ -232,10 +252,16 @@ final class AuthManager: ObservableObject {
     /// authenticated, when the sign-in attempt settles unsuccessfully (popup
     /// dismissed/cancelled/error), or when the deadline elapses. No polling
     /// — the $isAuthenticated / $isLoading AsyncPublishers drive the wait.
-    func beginSignInAndAwait(timeout: TimeInterval) async -> Bool {
-        if isAuthenticated { return true }
-        beginSignIn()
-        return await waitForSignInSettled(timeout: timeout)
+    func beginSignInAndAwait(timeout: TimeInterval) async -> AuthSignInAwaitResult {
+        if isAuthenticated { return .signedIn }
+        if !isLoading || webAuthSession == nil {
+            beginSignIn()
+        }
+        let result = await waitForSignInSettled(timeout: timeout)
+        if result == .timedOut {
+            cancelActiveWebAuthSession(setLoading: true)
+        }
+        return result
     }
 
     /// Signs out and awaits the state to flip. signOut() is already async and
@@ -247,36 +273,46 @@ final class AuthManager: ObservableObject {
         return await waitForAuthState(target: false, timeout: timeout)
     }
 
-    private func waitForSignInSettled(timeout: TimeInterval) async -> Bool {
-        await withTaskGroup(of: Bool.self) { group in
+    private func waitForSignInSettled(timeout: TimeInterval) async -> AuthSignInAwaitResult {
+        await withTaskGroup(of: AuthSignInAwaitResult.self) { group in
             group.addTask { @MainActor [weak self] in
-                guard let self else { return false }
+                guard let self else { return .cancelled }
                 for await value in self.$isAuthenticated.values {
-                    if value { return true }
+                    if value { return .signedIn }
                 }
-                return false
+                return .cancelled
             }
             group.addTask { @MainActor [weak self] in
-                guard let self else { return false }
+                guard let self else { return .cancelled }
                 // Wait for isLoading to flip false after we started the
                 // popup. If authentication hasn't succeeded by then the
                 // user cancelled/errored and we can resolve early.
                 for await loading in self.$isLoading.values {
-                    if !loading && !self.isAuthenticated { return false }
-                    if self.isAuthenticated { return true }
+                    if !loading && !self.isAuthenticated { return .cancelled }
+                    if self.isAuthenticated { return .signedIn }
                 }
-                return false
+                return .cancelled
             }
             group.addTask {
                 let maxSeconds: Double = 24 * 60 * 60
                 let clamped = max(0, min(timeout, maxSeconds))
                 try? await Task.sleep(nanoseconds: UInt64(clamped * 1_000_000_000))
-                return false
+                return .timedOut
             }
-            let first = await group.next() ?? false
+            let first = await group.next() ?? .cancelled
             group.cancelAll()
             return first
         }
+    }
+
+    private func cancelActiveWebAuthSession(setLoading: Bool) {
+        let session = webAuthSession
+        webAuthSession = nil
+        webAuthSessionID = nil
+        if setLoading {
+            isLoading = false
+        }
+        session?.cancel()
     }
 
     private func waitForAuthState(target: Bool, timeout: TimeInterval) async -> Bool {

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -7,6 +7,13 @@ import StackAuth
 import Security
 #endif
 
+@inline(__always)
+private func authDebugLog(_ message: @autoclosure () -> String) {
+    #if DEBUG
+    cmuxDebugLog(message())
+    #endif
+}
+
 private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresentationContextProviding {
     static let shared = AuthPresentationContext()
     @MainActor private static var fallbackAnchor: NSWindow?
@@ -39,7 +46,7 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
             await requestApplicationActivation()
         }
         window.makeKeyAndOrderFront(nil)
-        cmuxDebugLog(
+        authDebugLog(
             "auth.webauth.prepare active=\(NSApp.isActive ? 1 : 0) visible=\(window.isVisible ? 1 : 0) key=\(window.isKeyWindow ? 1 : 0) main=\(window.isMainWindow ? 1 : 0)"
         )
     }
@@ -47,36 +54,27 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
     @MainActor
     private static func requestApplicationActivation() async {
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            var observer: NSObjectProtocol?
-            var didResume = false
+            let activationRequest = AuthActivationRequest(continuation: continuation)
 
-            func resumeOnce() {
-                guard !didResume else { return }
-                didResume = true
-                if let observer {
-                    NotificationCenter.default.removeObserver(observer)
-                }
-                continuation.resume()
-            }
-
-            observer = NotificationCenter.default.addObserver(
+            let observer = NotificationCenter.default.addObserver(
                 forName: NSApplication.didBecomeActiveNotification,
                 object: NSApp,
                 queue: .main
             ) { _ in
-                resumeOnce()
+                activationRequest.resume()
             }
+            activationRequest.observer = observer
 
             let didRequestActivation = NSRunningApplication.current.activate(
                 options: [.activateAllWindows]
             )
             if !didRequestActivation || NSApp.isActive {
-                resumeOnce()
+                activationRequest.resume()
                 return
             }
 
             DispatchQueue.main.async {
-                resumeOnce()
+                activationRequest.resume()
             }
         }
     }
@@ -106,6 +104,25 @@ private final class AuthPresentationContext: NSObject, ASWebAuthenticationPresen
         )
         fallbackAnchor = window
         return window
+    }
+}
+
+private final class AuthActivationRequest: @unchecked Sendable {
+    let continuation: CheckedContinuation<Void, Never>
+    var observer: NSObjectProtocol?
+    private var didResume = false
+
+    init(continuation: CheckedContinuation<Void, Never>) {
+        self.continuation = continuation
+    }
+
+    func resume() {
+        guard !didResume else { return }
+        didResume = true
+        if let observer {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        continuation.resume()
     }
 }
 
@@ -318,7 +335,7 @@ final class AuthManager: ObservableObject {
                     }
                 }
                 if let error {
-                    cmuxDebugLog("auth.webauth.failed session=\(sessionID.uuidString.prefix(8)) error=\(error)")
+                    authDebugLog("auth.webauth.failed session=\(sessionID.uuidString.prefix(8)) error=\(error)")
                     NSLog("auth.webauth failed: %@", "\(error)")
                     return
                 }
@@ -334,15 +351,15 @@ final class AuthManager: ObservableObject {
         session.prefersEphemeralWebBrowserSession = false
 
         await AuthPresentationContext.prepareForPresentation()
-        cmuxDebugLog(
+        authDebugLog(
             "auth.webauth.start session=\(sessionID.uuidString.prefix(8)) scheme=\(callbackScheme) active=\(NSApp.isActive ? 1 : 0)"
         )
         if session.start() {
             webAuthSession = session
-            cmuxDebugLog("auth.webauth.started session=\(sessionID.uuidString.prefix(8))")
+            authDebugLog("auth.webauth.started session=\(sessionID.uuidString.prefix(8))")
             return AuthSignInAttempt(sessionID: sessionID, startedNewSession: true)
         } else {
-            cmuxDebugLog("auth.webauth.startFailed session=\(sessionID.uuidString.prefix(8))")
+            authDebugLog("auth.webauth.startFailed session=\(sessionID.uuidString.prefix(8))")
             NSLog("auth.webauth: session.start() returned false")
             if webAuthSessionID == sessionID {
                 isLoading = false

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -305,6 +305,10 @@ final class AuthManager: ObservableObject {
     }
 
     private func startOrAttachSignIn() async -> AuthSignInAttempt {
+        await awaitBootstrapped()
+        if isAuthenticated {
+            return AuthSignInAttempt(sessionID: nil, startedNewSession: false)
+        }
         if let activeSessionID = webAuthSessionID {
             return AuthSignInAttempt(sessionID: activeSessionID, startedNewSession: false)
         }

--- a/Sources/Auth/AuthManager.swift
+++ b/Sources/Auth/AuthManager.swift
@@ -288,7 +288,7 @@ final class AuthManager: ObservableObject {
     }
 
     private func startOrAttachSignIn() async -> AuthSignInAttempt {
-        if let activeSessionID = webAuthSessionID, webAuthSession != nil {
+        if let activeSessionID = webAuthSessionID {
             return AuthSignInAttempt(sessionID: activeSessionID, startedNewSession: false)
         }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1535,17 +1535,20 @@ class TerminalController {
             semaphore.wait()
             return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: false))
         case "auth.begin_sign_in":
-            let timeoutSeconds = (request.params["timeout_seconds"] as? Double) ?? 300
+            let timeoutSeconds = Self.socketWorkerDouble(request.params["timeout_seconds"]) ?? 300
             let semaphore = DispatchSemaphore(value: 0)
-            nonisolated(unsafe) var signedIn = false
+            nonisolated(unsafe) var signInResult: AuthSignInAwaitResult = .cancelled
             Task { @MainActor in
-                signedIn = await AuthManager.shared.beginSignInAndAwait(
+                signInResult = await AuthManager.shared.beginSignInAndAwait(
                     timeout: timeoutSeconds
                 )
                 semaphore.signal()
             }
             semaphore.wait()
-            return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: !signedIn))
+            return v2Ok(
+                id: request.id,
+                result: v2AuthStatusPayload(timedOut: signInResult == .timedOut)
+            )
         case "auth.sign_out":
             let semaphore = DispatchSemaphore(value: 0)
             Task { @MainActor in
@@ -1571,6 +1574,16 @@ class TerminalController {
         default:
             return v2Error(id: request.id, code: "method_not_found", message: "Unknown method")
         }
+    }
+
+    private nonisolated static func socketWorkerDouble(_ raw: Any?) -> Double? {
+        if let double = raw as? Double { return double }
+        if let float = raw as? Float { return Double(float) }
+        if let number = raw as? NSNumber { return number.doubleValue }
+        if let string = raw as? String {
+            return Double(string.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        return nil
     }
 
     private nonisolated func startAcceptSource(listenerSocket: Int32, generation: UInt64) {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1535,7 +1535,10 @@ class TerminalController {
             semaphore.wait()
             return v2Ok(id: request.id, result: v2AuthStatusPayload(timedOut: false))
         case "auth.begin_sign_in":
-            let timeoutSeconds = Self.socketWorkerDouble(request.params["timeout_seconds"]) ?? 300
+            let parsedTimeoutSeconds = Self.socketWorkerDouble(request.params["timeout_seconds"]) ?? 300
+            let timeoutSeconds = parsedTimeoutSeconds.isFinite
+                ? min(max(parsedTimeoutSeconds, 1), 3600)
+                : 300
             let semaphore = DispatchSemaphore(value: 0)
             nonisolated(unsafe) var signInResult: AuthSignInAwaitResult = .cancelled
             Task { @MainActor in

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3749,6 +3749,9 @@ class TerminalController {
                     "is_loading": manager.isLoading,
                     "timed_out": timedOut
                 ]
+                if let signInURL = manager.currentSignInURL {
+                    status["sign_in_url"] = signInURL.absoluteString
+                }
                 if let user = manager.currentUser {
                     var userDict: [String: Any] = ["id": user.id]
                     if let email = user.primaryEmail { userDict["email"] = email }

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -556,6 +556,7 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       CMUXD_SOCKET="${APP_SUPPORT_DIR}/cmuxd-dev-${TAG_SLUG}.sock"
       CMUX_SOCKET_PATH_VALUE="/tmp/cmux-debug-${TAG_SLUG}.sock"
       CMUX_DEBUG_LOG="/tmp/cmux-debug-${TAG_SLUG}.log"
+      CMUX_AUTH_CALLBACK_SCHEME_VALUE="cmux-dev-${TAG_SLUG}"
       write_last_socket_path "$CMUX_SOCKET_PATH_VALUE"
       echo "$CMUX_DEBUG_LOG" > /tmp/cmux-last-debug-log-path || true
       /usr/libexec/PlistBuddy -c "Add :LSEnvironment dict" "$INFO_PLIST" 2>/dev/null || true
@@ -573,6 +574,8 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       set_plist_env "$INFO_PLIST" CMUX_AUTH_WWW_ORIGIN "$CMUX_DEV_ORIGIN"
       set_plist_env "$INFO_PLIST" CMUX_API_BASE_URL "$CMUX_DEV_ORIGIN"
       set_plist_env "$INFO_PLIST" CMUX_VM_API_BASE_URL "$CMUX_DEV_ORIGIN"
+      set_plist_env "$INFO_PLIST" CMUX_AUTH_CALLBACK_SCHEME "$CMUX_AUTH_CALLBACK_SCHEME_VALUE"
+      /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:1:CFBundleURLSchemes:0 ${CMUX_AUTH_CALLBACK_SCHEME_VALUE}" "$INFO_PLIST" 2>/dev/null || true
       if [[ -S "$CMUXD_SOCKET" ]]; then
         for PID in $(lsof -t "$CMUXD_SOCKET" 2>/dev/null); do
           kill "$PID" 2>/dev/null || true
@@ -674,6 +677,7 @@ if [[ "$LAUNCH" -eq 1 ]]; then
     -u CMUXD_UNIX_PATH
     -u CMUX_TAG
     -u CMUX_DEBUG_LOG
+    -u CMUX_AUTH_CALLBACK_SCHEME
     -u CMUX_BUNDLE_ID
     -u CMUX_SHELL_INTEGRATION
     -u GHOSTTY_BIN_DIR
@@ -699,6 +703,7 @@ if [[ "$LAUNCH" -eq 1 ]]; then
     CMUX_PORT_RANGE="$CMUX_DEV_PORT_RANGE"
     PORT="$CMUX_DEV_PORT"
     CMUX_AUTH_WWW_ORIGIN="$CMUX_DEV_ORIGIN"
+    CMUX_AUTH_CALLBACK_SCHEME="cmux-dev-${TAG_SLUG:-dev}"
     CMUX_API_BASE_URL="$CMUX_DEV_ORIGIN"
     CMUX_VM_API_BASE_URL="$CMUX_DEV_ORIGIN"
   )

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -575,7 +575,19 @@ if [[ -n "$TAG" && "$APP_NAME" != "$SEARCH_APP_NAME" ]]; then
       set_plist_env "$INFO_PLIST" CMUX_API_BASE_URL "$CMUX_DEV_ORIGIN"
       set_plist_env "$INFO_PLIST" CMUX_VM_API_BASE_URL "$CMUX_DEV_ORIGIN"
       set_plist_env "$INFO_PLIST" CMUX_AUTH_CALLBACK_SCHEME "$CMUX_AUTH_CALLBACK_SCHEME_VALUE"
-      /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:1:CFBundleURLSchemes:0 ${CMUX_AUTH_CALLBACK_SCHEME_VALUE}" "$INFO_PLIST" 2>/dev/null || true
+      AUTH_URL_INDEX=""
+      for ((URL_TYPE_INDEX = 0; ; URL_TYPE_INDEX++)); do
+        URL_TYPE_NAME="$(/usr/libexec/PlistBuddy -c "Print :CFBundleURLTypes:${URL_TYPE_INDEX}:CFBundleURLName" "$INFO_PLIST" 2>/dev/null)" || break
+        if [[ "$URL_TYPE_NAME" == *.auth ]]; then
+          AUTH_URL_INDEX="$URL_TYPE_INDEX"
+          break
+        fi
+      done
+      if [[ -z "$AUTH_URL_INDEX" ]]; then
+        echo "error: auth CFBundleURLTypes entry not found in $INFO_PLIST" >&2
+        exit 1
+      fi
+      /usr/libexec/PlistBuddy -c "Set :CFBundleURLTypes:${AUTH_URL_INDEX}:CFBundleURLSchemes:0 ${CMUX_AUTH_CALLBACK_SCHEME_VALUE}" "$INFO_PLIST"
       if [[ -S "$CMUXD_SOCKET" ]]; then
         for PID in $(lsof -t "$CMUXD_SOCKET" 2>/dev/null); do
           kill "$PID" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- keep repeated auth login requests attached to the active `ASWebAuthenticationSession` without letting a later waiter cancel the starter's sheet
- add `sign_in_url` to auth socket payloads and print a copy/paste fallback from `cmux auth login`
- give tagged dev builds a unique `cmux-dev-<tag>` callback scheme so one dev build cannot steal another build's auth callback
- activate cmux before starting the native auth session so background-launched login has a real presentation anchor

## Verification
- `./scripts/reload.sh --tag authfix`
- `bash -n scripts/reload.sh`
- `git diff --check`
- verified the built `cmux DEV authfix.app` Info.plist contains `cmux-dev-authfix` in `CFBundleURLSchemes` and `LSEnvironment:CMUX_AUTH_CALLBACK_SCHEME`
- verified `cmux --json auth status` returns `sign_in_url` with `native_app_return_to=cmux-dev-authfix://auth-callback`
- verified `cmux auth login` prints the fallback URL before waiting

No automated test added. The failure depends on LaunchServices and `ASWebAuthenticationSession` native UI behavior, so a source-shape test would not prove the regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More reliable browser sign-in: per-attempt session tracking prevents cross-attempt interference and fixes cleanup/callback races
  * Presentation anchor access fixed to avoid UI threading issues

* **New Features**
  * Sign-in now reports three outcomes: signed in, cancelled, or timed out
  * CLI and terminal flows include sign-in URL and print a manual browser fallback; timeout messaging updated

* **Refactor**
  * More robust parsing and clamping of numeric timeout values

* **Chores**
  * Dev launch script sets tag-specific callback URL schemes for local app launches
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the native `ASWebAuthenticationSession` sign-in flow and socket/CLI auth plumbing; behavior changes are user-facing and timing-dependent, so regressions are possible despite limited surface area.
> 
> **Overview**
> Fixes a race in native browser sign-in by tracking `ASWebAuthenticationSession` attempts with a session id, letting repeated `auth login` calls attach to the in-flight session, and only cancelling the session that a given waiter started (e.g., on timeout).
> 
> Adds a `sign_in_url` field to `auth.status` socket responses and updates `cmux auth login` to print a copy/paste fallback URL, improving recovery when the popup fails or times out.
> 
> Hardens socket `timeout_seconds` parsing/clamping and updates `scripts/reload.sh` so tagged dev builds get unique `CMUX_AUTH_CALLBACK_SCHEME`/`CFBundleURLSchemes`, preventing one dev build from stealing another’s auth callback; the app is also activated/anchored before starting the auth session.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2896091b77ff66bd64a36f6a59859f9a9fb2658. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->