### PR TITLE
Add mobile sync status foundation

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2380,6 +2380,9 @@ struct CMUXCLI {
                 throw CLIError(message: "Usage: cmux auth <status|login|logout>")
             }
 
+        case "ios":
+            try runIOSCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
+
         case "vm", "cloud":
             let sub = commandArgs.first?.lowercased() ?? "ls"
             let rest = Array(commandArgs.dropFirst())
@@ -4170,6 +4173,53 @@ struct CMUXCLI {
         } else {
             print(fallbackText)
         }
+    }
+
+    func runIOSCommand(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let subcommand = commandArgs.first?.lowercased() ?? "status"
+        let remaining = Array(commandArgs.dropFirst())
+        guard remaining.isEmpty else {
+            throw CLIError(message: "Usage: cmux ios status")
+        }
+
+        switch subcommand {
+        case "status":
+            let payload = try client.sendV2(method: "mobile_sync.status")
+            if jsonOutput {
+                print(jsonString(payload))
+                return
+            }
+            printIOSStatus(payload)
+        default:
+            throw CLIError(message: "Usage: cmux ios status")
+        }
+    }
+
+    private func printIOSStatus(_ payload: [String: Any]) {
+        let enabled = (payload["enabled"] as? Bool) == true
+        let listener = payload["listener"] as? [String: Any]
+        let listenerState = (listener?["state"] as? String) ?? "unknown"
+        let tailscale = payload["tailscale"] as? [String: Any]
+        let tailscaleAvailable = (tailscale?["available"] as? Bool) == true
+        let selectedAddress = tailscale?["selected_address"] as? String
+        let workspaceCount = payload["workspace_count"] as? Int ?? 0
+        let terminalCount = payload["terminal_count"] as? Int ?? 0
+        let activeAttachmentCount = payload["active_attachment_count"] as? Int ?? 0
+
+        print("Mobile Sync: \(enabled ? "enabled" : "disabled")")
+        print("Listener: \(listenerState)")
+        if tailscaleAvailable {
+            if let selectedAddress, !selectedAddress.isEmpty {
+                print("Tailscale: available (\(selectedAddress))")
+            } else {
+                print("Tailscale: available")
+            }
+        } else {
+            print("Tailscale: unavailable")
+        }
+        print("Workspaces: \(workspaceCount)")
+        print("Terminals: \(terminalCount)")
+        print("Active attachments: \(activeAttachmentCount)")
     }
 
     private func debugString(_ value: Any?) -> String? {
@@ -8306,6 +8356,12 @@ struct CMUXCLI {
             status   Print whether the user is signed in (add `cmux --json` for JSON).
             login    Open the sign-in popup on the cmux web app and wait for it to finish.
             logout   Clear the current session.
+            """
+        case "ios":
+            return """
+            Usage: cmux ios status
+
+            Show iOS/iPadOS mobile sync status. Mobile sync is off by default and does not listen until enabled by a later command or Settings.
             """
         case "login":
             return """
@@ -20374,6 +20430,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           capabilities
           events [--after <seq>] [--cursor-file <path>] [--name <event>] [--category <category>] [--reconnect] [--limit <n>] [--no-ack] [--no-heartbeat]
           auth <status|login|logout>
+          ios status
           login | logout                                      (aliases for auth login/logout)
           vm <new|ls|rm|exec|shell|ssh> [args...]    (alias: cloud)
           rpc <method> [json-params]

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -34,6 +34,9 @@
 		C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35530000000000000102 /* BundledCLILinkageTests.swift */; };
 		C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
+		C0DE10510000000000000001 /* MobileSyncModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000002 /* MobileSyncModels.swift */; };
+		C0DE10510000000000000003 /* MobileSyncModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000004 /* MobileSyncModelTests.swift */; };
+		C0DE10510000000000000005 /* CLIMobileSyncTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000006 /* CLIMobileSyncTests.swift */; };
 		C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A10000000000000002 /* CmuxConfigUI.swift */; };
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
 		C0DEF0B10000000000000001 /* JSONCParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0B10000000000000002 /* JSONCParser.swift */; };
@@ -815,6 +818,9 @@
 		2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateIssue2907RoutingTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXOpenCommandTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReviewFeedbackTests.swift; sourceTree = "<group>"; };
+		C0DE10510000000000000002 /* MobileSyncModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSyncModels.swift; sourceTree = "<group>"; };
+		C0DE10510000000000000004 /* MobileSyncModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSyncModelTests.swift; sourceTree = "<group>"; };
+		C0DE10510000000000000006 /* CLIMobileSyncTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIMobileSyncTests.swift; sourceTree = "<group>"; };
 		C0DEF0A10000000000000002 /* CmuxConfigUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigUI.swift; sourceTree = "<group>"; };
 		C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPortDisplayText.swift; sourceTree = "<group>"; };
 		C0DEF0A40000000000000002 /* CmuxConfigContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigContextMenuTests.swift; sourceTree = "<group>"; };
@@ -1154,6 +1160,7 @@
 					E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */,
 					E7E000000000000000000008 /* CmuxEventPublishing.swift */,
 					A5001019 /* TerminalController.swift */,
