### PR TITLE
Add mobile sync opt-in controls

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4176,10 +4176,10 @@ struct CMUXCLI {
     }
 
     func runIOSCommand(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
-        let subcommand = commandArgs.first?.lowercased() ?? "status"
+        let subcommand = commandArgs.first?.lowercased() ?? "on"
         let remaining = Array(commandArgs.dropFirst())
         guard remaining.isEmpty else {
-            throw CLIError(message: "Usage: cmux ios status")
+            throw CLIError(message: "Usage: cmux ios [status|on|off]")
         }
 
         switch subcommand {
@@ -4190,8 +4190,22 @@ struct CMUXCLI {
                 return
             }
             printIOSStatus(payload)
+        case "on", "enable", "start":
+            let payload = try client.sendV2(method: "mobile_sync.enable")
+            if jsonOutput {
+                print(jsonString(payload))
+                return
+            }
+            printIOSStatus(payload)
+        case "off", "disable", "stop":
+            let payload = try client.sendV2(method: "mobile_sync.disable")
+            if jsonOutput {
+                print(jsonString(payload))
+                return
+            }
+            printIOSStatus(payload)
         default:
-            throw CLIError(message: "Usage: cmux ios status")
+            throw CLIError(message: "Usage: cmux ios [status|on|off]")
         }
     }
 
@@ -8359,9 +8373,9 @@ struct CMUXCLI {
             """
         case "ios":
             return """
-            Usage: cmux ios status
+            Usage: cmux ios [status|on|off]
 
-            Show iOS/iPadOS mobile sync status. Mobile sync is off by default and does not listen until enabled by a later command or Settings.
+            Enable, disable, or show iOS/iPadOS mobile sync status. Mobile sync is off by default and this build does not start a listener yet.
             """
         case "login":
             return """
@@ -20430,7 +20444,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           capabilities
           events [--after <seq>] [--cursor-file <path>] [--name <event>] [--category <category>] [--reconnect] [--limit <n>] [--no-ack] [--no-heartbeat]
           auth <status|login|logout>
-          ios status
+          ios [status|on|off]
           login | logout                                      (aliases for auth login/logout)
           vm <new|ls|rm|exec|shell|ssh> [args...]    (alias: cloud)
           rpc <method> [json-params]

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -107065,6 +107065,41 @@
         }
       }
     },
+    "settings.automation.mobileSync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "iOS and iPadOS Sync" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "iOS と iPadOS の同期" } }
+      }
+    },
+    "settings.automation.mobileSync.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Enabled. Pairing will require Tailscale; this build keeps the listener stopped until the server phase lands." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "有効です。ペアリングには Tailscale が必要です。このビルドではサーバーフェーズまでリスナーは停止したままです。" } }
+      }
+    },
+    "settings.automation.mobileSync.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Off. cmux is not listening for iPhone or iPad connections." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "オフです。cmux は iPhone または iPad からの接続を待ち受けていません。" } }
+      }
+    },
+    "settings.automation.mobileSync.note": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Production pairing will be Tailscale-only. You can also toggle this with `cmux ios` and `cmux ios off`." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "本番のペアリングは Tailscale のみを使用します。`cmux ios` と `cmux ios off` でも切り替えられます。" } }
+      }
+    },
+    "settings.search.alias.setting.automation.mobile-sync": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "ios ipad tailscale mobile sync remote control pairing" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ios ipad tailscale mobile sync remote control pairing iOS iPad Tailscale モバイル 同期 リモート 制御 ペアリング" } }
+      }
+    },
     "terminal.mobileSizeOverlay.label": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/MobileSyncModels.swift
