### PR TITLE
Fix multi-image terminal drops

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -20521,6 +20521,32 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 #endif
 }
 
+private enum CMUXCLIOutput {
+    static func writeStandardError(_ message: String) {
+        write(Data(message.utf8), to: STDERR_FILENO)
+    }
+
+    private static func write(_ data: Data, to fd: Int32) {
+        data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else {
+                return
+            }
+
+            var offset = 0
+            while offset < data.count {
+                let bytesWritten = Darwin.write(fd, baseAddress.advanced(by: offset), data.count - offset)
+                if bytesWritten > 0 {
+                    offset += bytesWritten
+                } else if bytesWritten == -1, errno == EINTR {
+                    continue
+                } else {
+                    return
+                }
+            }
+        }
+    }
+}
+
 @main
 struct CMUXTermMain {
     static func main() {
@@ -20530,7 +20556,7 @@ struct CMUXTermMain {
         do {
             try cli.run()
         } catch {
-            FileHandle.standardError.write(Data("Error: \(error)\n".utf8))
+            CMUXCLIOutput.writeStandardError("Error: \(error)\n")
             let exitCode = (error as? CLIError)?.exitCode ?? 1
             exit(exitCode)
         }

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -33,6 +33,7 @@
 		51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51D800000000000000000002 /* SidebarIdentifierFormattingTests.swift */; };
 		C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE35530000000000000102 /* BundledCLILinkageTests.swift */; };
 		C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */; };
+		C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
 		C0DEF0A10000000000000001 /* CmuxConfigUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A10000000000000002 /* CmuxConfigUI.swift */; };
 		C0DEF0A30000000000000001 /* SidebarPortDisplayText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */; };
@@ -814,6 +815,7 @@
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateIssue2907RoutingTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXOpenCommandTests.swift; sourceTree = "<group>"; };
+		C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIErrorOutputRegressionTests.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReviewFeedbackTests.swift; sourceTree = "<group>"; };
 		C0DEF0A10000000000000002 /* CmuxConfigUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxConfigUI.swift; sourceTree = "<group>"; };
 		C0DEF0A30000000000000002 /* SidebarPortDisplayText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarPortDisplayText.swift; sourceTree = "<group>"; };
@@ -1377,6 +1379,7 @@
 				A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */,
 				1A1B2C3D4E5F607180000004 /* WorkspacePromptSubmitTests.swift */,
 				C0DE31390000000000000102 /* CMUXOpenCommandTests.swift */,
+				C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 				BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */,
 				D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */,
 				2907A0042907A0042907A004 /* AppDelegateIssue2907RoutingTests.swift */,
@@ -2036,6 +2039,7 @@
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
 				1A1B2C3D4E5F607180000003 /* WorkspacePromptSubmitTests.swift in Sources */,
 				C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