+					C0DE10510000000000000002 /* MobileSyncModels.swift */,
 					E7E000000000000000000002 /* CmuxEventStream.swift */,
 					E7E00000000000000000000A /* CmuxSocketEventMapper.swift */,
 						A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */,
@@ -1415,9 +1422,11 @@
 					A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 					A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
 					A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */,
+					C0DE10510000000000000006 /* CLIMobileSyncTests.swift */,
 					C0DE35530000000000000102 /* BundledCLILinkageTests.swift */,
 					A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */,
 				10D684CFFB8CDEF89CE2D9E1 /* TabManagerSessionSnapshotTests.swift */,
+				C0DE10510000000000000004 /* MobileSyncModelTests.swift */,
 				C1A2B3C4D5E6F70800000002 /* CmuxConfigTests.swift */,
 				C0DEF0A40000000000000002 /* CmuxConfigContextMenuTests.swift */,
 				E30750000000000000000005 /* CmuxConfigNamedColorTests.swift */,
@@ -1774,6 +1783,7 @@
 					E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */,
 					E7E000000000000000000007 /* CmuxEventPublishing.swift in Sources */,
 					A5001007 /* TerminalController.swift in Sources */,
+					C0DE10510000000000000001 /* MobileSyncModels.swift in Sources */,
 					E7E000000000000000000001 /* CmuxEventStream.swift in Sources */,
 					E7E000000000000000000009 /* CmuxSocketEventMapper.swift in Sources */,
 					A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */,
@@ -2075,9 +2085,11 @@
 					A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */,
 					A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
 					A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
+					C0DE10510000000000000005 /* CLIMobileSyncTests.swift in Sources */,
 					C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */,
 					A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				2BB56A710BB1FC50367E5BCF /* TabManagerSessionSnapshotTests.swift in Sources */,
+				C0DE10510000000000000003 /* MobileSyncModelTests.swift in Sources */,
 				C1A2B3C4D5E6F70800000001 /* CmuxConfigTests.swift in Sources */,
 				C0DEF0A40000000000000001 /* CmuxConfigContextMenuTests.swift in Sources */,
 				E30750000000000000000006 /* CmuxConfigNamedColorTests.swift in Sources */,

