### PR TITLE
Add mobile size overlay debug hook

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -330,6 +330,7 @@
 		B9000052A1B2C3D4E5F60719 /* CMUXCLI+Events.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000053A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */; };
 		B9000054A1B2C3D4E5F60719 /* CMUXCLI+Process.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */; };
 		B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */; };
+		C0DE10510000000000000008 /* MobileSizeOverlayUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE10510000000000000009 /* MobileSizeOverlayUITests.swift */; };
 		FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F008 /* FeedSidebarUITests.swift */; };
 		B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */; };
 		B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */; };
@@ -803,6 +804,7 @@
 		B9000053A1B2C3D4E5F60719 /* CMUXCLI+Events.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Events.swift"; sourceTree = "<group>"; };
 		B9000055A1B2C3D4E5F60719 /* CMUXCLI+Process.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Process.swift"; sourceTree = "<group>"; };
 		B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutomationSocketUITests.swift; sourceTree = "<group>"; };
+		C0DE10510000000000000009 /* MobileSizeOverlayUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileSizeOverlayUITests.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F008 /* FeedSidebarUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedSidebarUITests.swift; sourceTree = "<group>"; };
 		B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JumpToUnreadUITests.swift; sourceTree = "<group>"; };
 		B9000016A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultiWindowNotificationsUITests.swift; sourceTree = "<group>"; };
@@ -998,6 +1000,7 @@
 			isa = PBXGroup;
 			children = (
 				B9000011A1B2C3D4E5F60719 /* AutomationSocketUITests.swift */,
+				C0DE10510000000000000009 /* MobileSizeOverlayUITests.swift */,
 				FEED0000000000000000F008 /* FeedSidebarUITests.swift */,
 				B9000013A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift */,
 				B9000022A1B2C3D4E5F60719 /* CloseWorkspaceCmdDUITests.swift */,
