### PR TITLE
feat: add workspace commands with SSH and custom shell support

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -25,6 +25,9 @@
 		C2B6A97D1F2E4C71A8B9D001 /* BrowserOmnibarPerformanceSupportTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2B6A97D1F2E4C71A8B9D002 /* BrowserOmnibarPerformanceSupportTests.swift */; };
 		3023A1003023A1003023A100 /* ConfigSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1003023B1003023B100 /* ConfigSource.swift */; };
 		3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1013023B1013023B101 /* ConfigSettingsView.swift */; };
+		3023A1023023A1023023A102 /* WorkspaceCommandsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1023023B1023023B102 /* WorkspaceCommandsStore.swift */; };
+		3023A1033023A1033023A103 /* WorkspaceCommandsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1033023B1033023B103 /* WorkspaceCommandsSettingsView.swift */; };
+		3023A1043023A1043023A104 /* WorkspaceCommandsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023B1043023B1043023B104 /* WorkspaceCommandsWindowPresenter.swift */; };
 		350DAC5EBD38642A3E81471A /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 312DE7503B4658DD173121B8 /* AuthManager.swift */; };
 		36CE99ED050785B5E96B72BB /* AuthCallbackRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61A19A4145F034965110CF87 /* AuthCallbackRouter.swift */; };
 		4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */; };
@@ -519,6 +522,9 @@
 		2F0C05000000000000000001 /* MainWindowFocusController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowFocusController.swift; sourceTree = "<group>"; };
 		3023B1003023B1003023B100 /* ConfigSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSource.swift; sourceTree = "<group>"; };
 		3023B1013023B1013023B101 /* ConfigSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/ConfigSettingsView.swift; sourceTree = "<group>"; };
+		3023B1023023B1023023B102 /* WorkspaceCommandsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/WorkspaceCommandsStore.swift; sourceTree = "<group>"; };
+		3023B1033023B1033023B103 /* WorkspaceCommandsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/WorkspaceCommandsSettingsView.swift; sourceTree = "<group>"; };
+		3023B1043023B1043023B104 /* WorkspaceCommandsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings/WorkspaceCommandsWindowPresenter.swift; sourceTree = "<group>"; };
 		312DE7503B4658DD173121B8 /* AuthManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F004 /* FeedPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedPanelView.swift; sourceTree = "<group>"; };
@@ -1084,6 +1090,9 @@
 			children = (
 				3023B1003023B1003023B100 /* ConfigSource.swift */,
 				3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
+				3023B1023023B1023023B102 /* WorkspaceCommandsStore.swift */,
+				3023B1033023B1033023B103 /* WorkspaceCommandsSettingsView.swift */,
+				3023B1043023B1043023B104 /* WorkspaceCommandsWindowPresenter.swift */,
 				A11EAB000000000000000001 /* AppearanceSettings.swift */,
 				A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */,
 				A11EAD000000000000000001 /* WorkspaceAppearanceResolution.swift */,
@@ -1721,6 +1730,9 @@
 			files = (
 				3023A1003023A1003023A100 /* ConfigSource.swift in Sources */,
 				3023A1013023A1013023A101 /* ConfigSettingsView.swift in Sources */,
+				3023A1023023A1023023A102 /* WorkspaceCommandsStore.swift in Sources */,
+				3023A1033023A1033023A103 /* WorkspaceCommandsSettingsView.swift in Sources */,
+				3023A1043023A1043023A104 /* WorkspaceCommandsWindowPresenter.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */,
 				A11EAD000000000000000000 /* WorkspaceAppearanceResolution.swift in Sources */,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5972,11 +5972,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     @discardableResult
     func bootstrapInitialMainWindowIfNeeded(debugSource: String, shouldActivate: Bool = true) -> UUID {
+        // Detect whether this call is creating a brand-new window (vs surfacing
+        // one that session restore already populated). When fresh, run the
+        // user's configured default workspace command so the first window opens
+        // with their chosen profile (e.g. a remote SSH workspace) instead of a
+        // bare local terminal.
+        let willRestoreStartupSession =
+            startupSessionSnapshot != nil && !didHandleExplicitOpenIntentAtStartup
+        let isFreshLaunch = mainWindowContexts.isEmpty && !willRestoreStartupSession
         let windowId = ensureInitialMainWindowIfNeeded(shouldActivate: shouldActivate)
         if let manager = tabManagerFor(windowId: windowId) {
             startSocketListenerIfEnabled(
                 tabManager: manager,
                 source: "bootstrapInitialMainWindow.\(debugSource)"
+            )
+        }
+        // Only override the bare initial workspace when the user explicitly
+        // picked a non-Local default. Built-in `Local` (defaultCommandID == nil)
+        // is the implicit fallback and doesn't add anything over the plain
+        // workspace TabManager.init already created.
+        if isFreshLaunch,
+           WorkspaceCommandsStore.shared.defaultCommandID != nil,
+           let context = mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
+            let initialWorkspace = context.tabManager.selectedWorkspace
+            let initialWorkspaceId = initialWorkspace?.id
+            _ = runWorkspaceCommandConfig(
+                WorkspaceCommandsStore.shared.defaultCommand()!,
+                preferredContext: context,
+                debugSource: "bootstrap.\(debugSource)",
+                onExecuted: { [weak self, weak context] in
+                    self?.closeInitialWorkspaceIfNeeded(
+                        initialWorkspaceId: initialWorkspaceId,
+                        in: context
+                    )
+                }
             )
         }
         guard !didBootstrapInitialMainWindow else { return windowId }
@@ -5986,6 +6015,65 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             openPreferencesWindow(debugSource: "uiTestShowSettings.\(debugSource)")
         }
         return windowId
+    }
+
+    /// Returns the workspace commands the user has configured in the
+    /// Preferences "Workspaces" section. Used to populate the titlebar `+`
+    /// split menu and the command palette.
+    func availableWorkspaceCommands() -> [WorkspaceCommandConfig] {
+        WorkspaceCommandsStore.shared.commands
+    }
+
+    /// Runs a workspace command by its identifier. Returns true if a matching
+    /// command was found and executed.
+    @discardableResult
+    func performWorkspaceCommand(id: WorkspaceCommandConfig.ID, debugSource: String) -> Bool {
+        guard let config = WorkspaceCommandsStore.shared.command(id: id) else { return false }
+        return runWorkspaceCommandConfig(config, preferredContext: nil, debugSource: debugSource, onExecuted: nil)
+    }
+
+    /// Runs the user's configured default workspace command (set in
+    /// Preferences → Workspaces). Returns false if no default is selected so
+    /// callers can fall back to the plain `addWorkspace()` path.
+    @discardableResult
+    func performDefaultWorkspaceCommand(debugSource: String) -> Bool {
+        guard let config = WorkspaceCommandsStore.shared.defaultCommand() else { return false }
+        return runWorkspaceCommandConfig(config, preferredContext: nil, debugSource: debugSource, onExecuted: nil)
+    }
+
+    /// Opens the Preferences → Workspaces editor window via
+    /// `WorkspaceCommandsWindowPresenter`.
+    func openWorkspaceCommandsWindow(debugSource: String) {
+#if DEBUG
+        cmuxDebugLog("workspaceCommands.openWindow source=\(debugSource)")
+#endif
+        WorkspaceCommandsWindowPresenter.show()
+    }
+
+    @discardableResult
+    private func runWorkspaceCommandConfig(
+        _ config: WorkspaceCommandConfig,
+        preferredContext: MainWindowContext?,
+        debugSource: String,
+        onExecuted: (() -> Void)?
+    ) -> Bool {
+        let context = preferredContext
+            ?? preferredMainWindowContextForWorkspaceCreation(event: nil, debugSource: debugSource)
+        guard let context else { return false }
+        let rawCwd = context.tabManager.selectedWorkspace?.currentDirectory
+        let baseCwd = (rawCwd?.isEmpty == false) ? rawCwd!
+            : FileManager.default.homeDirectoryForCurrentUser.path
+        let globalConfigPath = context.cmuxConfigStore?.globalConfigPath
+            ?? FileManager.default.homeDirectoryForCurrentUser
+                .appendingPathComponent(".config/cmux/cmux.json").path
+        return CmuxConfigExecutor.execute(
+            command: config.asCmuxCommandDefinition(),
+            tabManager: context.tabManager,
+            baseCwd: baseCwd,
+            configSourcePath: nil,
+            globalConfigPath: globalConfigPath,
+            onExecuted: onExecuted
+        )
     }
 
     @discardableResult
