### PR TITLE
Coalesce Ghostty title updates per runloop tick

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1411,6 +1411,68 @@ private final class GhosttySurfaceCallbackContext {
     }
 }
 
+/// Coalesces OSC 0/1/2 title-change callbacks into one main-thread notification
+/// post per surface per runloop tick. Ghostty fires SET_TITLE on the I/O thread
+/// once per escape sequence; a process emitting `\e]0;...\a` in a tight loop
+/// previously scheduled a `DispatchQueue.main.async` and a multi-observer
+/// NotificationCenter fan-out per call, saturating the main thread and starving
+/// scroll/render frames.
+private final class TitleNotificationCoalescer {
+    private struct Key: Hashable {
+        let tabId: UUID
+        let surfaceId: UUID
+    }
+
+    private struct Pending {
+        weak var surfaceView: GhosttyNSView?
+        var title: String
+    }
+
+    private let lock = NSLock()
+    private var pending: [Key: Pending] = [:]
+    private var drainScheduled = false
+
+    func record(tabId: UUID, surfaceId: UUID, title: String, surfaceView: GhosttyNSView) {
+        lock.lock()
+        pending[Key(tabId: tabId, surfaceId: surfaceId)] = Pending(
+            surfaceView: surfaceView,
+            title: title
+        )
+        let needsSchedule = !drainScheduled
+        if needsSchedule {
+            drainScheduled = true
+        }
+        lock.unlock()
+
+        if needsSchedule {
+            DispatchQueue.main.async { [weak self] in
+                self?.drain()
+            }
+        }
+    }
+
+    private func drain() {
+        lock.lock()
+        let drained = pending
+        pending.removeAll(keepingCapacity: true)
+        drainScheduled = false
+        lock.unlock()
+
+        for (key, entry) in drained {
+            guard let surfaceView = entry.surfaceView else { continue }
+            NotificationCenter.default.post(
+                name: .ghosttyDidSetTitle,
+                object: surfaceView,
+                userInfo: [
+                    GhosttyNotificationKey.tabId: key.tabId,
+                    GhosttyNotificationKey.surfaceId: key.surfaceId,
+                    GhosttyNotificationKey.title: entry.title,
+                ]
+            )
+        }
+    }
+}
+
 // Minimal Ghostty wrapper for terminal rendering
 // This uses libghostty (GhosttyKit.xcframework) for actual terminal emulation
 
@@ -1438,6 +1500,7 @@ class GhosttyApp {
     /// pending tick on the main queue at any time.
     private var _tickScheduled = false
     private let _tickLock = NSLock()
+    private let titleNotificationCoalescer = TitleNotificationCoalescer()
     private(set) var defaultBackgroundColor: NSColor = .windowBackgroundColor
     private(set) var defaultBackgroundOpacity: Double = 1.0
     private(set) var defaultBackgroundBlur: GhosttyBackgroundBlur = .disabled
@@ -3641,17 +3704,12 @@ class GhosttyApp {
                 .flatMap { String(cString: $0) } ?? ""
             if let tabId = surfaceView.tabId,
                let surfaceId = surfaceView.terminalSurface?.id {
-                DispatchQueue.main.async {
-                    NotificationCenter.default.post(
-                        name: .ghosttyDidSetTitle,
-                        object: surfaceView,
-                        userInfo: [
-                            GhosttyNotificationKey.tabId: tabId,
-                            GhosttyNotificationKey.surfaceId: surfaceId,
-                            GhosttyNotificationKey.title: title,
-                        ]
-                    )
-                }
+                titleNotificationCoalescer.record(
+                    tabId: tabId,
+                    surfaceId: surfaceId,
+                    title: title,
+                    surfaceView: surfaceView
+                )
             }
             return true
         case GHOSTTY_ACTION_PWD:

--- a/dogfood/repro-title-spam.sh
+++ b/dogfood/repro-title-spam.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# Repro: rapid OSC 0/2 title updates saturate the main thread and starve scroll.
+#
+# Run this inside a cmux DEV terminal pane, then try to scroll a large file in
+# another pane (e.g. `cat ~/some-large-log` in a split, then mouse-wheel through
+# its scrollback). On a build without coalescing, scroll is jerky while this
+# loop runs. With the fix, scroll stays smooth.
+#
+# Stops on Ctrl-C.
+
+set -u
+
+i=0
+while true; do
+  printf '\033]0;t-%d\a' "$i"
+  i=$((i + 1))
+done


### PR DESCRIPTION
## Summary
- A process emitting OSC 0/1/2 title escapes in a tight loop fired one `DispatchQueue.main.async` + NotificationCenter post per call. Three observers (TabManager, WindowToolbarController, ContentView) each scheduled further main-thread work on every post, saturating the main thread and starving Ghostty's render frames so terminal scroll became jerky.
- Move coalescing to the source: `TitleNotificationCoalescer` keeps the latest title per `(tabId, surfaceId)` under an `NSLock` and schedules at most one main-thread drain per runloop tick. Mirrors the existing `_tickScheduled` wakeup-coalescer pattern in `GhosttyApp` (which already does this for `wakeup_cb` for the same reason).
- Downstream observers and the 30Hz `panelTitleUpdateCoalescer` in `TabManager` are unchanged.

## Testing
- `./scripts/reload.sh --tag coal-title` builds clean (with `CMUX_SKIP_ZIG_BUILD=1` on macOS 26).
- Manual repro: run `dogfood/repro-title-spam.sh` in one pane and try to scroll a long file in another pane. Before: jerky. After: smooth.
- No automated regression test added — a meaningful test would be a perf benchmark on main-thread saturation, which is too flaky and environment-dependent. The repro script ships with the PR for manual verification.

## Related
- Task: Reproduce and fix laggy terminal scroll caused by rapid OSC 0/1/2 title escape sequences (no GitHub issue; reported in chat).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance change that alters timing of `ghosttyDidSetTitle` notifications (now batched per runloop tick), which could slightly delay or drop intermediate title updates under heavy spam.
> 
> **Overview**
> Reduces main-thread churn from rapid OSC title escape sequences by introducing a `TitleNotificationCoalescer` that batches `GHOSTTY_ACTION_SET_TITLE` events and posts at most one `ghosttyDidSetTitle` notification per `(tabId, surfaceId)` per runloop tick.
> 
> Adds a `dogfood/repro-title-spam.sh` script to manually reproduce and verify the scroll/render stutter caused by title-notification spam.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87bfa065849757c615cdeb2085a10e94dbdabf70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized terminal title notification handling by batching rapid consecutive title updates into single notifications per cycle, reducing overhead and improving performance.

* **Tests**
  * Added reproduction script to validate terminal behavior under high-frequency title update scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->