@@ -1951,6 +1954,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B9000012A1B2C3D4E5F60719 /* AutomationSocketUITests.swift in Sources */,
+				C0DE10510000000000000008 /* MobileSizeOverlayUITests.swift in Sources */,
 				FEED0000000000000000F009 /* FeedSidebarUITests.swift in Sources */,
 				B9000014A1B2C3D4E5F60719 /* JumpToUnreadUITests.swift in Sources */,
 				B900001AA1B2C3D4E5F60719 /* CloseWorkspaceConfirmDialogUITests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -107065,6 +107065,48 @@
         }
       }
     },
+    "terminal.mobileSizeOverlay.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Sized for %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ 用にサイズ調整" } }
+      }
+    },
+    "terminal.mobileSizeOverlay.device.mac": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Mac" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Mac" } }
+      }
+    },
+    "terminal.mobileSizeOverlay.device.iPhone": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iPhone" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPhone" } }
+      }
+    },
+    "terminal.mobileSizeOverlay.device.iPad": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iPad" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iPad" } }
+      }
+    },
+    "terminal.mobileSizeOverlay.device.simulator": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Simulator" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "Simulator" } }
+      }
+    },
+    "terminal.mobileSizeOverlay.device.unknown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "device" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "デバイス" } }
+      }
+    },
     "settings.account.error.missingAccessToken": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -778,6 +778,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var feedSidebarUITestObservers: [NSObjectProtocol] = []
     private var didSetupPortalStatsUITestDiagnostics = false
     private var portalStatsUITestObservers: [NSObjectProtocol] = []
+    private var didSetupMobileSizeOverlayUITest = false
+    private var mobileSizeOverlayUITestSnapshot: TerminalSizeOverlaySnapshot?
+    private var mobileSizeOverlayUITestObservers: [NSObjectProtocol] = []
+    private var mobileSizeOverlayUITestCancellables: [AnyCancellable] = []
     private struct UITestRenderDiagnosticsSnapshot {
         let panelId: UUID
         let drawCount: Int
@@ -1247,6 +1251,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             payload["targetDisplayMoveSucceeded"] = movedWindow ? "1" : "0"
         }
         appendUITestRenderDiagnosticsIfNeeded(&payload, environment: env)
+        appendUITestMobileSizeOverlayDiagnosticsIfNeeded(&payload, environment: env)
         appendUITestSocketDiagnosticsIfNeeded(&payload, environment: env)
         appendUITestPortalDiagnosticsIfNeeded(&payload, environment: env)
 
@@ -1369,6 +1374,69 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         payload["renderDesiredFocus"] = renderState.desiredFocus ? "1" : "0"
         payload["renderIsFirstResponder"] = renderState.isFirstResponder ? "1" : "0"
         payload["renderDiagnosticsUpdatedAt"] = String(format: "%.6f", ProcessInfo.processInfo.systemUptime)
+    }
+
+    private func appendUITestMobileSizeOverlayDiagnosticsIfNeeded(
+        _ payload: inout [String: String],
+        environment env: [String: String]
+    ) {
+        guard env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_SETUP"] == "1" else { return }
+
+        guard let tabManager,
+              let tabId = tabManager.selectedTabId,
+              let workspace = tabManager.tabs.first(where: { $0.id == tabId }) else {
+            payload["mobileSizeOverlaySnapshotPresent"] = "0"
+            payload["mobileSizeOverlayGeometryVisible"] = "0"
+            return
+        }
+
+        let terminalPanels = workspace.panels.values.compactMap { $0 as? TerminalPanel }
+        if let snapshot = mobileSizeOverlayUITestSnapshot {
+            for panel in terminalPanels {
+                panel.surface.setMobileSizeOverlaySnapshot(snapshot)
+            }
+        }
+
+        let terminalPanel: TerminalPanel? = {
+            if let focusedPanelId = workspace.focusedPanelId,
+               let terminalPanel = workspace.terminalPanel(for: focusedPanelId) {
+                return terminalPanel
+            }
+            if let focusedTerminalPanel = workspace.focusedTerminalPanel {
+                return focusedTerminalPanel
+            }
+            if let terminalPanel = terminalPanels.first(where: {
+                $0.surface.debugMobileSizeOverlayGeometry().isVisible
+            }) {
+                return terminalPanel
+            }
+            if let surfaceIdString = payload["mobileSizeOverlaySurfaceId"],
+               let surfaceId = UUID(uuidString: surfaceIdString),
+               let terminalPanel = workspace.terminalPanel(for: surfaceId) {
+                return terminalPanel
+            }
+            if let terminalPanel = terminalPanels.first(where: {
+                $0.surface.debugMobileSizeOverlaySnapshot() != nil
+            }) {
+                return terminalPanel
+            }
+            return terminalPanels.first
+        }()
+
+        guard let terminalPanel else {
+            payload["mobileSizeOverlaySnapshotPresent"] = "0"
+            payload["mobileSizeOverlayGeometryVisible"] = "0"
+            return
+        }
+
+        let snapshot = terminalPanel.surface.debugMobileSizeOverlaySnapshot()
+        let geometry = terminalPanel.surface.debugMobileSizeOverlayGeometry()
+        payload["mobileSizeOverlayDiagnosticsSurfaceId"] = terminalPanel.id.uuidString
+        payload["mobileSizeOverlaySnapshotPresent"] = snapshot == nil ? "0" : "1"
+        payload["mobileSizeOverlayGeometryVisible"] = geometry.isVisible ? "1" : "0"
+        payload["mobileSizeOverlayGeometryWidth"] = Self.uiTestStringValue(geometry.activeRect.width)
+        payload["mobileSizeOverlayGeometryHeight"] = Self.uiTestStringValue(geometry.activeRect.height)
+        payload["mobileSizeOverlayLabelText"] = terminalPanel.surface.debugMobileSizeOverlayLabelText()
     }
 
     private func currentUITestRenderDiagnostics() -> UITestRenderDiagnosticsSnapshot? {
@@ -1574,6 +1642,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         setupMultiWindowNotificationsUITestIfNeeded()
         setupDisplayResolutionUITestDiagnosticsIfNeeded()
         setupPortalStatsUITestDiagnosticsIfNeeded()
+        setupMobileSizeOverlayUITestIfNeeded()
 
         let env = ProcessInfo.processInfo.environment
         if isRunningUnderXCTest(env) || env["CMUX_UI_TEST_MODE"] == "1" {
@@ -1583,6 +1652,172 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
 #if DEBUG
+    private func setupMobileSizeOverlayUITestIfNeeded() {
+        guard !didSetupMobileSizeOverlayUITest else { return }
+        let env = ProcessInfo.processInfo.environment
+        guard env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_SETUP"] == "1" else { return }
+        didSetupMobileSizeOverlayUITest = true
+        guard let tabManager else {
+            writeMobileSizeOverlayUITestData(["mobileSizeOverlayError": "missing_tab_manager"])
+            return
+        }
+
+        let localColumns = Int(env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_LOCAL_COLUMNS"] ?? "") ?? 120
+        let localRows = Int(env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_LOCAL_ROWS"] ?? "") ?? 40
+        let effectiveColumns = Int(env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_COLUMNS"] ?? "") ?? 80
+        let effectiveRows = Int(env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_ROWS"] ?? "") ?? 24
+        guard let localSize = TerminalGridSize(validatingColumns: localColumns, rows: localRows),
+              let effectiveSize = TerminalGridSize(validatingColumns: effectiveColumns, rows: effectiveRows) else {
+            writeMobileSizeOverlayUITestData(["mobileSizeOverlayError": "invalid_size"])
+            return
+        }
+
+        let kindRaw = env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_KIND"] ?? TerminalAttachmentSurfaceKind.iPad.rawValue
+        guard let surfaceKind = TerminalAttachmentSurfaceKind(rawValue: kindRaw) else {
+            writeMobileSizeOverlayUITestData([
+                "mobileSizeOverlayError": "invalid_kind",
+                "mobileSizeOverlayKind": kindRaw,
+            ])
+            return
+        }
+
+        let snapshot = TerminalSizeOverlaySnapshot(
+            localSize: localSize,
+            effectiveSize: effectiveSize,
+            surfaceKind: surfaceKind,
+            deviceName: env["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_DEVICE_NAME"] ?? "iPad",
+            activeAttachmentCount: 1
+        )
+        mobileSizeOverlayUITestSnapshot = snapshot
+        var didFinish = false
+
+        func cleanup() {
+            for observer in mobileSizeOverlayUITestObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            mobileSizeOverlayUITestObservers.removeAll()
+            mobileSizeOverlayUITestCancellables.forEach { $0.cancel() }
+            mobileSizeOverlayUITestCancellables.removeAll()
+        }
+
+        func attemptApply(reason: String) {
+            guard !didFinish else { return }
+            guard let workspace = tabManager.selectedWorkspace else {
+                writeMobileSizeOverlayUITestData([
+                    "mobileSizeOverlayApplied": "0",
+                    "mobileSizeOverlayLastAttempt": reason,
+                    "mobileSizeOverlayError": "missing_workspace",
+                ])
+                return
+            }
+            let terminalPanels = workspace.panels.values.compactMap { $0 as? TerminalPanel }
+            guard !terminalPanels.isEmpty else {
+                writeMobileSizeOverlayUITestData([
+                    "mobileSizeOverlayApplied": "0",
+                    "mobileSizeOverlayLastAttempt": reason,
+                    "mobileSizeOverlayWorkspaceId": workspace.id.uuidString,
+                    "mobileSizeOverlayError": "missing_terminal",
+                ])
+                return
+            }
+
+            var reportedPanel = terminalPanels.first
+            var reportedGeometry = TerminalSizeOverlayGeometry(
+                containerRect: .zero,
+                activeRect: .zero,
+                isVisible: false
+            )
+            for panel in terminalPanels {
+                panel.surface.setMobileSizeOverlaySnapshot(snapshot)
+                let geometry = panel.surface.debugMobileSizeOverlayGeometry()
+                if geometry.isVisible || panel.id == workspace.focusedPanelId {
+                    reportedPanel = panel
+                    reportedGeometry = geometry
+                    if geometry.isVisible {
+                        break
+                    }
+                }
+            }
+            guard let reportedPanel else {
+                return
+            }
+            writeMobileSizeOverlayUITestData([
+                "mobileSizeOverlayApplied": "1",
+                "mobileSizeOverlayLastAttempt": reason,
+                "mobileSizeOverlayWorkspaceId": workspace.id.uuidString,
+                "mobileSizeOverlaySurfaceId": reportedPanel.id.uuidString,
+                "mobileSizeOverlaySurfaceIds": terminalPanels.map { $0.id.uuidString }.joined(separator: ","),
+                "mobileSizeOverlayVisible": snapshot.isRemotelyConstrained ? "1" : "0",
+                "mobileSizeOverlayGeometryVisible": reportedGeometry.isVisible ? "1" : "0",
+                "mobileSizeOverlayGeometryWidth": Self.uiTestStringValue(reportedGeometry.activeRect.width),
+                "mobileSizeOverlayGeometryHeight": Self.uiTestStringValue(reportedGeometry.activeRect.height),
+                "mobileSizeOverlayLabelText": reportedPanel.surface.debugMobileSizeOverlayLabelText(),
+            ])
+            guard reportedGeometry.isVisible else { return }
+            didFinish = true
+            cleanup()
+        }
+
+        func scheduleRetry(attempt: Int) {
+            guard !didFinish, attempt <= 40 else { return }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                attemptApply(reason: "retry_\(attempt)")
+                scheduleRetry(attempt: attempt + 1)
+            }
+        }
+
+        attemptApply(reason: "initial")
+        guard !didFinish else { return }
+
+        mobileSizeOverlayUITestObservers.append(NotificationCenter.default.addObserver(
+            forName: .mainWindowContextsDidChange,
+            object: self,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                attemptApply(reason: "main_window_contexts")
+            }
+        })
+        mobileSizeOverlayUITestObservers.append(NotificationCenter.default.addObserver(
+            forName: .terminalSurfaceDidBecomeReady,
+            object: nil,
+            queue: .main
+        ) { _ in
+            Task { @MainActor in
+                attemptApply(reason: "surface_ready")
+            }
+        })
+        mobileSizeOverlayUITestCancellables.append(tabManager.$selectedTabId.dropFirst().sink { _ in
+            Task { @MainActor in
+                attemptApply(reason: "selected_tab")
+            }
+        })
+        mobileSizeOverlayUITestCancellables.append(tabManager.$tabs.dropFirst().sink { _ in
+            Task { @MainActor in
+                attemptApply(reason: "tabs")
+            }
+        })
+        if let workspace = tabManager.selectedWorkspace {
+            mobileSizeOverlayUITestCancellables.append(workspace.$panels.dropFirst().sink { _ in
+                Task { @MainActor in
+                    attemptApply(reason: "panels")
+                }
+            })
+        }
+        scheduleRetry(attempt: 1)
+    }
+
+    private func writeMobileSizeOverlayUITestData(_ updates: [String: String]) {
+        let env = ProcessInfo.processInfo.environment
+        guard let path = env["CMUX_UI_TEST_DIAGNOSTICS_PATH"], !path.isEmpty else { return }
+        var payload = loadUITestDiagnostics(at: path)
+        for (key, value) in updates {
+            payload[key] = value
+        }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
     private func setupTerminalCmdClickUITestIfNeeded() {
         guard !didSetupTerminalCmdClickUITest else { return }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4199,6 +4199,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var additionalEnvironment: [String: String]
     let hostedView: GhosttySurfaceScrollView
     private let surfaceView: GhosttyNSView
+    private(set) var mobileSizeOverlaySnapshot: TerminalSizeOverlaySnapshot?
     private var lastPixelWidth: UInt32 = 0
     private var lastPixelHeight: UInt32 = 0
     private var lastXScale: CGFloat = 0
@@ -4329,6 +4330,41 @@ final class TerminalSurface: Identifiable, ObservableObject {
         attachedView?.tabId = newTabId
         surfaceView.tabId = newTabId
     }
+
+    @MainActor
+    func setMobileSizeOverlaySnapshot(_ snapshot: TerminalSizeOverlaySnapshot?) {
+        mobileSizeOverlaySnapshot = snapshot
+        hostedView.setMobileSizeOverlay(snapshot)
+    }
+
+    @MainActor
+    func currentTerminalGridSize() -> TerminalGridSize? {
+        guard let surface = liveSurfaceForGhosttyAccess(reason: "mobileSync.currentTerminalGridSize") else {
+            return nil
+        }
+        let size = ghostty_surface_size(surface)
+        return TerminalGridSize(
+            validatingColumns: Int(size.columns),
+            rows: Int(size.rows)
+        )
+    }
+
+#if DEBUG
+    @MainActor
+    func debugMobileSizeOverlaySnapshot() -> TerminalSizeOverlaySnapshot? {
+        mobileSizeOverlaySnapshot
+    }
+
+    @MainActor
+    func debugMobileSizeOverlayGeometry() -> TerminalSizeOverlayGeometry {
+        hostedView.debugMobileSizeOverlayGeometry()
+    }
+
+    @MainActor
+    func debugMobileSizeOverlayLabelText() -> String {
+        hostedView.debugMobileSizeOverlayLabelText()
+    }
+#endif
 
     private static func mergedNormalizedEnvironment(
         base: [String: String],
@@ -9507,6 +9543,208 @@ private final class GhosttyFlashOverlayView: NSView {
     }
 }
 
+private final class TerminalActiveAreaOverlayView: NSView {
+    private enum Metrics {
+        static let borderInset: CGFloat = 1
+        static let borderWidth: CGFloat = 2
+        static let badgeHeight: CGFloat = 26
+        static let badgeHorizontalPadding: CGFloat = 11
+        static let badgeEdgeInset: CGFloat = 8
+        static let maxBadgeWidth: CGFloat = 240
+    }
+
+    private let dimLayer = CAShapeLayer()
+    private let borderLayer = CAShapeLayer()
+    private let badgeContainerView = NSVisualEffectView(frame: .zero)
+    private let badgeLabel = NSTextField(labelWithString: "")
+    private(set) var currentGeometry = TerminalSizeOverlayGeometry.hidden
+    private(set) var currentLabelText = ""
+
+    override var acceptsFirstResponder: Bool { false }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.masksToBounds = false
+
+        dimLayer.fillColor = NSColor.black.withAlphaComponent(0.30).cgColor
+        dimLayer.fillRule = .evenOdd
+        dimLayer.opacity = 0
+        layer?.addSublayer(dimLayer)
+
+        borderLayer.fillColor = NSColor.clear.cgColor
+        borderLayer.strokeColor = NSColor.systemBlue.cgColor
+        borderLayer.lineWidth = Metrics.borderWidth
+        borderLayer.lineJoin = .miter
+        borderLayer.lineCap = .butt
+        borderLayer.shadowColor = NSColor.systemBlue.cgColor
+        borderLayer.shadowOpacity = 0.35
+        borderLayer.shadowRadius = 3
+        borderLayer.shadowOffset = .zero
+        borderLayer.opacity = 0
+        layer?.addSublayer(borderLayer)
+
+        badgeContainerView.material = .hudWindow
+        badgeContainerView.blendingMode = .withinWindow
+        badgeContainerView.state = .active
+        badgeContainerView.wantsLayer = true
+        badgeContainerView.layer?.cornerRadius = Metrics.badgeHeight / 2
+        badgeContainerView.layer?.masksToBounds = true
+        badgeContainerView.layer?.borderWidth = 1
+        badgeContainerView.layer?.borderColor = NSColor.white.withAlphaComponent(0.14).cgColor
+        badgeContainerView.isHidden = true
+
+        badgeLabel.font = NSFont.systemFont(ofSize: 12, weight: .semibold)
+        badgeLabel.textColor = NSColor.labelColor
+        badgeLabel.lineBreakMode = .byTruncatingTail
+        badgeLabel.maximumNumberOfLines = 1
+        badgeLabel.setAccessibilityIdentifier("terminal.mobileSizeOverlay.label")
+        badgeLabel.setAccessibilityElement(true)
+        badgeLabel.setAccessibilityRole(.staticText)
+        badgeContainerView.addSubview(badgeLabel)
+        addSubview(badgeContainerView)
+        isHidden = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) not implemented")
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    override func layout() {
+        super.layout()
+        applyGeometry(currentGeometry)
+    }
+
+    @discardableResult
+    func update(
+        snapshot: TerminalSizeOverlaySnapshot?,
+        containerSize: CGSize,
+        cellSize: CGSize
+    ) -> TerminalSizeOverlayGeometry {
+        let geometry = TerminalSizeOverlayGeometry.resolve(
+            containerSize: containerSize,
+            cellSize: cellSize,
+            snapshot: snapshot
+        )
+        currentGeometry = geometry
+
+        guard geometry.isVisible, let snapshot else {
+            applyHiddenState()
+            return geometry
+        }
+
+        currentLabelText = Self.labelText(for: snapshot)
+        badgeLabel.stringValue = currentLabelText
+        badgeLabel.setAccessibilityLabel(badgeLabel.stringValue)
+        applyGeometry(geometry)
+        return geometry
+    }
+
+    private func applyHiddenState() {
+        isHidden = true
+        currentLabelText = ""
+        badgeContainerView.isHidden = true
+        dimLayer.opacity = 0
+        borderLayer.opacity = 0
+        dimLayer.path = nil
+        borderLayer.path = nil
+    }
+
+    private func applyGeometry(_ geometry: TerminalSizeOverlayGeometry) {
+        guard geometry.isVisible else {
+            applyHiddenState()
+            return
+        }
+
+        isHidden = false
+        dimLayer.frame = bounds
+        borderLayer.frame = bounds
+
+        let dimPath = CGMutablePath()
+        dimPath.addRect(bounds)
+        dimPath.addRect(geometry.activeRect.insetBy(dx: -Metrics.borderInset, dy: -Metrics.borderInset))
+        dimLayer.path = dimPath
+        dimLayer.opacity = 1
+
+        let borderRect = geometry.activeRect.insetBy(
+            dx: Metrics.borderInset,
+            dy: Metrics.borderInset
+        )
+        borderLayer.path = CGPath(rect: borderRect, transform: nil)
+        borderLayer.opacity = 1
+        layoutBadge(in: geometry.activeRect)
+    }
+
+    private func layoutBadge(in activeRect: CGRect) {
+        let availableWidth = min(
+            Metrics.maxBadgeWidth,
+            activeRect.width - (Metrics.badgeEdgeInset * 2),
+            bounds.width - (Metrics.badgeEdgeInset * 2)
+        )
+        guard availableWidth >= 44, activeRect.height >= Metrics.badgeHeight + Metrics.badgeEdgeInset else {
+            badgeContainerView.isHidden = true
+            return
+        }
+
+        let labelSize = badgeLabel.intrinsicContentSize
+        let badgeWidth = min(
+            Metrics.maxBadgeWidth,
+            availableWidth,
+            ceil(labelSize.width) + (Metrics.badgeHorizontalPadding * 2)
+        )
+        let badgeHeight = Metrics.badgeHeight
+        let proposedX = activeRect.maxX - badgeWidth - Metrics.badgeEdgeInset
+        let proposedY = activeRect.maxY - badgeHeight - Metrics.badgeEdgeInset
+        let x = min(
+            max(Metrics.badgeEdgeInset, proposedX),
+            max(Metrics.badgeEdgeInset, bounds.width - badgeWidth - Metrics.badgeEdgeInset)
+        )
+        let y = min(
+            max(Metrics.badgeEdgeInset, proposedY),
+            max(Metrics.badgeEdgeInset, bounds.height - badgeHeight - Metrics.badgeEdgeInset)
+        )
+
+        badgeContainerView.isHidden = false
+        badgeContainerView.frame = CGRect(x: x, y: y, width: badgeWidth, height: badgeHeight)
+        badgeLabel.frame = CGRect(
+            x: Metrics.badgeHorizontalPadding,
+            y: floor((badgeHeight - labelSize.height) / 2),
+            width: max(0, badgeWidth - (Metrics.badgeHorizontalPadding * 2)),
+            height: ceil(labelSize.height)
+        )
+    }
+
+    private static func labelText(for snapshot: TerminalSizeOverlaySnapshot) -> String {
+        let fallbackName = defaultDeviceName(for: snapshot.surfaceKind)
+        let trimmedName = snapshot.deviceName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let name = trimmedName?.isEmpty == false ? (trimmedName ?? fallbackName) : fallbackName
+        let format = String(
+            localized: "terminal.mobileSizeOverlay.label",
+            defaultValue: "Sized for %@"
+        )
+        return String(format: format, name)
+    }
+
+    private static func defaultDeviceName(for kind: TerminalAttachmentSurfaceKind) -> String {
+        switch kind {
+        case .mac:
+            return String(localized: "terminal.mobileSizeOverlay.device.mac", defaultValue: "Mac")
+        case .iPhone:
+            return String(localized: "terminal.mobileSizeOverlay.device.iPhone", defaultValue: "iPhone")
+        case .iPad:
+            return String(localized: "terminal.mobileSizeOverlay.device.iPad", defaultValue: "iPad")
+        case .simulator:
+            return String(localized: "terminal.mobileSizeOverlay.device.simulator", defaultValue: "Simulator")
+        case .unknown:
+            return String(localized: "terminal.mobileSizeOverlay.device.unknown", defaultValue: "device")
+        }
+    }
+}
+
 final class GhosttySurfaceScrollView: NSView {
     enum FlashStyle {
         case navigation
@@ -9548,6 +9786,7 @@ final class GhosttySurfaceScrollView: NSView {
     private let notificationRingLayer: CAShapeLayer
     private let flashOverlayView: GhosttyFlashOverlayView
     private let flashLayer: CAShapeLayer
+    private let mobileSizeOverlayView: TerminalActiveAreaOverlayView
     var isRightSidebarDockSurface: Bool {
         surfaceView.terminalSurface?.focusPlacement == .rightSidebarDock
     }
@@ -9557,6 +9796,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     private var lastFlashStyle: FlashStyle = .navigation
+    private var mobileSizeOverlaySnapshot: TerminalSizeOverlaySnapshot?
     private let keyboardCopyModeBadgeContainerView: GhosttyFlashOverlayView
     private let keyboardCopyModeBadgeView: GhosttyPassthroughVisualEffectView
     private let keyboardCopyModeBadgeIconView: NSImageView
@@ -9721,6 +9961,14 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.cellSize
     }
 
+    func debugMobileSizeOverlayGeometry() -> TerminalSizeOverlayGeometry {
+        mobileSizeOverlayView.currentGeometry
+    }
+
+    func debugMobileSizeOverlayLabelText() -> String {
+        mobileSizeOverlayView.currentLabelText
+    }
+
     private func debugPointInSurface(_ point: NSPoint) -> NSPoint {
         surfaceView.convert(point, from: self)
     }
@@ -9792,6 +10040,7 @@ final class GhosttySurfaceScrollView: NSView {
         notificationRingLayer = CAShapeLayer()
         flashOverlayView = GhosttyFlashOverlayView(frame: .zero)
         flashLayer = CAShapeLayer()
+        mobileSizeOverlayView = TerminalActiveAreaOverlayView(frame: .zero)
         keyboardCopyModeBadgeContainerView = GhosttyFlashOverlayView(frame: .zero)
         keyboardCopyModeBadgeView = GhosttyPassthroughVisualEffectView(frame: .zero)
         keyboardCopyModeBadgeIconView = NSImageView(frame: .zero)
@@ -9871,6 +10120,8 @@ final class GhosttySurfaceScrollView: NSView {
         flashLayer.opacity = 0
         flashOverlayView.layer?.addSublayer(flashLayer)
         addSubview(flashOverlayView)
+        mobileSizeOverlayView.autoresizingMask = [.width, .height]
+        addSubview(mobileSizeOverlayView)
         keyboardCopyModeBadgeContainerView.translatesAutoresizingMaskIntoConstraints = false
         keyboardCopyModeBadgeContainerView.wantsLayer = true
         keyboardCopyModeBadgeContainerView.layer?.masksToBounds = false
@@ -10084,6 +10335,7 @@ final class GhosttySurfaceScrollView: NSView {
             queue: .main
         ) { [weak self] _ in
             self?.synchronizeScrollView()
+            self?.synchronizeMobileSizeOverlay()
         })
 
         observers.append(NotificationCenter.default.addObserver(
@@ -10253,6 +10505,7 @@ final class GhosttySurfaceScrollView: NSView {
         }
         _ = setFrameIfNeeded(notificationRingOverlayView, to: bounds)
         _ = setFrameIfNeeded(flashOverlayView, to: bounds)
+        _ = setFrameIfNeeded(mobileSizeOverlayView, to: bounds)
         if let overlay = searchOverlayHostingView {
             _ = setFrameIfNeeded(overlay, to: bounds)
         }
@@ -10266,6 +10519,7 @@ final class GhosttySurfaceScrollView: NSView {
         updateNotificationRingPath()
         updateFlashPath(style: lastFlashStyle)
         updateFlashAppearance(style: lastFlashStyle)
+        synchronizeMobileSizeOverlay()
         synchronizeScrollView()
         synchronizeSurfaceView()
         let didCoreSurfaceChange = synchronizeCoreSurface()
@@ -10444,6 +10698,7 @@ final class GhosttySurfaceScrollView: NSView {
 
     func attachSurface(_ terminalSurface: TerminalSurface) {
         surfaceView.attachSurface(terminalSurface)
+        setMobileSizeOverlay(terminalSurface.mobileSizeOverlaySnapshot)
         let workspace = terminalSurface.owningWorkspace()
         cachedOwningWorkspace = workspace
         updateWorkspaceTerminalScrollBarObserver(workspace)
@@ -10492,6 +10747,36 @@ final class GhosttySurfaceScrollView: NSView {
         inactiveOverlayView.layer?.backgroundColor = color.withAlphaComponent(clampedOpacity).cgColor
         inactiveOverlayView.isHidden = !(visible && clampedOpacity > 0.0001)
         CATransaction.commit()
+    }
+
+    func setMobileSizeOverlay(_ snapshot: TerminalSizeOverlaySnapshot?) {
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.setMobileSizeOverlay(snapshot)
+            }
+            return
+        }
+
+        guard mobileSizeOverlaySnapshot != snapshot else {
+            synchronizeMobileSizeOverlay()
+            return
+        }
+
+        mobileSizeOverlaySnapshot = snapshot
+        synchronizeMobileSizeOverlay()
+    }
+
+    @discardableResult
+    private func synchronizeMobileSizeOverlay() -> TerminalSizeOverlayGeometry {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        defer { CATransaction.commit() }
+
+        return mobileSizeOverlayView.update(
+            snapshot: mobileSizeOverlaySnapshot,
+            containerSize: bounds.size,
+            cellSize: surfaceView.cellSize
+        )
     }
 
     func setNotificationRing(visible: Bool) {

--- a/Sources/MobileSyncModels.swift
+++ b/Sources/MobileSyncModels.swift
@@ -1,4 +1,5 @@
 import Darwin
+import CoreGraphics
 import Foundation
 
 nonisolated struct MobileWorkspaceID: Hashable, Sendable, Codable, CustomStringConvertible {
@@ -214,6 +215,90 @@ nonisolated struct TerminalSizeDecision: Equatable, Sendable {
 
     var isRemotelyConstrained: Bool {
         columnSourceAttachmentID != nil || rowSourceAttachmentID != nil
+    }
+}
+
+nonisolated struct TerminalSizeOverlaySnapshot: Equatable, Sendable, Codable {
+    let localSize: TerminalGridSize
+    let effectiveSize: TerminalGridSize
+    let surfaceKind: TerminalAttachmentSurfaceKind
+    let deviceName: String?
+    let activeAttachmentCount: Int
+
+    var isRemotelyConstrained: Bool {
+        activeAttachmentCount > 0 &&
+            (effectiveSize.columns < localSize.columns || effectiveSize.rows < localSize.rows)
+    }
+
+    var socketPayload: [String: Any] {
+        [
+            "visible": isRemotelyConstrained,
+            "local": [
+                "columns": localSize.columns,
+                "rows": localSize.rows,
+            ],
+            "effective": [
+                "columns": effectiveSize.columns,
+                "rows": effectiveSize.rows,
+            ],
+            "surface_kind": surfaceKind.rawValue,
+            "device_name": deviceName ?? NSNull(),
+            "active_attachment_count": activeAttachmentCount,
+        ]
+    }
+}
+
+nonisolated struct TerminalSizeOverlayGeometry: Equatable, Sendable {
+    let containerRect: CGRect
+    let activeRect: CGRect
+    let isVisible: Bool
+
+    static let hidden = TerminalSizeOverlayGeometry(
+        containerRect: .zero,
+        activeRect: .zero,
+        isVisible: false
+    )
+
+    static func resolve(
+        containerSize: CGSize,
+        cellSize: CGSize,
+        snapshot: TerminalSizeOverlaySnapshot?
+    ) -> TerminalSizeOverlayGeometry {
+        guard let snapshot,
+              snapshot.isRemotelyConstrained,
+              containerSize.width > 0,
+              containerSize.height > 0 else {
+            return .hidden
+        }
+
+        let localColumns = max(snapshot.localSize.columns, 1)
+        let localRows = max(snapshot.localSize.rows, 1)
+        let resolvedCellWidth = cellSize.width > 0
+            ? cellSize.width
+            : containerSize.width / CGFloat(localColumns)
+        let resolvedCellHeight = cellSize.height > 0
+            ? cellSize.height
+            : containerSize.height / CGFloat(localRows)
+        let activeWidth = min(
+            containerSize.width,
+            max(1, CGFloat(snapshot.effectiveSize.columns) * resolvedCellWidth)
+        )
+        let activeHeight = min(
+            containerSize.height,
+            max(1, CGFloat(snapshot.effectiveSize.rows) * resolvedCellHeight)
+        )
+        let activeRect = CGRect(
+            x: 0,
+            y: max(0, containerSize.height - activeHeight),
+            width: activeWidth,
+            height: activeHeight
+        )
+
+        return TerminalSizeOverlayGeometry(
+            containerRect: CGRect(origin: .zero, size: containerSize),
+            activeRect: activeRect,
+            isVisible: activeWidth < containerSize.width || activeHeight < containerSize.height
+        )
     }
 }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2394,6 +2394,10 @@ class TerminalController {
         case "mobile_sync.status":
             return v2Ok(id: id, result: self.v2MobileSyncStatus(params: params))
 #if DEBUG
+        case "debug.mobile_sync.set_fake_remote_size":
+            return v2Result(id: id, self.v2DebugMobileSyncSetFakeRemoteSize(params: params))
+        case "debug.mobile_sync.clear_fake_remote_size":
+            return v2Result(id: id, self.v2DebugMobileSyncClearFakeRemoteSize(params: params))
         case "debug.session_snapshot_benchmark":
             return v2Result(id: id, self.v2DebugSessionSnapshotBenchmark(params: params))
         case "debug.session_snapshot_seed_scrollback":
@@ -3028,6 +3032,8 @@ class TerminalController {
             "debug.bonsplit_underflow.reset",
             "debug.empty_panel.count",
             "debug.empty_panel.reset",
+            "debug.mobile_sync.set_fake_remote_size",
+            "debug.mobile_sync.clear_fake_remote_size",
             "debug.notification.focus",
             "debug.flash.count",
             "debug.flash.reset",
@@ -3052,6 +3058,109 @@ class TerminalController {
         let manager = v2ResolveTabManager(params: params)
         return MobileSyncStatusBuilder.status(tabManager: manager).socketPayload
     }
+
+#if DEBUG
+    private func v2DebugMobileSyncSetFakeRemoteSize(params: [String: Any]) -> V2CallResult {
+        guard let surfaceId = v2UUID(params, "surface_id") ?? v2UUID(params, "tab_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+        guard let columns = v2StrictInt(params, "columns"), columns > 0,
+              let rows = v2StrictInt(params, "rows"), rows > 0 else {
+            return .err(
+                code: "invalid_params",
+                message: "columns and rows must be positive integers",
+                data: ["surface_id": surfaceId.uuidString]
+            )
+        }
+
+        let kindRaw = v2String(params, "surface_kind") ?? v2String(params, "kind")
+        let surfaceKind: TerminalAttachmentSurfaceKind
+        if let kindRaw {
+            guard let parsed = TerminalAttachmentSurfaceKind(rawValue: kindRaw) else {
+                return .err(
+                    code: "invalid_params",
+                    message: "Invalid surface_kind",
+                    data: ["surface_kind": kindRaw]
+                )
+            }
+            surfaceKind = parsed
+        } else {
+            surfaceKind = .iPad
+        }
+
+        var result: V2CallResult = .err(
+            code: "not_found",
+            message: "Surface not found",
+            data: ["surface_id": surfaceId.uuidString]
+        )
+
+        v2MainSync {
+            guard let surface = TerminalSurfaceRegistry.shared.surface(id: surfaceId) else {
+                return
+            }
+            let currentLocalSize = surface.currentTerminalGridSize()
+            let fallbackLocalColumns = columns < Int.max ? columns + 1 : columns
+            let fallbackLocalRows = rows < Int.max ? rows + 1 : rows
+            let localColumns = v2StrictInt(params, "local_columns")
+                ?? currentLocalSize?.columns
+                ?? fallbackLocalColumns
+            let localRows = v2StrictInt(params, "local_rows")
+                ?? currentLocalSize?.rows
+                ?? fallbackLocalRows
+            guard let localSize = TerminalGridSize(
+                validatingColumns: localColumns,
+                rows: localRows
+            ) else {
+                result = .err(
+                    code: "invalid_params",
+                    message: "local_columns and local_rows must be positive integers",
+                    data: ["surface_id": surfaceId.uuidString]
+                )
+                return
+            }
+            let snapshot = TerminalSizeOverlaySnapshot(
+                localSize: localSize,
+                effectiveSize: TerminalGridSize(columns: columns, rows: rows),
+                surfaceKind: surfaceKind,
+                deviceName: v2RawString(params, "device_name")?.trimmingCharacters(in: .whitespacesAndNewlines),
+                activeAttachmentCount: 1
+            )
+            surface.setMobileSizeOverlaySnapshot(snapshot)
+            var payload = snapshot.socketPayload
+            payload["surface_id"] = surfaceId.uuidString
+            payload["surface_ref"] = v2Ref(kind: .surface, uuid: surfaceId)
+            result = .ok(payload)
+        }
+
+        return result
+    }
+
+    private func v2DebugMobileSyncClearFakeRemoteSize(params: [String: Any]) -> V2CallResult {
+        guard let surfaceId = v2UUID(params, "surface_id") ?? v2UUID(params, "tab_id") else {
+            return .err(code: "invalid_params", message: "Missing or invalid surface_id", data: nil)
+        }
+
+        var result: V2CallResult = .err(
+            code: "not_found",
+            message: "Surface not found",
+            data: ["surface_id": surfaceId.uuidString]
+        )
+
+        v2MainSync {
+            guard let surface = TerminalSurfaceRegistry.shared.surface(id: surfaceId) else {
+                return
+            }
+            surface.setMobileSizeOverlaySnapshot(nil)
+            result = .ok([
+                "surface_id": surfaceId.uuidString,
+                "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                "visible": false,
+            ])
+        }
+
+        return result
+    }
+#endif
 
     private func v2Identify(params: [String: Any]) -> [String: Any] {
         guard let tabManager = v2ResolveTabManager(params: params) else {

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -103,6 +103,68 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         XCTAssertEqual(status["active_attachment_count"] as? Int, 0)
     }
 
+#if DEBUG
+    func testDebugMobileSyncFakeRemoteSizeSetsAndClearsOverlay() throws {
+        _ = NSApplication.shared
+        defer {
+            TerminalController.shared.setActiveTabManager(nil)
+        }
+
+        let manager = TabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let terminalPanel = try XCTUnwrap(workspace.focusedTerminalPanel)
+        let surface = terminalPanel.surface
+        let surfaceId = terminalPanel.id
+        surface.hostedView.frame = NSRect(x: 0, y: 0, width: 1200, height: 800)
+        surface.hostedView.layoutSubtreeIfNeeded()
+
+        let capabilities = try v2Result(method: "system.capabilities")
+        let methods = try XCTUnwrap(capabilities["methods"] as? [String])
+        XCTAssertTrue(methods.contains("debug.mobile_sync.set_fake_remote_size"))
+        XCTAssertTrue(methods.contains("debug.mobile_sync.clear_fake_remote_size"))
+
+        let setPayload = try v2Result(
+            method: "debug.mobile_sync.set_fake_remote_size",
+            params: [
+                "surface_id": surfaceId.uuidString,
+                "columns": 80,
+                "rows": 24,
+                "local_columns": 120,
+                "local_rows": 40,
+                "surface_kind": "iPad",
+                "device_name": "iPad",
+            ]
+        )
+
+        XCTAssertEqual(setPayload["surface_id"] as? String, surfaceId.uuidString)
+        XCTAssertEqual(setPayload["visible"] as? Bool, true)
+        XCTAssertEqual((setPayload["effective"] as? [String: Any])?["columns"] as? Int, 80)
+        XCTAssertEqual((setPayload["effective"] as? [String: Any])?["rows"] as? Int, 24)
+        XCTAssertEqual((setPayload["local"] as? [String: Any])?["columns"] as? Int, 120)
+        XCTAssertEqual((setPayload["local"] as? [String: Any])?["rows"] as? Int, 40)
+
+        let snapshot = try XCTUnwrap(surface.debugMobileSizeOverlaySnapshot())
+        XCTAssertTrue(snapshot.isRemotelyConstrained)
+        XCTAssertEqual(snapshot.effectiveSize, TerminalGridSize(columns: 80, rows: 24))
+        XCTAssertEqual(snapshot.localSize, TerminalGridSize(columns: 120, rows: 40))
+
+        let geometry = surface.debugMobileSizeOverlayGeometry()
+        XCTAssertTrue(geometry.isVisible)
+        XCTAssertEqual(geometry.activeRect, CGRect(x: 0, y: 320, width: 800, height: 480))
+
+        let clearPayload = try v2Result(
+            method: "debug.mobile_sync.clear_fake_remote_size",
+            params: ["surface_id": surfaceId.uuidString]
+        )
+        XCTAssertEqual(clearPayload["surface_id"] as? String, surfaceId.uuidString)
+        XCTAssertEqual(clearPayload["visible"] as? Bool, false)
+        XCTAssertNil(surface.debugMobileSizeOverlaySnapshot())
+        XCTAssertFalse(surface.debugMobileSizeOverlayGeometry().isVisible)
+    }
+#endif
+
     func testWorkspaceListResolvesLiveSurfaceAfterMainWindowContextAssociationIsLost() throws {
         _ = NSApplication.shared
         let previousAppDelegate = AppDelegate.shared

--- a/cmuxTests/MobileSyncModelTests.swift
+++ b/cmuxTests/MobileSyncModelTests.swift
@@ -157,6 +157,45 @@ final class MobileSyncModelTests: XCTestCase {
         XCTAssertEqual(status.socketPayload["enabled"] as? Bool, false)
     }
 
+    func testOverlayGeometryUsesTopAlignedEffectiveGrid() {
+        let snapshot = TerminalSizeOverlaySnapshot(
+            localSize: TerminalGridSize(columns: 100, rows: 40),
+            effectiveSize: TerminalGridSize(columns: 80, rows: 24),
+            surfaceKind: .iPad,
+            deviceName: "iPad",
+            activeAttachmentCount: 1
+        )
+
+        let geometry = TerminalSizeOverlayGeometry.resolve(
+            containerSize: CGSize(width: 1000, height: 800),
+            cellSize: CGSize(width: 10, height: 20),
+            snapshot: snapshot
+        )
+
+        XCTAssertTrue(geometry.isVisible)
+        XCTAssertEqual(geometry.containerRect, CGRect(x: 0, y: 0, width: 1000, height: 800))
+        XCTAssertEqual(geometry.activeRect, CGRect(x: 0, y: 320, width: 800, height: 480))
+    }
+
+    func testOverlayGeometryIsHiddenWhenEffectiveSizeMatchesLocalSize() {
+        let snapshot = TerminalSizeOverlaySnapshot(
+            localSize: TerminalGridSize(columns: 100, rows: 40),
+            effectiveSize: TerminalGridSize(columns: 100, rows: 40),
+            surfaceKind: .iPad,
+            deviceName: "iPad",
+            activeAttachmentCount: 1
+        )
+
+        let geometry = TerminalSizeOverlayGeometry.resolve(
+            containerSize: CGSize(width: 1000, height: 800),
+            cellSize: CGSize(width: 10, height: 20),
+            snapshot: snapshot
+        )
+
+        XCTAssertFalse(geometry.isVisible)
+        XCTAssertEqual(geometry, .hidden)
+    }
+
     func testSnapshotsFromTabManagerContainSelectedWorkspaceAndTerminal() throws {
         _ = NSApplication.shared
         let manager = TabManager()

--- a/cmuxUITests/MobileSizeOverlayUITests.swift
+++ b/cmuxUITests/MobileSizeOverlayUITests.swift
@@ -1,0 +1,89 @@
+import Foundation
+import XCTest
+
+final class MobileSizeOverlayUITests: XCTestCase {
+    private var diagnosticsPath = ""
+
+    override func setUp() {
+        super.setUp()
+        continueAfterFailure = false
+        diagnosticsPath = "/tmp/cmux-ui-mobile-size-\(UUID().uuidString).json"
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(atPath: diagnosticsPath)
+        super.tearDown()
+    }
+
+    func testLaunchHookShowsActiveAreaOverlay() throws {
+        let app = XCUIApplication()
+        addTeardownBlock { app.terminate() }
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_SETUP"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_COLUMNS"] = "80"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_ROWS"] = "24"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_LOCAL_COLUMNS"] = "120"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_LOCAL_ROWS"] = "40"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_KIND"] = "iPad"
+        app.launchEnvironment["CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_DEVICE_NAME"] = "iPad"
+        app.launchEnvironment["CMUX_UI_TEST_DIAGNOSTICS_PATH"] = diagnosticsPath
+        app.launchEnvironment["CMUX_TAG"] = "uiiosm"
+        launchAndAllowBackground(app)
+
+        XCTAssertTrue(
+            waitForDiagnostics(timeout: 12.0) { diagnostics in
+                diagnostics["mobileSizeOverlayApplied"] == "1" &&
+                    diagnostics["mobileSizeOverlayVisible"] == "1" &&
+                    diagnostics["mobileSizeOverlayGeometryVisible"] == "1" &&
+                    diagnostics["mobileSizeOverlayLabelText"]?.contains("iPad") == true
+            },
+            "Expected launch hook to apply the mobile active-area overlay. diagnostics=\(loadDiagnostics() ?? [:])"
+        )
+
+        let overlayLabel = app.staticTexts.matching(identifier: "terminal.mobileSizeOverlay.label").firstMatch
+        let fallbackLabel = app.staticTexts["Sized for iPad"]
+        if overlayLabel.waitForExistence(timeout: 2.0) || fallbackLabel.waitForExistence(timeout: 1.0) {
+            let visibleLabel = overlayLabel.exists ? overlayLabel : fallbackLabel
+            let labelText = visibleLabel.label.isEmpty ? (visibleLabel.value as? String ?? "") : visibleLabel.label
+            XCTAssertTrue(labelText.contains("iPad"), "Expected overlay label to name the remote device, saw \(labelText)")
+        }
+    }
+
+    private func launchAndAllowBackground(_ app: XCUIApplication) {
+        let options = XCTExpectedFailure.Options()
+        options.isStrict = false
+        XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
+            app.launch()
+        }
+
+        if app.state == .runningForeground || app.state == .runningBackground {
+            return
+        }
+
+        XCTFail("App failed to start for mobile size overlay test. state=\(app.state.rawValue)")
+    }
+
+    private func loadDiagnostics() -> [String: String]? {
+        guard let data = try? Data(contentsOf: URL(fileURLWithPath: diagnosticsPath)),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: String] else {
+            return nil
+        }
+        return json
+    }
+
+    private func waitForDiagnostics(
+        timeout: TimeInterval,
+        predicate: ([String: String]) -> Bool
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let diagnostics = loadDiagnostics(), predicate(diagnostics) {
+                return true
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        return false
+    }
+}


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/3758.

This adds the macOS active terminal-area overlay for remote size constraints. It includes:

- a shared `TerminalSizeOverlaySnapshot` and geometry resolver
- an AppKit overlay around the active terminal grid when a remote client constrains size
- DEBUG socket hooks for setting and clearing fake remote sizes
- focused unit coverage for geometry and the debug hook
- a CI-only XCUITest that drives the debug socket and verifies the overlay label appears and clears

Verification:

- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-iosm2-bft test -only-testing:cmuxTests/MobileSyncModelTests -only-testing:cmuxTests/AppDelegateIssue2907RoutingTests/testDebugMobileSyncFakeRemoteSizeSetsAndClearsOverlay`, 10 tests passed
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -destination 'platform=macOS' -derivedDataPath /tmp/cmux-iosm2-uitest-bft build-for-testing -only-testing:cmuxUITests/MobileSizeOverlayUITests`
- GitHub E2E `MobileSizeOverlayUITests`: https://github.com/manaflow-ai/cmux/actions/runs/25584009630

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a macOS terminal active-area overlay that dims unused space, outlines the effective grid, and shows a localized “Sized for %@” badge when a remote device constrains size. Includes DEBUG socket methods and a UI-test launch hook to apply and verify the overlay, wiring state from `TerminalSurface` into `GhosttySurfaceScrollView`.

- New Features
  - Overlay via TerminalActiveAreaOverlayView using `TerminalSizeOverlaySnapshot`/`TerminalSizeOverlayGeometry` (top-aligned, cell-size aware; badge accessibility id `terminal.mobileSizeOverlay.label`).
  - Localized strings for the badge and device-name fallbacks (Mac/iPhone/iPad/Simulator/Unknown) in EN/JA.
  - DEBUG endpoints `debug.mobile_sync.set_fake_remote_size` and `debug.mobile_sync.clear_fake_remote_size` (listed in `system.capabilities`); accept surface/tab id, sizes, kind/device; return visibility and local/effective sizes.
  - UI test launch hook `CMUX_UI_TEST_MOBILE_SIZE_OVERLAY_SETUP` (env for local/effective sizes, kind, device name) applies a snapshot and writes diagnostics (surface id, geometry, label); includes unit tests and a `MobileSizeOverlayUITests` XCUITest (added to the Xcode project).

<sup>Written for commit 2f539bef9b56d62bf34b442f70aff2b2dea12442. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new UI overlay rendering tied to terminal sizing plus DEBUG socket endpoints and UI-test launch hooks, which could impact terminal view layout/refresh behavior if wiring is incorrect. Most behavioral changes are gated behind a snapshot being set (or DEBUG/test flags), reducing production risk.
> 
> **Overview**
> Adds a *mobile size/active-area overlay* to terminal surfaces that visually highlights the effective grid when a remote/mobile client constrains terminal size, including a localized “Sized for %@” badge.
> 
> Introduces shared models `TerminalSizeOverlaySnapshot` and `TerminalSizeOverlayGeometry` (plus EN/JA strings) and wires snapshot propagation from `TerminalSurface` into `GhosttySurfaceScrollView` so the overlay updates on layout/cell-size changes.
> 
> In DEBUG builds, adds socket methods `debug.mobile_sync.set_fake_remote_size` and `debug.mobile_sync.clear_fake_remote_size`, plus an AppDelegate UI-test setup/diagnostics path and new unit/UI tests (including `MobileSizeOverlayUITests`) to validate overlay visibility/label and geometry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f539bef9b56d62bf34b442f70aff2b2dea12442. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->