--- a/Sources/MobileSyncModels.swift
+++ b/Sources/MobileSyncModels.swift
@@ -1,0 +1,587 @@
+import Darwin
+import Foundation
+
+nonisolated struct MobileWorkspaceID: Hashable, Sendable, Codable, CustomStringConvertible {
+    let rawValue: UUID
+
+    init(_ rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+
+    init?(uuidString: String) {
+        guard let uuid = UUID(uuidString: uuidString) else { return nil }
+        rawValue = uuid
+    }
+
+    var uuidString: String { rawValue.uuidString }
+    var description: String { uuidString }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        guard let uuid = UUID(uuidString: raw) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid workspace UUID: \(raw)"
+            )
+        }
+        rawValue = uuid
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(uuidString)
+    }
+}
+
+nonisolated struct MobileTerminalID: Hashable, Sendable, Codable, CustomStringConvertible {
+    let rawValue: UUID
+
+    init(_ rawValue: UUID) {
+        self.rawValue = rawValue
+    }
+
+    init?(uuidString: String) {
+        guard let uuid = UUID(uuidString: uuidString) else { return nil }
+        rawValue = uuid
+    }
+
+    var uuidString: String { rawValue.uuidString }
+    var description: String { uuidString }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        guard let uuid = UUID(uuidString: raw) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid terminal UUID: \(raw)"
+            )
+        }
+        rawValue = uuid
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(uuidString)
+    }
+}
+
+nonisolated struct MobileDeviceID: Hashable, Sendable, Codable, CustomStringConvertible {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    var description: String { rawValue }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        rawValue = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+nonisolated struct MobileClientID: Hashable, Sendable, Codable, CustomStringConvertible {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    var description: String { rawValue }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        rawValue = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+nonisolated struct MobileAttachmentID: Hashable, Sendable, Codable, CustomStringConvertible {
+    let rawValue: String
+
+    init(_ rawValue: String) {
+        self.rawValue = rawValue
+    }
+
+    var description: String { rawValue }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        rawValue = try container.decode(String.self)
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}
+
+nonisolated struct TerminalGridSize: Equatable, Sendable, Codable {
+    let columns: Int
+    let rows: Int
+
+    init(columns: Int, rows: Int) {
+        precondition(columns > 0, "TerminalGridSize columns must be positive")
+        precondition(rows > 0, "TerminalGridSize rows must be positive")
+        self.columns = columns
+        self.rows = rows
+    }
+
+    init?(validatingColumns columns: Int, rows: Int) {
+        guard columns > 0, rows > 0 else { return nil }
+        self.columns = columns
+        self.rows = rows
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let columns = try container.decode(Int.self, forKey: .columns)
+        let rows = try container.decode(Int.self, forKey: .rows)
+        guard columns > 0, rows > 0 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: columns <= 0 ? .columns : .rows,
+                in: container,
+                debugDescription: "Terminal grid dimensions must be positive"
+            )
+        }
+        self.columns = columns
+        self.rows = rows
+    }
+}
+
+nonisolated enum TerminalAttachmentSurfaceKind: String, Sendable, Codable {
+    case mac
+    case iPhone
+    case iPad
+    case simulator
+    case unknown
+}
+
+nonisolated struct TerminalAttachment: Equatable, Sendable, Codable, Identifiable {
+    let id: MobileAttachmentID
+    let clientID: MobileClientID
+    let deviceID: MobileDeviceID
+    let workspaceID: MobileWorkspaceID
+    let terminalID: MobileTerminalID
+    let surfaceKind: TerminalAttachmentSurfaceKind
+    var deviceName: String?
+    var gridSize: TerminalGridSize
+    var isActive: Bool
+    var lastHeartbeatAt: Date
+
+    init(
+        id: MobileAttachmentID,
+        clientID: MobileClientID,
+        deviceID: MobileDeviceID,
+        workspaceID: MobileWorkspaceID,
+        terminalID: MobileTerminalID,
+        surfaceKind: TerminalAttachmentSurfaceKind,
+        deviceName: String? = nil,
+        gridSize: TerminalGridSize,
+        isActive: Bool = true,
+        lastHeartbeatAt: Date = Date()
+    ) {
+        self.id = id
+        self.clientID = clientID
+        self.deviceID = deviceID
+        self.workspaceID = workspaceID
+        self.terminalID = terminalID
+        self.surfaceKind = surfaceKind
+        self.deviceName = deviceName
+        self.gridSize = gridSize
+        self.isActive = isActive
+        self.lastHeartbeatAt = lastHeartbeatAt
+    }
+}
+
+nonisolated struct TerminalSizeDecision: Equatable, Sendable {
+    let effectiveSize: TerminalGridSize
+    let fallbackSize: TerminalGridSize
+    let columnSourceAttachmentID: MobileAttachmentID?
+    let rowSourceAttachmentID: MobileAttachmentID?
+    let activeAttachmentCount: Int
+
+    var isRemotelyConstrained: Bool {
+        columnSourceAttachmentID != nil || rowSourceAttachmentID != nil
+    }
+}
+
+nonisolated enum TerminalSizeCoordinator {
+    static func decision(
+        fallbackSize: TerminalGridSize,
+        attachments: [TerminalAttachment]
+    ) -> TerminalSizeDecision {
+        let activeAttachments = attachments.filter(\.isActive)
+        var columns = fallbackSize.columns
+        var rows = fallbackSize.rows
+        var columnSourceAttachmentID: MobileAttachmentID?
+        var rowSourceAttachmentID: MobileAttachmentID?
+
+        for attachment in activeAttachments {
+            if attachment.gridSize.columns < columns {
+                columns = attachment.gridSize.columns
+                columnSourceAttachmentID = attachment.id
+            }
+            if attachment.gridSize.rows < rows {
+                rows = attachment.gridSize.rows
+                rowSourceAttachmentID = attachment.id
+            }
+        }
+
+        return TerminalSizeDecision(
+            effectiveSize: TerminalGridSize(columns: columns, rows: rows),
+            fallbackSize: fallbackSize,
+            columnSourceAttachmentID: columnSourceAttachmentID,
+            rowSourceAttachmentID: rowSourceAttachmentID,
+            activeAttachmentCount: activeAttachments.count
+        )
+    }
+}
+
+actor MobileTerminalAttachmentStore {
+    private var attachmentsByID: [MobileAttachmentID: TerminalAttachment] = [:]
+
+    func upsert(_ attachment: TerminalAttachment) {
+        attachmentsByID[attachment.id] = attachment
+    }
+
+    func remove(_ attachmentID: MobileAttachmentID) {
+        attachmentsByID.removeValue(forKey: attachmentID)
+    }
+
+    func removeAll(for terminalID: MobileTerminalID) {
+        attachmentsByID = attachmentsByID.filter { _, attachment in
+            attachment.terminalID != terminalID
+        }
+    }
+
+    func attachments(for terminalID: MobileTerminalID) -> [TerminalAttachment] {
+        attachmentsByID.values
+            .filter { $0.terminalID == terminalID }
+            .sorted { $0.id.rawValue < $1.id.rawValue }
+    }
+
+    func activeAttachmentCount() -> Int {
+        attachmentsByID.values.filter(\.isActive).count
+    }
+
+    func decision(
+        for terminalID: MobileTerminalID,
+        fallbackSize: TerminalGridSize
+    ) -> TerminalSizeDecision {
+        TerminalSizeCoordinator.decision(
+            fallbackSize: fallbackSize,
+            attachments: attachments(for: terminalID)
+        )
+    }
+}
+
+nonisolated struct MobileTerminalSnapshot: Equatable, Sendable, Codable, Identifiable {
+    let id: MobileTerminalID
+    let workspaceID: MobileWorkspaceID
+    let title: String
+    let currentDirectory: String?
+    let isFocused: Bool
+    let displayOrder: Int
+}
+
+nonisolated struct MobileWorkspaceSnapshot: Equatable, Sendable, Codable, Identifiable {
+    let id: MobileWorkspaceID
+    let title: String
+    let customTitle: String?
+    let description: String?
+    let currentDirectory: String?
+    let isSelected: Bool
+    let isPinned: Bool
+    let customColor: String?
+    let terminals: [MobileTerminalSnapshot]
+}
+
+extension MobileTerminalSnapshot {
+    @MainActor
+    init?(
+        workspaceID: MobileWorkspaceID,
+        panel: any Panel,
+        focusedPanelID: UUID?,
+        displayOrder: Int
+    ) {
+        guard let terminalPanel = panel as? TerminalPanel else { return nil }
+        let directory = Self.normalizedDirectory(
+            terminalPanel.directory.isEmpty ? terminalPanel.requestedWorkingDirectory : terminalPanel.directory
+        )
+        self.init(
+            id: MobileTerminalID(terminalPanel.id),
+            workspaceID: workspaceID,
+            title: terminalPanel.displayTitle,
+            currentDirectory: directory,
+            isFocused: terminalPanel.id == focusedPanelID,
+            displayOrder: displayOrder
+        )
+    }
+
+    private nonisolated static func normalizedDirectory(_ directory: String?) -> String? {
+        guard let directory else { return nil }
+        let trimmed = directory.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+extension MobileWorkspaceSnapshot {
+    @MainActor
+    init(workspace: Workspace, isSelected: Bool) {
+        let workspaceID = MobileWorkspaceID(workspace.id)
+        let orderedPanelIDs = Self.orderedPanelIDs(for: workspace)
+        let terminals = orderedPanelIDs.enumerated().compactMap { displayOrder, panelID in
+            workspace.panels[panelID].flatMap { panel in
+                MobileTerminalSnapshot(
+                    workspaceID: workspaceID,
+                    panel: panel,
+                    focusedPanelID: workspace.focusedPanelId,
+                    displayOrder: displayOrder
+                )
+            }
+        }
+
+        self.init(
+            id: workspaceID,
+            title: workspace.customTitle ?? workspace.title,
+            customTitle: workspace.customTitle,
+            description: workspace.customDescription,
+            currentDirectory: Self.normalizedText(workspace.currentDirectory),
+            isSelected: isSelected,
+            isPinned: workspace.isPinned,
+            customColor: workspace.customColor,
+            terminals: terminals
+        )
+    }
+
+    @MainActor
+    static func snapshots(from tabManager: TabManager) -> [MobileWorkspaceSnapshot] {
+        tabManager.tabs.map { workspace in
+            MobileWorkspaceSnapshot(
+                workspace: workspace,
+                isSelected: workspace.id == tabManager.selectedTabId
+            )
+        }
+    }
+
+    @MainActor
+    private static func orderedPanelIDs(for workspace: Workspace) -> [UUID] {
+        var seen: Set<UUID> = []
+        var ordered: [UUID] = []
+        for panelID in workspace.sidebarOrderedPanelIds() where seen.insert(panelID).inserted {
+            ordered.append(panelID)
+        }
+        for panelID in workspace.panels.keys.sorted(by: { $0.uuidString < $1.uuidString })
+            where seen.insert(panelID).inserted {
+            ordered.append(panelID)
+        }
+        return ordered
+    }
+
+    private nonisolated static func normalizedText(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+nonisolated enum MobileSyncListenerState: String, Sendable, Codable {
+    case stopped
+    case waitingForTailscale = "waiting_for_tailscale"
+    case listening
+}
+
+nonisolated enum MobileSyncInterfaceAddressKind: String, Sendable, Codable {
+    case ipv4
+    case ipv6
+}
+
+nonisolated struct MobileSyncInterfaceAddress: Equatable, Sendable, Codable {
+    let interfaceName: String
+    let address: String
+    let kind: MobileSyncInterfaceAddressKind
+}
+
+nonisolated struct MobileSyncTailscaleDetection: Equatable, Sendable, Codable {
+    let addresses: [MobileSyncInterfaceAddress]
+
+    var isAvailable: Bool { selectedAddress != nil }
+
+    var selectedAddress: MobileSyncInterfaceAddress? {
+        addresses.first(where: MobileSyncTailscaleDetector.isTailscaleAddress)
+    }
+}
+
+nonisolated enum MobileSyncTailscaleDetector {
+    static func detect(addresses: [MobileSyncInterfaceAddress]) -> MobileSyncTailscaleDetection {
+        MobileSyncTailscaleDetection(addresses: addresses.filter(isTailscaleAddress))
+    }
+
+    static func detectCurrentSystem() -> MobileSyncTailscaleDetection {
+        detect(addresses: currentInterfaceAddresses())
+    }
+
+    static func isTailscaleAddress(_ address: MobileSyncInterfaceAddress) -> Bool {
+        switch address.kind {
+        case .ipv4:
+            return isTailscaleIPv4(address.address)
+        case .ipv6:
+            return isTailscaleIPv6(address.address)
+        }
+    }
+
+    static func isTailscaleIPv4(_ address: String) -> Bool {
+        let octets = address.split(separator: ".").compactMap { UInt8($0) }
+        guard octets.count == 4 else { return false }
+        return octets[0] == 100 && (64...127).contains(octets[1])
+    }
+
+    static func isTailscaleIPv6(_ address: String) -> Bool {
+        address.lowercased().hasPrefix("fd7a:115c:a1e0:")
+    }
+
+    private static func currentInterfaceAddresses() -> [MobileSyncInterfaceAddress] {
+        var interfaces: UnsafeMutablePointer<ifaddrs>?
+        guard getifaddrs(&interfaces) == 0, let first = interfaces else {
+            return []
+        }
+        defer { freeifaddrs(interfaces) }
+
+        var addresses: [MobileSyncInterfaceAddress] = []
+        var cursor: UnsafeMutablePointer<ifaddrs>? = first
+        while let current = cursor {
+            defer { cursor = current.pointee.ifa_next }
+            guard let socketAddress = current.pointee.ifa_addr else { continue }
+            let family = Int32(socketAddress.pointee.sa_family)
+            guard family == AF_INET || family == AF_INET6 else { continue }
+
+            var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+            let length = family == AF_INET
+                ? socklen_t(MemoryLayout<sockaddr_in>.size)
+                : socklen_t(MemoryLayout<sockaddr_in6>.size)
+            guard getnameinfo(
+                socketAddress,
+                length,
+                &host,
+                socklen_t(host.count),
+                nil,
+                0,
+                NI_NUMERICHOST
+            ) == 0 else {
+                continue
+            }
+
+            let interfaceName = current.pointee.ifa_name.map { String(cString: $0) } ?? ""
+            addresses.append(
+                MobileSyncInterfaceAddress(
+                    interfaceName: interfaceName,
+                    address: String(cString: host),
+                    kind: family == AF_INET ? .ipv4 : .ipv6
+                )
+            )
+        }
+
+        return addresses.sorted {
+            if $0.interfaceName != $1.interfaceName {
+                return $0.interfaceName < $1.interfaceName
+            }
+            return $0.address < $1.address
+        }
+    }
+}
+
+nonisolated struct MobileSyncSettingsSnapshot: Equatable, Sendable, Codable {
+    let enabled: Bool
+}
+
+enum MobileSyncSettings {
+    nonisolated static let enabledKey = "mobileSyncEnabled"
+    nonisolated static let defaultEnabled = false
+
+    @MainActor
+    static func snapshot(defaults: UserDefaults = .standard) -> MobileSyncSettingsSnapshot {
+        guard defaults.object(forKey: enabledKey) != nil else {
+            return MobileSyncSettingsSnapshot(enabled: defaultEnabled)
+        }
+        return MobileSyncSettingsSnapshot(enabled: defaults.bool(forKey: enabledKey))
+    }
+
+    @MainActor
+    static func setEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        defaults.set(enabled, forKey: enabledKey)
+    }
+}
+
+nonisolated struct MobileSyncStatusSnapshot: Equatable, Sendable, Codable {
+    let settings: MobileSyncSettingsSnapshot
+    let listenerState: MobileSyncListenerState
+    let tailscale: MobileSyncTailscaleDetection
+    let workspaceCount: Int
+    let terminalCount: Int
+    let activeAttachmentCount: Int
+}
+
+enum MobileSyncStatusBuilder {
+    @MainActor
+    static func status(
+        tabManager: TabManager?,
+        settings: MobileSyncSettingsSnapshot? = nil,
+        tailscale: MobileSyncTailscaleDetection? = nil,
+        activeAttachmentCount: Int = 0
+    ) -> MobileSyncStatusSnapshot {
+        let resolvedSettings = settings ?? MobileSyncSettings.snapshot()
+        let resolvedTailscale = tailscale ?? MobileSyncTailscaleDetector.detectCurrentSystem()
+        let workspaces = tabManager.map(MobileWorkspaceSnapshot.snapshots(from:)) ?? []
+        let listenerState: MobileSyncListenerState = {
+            guard resolvedSettings.enabled else { return .stopped }
+            return resolvedTailscale.isAvailable ? .stopped : .waitingForTailscale
+        }()
+
+        return MobileSyncStatusSnapshot(
+            settings: resolvedSettings,
+            listenerState: listenerState,
+            tailscale: resolvedTailscale,
+            workspaceCount: workspaces.count,
+            terminalCount: workspaces.reduce(0) { $0 + $1.terminals.count },
+            activeAttachmentCount: activeAttachmentCount
+        )
+    }
+}
+
+extension MobileSyncStatusSnapshot {
+    nonisolated var socketPayload: [String: Any] {
+        let selectedAddressValue: Any = tailscale.selectedAddress.map { $0.address as Any } ?? NSNull()
+        return [
+            "enabled": settings.enabled,
+            "listener": [
+                "state": listenerState.rawValue,
+            ],
+            "tailscale": [
+                "available": tailscale.isAvailable,
+                "selected_address": selectedAddressValue,
+                "addresses": tailscale.addresses.map { address in
+                    [
+                        "interface": address.interfaceName,
+                        "address": address.address,
+                        "kind": address.kind.rawValue,
+                    ]
+                },
+            ],
+            "workspace_count": workspaceCount,
+            "terminal_count": terminalCount,
+            "active_attachment_count": activeAttachmentCount,
+        ]
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2391,6 +2391,8 @@ class TerminalController {
             return v2Ok(id: id, result: v2Identify(params: params))
         case "system.tree":
             return v2Result(id: id, self.v2SystemTree(params: params))
+        case "mobile_sync.status":
+            return v2Ok(id: id, result: self.v2MobileSyncStatus(params: params))
 #if DEBUG
         case "debug.session_snapshot_benchmark":
             return v2Result(id: id, self.v2DebugSessionSnapshotBenchmark(params: params))
@@ -2825,6 +2827,7 @@ class TerminalController {
             "system.tree",
             "system.top",
             "events.stream",
+            "mobile_sync.status",
             "auth.login",
             "auth.status",
             "auth.begin_sign_in",
@@ -3043,6 +3046,11 @@ class TerminalController {
             "access_mode": accessMode.rawValue,
             "methods": methods.sorted()
         ]
+    }
+
+    private func v2MobileSyncStatus(params: [String: Any]) -> [String: Any] {
+        let manager = v2ResolveTabManager(params: params)
+        return MobileSyncStatusBuilder.status(tabManager: manager).socketPayload
     }
 
     private func v2Identify(params: [String: Any]) -> [String: Any] {

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -80,6 +80,29 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         )
     }
 
+    func testMobileSyncStatusReportsDisabledModelStateWithoutListener() throws {
+        _ = NSApplication.shared
+        UserDefaults.standard.removeObject(forKey: MobileSyncSettings.enabledKey)
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+            UserDefaults.standard.removeObject(forKey: MobileSyncSettings.enabledKey)
+        }
+
+        let manager = TabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let capabilities = try v2Result(method: "system.capabilities")
+        let methods = try XCTUnwrap(capabilities["methods"] as? [String])
+        XCTAssertTrue(methods.contains("mobile_sync.status"))
+
+        let status = try v2Result(method: "mobile_sync.status")
+        XCTAssertEqual(status["enabled"] as? Bool, false)
+        XCTAssertEqual((status["listener"] as? [String: Any])?["state"] as? String, "stopped")
+        XCTAssertGreaterThanOrEqual(status["workspace_count"] as? Int ?? 0, 1)
+        XCTAssertGreaterThanOrEqual(status["terminal_count"] as? Int ?? 0, 1)
+        XCTAssertEqual(status["active_attachment_count"] as? Int, 0)
+    }
+
     func testWorkspaceListResolvesLiveSurfaceAfterMainWindowContextAssociationIsLost() throws {
         _ = NSApplication.shared
         let previousAppDelegate = AppDelegate.shared

--- a/cmuxTests/CLIMobileSyncTests.swift
+++ b/cmuxTests/CLIMobileSyncTests.swift
@@ -1,0 +1,140 @@
+import Darwin
+import XCTest
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    func testIOSStatusRendersDisabledProductionSafeStatus() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ios-status")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            XCTAssertEqual(method, "mobile_sync.status")
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: self.iosStatusPayload(
+                    enabled: false,
+                    listenerState: "stopped",
+                    tailscaleAvailable: false,
+                    selectedAddress: nil
+                )
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ios", "status"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            """
+            Mobile Sync: disabled
+            Listener: stopped
+            Tailscale: unavailable
+            Workspaces: 2
+            Terminals: 3
+            Active attachments: 0
+
+            """
+        )
+        XCTAssertTrue(
+            state.commands.contains { $0.contains(#""method":"mobile_sync.status""#) },
+            "Expected ios status to call mobile_sync.status, saw \(state.commands)"
+        )
+    }
+
+    func testIOSStatusJSONForwardsSocketPayload() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ios-json")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: self.iosStatusPayload(
+                    enabled: false,
+                    listenerState: "stopped",
+                    tailscaleAvailable: true,
+                    selectedAddress: "100.64.1.2"
+                )
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["--json", "ios", "status"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let output = try XCTUnwrap(jsonObject(result.stdout))
+        XCTAssertEqual(output["enabled"] as? Bool, false)
+        let tailscale = try XCTUnwrap(output["tailscale"] as? [String: Any])
+        XCTAssertEqual(tailscale["available"] as? Bool, true)
+        XCTAssertEqual(tailscale["selected_address"] as? String, "100.64.1.2")
+    }
+
+    private func iosStatusPayload(
+        enabled: Bool,
+        listenerState: String,
+        tailscaleAvailable: Bool,
+        selectedAddress: String?
+    ) -> [String: Any] {
+        let selectedAddressValue: Any = selectedAddress.map { $0 as Any } ?? NSNull()
+        let addresses: [[String: Any]] = selectedAddress.map {
+            [["interface": "utun4", "address": $0, "kind": "ipv4"]]
+        } ?? []
+        return [
+            "enabled": enabled,
+            "listener": ["state": listenerState],
+            "tailscale": [
+                "available": tailscaleAvailable,
+                "selected_address": selectedAddressValue,
+                "addresses": addresses,
+            ],
+            "workspace_count": 2,
+            "terminal_count": 3,
+            "active_attachment_count": 0,
+        ]
+    }
+}

--- a/cmuxTests/MobileSyncModelTests.swift
+++ b/cmuxTests/MobileSyncModelTests.swift
@@ -1,0 +1,198 @@
+import AppKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class MobileSyncModelTests: XCTestCase {
+    func testSmallestActiveAttachmentWinsByAxis() {
+        let terminalID = MobileTerminalID(UUID())
+        let workspaceID = MobileWorkspaceID(UUID())
+        let wideButShort = attachment(
+            id: "ipad",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            size: TerminalGridSize(columns: 100, rows: 28)
+        )
+        let narrowButTall = attachment(
+            id: "iphone",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            size: TerminalGridSize(columns: 72, rows: 40)
+        )
+
+        let decision = TerminalSizeCoordinator.decision(
+            fallbackSize: TerminalGridSize(columns: 120, rows: 50),
+            attachments: [wideButShort, narrowButTall]
+        )
+
+        XCTAssertEqual(decision.effectiveSize, TerminalGridSize(columns: 72, rows: 28))
+        XCTAssertEqual(decision.columnSourceAttachmentID, narrowButTall.id)
+        XCTAssertEqual(decision.rowSourceAttachmentID, wideButShort.id)
+        XCTAssertTrue(decision.isRemotelyConstrained)
+    }
+
+    func testInactiveAttachmentsDoNotVote() {
+        let terminalID = MobileTerminalID(UUID())
+        let workspaceID = MobileWorkspaceID(UUID())
+        let inactive = attachment(
+            id: "stale",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            size: TerminalGridSize(columns: 40, rows: 12),
+            isActive: false
+        )
+
+        let decision = TerminalSizeCoordinator.decision(
+            fallbackSize: TerminalGridSize(columns: 120, rows: 50),
+            attachments: [inactive]
+        )
+
+        XCTAssertEqual(decision.effectiveSize, TerminalGridSize(columns: 120, rows: 50))
+        XCTAssertEqual(decision.activeAttachmentCount, 0)
+        XCTAssertFalse(decision.isRemotelyConstrained)
+    }
+
+    func testAttachmentStoreRemovalRecomputesSmallestVoteImmediately() async {
+        let store = MobileTerminalAttachmentStore()
+        let terminalID = MobileTerminalID(UUID())
+        let workspaceID = MobileWorkspaceID(UUID())
+        let smallest = attachment(
+            id: "smallest",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            size: TerminalGridSize(columns: 70, rows: 24)
+        )
+        let next = attachment(
+            id: "next",
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            size: TerminalGridSize(columns: 90, rows: 30)
+        )
+
+        await store.upsert(smallest)
+        await store.upsert(next)
+        var decision = await store.decision(
+            for: terminalID,
+            fallbackSize: TerminalGridSize(columns: 120, rows: 50)
+        )
+        XCTAssertEqual(decision.effectiveSize, TerminalGridSize(columns: 70, rows: 24))
+
+        await store.remove(smallest.id)
+        decision = await store.decision(
+            for: terminalID,
+            fallbackSize: TerminalGridSize(columns: 120, rows: 50)
+        )
+        XCTAssertEqual(decision.effectiveSize, TerminalGridSize(columns: 90, rows: 30))
+        XCTAssertEqual(decision.columnSourceAttachmentID, next.id)
+        XCTAssertEqual(decision.rowSourceAttachmentID, next.id)
+    }
+
+    func testSnapshotsAreCodableAndSendableValueModels() throws {
+        let workspaceID = MobileWorkspaceID(UUID())
+        let terminal = MobileTerminalSnapshot(
+            id: MobileTerminalID(UUID()),
+            workspaceID: workspaceID,
+            title: "shell",
+            currentDirectory: "/tmp",
+            isFocused: true,
+            displayOrder: 0
+        )
+        let snapshot = MobileWorkspaceSnapshot(
+            id: workspaceID,
+            title: "work",
+            customTitle: nil,
+            description: "description",
+            currentDirectory: "/tmp",
+            isSelected: true,
+            isPinned: false,
+            customColor: "#008080",
+            terminals: [terminal]
+        )
+
+        let encoded = try JSONEncoder().encode(sendableValue(snapshot))
+        let decoded = try JSONDecoder().decode(MobileWorkspaceSnapshot.self, from: encoded)
+
+        XCTAssertEqual(decoded, snapshot)
+        XCTAssertEqual(decoded.terminals.first?.workspaceID, workspaceID)
+    }
+
+    func testTailscaleDetectionFiltersTailnetAddresses() {
+        let addresses = [
+            MobileSyncInterfaceAddress(interfaceName: "en0", address: "192.168.0.20", kind: .ipv4),
+            MobileSyncInterfaceAddress(interfaceName: "utun4", address: "100.64.0.1", kind: .ipv4),
+            MobileSyncInterfaceAddress(interfaceName: "utun5", address: "100.127.255.255", kind: .ipv4),
+            MobileSyncInterfaceAddress(interfaceName: "utun6", address: "100.128.0.1", kind: .ipv4),
+            MobileSyncInterfaceAddress(interfaceName: "utun7", address: "fd7a:115c:a1e0:abcd::1", kind: .ipv6),
+        ]
+
+        let detection = MobileSyncTailscaleDetector.detect(addresses: addresses)
+
+        XCTAssertTrue(detection.isAvailable)
+        XCTAssertEqual(detection.addresses.map(\.address), [
+            "100.64.0.1",
+            "100.127.255.255",
+            "fd7a:115c:a1e0:abcd::1",
+        ])
+        XCTAssertEqual(detection.selectedAddress?.address, "100.64.0.1")
+    }
+
+    func testStatusBuilderReportsDisabledStoppedWithoutListener() {
+        let status = MobileSyncStatusBuilder.status(
+            tabManager: nil,
+            settings: MobileSyncSettingsSnapshot(enabled: false),
+            tailscale: MobileSyncTailscaleDetection(addresses: [])
+        )
+
+        XCTAssertFalse(status.settings.enabled)
+        XCTAssertEqual(status.listenerState, .stopped)
+        XCTAssertFalse(status.tailscale.isAvailable)
+        XCTAssertEqual(status.workspaceCount, 0)
+        XCTAssertEqual(status.terminalCount, 0)
+        XCTAssertEqual(status.activeAttachmentCount, 0)
+        XCTAssertEqual(status.socketPayload["enabled"] as? Bool, false)
+    }
+
+    func testSnapshotsFromTabManagerContainSelectedWorkspaceAndTerminal() throws {
+        _ = NSApplication.shared
+        let manager = TabManager()
+
+        let snapshots = MobileWorkspaceSnapshot.snapshots(from: manager)
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let snapshot = try XCTUnwrap(snapshots.first)
+        XCTAssertEqual(snapshot.id, MobileWorkspaceID(workspace.id))
+        XCTAssertTrue(snapshot.isSelected)
+        XCTAssertEqual(snapshot.terminals.count, 1)
+        XCTAssertEqual(snapshot.terminals.first?.workspaceID, snapshot.id)
+        XCTAssertEqual(snapshot.terminals.first?.id, MobileTerminalID(try XCTUnwrap(workspace.focusedTerminalPanel).id))
+    }
+
+    private func attachment(
+        id: String,
+        workspaceID: MobileWorkspaceID,
+        terminalID: MobileTerminalID,
+        size: TerminalGridSize,
+        isActive: Bool = true
+    ) -> TerminalAttachment {
+        TerminalAttachment(
+            id: MobileAttachmentID(id),
+            clientID: MobileClientID("client-\(id)"),
+            deviceID: MobileDeviceID("device-\(id)"),
+            workspaceID: workspaceID,
+            terminalID: terminalID,
+            surfaceKind: .iPad,
+            gridSize: size,
+            isActive: isActive,
+            lastHeartbeatAt: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+    }
+
+    private nonisolated func sendableValue<T: Sendable>(_ value: T) -> T {
+        value
+    }
+}


### PR DESCRIPTION
Summary
- Add Mac-side mobile sync value models for workspace snapshots, terminal snapshots, Tailscale address detection, and terminal size votes.
- Expose a read-only `mobile_sync.status` socket method plus `cmux ios status`.
- Keep mobile sync off by default. This PR does not add a listener, QR pairing, or iOS app yet.

Verification
- `git diff --check`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-iosm1-bft3 build-for-testing -only-testing:cmuxTests/MobileSyncModelTests -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testIOSStatusRendersDisabledProductionSafeStatus -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testIOSStatusJSONForwardsSocketPayload -only-testing:cmuxTests/AppDelegateIssue2907RoutingTests/testMobileSyncStatusReportsDisabledModelStateWithoutListener -quiet`\n- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-iosm1-bft3 test-without-building -only-testing:cmuxTests/MobileSyncModelTests -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testIOSStatusRendersDisabledProductionSafeStatus -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testIOSStatusJSONForwardsSocketPayload -only-testing:cmuxTests/AppDelegateIssue2907RoutingTests/testMobileSyncStatusReportsDisabledModelStateWithoutListener`\n- `./scripts/reload.sh --tag iosm1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new socket RPC method and CLI surface (`cmux ios status`) that expose system/network-derived state (Tailscale interface detection) and workspace/terminal counts, which could impact compatibility and output expectations. Changes are read-only and default-disabled, limiting behavioral risk.
> 
> **Overview**
> Adds the initial *read-only* “mobile sync status” foundation: new Swift value models for mobile sync state (workspace/terminal snapshots, attachment sizing votes, settings snapshot, and Tailscale address detection).
> 
> Exposes this via a new `mobile_sync.status` v2 socket method (advertised in `system.capabilities`) and a new CLI entrypoint `cmux ios status` that prints a human-readable status or forwards JSON unchanged with `--json`, with accompanying unit/integration tests and Xcode project wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b52429d5dc81093fbbffea07aae350ff618882. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the foundation for iOS mobile sync with value models and a read-only status endpoint. Exposes `mobile_sync.status` over the socket and a new `cmux ios status` CLI; the feature stays disabled by default.

- **New Features**
  - Added value models for workspace/terminal snapshots, terminal attachment store and size voting, and Tailscale address detection.
  - Socket method `mobile_sync.status` returns settings, listener state, Tailscale availability/addresses, and workspace/terminal/active attachment counts; advertised via `system.capabilities`.
  - CLI `cmux ios status` prints a readable status; `--json` forwards the raw payload.
  - Mobile sync is off by default; no listener, pairing, or iOS app in this PR.

- **Migration**
  - No action required. To check status: run `cmux ios status` (or `--json`).

<sup>Written for commit 35b52429d5dc81093fbbffea07aae350ff618882. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added `ios status` CLI command to display mobile sync status, including listener state, Tailscale connectivity, and device attachment information.
* Support for `--json` flag to output mobile sync status in JSON format for programmatic use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->