+++ b/Sources/MobileSyncModels.swift
@@ -594,6 +594,7 @@ nonisolated struct MobileSyncSettingsSnapshot: Equatable, Sendable, Codable {
 enum MobileSyncSettings {
     nonisolated static let enabledKey = "mobileSyncEnabled"
     nonisolated static let defaultEnabled = false
+    nonisolated static let didChangeNotification = Notification.Name("cmux.mobileSyncSettingsDidChange")
 
     @MainActor
     static func snapshot(defaults: UserDefaults = .standard) -> MobileSyncSettingsSnapshot {
@@ -605,7 +606,56 @@ enum MobileSyncSettings {
 
     @MainActor
     static func setEnabled(_ enabled: Bool, defaults: UserDefaults = .standard) {
+        let previous = snapshot(defaults: defaults).enabled
         defaults.set(enabled, forKey: enabledKey)
+        guard previous != enabled else { return }
+        NotificationCenter.default.post(name: didChangeNotification, object: nil)
+    }
+}
+
+enum MobileSyncActions {
+    @MainActor
+    static func enable(
+        tabManager: TabManager?,
+        defaults: UserDefaults = .standard,
+        tailscale: MobileSyncTailscaleDetection? = nil
+    ) -> MobileSyncStatusSnapshot {
+        setEnabled(true, tabManager: tabManager, defaults: defaults, tailscale: tailscale)
+    }
+
+    @MainActor
+    static func disable(
+        tabManager: TabManager?,
+        defaults: UserDefaults = .standard,
+        tailscale: MobileSyncTailscaleDetection? = nil
+    ) -> MobileSyncStatusSnapshot {
+        setEnabled(false, tabManager: tabManager, defaults: defaults, tailscale: tailscale)
+    }
+
+    @MainActor
+    static func setEnabled(
+        _ enabled: Bool,
+        tabManager: TabManager?,
+        defaults: UserDefaults = .standard,
+        tailscale: MobileSyncTailscaleDetection? = nil
+    ) -> MobileSyncStatusSnapshot {
+        MobileSyncSettings.setEnabled(enabled, defaults: defaults)
+        return status(tabManager: tabManager, defaults: defaults, tailscale: tailscale)
+    }
+
+    @MainActor
+    static func status(
+        tabManager: TabManager?,
+        defaults: UserDefaults = .standard,
+        tailscale: MobileSyncTailscaleDetection? = nil,
+        activeAttachmentCount: Int = 0
+    ) -> MobileSyncStatusSnapshot {
+        MobileSyncStatusBuilder.status(
+            tabManager: tabManager,
+            settings: MobileSyncSettings.snapshot(defaults: defaults),
+            tailscale: tailscale,
+            activeAttachmentCount: activeAttachmentCount
+        )
     }
 }
 
@@ -623,10 +673,11 @@ enum MobileSyncStatusBuilder {
     static func status(
         tabManager: TabManager?,
         settings: MobileSyncSettingsSnapshot? = nil,
+        defaults: UserDefaults = .standard,
         tailscale: MobileSyncTailscaleDetection? = nil,
         activeAttachmentCount: Int = 0
     ) -> MobileSyncStatusSnapshot {
-        let resolvedSettings = settings ?? MobileSyncSettings.snapshot()
+        let resolvedSettings = settings ?? MobileSyncSettings.snapshot(defaults: defaults)
         let resolvedTailscale = tailscale ?? MobileSyncTailscaleDetector.detectCurrentSystem()
         let workspaces = tabManager.map(MobileWorkspaceSnapshot.snapshots(from:)) ?? []
         let listenerState: MobileSyncListenerState = {

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -94,7 +94,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         case .betaFeatures:
             return "\(title) beta experimental unstable feed dock right sidebar"
         case .automation:
-            return "\(title) socket integrations hooks ports claude cursor gemini"
+            return "\(title) socket integrations hooks ports claude cursor gemini ios ipad tailscale mobile sync"
         case .browser:
             return "\(title) search engine links history theme"
         case .browserImport:
@@ -330,6 +330,7 @@ enum SettingsSearchIndex {
         setting(.sidebarAppearance, "show-metadata", String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar"), "report meta status block"),
         setting(.betaFeatures, "feed", String(localized: "settings.betaFeatures.feed", defaultValue: "Feed"), "feed right sidebar agent decisions permissions questions"),
         setting(.betaFeatures, "dock", String(localized: "settings.betaFeatures.dock", defaultValue: "Dock"), "dock right sidebar terminal controls tui"),
+        setting(.automation, "mobile-sync", String(localized: "settings.automation.mobileSync", defaultValue: "iOS and iPadOS Sync"), "ios ipad tailscale mobile sync remote control"),
         setting(.automation, "socket-mode", String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"), "unix socket api access password auth"),
         setting(.automation, "socket-password", String(localized: "settings.automation.socketPassword", defaultValue: "Socket Password"), "socket auth credential"),
         setting(.automation, "claude-code", String(localized: "settings.automation.claudeCode", defaultValue: "Claude Code Integration"), "agent hooks notifications"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -12,7 +12,7 @@ enum SettingsSearchAliasIndex {
         case .betaFeatures:
             return localized("settings.search.alias.section.betaFeatures", defaultValue: "beta experimental unstable preview feed dock right sidebar")
         case .automation:
-            return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports")
+            return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports ios ipad tailscale mobile sync")
         case .browser:
             return localized("settings.search.alias.section.browser", defaultValue: "web webview address bar omnibar links urls embedded default browser")
         case .browserImport:
@@ -79,6 +79,7 @@ enum SettingsSearchAliasIndex {
         "sidebarAppearance:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
         "betaFeatures:feed": localized("settings.search.alias.setting.betaFeatures.feed", defaultValue: "feed right sidebar agent decisions permissions questions approval beta unstable"),
         "betaFeatures:dock": localized("settings.search.alias.setting.betaFeatures.dock", defaultValue: "dock right sidebar terminal controls tui beta unstable"),
+        "automation:mobile-sync": localized("settings.search.alias.setting.automation.mobile-sync", defaultValue: "ios ipad tailscale mobile sync remote control pairing"),
         "automation:socket-mode": localized("settings.search.alias.setting.automation.socket-mode", defaultValue: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),
         "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),
         "automation:claude-code": localized("settings.search.alias.setting.automation.claude-code", defaultValue: "automation.claudeCodeIntegration claude code hooks agent integration status notifications"),

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2393,6 +2393,10 @@ class TerminalController {
             return v2Result(id: id, self.v2SystemTree(params: params))
         case "mobile_sync.status":
             return v2Ok(id: id, result: self.v2MobileSyncStatus(params: params))
+        case "mobile_sync.enable":
+            return v2Ok(id: id, result: self.v2MobileSyncEnable(params: params))
+        case "mobile_sync.disable":
+            return v2Ok(id: id, result: self.v2MobileSyncDisable(params: params))
 #if DEBUG
         case "debug.mobile_sync.set_fake_remote_size":
             return v2Result(id: id, self.v2DebugMobileSyncSetFakeRemoteSize(params: params))
@@ -2832,6 +2836,8 @@ class TerminalController {
             "system.top",
             "events.stream",
             "mobile_sync.status",
+            "mobile_sync.enable",
+            "mobile_sync.disable",
             "auth.login",
             "auth.status",
             "auth.begin_sign_in",
@@ -3056,7 +3062,17 @@ class TerminalController {
 
     private func v2MobileSyncStatus(params: [String: Any]) -> [String: Any] {
         let manager = v2ResolveTabManager(params: params)
-        return MobileSyncStatusBuilder.status(tabManager: manager).socketPayload
+        return MobileSyncActions.status(tabManager: manager).socketPayload
+    }
+
+    private func v2MobileSyncEnable(params: [String: Any]) -> [String: Any] {
+        let manager = v2ResolveTabManager(params: params)
+        return MobileSyncActions.enable(tabManager: manager).socketPayload
+    }
+
+    private func v2MobileSyncDisable(params: [String: Any]) -> [String: Any] {
+        let manager = v2ResolveTabManager(params: params)
+        return MobileSyncActions.disable(tabManager: manager).socketPayload
     }
 
 #if DEBUG

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5210,6 +5210,7 @@ struct SettingsView: View {
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
     @AppStorage(SocketControlSettings.appStorageKey) private var socketControlMode = SocketControlSettings.defaultMode.rawValue
+    @AppStorage(MobileSyncSettings.enabledKey) private var mobileSyncEnabled = MobileSyncSettings.defaultEnabled
     @AppStorage(ClaudeCodeIntegrationSettings.hooksEnabledKey)
     private var claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
     @AppStorage(ClaudeCodeIntegrationSettings.customClaudePathKey)
@@ -5550,6 +5551,33 @@ struct SettingsView: View {
                     socketPasswordStatusIsError = false
                 }
             }
+        )
+    }
+
+    private var mobileSyncEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { mobileSyncEnabled },
+            set: { newValue in
+                let status = MobileSyncActions.setEnabled(
+                    newValue,
+                    tabManager: nil,
+                    defaults: .standard
+                )
+                mobileSyncEnabled = status.settings.enabled
+            }
+        )
+    }
+
+    private var mobileSyncSubtitle: String {
+        if mobileSyncEnabled {
+            return String(
+                localized: "settings.automation.mobileSync.subtitleOn",
+                defaultValue: "Enabled. Pairing will require Tailscale; this build keeps the listener stopped until the server phase lands."
+            )
+        }
+        return String(
+            localized: "settings.automation.mobileSync.subtitleOff",
+            defaultValue: "Off. cmux is not listening for iPhone or iPad connections."
         )
     }
 
@@ -6550,6 +6578,24 @@ struct SettingsView: View {
                     SettingsSectionHeader(title: String(localized: "settings.section.automation", defaultValue: "Automation"))
                         .settingsSearchAnchor(SettingsSearchIndex.sectionID(for: .automation))
                     SettingsCard {
+                        SettingsCardRow(
+                            configurationReview: .settingsOnly,
+                            String(localized: "settings.automation.mobileSync", defaultValue: "iOS and iPadOS Sync"),
+                            subtitle: mobileSyncSubtitle,
+                            searchAnchorID: SettingsSearchIndex.settingID(for: .automation, idSuffix: "mobile-sync")
+                        ) {
+                            Toggle("", isOn: mobileSyncEnabledBinding)
+                                .labelsHidden()
+                                .controlSize(.small)
+                                .accessibilityIdentifier("SettingsMobileSyncToggle")
+                        }
+
+                        SettingsCardDivider()
+
+                        SettingsCardNote(String(localized: "settings.automation.mobileSync.note", defaultValue: "Production pairing will be Tailscale-only. You can also toggle this with `cmux ios` and `cmux ios off`."))
+                    }
+
+                    SettingsCard {
                         SettingsPickerRow(
                             configurationReview: .json("automation.socketControlMode"),
                             String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"),
@@ -7442,6 +7488,10 @@ struct SettingsView: View {
         appIconMode = AppIconSettings.defaultMode.rawValue
         AppIconSettings.applyIcon(.automatic)
         socketControlMode = SocketControlSettings.defaultMode.rawValue
+        mobileSyncEnabled = MobileSyncActions.disable(
+            tabManager: nil,
+            defaults: .standard
+        ).settings.enabled
         claudeCodeHooksEnabled = ClaudeCodeIntegrationSettings.defaultHooksEnabled
         customClaudePath = ""
         cursorHooksEnabled = CursorIntegrationSettings.defaultHooksEnabled

--- a/cmuxTests/AppDelegateIssue2907RoutingTests.swift
+++ b/cmuxTests/AppDelegateIssue2907RoutingTests.swift
@@ -94,6 +94,8 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         let capabilities = try v2Result(method: "system.capabilities")
         let methods = try XCTUnwrap(capabilities["methods"] as? [String])
         XCTAssertTrue(methods.contains("mobile_sync.status"))
+        XCTAssertTrue(methods.contains("mobile_sync.enable"))
+        XCTAssertTrue(methods.contains("mobile_sync.disable"))
 
         let status = try v2Result(method: "mobile_sync.status")
         XCTAssertEqual(status["enabled"] as? Bool, false)
@@ -101,6 +103,15 @@ final class AppDelegateIssue2907RoutingTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(status["workspace_count"] as? Int ?? 0, 1)
         XCTAssertGreaterThanOrEqual(status["terminal_count"] as? Int ?? 0, 1)
         XCTAssertEqual(status["active_attachment_count"] as? Int, 0)
+
+        let enabled = try v2Result(method: "mobile_sync.enable")
+        XCTAssertEqual(enabled["enabled"] as? Bool, true)
+        XCTAssertTrue(MobileSyncSettings.snapshot().enabled)
+
+        let disabled = try v2Result(method: "mobile_sync.disable")
+        XCTAssertEqual(disabled["enabled"] as? Bool, false)
+        XCTAssertFalse(MobileSyncSettings.snapshot().enabled)
+        XCTAssertEqual((disabled["listener"] as? [String: Any])?["state"] as? String, "stopped")
     }
 
 #if DEBUG

--- a/cmuxTests/CLIMobileSyncTests.swift
+++ b/cmuxTests/CLIMobileSyncTests.swift
@@ -2,6 +2,132 @@ import Darwin
 import XCTest
 
 extension CLINotifyProcessIntegrationRegressionTests {
+    func testIOSDefaultCommandEnablesMobileSync() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ios-enable")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            XCTAssertEqual(method, "mobile_sync.enable")
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: self.iosStatusPayload(
+                    enabled: true,
+                    listenerState: "stopped",
+                    tailscaleAvailable: true,
+                    selectedAddress: "100.64.1.2"
+                )
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ios"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            """
+            Mobile Sync: enabled
+            Listener: stopped
+            Tailscale: available (100.64.1.2)
+            Workspaces: 2
+            Terminals: 3
+            Active attachments: 0
+
+            """
+        )
+        XCTAssertTrue(
+            state.commands.contains { $0.contains(#""method":"mobile_sync.enable""#) },
+            "Expected ios to call mobile_sync.enable, saw \(state.commands)"
+        )
+    }
+
+    func testIOSOffDisablesMobileSync() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("ios-disable")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            XCTAssertEqual(method, "mobile_sync.disable")
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: self.iosStatusPayload(
+                    enabled: false,
+                    listenerState: "stopped",
+                    tailscaleAvailable: false,
+                    selectedAddress: nil
+                )
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["ios", "off"],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            """
+            Mobile Sync: disabled
+            Listener: stopped
+            Tailscale: unavailable
+            Workspaces: 2
+            Terminals: 3
+            Active attachments: 0
+
+            """
+        )
+        XCTAssertTrue(
+            state.commands.contains { $0.contains(#""method":"mobile_sync.disable""#) },
+            "Expected ios off to call mobile_sync.disable, saw \(state.commands)"
+        )
+    }
+
     func testIOSStatusRendersDisabledProductionSafeStatus() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("ios-status")

--- a/cmuxTests/MobileSyncModelTests.swift
+++ b/cmuxTests/MobileSyncModelTests.swift
@@ -157,6 +157,60 @@ final class MobileSyncModelTests: XCTestCase {
         XCTAssertEqual(status.socketPayload["enabled"] as? Bool, false)
     }
 
+    @MainActor
+    func testMobileSyncActionsPersistEnableDisableState() {
+        let suiteName = "MobileSyncActionsTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let unavailableTailscale = MobileSyncTailscaleDetection(addresses: [])
+        let enabled = MobileSyncActions.enable(
+            tabManager: nil,
+            defaults: defaults,
+            tailscale: unavailableTailscale
+        )
+
+        XCTAssertTrue(enabled.settings.enabled)
+        XCTAssertTrue(MobileSyncSettings.snapshot(defaults: defaults).enabled)
+        XCTAssertEqual(enabled.listenerState, .waitingForTailscale)
+
+        let disabled = MobileSyncActions.disable(
+            tabManager: nil,
+            defaults: defaults,
+            tailscale: unavailableTailscale
+        )
+
+        XCTAssertFalse(disabled.settings.enabled)
+        XCTAssertFalse(MobileSyncSettings.snapshot(defaults: defaults).enabled)
+        XCTAssertEqual(disabled.listenerState, .stopped)
+    }
+
+    @MainActor
+    func testMobileSyncActionsPostChangeNotificationOnlyWhenValueChanges() {
+        let suiteName = "MobileSyncActionsNotificationTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        var notificationCount = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: MobileSyncSettings.didChangeNotification,
+            object: nil,
+            queue: nil
+        ) { _ in
+            notificationCount += 1
+        }
+        defer {
+            NotificationCenter.default.removeObserver(observer)
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        _ = MobileSyncActions.enable(tabManager: nil, defaults: defaults)
+        _ = MobileSyncActions.enable(tabManager: nil, defaults: defaults)
+        _ = MobileSyncActions.disable(tabManager: nil, defaults: defaults)
+
+        XCTAssertEqual(notificationCount, 2)
+    }
+
     func testOverlayGeometryUsesTopAlignedEffectiveGrid() {
         let snapshot = TerminalSizeOverlaySnapshot(
             localSize: TerminalGridSize(columns: 100, rows: 40),

--- a/cmuxUITests/AutomationSocketUITests.swift
+++ b/cmuxUITests/AutomationSocketUITests.swift
@@ -13,6 +13,7 @@ final class AutomationSocketUITests: XCTestCase {
         continueAfterFailure = false
         socketPath = "/tmp/cmux-debug-\(UUID().uuidString).sock"
         resetSocketDefaults()
+        resetMobileSyncDefaults()
         removeSocketFile()
     }
 
@@ -45,6 +46,38 @@ final class AutomationSocketUITests: XCTestCase {
         app.terminate()
     }
 
+    func testMobileSyncSettingsTogglePersists() throws {
+        let app = configuredApp(mode: "cmuxOnly")
+        app.launchEnvironment["CMUX_UI_TEST_SHOW_SETTINGS"] = "1"
+        app.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        app.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(app, timeout: 12.0),
+            "Expected app to launch for mobile sync Settings test. state=\(app.state.rawValue)"
+        )
+
+        let toggle = try requireMobileSyncToggle(app: app)
+        XCTAssertFalse(toggleIsOn(toggle), "Mobile sync should default off")
+        toggle.click()
+        XCTAssertTrue(waitForMobileSyncToggle(app: app, isOn: true, timeout: 4.0))
+        app.terminate()
+
+        let relaunchedApp = configuredApp(mode: "cmuxOnly")
+        relaunchedApp.launchEnvironment["CMUX_UI_TEST_SHOW_SETTINGS"] = "1"
+        relaunchedApp.launchArguments += ["-AppleLanguages", "(en)", "-AppleLocale", "en_US"]
+        relaunchedApp.launch()
+        XCTAssertTrue(
+            ensureForegroundAfterLaunch(relaunchedApp, timeout: 12.0),
+            "Expected app to relaunch for mobile sync Settings test. state=\(relaunchedApp.state.rawValue)"
+        )
+        addTeardownBlock { relaunchedApp.terminate() }
+
+        let persistedToggle = try requireMobileSyncToggle(app: relaunchedApp)
+        XCTAssertTrue(toggleIsOn(persistedToggle), "Mobile sync setting should persist across launch")
+        persistedToggle.click()
+        XCTAssertTrue(waitForMobileSyncToggle(app: relaunchedApp, isOn: false, timeout: 4.0))
+    }
+
     private func configuredApp(mode: String) -> XCUIApplication {
         let app = XCUIApplication()
         app.launchArguments += ["-\(modeKey)", mode]
@@ -66,6 +99,67 @@ final class AutomationSocketUITests: XCTestCase {
             return app.wait(for: .runningForeground, timeout: 6.0)
         }
         return false
+    }
+
+    private func requireMobileSyncToggle(app: XCUIApplication) throws -> XCUIElement {
+        let scrollView = app.scrollViews.firstMatch
+        let candidates = mobileSyncToggleCandidates(app: app)
+
+        for _ in 0..<10 {
+            if let element = firstExistingElement(candidates: candidates, timeout: 0.5), element.isHittable {
+                return element
+            }
+            if scrollView.exists {
+                scrollView.swipeUp()
+            } else {
+                app.typeKey(",", modifierFlags: [.command])
+            }
+        }
+
+        throw XCTSkip("Could not find the iOS and iPadOS Sync toggle")
+    }
+
+    private func waitForMobileSyncToggle(app: XCUIApplication, isOn: Bool, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let toggle = firstExistingElement(candidates: mobileSyncToggleCandidates(app: app), timeout: 0.2),
+               toggleIsOn(toggle) == isOn {
+                return true
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        return false
+    }
+
+    private func mobileSyncToggleCandidates(app: XCUIApplication) -> [XCUIElement] {
+        [
+            app.switches["SettingsMobileSyncToggle"],
+            app.checkBoxes["SettingsMobileSyncToggle"],
+            app.buttons["SettingsMobileSyncToggle"],
+            app.otherElements["SettingsMobileSyncToggle"],
+            app.switches["iOS and iPadOS Sync"],
+            app.checkBoxes["iOS and iPadOS Sync"],
+            app.buttons["iOS and iPadOS Sync"],
+            app.otherElements["iOS and iPadOS Sync"],
+        ]
+    }
+
+    private func toggleIsOn(_ element: XCUIElement) -> Bool {
+        let value = String(describing: element.value ?? "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return value == "1" || value == "true" || value == "on"
+    }
+
+    private func firstExistingElement(candidates: [XCUIElement], timeout: TimeInterval) -> XCUIElement? {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if let match = candidates.first(where: { $0.exists }) {
+                return match
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.05))
+        }
+        return candidates.first(where: { $0.exists })
     }
 
     private func waitForSocket(exists: Bool, timeout: TimeInterval) -> Bool {
@@ -136,7 +230,23 @@ final class AutomationSocketUITests: XCTestCase {
         }
     }
 
+    private func resetMobileSyncDefaults() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/defaults")
+        process.arguments = ["delete", defaultsDomain, MobileSyncDefaultsKey.enabled]
+        do {
+            try process.run()
+            process.waitUntilExit()
+        } catch {
+            return
+        }
+    }
+
     private func removeSocketFile() {
         try? FileManager.default.removeItem(atPath: socketPath)
     }
+}
+
+private enum MobileSyncDefaultsKey {
+    static let enabled = "mobileSyncEnabled"
 }


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/3759.

This adds the PR3 opt-in surface for iOS/iPadOS sync without starting a listener yet. Mobile sync remains off by default, Settings and CLI use the same `MobileSyncActions` path, and `cmux ios`/`cmux ios off` toggle persisted state through the app socket.

Verification run:

- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- XcodeBuildMCP `cmux-unit` focused tests: 16 passed, 0 failed
- XcodeBuildMCP `cmux` build-for-testing for `cmuxUITests/AutomationSocketUITests`
- `./scripts/reload.sh --tag iosm3`
- Tagged CLI smoke against `/tmp/cmux-debug-iosm3.sock`: `cmux ios status`, `cmux ios`, `cmux ios status`, `cmux ios off`, `cmux ios status`
- `python3 scripts/swift_warning_budget.py --log /tmp/cmux-reload-iosm3.log`
- Confirmed the tagged app had no TCP LISTEN sockets while running this phase

Hosted E2E for `AutomationSocketUITests`: https://github.com/manaflow-ai/cmux/actions/runs/25589124850 passed; artifact issue: https://github.com/manaflow-ai/cmux-dev-artifacts/issues/1408.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new persisted enable/disable controls surfaced via both UI and socket/CLI RPC, which can affect automation flows and user defaults state. No listener/network behavior is started yet, so impact is mostly around state transitions and API compatibility.
> 
> **Overview**
> Adds an **opt-in control surface for iOS/iPadOS Mobile Sync** without starting any listener yet: a new Automation Settings toggle (with localized copy and search aliases) persists `mobileSyncEnabled` and can be reset to off.
> 
> Extends the socket API and CLI to support toggling that persisted state: new RPC methods `mobile_sync.enable`/`mobile_sync.disable` (advertised in capabilities) and `cmux ios` now defaults to `on` with `off`/`status` subcommands.
> 
> Introduces `MobileSyncActions` as the shared path for enable/disable/status, posts a change notification only on actual value changes, and adds unit/CLI/UI tests covering the new endpoints and persistence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 113e708405f87395336c1f987cae640734d18d2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt‑in controls for iOS/iPadOS Mobile Sync. Users can toggle sync in Settings or via the CLI; the state persists. The listener remains stopped in this build.

- **New Features**
  - Settings: new “iOS and iPadOS Sync” toggle under Automation with localized subtitles and note; searchable; persists via `AppStorage`.
  - CLI: `cmux ios [status|on|off]` (default is `on`), prints structured status; JSON output supported.
  - Socket API: adds `mobile_sync.enable` and `mobile_sync.disable`; capabilities list updated.
  - Models: `MobileSyncActions` centralizes enable/disable/status, persists via `UserDefaults`, and posts a change notification.
  - Tests: unit, CLI, and UI tests cover enable/disable flows, persistence, and capabilities; ensures the listener stays stopped.

- **Migration**
  - Mobile Sync is off by default and this build does not start a listener.
  - The CLI default changed: `cmux ios` now enables sync. Use `cmux ios status` to check, and `cmux ios off` to disable.

<sup>Written for commit 113e708405f87395336c1f987cae640734d18d2d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->