@@ -6111,6 +6199,26 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         debugSource: String,
         replacingInitialWorkspace initialWorkspace: Workspace? = nil
     ) -> Bool {
+        // The user's Preferences → Workspaces default takes precedence over
+        // any cmux.json `newWorkspaceCommand` action. `defaultCommandID == nil`
+        // resolves to built-in Local, which adds nothing over the plain
+        // addWorkspace() path — so only short-circuit when an explicit non-
+        // Local default is configured.
+        if WorkspaceCommandsStore.shared.defaultCommandID != nil,
+           let config = WorkspaceCommandsStore.shared.defaultCommand() {
+            let initialWorkspaceId = initialWorkspace?.id
+            return runWorkspaceCommandConfig(
+                config,
+                preferredContext: context,
+                debugSource: "workspaceCommandsStore.\(debugSource)",
+                onExecuted: { [weak self, weak context] in
+                    self?.closeInitialWorkspaceIfNeeded(
+                        initialWorkspaceId: initialWorkspaceId,
+                        in: context
+                    )
+                }
+            )
+        }
         guard let cmuxConfigStore = context.cmuxConfigStore,
               let action = cmuxConfigStore.resolvedNewWorkspaceAction() else {
             return false

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5993,11 +5993,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // workspace TabManager.init already created.
         if isFreshLaunch,
            WorkspaceCommandsStore.shared.defaultCommandID != nil,
+           let defaultConfig = WorkspaceCommandsStore.shared.defaultCommand(),
            let context = mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
             let initialWorkspace = context.tabManager.selectedWorkspace
             let initialWorkspaceId = initialWorkspace?.id
             _ = runWorkspaceCommandConfig(
-                WorkspaceCommandsStore.shared.defaultCommand()!,
+                defaultConfig,
                 preferredContext: context,
                 debugSource: "bootstrap.\(debugSource)",
                 onExecuted: { [weak self, weak context] in

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5981,8 +5981,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             startupSessionSnapshot != nil && !didHandleExplicitOpenIntentAtStartup
         // Use the bootstrap-once flag rather than `mainWindowContexts.isEmpty`:
         // SwiftUI's WindowGroup can register a main window context before this
-        // method runs, which would otherwise mask a genuine fresh launch.
-        let isFreshLaunch = !didBootstrapInitialMainWindow && !willRestoreStartupSession
+        // method runs, which would otherwise mask a genuine fresh launch. Also
+        // skip when Finder/services/URL-open already populated the first window
+        // for an explicit intent, so we don't stack the default profile on top.
+        let isFreshLaunch =
+            !didBootstrapInitialMainWindow
+            && !willRestoreStartupSession
+            && !didHandleExplicitOpenIntentAtStartup
         let windowId = ensureInitialMainWindowIfNeeded(shouldActivate: shouldActivate)
         if let manager = tabManagerFor(windowId: windowId) {
             startSocketListenerIfEnabled(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -5979,7 +5979,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // bare local terminal.
         let willRestoreStartupSession =
             startupSessionSnapshot != nil && !didHandleExplicitOpenIntentAtStartup
-        let isFreshLaunch = mainWindowContexts.isEmpty && !willRestoreStartupSession
+        // Use the bootstrap-once flag rather than `mainWindowContexts.isEmpty`:
+        // SwiftUI's WindowGroup can register a main window context before this
+        // method runs, which would otherwise mask a genuine fresh launch.
+        let isFreshLaunch = !didBootstrapInitialMainWindow && !willRestoreStartupSession
         let windowId = ensureInitialMainWindowIfNeeded(shouldActivate: shouldActivate)
         if let manager = tabManagerFor(windowId: windowId) {
             startSocketListenerIfEnabled(

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -480,9 +480,25 @@ struct CmuxConfigExecutor {
         }
 
         let resolvedCwd = CmuxConfigStore.resolveCwd(wsDef.cwd, relativeTo: baseCwd)
-        let remoteStartupCommand: String? = wsDef.remote.map { buildRemoteTerminalStartupCommand(remote: $0) }
+        let normalizedRemote: CmuxRemoteDefinition? = wsDef.remote.flatMap { remote in
+            let host = remote.host.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !host.isEmpty else { return nil }
+            let identityFile = remote.identityFile?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let startupCommand = remote.startupCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let sshOptions = remote.sshOptions?
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            return CmuxRemoteDefinition(
+                host: host,
+                port: remote.port,
+                identityFile: (identityFile?.isEmpty == false) ? identityFile : nil,
+                sshOptions: (sshOptions?.isEmpty == false) ? sshOptions : nil,
+                startupCommand: (startupCommand?.isEmpty == false) ? startupCommand : nil
+            )
+        }
+        let remoteStartupCommand: String? = normalizedRemote.map { buildRemoteTerminalStartupCommand(remote: $0) }
         let resolvedProgram: String? = {
-            guard wsDef.remote == nil else { return nil }
+            guard normalizedRemote == nil else { return nil }
             let trimmed = wsDef.program?.trimmingCharacters(in: .whitespacesAndNewlines)
             return (trimmed?.isEmpty == false) ? trimmed : nil
         }()
@@ -501,7 +517,7 @@ struct CmuxConfigExecutor {
             tabManager.closeWorkspace(existingWorkspaceToClose)
         }
 
-        if let remote = wsDef.remote, let remoteStartupCommand {
+        if let remote = normalizedRemote, let remoteStartupCommand {
             let config = WorkspaceRemoteConfiguration(
                 transport: .ssh,
                 destination: remote.host,

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -427,11 +427,20 @@ struct CmuxConfigExecutor {
         tabManager: TabManager,
         baseCwd: String
     ) -> Bool {
-        let workspaceName = wsDef.name ?? command.name
+        let baseWorkspaceName = wsDef.name ?? command.name
         let restart = command.restart ?? .new
+        let workspaceName: String = {
+            guard restart == .always else { return baseWorkspaceName }
+            let existingTitles = Set(tabManager.tabs.compactMap { $0.customTitle })
+            guard existingTitles.contains(baseWorkspaceName) else { return baseWorkspaceName }
+            var n = 2
+            while existingTitles.contains("\(baseWorkspaceName) \(n)") { n += 1 }
+            return "\(baseWorkspaceName) \(n)"
+        }()
         var existingWorkspaceToClose: Workspace?
 
-        if let existing = tabManager.tabs.first(where: { $0.customTitle == workspaceName }) {
+        if restart != .always,
+           let existing = tabManager.tabs.first(where: { $0.customTitle == workspaceName }) {
             switch restart {
             case .new:
                 break
@@ -440,6 +449,9 @@ struct CmuxConfigExecutor {
                 return true
             case .recreate:
                 existingWorkspaceToClose = existing
+            case .always:
+                // Unreachable: outer guard excludes .always.
+                break
             case .confirm:
                 let alert = NSAlert()
                 alert.messageText = String(
@@ -468,7 +480,18 @@ struct CmuxConfigExecutor {
         }
 
         let resolvedCwd = CmuxConfigStore.resolveCwd(wsDef.cwd, relativeTo: baseCwd)
-        let newWorkspace = tabManager.addWorkspace(workingDirectory: resolvedCwd)
+        let remoteStartupCommand: String? = wsDef.remote.map { buildRemoteTerminalStartupCommand(remote: $0) }
+        let resolvedProgram: String? = {
+            guard wsDef.remote == nil else { return nil }
+            let trimmed = wsDef.program?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return (trimmed?.isEmpty == false) ? trimmed : nil
+        }()
+        let initialCommand = remoteStartupCommand ?? resolvedProgram
+        let newWorkspace = tabManager.addWorkspace(
+            workingDirectory: resolvedCwd,
+            initialTerminalCommand: initialCommand,
+            closePanesOnInitialCommandExit: initialCommand != nil
+        )
         newWorkspace.setCustomTitle(workspaceName)
         if let color = wsDef.color {
             newWorkspace.setCustomColor(color)
@@ -478,9 +501,79 @@ struct CmuxConfigExecutor {
             tabManager.closeWorkspace(existingWorkspaceToClose)
         }
 
+        if let remote = wsDef.remote, let remoteStartupCommand {
+            let config = WorkspaceRemoteConfiguration(
+                transport: .ssh,
+                destination: remote.host,
+                port: remote.port,
+                identityFile: remote.identityFile.flatMap {
+                    let path = expandTildePath($0)
+                    return path.isEmpty ? nil : path
+                },
+                sshOptions: remote.sshOptions ?? [],
+                localProxyPort: nil,
+                relayPort: nil,
+                relayID: nil,
+                relayToken: nil,
+                localSocketPath: nil,
+                terminalStartupCommand: remoteStartupCommand,
+                skipDaemonBootstrap: false
+            )
+            newWorkspace.configureRemoteConnection(config, autoConnect: true)
+        }
+
         if let layout = wsDef.layout {
             newWorkspace.applyCustomLayout(layout, baseCwd: resolvedCwd)
         }
         return true
+    }
+
+    /// Builds the shell command each terminal pane in a remote workspace runs
+    /// to establish (or re-establish) the SSH connection. Mirrors the shape of
+    /// `cmux ssh` minus the daemon bootstrap relay — those plumbing pieces
+    /// require a live CLI invocation to allocate.
+    private static func buildRemoteTerminalStartupCommand(remote: CmuxRemoteDefinition) -> String {
+        var args: [String] = ["ssh"]
+        if let identityFile = remote.identityFile,
+           !identityFile.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            args.append("-i")
+            args.append(shellQuoteArgument(expandTildePath(identityFile)))
+        }
+        if let port = remote.port {
+            args.append("-p")
+            args.append(String(port))
+        }
+        for option in remote.sshOptions ?? [] {
+            let trimmed = option.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            args.append("-o")
+            args.append(shellQuoteArgument(trimmed))
+        }
+        // ssh(1) parses options up to `destination`; anything after is treated
+        // as the remote command. `-t` therefore must precede the host or it
+        // gets passed to the remote shell instead of allocating a TTY.
+        let startupCommand = remote.startupCommand?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let startupCommand, !startupCommand.isEmpty {
+            args.append("-t")
+        }
+        args.append(shellQuoteArgument(remote.host))
+        if let startupCommand, !startupCommand.isEmpty {
+            args.append(shellQuoteArgument(startupCommand))
+        }
+        return args.joined(separator: " ")
+    }
+
+    private static func expandTildePath(_ path: String) -> String {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return trimmed }
+        return NSString(string: trimmed).expandingTildeInPath
+    }
+
+    private static func shellQuoteArgument(_ value: String) -> String {
+        let safePattern = "^[A-Za-z0-9_@%+=:,./-]+$"
+        if value.range(of: safePattern, options: .regularExpression) != nil {
+            return value
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\"'\"'") + "'"
     }
 }

--- a/Sources/CmuxConfigUI.swift
+++ b/Sources/CmuxConfigUI.swift
@@ -229,6 +229,7 @@ enum CmuxRestartBehavior: String, Codable, Sendable {
     case recreate
     case ignore
     case confirm
+    case always
 }
 
 extension CmuxButtonIcon {

--- a/Sources/CmuxWorkspaceDefinition.swift
+++ b/Sources/CmuxWorkspaceDefinition.swift
@@ -5,12 +5,26 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
     var cwd: String?
     var color: String?
     var layout: CmuxLayoutNode?
+    var remote: CmuxRemoteDefinition?
+    /// Program to run as the surface's child process for non-remote workspaces.
+    /// Empty/nil falls back to Ghostty's default shell. Ignored when
+    /// `remote` is set — the SSH invocation always wins.
+    var program: String?
 
-    init(name: String? = nil, cwd: String? = nil, color: String? = nil, layout: CmuxLayoutNode? = nil) {
+    init(
+        name: String? = nil,
+        cwd: String? = nil,
+        color: String? = nil,
+        layout: CmuxLayoutNode? = nil,
+        remote: CmuxRemoteDefinition? = nil,
+        program: String? = nil
+    ) {
         self.name = name
         self.cwd = cwd
         self.color = color
         self.layout = layout
+        self.remote = remote
+        self.program = program
     }
 
     init(from decoder: Decoder) throws {
@@ -18,6 +32,12 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
         name = try container.decodeIfPresent(String.self, forKey: .name)
         cwd = try container.decodeIfPresent(String.self, forKey: .cwd)
         layout = try container.decodeIfPresent(CmuxLayoutNode.self, forKey: .layout)
+        // `remote` and `program` are runtime-only — the WorkspaceCommandsStore
+        // projection sets them when the executor runs a workspace command.
+        // Workspace commands aren't authored in cmux.json, so the JSON decoder
+        // does not accept these keys.
+        remote = nil
+        program = nil
 
         if let rawColor = try container.decodeIfPresent(String.self, forKey: .color) {
             let defaults = decoder.userInfo[.cmuxWorkspaceColorDefaults] as? UserDefaults ?? .standard
@@ -32,5 +52,27 @@ struct CmuxWorkspaceDefinition: Codable, Sendable {
         } else {
             color = nil
         }
+    }
+}
+
+struct CmuxRemoteDefinition: Codable, Sendable, Equatable {
+    var host: String
+    var port: Int?
+    var identityFile: String?
+    var sshOptions: [String]?
+    var startupCommand: String?
+
+    init(
+        host: String,
+        port: Int? = nil,
+        identityFile: String? = nil,
+        sshOptions: [String]? = nil,
+        startupCommand: String? = nil
+    ) {
+        self.host = host
+        self.port = port
+        self.identityFile = identityFile
+        self.sshOptions = sshOptions
+        self.startupCommand = startupCommand
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1056,7 +1056,7 @@ struct ContentView: View {
     @EnvironmentObject var fileExplorerState: FileExplorerState
     @Environment(\.colorScheme) private var colorScheme
     @AppStorage("titlebarControlsStyle") private var titlebarControlsStyleRawValue = TitlebarControlsStyle.classic.rawValue
-    @State private var sidebarWidth: CGFloat = 200
+    @State private var sidebarWidth: CGFloat = CGFloat(SessionPersistencePolicy.defaultSidebarWidth)
     @State private var hoveredResizerHandles: Set<SidebarResizerHandle> = []
     @State private var isResizerDragging = false
     @State private var sidebarDragStartWidth: CGFloat?

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -7,8 +7,8 @@ enum SessionSnapshotSchema {
 }
 
 enum SessionPersistencePolicy {
-    static let defaultSidebarWidth: Double = 200
-    static let minimumSidebarWidth: Double = 180
+    static let defaultSidebarWidth: Double = 214
+    static let minimumSidebarWidth: Double = 194
     static let maximumSidebarWidth: Double = 600
     static let minimumWindowWidth: Double = 300
     static let minimumWindowHeight: Double = 200

--- a/Sources/Settings/WorkspaceCommandsSettingsView.swift
+++ b/Sources/Settings/WorkspaceCommandsSettingsView.swift
@@ -95,6 +95,7 @@ struct WorkspaceCommandsSettingsView: View {
                                 && command.id == WorkspaceCommandsStore.builtInLocalID)
                     )
                     .tag(command.id as WorkspaceCommandConfig.ID?)
+                    .moveDisabled(store.isBuiltIn(id: command.id))
                 }
                 .onMove { source, destination in
                     store.move(fromOffsets: source, toOffset: destination)
@@ -300,7 +301,14 @@ private struct WorkspaceCommandDetailEditor: View {
                 )
             }
 
-            if command.remote == nil {
+            // The runtime treats a blank-host remote as no remote and falls
+            // back to the local program. Keep the local editor visible in
+            // that transitional state so the user can still configure it.
+            let hasConfiguredRemoteHost: Bool = {
+                guard let host = command.remote?.host else { return false }
+                return !host.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            }()
+            if !hasConfiguredRemoteHost {
                 Section(String(
                     localized: "settings.workspaces.section.local",
                     defaultValue: "Local"

--- a/Sources/Settings/WorkspaceCommandsSettingsView.swift
+++ b/Sources/Settings/WorkspaceCommandsSettingsView.swift
@@ -1,0 +1,445 @@
+import AppKit
+import SwiftUI
+
+/// List/detail editor for the user's workspace commands. Surfaced in its own
+/// window (opened from `Settings → Workspaces → Manage Workspaces…`) because
+/// the schema is wide enough that inlining it in the main settings scroll
+/// would dominate the page.
+struct WorkspaceCommandsSettingsView: View {
+    static let windowID = "workspace-commands-editor"
+
+    @ObservedObject private var store = WorkspaceCommandsStore.shared
+    @State private var selectedID: WorkspaceCommandConfig.ID?
+
+    @State private var showRestoreConfirmation = false
+
+    var body: some View {
+        NavigationSplitView {
+            commandList
+        } detail: {
+            if let id = selectedID,
+               let snapshot = store.command(id: id) {
+                if store.isBuiltIn(id: id) {
+                    BuiltInWorkspaceCommandView(
+                        command: snapshot,
+                        isDefault: store.defaultCommandID == nil
+                            || store.defaultCommandID == id,
+                        onMakeDefault: { store.setDefault(id: nil) }
+                    )
+                    .id(id)
+                } else if let binding = bindingForCommand(id: id) {
+                    WorkspaceCommandDetailEditor(
+                        command: binding,
+                        isDefault: store.defaultCommandID == id,
+                        onToggleDefault: { store.setDefault(id: $0 ? id : nil) },
+                        onDelete: {
+                            store.remove(id: id)
+                            selectedID = WorkspaceCommandsStore.builtInLocalID
+                        }
+                    )
+                    .id(id)
+                }
+            } else {
+                emptyDetail
+            }
+        }
+        .navigationTitle(String(
+            localized: "settings.workspaces.windowTitle",
+            defaultValue: "Workspaces"
+        ))
+        .frame(minWidth: 720, minHeight: 460)
+        .onAppear {
+            if selectedID == nil {
+                selectedID = WorkspaceCommandsStore.builtInLocalID
+            }
+        }
+        .alert(
+            String(
+                localized: "settings.workspaces.restoreDefaults.confirm.title",
+                defaultValue: "Restore Default Workspaces?"
+            ),
+            isPresented: $showRestoreConfirmation
+        ) {
+            Button(role: .destructive) {
+                store.restoreDefaults()
+                selectedID = WorkspaceCommandsStore.builtInLocalID
+            } label: {
+                Text(String(
+                    localized: "settings.workspaces.restoreDefaults.confirm.button",
+                    defaultValue: "Restore"
+                ))
+            }
+            Button(role: .cancel) {} label: {
+                Text(String(
+                    localized: "settings.workspaces.restoreDefaults.confirm.cancel",
+                    defaultValue: "Cancel"
+                ))
+            }
+        } message: {
+            Text(String(
+                localized: "settings.workspaces.restoreDefaults.confirm.message",
+                defaultValue: "This removes every workspace command you've added and leaves only the built-in Local workspace. This cannot be undone."
+            ))
+        }
+    }
+
+    private var commandList: some View {
+        VStack(spacing: 0) {
+            List(selection: $selectedID) {
+                ForEach(store.commands) { command in
+                    WorkspaceCommandListRow(
+                        name: command.name,
+                        isRemote: command.remote != nil,
+                        isDefault: store.defaultCommandID == command.id
+                            || (store.defaultCommandID == nil
+                                && command.id == WorkspaceCommandsStore.builtInLocalID)
+                    )
+                    .tag(command.id as WorkspaceCommandConfig.ID?)
+                }
+                .onMove { source, destination in
+                    store.move(fromOffsets: source, toOffset: destination)
+                }
+            }
+            .listStyle(.sidebar)
+
+            Divider()
+
+            HStack(spacing: 8) {
+                Button {
+                    let new = store.addCommand()
+                    selectedID = new.id
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .buttonStyle(.borderless)
+                .help(String(
+                    localized: "settings.workspaces.addCommand",
+                    defaultValue: "Add workspace command"
+                ))
+
+                Button {
+                    if let id = selectedID, !store.isBuiltIn(id: id) {
+                        store.remove(id: id)
+                        selectedID = WorkspaceCommandsStore.builtInLocalID
+                    }
+                } label: {
+                    Image(systemName: "minus")
+                }
+                .buttonStyle(.borderless)
+                .disabled(selectedID.map { store.isBuiltIn(id: $0) } ?? true)
+                .help(String(
+                    localized: "settings.workspaces.removeCommand",
+                    defaultValue: "Remove selected command"
+                ))
+
+                Spacer()
+
+                Button {
+                    showRestoreConfirmation = true
+                } label: {
+                    Text(String(
+                        localized: "settings.workspaces.restoreDefaults",
+                        defaultValue: "Restore Defaults"
+                    ))
+                    .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .disabled(store.userCommands.isEmpty && store.defaultCommandID == nil)
+                .help(String(
+                    localized: "settings.workspaces.restoreDefaults.help",
+                    defaultValue: "Remove all custom commands and reset to just Local"
+                ))
+            }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
+            .background(Color(nsColor: .underPageBackgroundColor))
+        }
+        .navigationSplitViewColumnWidth(min: 280, ideal: 300, max: 360)
+    }
+
+    private var emptyDetail: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "rectangle.stack.badge.plus")
+                .font(.system(size: 36, weight: .light))
+                .foregroundColor(.secondary)
+            Text(String(
+                localized: "settings.workspaces.empty.title",
+                defaultValue: "No workspace selected"
+            ))
+                .font(.headline)
+            Text(String(
+                localized: "settings.workspaces.empty.subtitle",
+                defaultValue: "Select a workspace command on the left, or click + to create one."
+            ))
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 320)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func bindingForCommand(id: WorkspaceCommandConfig.ID) -> Binding<WorkspaceCommandConfig>? {
+        guard let initial = store.command(id: id) else { return nil }
+        return Binding(
+            get: { store.command(id: id) ?? initial },
+            set: { store.update($0) }
+        )
+    }
+}
+
+private struct WorkspaceCommandListRow: View {
+    let name: String
+    let isRemote: Bool
+    let isDefault: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: isRemote ? "network" : "terminal")
+                .foregroundColor(.secondary)
+            Text(name.isEmpty
+                 ? String(localized: "settings.workspaces.unnamed", defaultValue: "Untitled")
+                 : name)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer()
+            if isDefault {
+                Text(String(
+                    localized: "settings.workspaces.defaultBadge",
+                    defaultValue: "Default"
+                ))
+                .font(.caption2)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(
+                    RoundedRectangle(cornerRadius: 4, style: .continuous)
+                        .fill(Color.secondary.opacity(0.15))
+                )
+            }
+        }
+    }
+}
+
+private struct BuiltInWorkspaceCommandView: View {
+    let command: WorkspaceCommandConfig
+    let isDefault: Bool
+    let onMakeDefault: () -> Void
+
+    var body: some View {
+        Form {
+            Section {
+                LabeledContent {
+                    Text(command.name)
+                        .foregroundColor(.secondary)
+                } label: {
+                    Text(String(localized: "settings.workspaces.field.name", defaultValue: "Name"))
+                }
+                Toggle(
+                    String(
+                        localized: "settings.workspaces.field.useAsDefault",
+                        defaultValue: "Use as default for new workspaces (Cmd-N)"
+                    ),
+                    isOn: Binding(
+                        get: { isDefault },
+                        set: { isOn in
+                            // Local is the fallback when no default is set, so we
+                            // only act on "turn on": switch the explicit default
+                            // back to Local. Turning it off has no meaning — pick
+                            // a different command's "default" toggle instead.
+                            if isOn { onMakeDefault() }
+                        }
+                    )
+                )
+                .disabled(isDefault)
+            }
+            Section {
+                Text(String(
+                    localized: "settings.workspaces.builtIn.local.note",
+                    defaultValue: "Local is built into cmux. It opens a new workspace using your default shell. To customize it, add a separate workspace command."
+                ))
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+        .padding(.top, 4)
+    }
+}
+
+private struct WorkspaceCommandDetailEditor: View {
+    @Binding var command: WorkspaceCommandConfig
+    let isDefault: Bool
+    let onToggleDefault: (Bool) -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Form {
+            Section {
+                TextField(
+                    String(localized: "settings.workspaces.field.name", defaultValue: "Name"),
+                    text: $command.name
+                )
+                Picker(
+                    String(localized: "settings.workspaces.field.restart", defaultValue: "Open behavior"),
+                    selection: $command.restart
+                ) {
+                    ForEach(WorkspaceCommandConfig.Restart.allCases) { mode in
+                        Text(mode.displayName).tag(mode)
+                    }
+                }
+                Toggle(
+                    String(
+                        localized: "settings.workspaces.field.useAsDefault",
+                        defaultValue: "Use as default for new workspaces (Cmd-N)"
+                    ),
+                    isOn: Binding(
+                        get: { isDefault },
+                        set: { onToggleDefault($0) }
+                    )
+                )
+            }
+
+            if command.remote == nil {
+                Section(String(
+                    localized: "settings.workspaces.section.local",
+                    defaultValue: "Local"
+                )) {
+                    let programBinding = Binding<String>(
+                        get: { command.program ?? "" },
+                        set: { newValue in
+                            let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                            command.program = trimmed.isEmpty ? nil : trimmed
+                        }
+                    )
+                    TextField(
+                        String(
+                            localized: "settings.workspaces.field.program",
+                            defaultValue: "Program"
+                        ),
+                        text: programBinding,
+                        prompt: Text(verbatim: "/bin/zsh -l")
+                    )
+                    Text(String(
+                        localized: "settings.workspaces.field.program.help",
+                        defaultValue: "Optional. Leave empty to use your default shell. Provide a full path (e.g. /opt/homebrew/bin/fish) or a command with arguments. The pane closes automatically when the program exits."
+                    ))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                }
+            }
+
+            Section(String(localized: "settings.workspaces.section.remote", defaultValue: "Remote (SSH)")) {
+                Toggle(
+                    String(
+                        localized: "settings.workspaces.field.remoteEnabled",
+                        defaultValue: "Connect via SSH"
+                    ),
+                    isOn: Binding(
+                        get: { command.remote != nil },
+                        set: { enabled in
+                            if enabled, command.remote == nil {
+                                command.remote = WorkspaceCommandConfig.Remote()
+                            } else if !enabled {
+                                command.remote = nil
+                            }
+                        }
+                    )
+                )
+
+                if command.remote != nil {
+                    remoteFields
+                }
+            }
+
+            Section {
+                Button(role: .destructive, action: onDelete) {
+                    Text(String(
+                        localized: "settings.workspaces.deleteCommand",
+                        defaultValue: "Delete Workspace Command"
+                    ))
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .padding(.top, 4)
+    }
+
+    @ViewBuilder
+    private var remoteFields: some View {
+        let hostBinding = Binding(
+            get: { command.remote?.host ?? "" },
+            set: { command.remote?.host = $0 }
+        )
+        TextField(
+            String(localized: "settings.workspaces.field.host", defaultValue: "Host"),
+            text: hostBinding,
+            prompt: Text(verbatim: "user@host.example.com")
+        )
+
+        let portBinding = Binding<String>(
+            get: { command.remote?.port.map(String.init) ?? "" },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                if trimmed.isEmpty {
+                    command.remote?.port = nil
+                } else if let port = Int(trimmed), (1...65535).contains(port) {
+                    command.remote?.port = port
+                }
+            }
+        )
+        TextField(
+            String(localized: "settings.workspaces.field.port", defaultValue: "Port"),
+            text: portBinding,
+            prompt: Text(verbatim: "22")
+        )
+
+        let identityBinding = Binding(
+            get: { command.remote?.identityFile ?? "" },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                command.remote?.identityFile = trimmed.isEmpty ? nil : trimmed
+            }
+        )
+        TextField(
+            String(localized: "settings.workspaces.field.identityFile", defaultValue: "Identity file"),
+            text: identityBinding,
+            prompt: Text(verbatim: "~/.ssh/id_ed25519")
+        )
+
+        let optionsBinding = Binding<String>(
+            get: { (command.remote?.sshOptions ?? []).joined(separator: "\n") },
+            set: { newValue in
+                let lines = newValue
+                    .split(separator: "\n", omittingEmptySubsequences: false)
+                    .map { $0.trimmingCharacters(in: .whitespaces) }
+                    .filter { !$0.isEmpty }
+                command.remote?.sshOptions = lines
+            }
+        )
+        VStack(alignment: .leading, spacing: 4) {
+            Text(String(localized: "settings.workspaces.field.sshOptions", defaultValue: "SSH options (one per line)"))
+                .font(.subheadline)
+            TextEditor(text: optionsBinding)
+                .font(.system(.body, design: .monospaced))
+                .frame(minHeight: 60, maxHeight: 100)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(Color.secondary.opacity(0.3), lineWidth: 1)
+                )
+        }
+
+        let startupBinding = Binding(
+            get: { command.remote?.startupCommand ?? "" },
+            set: { newValue in
+                let trimmed = newValue.trimmingCharacters(in: .whitespacesAndNewlines)
+                command.remote?.startupCommand = trimmed.isEmpty ? nil : trimmed
+            }
+        )
+        TextField(
+            String(localized: "settings.workspaces.field.startupCommand", defaultValue: "Startup command"),
+            text: startupBinding,
+            prompt: Text(verbatim: "tmux attach || tmux new")
+        )
+    }
+}

--- a/Sources/Settings/WorkspaceCommandsSettingsView.swift
+++ b/Sources/Settings/WorkspaceCommandsSettingsView.swift
@@ -8,7 +8,7 @@ import SwiftUI
 struct WorkspaceCommandsSettingsView: View {
     static let windowID = "workspace-commands-editor"
 
-    @ObservedObject private var store = WorkspaceCommandsStore.shared
+    private let store = WorkspaceCommandsStore.shared
     @State private var selectedID: WorkspaceCommandConfig.ID?
 
     @State private var showRestoreConfirmation = false

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -87,8 +87,14 @@ final class WorkspaceCommandsStore: ObservableObject {
     func update(_ command: WorkspaceCommandConfig) {
         guard !isBuiltIn(id: command.id) else { return }
         guard let index = userCommands.firstIndex(where: { $0.id == command.id }) else { return }
+        var sanitized = command
+        // Only collapse whitespace-only names; preserve in-progress typing
+        // (e.g. trailing space while the user types "My Workspace").
+        if command.name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            sanitized.name = defaultNewCommandName()
+        }
         var updated = userCommands
-        updated[index] = command
+        updated[index] = sanitized
         applyUserCommands(updated)
     }
 

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -27,7 +27,6 @@ final class WorkspaceCommandsStore: ObservableObject {
     @Published private(set) var defaultCommandID: WorkspaceCommandConfig.ID?
 
     private let defaults: UserDefaults
-    private var suppressPersist = false
 
     /// Stable identifier for the built-in `Local` command so persisted
     /// `defaultCommandID` references survive across launches.
@@ -162,7 +161,6 @@ final class WorkspaceCommandsStore: ObservableObject {
     }
 
     private func persist() {
-        guard !suppressPersist else { return }
         let snapshot = StoredSnapshot(
             userCommands: userCommands,
             defaultCommandID: defaultCommandID
@@ -176,7 +174,6 @@ final class WorkspaceCommandsStore: ObservableObject {
     private func load() {
         guard let data = defaults.data(forKey: Self.storageKey) else { return }
         guard let snapshot = try? JSONDecoder().decode(StoredSnapshot.self, from: data) else { return }
-        suppressPersist = true
         let sanitizedUserCommands = snapshot.userCommands.filter { $0.id != Self.builtInLocalID }
         userCommands = sanitizedUserCommands
         if let id = snapshot.defaultCommandID,
@@ -186,7 +183,6 @@ final class WorkspaceCommandsStore: ObservableObject {
         } else {
             defaultCommandID = nil
         }
-        suppressPersist = false
     }
 
     private struct StoredSnapshot: Codable {

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -1,6 +1,6 @@
 import AppKit
-import Combine
 import Foundation
+import Observation
 
 /// Single source of truth for the named workspace commands surfaced by the
 /// titlebar `+` picker, the command palette, and Cmd+N. Persisted to
@@ -9,7 +9,8 @@ import Foundation
 /// fallback: workspace commands live in UserDefaults and are edited from the
 /// Preferences UI.
 @MainActor
-final class WorkspaceCommandsStore: ObservableObject {
+@Observable
+final class WorkspaceCommandsStore {
     static let shared = WorkspaceCommandsStore()
 
     static let didChange = Notification.Name("cmux.workspaceCommandsStore.didChange")
@@ -21,10 +22,10 @@ final class WorkspaceCommandsStore: ObservableObject {
     var commands: [WorkspaceCommandConfig] {
         [Self.builtInLocal] + userCommands
     }
-    @Published private(set) var userCommands: [WorkspaceCommandConfig] = []
+    private(set) var userCommands: [WorkspaceCommandConfig] = []
     /// Identifier of the command treated as the default for Cmd+N. `nil`
     /// resolves to the built-in `Local` command.
-    @Published private(set) var defaultCommandID: WorkspaceCommandConfig.ID?
+    private(set) var defaultCommandID: WorkspaceCommandConfig.ID?
 
     private let defaults: UserDefaults
 

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -279,8 +279,9 @@ extension WorkspaceCommandConfig {
             cwd: nil,
             color: normalizedColor,
             layout: nil,
-            remote: remote.map { remote in
+            remote: remote.flatMap { remote in
                 let host = remote.host.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !host.isEmpty else { return nil }
                 let identityFile = remote.identityFile?
                     .trimmingCharacters(in: .whitespacesAndNewlines)
                 let startupCommand = remote.startupCommand?

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -273,10 +273,11 @@ extension WorkspaceCommandConfig {
     /// it without changes.
     func asCmuxCommandDefinition() -> CmuxCommandDefinition {
         let trimmedProgram = program?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let normalizedColor = color.flatMap { WorkspaceTabColorSettings.normalizedHex($0) }
         let workspace = CmuxWorkspaceDefinition(
             name: name,
             cwd: nil,
-            color: color,
+            color: normalizedColor,
             layout: nil,
             remote: remote.map { remote in
                 let host = remote.host.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Sources/Settings/WorkspaceCommandsStore.swift
+++ b/Sources/Settings/WorkspaceCommandsStore.swift
@@ -1,0 +1,318 @@
+import AppKit
+import Combine
+import Foundation
+
+/// Single source of truth for the named workspace commands surfaced by the
+/// titlebar `+` picker, the command palette, and Cmd+N. Persisted to
+/// UserDefaults as a single JSON blob so we can evolve the shape without
+/// schema migrations across many keys. There is intentionally no JSON-file
+/// fallback: workspace commands live in UserDefaults and are edited from the
+/// Preferences UI.
+@MainActor
+final class WorkspaceCommandsStore: ObservableObject {
+    static let shared = WorkspaceCommandsStore()
+
+    static let didChange = Notification.Name("cmux.workspaceCommandsStore.didChange")
+
+    private static let storageKey = "cmux.workspaceCommands.v1"
+
+    /// Full command list surfaced to the UI: the built-in `Local` entry
+    /// always comes first, followed by any commands the user added.
+    var commands: [WorkspaceCommandConfig] {
+        [Self.builtInLocal] + userCommands
+    }
+    @Published private(set) var userCommands: [WorkspaceCommandConfig] = []
+    /// Identifier of the command treated as the default for Cmd+N. `nil`
+    /// resolves to the built-in `Local` command.
+    @Published private(set) var defaultCommandID: WorkspaceCommandConfig.ID?
+
+    private let defaults: UserDefaults
+    private var suppressPersist = false
+
+    /// Stable identifier for the built-in `Local` command so persisted
+    /// `defaultCommandID` references survive across launches.
+    static let builtInLocalID = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
+    static var builtInLocal: WorkspaceCommandConfig {
+        WorkspaceCommandConfig(
+            id: builtInLocalID,
+            name: String(
+                localized: "settings.workspaces.builtIn.local.name",
+                defaultValue: "Local"
+            ),
+            color: nil,
+            restart: .always,
+            remote: nil
+        )
+    }
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        load()
+    }
+
+    func command(id: WorkspaceCommandConfig.ID) -> WorkspaceCommandConfig? {
+        commands.first(where: { $0.id == id })
+    }
+
+    func isBuiltIn(id: WorkspaceCommandConfig.ID) -> Bool {
+        id == Self.builtInLocalID
+    }
+
+    func defaultCommand() -> WorkspaceCommandConfig? {
+        if let id = defaultCommandID, let match = command(id: id) {
+            return match
+        }
+        return Self.builtInLocal
+    }
+
+    func restoreDefaults() {
+        defaultCommandID = nil
+        applyUserCommands([])
+    }
+
+    func addCommand() -> WorkspaceCommandConfig {
+        let new = WorkspaceCommandConfig(
+            id: UUID(),
+            name: defaultNewCommandName(),
+            color: nil,
+            restart: .always,
+            remote: nil
+        )
+        var updated = userCommands
+        updated.append(new)
+        applyUserCommands(updated)
+        return new
+    }
+
+    func update(_ command: WorkspaceCommandConfig) {
+        guard !isBuiltIn(id: command.id) else { return }
+        guard let index = userCommands.firstIndex(where: { $0.id == command.id }) else { return }
+        var updated = userCommands
+        updated[index] = command
+        applyUserCommands(updated)
+    }
+
+    func remove(id: WorkspaceCommandConfig.ID) {
+        guard !isBuiltIn(id: id) else { return }
+        var updated = userCommands
+        updated.removeAll(where: { $0.id == id })
+        applyUserCommands(updated)
+        if defaultCommandID == id {
+            setDefault(id: nil)
+        }
+    }
+
+    func move(fromOffsets source: IndexSet, toOffset destination: Int) {
+        let builtInIndex = 0
+        var translatedSource = IndexSet()
+        for offset in source where offset != builtInIndex {
+            translatedSource.insert(offset - 1)
+        }
+        guard !translatedSource.isEmpty else { return }
+        let translatedDestination = max(destination - 1, 0)
+        var updated = userCommands
+        updated.move(fromOffsets: translatedSource, toOffset: translatedDestination)
+        applyUserCommands(updated)
+    }
+
+    func setDefault(id: WorkspaceCommandConfig.ID?) {
+        let sanitized: WorkspaceCommandConfig.ID?
+        switch id {
+        case nil:
+            sanitized = nil
+        case let id? where id == Self.builtInLocalID
+            || userCommands.contains(where: { $0.id == id }):
+            sanitized = id
+        default:
+            sanitized = nil
+        }
+        guard defaultCommandID != sanitized else { return }
+        defaultCommandID = sanitized
+        persist()
+    }
+
+    private func defaultNewCommandName() -> String {
+        let base = String(localized: "settings.workspaces.newCommand.defaultName", defaultValue: "New Workspace")
+        let existing = Set(commands.map(\.name))
+        if !existing.contains(base) { return base }
+        var n = 2
+        while true {
+            let candidate = String(
+                format: String(
+                    localized: "settings.workspaces.newCommand.numberedName",
+                    defaultValue: "%@ %lld"
+                ),
+                base,
+                Int64(n)
+            )
+            if !existing.contains(candidate) { return candidate }
+            n += 1
+        }
+    }
+
+    private func applyUserCommands(_ next: [WorkspaceCommandConfig]) {
+        userCommands = next
+        if let defaultID = defaultCommandID,
+           defaultID != Self.builtInLocalID,
+           !next.contains(where: { $0.id == defaultID }) {
+            defaultCommandID = nil
+        }
+        persist()
+    }
+
+    private func persist() {
+        guard !suppressPersist else { return }
+        let snapshot = StoredSnapshot(
+            userCommands: userCommands,
+            defaultCommandID: defaultCommandID
+        )
+        if let data = try? JSONEncoder().encode(snapshot) {
+            defaults.set(data, forKey: Self.storageKey)
+        }
+        NotificationCenter.default.post(name: Self.didChange, object: self)
+    }
+
+    private func load() {
+        guard let data = defaults.data(forKey: Self.storageKey) else { return }
+        guard let snapshot = try? JSONDecoder().decode(StoredSnapshot.self, from: data) else { return }
+        suppressPersist = true
+        let sanitizedUserCommands = snapshot.userCommands.filter { $0.id != Self.builtInLocalID }
+        userCommands = sanitizedUserCommands
+        if let id = snapshot.defaultCommandID,
+           id != Self.builtInLocalID,
+           sanitizedUserCommands.contains(where: { $0.id == id }) {
+            defaultCommandID = id
+        } else {
+            defaultCommandID = nil
+        }
+        suppressPersist = false
+    }
+
+    private struct StoredSnapshot: Codable {
+        var userCommands: [WorkspaceCommandConfig]
+        var defaultCommandID: WorkspaceCommandConfig.ID?
+    }
+}
+
+struct WorkspaceCommandConfig: Codable, Identifiable, Equatable, Sendable {
+    var id: UUID
+    var name: String
+    /// Tab/title color as `#RRGGBB`. Optional.
+    var color: String?
+    var restart: Restart
+    /// Program to run as the surface's child process for *non-remote* commands.
+    /// Empty/nil falls back to Ghostty's default. Ignored when `remote != nil`.
+    var program: String?
+    var remote: Remote?
+
+    init(
+        id: UUID,
+        name: String,
+        color: String? = nil,
+        restart: Restart = .always,
+        program: String? = nil,
+        remote: Remote? = nil
+    ) {
+        self.id = id
+        self.name = name
+        self.color = color
+        self.restart = restart
+        self.program = program
+        self.remote = remote
+    }
+
+    enum Restart: String, Codable, Sendable, CaseIterable, Identifiable {
+        case always
+        case ignore
+        case recreate
+        case confirm
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .always:
+                return String(localized: "settings.workspaces.restart.always", defaultValue: "Always create new")
+            case .ignore:
+                return String(localized: "settings.workspaces.restart.ignore", defaultValue: "Reuse existing")
+            case .recreate:
+                return String(localized: "settings.workspaces.restart.recreate", defaultValue: "Replace existing")
+            case .confirm:
+                return String(localized: "settings.workspaces.restart.confirm", defaultValue: "Ask before replacing")
+            }
+        }
+    }
+
+    struct Remote: Codable, Equatable, Sendable {
+        var host: String
+        var port: Int?
+        var identityFile: String?
+        var sshOptions: [String]
+        var startupCommand: String?
+
+        init(
+            host: String = "",
+            port: Int? = nil,
+            identityFile: String? = nil,
+            sshOptions: [String] = [],
+            startupCommand: String? = nil
+        ) {
+            self.host = host
+            self.port = port
+            self.identityFile = identityFile
+            self.sshOptions = sshOptions
+            self.startupCommand = startupCommand
+        }
+    }
+}
+
+extension WorkspaceCommandConfig {
+    /// Project the UserDefaults-backed configuration into the existing
+    /// `CmuxCommandDefinition` shape so the existing executor pipeline can run
+    /// it without changes.
+    func asCmuxCommandDefinition() -> CmuxCommandDefinition {
+        let trimmedProgram = program?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let workspace = CmuxWorkspaceDefinition(
+            name: name,
+            cwd: nil,
+            color: color,
+            layout: nil,
+            remote: remote.map { remote in
+                let host = remote.host.trimmingCharacters(in: .whitespacesAndNewlines)
+                let identityFile = remote.identityFile?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let startupCommand = remote.startupCommand?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                let sshOptions = remote.sshOptions
+                    .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    .filter { !$0.isEmpty }
+                return CmuxRemoteDefinition(
+                    host: host,
+                    port: remote.port,
+                    identityFile: (identityFile?.isEmpty == false) ? identityFile : nil,
+                    sshOptions: sshOptions.isEmpty ? nil : sshOptions,
+                    startupCommand: (startupCommand?.isEmpty == false) ? startupCommand : nil
+                )
+            },
+            program: (trimmedProgram?.isEmpty == false) ? trimmedProgram : nil
+        )
+        let restartBehavior: CmuxRestartBehavior = {
+            switch restart {
+            case .always: return .always
+            case .ignore: return .ignore
+            case .recreate: return .recreate
+            case .confirm: return .confirm
+            }
+        }()
+        return CmuxCommandDefinition(
+            name: name,
+            description: nil,
+            keywords: nil,
+            restart: restartBehavior,
+            workspace: workspace,
+            command: nil,
+            confirm: nil
+        )
+    }
+}

--- a/Sources/Settings/WorkspaceCommandsWindowPresenter.swift
+++ b/Sources/Settings/WorkspaceCommandsWindowPresenter.swift
@@ -1,0 +1,29 @@
+import AppKit
+
+/// Presenter for the Workspaces editor `Window` scene. Mirrors the existing
+/// `SettingsWindowPresenter` pattern: the main `WindowGroup`'s onAppear hands
+/// in an `openWindow(id:)` closure once, and `AppDelegate.openWorkspaceCommandsWindow`
+/// calls `show()` to invoke it. Avoids attaching a view modifier that would
+/// change the WindowGroup's content type identity, which silently breaks
+/// SwiftUI's scene routing and per-window frame persistence.
+@MainActor
+enum WorkspaceCommandsWindowPresenter {
+    private static var openWindow: (@MainActor () -> Void)?
+    private static var shouldOpenWhenConfigured = false
+
+    static func configure(openWindow: @escaping @MainActor () -> Void) {
+        self.openWindow = openWindow
+        if shouldOpenWhenConfigured {
+            shouldOpenWhenConfigured = false
+            openWindow()
+        }
+    }
+
+    static func show() {
+        guard let openWindow else {
+            shouldOpenWhenConfigured = true
+            return
+        }
+        openWindow()
+    }
+}

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -12,6 +12,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
     case globalHotkey
     case keyboardShortcuts
     case workspaceColors
+    case workspaces
     case settingsJSON
     case reset
 
@@ -27,6 +28,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return String(localized: "settings.section.terminal", defaultValue: "Terminal")
         case .workspaceColors:
             return String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors")
+        case .workspaces:
+            return String(localized: "settings.section.workspaces", defaultValue: "Workspaces")
         case .sidebarAppearance:
             return String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar")
         case .betaFeatures:
@@ -58,6 +61,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "terminal"
         case .workspaceColors:
             return "paintpalette"
+        case .workspaces:
+            return "rectangle.stack"
         case .sidebarAppearance:
             return "sidebar.left"
         case .betaFeatures:
@@ -89,6 +94,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev toggle"
         case .workspaceColors:
             return "\(title) palette tabs"
+        case .workspaces:
+            return "\(title) commands local remote ssh launch new workspace cmd n"
         case .sidebarAppearance:
             return "\(title) sidebar details branches badges material terminal background"
         case .betaFeatures:

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -23,6 +23,8 @@ enum SettingsSearchAliasIndex {
             return localized("settings.search.alias.section.keyboardShortcuts", defaultValue: "keybinds key bindings hotkeys chords accelerators commands")
         case .workspaceColors:
             return localized("settings.search.alias.section.workspaceColors", defaultValue: "tab colors palette accent badge selected highlight")
+        case .workspaces:
+            return localized("settings.search.alias.section.workspaces", defaultValue: "workspace commands local remote ssh launch new cmd-n titlebar plus")
         case .settingsJSON:
             return localized("settings.search.alias.section.settingsJSON", defaultValue: "configuration config file json jsonc dotfile ~/.config schema docs")
         case .reset:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1997,7 +1997,8 @@ class TabManager: ObservableObject {
         configTemplate: CmuxSurfaceConfigTemplate?,
         initialTerminalCommand: String?,
         initialTerminalInput: String? = nil,
-        initialTerminalEnvironment: [String: String]
+        initialTerminalEnvironment: [String: String],
+        closePanesOnInitialCommandExit: Bool = false
     ) -> Workspace {
         Workspace(
             title: title,
@@ -2006,7 +2007,8 @@ class TabManager: ObservableObject {
             configTemplate: configTemplate,
             initialTerminalCommand: initialTerminalCommand,
             initialTerminalInput: initialTerminalInput,
-            initialTerminalEnvironment: initialTerminalEnvironment
+            initialTerminalEnvironment: initialTerminalEnvironment,
+            closePanesOnInitialCommandExit: closePanesOnInitialCommandExit
         )
     }
 
@@ -2075,7 +2077,8 @@ class TabManager: ObservableObject {
         select: Bool = true,
         eagerLoadTerminal: Bool = false,
         placementOverride: NewWorkspacePlacement? = nil,
-        autoWelcomeIfNeeded: Bool = true
+        autoWelcomeIfNeeded: Bool = true,
+        closePanesOnInitialCommandExit: Bool = false
     ) -> Workspace {
         let sourceWorkspace = selectedWorkspace
         let capturedTabs = tabs
@@ -2119,7 +2122,8 @@ class TabManager: ObservableObject {
                 configTemplate: inheritedConfig,
                 initialTerminalCommand: initialTerminalCommand,
                 initialTerminalInput: initialTerminalInput,
-                initialTerminalEnvironment: initialTerminalEnvironment
+                initialTerminalEnvironment: initialTerminalEnvironment,
+                closePanesOnInitialCommandExit: closePanesOnInitialCommandExit
             )
             applyCreationChromeInheritance(
                 to: newWorkspace,

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -347,6 +347,173 @@ func titlebarShortcutHintVerticalOffset(for config: TitlebarControlsStyleConfig)
     max(0, floor(config.buttonSize - titlebarShortcutHintHeight(for: config)))
 }
 
+/// Split button: the `+` half runs the default new-workspace action; clicking
+/// the chevron opens an NSMenu listing every workspace command from the user's
+/// store. Backed by AppKit so the menu rebuilds via `menuNeedsUpdate(_:)` every
+/// time the user opens it — a SwiftUI `Menu` inside the titlebar's detached
+/// `NSHostingView` did not reliably re-render in response to
+/// `WorkspaceCommandsStore` mutations.
+struct NewWorkspaceTitlebarControl: NSViewRepresentable {
+    let config: TitlebarControlsStyleConfig
+    let onNewTab: () -> Void
+    let onOpenManager: () -> Void
+
+    func makeNSView(context: Context) -> NewWorkspaceSplitButtonView {
+        let view = NewWorkspaceSplitButtonView(config: config)
+        view.onNewTab = onNewTab
+        view.onOpenManager = onOpenManager
+        return view
+    }
+
+    func updateNSView(_ nsView: NewWorkspaceSplitButtonView, context: Context) {
+        nsView.applyConfig(config)
+        nsView.onNewTab = onNewTab
+        nsView.onOpenManager = onOpenManager
+    }
+}
+
+final class NewWorkspaceSplitButtonView: NSView, NSMenuDelegate {
+    var onNewTab: (() -> Void)?
+    var onOpenManager: (() -> Void)?
+
+    private var styleConfig: TitlebarControlsStyleConfig
+    private let primaryButton = NSButton()
+    private let chevronButton = NSButton()
+    private let dynamicMenu = NSMenu()
+
+    init(config: TitlebarControlsStyleConfig) {
+        self.styleConfig = config
+        super.init(frame: .zero)
+        wantsLayer = true
+        translatesAutoresizingMaskIntoConstraints = false
+
+        primaryButton.translatesAutoresizingMaskIntoConstraints = false
+        primaryButton.bezelStyle = .accessoryBarAction
+        primaryButton.isBordered = false
+        primaryButton.image = NSImage(
+            systemSymbolName: "plus",
+            accessibilityDescription: String(
+                localized: "titlebar.newWorkspace.accessibilityLabel",
+                defaultValue: "New Workspace"
+            )
+        )
+        primaryButton.imageScaling = .scaleProportionallyDown
+        primaryButton.target = self
+        primaryButton.action = #selector(primaryTapped)
+        primaryButton.toolTip = String(
+            localized: "titlebar.newWorkspace.tooltip",
+            defaultValue: "New workspace"
+        )
+        addSubview(primaryButton)
+
+        chevronButton.translatesAutoresizingMaskIntoConstraints = false
+        chevronButton.bezelStyle = .accessoryBarAction
+        chevronButton.isBordered = false
+        chevronButton.image = NSImage(
+            systemSymbolName: "chevron.down",
+            accessibilityDescription: String(
+                localized: "titlebar.newWorkspace.menu.accessibilityLabel",
+                defaultValue: "Pick Workspace Command"
+            )
+        )
+        chevronButton.imageScaling = .scaleProportionallyDown
+        chevronButton.target = self
+        chevronButton.action = #selector(chevronTapped)
+        addSubview(chevronButton)
+
+        dynamicMenu.delegate = self
+        dynamicMenu.autoenablesItems = false
+
+        applyConfig(config)
+        rebuildLayoutConstraints()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func applyConfig(_ config: TitlebarControlsStyleConfig) {
+        styleConfig = config
+        let pointSize = config.iconSize
+        let symbolConfig = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .semibold)
+        primaryButton.symbolConfiguration = symbolConfig
+        chevronButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: max(7, pointSize - 4),
+            weight: .semibold
+        )
+    }
+
+    private func rebuildLayoutConstraints() {
+        let buttonSize = styleConfig.buttonSize
+        let chevronWidth: CGFloat = 14
+        NSLayoutConstraint.activate([
+            primaryButton.leadingAnchor.constraint(equalTo: leadingAnchor),
+            primaryButton.topAnchor.constraint(equalTo: topAnchor),
+            primaryButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+            primaryButton.widthAnchor.constraint(equalToConstant: buttonSize),
+
+            chevronButton.leadingAnchor.constraint(equalTo: primaryButton.trailingAnchor, constant: -2),
+            chevronButton.topAnchor.constraint(equalTo: topAnchor),
+            chevronButton.bottomAnchor.constraint(equalTo: bottomAnchor),
+            chevronButton.widthAnchor.constraint(equalToConstant: chevronWidth),
+            chevronButton.trailingAnchor.constraint(equalTo: trailingAnchor),
+
+            heightAnchor.constraint(equalToConstant: buttonSize),
+        ])
+    }
+
+    @objc private func primaryTapped() {
+        #if DEBUG
+        cmuxDebugLog("titlebar.newTab")
+        #endif
+        onNewTab?()
+    }
+
+    @objc private func chevronTapped() {
+        let location = NSPoint(x: 0, y: bounds.height + 2)
+        dynamicMenu.popUp(positioning: nil, at: location, in: self)
+    }
+
+    func menuNeedsUpdate(_ menu: NSMenu) {
+        menu.removeAllItems()
+        let commands = WorkspaceCommandsStore.shared.commands
+        for command in commands {
+            let item = NSMenuItem(
+                title: command.name,
+                action: #selector(menuItemSelected(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = command.id
+            menu.addItem(item)
+        }
+        menu.addItem(NSMenuItem.separator())
+        let manage = NSMenuItem(
+            title: String(
+                localized: "titlebar.newWorkspace.menu.manage",
+                defaultValue: "Manage Workspaces…"
+            ),
+            action: #selector(manageTapped),
+            keyEquivalent: ""
+        )
+        manage.target = self
+        menu.addItem(manage)
+    }
+
+    @objc private func menuItemSelected(_ sender: NSMenuItem) {
+        guard let id = sender.representedObject as? UUID else { return }
+        AppDelegate.shared?.performWorkspaceCommand(
+            id: id,
+            debugSource: "titlebar.workspaceCommandMenu"
+        )
+    }
+
+    @objc private func manageTapped() {
+        onOpenManager?()
+    }
+}
+
 struct TitlebarControlButton<Content: View>: View {
     let config: TitlebarControlsStyleConfig
     let accessibilityIdentifier: String
@@ -579,21 +746,18 @@ struct TitlebarControlsView: View {
             .background(NotificationsAnchorView { viewModel.notificationsAnchorView = $0 })
             .safeHelp(KeyboardShortcutSettings.Action.showNotifications.tooltip(String(localized: "titlebar.notifications.tooltip", defaultValue: "Show notifications")))
 
-            TitlebarControlButton(
+            NewWorkspaceTitlebarControl(
                 config: config,
-                accessibilityIdentifier: "titlebarControl.newTab",
-                accessibilityLabel: String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"),
-                action: {
-                #if DEBUG
-                cmuxDebugLog("titlebar.newTab")
-                #endif
-                onNewTab()
-            },
-                rightClickAction: { anchorView, event in
-                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: anchorView, event: event)
-                }) {
-                iconLabel(systemName: "plus", config: config)
-            }
+                onNewTab: onNewTab,
+                onOpenManager: {
+                    AppDelegate.shared?.openWorkspaceCommandsWindow(
+                        debugSource: "titlebar.workspaceCommandMenu"
+                    )
+                }
+            )
+            .frame(width: config.buttonSize + 14, height: config.buttonSize)
+            .accessibilityIdentifier("titlebarControl.newTab")
+            .accessibilityLabel(String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"))
             .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
 
         }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -347,6 +347,11 @@ func titlebarShortcutHintVerticalOffset(for config: TitlebarControlsStyleConfig)
     max(0, floor(config.buttonSize - titlebarShortcutHintHeight(for: config)))
 }
 
+/// Extra width the new-workspace split button adds to its primary `+` square
+/// for the chevron half. Shared by the AppKit layout and the SwiftUI titlebar
+/// frame so the shortcut-hint pill can stay aligned with the visual right edge.
+let newWorkspaceChevronWidth: CGFloat = 14
+
 /// Split button: the `+` half runs the default new-workspace action; clicking
 /// the chevron opens an NSMenu listing every workspace command from the user's
 /// store. Backed by AppKit so the menu rebuilds via `menuNeedsUpdate(_:)` every
@@ -446,7 +451,7 @@ final class NewWorkspaceSplitButtonView: NSView, NSMenuDelegate {
 
     private func rebuildLayoutConstraints() {
         let buttonSize = styleConfig.buttonSize
-        let chevronWidth: CGFloat = 14
+        let chevronWidth = newWorkspaceChevronWidth
         NSLayoutConstraint.activate([
             primaryButton.leadingAnchor.constraint(equalTo: leadingAnchor),
             primaryButton.topAnchor.constraint(equalTo: topAnchor),
@@ -755,7 +760,7 @@ struct TitlebarControlsView: View {
                     )
                 }
             )
-            .frame(width: config.buttonSize + 14, height: config.buttonSize)
+            .frame(width: config.buttonSize + newWorkspaceChevronWidth, height: config.buttonSize)
             .accessibilityIdentifier("titlebarControl.newTab")
             .accessibilityLabel(String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"))
             .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
@@ -841,7 +846,11 @@ struct TitlebarControlsView: View {
 
     private func titlebarButtonRightEdge(for slot: HintSlot, config: TitlebarControlsStyleConfig) -> CGFloat {
         let index = CGFloat(slot.rawValue)
-        return (index + 1) * config.buttonSize + index * config.spacing
+        let baseEdge = (index + 1) * config.buttonSize + index * config.spacing
+        // The new-tab slot hosts a split button whose frame is
+        // `buttonSize + newWorkspaceChevronWidth`. Shift the hint pill by the
+        // chevron's width so it lines up with the visual right edge.
+        return slot == .newTab ? baseEdge + newWorkspaceChevronWidth : baseEdge
     }
 
     @ViewBuilder

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7030,6 +7030,12 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customTitle: String?
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
+    /// When true, terminal panes auto-close after the initial command exits
+    /// instead of holding the PTY open with a "Process exited" prompt. Set by
+    /// `CmuxConfigExecutor` for config-driven remote/program workspaces; the
+    /// `cmux ssh` and `vm new` flows leave it false so they keep showing the
+    /// SSH exit message.
+    var closePanesOnInitialCommandExit: Bool = false
     @Published var customColor: String?  // hex string, e.g. "#C0392B"
     @Published private(set) var terminalScrollBarHidden: Bool = false
     @Published var currentDirectory: String
@@ -7591,8 +7597,10 @@ final class Workspace: Identifiable, ObservableObject {
         configTemplate: CmuxSurfaceConfigTemplate? = nil,
         initialTerminalCommand: String? = nil,
         initialTerminalInput: String? = nil,
-        initialTerminalEnvironment: [String: String] = [:], initialDetachedSurface: DetachedSurfaceTransfer? = nil
+        initialTerminalEnvironment: [String: String] = [:], initialDetachedSurface: DetachedSurfaceTransfer? = nil,
+        closePanesOnInitialCommandExit: Bool = false
     ) {
+        self.closePanesOnInitialCommandExit = closePanesOnInitialCommandExit
         self.id = UUID()
         self.portOrdinal = portOrdinal
         self.processTitle = title
@@ -7646,7 +7654,7 @@ final class Workspace: Identifiable, ObservableObject {
         if let trimmedCommand = initialTerminalCommand?.trimmingCharacters(in: .whitespacesAndNewlines),
            !trimmedCommand.isEmpty {
             var template = resolvedConfigTemplate ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
+            template.waitAfterCommand = !closePanesOnInitialCommandExit
             resolvedConfigTemplate = template
         }
 
@@ -9818,7 +9826,7 @@ final class Workspace: Identifiable, ObservableObject {
         // local prompt — which is what we saw during dogfood.
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
+            template.waitAfterCommand = !closePanesOnInitialCommandExit
             inheritedConfig = template
         }
 #if DEBUG
@@ -9983,7 +9991,7 @@ final class Workspace: Identifiable, ObservableObject {
         // local login shell.
         if startupCommand != nil {
             var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
-            template.waitAfterCommand = true
+            template.waitAfterCommand = !closePanesOnInitialCommandExit
             inheritedConfig = template
         }
 
@@ -12614,7 +12622,13 @@ final class Workspace: Identifiable, ObservableObject {
         workingDirectory: String?,
         initialInput: String?
     ) -> TerminalPanel? {
-        let inheritedConfig = inheritedTerminalConfig(inPane: paneId)
+        var inheritedConfig = inheritedTerminalConfig(inPane: paneId)
+        let remoteStartupCommand = remoteTerminalStartupCommand()
+        if remoteStartupCommand != nil {
+            var template = inheritedConfig ?? CmuxSurfaceConfigTemplate()
+            template.waitAfterCommand = !closePanesOnInitialCommandExit
+            inheritedConfig = template
+        }
 
         let newPanel = TerminalPanel(
             workspaceId: id,
@@ -12622,11 +12636,15 @@ final class Workspace: Identifiable, ObservableObject {
             configTemplate: inheritedConfig,
             workingDirectory: workingDirectory,
             portOrdinal: portOrdinal,
+            initialCommand: remoteStartupCommand,
             initialInput: initialInput
         )
         configureTerminalPanel(newPanel)
         panels[newPanel.id] = newPanel
         panelTitles[newPanel.id] = newPanel.displayTitle
+        if remoteStartupCommand != nil {
+            trackRemoteTerminalSurface(newPanel.id)
+        }
         seedTerminalInheritanceFontPoints(panelId: newPanel.id, configTemplate: inheritedConfig)
 
         let newTab = Bonsplit.Tab(
@@ -12644,6 +12662,9 @@ final class Workspace: Identifiable, ObservableObject {
             panels.removeValue(forKey: newPanel.id)
             panelTitles.removeValue(forKey: newPanel.id)
             surfaceIdToPanelId.removeValue(forKey: newTab.id)
+            if remoteStartupCommand != nil {
+                untrackRemoteTerminalSurface(newPanel.id)
+            }
             terminalInheritanceFontPointsByPanelId.removeValue(forKey: newPanel.id)
             return nil
         }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1164,6 +1164,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.browser-popup",
     "cmux.browserProfilePopoverDebug",
     "cmux.configEditor",
+    WorkspaceCommandsSettingsView.windowID,
     "cmux.feedButtonStyleDebug",
     "cmux.feedPreview",
     "cmux.feedTextEditorDebug",
@@ -6130,6 +6131,7 @@ struct SettingsView: View {
                     }
 
                     SettingsSectionHeader(title: String(localized: "settings.section.workspaces", defaultValue: "Workspaces"))
+                        .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .workspaces))
                     SettingsCard {
                         WorkspaceCommandsSettingsRow(openWindow: openWindow)
                     }
@@ -7403,18 +7405,29 @@ private struct WorkspaceCommandsSettingsRow: View {
         if store.userCommands.isEmpty {
             return String(
                 localized: "settings.workspaces.row.summary.empty",
-                defaultValue: "No commands yet. Add a Local or Remote (SSH) workspace to launch from Cmd-N or the titlebar +."
+                defaultValue: "Only the built-in Local workspace is available. Add a Local or Remote (SSH) command to launch from Cmd-N or the titlebar +."
             )
         }
         let count = store.commands.count
         let defaultName = store.defaultCommand()?.name
-        let countLabel = String(
-            format: String(
-                localized: "settings.workspaces.row.summary.count",
-                defaultValue: "%d configured"
-            ),
-            count
-        )
+        let countLabel: String
+        if count == 1 {
+            countLabel = String(
+                format: String(
+                    localized: "settings.workspaces.row.summary.count.one",
+                    defaultValue: "%d configured"
+                ),
+                count
+            )
+        } else {
+            countLabel = String(
+                format: String(
+                    localized: "settings.workspaces.row.summary.count.other",
+                    defaultValue: "%d configured"
+                ),
+                count
+            )
+        }
         if let defaultName, !defaultName.isEmpty {
             return countLabel + " · " + String(
                 format: String(

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -196,6 +196,9 @@ struct cmuxApp: App {
                             AppDelegate.shared?.preferredMainWindowForSettingsPresentation()
                         }
                     )
+                    WorkspaceCommandsWindowPresenter.configure {
+                        openWindow(id: WorkspaceCommandsSettingsView.windowID)
+                    }
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
                         UpdateLogStore.shared.append("ui test: cmuxApp onAppear")
@@ -625,6 +628,16 @@ struct cmuxApp: App {
             ConfigSettingsView()
                 .cmuxAppearanceColorScheme(appearanceMode)
         }
+
+        Window(
+            String(localized: "settings.workspaces.windowTitle", defaultValue: "Workspaces"),
+            id: WorkspaceCommandsSettingsView.windowID
+        ) {
+            WorkspaceCommandsSettingsView()
+                .cmuxAppearanceColorScheme(appearanceMode)
+        }
+        .defaultSize(width: 760, height: 500)
+        .windowResizability(.contentMinSize)
     }
 
     @CommandsBuilder
@@ -6116,6 +6129,11 @@ struct SettingsView: View {
 
                     }
 
+                    SettingsSectionHeader(title: String(localized: "settings.section.workspaces", defaultValue: "Workspaces"))
+                    SettingsCard {
+                        WorkspaceCommandsSettingsRow(openWindow: openWindow)
+                    }
+
                     SettingsSectionHeader(title: String(localized: "settings.section.terminal", defaultValue: "Terminal"))
                         .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .terminal))
                     SettingsCard {
@@ -7350,6 +7368,63 @@ struct SettingsSectionHeader: View {
             .foregroundColor(.secondary)
             .padding(.leading, 2)
             .padding(.bottom, -2)
+    }
+}
+
+private struct WorkspaceCommandsSettingsRow: View {
+    let openWindow: OpenWindowAction
+    @ObservedObject private var store = WorkspaceCommandsStore.shared
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(String(
+                    localized: "settings.workspaces.row.title",
+                    defaultValue: "Workspace commands"
+                ))
+                .font(.system(size: 13, weight: .medium))
+                Text(summary)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+            Spacer()
+            Button(String(
+                localized: "settings.workspaces.row.manage",
+                defaultValue: "Manage Workspaces…"
+            )) {
+                openWindow(id: WorkspaceCommandsSettingsView.windowID)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+    }
+
+    private var summary: String {
+        if store.userCommands.isEmpty {
+            return String(
+                localized: "settings.workspaces.row.summary.empty",
+                defaultValue: "No commands yet. Add a Local or Remote (SSH) workspace to launch from Cmd-N or the titlebar +."
+            )
+        }
+        let count = store.commands.count
+        let defaultName = store.defaultCommand()?.name
+        let countLabel = String(
+            format: String(
+                localized: "settings.workspaces.row.summary.count",
+                defaultValue: "%d configured"
+            ),
+            count
+        )
+        if let defaultName, !defaultName.isEmpty {
+            return countLabel + " · " + String(
+                format: String(
+                    localized: "settings.workspaces.row.summary.default",
+                    defaultValue: "Default: %@"
+                ),
+                defaultName
+            )
+        }
+        return countLabel
     }
 }
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -7375,7 +7375,7 @@ struct SettingsSectionHeader: View {
 
 private struct WorkspaceCommandsSettingsRow: View {
     let openWindow: OpenWindowAction
-    @ObservedObject private var store = WorkspaceCommandsStore.shared
+    private let store = WorkspaceCommandsStore.shared
 
     var body: some View {
         HStack(alignment: .firstTextBaseline) {

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1150,7 +1150,7 @@ final class CmuxConfigDecodingTests: XCTestCase {
     }
 
     func testDecodeRestartBehaviors() throws {
-        for behavior in ["new", "recreate", "ignore", "confirm"] {
+        for behavior in ["new", "recreate", "ignore", "confirm", "always"] {
             let json = """
             {
               "commands": [{


### PR DESCRIPTION
## Summary

Adds a **Workspaces** section in Settings so you can define named workspace profiles — local shells, custom programs (fish, bash with flags, etc.), or remote SSH targets — and launch them from Cmd-N, the titlebar `+`, or the new chevron menu next to it. Closes #3257.

### What you can do

- **Manage workspaces in Settings → Workspaces.** Add, remove, reorder, and edit profiles in a list/detail editor. A built-in `Local` profile is always pinned at the top.
- **Pick a default for Cmd-N.** Each profile has a "Use as default for new workspaces" toggle. The titlebar `+` runs the default; its chevron opens an `NSMenu` of every profile plus a shortcut to the editor.
- **Configure remote SSH workspaces** with host, port, identity file, ssh `-o` options, and an optional startup command.
- **Configure custom local shells** with a "Program" field — e.g. `/opt/homebrew/bin/fish`, `/bin/bash -l`, `/usr/bin/env zsh --no-rcs`. Empty falls back to your default shell.
- **Auto-suffix duplicate names.** Each Cmd-N spawns a fresh tab (`server`, `server 2`, …) by default. The previous "Reuse / Replace / Ask" behaviors remain available per profile.
- **Restore defaults.** A button in the editor wipes everything you've added and leaves only `Local`.
- **First launch respects your default.** Opening cmux with no prior session uses your configured default profile for the first window instead of a bare local tab.

### Routing

The user's `WorkspaceCommandsStore` default takes precedence over `cmux.json`'s `newWorkspaceCommand` action whenever an explicit non-Local default is set. `Local` (no explicit default) falls through to the existing JSON-based path.

### Storage

Workspace commands live in `UserDefaults` under `cmux.workspaceCommands.v1`. Old workspace commands in `~/.config/cmux/cmux.json` are not migrated — re-enter them in Settings → Workspaces and pick a default.

---

Demo video: https://youtu.be/BN-ju-sKIjU

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable workspace commands with SSH and custom shell support so you can define profiles and launch them via Cmd‑N or the titlebar + menu. Implements #3257 to make new workspaces faster to start and easier to customize.

- **New Features**
  - Settings → Workspaces: add/remove/reorder profiles; built‑in “Local” pinned; stored in `UserDefaults` (`cmux.workspaceCommands.v1`); Restore Defaults; opens in its own editor window; searchable in Settings.
  - Profile types: Local (optional Program path/args) and Remote (SSH host/port/identity, `-o` options, startup command). Panes auto‑close after the initial program/SSH command exits.
  - Launching: Cmd‑N and the titlebar split “+” run your default; the chevron menu lists all profiles and “Manage Workspaces…”.
  - Behavior: restart modes (Always create new, Reuse, Replace, Ask). “Always” auto‑suffixes titles (e.g. “server 2”). Optional tab color (`#RRGGBB`).
  - Routing: an explicit default profile overrides `cmux.json`’s `newWorkspaceCommand`; on a true fresh launch (no session restore and no explicit open intent), the default runs for the first window.
  - Note: existing commands in `~/.config/cmux/cmux.json` are not migrated; re‑enter them in Settings → Workspaces and set a default if desired.

- **Bug Fixes**
  - Align the Cmd‑N titlebar shortcut hint with the new split “+” button.
  - Normalize Remote inputs: trim fields and treat a blank SSH host as “no remote” so the Program fallback works.
  - Avoid a startup crash by not force‑unwrapping the persisted default profile.
  - Settings editor tweaks: the built‑in Local row isn’t draggable; show the Local Program field whenever the Remote host is blank; replace whitespace‑only names at save while preserving normal typing.
  - Register the Workspaces editor as an auxiliary window so Cmd‑W closes it.
  - Normalize saved tab colors to `#RRGGBB`; improve empty‑state copy and pluralized summaries; slightly increase default/min sidebar width to fit the new split control.
  - Refactor: migrate `WorkspaceCommandsStore` to `@Observable` and remove a dead `suppressPersist` flag to fix state layout checks and simplify persistence.

<sup>Written for commit 9779fb9b3f6b4d6671d050e884426f4ce94288e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspaces editor for creating/managing workspace commands (including SSH/remote options), ordering, and setting a default.
  * Titlebar split “New Workspace” button with dropdown to run commands or open the manager.
  * App menu/controls to run workspace commands and open the Workspaces manager window.
  * Workspaces window added and a Settings row to open it.

* **Improvements**
  * Workspace commands can run automatically at creation (supports remote auto-connect and initial terminal commands); option to auto-close panes after initial command.
  * Added "always" restart behavior for workspace creation.
  * Sidebar default/minimum widths adjusted for more consistent layout.

* **Tests**
  * Config decoding tests updated to include the new "always" restart value.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3771)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->