+				C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 				D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */,
 				2907A0032907A0032907A003 /* AppDelegateIssue2907RoutingTests.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1538,6 +1538,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         CloudVMActionLauncher.shared.terminateAll()
         CmuxSSHURLProcessLauncher.shared.terminateAll()
         TerminalController.shared.stop()
+        GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
         if TelemetrySettings.enabledForCurrentLaunch {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9411,8 +9411,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) {
         case .insertText(let text):
             return .insertText(text)
-        case .insertTextSegments(let segments):
-            return .insertText(segments.joined())
         case .uploadFiles(let fileURLs, _):
             return .uploadFiles(fileURLs)
         case .reject:

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -708,13 +708,15 @@ enum GhosttyPasteboardHelper {
     private static func pasteboardFallbackImageRepresentations(
         for item: NSPasteboardItem
     ) -> [(data: Data, fileExtension: String)] {
+        guard let copiedItem = copiedPasteboardItem(from: item) else { return [] }
+
         let pasteboard = NSPasteboard(name: .init("cmux-single-image-item-\(UUID().uuidString)"))
         pasteboard.clearContents()
         defer {
             pasteboard.clearContents()
             pasteboard.releaseGlobally()
         }
-        guard pasteboard.writeObjects([item]) else { return [] }
+        guard pasteboard.writeObjects([copiedItem]) else { return [] }
 
         if let directImage = directImageRepresentation(in: pasteboard) {
             return [directImage]
@@ -727,6 +729,24 @@ enum GhosttyPasteboardHelper {
             return [fallbackImage]
         }
         return []
+    }
+
+    private static func copiedPasteboardItem(from item: NSPasteboardItem) -> NSPasteboardItem? {
+        let copiedItem = NSPasteboardItem()
+        var copiedAnyType = false
+
+        for type in item.types {
+            if let data = item.data(forType: type) {
+                copiedAnyType = copiedItem.setData(data, forType: type) || copiedAnyType
+                continue
+            }
+
+            if let string = item.string(forType: type) {
+                copiedAnyType = copiedItem.setString(string, forType: type) || copiedAnyType
+            }
+        }
+
+        return copiedAnyType ? copiedItem : nil
     }
 
     private static func imageRepresentations(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -801,21 +801,6 @@ enum GhosttyPasteboardHelper {
         return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
     }
 
-    static func isLocalImageFileURL(_ fileURL: URL) -> Bool {
-        localImageFileExtension(for: fileURL.standardizedFileURL) != nil
-    }
-
-    private static func localImageFileExtension(for fileURL: URL) -> String? {
-        guard let resourceValues = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
-              resourceValues.isRegularFile == true else { return nil }
-
-        let pathExtension = fileURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !pathExtension.isEmpty,
-              let type = UTType(filenameExtension: pathExtension),
-              type.conforms(to: .image) else { return nil }
-        return type.preferredFilenameExtension ?? nonEmpty(pathExtension)
-    }
-
     /// Attempts to materialize a decodable pasteboard image into a temporary file.
     /// `rejectedImagePayload` means a real image was found but could not be used,
     /// so callers should not fall back to auxiliary plain text or URLs.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -9416,6 +9416,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) {
         case .insertText(let text):
             return .insertText(text)
+        case .insertTextSegments(let segments, _):
+            return .insertText(segments.joined())
         case .uploadFiles(let fileURLs, _):
             return .uploadFiles(fileURLs)
         case .reject:
@@ -9598,7 +9600,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         case .fileURLs(let fileURLs):
             let plan = TerminalImageTransferPlanner.plan(
                 fileURLs: fileURLs,
-                target: resolvedImageTransferTarget()
+                target: resolvedImageTransferTarget(),
+                mode: .drop
             )
             return executeImageTransferPlan(plan, onCancel: onCancel)
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -299,6 +299,12 @@ enum GhosttyPasteboardHelper {
         case rejectedImagePayload
     }
 
+    enum ImageFileListMaterializationResult {
+        case saved([URL])
+        case noDecodableImagePayload
+        case rejectedImagePayload
+    }
+
     private static let selectionPasteboard = NSPasteboard(
         name: NSPasteboard.Name("com.mitchellh.ghostty.selection")
     )
@@ -493,20 +499,34 @@ enum GhosttyPasteboardHelper {
         )
     }
 
-    private static func rtfdAttachmentImageRepresentation(
-        in pasteboard: NSPasteboard
-    ) -> (data: Data, fileExtension: String)? {
-        guard let attributed = attributedString(
-            from: pasteboard,
-            type: .rtfd,
-            documentType: .rtfd
-        ) else { return nil }
+    private static func attributedString(
+        from item: NSPasteboardItem,
+        type: NSPasteboard.PasteboardType,
+        documentType: NSAttributedString.DocumentType
+    ) -> NSAttributedString? {
+        let data =
+            item.data(forType: type)
+            ?? item.string(forType: type)?.data(using: .utf8)
+        guard let data else { return nil }
 
-        var result: (data: Data, fileExtension: String)?
+        return try? NSAttributedString(
+            data: data,
+            options: [
+                .documentType: documentType,
+                .characterEncoding: String.Encoding.utf8.rawValue
+            ],
+            documentAttributes: nil
+        )
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        from attributed: NSAttributedString
+    ) -> [(data: Data, fileExtension: String)] {
+        var results: [(data: Data, fileExtension: String)] = []
         attributed.enumerateAttribute(
             .attachment,
             in: NSRange(location: 0, length: attributed.length)
-        ) { value, _, stop in
+        ) { value, _, _ in
             guard let attachment = value as? NSTextAttachment else { return }
 
             if let fileWrapper = attachment.fileWrapper,
@@ -515,12 +535,33 @@ enum GhosttyPasteboardHelper {
                 data: data,
                 preferredFilename: fileWrapper.preferredFilename
                ) {
-                result = imageRepresentation
-                stop.pointee = true
+                results.append(imageRepresentation)
             }
         }
 
-        return result
+        return results
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        in pasteboard: NSPasteboard
+    ) -> [(data: Data, fileExtension: String)] {
+        guard let attributed = attributedString(
+            from: pasteboard,
+            type: .rtfd,
+            documentType: .rtfd
+        ) else { return [] }
+        return rtfdAttachmentImageRepresentations(from: attributed)
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        in item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        guard let attributed = attributedString(
+            from: item,
+            type: .rtfd,
+            documentType: .rtfd
+        ) else { return [] }
+        return rtfdAttachmentImageRepresentations(from: attributed)
     }
 
     private static func imageAttachmentRepresentation(
@@ -533,6 +574,9 @@ enum GhosttyPasteboardHelper {
         if let type = !pathExtension.isEmpty ? UTType(filenameExtension: pathExtension) : nil,
            type.conforms(to: .image),
            let fileExtension = type.preferredFilenameExtension ?? nonEmpty(pathExtension) {
+            if isTIFFType(type) {
+                return normalizedPNGRepresentation(from: data)
+            }
             return (data, fileExtension)
         }
 
@@ -541,7 +585,36 @@ enum GhosttyPasteboardHelper {
               let type = UTType(typeIdentifier),
               type.conforms(to: .image),
               let fileExtension = type.preferredFilenameExtension else { return nil }
+        if isTIFFType(type) {
+            return normalizedPNGRepresentation(from: data)
+        }
         return (data, fileExtension)
+    }
+
+    private static func imageDataRepresentation(
+        data: Data,
+        type: NSPasteboard.PasteboardType
+    ) -> (data: Data, fileExtension: String)? {
+        guard let utType = UTType(type.rawValue),
+              utType.conforms(to: .image),
+              let fileExtension = utType.preferredFilenameExtension,
+              !fileExtension.isEmpty else { return nil }
+        if isTIFFType(utType) {
+            return normalizedPNGRepresentation(from: data)
+        }
+        return (data, fileExtension)
+    }
+
+    private static func isTIFFType(_ type: UTType) -> Bool {
+        type == .tiff || type.conforms(to: .tiff)
+    }
+
+    private static func normalizedPNGRepresentation(from data: Data) -> (data: Data, fileExtension: String)? {
+        guard let image = NSImage(data: data),
+              let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else { return nil }
+        return (pngData, "png")
     }
 
     private static func nonEmpty(_ value: String) -> String? {
@@ -570,16 +643,177 @@ enum GhosttyPasteboardHelper {
 
         for type in pasteboard.types ?? [] {
             guard type != .png,
-                  type != .tiff,
-                  let utType = UTType(type.rawValue),
-                  utType.conforms(to: .image),
                   let imageData = pasteboard.data(forType: type),
-                  let fileExtension = utType.preferredFilenameExtension,
-                  !fileExtension.isEmpty else { continue }
-            return (imageData, fileExtension)
+                  let representation = imageDataRepresentation(data: imageData, type: type) else { continue }
+            return representation
         }
 
         return nil
+    }
+
+    private static func directImageRepresentation(
+        in item: NSPasteboardItem
+    ) -> (data: Data, fileExtension: String)? {
+        if let pngData = item.data(forType: .png) {
+            return (pngData, "png")
+        }
+
+        for type in item.types {
+            guard type != .png,
+                  let imageData = item.data(forType: type),
+                  let representation = imageDataRepresentation(data: imageData, type: type) else { continue }
+            return representation
+        }
+
+        return nil
+    }
+
+    private static func fallbackImageRepresentation(
+        in item: NSPasteboardItem
+    ) -> (data: Data, fileExtension: String)? {
+        for type in item.types {
+            guard let utType = UTType(type.rawValue),
+                  utType.conforms(to: .image),
+                  let data = item.data(forType: type),
+                  let normalized = normalizedPNGRepresentation(from: data) else { continue }
+            return normalized
+        }
+        return nil
+    }
+
+    private static func fallbackImageRepresentation(
+        in pasteboard: NSPasteboard
+    ) -> (data: Data, fileExtension: String)? {
+        guard hasImageData(in: pasteboard),
+              let tiffData = NSImage(pasteboard: pasteboard)?.tiffRepresentation else { return nil }
+        return normalizedPNGRepresentation(from: tiffData)
+    }
+
+    private static func imageRepresentations(
+        in item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        if let directImage = directImageRepresentation(in: item) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: item)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: item) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func pasteboardFallbackImageRepresentations(
+        for item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        let pasteboard = NSPasteboard(name: .init("cmux-single-image-item-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        defer {
+            pasteboard.clearContents()
+            pasteboard.releaseGlobally()
+        }
+        guard pasteboard.writeObjects([item]) else { return [] }
+
+        if let directImage = directImageRepresentation(in: pasteboard) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: pasteboard)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: pasteboard) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func imageRepresentations(
+        in pasteboard: NSPasteboard
+    ) -> [(data: Data, fileExtension: String)] {
+        let itemRepresentations = (pasteboard.pasteboardItems ?? [])
+            .flatMap { item in
+                let representations = imageRepresentations(in: item)
+                if !representations.isEmpty {
+                    return representations
+                }
+                return pasteboardFallbackImageRepresentations(for: item)
+            }
+        if !itemRepresentations.isEmpty {
+            return itemRepresentations
+        }
+        if let directImage = directImageRepresentation(in: pasteboard) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: pasteboard)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: pasteboard) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func materializeImageFileURLs(
+        from representations: [(data: Data, fileExtension: String)]
+    ) -> ImageFileListMaterializationResult {
+        guard !representations.isEmpty else { return .noDecodableImagePayload }
+
+        let maxClipboardImageSize = 10 * 1024 * 1024  // 10 MB
+        var fileURLs: [URL] = []
+        for representation in representations {
+            guard representation.data.count <= maxClipboardImageSize else {
+#if DEBUG
+                cmuxDebugLog("terminal.paste.image.rejected reason=tooLarge bytes=\(representation.data.count)")
+#endif
+                cleanupTransferredTemporaryImageFiles(fileURLs)
+                return .rejectedImagePayload
+            }
+
+            let fileURL = temporaryImageFileURL(fileExtension: representation.fileExtension)
+
+            do {
+                try representation.data.write(to: fileURL)
+            } catch {
+#if DEBUG
+                cmuxDebugLog("terminal.paste.image.writeFailed error=\(error.localizedDescription)")
+#endif
+                try? FileManager.default.removeItem(at: fileURL)
+                cleanupTransferredTemporaryImageFiles(fileURLs)
+                return .rejectedImagePayload
+            }
+
+            registerOwnedTemporaryImageFile(fileURL)
+            fileURLs.append(fileURL)
+        }
+
+        return .saved(fileURLs)
+    }
+
+    private static func temporaryImageFileURL(fileExtension: String) -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let timestamp = formatter.string(from: Date())
+        let filename = "\(temporaryImageFilenamePrefix)\(timestamp)-\(UUID().uuidString.prefix(8)).\(fileExtension)"
+        return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    }
+
+    static func isLocalImageFileURL(_ fileURL: URL) -> Bool {
+        localImageFileExtension(for: fileURL.standardizedFileURL) != nil
+    }
+
+    private static func localImageFileExtension(for fileURL: URL) -> String? {
+        guard let resourceValues = try? fileURL.resourceValues(forKeys: [.isRegularFileKey]),
+              resourceValues.isRegularFile == true else { return nil }
+
+        let pathExtension = fileURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pathExtension.isEmpty,
+              let type = UTType(filenameExtension: pathExtension),
+              type.conforms(to: .image) else { return nil }
+        return type.preferredFilenameExtension ?? nonEmpty(pathExtension)
     }
 
     /// Attempts to materialize a decodable pasteboard image into a temporary file.
@@ -588,52 +822,34 @@ enum GhosttyPasteboardHelper {
     static func materializeImageFileURLIfNeeded(
         from pasteboard: NSPasteboard = .general
     ) -> ImageFileMaterializationResult {
-        let imageData: Data
-        let fileExtension: String
-        if let directImage = directImageRepresentation(in: pasteboard) {
-            imageData = directImage.data
-            fileExtension = directImage.fileExtension
-        } else if let rtfdAttachment = rtfdAttachmentImageRepresentation(in: pasteboard) {
-            imageData = rtfdAttachment.data
-            fileExtension = rtfdAttachment.fileExtension
-        } else {
-            guard hasImageData(in: pasteboard),
-                  let image = NSImage(pasteboard: pasteboard),
-                  let tiffData = image.tiffRepresentation,
-                  let bitmap = NSBitmapImageRep(data: tiffData),
-                  let pngData = bitmap.representation(using: .png, properties: [:]) else {
-                return .noDecodableImagePayload
-            }
-            imageData = pngData
-            fileExtension = "png"
-        }
-
-        let maxClipboardImageSize = 10 * 1024 * 1024  // 10 MB
-        guard imageData.count <= maxClipboardImageSize else {
-#if DEBUG
-            cmuxDebugLog("terminal.paste.image.rejected reason=tooLarge bytes=\(imageData.count)")
-#endif
+        let representations = Array(imageRepresentations(in: pasteboard).prefix(1))
+        switch materializeImageFileURLs(from: representations) {
+        case .saved(let fileURLs):
+            guard let fileURL = fileURLs.first else { return .noDecodableImagePayload }
+            return .saved(fileURL)
+        case .noDecodableImagePayload:
+            return .noDecodableImagePayload
+        case .rejectedImagePayload:
             return .rejectedImagePayload
         }
+    }
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        let timestamp = formatter.string(from: Date())
-        let filename = "\(temporaryImageFilenamePrefix)\(timestamp)-\(UUID().uuidString.prefix(8)).\(fileExtension)"
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    static func materializeImageFileURLsIfNeeded(
+        from pasteboard: NSPasteboard = .general
+    ) -> ImageFileListMaterializationResult {
+        materializeImageFileURLs(from: imageRepresentations(in: pasteboard))
+    }
 
-        do {
-            try imageData.write(to: fileURL)
-        } catch {
-#if DEBUG
-            cmuxDebugLog("terminal.paste.image.writeFailed error=\(error.localizedDescription)")
-#endif
-            return .rejectedImagePayload
+    static func saveImageFileURLsIfNeeded(
+        from pasteboard: NSPasteboard = .general,
+        assumeNoText: Bool = false
+    ) -> [URL] {
+        if !assumeNoText && stringContents(from: pasteboard) != nil { return [] }
+
+        guard case .saved(let fileURLs) = materializeImageFileURLsIfNeeded(from: pasteboard) else {
+            return []
         }
-
-        registerOwnedTemporaryImageFile(fileURL)
-        return .saved(fileURL)
+        return fileURLs
     }
 
     /// When the clipboard contains only image data (or rich text that resolves to
@@ -670,6 +886,17 @@ enum GhosttyPasteboardHelper {
                 continue
             }
             try? FileManager.default.removeItem(at: normalizedURL)
+        }
+    }
+
+    static func cleanupAllOwnedTemporaryImageFiles() {
+        temporaryImageOwnershipLock.lock()
+        let paths = ownedTemporaryImagePaths
+        ownedTemporaryImagePaths.removeAll()
+        temporaryImageOwnershipLock.unlock()
+
+        for path in paths {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
         }
     }
 
@@ -9184,6 +9411,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         ) {
         case .insertText(let text):
             return .insertText(text)
+        case .insertTextSegments(let segments):
+            return .insertText(segments.joined())
         case .uploadFiles(let fileURLs, _):
             return .uploadFiles(fileURLs)
         case .reject:
@@ -9373,15 +9602,44 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
 #if DEBUG
+    fileprivate enum DebugDropPayloadKind {
+        case fileURLs
+        case imageData
+    }
+
     @discardableResult
-    fileprivate func debugSimulateFileDrop(paths: [String]) -> Bool {
+    fileprivate func debugSimulateFileDrop(
+        paths: [String],
+        asImageData: Bool = false
+    ) -> Bool {
         guard !paths.isEmpty else { return false }
-        let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
         let pbName = NSPasteboard.Name("cmux.debug.drop.\(UUID().uuidString)")
         let pasteboard = NSPasteboard(name: pbName)
         pasteboard.clearContents()
-        pasteboard.writeObjects(urls)
+        switch asImageData ? DebugDropPayloadKind.imageData : .fileURLs {
+        case .fileURLs:
+            let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
+            pasteboard.writeObjects(urls)
+        case .imageData:
+            let items = paths.compactMap { path -> NSPasteboardItem? in
+                let url = URL(fileURLWithPath: path)
+                guard let data = try? Data(contentsOf: url),
+                      let type = debugImagePasteboardType(for: url) else { return nil }
+                let item = NSPasteboardItem()
+                item.setData(data, forType: type)
+                return item
+            }
+            guard items.count == paths.count else { return false }
+            pasteboard.writeObjects(items)
+        }
         return insertDroppedPasteboard(pasteboard)
+    }
+
+    private func debugImagePasteboardType(for url: URL) -> NSPasteboard.PasteboardType? {
+        let pathExtension = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let utType = UTType(filenameExtension: pathExtension),
+              utType.conforms(to: .image) else { return nil }
+        return NSPasteboard.PasteboardType(utType.identifier)
     }
 
     fileprivate func debugRegisteredDropTypes() -> [String] {
@@ -11248,8 +11506,8 @@ final class GhosttySurfaceScrollView: NSView {
 
 #if DEBUG
     @discardableResult
-    func debugSimulateFileDrop(paths: [String]) -> Bool {
-        surfaceView.debugSimulateFileDrop(paths: paths)
+    func debugSimulateFileDrop(paths: [String], asImageData: Bool = false) -> Bool {
+        surfaceView.debugSimulateFileDrop(paths: paths, asImageData: asImageData)
     }
 
     func debugPendingSurfaceSize() -> CGSize? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12433,6 +12433,10 @@ class TerminalController {
             case terminal
             case textDestination
         }
+        enum TerminalFileDropSimulationPayload {
+            case fileURLs
+            case imageData
+        }
         let simulationRoute: TerminalFileDropSimulationRoute
         switch route {
         case "terminal", "direct":
@@ -12442,6 +12446,20 @@ class TerminalController {
         default:
             return .err(code: "invalid_params", message: "Unknown route", data: [
                 "route": route
+            ])
+        }
+        let payload = (v2String(params, "payload") ?? "file_urls")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let simulationPayload: TerminalFileDropSimulationPayload
+        switch payload {
+        case "file", "files", "file_url", "file_urls":
+            simulationPayload = .fileURLs
+        case "image", "image_data", "images":
+            simulationPayload = .imageData
+        default:
+            return .err(code: "invalid_params", message: "Unknown payload", data: [
+                "payload": payload
             ])
         }
 
@@ -12455,11 +12473,21 @@ class TerminalController {
 
             switch simulationRoute {
             case .terminal:
-                let handled = panel.hostedView.debugSimulateFileDrop(paths: paths)
+                let handled = panel.hostedView.debugSimulateFileDrop(
+                    paths: paths,
+                    asImageData: simulationPayload == .imageData
+                )
                 result = handled
-                    ? .ok(["handled": true, "route": "terminal"])
+                    ? .ok(["handled": true, "route": "terminal", "payload": payload])
                     : .err(code: "internal_error", message: "Terminal drop simulation failed", data: nil)
             case .textDestination:
+                guard simulationPayload == .fileURLs else {
+                    result = .err(code: "invalid_params", message: "Image data payload requires terminal route", data: [
+                        "route": route,
+                        "payload": payload
+                    ])
+                    return
+                }
                 guard let workspace = tabManager.tabs.first(where: { $0.id == panel.workspaceId }) else {
                     result = .err(code: "not_found", message: "Workspace not found", data: [
                         "workspace_id": panel.workspaceId.uuidString
@@ -12475,7 +12503,7 @@ class TerminalController {
                     window: panel.hostedView.window
                 )
                 result = handled
-                    ? .ok(["handled": true, "route": "text_destination"])
+                    ? .ok(["handled": true, "route": "text_destination", "payload": payload])
                     : .err(code: "internal_error", message: "Text destination drop simulation failed", data: nil)
             }
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -18,7 +18,6 @@ enum TerminalImageTransferTarget: Equatable {
 
 enum TerminalImageTransferPlan: Equatable {
     case insertText(String)
-    case insertTextSegments([String])
     case uploadFiles([URL], TerminalRemoteUploadTarget)
     case reject
 }
@@ -212,9 +211,6 @@ enum TerminalImageTransferPlanner {
 
         switch target {
         case .local:
-            if fileURLs.allSatisfy(isLocalImageFileURL) {
-                return .insertTextSegments(insertedTextSegments(forFileURLs: fileURLs))
-            }
             return .insertText(insertedText(forFileURLs: fileURLs))
         case .remote(let remoteTarget):
             guard fileURLs.allSatisfy(isRemoteUploadableFileURL) else {
@@ -259,14 +255,6 @@ enum TerminalImageTransferPlanner {
             }
             insertText(text)
             return operation
-        case .insertTextSegments(let segments):
-            if let operation, !operation.finish() {
-                return operation
-            }
-            for segment in segments where !segment.isEmpty {
-                insertText(segment)
-            }
-            return operation
         case .uploadFiles(let fileURLs, .workspaceRemote):
             let operation = operation ?? TerminalImageTransferOperation()
             uploadWorkspaceRemote(fileURLs, operation) { result in
@@ -298,16 +286,6 @@ enum TerminalImageTransferPlanner {
 
     static func insertedText(forFileURLs fileURLs: [URL]) -> String {
         insertedText(forPathStrings: fileURLs.map(\.path))
-    }
-
-    private static func insertedTextSegments(forFileURLs fileURLs: [URL]) -> [String] {
-        fileURLs
-            .map(\.path)
-            .map(escapeForShell)
-            .enumerated()
-            .map { index, text in
-                index == 0 ? text : " " + text
-            }
     }
 
     private static func isLocalImageFileURL(_ fileURL: URL) -> Bool {

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AppKit
+import UniformTypeIdentifiers
 
 enum TerminalImageTransferMode {
     case paste
@@ -18,6 +19,7 @@ enum TerminalImageTransferTarget: Equatable {
 
 enum TerminalImageTransferPlan: Equatable {
     case insertText(String)
+    case insertTextSegments([String], interSegmentDelay: TimeInterval)
     case uploadFiles([URL], TerminalRemoteUploadTarget)
     case reject
 }
@@ -162,7 +164,8 @@ enum TerminalImageTransferPlanner {
     ) -> TerminalImageTransferPlan {
         plan(
             preparedContent: prepare(pasteboard: pasteboard, mode: mode),
-            target: target
+            target: target,
+            mode: mode
         )
     }
 
@@ -174,9 +177,9 @@ enum TerminalImageTransferPlanner {
         let preparedContent = prepare(pasteboard: pasteboard, mode: mode)
         switch preparedContent {
         case .insertText, .reject:
-            return plan(preparedContent: preparedContent, target: .local)
+            return plan(preparedContent: preparedContent, target: .local, mode: mode)
         case .fileURLs:
-            return plan(preparedContent: preparedContent, target: resolveTarget())
+            return plan(preparedContent: preparedContent, target: resolveTarget(), mode: mode)
         }
     }
 
@@ -194,23 +197,36 @@ enum TerminalImageTransferPlanner {
 
     static func plan(
         preparedContent: TerminalImageTransferPreparedContent,
-        target: TerminalImageTransferTarget
+        target: TerminalImageTransferTarget,
+        mode: TerminalImageTransferMode = .paste
     ) -> TerminalImageTransferPlan {
         switch preparedContent {
         case .insertText(let text):
             return .insertText(text)
         case .fileURLs(let fileURLs):
-            return plan(fileURLs: fileURLs, target: target)
+            return plan(fileURLs: fileURLs, target: target, mode: mode)
         case .reject:
             return .reject
         }
     }
 
-    static func plan(fileURLs: [URL], target: TerminalImageTransferTarget) -> TerminalImageTransferPlan {
+    static func plan(
+        fileURLs: [URL],
+        target: TerminalImageTransferTarget,
+        mode: TerminalImageTransferMode = .paste
+    ) -> TerminalImageTransferPlan {
         guard !fileURLs.isEmpty else { return .reject }
 
         switch target {
         case .local:
+            if mode == .drop,
+               fileURLs.count > 1,
+               fileURLs.allSatisfy(isLocalImageFileURL) {
+                return .insertTextSegments(
+                    insertedTextSegments(forFileURLs: fileURLs),
+                    interSegmentDelay: 2.0
+                )
+            }
             return .insertText(insertedText(forFileURLs: fileURLs))
         case .remote(let remoteTarget):
             guard fileURLs.allSatisfy(isRemoteUploadableFileURL) else {
@@ -227,6 +243,9 @@ enum TerminalImageTransferPlanner {
         uploadWorkspaceRemote: ([URL], TerminalImageTransferOperation, @escaping (Result<[String], Error>) -> Void) -> Void,
         uploadDetectedSSH: (DetectedSSHSession, [URL], TerminalImageTransferOperation, @escaping (Result<[String], Error>) -> Void) -> Void,
         insertText: @escaping (String) -> Void,
+        scheduleAfter: @escaping (TimeInterval, @escaping () -> Void) -> Void = { delay, work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        },
         onFailure: @escaping (Error) -> Void
     ) -> TerminalImageTransferOperation? {
         execute(
@@ -235,6 +254,7 @@ enum TerminalImageTransferPlanner {
             uploadWorkspaceRemote: uploadWorkspaceRemote,
             uploadDetectedSSH: uploadDetectedSSH,
             insertText: insertText,
+            scheduleAfter: scheduleAfter,
             onFailure: onFailure
         )
     }
@@ -246,6 +266,9 @@ enum TerminalImageTransferPlanner {
         uploadWorkspaceRemote: ([URL], TerminalImageTransferOperation, @escaping (Result<[String], Error>) -> Void) -> Void,
         uploadDetectedSSH: (DetectedSSHSession, [URL], TerminalImageTransferOperation, @escaping (Result<[String], Error>) -> Void) -> Void,
         insertText: @escaping (String) -> Void,
+        scheduleAfter: @escaping (TimeInterval, @escaping () -> Void) -> Void = { delay, work in
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        },
         onFailure: @escaping (Error) -> Void
     ) -> TerminalImageTransferOperation? {
         switch plan {
@@ -254,6 +277,17 @@ enum TerminalImageTransferPlanner {
                 return operation
             }
             insertText(text)
+            return operation
+        case .insertTextSegments(let segments, let interSegmentDelay):
+            let operation = operation ?? TerminalImageTransferOperation()
+            sendTextSegments(
+                segments,
+                index: 0,
+                interSegmentDelay: interSegmentDelay,
+                operation: operation,
+                insertText: insertText,
+                scheduleAfter: scheduleAfter
+            )
             return operation
         case .uploadFiles(let fileURLs, .workspaceRemote):
             let operation = operation ?? TerminalImageTransferOperation()
@@ -286,6 +320,33 @@ enum TerminalImageTransferPlanner {
 
     static func insertedText(forFileURLs fileURLs: [URL]) -> String {
         insertedText(forPathStrings: fileURLs.map(\.path))
+    }
+
+    private static func insertedTextSegments(forFileURLs fileURLs: [URL]) -> [String] {
+        fileURLs
+            .map(\.path)
+            .map(escapeForShell)
+            .enumerated()
+            .map { index, text in
+                index == 0 ? text : " " + text
+            }
+    }
+
+    private static func isLocalImageFileURL(_ fileURL: URL) -> Bool {
+        let normalizedFileURL = fileURL.standardizedFileURL
+        guard normalizedFileURL.isFileURL,
+              let resourceValues = try? normalizedFileURL.resourceValues(forKeys: [.isRegularFileKey]),
+              resourceValues.isRegularFile == true else {
+            return false
+        }
+
+        let pathExtension = normalizedFileURL.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !pathExtension.isEmpty,
+              let type = UTType(filenameExtension: pathExtension),
+              type.conforms(to: .image) else {
+            return false
+        }
+        return true
     }
 
     private static func isRemoteUploadableFileURL(_ fileURL: URL) -> Bool {
@@ -379,6 +440,43 @@ enum TerminalImageTransferPlanner {
             insertText(content)
         case .failure(let error):
             onFailure(error)
+        }
+    }
+
+    private static func sendTextSegments(
+        _ segments: [String],
+        index: Int,
+        interSegmentDelay: TimeInterval,
+        operation: TerminalImageTransferOperation,
+        insertText: @escaping (String) -> Void,
+        scheduleAfter: @escaping (TimeInterval, @escaping () -> Void) -> Void
+    ) {
+        guard !operation.isCancelled else { return }
+        guard index < segments.count else {
+            _ = operation.finish()
+            return
+        }
+
+        let segment = segments[index]
+        if !segment.isEmpty {
+            insertText(segment)
+        }
+
+        let nextIndex = index + 1
+        guard nextIndex < segments.count else {
+            _ = operation.finish()
+            return
+        }
+
+        scheduleAfter(interSegmentDelay) {
+            sendTextSegments(
+                segments,
+                index: nextIndex,
+                interSegmentDelay: interSegmentDelay,
+                operation: operation,
+                insertText: insertText,
+                scheduleAfter: scheduleAfter
+            )
         }
     }
 }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -18,6 +18,7 @@ enum TerminalImageTransferTarget: Equatable {
 
 enum TerminalImageTransferPlan: Equatable {
     case insertText(String)
+    case insertTextSegments([String])
     case uploadFiles([URL], TerminalRemoteUploadTarget)
     case reject
 }
@@ -211,6 +212,9 @@ enum TerminalImageTransferPlanner {
 
         switch target {
         case .local:
+            if fileURLs.allSatisfy(isLocalImageFileURL) {
+                return .insertTextSegments(insertedTextSegments(forFileURLs: fileURLs))
+            }
             return .insertText(insertedText(forFileURLs: fileURLs))
         case .remote(let remoteTarget):
             guard fileURLs.allSatisfy(isRemoteUploadableFileURL) else {
@@ -255,6 +259,14 @@ enum TerminalImageTransferPlanner {
             }
             insertText(text)
             return operation
+        case .insertTextSegments(let segments):
+            if let operation, !operation.finish() {
+                return operation
+            }
+            for segment in segments where !segment.isEmpty {
+                insertText(segment)
+            }
+            return operation
         case .uploadFiles(let fileURLs, .workspaceRemote):
             let operation = operation ?? TerminalImageTransferOperation()
             uploadWorkspaceRemote(fileURLs, operation) { result in
@@ -286,6 +298,20 @@ enum TerminalImageTransferPlanner {
 
     static func insertedText(forFileURLs fileURLs: [URL]) -> String {
         insertedText(forPathStrings: fileURLs.map(\.path))
+    }
+
+    private static func insertedTextSegments(forFileURLs fileURLs: [URL]) -> [String] {
+        fileURLs
+            .map(\.path)
+            .map(escapeForShell)
+            .enumerated()
+            .map { index, text in
+                index == 0 ? text : " " + text
+            }
+    }
+
+    private static func isLocalImageFileURL(_ fileURL: URL) -> Bool {
+        GhosttyPasteboardHelper.isLocalImageFileURL(fileURL)
     }
 
     private static func isRemoteUploadableFileURL(_ fileURL: URL) -> Bool {
@@ -355,10 +381,7 @@ enum TerminalImageTransferPlanner {
         if !urls.isEmpty {
             return urls
         }
-        if let imageURL = GhosttyPasteboardHelper.saveImageFileURLIfNeeded(from: pasteboard, assumeNoText: true) {
-            return [imageURL]
-        }
-        return []
+        return GhosttyPasteboardHelper.saveImageFileURLsIfNeeded(from: pasteboard, assumeNoText: true)
     }
 
     private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -288,10 +288,6 @@ enum TerminalImageTransferPlanner {
         insertedText(forPathStrings: fileURLs.map(\.path))
     }
 
-    private static func isLocalImageFileURL(_ fileURL: URL) -> Bool {
-        GhosttyPasteboardHelper.isLocalImageFileURL(fileURL)
-    }
-
     private static func isRemoteUploadableFileURL(_ fileURL: URL) -> Bool {
         let normalizedFileURL = fileURL.standardizedFileURL
         guard normalizedFileURL.isFileURL,

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1,0 +1,78 @@
+import XCTest
+
+final class CMUXCLIErrorOutputRegressionTests: XCTestCase {
+    private struct ProcessRunResult {
+        let status: Int32
+        let stdout: String
+        let timedOut: Bool
+    }
+
+    func testCLIErrorPathDoesNotCrashWhenStderrIsClosed() throws {
+        let cliPath = try bundledCLIPath()
+        let result = runShell(
+            "CMUX_CLI_SENTRY_DISABLED=1 \(shellSingleQuote(cliPath)) definitely-not-a-command 2>&-",
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertEqual(result.status, 1, result.stdout)
+        XCTAssertTrue(result.stdout.contains("Usage:"), result.stdout)
+    }
+
+    private func bundledCLIPath() throws -> String {
+        let fileManager = FileManager.default
+        let appBundleURL = Bundle(for: Self.self)
+            .bundleURL
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let enumerator = fileManager.enumerator(at: appBundleURL, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles])
+
+        while let item = enumerator?.nextObject() as? URL {
+            guard item.lastPathComponent == "cmux",
+                  item.path.contains(".app/Contents/Resources/bin/cmux") else {
+                continue
+            }
+            return item.path
+        }
+
+        throw XCTSkip("Bundled cmux CLI not found in \(appBundleURL.path)")
+    }
+
+    private func shellSingleQuote(_ value: String) -> String {
+        "'\(value.replacingOccurrences(of: "'", with: "'\"'\"'"))'"
+    }
+
+    private func runShell(_ command: String, timeout: TimeInterval) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            _ = exitSignal.wait(timeout: .now() + 1)
+        }
+
+        return ProcessRunResult(
+            status: process.terminationStatus,
+            stdout: String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? "",
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -20,6 +20,15 @@ final class FinderFileDropRegressionTests: XCTestCase {
         return try XCTUnwrap(bitmap.representation(using: .png, properties: [:]))
     }
 
+    private func make1x1TIFF(color: NSColor) throws -> Data {
+        let image = NSImage(size: NSSize(width: 1, height: 1))
+        image.lockFocus()
+        color.setFill()
+        NSRect(x: 0, y: 0, width: 1, height: 1).fill()
+        image.unlockFocus()
+        return try XCTUnwrap(image.tiffRepresentation)
+    }
+
     func testOverlayCapturesFileURLDropsIncludingLocalPaneDrags() {
         XCTAssertTrue(
             DragOverlayRoutingPolicy.shouldCaptureFileDropDestination(
@@ -177,8 +186,8 @@ final class FinderFileDropRegressionTests: XCTestCase {
     func testLegacyFinderFilenameDropPlanInsertsEscapedLocalPath() throws {
         let fileURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("finder legacy \(UUID().uuidString)")
-            .appendingPathExtension("png")
-        try make1x1PNG(color: .systemBlue).write(to: fileURL)
+            .appendingPathExtension("txt")
+        try "plain text".write(to: fileURL, atomically: true, encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: fileURL) }
 
         let pasteboard = NSPasteboard(name: .init("cmux-test-legacy-filename-drop-\(UUID().uuidString)"))
@@ -198,6 +207,186 @@ final class FinderFileDropRegressionTests: XCTestCase {
         }
 
         XCTAssertEqual(text, TerminalImageTransferPlanner.escapeForShell(fileURL.path))
+    }
+
+    func testImageFileURLDropInsertsOriginalLocalImagePaths() throws {
+        let imageDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux image file drop \(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: imageDirectory) }
+
+        let firstURL = imageDirectory.appendingPathComponent("cmux ssh 2.png")
+        let secondURL = imageDirectory.appendingPathComponent("cmux ssh.png")
+        try make1x1PNG(color: .systemRed).write(to: firstURL)
+        try make1x1PNG(color: .systemGreen).write(to: secondURL)
+
+        let pasteboard = NSPasteboard(name: .init("cmux-test-image-file-url-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([firstURL as NSURL, secondURL as NSURL]))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: false
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected original local image path insertion, got \(plan)")
+        }
+
+        XCTAssertEqual(
+            text,
+            [firstURL, secondURL]
+                .map(\.path)
+                .map(TerminalImageTransferPlanner.escapeForShell)
+                .joined(separator: " ")
+        )
+        XCTAssertFalse(text.contains("/clipboard-"))
+    }
+
+    func testImageFileURLDropUploadsOriginalFilesForRemoteTerminal() throws {
+        let imageDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux remote image file drop \(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: imageDirectory) }
+
+        let firstURL = imageDirectory.appendingPathComponent("cmux ssh 2.png")
+        let secondURL = imageDirectory.appendingPathComponent("cmux ssh.png")
+        try make1x1PNG(color: .systemRed).write(to: firstURL)
+        try make1x1PNG(color: .systemGreen).write(to: secondURL)
+
+        let pasteboard = NSPasteboard(name: .init("cmux-test-remote-image-file-url-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([firstURL as NSURL, secondURL as NSURL]))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: true
+        )
+
+        guard case .uploadFiles(let urls) = plan else {
+            return XCTFail("expected remote upload plan, got \(plan)")
+        }
+
+        XCTAssertEqual(urls, [firstURL.standardizedFileURL, secondURL.standardizedFileURL])
+    }
+
+    func testImagePasteboardDropMaterializesEveryImageForLocalInsertion() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-multi-image-local-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let items = try [
+            makeImagePasteboardItem(color: .systemRed),
+            makeImagePasteboardItem(color: .systemGreen),
+        ]
+        XCTAssertTrue(pasteboard.writeObjects(items))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: false
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected local image path insertion, got \(plan)")
+        }
+
+        let paths = text
+            .split(separator: " ")
+            .map(String.init)
+        defer {
+            GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles(
+                paths.map { URL(fileURLWithPath: $0) }
+            )
+        }
+
+        XCTAssertEqual(paths.count, 2)
+        XCTAssertTrue(paths.allSatisfy { $0.contains("/clipboard-") && $0.hasSuffix(".png") })
+        XCTAssertTrue(paths.allSatisfy { FileManager.default.fileExists(atPath: $0) })
+    }
+
+    func testImagePasteboardItemWithDirectImageAndRTFDAttachmentMaterializesOnce() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-image-rtfd-duplicate-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        XCTAssertTrue(pasteboard.writeObjects([try makeImagePasteboardItemWithRTFDAttachment(color: .systemRed)]))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: false
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected local image path insertion, got \(plan)")
+        }
+
+        let paths = text
+            .split(separator: " ")
+            .map(String.init)
+        defer {
+            GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles(
+                paths.map { URL(fileURLWithPath: $0) }
+            )
+        }
+
+        XCTAssertEqual(paths.count, 1)
+        XCTAssertTrue(paths.allSatisfy { $0.contains("/clipboard-") && $0.hasSuffix(".png") })
+        XCTAssertTrue(paths.allSatisfy { FileManager.default.fileExists(atPath: $0) })
+    }
+
+    func testImagePasteboardItemTIFFDropNormalizesToPNGForLocalInsertion() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-image-tiff-normalization-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let item = NSPasteboardItem()
+        item.setData(try make1x1TIFF(color: .systemBlue), forType: .tiff)
+        XCTAssertTrue(pasteboard.writeObjects([item]))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: false
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected local image path insertion, got \(plan)")
+        }
+
+        let paths = text
+            .split(separator: " ")
+            .map(String.init)
+        defer {
+            GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles(
+                paths.map { URL(fileURLWithPath: $0) }
+            )
+        }
+
+        XCTAssertEqual(paths.count, 1)
+        XCTAssertTrue(paths[0].contains("/clipboard-"))
+        XCTAssertEqual(URL(fileURLWithPath: paths[0]).pathExtension, "png")
+        let pngSignature = Data([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A])
+        let materializedData = try Data(contentsOf: URL(fileURLWithPath: paths[0]))
+        XCTAssertEqual(Data(materializedData.prefix(pngSignature.count)), pngSignature)
+    }
+
+    func testImagePasteboardDropMaterializesEveryImageForRemoteUpload() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-multi-image-remote-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let items = try [
+            makeImagePasteboardItem(color: .systemRed),
+            makeImagePasteboardItem(color: .systemGreen),
+        ]
+        XCTAssertTrue(pasteboard.writeObjects(items))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: true
+        )
+
+        guard case .uploadFiles(let urls) = plan else {
+            return XCTFail("expected remote image upload plan, got \(plan)")
+        }
+        defer {
+            GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles(urls)
+        }
+
+        XCTAssertEqual(urls.count, 2)
+        XCTAssertTrue(urls.allSatisfy { $0.lastPathComponent.hasPrefix("clipboard-") && $0.pathExtension == "png" })
+        XCTAssertTrue(urls.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
     }
 
     func testFileExplorerPathInsertionEscapesMultiplePathsLikeTerminalDrop() {
@@ -403,5 +592,28 @@ final class FinderFileDropRegressionTests: XCTestCase {
             ),
             "Sources/App.swift"
         )
+    }
+
+    private func makeImagePasteboardItem(color: NSColor) throws -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setData(try make1x1PNG(color: color), forType: .png)
+        return item
+    }
+
+    private func makeImagePasteboardItemWithRTFDAttachment(color: NSColor) throws -> NSPasteboardItem {
+        let imageData = try make1x1PNG(color: color)
+        let wrapper = FileWrapper(regularFileWithContents: imageData)
+        wrapper.preferredFilename = "image.png"
+        let attachment = NSTextAttachment(fileWrapper: wrapper)
+        let attributed = NSAttributedString(attachment: attachment)
+        let rtfdData = try attributed.data(
+            from: NSRange(location: 0, length: attributed.length),
+            documentAttributes: [.documentType: NSAttributedString.DocumentType.rtfd]
+        )
+
+        let item = NSPasteboardItem()
+        item.setData(imageData, forType: .png)
+        item.setData(rtfdData, forType: .rtfd)
+        return item
     }
 }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -511,6 +511,35 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: localPath))
     }
 
+    func testLocalImageFileURLDropPlanUsesSinglePastePayload() throws {
+        let imageDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux local image paste \(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: imageDirectory) }
+
+        let firstURL = imageDirectory.appendingPathComponent("first image.png")
+        let secondURL = imageDirectory.appendingPathComponent("second image.png")
+        try make1x1PNG(color: .systemRed).write(to: firstURL)
+        try make1x1PNG(color: .systemGreen).write(to: secondURL)
+
+        let plan = TerminalImageTransferPlanner.plan(
+            fileURLs: [firstURL, secondURL],
+            target: .local
+        )
+
+        guard case .insertText(let text) = plan else {
+            return XCTFail("expected one local insert plan for image paths, got \(plan)")
+        }
+
+        XCTAssertEqual(
+            text,
+            [firstURL, secondURL]
+                .map(\.path)
+                .map(TerminalImageTransferPlanner.escapeForShell)
+                .joined(separator: " ")
+        )
+    }
+
     func testRemoteImagePastePlanUploadsMaterializedFile() throws {
         let pasteboard = NSPasteboard(name: .init("cmux-test-remote-paste-\(UUID().uuidString)"))
         pasteboard.clearContents()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -511,7 +511,7 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: localPath))
     }
 
-    func testLocalImageFileURLDropPlanUsesSinglePastePayload() throws {
+    func testLocalImageFileURLPastePlanUsesSinglePastePayload() throws {
         let imageDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux local image paste \(UUID().uuidString)")
         try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
@@ -538,6 +538,37 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
                 .map(TerminalImageTransferPlanner.escapeForShell)
                 .joined(separator: " ")
         )
+    }
+
+    func testLocalImageFileURLDropPlanUsesDelayedPasteSegments() throws {
+        let imageDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux local image drop \(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: imageDirectory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: imageDirectory) }
+
+        let firstURL = imageDirectory.appendingPathComponent("first image.png")
+        let secondURL = imageDirectory.appendingPathComponent("second image.png")
+        try make1x1PNG(color: .systemRed).write(to: firstURL)
+        try make1x1PNG(color: .systemGreen).write(to: secondURL)
+
+        let plan = TerminalImageTransferPlanner.plan(
+            fileURLs: [firstURL, secondURL],
+            target: .local,
+            mode: .drop
+        )
+
+        guard case .insertTextSegments(let segments, let delay) = plan else {
+            return XCTFail("expected delayed local image paste segments, got \(plan)")
+        }
+
+        XCTAssertEqual(
+            segments,
+            [
+                TerminalImageTransferPlanner.escapeForShell(firstURL.path),
+                " " + TerminalImageTransferPlanner.escapeForShell(secondURL.path)
+            ]
+        )
+        XCTAssertEqual(delay, 2.0)
     }
 
     func testRemoteImagePastePlanUploadsMaterializedFile() throws {

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -985,11 +985,17 @@ class cmux:
         panel: Union[str, int],
         paths: list[str],
         route: str = "text_destination",
+        payload: str = "file_urls",
     ) -> None:
         sid = self._resolve_surface_id(panel)
         self._call(
             "debug.terminal.simulate_file_drop",
-            {"surface_id": sid, "paths": [str(path) for path in paths], "route": route},
+            {
+                "surface_id": sid,
+                "paths": [str(path) for path in paths],
+                "route": route,
+                "payload": payload,
+            },
             timeout_s=30.0,
         )
 

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -286,8 +286,8 @@ def main() -> int:
             for remote_path in remote_paths
         ]
         _must(
-            remote_shas == local_shas,
-            f"Uploaded file hashes mismatch local={local_shas} remote={remote_shas} paths={remote_paths}",
+            sorted(remote_shas) == sorted(local_shas),
+            f"Uploaded file hashes mismatch local={sorted(local_shas)} remote={sorted(remote_shas)} paths={remote_paths}",
         )
         print(f"PASS: ssh image drop uploaded {len(remote_paths)} files: {', '.join(remote_paths)}")
         return 0

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -183,17 +183,23 @@ def _focused_surface_id(client: cmux) -> str:
     return surface_id
 
 
-def _wait_for_remote_drop_path(client: cmux, surface_id: str, timeout: float = 20.0) -> str:
+def _wait_for_remote_drop_paths(client: cmux, surface_id: str, expected_count: int, timeout: float = 20.0) -> list[str]:
     pattern = re.compile(r"/tmp/cmux-drop-[0-9a-f-]+\.png")
     deadline = time.time() + timeout
     last = ""
     while time.time() < deadline:
         last = client.read_terminal_text(surface_id)
-        match = pattern.search(last)
-        if match:
-            return match.group(0)
+        search_text = last.replace("\r", "").replace("\n", "")
+        remote_paths: list[str] = []
+        for match in pattern.findall(search_text):
+            if match not in remote_paths:
+                remote_paths.append(match)
+        if len(remote_paths) >= expected_count:
+            return remote_paths[:expected_count]
         time.sleep(0.25)
-    raise cmuxError(f"Timed out waiting for remote drop path in terminal text: {last[-1000:]!r}")
+    raise cmuxError(
+        f"Timed out waiting for {expected_count} remote drop paths in terminal text: {last[-1000:]!r}"
+    )
 
 
 def main() -> int:
@@ -248,27 +254,42 @@ def main() -> int:
             _wait_remote_ready(client, workspace_id)
             client.select_workspace(workspace_id)
 
-            image_path = temp_dir / "dragged-image.png"
-            image_path.write_bytes(base64.b64decode(
+            first_image_path = temp_dir / "dragged-image-one.png"
+            second_image_path = temp_dir / "dragged-image-two.png"
+            first_image_path.write_bytes(base64.b64decode(
                 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lS2cWQAAAABJRU5ErkJggg=="
             ))
-            local_sha = hashlib.sha256(image_path.read_bytes()).hexdigest()
+            second_image_path.write_bytes(base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+            ))
+            local_shas = [
+                hashlib.sha256(first_image_path.read_bytes()).hexdigest(),
+                hashlib.sha256(second_image_path.read_bytes()).hexdigest(),
+            ]
 
             surface_id = _focused_surface_id(client)
-            client.simulate_terminal_file_drop(surface_id, [str(image_path)], route="text_destination")
-            remote_path = _wait_for_remote_drop_path(client, surface_id)
+            client.simulate_terminal_file_drop(
+                surface_id,
+                [str(first_image_path), str(second_image_path)],
+                route="terminal",
+                payload="image_data",
+            )
+            remote_paths = _wait_for_remote_drop_paths(client, surface_id, expected_count=2)
 
-        remote_sha = _ssh_run(
-            host,
-            host_ssh_port,
-            key_path,
-            f"sha256sum {_shell_single_quote(remote_path)}",
-        ).stdout.split()[0]
+        remote_shas = [
+            _ssh_run(
+                host,
+                host_ssh_port,
+                key_path,
+                f"sha256sum {_shell_single_quote(remote_path)}",
+            ).stdout.split()[0]
+            for remote_path in remote_paths
+        ]
         _must(
-            remote_sha == local_sha,
-            f"Uploaded file hash mismatch local={local_sha} remote={remote_sha} path={remote_path}",
+            remote_shas == local_shas,
+            f"Uploaded file hashes mismatch local={local_shas} remote={remote_shas} paths={remote_paths}",
         )
-        print(f"PASS: ssh image drop uploaded {remote_path}")
+        print(f"PASS: ssh image drop uploaded {len(remote_paths)} files: {', '.join(remote_paths)}")
         return 0
     finally:
         if workspace_id:

--- a/tests_v2/test_terminal_multi_image_drop.py
+++ b/tests_v2/test_terminal_multi_image_drop.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""Regression: multiple local image drops insert every materialized path."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import os
+import re
+import secrets
+import shlex
+import shutil
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from cmux import cmux, cmuxError
+
+
+SOCKET_PATH = os.environ.get("CMUX_SOCKET_PATH", "/tmp/cmux-debug.sock")
+
+
+def _must(condition: bool, message: str) -> None:
+    if not condition:
+        raise cmuxError(message)
+
+
+def _escape_for_shell_path(path: str) -> str:
+    if "\n" in path or "\r" in path:
+        return "'" + path.replace("'", "'\\''") + "'"
+    result = path
+    for char in "\\ ()[]{}<>\"'`!#$&;|*?\t":
+        result = result.replace(char, "\\" + char)
+    return result
+
+
+def _focused_surface_id(client: cmux) -> str:
+    ident = client.identify()
+    surface_id = str((ident.get("focused") or {}).get("surface_id") or "")
+    _must(bool(surface_id), f"Missing focused surface in identify payload: {ident}")
+    return surface_id
+
+
+def _wait_for_materialized_paths(client: cmux, surface_id: str, expected_count: int, timeout: float = 10.0) -> list[str]:
+    pattern = re.compile(r"/[^\s%]*/clipboard-[^\s%]+\.png")
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        last = client.read_terminal_text(surface_id)
+        search_text = last.replace("\r", "").replace("\n", "")
+        paths: list[str] = []
+        for match in pattern.findall(search_text):
+            if match not in paths:
+                paths.append(match)
+        if len(paths) >= expected_count:
+            return paths[:expected_count]
+        time.sleep(0.2)
+    raise cmuxError(f"Timed out waiting for {expected_count} materialized image paths: {last[-1000:]!r}")
+
+
+def _wait_for_terminal_text(client: cmux, surface_id: str, predicate, timeout: float = 10.0) -> str:
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        last = client.read_terminal_text(surface_id)
+        if predicate(last):
+            return last
+        time.sleep(0.2)
+    raise cmuxError(f"Timed out waiting for terminal predicate: {last[-1000:]!r}")
+
+
+def _run_drop_case(client: cmux, expected_paths: list[str], payload: str) -> tuple[str, str]:
+    workspace_id = client.new_workspace()
+    client.select_workspace(workspace_id)
+    surface_id = _focused_surface_id(client)
+    client.simulate_terminal_file_drop(
+        surface_id,
+        expected_paths,
+        route="terminal",
+        payload=payload,
+    )
+    return workspace_id, surface_id
+
+
+def _write_bracketed_paste_capture_script(temp_dir: Path, token: str) -> Path:
+    script_path = temp_dir / f"capture-bracketed-paste-{token}.py"
+    script_path.write_text(
+        f"""
+import os
+import select
+import sys
+import termios
+import time
+import tty
+
+token = {token!r}
+fd = sys.stdin.fileno()
+old = termios.tcgetattr(fd)
+data = b""
+last_data_at = 0.0
+try:
+    sys.stdout.write("\\x1b[?2004hREADY-" + token + "\\r\\n")
+    sys.stdout.flush()
+    tty.setraw(fd)
+    deadline = time.time() + 8.0
+    while time.time() < deadline:
+        readable, _, _ = select.select([fd], [], [], 0.1)
+        if readable:
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+            data += chunk
+            last_data_at = time.time()
+        if data.count(b"\\x1b[201~") >= 2:
+            break
+        if data and time.time() - last_data_at > 0.6:
+            break
+    sys.stdout.write("\\r\\nPASTE-" + token + " " + data.hex() + "\\r\\n")
+    sys.stdout.flush()
+    time.sleep(2.0)
+finally:
+    termios.tcsetattr(fd, termios.TCSADRAIN, old)
+    sys.stdout.write("\\x1b[?2004l\\r\\n")
+    sys.stdout.flush()
+""".lstrip(),
+        encoding="utf-8",
+    )
+    return script_path
+
+
+def _run_bracketed_paste_case(client: cmux, expected_paths: list[str], payload: str, temp_dir: Path) -> tuple[str, bytes]:
+    token = f"{payload}-{secrets.token_hex(4)}"
+    script_path = _write_bracketed_paste_capture_script(temp_dir, token)
+    workspace_id = client.new_workspace()
+    client.select_workspace(workspace_id)
+    surface_id = _focused_surface_id(client)
+    client.send_surface(surface_id, f"python3 {shlex.quote(str(script_path))}\\r")
+    _wait_for_terminal_text(client, surface_id, lambda text: f"READY-{token}" in text)
+    client.simulate_terminal_file_drop(
+        surface_id,
+        expected_paths,
+        route="terminal",
+        payload=payload,
+    )
+    terminal_text = _wait_for_terminal_text(
+        client,
+        surface_id,
+        lambda text: f"PASTE-{token} " in text,
+        timeout=12.0,
+    )
+    match = re.search(rf"PASTE-{re.escape(token)} ([0-9a-f]+)", terminal_text)
+    _must(match is not None, f"missing paste capture line for {token}: {terminal_text[-1000:]!r}")
+    return workspace_id, bytes.fromhex(match.group(1))
+
+
+def main() -> int:
+    temp_dir = Path(tempfile.mkdtemp(prefix="cmux-local-multi-image-drop-"))
+    workspace_ids: list[str] = []
+    materialized_paths: list[str] = []
+    try:
+        first_image_path = temp_dir / f"dragged image one {secrets.token_hex(4)}.png"
+        second_image_path = temp_dir / f"dragged image two {secrets.token_hex(4)}.png"
+        first_image_path.write_bytes(base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lS2cWQAAAABJRU5ErkJggg=="
+        ))
+        second_image_path.write_bytes(base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+        ))
+        expected_paths = [str(first_image_path), str(second_image_path)]
+        expected_shas = [
+            hashlib.sha256(first_image_path.read_bytes()).hexdigest(),
+            hashlib.sha256(second_image_path.read_bytes()).hexdigest(),
+        ]
+        with cmux(SOCKET_PATH) as client:
+            workspace_id, surface_id = _run_drop_case(client, expected_paths, "image_data")
+            workspace_ids.append(workspace_id)
+            paths = _wait_for_materialized_paths(client, surface_id, expected_count=2)
+            materialized_paths.extend(paths)
+
+            materialized_shas = [
+                hashlib.sha256(Path(path).read_bytes()).hexdigest()
+                for path in paths
+            ]
+            _must(
+                sorted(materialized_shas) == sorted(expected_shas),
+                f"image_data materialized image hashes mismatch expected={sorted(expected_shas)} actual={sorted(materialized_shas)} paths={paths}",
+            )
+
+            escaped_paths = [_escape_for_shell_path(path) for path in expected_paths]
+            workspace_id, surface_id = _run_drop_case(client, expected_paths, "file_urls")
+            workspace_ids.append(workspace_id)
+            terminal_text = _wait_for_terminal_text(
+                client,
+                surface_id,
+                lambda text: all(path in text for path in escaped_paths),
+            )
+            for escaped_path in escaped_paths:
+                _must(escaped_path in terminal_text, f"file URL image drop did not insert original path {escaped_path!r}: {terminal_text[-1000:]!r}")
+            _must("/clipboard-" not in terminal_text, f"file URL image drop inserted temp clipboard path: {terminal_text[-1000:]!r}")
+
+            for payload in ["image_data", "file_urls"]:
+                workspace_id, raw_paste = _run_bracketed_paste_case(client, expected_paths, payload, temp_dir)
+                workspace_ids.append(workspace_id)
+                if payload == "file_urls":
+                    for escaped_path in escaped_paths:
+                        _must(escaped_path.encode() in raw_paste, f"file URL paste did not include original path {escaped_path!r}: {raw_paste!r}")
+                    _must(b"/clipboard-" not in raw_paste, f"file URL paste used temp clipboard path: {raw_paste!r}")
+                paste_starts = raw_paste.count(b"\x1b[200~")
+                paste_ends = raw_paste.count(b"\x1b[201~")
+                _must(
+                    paste_starts >= 2 and paste_ends >= 2,
+                    f"{payload} drop should arrive as separate bracketed paste transactions; starts={paste_starts} ends={paste_ends} raw={raw_paste!r}",
+                )
+
+        print(f"PASS: local image drop materialized {len(materialized_paths)} image_data images, preserved original file_urls, and used separate paste transactions")
+        return 0
+    finally:
+        if workspace_ids:
+            try:
+                with cmux(SOCKET_PATH) as client:
+                    for workspace_id in workspace_ids:
+                        client.close_workspace(workspace_id)
+            except cmuxError:
+                pass
+        for path in materialized_paths:
+            try:
+                Path(path).unlink()
+            except FileNotFoundError:
+                pass
+        shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests_v2/test_terminal_multi_image_drop.py
+++ b/tests_v2/test_terminal_multi_image_drop.py
@@ -49,11 +49,11 @@ def _wait_for_materialized_paths(client: cmux, surface_id: str, expected_count: 
     last = ""
     while time.time() < deadline:
         last = client.read_terminal_text(surface_id)
-        search_text = last.replace("\r", "").replace("\n", "")
         paths: list[str] = []
-        for match in pattern.findall(search_text):
-            if match not in paths:
-                paths.append(match)
+        for line in last.replace("\r", "").splitlines():
+            for match in pattern.findall(line):
+                if match not in paths:
+                    paths.append(match)
         if len(paths) >= expected_count:
             return paths[:expected_count]
         time.sleep(0.2)

--- a/tests_v2/test_terminal_multi_image_drop.py
+++ b/tests_v2/test_terminal_multi_image_drop.py
@@ -210,11 +210,11 @@ def main() -> int:
                 paste_starts = raw_paste.count(b"\x1b[200~")
                 paste_ends = raw_paste.count(b"\x1b[201~")
                 _must(
-                    paste_starts >= 2 and paste_ends >= 2,
-                    f"{payload} drop should arrive as separate bracketed paste transactions; starts={paste_starts} ends={paste_ends} raw={raw_paste!r}",
+                    paste_starts == 1 and paste_ends == 1,
+                    f"{payload} drop should arrive as one bracketed paste transaction; starts={paste_starts} ends={paste_ends} raw={raw_paste!r}",
                 )
 
-        print(f"PASS: local image drop materialized {len(materialized_paths)} image_data images, preserved original file_urls, and used separate paste transactions")
+        print(f"PASS: local image drop materialized {len(materialized_paths)} image_data images, preserved original file_urls, and used one paste transaction")
         return 0
     finally:
         if workspace_ids:

--- a/tests_v2/test_terminal_multi_image_drop.py
+++ b/tests_v2/test_terminal_multi_image_drop.py
@@ -99,12 +99,13 @@ token = {token!r}
 fd = sys.stdin.fileno()
 old = termios.tcgetattr(fd)
 data = b""
+end_times = []
 last_data_at = 0.0
 try:
     sys.stdout.write("\\x1b[?2004hREADY-" + token + "\\r\\n")
     sys.stdout.flush()
     tty.setraw(fd)
-    deadline = time.time() + 8.0
+    deadline = time.time() + 15.0
     while time.time() < deadline:
         readable, _, _ = select.select([fd], [], [], 0.1)
         if readable:
@@ -113,11 +114,14 @@ try:
                 break
             data += chunk
             last_data_at = time.time()
+            while len(end_times) < data.count(b"\\x1b[201~"):
+                end_times.append(last_data_at)
         if data.count(b"\\x1b[201~") >= 2:
             break
-        if data and time.time() - last_data_at > 0.6:
+        if data and time.time() - last_data_at > 3.5:
             break
-    sys.stdout.write("\\r\\nPASTE-" + token + " " + data.hex() + "\\r\\n")
+    timings = ",".join(f"{{value:.3f}}" for value in end_times)
+    sys.stdout.write("\\r\\nPASTE-" + token + " " + data.hex() + " " + timings + "\\r\\n")
     sys.stdout.flush()
     time.sleep(2.0)
 finally:
@@ -130,7 +134,7 @@ finally:
     return script_path
 
 
-def _run_bracketed_paste_case(client: cmux, expected_paths: list[str], payload: str, temp_dir: Path) -> tuple[str, bytes]:
+def _run_bracketed_paste_case(client: cmux, expected_paths: list[str], payload: str, temp_dir: Path) -> tuple[str, bytes, list[float]]:
     token = f"{payload}-{secrets.token_hex(4)}"
     script_path = _write_bracketed_paste_capture_script(temp_dir, token)
     workspace_id = client.new_workspace()
@@ -150,9 +154,14 @@ def _run_bracketed_paste_case(client: cmux, expected_paths: list[str], payload: 
         lambda text: f"PASTE-{token} " in text,
         timeout=12.0,
     )
-    match = re.search(rf"PASTE-{re.escape(token)} ([0-9a-f]+)", terminal_text)
+    match = re.search(rf"PASTE-{re.escape(token)} ([0-9a-f]+) ([0-9.,]*)", terminal_text)
     _must(match is not None, f"missing paste capture line for {token}: {terminal_text[-1000:]!r}")
-    return workspace_id, bytes.fromhex(match.group(1))
+    timings = [
+        float(value)
+        for value in match.group(2).split(",")
+        if value
+    ]
+    return workspace_id, bytes.fromhex(match.group(1)), timings
 
 
 def main() -> int:
@@ -201,7 +210,7 @@ def main() -> int:
             _must("/clipboard-" not in terminal_text, f"file URL image drop inserted temp clipboard path: {terminal_text[-1000:]!r}")
 
             for payload in ["image_data", "file_urls"]:
-                workspace_id, raw_paste = _run_bracketed_paste_case(client, expected_paths, payload, temp_dir)
+                workspace_id, raw_paste, paste_end_times = _run_bracketed_paste_case(client, expected_paths, payload, temp_dir)
                 workspace_ids.append(workspace_id)
                 if payload == "file_urls":
                     for escaped_path in escaped_paths:
@@ -210,11 +219,15 @@ def main() -> int:
                 paste_starts = raw_paste.count(b"\x1b[200~")
                 paste_ends = raw_paste.count(b"\x1b[201~")
                 _must(
-                    paste_starts == 1 and paste_ends == 1,
-                    f"{payload} drop should arrive as one bracketed paste transaction; starts={paste_starts} ends={paste_ends} raw={raw_paste!r}",
+                    paste_starts >= 2 and paste_ends >= 2,
+                    f"{payload} drop should arrive as separate bracketed paste transactions; starts={paste_starts} ends={paste_ends} raw={raw_paste!r}",
+                )
+                _must(
+                    len(paste_end_times) >= 2 and paste_end_times[1] - paste_end_times[0] >= 1.8,
+                    f"{payload} paste transactions should be spaced for Claude image ingestion; timings={paste_end_times} raw={raw_paste!r}",
                 )
 
-        print(f"PASS: local image drop materialized {len(materialized_paths)} image_data images, preserved original file_urls, and used one paste transaction")
+        print(f"PASS: local image drop materialized {len(materialized_paths)} image_data images, preserved original file_urls, and used delayed paste transactions")
         return 0
     finally:
         if workspace_ids:


### PR DESCRIPTION
Fix multi-image image-data drops into local and SSH terminals.

Regression proof:
- First commit adds multi-image drop regressions. `FinderFileDropRegressionTests/testImagePasteboardDropMaterializesEveryImageForRemoteUpload` fails on the previous implementation with `1 != 2`.
- Second commit materializes every image pasteboard item and makes the regressions pass.

Verification:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-multidrop-green test -only-testing:cmuxTests/FinderFileDropRegressionTests/testImagePasteboardDropMaterializesEveryImageForRemoteUpload -only-testing:cmuxTests/FinderFileDropRegressionTests/testImagePasteboardDropMaterializesEveryImageForLocalInsertion`
- `CMUX_SOCKET_PATH=/tmp/cmux-debug-fix-multi-image-drop.sock CMUXTERM_CLI=/tmp/cmux-cli python3 tests_v2/test_terminal_multi_image_drop.py`
- `CMUX_SOCKET_PATH=/tmp/cmux-debug-fix-multi-image-drop.sock CMUXTERM_CLI=/tmp/cmux-cli python3 tests_v2/test_ssh_remote_image_drop_upload.py`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes touch pasteboard/image materialization and terminal drop/paste planning (including remote uploads), which can affect core user workflows and file handling. Risk is mitigated by extensive new regression and end-to-end tests for multi-image local and SSH scenarios.
> 
> **Overview**
> Fixes multi-image drag-and-drop/paste handling by materializing **all** image items from the pasteboard (including per-item RTFD attachments) into temporary files, normalizing TIFF payloads to PNG, enforcing a per-image size limit, and adding cleanup of owned temp files on app termination.
> 
> Updates terminal image transfer planning/execution to support multi-image local drops via a new delayed `insertTextSegments` plan, while preserving original paths for file-URL drops and ensuring remote targets upload the correct set of files. Debug drop simulation and v2 test harness add a `payload` selector (`file_urls` vs `image_data`), and new/expanded unit + integration tests cover multi-image insertion, TIFF normalization, de-duping, and SSH upload hash verification.
> 
> Hardens `cmux` CLI error printing by replacing `FileHandle.standardError` writes with an EINTR-safe `Darwin.write` loop, plus a regression test to ensure the CLI doesn’t crash when stderr is closed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87fc4aa5e34695032a24deaa311a56879cd23ae4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes multi-image drops in local and SSH terminals. Local drops (file-URL and image-data) now paste as separate, delayed bracketed transactions per image for Claude; plain paste remains a single bracketed transaction. Also hardens the `cmux` CLI when stderr is closed.

- **Bug Fixes**
  - Pasteboard: per-item image extraction (direct and RTFD), TIFF→PNG normalization across UTIs, 10 MB per-image limit, dedupe direct+RTFD per item, per-item fallback via isolated pasteboard, and cleanup of owned temp files on app exit.
  - Transfers: plan/execute multiple images; local file-URL drops preserve original paths; local image-data drops materialize every image; remote uploads use originals or materialized PNGs. Drops use staggered bracketed pastes (2s spacing); paste still uses a single transaction. Debug drop simulation adds a `payload` selector (`image_data` for terminal route). Tests cover multi-image insertion, TIFF→PNG, per-item fallback, Claude multi-image timing, and SSH uploads with per-file hash verification.
  - CLI: resilient low-level stderr writes to handle closed pipes; `CMUXCLIErrorOutputRegressionTests` added.

- **Refactors**
  - Removed unused local image type helpers.

<sup>Written for commit 87fc4aa5e34695032a24deaa311a56879cd23ae4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-image support for clipboard and drag-and-drop in local and remote terminal sessions.
  * Materialized images are written as one or many temporary image files and image formats are normalized (e.g., TIFF → PNG).
  * Debug simulation and CLI test helper now support sending image data payloads in addition to file URLs.

* **Tests**
  * Added regression and CLI tests verifying multi-image drop, remote upload, and end-to-end hash verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->