### PR TITLE
Add Zero Native cmux prototype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ tests/visual_report.html
 # Local scratch (screenshots, etc.)
 tmp/
 tmp-*/
+
+# Local Zero Native experiment dependencies
+experiments/zero-native-cmux/third_party/

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -3,9 +3,9 @@
 This is a standalone prototype for a cmux-style workbench built on
 `vercel-labs/zero-native`.
 
-The prototype keeps the terminal boundary native: terminal panes are modeled as
-Ghostty host slots backed by the Ghostty C API contract from `../../ghostty`.
-Browser panes run inside the Zero Native Chromium/CEF backend.
+The prototype keeps the terminal boundary native: the window is an AppKit split
+owned by the Zero Native host, with a native Ghostty host slot beside a Chromium
+CEF browser view. Chromium owns browser content only.
 
 ## Run
 
@@ -17,6 +17,15 @@ zig build run
 ```
 
 Use `-Dweb-engine=system` to compare against WKWebView. Chromium is the default.
+`setup.sh` applies the local CEF startup and native shell patches before
+installing the CEF runtime.
+
+To build the clickable macOS app bundle:
+
+```bash
+zig build -Dplatform=macos -Dweb-engine=chromium
+node third_party/zero-native/packages/zero-native/bin/zero-native.js package --target macos --output zig-out/package/zero-cmux.app --binary zig-out/bin/zero-cmux --web-engine chromium --cef-dir third_party/cef/macos --signing adhoc
+```
 
 ## Test
 
@@ -29,5 +38,5 @@ Pass `-Dzero-native-path=<path>` if your Zero Native checkout is elsewhere.
 ## Scope
 
 This is an experiment, not part of the shipping cmux app target. The next hard
-step is adding native pane slots to Zero Native's AppKit host so a live
-Ghostty `NSView` can be mounted beside CEF browser views in the same window.
+step is replacing the native placeholder slot with a live Ghostty `NSView`
+created through `ghostty_surface_new`.

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -4,8 +4,14 @@ This is a standalone prototype for a cmux-style workbench built on
 `vercel-labs/zero-native`.
 
 The prototype keeps the terminal boundary native: the window is an AppKit split
-owned by the Zero Native host, with a native Ghostty host slot beside a Chromium
-CEF browser view. Chromium owns browser content only.
+owned by the Zero Native host, with a live Ghostty `NSView` surface beside a
+Chromium CEF browser view. Chromium owns browser content only.
+
+The Ghostty side loads the normal Ghostty config files plus cmux's App Support
+config fallback (`com.cmuxterm.app/config.ghostty` or `config`). The Chromium
+side has buttons for an internal DevTools pane and a separate DevTools window.
+Both are normal CEF browser views backed by CEF remote debugging, so they can
+stay open independently.
 
 ## Run
 
@@ -32,6 +38,6 @@ Pass `-Dzero-native-path=<path>` if your Zero Native checkout is elsewhere.
 
 ## Scope
 
-This is an experiment, not part of the shipping cmux app target. The next hard
-step is replacing the native placeholder slot with a live Ghostty `NSView`
-created through `ghostty_surface_new`.
+This is an experiment, not part of the shipping cmux app target. The current
+path runs a live Ghostty surface through `ghostty_surface_new` in the native
+AppKit host while CEF is mounted only into the browser pane.

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -18,14 +18,9 @@ zig build run
 
 Use `-Dweb-engine=system` to compare against WKWebView. Chromium is the default.
 `setup.sh` applies the local CEF startup and native shell patches before
-installing the CEF runtime.
-
-To build the clickable macOS app bundle:
-
-```bash
-zig build -Dplatform=macos -Dweb-engine=chromium
-node third_party/zero-native/packages/zero-native/bin/zero-native.js package --target macos --output zig-out/package/zero-cmux.app --binary zig-out/bin/zero-cmux --web-engine chromium --cef-dir third_party/cef/macos --signing adhoc
-```
+installing the CEF runtime. The verified path is `zig build run`; packaging the
+Chromium build as a cmd-clickable `.app` still needs Zero Native helper bundle
+work.
 
 ## Test
 

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -25,9 +25,14 @@ zig build run
 
 Use `-Dweb-engine=system` to compare against WKWebView. Chromium is the default.
 `setup.sh` applies the local CEF startup and native shell patches before
-installing the CEF runtime. The verified path is `zig build run`; packaging the
-Chromium build as a cmd-clickable `.app` still needs Zero Native helper bundle
-work.
+installing the CEF runtime.
+
+To build a cmd-clickable Chromium `.app` with the required CEF helper apps:
+
+```bash
+zig build app
+open zig-out/package/zero-cmux.app
+```
 
 ## Test
 

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -9,9 +9,10 @@ Chromium CEF browser view. Chromium owns browser content only.
 
 The Ghostty side loads the normal Ghostty config files plus cmux's App Support
 config fallback (`com.cmuxterm.app/config.ghostty` or `config`). The Chromium
-side has buttons for an internal DevTools pane and a separate DevTools window.
-Both are normal CEF browser views backed by CEF remote debugging, so they can
-stay open independently.
+side has a vertical workspace rail, horizontal browser tabs per workspace,
+buttons for an internal DevTools pane, and a separate DevTools window. DevTools
+surfaces are normal CEF browser views backed by CEF remote debugging, so they
+can stay open independently.
 
 ## Run
 

--- a/experiments/zero-native-cmux/README.md
+++ b/experiments/zero-native-cmux/README.md
@@ -1,0 +1,33 @@
+# zero-native cmux prototype
+
+This is a standalone prototype for a cmux-style workbench built on
+`vercel-labs/zero-native`.
+
+The prototype keeps the terminal boundary native: terminal panes are modeled as
+Ghostty host slots backed by the Ghostty C API contract from `../../ghostty`.
+Browser panes run inside the Zero Native Chromium/CEF backend.
+
+## Run
+
+Requires Zig 0.16 or newer.
+
+```bash
+./scripts/setup.sh
+zig build run
+```
+
+Use `-Dweb-engine=system` to compare against WKWebView. Chromium is the default.
+
+## Test
+
+```bash
+zig build test -Dplatform=null -Dzero-native-path=/tmp/zero-native
+```
+
+Pass `-Dzero-native-path=<path>` if your Zero Native checkout is elsewhere.
+
+## Scope
+
+This is an experiment, not part of the shipping cmux app target. The next hard
+step is adding native pane slots to Zero Native's AppKit host so a live
+Ghostty `NSView` can be mounted beside CEF browser views in the same window.

--- a/experiments/zero-native-cmux/app.zon
+++ b/experiments/zero-native-cmux/app.zon
@@ -1,0 +1,21 @@
+.{
+    .id = "com.cmux.zero-native",
+    .name = "zero-cmux",
+    .display_name = "cmux Zero Native",
+    .version = "0.1.0",
+    .icons = .{},
+    .platforms = .{ "macos" },
+    .permissions = .{ "window" },
+    .capabilities = .{ "webview", "js_bridge" },
+    .security = .{
+        .navigation = .{
+            .allowed_origins = .{ "zero://inline", "zero://app", "https://zero-native.dev" },
+            .external_links = .{ .action = "deny" },
+        },
+    },
+    .web_engine = "chromium",
+    .cef = .{ .dir = "third_party/cef/macos", .auto_install = false },
+    .windows = .{
+        .{ .label = "main", .title = "cmux Zero Native", .width = 1240, .height = 780, .restore_state = true },
+    },
+}

--- a/experiments/zero-native-cmux/build.zig
+++ b/experiments/zero-native-cmux/build.zig
@@ -61,6 +61,7 @@ pub fn build(b: *std.Build) void {
     });
     linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, zero_native_path, cef_dir, cef_auto_install);
     b.installArtifact(exe);
+    addMacosAppBundleStep(b, target, exe, selected_platform, web_engine, cef_dir);
 
     const run = b.addRunArtifact(exe);
     addCefRuntimeRunFiles(b, target, run, exe, web_engine, cef_dir);
@@ -165,6 +166,36 @@ fn linkPlatform(
     app_mod.linkFramework("UniformTypeIdentifiers", .{});
     app_mod.linkFramework("Carbon", .{});
     app_mod.linkSystemLibrary("c", .{});
+}
+
+fn addMacosAppBundleStep(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    exe: *std.Build.Step.Compile,
+    platform: PlatformOption,
+    web_engine: WebEngineOption,
+    cef_dir: []const u8,
+) void {
+    if (platform != .macos) return;
+    if (target.result.os.tag != .macos) return;
+    if (web_engine != .chromium) return;
+
+    const package_app = b.addSystemCommand(&.{
+        "sh",
+        "scripts/package-app.sh",
+        "--output",
+        "zig-out/package/zero-cmux.app",
+        "--name",
+        app_exe_name,
+        "--bundle-id",
+        "com.cmux.zero-native",
+        "--cef-dir",
+        cef_dir,
+        "--binary",
+    });
+    package_app.addFileArg(exe.getEmittedBin());
+    const app_step = b.step("app", "Build cmd-clickable macOS app bundle");
+    app_step.dependOn(&package_app.step);
 }
 
 fn addCefRuntimeRunFiles(

--- a/experiments/zero-native-cmux/build.zig
+++ b/experiments/zero-native-cmux/build.zig
@@ -1,0 +1,226 @@
+const std = @import("std");
+
+const PlatformOption = enum {
+    auto,
+    null,
+    macos,
+};
+
+const WebEngineOption = enum {
+    system,
+    chromium,
+};
+
+const default_zero_native_path = "third_party/zero-native";
+const app_exe_name = "zero-cmux";
+
+pub fn build(b: *std.Build) void {
+    const target = b.standardTargetOptions(.{});
+    const optimize = b.standardOptimizeOption(.{});
+    const platform_option = b.option(PlatformOption, "platform", "Desktop backend: auto, null, macos") orelse .auto;
+    const requested_web_engine = b.option(WebEngineOption, "web-engine", "Web engine: system, chromium") orelse appWebEngine();
+    const cef_dir = b.option([]const u8, "cef-dir", "Path to the CEF runtime") orelse "third_party/cef/macos";
+    const cef_auto_install = b.option(bool, "cef-auto-install", "Install CEF through zero-native when missing") orelse false;
+    const zero_native_path = b.option([]const u8, "zero-native-path", "Path to the zero-native checkout") orelse default_zero_native_path;
+
+    const selected_platform: PlatformOption = switch (platform_option) {
+        .auto => if (target.result.os.tag == .macos) .macos else .null,
+        else => platform_option,
+    };
+    if (selected_platform == .macos and target.result.os.tag != .macos) {
+        @panic("-Dplatform=macos requires a macOS target");
+    }
+    const web_engine: WebEngineOption = if (selected_platform == .null) .system else requested_web_engine;
+
+    const zero_native_mod = zeroNativeModule(b, target, optimize, zero_native_path);
+    const options = b.addOptions();
+    options.addOption([]const u8, "platform", switch (selected_platform) {
+        .auto => unreachable,
+        .null => "null",
+        .macos => "macos",
+    });
+    options.addOption([]const u8, "web_engine", @tagName(web_engine));
+    const options_mod = options.createModule();
+
+    const runner_mod = localModule(b, target, optimize, "src/runner.zig");
+    runner_mod.addImport("zero-native", zero_native_mod);
+    runner_mod.addImport("build_options", options_mod);
+
+    const ghostty_contract_mod = localModule(b, target, optimize, "src/ghostty_contract.zig");
+    ghostty_contract_mod.addIncludePath(b.path("../../ghostty/include"));
+
+    const app_mod = localModule(b, target, optimize, "src/main.zig");
+    app_mod.addImport("zero-native", zero_native_mod);
+    app_mod.addImport("runner", runner_mod);
+    app_mod.addImport("ghostty-contract", ghostty_contract_mod);
+    app_mod.addIncludePath(b.path("../../ghostty/include"));
+
+    const exe = b.addExecutable(.{
+        .name = app_exe_name,
+        .root_module = app_mod,
+    });
+    linkPlatform(b, target, app_mod, exe, selected_platform, web_engine, zero_native_path, cef_dir, cef_auto_install);
+    b.installArtifact(exe);
+
+    const run = b.addRunArtifact(exe);
+    addCefRuntimeRunFiles(b, target, run, exe, web_engine, cef_dir);
+    const run_step = b.step("run", "Run the prototype");
+    run_step.dependOn(&run.step);
+
+    const tests = b.addTest(.{ .root_module = app_mod });
+    const test_step = b.step("test", "Run prototype tests");
+    test_step.dependOn(&b.addRunArtifact(tests).step);
+}
+
+fn localModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, path: []const u8) *std.Build.Module {
+    return b.createModule(.{
+        .root_source_file = b.path(path),
+        .target = target,
+        .optimize = optimize,
+    });
+}
+
+fn zeroNativePath(b: *std.Build, zero_native_path: []const u8, sub_path: []const u8) std.Build.LazyPath {
+    return .{ .cwd_relative = b.pathJoin(&.{ zero_native_path, sub_path }) };
+}
+
+fn externalModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, zero_native_path: []const u8, path: []const u8) *std.Build.Module {
+    return b.createModule(.{
+        .root_source_file = zeroNativePath(b, zero_native_path, path),
+        .target = target,
+        .optimize = optimize,
+    });
+}
+
+fn zeroNativeModule(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.builtin.OptimizeMode, zero_native_path: []const u8) *std.Build.Module {
+    const geometry_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/geometry/root.zig");
+    const assets_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/assets/root.zig");
+    const app_dirs_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/app_dirs/root.zig");
+    const trace_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/trace/root.zig");
+    const app_manifest_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/app_manifest/root.zig");
+    const diagnostics_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/diagnostics/root.zig");
+    const platform_info_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/platform_info/root.zig");
+    const json_mod = externalModule(b, target, optimize, zero_native_path, "src/primitives/json/root.zig");
+    const debug_mod = externalModule(b, target, optimize, zero_native_path, "src/debug/root.zig");
+    debug_mod.addImport("app_dirs", app_dirs_mod);
+    debug_mod.addImport("trace", trace_mod);
+
+    const zero_native_mod = externalModule(b, target, optimize, zero_native_path, "src/root.zig");
+    zero_native_mod.addImport("geometry", geometry_mod);
+    zero_native_mod.addImport("assets", assets_mod);
+    zero_native_mod.addImport("app_dirs", app_dirs_mod);
+    zero_native_mod.addImport("trace", trace_mod);
+    zero_native_mod.addImport("app_manifest", app_manifest_mod);
+    zero_native_mod.addImport("diagnostics", diagnostics_mod);
+    zero_native_mod.addImport("platform_info", platform_info_mod);
+    zero_native_mod.addImport("json", json_mod);
+    zero_native_mod.addImport("debug", debug_mod);
+    return zero_native_mod;
+}
+
+fn linkPlatform(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    app_mod: *std.Build.Module,
+    exe: *std.Build.Step.Compile,
+    platform: PlatformOption,
+    web_engine: WebEngineOption,
+    zero_native_path: []const u8,
+    cef_dir: []const u8,
+    cef_auto_install: bool,
+) void {
+    _ = target;
+    if (platform != .macos) return;
+
+    switch (web_engine) {
+        .system => {
+            app_mod.addCSourceFile(.{ .file = zeroNativePath(b, zero_native_path, "src/platform/macos/appkit_host.m"), .flags = &.{ "-fobjc-arc", "-ObjC" } });
+            app_mod.linkFramework("WebKit", .{});
+        },
+        .chromium => {
+            const cef_check = addCefCheck(b, cef_dir);
+            if (cef_auto_install) {
+                const cef_auto = b.addSystemCommand(&.{ "zero-native", "cef", "install", "--dir", cef_dir });
+                cef_check.step.dependOn(&cef_auto.step);
+            }
+            exe.step.dependOn(&cef_check.step);
+            const include_arg = b.fmt("-I{s}", .{cef_dir});
+            const define_arg = b.fmt("-DZERO_NATIVE_CEF_DIR=\"{s}\"", .{cef_dir});
+            app_mod.addCSourceFile(.{ .file = zeroNativePath(b, zero_native_path, "src/platform/macos/cef_host.mm"), .flags = &.{ "-fobjc-arc", "-ObjC++", "-std=c++17", "-stdlib=libc++", include_arg, define_arg } });
+            app_mod.addObjectFile(b.path(b.fmt("{s}/libcef_dll_wrapper/libcef_dll_wrapper.a", .{cef_dir})));
+            app_mod.addFrameworkPath(b.path(b.fmt("{s}/Release", .{cef_dir})));
+            app_mod.linkFramework("Chromium Embedded Framework", .{});
+            app_mod.linkSystemLibrary("c++", .{});
+            app_mod.addRPath(.{ .cwd_relative = "@executable_path/Frameworks" });
+        },
+    }
+
+    app_mod.linkFramework("AppKit", .{});
+    app_mod.linkFramework("Foundation", .{});
+    app_mod.linkFramework("UniformTypeIdentifiers", .{});
+    app_mod.linkSystemLibrary("c", .{});
+}
+
+fn addCefRuntimeRunFiles(
+    b: *std.Build,
+    target: std.Build.ResolvedTarget,
+    run: *std.Build.Step.Run,
+    exe: *std.Build.Step.Compile,
+    web_engine: WebEngineOption,
+    cef_dir: []const u8,
+) void {
+    if (web_engine != .chromium) return;
+    if (target.result.os.tag != .macos) return;
+    const copy = b.addSystemCommand(&.{
+        "sh", "-c",
+        b.fmt(
+            \\set -e
+            \\exe="$0"
+            \\exe_dir="$(dirname "$exe")"
+            \\rm -rf "zig-out/Frameworks/Chromium Embedded Framework.framework" "zig-out/bin/Frameworks/Chromium Embedded Framework.framework" ".zig-cache/o/Frameworks/Chromium Embedded Framework.framework"
+            \\mkdir -p "zig-out/Frameworks" "zig-out/bin/Frameworks" ".zig-cache/o/Frameworks" "$exe_dir"
+            \\cp -R "{s}/Release/Chromium Embedded Framework.framework" "zig-out/Frameworks/"
+            \\cp -R "{s}/Release/Chromium Embedded Framework.framework" "zig-out/bin/Frameworks/"
+            \\cp -R "{s}/Release/Chromium Embedded Framework.framework" ".zig-cache/o/Frameworks/"
+            \\cp "{s}/Release/Chromium Embedded Framework.framework/Libraries/libEGL.dylib" "$exe_dir/"
+            \\cp "{s}/Release/Chromium Embedded Framework.framework/Libraries/libGLESv2.dylib" "$exe_dir/"
+            \\cp "{s}/Release/Chromium Embedded Framework.framework/Libraries/libvk_swiftshader.dylib" "$exe_dir/"
+            \\cp "{s}/Release/Chromium Embedded Framework.framework/Libraries/vk_swiftshader_icd.json" "$exe_dir/"
+        , .{ cef_dir, cef_dir, cef_dir, cef_dir, cef_dir, cef_dir, cef_dir }),
+    });
+    copy.addFileArg(exe.getEmittedBin());
+    run.step.dependOn(&copy.step);
+}
+
+fn addCefCheck(b: *std.Build, cef_dir: []const u8) *std.Build.Step.Run {
+    return b.addSystemCommand(&.{
+        "sh", "-c",
+        b.fmt(
+            \\test -f "{s}/include/cef_app.h" &&
+            \\test -d "{s}/Release/Chromium Embedded Framework.framework" &&
+            \\test -f "{s}/libcef_dll_wrapper/libcef_dll_wrapper.a" || {{
+            \\  echo "missing CEF dependency for -Dweb-engine=chromium" >&2
+            \\  echo "Fix with: zero-native cef install --dir {s}" >&2
+            \\  echo "Or rerun with: -Dcef-auto-install=true" >&2
+            \\  exit 1
+            \\}}
+        , .{ cef_dir, cef_dir, cef_dir, cef_dir }),
+    });
+}
+
+fn appWebEngine() WebEngineOption {
+    const source = @embedFile("app.zon");
+    if (stringField(source, ".web_engine")) |value| {
+        if (std.mem.eql(u8, value, "system")) return .system;
+        if (std.mem.eql(u8, value, "chromium")) return .chromium;
+    }
+    return .chromium;
+}
+
+fn stringField(source: []const u8, field: []const u8) ?[]const u8 {
+    const field_index = std.mem.indexOf(u8, source, field) orelse return null;
+    const equals = std.mem.indexOfScalarPos(u8, source, field_index, '=') orelse return null;
+    const start_quote = std.mem.indexOfScalarPos(u8, source, equals, '"') orelse return null;
+    const end_quote = std.mem.indexOfScalarPos(u8, source, start_quote + 1, '"') orelse return null;
+    return source[start_quote + 1 .. end_quote];
+}

--- a/experiments/zero-native-cmux/build.zig
+++ b/experiments/zero-native-cmux/build.zig
@@ -155,9 +155,15 @@ fn linkPlatform(
         },
     }
 
+    app_mod.addIncludePath(b.path("../../GhosttyKit.xcframework/macos-arm64_x86_64/Headers"));
+    app_mod.addObjectFile(b.path("../../GhosttyKit.xcframework/macos-arm64_x86_64/ghostty-internal.a"));
     app_mod.linkFramework("AppKit", .{});
     app_mod.linkFramework("Foundation", .{});
+    app_mod.linkFramework("Metal", .{});
+    app_mod.linkFramework("QuartzCore", .{});
+    app_mod.linkFramework("IOSurface", .{});
     app_mod.linkFramework("UniformTypeIdentifiers", .{});
+    app_mod.linkFramework("Carbon", .{});
     app_mod.linkSystemLibrary("c", .{});
 }
 

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..608a48f 100644
+index ce9c747..8c43c67 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -75,7 +75,15 @@ index ce9c747..608a48f 100644
  
      CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
          return this;
-@@ -86,9 +119,34 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+@@ -79,6 +112,7 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+     }
+ 
+     void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
++    void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) override;
+     void OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) override;
+     bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;
+     bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) override;
+@@ -86,9 +120,34 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
  private:
      ZeroNativeChromiumHost *host_;
      uint64_t window_id_;
@@ -110,7 +118,7 @@ index ce9c747..608a48f 100644
  class ZeroNativeCefApp final : public CefApp, public CefRenderProcessHandler {
  public:
      ZeroNativeCefApp() = default;
-@@ -97,6 +155,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
+@@ -97,6 +156,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
          (void)process_type;
          command_line->AppendSwitchWithValue("password-store", "basic");
          command_line->AppendSwitch("use-mock-keychain");
@@ -118,13 +126,14 @@ index ce9c747..608a48f 100644
      }
  
      CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
-@@ -121,6 +180,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+@@ -121,6 +181,19 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
  static CefScopedLibraryLoader g_cef_library_loader;
  static bool g_cef_library_loaded = false;
  
 +static void ZeroNativeRunCefSubprocessIfNeeded() {
-+    if (!ZeroNativeShouldUseHelperLoader()) return;
-+    if (!g_cef_library_loader.LoadInHelper()) {
++    if (!ZeroNativeIsCefHelperProcess()) return;
++    const bool helperBundle = ZeroNativeShouldUseHelperLoader();
++    if (!(helperBundle ? g_cef_library_loader.LoadInHelper() : g_cef_library_loader.LoadInMain())) {
 +        fprintf(stderr, "failed to load Chromium Embedded Framework in helper\n");
 +        exit(1);
 +    }
@@ -137,7 +146,7 @@ index ce9c747..608a48f 100644
  static void shutdownCefIfNeeded() {
      if (!g_cef_initialized || g_cef_shutdown) return;
      CefShutdown();
-@@ -133,7 +204,8 @@ static void ensureCefInitialized() {
+@@ -133,7 +206,8 @@ static void ensureCefInitialized() {
      g_cef_shutdown = false;
  
      if (!g_cef_library_loaded) {
@@ -147,7 +156,7 @@ index ce9c747..608a48f 100644
              fprintf(stderr, "failed to load Chromium Embedded Framework\n");
              return;
          }
-@@ -148,13 +220,14 @@ static void ensureCefInitialized() {
+@@ -148,13 +222,14 @@ static void ensureCefInitialized() {
      CefSettings settings;
      settings.no_sandbox = true;
      settings.multi_threaded_message_loop = false;
@@ -163,7 +172,7 @@ index ce9c747..608a48f 100644
      CefString(&settings.framework_dir_path).FromString(frameworkPath.UTF8String);
      CefString(&settings.resources_dir_path).FromString(resourcesPath.UTF8String);
      CefString(&settings.root_cache_path).FromString(cefDataRoot.UTF8String);
-@@ -223,6 +296,33 @@ static void ensureCefInitialized() {
+@@ -223,6 +298,56 @@ static void ensureCefInitialized() {
      return [devRoot stringByAppendingPathComponent:@"Release/Chromium Embedded Framework.framework"];
  }
  
@@ -172,6 +181,29 @@ index ce9c747..608a48f 100644
 +    NSString *executablePath = bundle.executablePath ?: [[[NSProcessInfo processInfo] arguments] firstObject];
 +    NSString *executableName = executablePath.lastPathComponent;
 +    if (executableName.length == 0) return executablePath;
++
++    NSString *privateFrameworksPath = bundle.privateFrameworksPath;
++    if (privateFrameworksPath.length > 0) {
++        NSArray<NSString *> *helperNames = @[
++            [executableName stringByAppendingString:@" Helper"],
++            [executableName stringByAppendingString:@" Helper (GPU)"],
++            [executableName stringByAppendingString:@" Helper (Plugin)"],
++            [executableName stringByAppendingString:@" Helper (Renderer)"],
++        ];
++
++        BOOL hasCompleteHelperBundleSet = YES;
++        for (NSString *helperName in helperNames) {
++            NSString *helperBundlePath = [privateFrameworksPath stringByAppendingPathComponent:[helperName stringByAppendingString:@".app"]];
++            NSString *helperMacOSPath = [[helperBundlePath stringByAppendingPathComponent:@"Contents"] stringByAppendingPathComponent:@"MacOS"];
++            NSString *helperExecutable = [helperMacOSPath stringByAppendingPathComponent:helperName];
++            if (!ZeroNativeExistingPath(helperExecutable)) {
++                hasCompleteHelperBundleSet = NO;
++                break;
++            }
++        }
++        if (hasCompleteHelperBundleSet) return @"";
++    }
++
 +    NSString *helperName = [executableName stringByAppendingString:@" Helper"];
 +    NSString *helperPath = [[[[bundle privateFrameworksPath] stringByAppendingPathComponent:[helperName stringByAppendingString:@".app"]] stringByAppendingPathComponent:@"Contents/MacOS"] stringByAppendingPathComponent:helperName];
 +    if (ZeroNativeExistingPath(helperPath)) return helperPath;
@@ -191,13 +223,13 @@ index ce9c747..608a48f 100644
 +static bool ZeroNativeShouldUseHelperLoader(void) {
 +    if (!ZeroNativeIsCefHelperProcess()) return false;
 +    NSString *executableName = [NSBundle mainBundle].executablePath.lastPathComponent ?: @"";
-+    return [executableName hasSuffix:@" Helper"];
++    return [executableName containsString:@" Helper"];
 +}
 +
  static NSRect ZeroNativeConstrainFrame(NSRect frame) {
      NSScreen *screen = [NSScreen mainScreen];
      if (!screen) return frame;
-@@ -286,6 +386,141 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
+@@ -286,6 +411,141 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
          "})();";
  }
  
@@ -339,7 +371,7 @@ index ce9c747..608a48f 100644
  } // namespace
  
  @implementation ZeroNativeChromiumApplication
-@@ -305,20 +540,992 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -305,20 +565,1003 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
@@ -854,6 +886,7 @@ index ce9c747..608a48f 100644
 +@property(nonatomic, strong) NSButton *addTabButton;
 +- (void)configureForWindowId:(uint64_t)windowId;
 +- (uint64_t)activeBrowserKey;
++- (void)ensureActiveBrowserLoaded;
 +- (void)setBrowserURLString:(NSString *)urlString;
 +- (void)setBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey;
 +@end
@@ -964,7 +997,6 @@ index ce9c747..608a48f 100644
 +    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
 +    if (tab && tab.browserKey == 0) {
 +        tab.browserKey = windowId;
-+        tab.browserCreated = YES;
 +    }
 +    [self activateActiveTabCreatingBrowser:NO];
 +}
@@ -1057,13 +1089,22 @@ index ce9c747..608a48f 100644
 +    if (!active.browserCreated) {
 +        if ([self.host hasNativeBrowserForKey:active.browserKey]) {
 +            active.browserCreated = YES;
-+        } else if (createBrowser) {
++        } else if (createBrowser && active.browserContainer.bounds.size.width > 0 && active.browserContainer.bounds.size.height > 0) {
 +            [self.host createNativeBrowserForKey:active.browserKey container:active.browserContainer url:active.url ownerWindowId:self.windowId];
 +            active.browserCreated = YES;
 +        }
 +    } else {
 +        [self.host resizeNativeBrowserForKey:active.browserKey];
 +    }
++}
++
++- (void)ensureActiveBrowserLoaded {
++    [self activateActiveTabCreatingBrowser:YES];
++}
++
++- (void)viewDidMoveToWindow {
++    [super viewDidMoveToWindow];
++    if (self.window) [self ensureActiveBrowserLoaded];
 +}
 +
 +- (void)layout {
@@ -1130,6 +1171,7 @@ index ce9c747..608a48f 100644
 +        self.devToolsContainer.frame = NSZeroRect;
 +    }
 +    [self layoutTabSurfaces];
++    if (self.window) [self ensureActiveBrowserLoaded];
 +    uint64_t activeKey = [self activeBrowserKey];
 +    if (activeKey != 0) [self.host resizeNativeBrowserForKey:activeKey];
 +}
@@ -1330,10 +1372,11 @@ index ce9c747..608a48f 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *bridgeOrigins;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *internalURLPrefixes;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *inlineHTMLSources;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *pendingBrowserURLs;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +1542,13 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1578,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
@@ -1348,7 +1391,7 @@ index ce9c747..608a48f 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +1570,24 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1606,25 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
@@ -1361,6 +1404,7 @@ index ce9c747..608a48f 100644
 +- (void)setDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
 +- (void)clearDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
 +- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser;
++- (void)loadPendingInitialURLForBrowserKey:(uint64_t)browserKey browser:(CefRefPtr<CefBrowser>)browser;
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId;
 +- (void)updateNativeBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey windowId:(uint64_t)windowId;
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
@@ -1373,7 +1417,7 @@ index ce9c747..608a48f 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -391,11 +1619,17 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1656,18 @@ - (void)windowWillClose:(NSNotification *)notification {
      (void)notification;
      [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
@@ -1388,10 +1432,11 @@ index ce9c747..608a48f 100644
      [self.host.bridgeOrigins removeObjectForKey:key];
      [self.host.internalURLPrefixes removeObjectForKey:key];
 +    [self.host.inlineHTMLSources removeObjectForKey:key];
++    [self.host.pendingBrowserURLs removeObjectForKey:key];
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +1644,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1682,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -1400,7 +1445,7 @@ index ce9c747..608a48f 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,16 +1652,23 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1690,24 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
@@ -1415,6 +1460,7 @@ index ce9c747..608a48f 100644
      self.bridgeOrigins = [[NSMutableDictionary alloc] init];
      self.internalURLPrefixes = [[NSMutableDictionary alloc] init];
 +    self.inlineHTMLSources = [[NSMutableDictionary alloc] init];
++    self.pendingBrowserURLs = [[NSMutableDictionary alloc] init];
      self.windowLabels = [[NSMutableDictionary alloc] init];
      self.fallbackURLs = [[NSMutableDictionary alloc] init];
      self.cefClients = new std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>>();
@@ -1424,7 +1470,7 @@ index ce9c747..608a48f 100644
      self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
      self.allowedExternalURLs = @[];
      self.externalLinkAction = 0;
-@@ -509,7 +1750,8 @@ - (void)reload:(id)sender {
+@@ -509,7 +1789,8 @@ - (void)reload:(id)sender {
          }
      }
      if (self.browsers) {
@@ -1434,7 +1480,7 @@ index ce9c747..608a48f 100644
          if (it != self.browsers->end() && it->second) {
              it->second->ReloadIgnoreCache();
          }
-@@ -519,6 +1761,8 @@ - (void)reload:(id)sender {
+@@ -519,6 +1800,8 @@ - (void)reload:(id)sender {
  - (void)dealloc {
      delete self.cefClients;
      delete self.browsers;
@@ -1443,7 +1489,7 @@ index ce9c747..608a48f 100644
  }
  
  - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
-@@ -536,9 +1780,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -536,9 +1819,22 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -1460,6 +1506,7 @@ index ce9c747..608a48f 100644
 +        browserContainer = workbenchView.browserContainer;
 +        window.contentView = workbenchView;
 +        [workbenchView layoutSubtreeIfNeeded];
++        [workbenchView ensureActiveBrowserLoaded];
 +    } else {
 +        browserContainer = [[NSView alloc] initWithFrame:rect];
 +        browserContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
@@ -1468,7 +1515,7 @@ index ce9c747..608a48f 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +1804,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1844,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -1476,7 +1523,7 @@ index ce9c747..608a48f 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -601,14 +1858,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -601,14 +1898,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
  
@@ -1496,7 +1543,7 @@ index ce9c747..608a48f 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -649,7 +1908,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
+@@ -649,7 +1948,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
      NSWindow *window = self.windows[@(windowId)] ?: self.window;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
@@ -1506,7 +1553,22 @@ index ce9c747..608a48f 100644
          if (it != self.browsers->end()) browser = it->second;
      }
      NSRect bounds = container.bounds;
-@@ -702,9 +1962,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -698,13 +1998,24 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+ }
+ 
+ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *)assetRoot entry:(NSString *)entry origin:(NSString *)origin spaFallback:(BOOL)spaFallback windowId:(uint64_t)windowId {
++    if (self.cmuxNativeShellEnabled) {
++        (void)source;
++        (void)kind;
++        (void)assetRoot;
++        (void)entry;
++        (void)origin;
++        (void)spaFallback;
++        (void)windowId;
++        return;
++    }
++
+     NSString *urlString = source;
      NSString *bridgeOrigin = nil;
      NSString *internalURLPrefix = nil;
      if (kind == 0) {
@@ -1518,7 +1580,7 @@ index ce9c747..608a48f 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +1986,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +2037,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -1536,7 +1598,7 @@ index ce9c747..608a48f 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +2004,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +2055,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -1549,7 +1611,7 @@ index ce9c747..608a48f 100644
          return;
      }
  
-@@ -769,6 +2039,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +2090,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -1557,7 +1619,7 @@ index ce9c747..608a48f 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -781,7 +2052,284 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
+@@ -781,7 +2103,294 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
  
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (self.browsers) (*self.browsers)[windowId] = browser;
@@ -1599,6 +1661,7 @@ index ce9c747..608a48f 100644
 +
 +    [self setActiveNativeBrowserKey:browserKey container:container windowId:windowId];
 +    NSString *urlString = [self normalizedBrowserURLString:url ?: @"about:blank"];
++    self.pendingBrowserURLs[@(browserKey)] = urlString;
 +    CefRefPtr<ZeroNativeCefClient> client = new ZeroNativeCefClient(self, windowId, browserKey);
 +    (*self.cefClients)[browserKey] = client;
 +
@@ -1606,7 +1669,7 @@ index ce9c747..608a48f 100644
 +    CefRect rect(0, 0, MAX(1, (int)container.bounds.size.width), MAX(1, (int)container.bounds.size.height));
 +    windowInfo.SetAsChild((__bridge void *)container, rect);
 +    CefBrowserSettings browserSettings;
-+    CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(urlString.UTF8String), browserSettings, nullptr, nullptr);
++    CefBrowserHost::CreateBrowser(windowInfo, client.get(), "about:blank", browserSettings, nullptr, nullptr);
 +}
 +
 +- (void)navigateNativeBrowserForKey:(uint64_t)browserKey toString:(NSString *)value ownerWindowId:(uint64_t)windowId {
@@ -1641,6 +1704,16 @@ index ce9c747..608a48f 100644
 +        }
 +    }
 +    if (self.devToolsClients) self.devToolsClients->erase(devToolsKey);
++}
++
++- (void)loadPendingInitialURLForBrowserKey:(uint64_t)browserKey browser:(CefRefPtr<CefBrowser>)browser {
++    if (!browser) return;
++    NSNumber *key = @(browserKey);
++    NSString *urlString = self.pendingBrowserURLs[key];
++    if (urlString.length == 0) return;
++    [self.pendingBrowserURLs removeObjectForKey:key];
++    if ([urlString isEqualToString:@"about:blank"]) return;
++    browser->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
 +}
 +
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId {
@@ -1774,7 +1847,6 @@ index ce9c747..608a48f 100644
 +    windowInfo.SetAsChild((__bridge void *)container, rect);
 +    CefBrowserSettings settings;
 +    const bool created = CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(frontendURL.UTF8String), settings, nullptr, nullptr);
-+    fprintf(stderr, "zero-native: create DevTools browser mode=%ld url=%s created=%d\n", (long)mode, frontendURL.UTF8String, created ? 1 : 0);
 +    if (!created) {
 +        if (self.devToolsClients) self.devToolsClients->erase(devToolsKey);
 +        if (mode == 1) [self closeNativeBrowserDevToolsForWindowId:windowId mode:1 closeWindow:NO];
@@ -1843,33 +1915,43 @@ index ce9c747..608a48f 100644
  }
  
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
-@@ -881,7 +2429,12 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -881,7 +2490,22 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  }
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
 -    [host_ setBrowser:browser windowId:window_id_];
 +    [host_ setBrowser:browser windowId:browser_key_];
 +    [host_ loadInlineHTMLIfNeededForWindowId:window_id_ browser:browser];
++    [host_ loadPendingInitialURLForBrowserKey:browser_key_ browser:browser];
 +    ZeroNativeCmuxWorkbenchView *workbench = host_.nativeWorkbenchViews[@(window_id_)];
 +    if (workbench.internalDevToolsVisible) {
 +        [host_ openNativeBrowserInternalDevToolsForWindowId:window_id_];
 +    }
++}
++
++void ZeroNativeCefClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) {
++    (void)browser;
++    (void)httpStatusCode;
++    if (!frame || !frame->IsMain()) return;
++    std::string url = frame->GetURL().ToString();
++    NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
++    [host_ updateNativeBrowserURLString:urlString browserKey:browser_key_ windowId:window_id_];
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +2457,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2528,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
 -    if ([host_ allowsNavigationURL:nsURL]) return false;
-+    if ([host_ allowsNavigationURL:nsURL]) {
-+        [host_ updateNativeBrowserURLString:urlString browserKey:browser_key_ windowId:window_id_];
++    BOOL allowed = [host_ allowsNavigationURL:nsURL];
++    if (allowed) {
 +        return false;
 +    }
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2479,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2550,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  
@@ -1882,17 +1964,17 @@ index ce9c747..608a48f 100644
 +}
 +
 +void ZeroNativeCefDevToolsClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) {
++    (void)browser;
++    (void)httpStatusCode;
 +    if (!frame || !frame->IsMain()) return;
-+    std::string url = frame->GetURL().ToString();
-+    fprintf(stderr, "zero-native: DevTools load end mode=%ld status=%d url=%s\n", (long)mode_, httpStatusCode, url.c_str());
 +}
 +
 +void ZeroNativeCefDevToolsClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
 +    (void)browser;
-+    if (!frame || !frame->IsMain()) return;
-+    std::string error = errorText.ToString();
-+    std::string url = failedUrl.ToString();
-+    fprintf(stderr, "zero-native: DevTools load error mode=%ld code=%d error=%s url=%s\n", (long)mode_, (int)errorCode, error.c_str(), url.c_str());
++    (void)frame;
++    (void)errorCode;
++    (void)errorText;
++    (void)failedUrl;
 +}
 +
  } // namespace

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..8c43c67 100644
+index ce9c747..240ed51 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -371,7 +371,7 @@ index ce9c747..8c43c67 100644
  } // namespace
  
  @implementation ZeroNativeChromiumApplication
-@@ -305,20 +565,1003 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -305,20 +565,1037 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
@@ -887,9 +887,18 @@ index ce9c747..8c43c67 100644
 +- (void)configureForWindowId:(uint64_t)windowId;
 +- (uint64_t)activeBrowserKey;
 +- (void)ensureActiveBrowserLoaded;
++- (void)fitBrowserSurfaceForBrowserKey:(uint64_t)browserKey;
 +- (void)setBrowserURLString:(NSString *)urlString;
 +- (void)setBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey;
 +@end
++
++static void ZeroNativeCmuxFitSubviewTree(NSView *view) {
++    if (!view) return;
++    for (NSView *subview in view.subviews) {
++        subview.frame = view.bounds;
++        ZeroNativeCmuxFitSubviewTree(subview);
++    }
++}
 +
 +@implementation ZeroNativeCmuxWorkbenchView
 +
@@ -935,6 +944,7 @@ index ce9c747..8c43c67 100644
 +    _browserPane = [[NSView alloc] initWithFrame:NSZeroRect];
 +    _browserPane.wantsLayer = YES;
 +    _browserPane.layer.backgroundColor = NSColor.windowBackgroundColor.CGColor;
++    _browserPane.layer.masksToBounds = YES;
 +    [self addSubview:_browserPane];
 +
 +    _tabStrip = [[NSView alloc] initWithFrame:NSZeroRect];
@@ -1022,6 +1032,7 @@ index ce9c747..8c43c67 100644
 +        container.hidden = YES;
 +        container.wantsLayer = YES;
 +        container.layer.backgroundColor = NSColor.whiteColor.CGColor;
++        container.layer.masksToBounds = YES;
 +        if (self.tabStrip.superview == self.browserPane) {
 +            [self.browserPane addSubview:container positioned:NSWindowBelow relativeTo:self.tabStrip];
 +        } else {
@@ -1048,7 +1059,16 @@ index ce9c747..8c43c67 100644
 +    NSRect browserFrame = [self browserContentFrame];
 +    for (ZeroNativeCmuxBrowserTab *tab in [self allBrowserTabs]) {
 +        if (tab.terminalView) tab.terminalView.frame = self.terminalDeck.bounds;
-+        if (tab.browserContainer) tab.browserContainer.frame = browserFrame;
++        if (tab.browserContainer) {
++            NSRect frame = browserFrame;
++            NSView *browserView = tab.browserContainer.subviews.firstObject;
++            if (browserView && browserView.frame.size.height > browserFrame.size.height) {
++                frame.size.height = browserView.frame.size.height;
++                frame.origin.y = NSMaxY(browserFrame) - frame.size.height;
++            }
++            tab.browserContainer.frame = frame;
++            ZeroNativeCmuxFitSubviewTree(tab.browserContainer);
++        }
 +    }
 +}
 +
@@ -1089,7 +1109,7 @@ index ce9c747..8c43c67 100644
 +    if (!active.browserCreated) {
 +        if ([self.host hasNativeBrowserForKey:active.browserKey]) {
 +            active.browserCreated = YES;
-+        } else if (createBrowser && active.browserContainer.bounds.size.width > 0 && active.browserContainer.bounds.size.height > 0) {
++        } else if (createBrowser && self.window.isVisible && active.browserContainer.bounds.size.width > 0 && active.browserContainer.bounds.size.height > 0) {
 +            [self.host createNativeBrowserForKey:active.browserKey container:active.browserContainer url:active.url ownerWindowId:self.windowId];
 +            active.browserCreated = YES;
 +        }
@@ -1102,9 +1122,22 @@ index ce9c747..8c43c67 100644
 +    [self activateActiveTabCreatingBrowser:YES];
 +}
 +
++- (void)fitBrowserSurfaceForBrowserKey:(uint64_t)browserKey {
++    ZeroNativeCmuxBrowserTab *tab = [self browserTabForBrowserKey:browserKey];
++    if (!tab.browserContainer) return;
++    NSRect browserFrame = [self browserContentFrame];
++    NSView *browserView = tab.browserContainer.subviews.firstObject;
++    if (browserView && browserView.frame.size.height > browserFrame.size.height) {
++        browserFrame.size.height = browserView.frame.size.height;
++        browserFrame.origin.y = NSMaxY([self browserContentFrame]) - browserFrame.size.height;
++        tab.browserContainer.frame = browserFrame;
++    }
++    ZeroNativeCmuxFitSubviewTree(tab.browserContainer);
++}
++
 +- (void)viewDidMoveToWindow {
 +    [super viewDidMoveToWindow];
-+    if (self.window) [self ensureActiveBrowserLoaded];
++    if (self.window.isVisible) [self ensureActiveBrowserLoaded];
 +}
 +
 +- (void)layout {
@@ -1171,7 +1204,7 @@ index ce9c747..8c43c67 100644
 +        self.devToolsContainer.frame = NSZeroRect;
 +    }
 +    [self layoutTabSurfaces];
-+    if (self.window) [self ensureActiveBrowserLoaded];
++    if (self.window.isVisible) [self ensureActiveBrowserLoaded];
 +    uint64_t activeKey = [self activeBrowserKey];
 +    if (activeKey != 0) [self.host resizeNativeBrowserForKey:activeKey];
 +}
@@ -1366,6 +1399,7 @@ index ce9c747..8c43c67 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *windows;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *devToolsWindows;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSView *> *browserContainers;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSView *> *browserKeyContainers;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *activeBrowserKeys;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeCmuxWorkbenchView *> *nativeWorkbenchViews;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeChromiumWindowDelegate *> *delegates;
@@ -1376,7 +1410,7 @@ index ce9c747..8c43c67 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +1578,13 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1612,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
@@ -1391,7 +1425,7 @@ index ce9c747..8c43c67 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +1606,25 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1640,25 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
@@ -1417,7 +1451,7 @@ index ce9c747..8c43c67 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -391,11 +1656,18 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1690,19 @@ - (void)windowWillClose:(NSNotification *)notification {
      (void)notification;
      [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
@@ -1426,6 +1460,7 @@ index ce9c747..8c43c67 100644
      [self.host.windows removeObjectForKey:key];
 +    [self.host.devToolsWindows removeObjectForKey:key];
      [self.host.browserContainers removeObjectForKey:key];
++    [self.host.browserKeyContainers removeObjectForKey:key];
 +    [self.host.activeBrowserKeys removeObjectForKey:key];
 +    [self.host.nativeWorkbenchViews removeObjectForKey:key];
      [self.host.delegates removeObjectForKey:key];
@@ -1436,7 +1471,7 @@ index ce9c747..8c43c67 100644
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +1682,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1717,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -1445,7 +1480,7 @@ index ce9c747..8c43c67 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,16 +1690,24 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1725,25 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
@@ -1454,6 +1489,7 @@ index ce9c747..8c43c67 100644
      self.windows = [[NSMutableDictionary alloc] init];
 +    self.devToolsWindows = [[NSMutableDictionary alloc] init];
      self.browserContainers = [[NSMutableDictionary alloc] init];
++    self.browserKeyContainers = [[NSMutableDictionary alloc] init];
 +    self.activeBrowserKeys = [[NSMutableDictionary alloc] init];
 +    self.nativeWorkbenchViews = [[NSMutableDictionary alloc] init];
      self.delegates = [[NSMutableDictionary alloc] init];
@@ -1470,7 +1506,7 @@ index ce9c747..8c43c67 100644
      self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
      self.allowedExternalURLs = @[];
      self.externalLinkAction = 0;
-@@ -509,7 +1789,8 @@ - (void)reload:(id)sender {
+@@ -509,7 +1825,8 @@ - (void)reload:(id)sender {
          }
      }
      if (self.browsers) {
@@ -1480,7 +1516,7 @@ index ce9c747..8c43c67 100644
          if (it != self.browsers->end() && it->second) {
              it->second->ReloadIgnoreCache();
          }
-@@ -519,6 +1800,8 @@ - (void)reload:(id)sender {
+@@ -519,6 +1836,8 @@ - (void)reload:(id)sender {
  - (void)dealloc {
      delete self.cefClients;
      delete self.browsers;
@@ -1489,7 +1525,7 @@ index ce9c747..8c43c67 100644
  }
  
  - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
-@@ -536,9 +1819,22 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -536,9 +1855,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -1506,7 +1542,6 @@ index ce9c747..8c43c67 100644
 +        browserContainer = workbenchView.browserContainer;
 +        window.contentView = workbenchView;
 +        [workbenchView layoutSubtreeIfNeeded];
-+        [workbenchView ensureActiveBrowserLoaded];
 +    } else {
 +        browserContainer = [[NSView alloc] initWithFrame:rect];
 +        browserContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
@@ -1515,7 +1550,7 @@ index ce9c747..8c43c67 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +1844,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1879,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -1523,9 +1558,22 @@ index ce9c747..8c43c67 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -601,14 +1898,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -559,6 +1891,8 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+     } else {
+         [window makeKeyAndOrderFront:nil];
+         [NSApp activateIgnoringOtherApps:YES];
++        [workbenchView layoutSubtreeIfNeeded];
++        [workbenchView ensureActiveBrowserLoaded];
+     }
+     return YES;
+ }
+@@ -600,15 +1934,20 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+ 
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
++    ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[@1];
++    [workbench layoutSubtreeIfNeeded];
++    [workbench ensureActiveBrowserLoaded];
  
 -    [self emitEvent:(zero_native_appkit_event_t){ .kind = ZERO_NATIVE_APPKIT_EVENT_START }];
 -    [self emitResize];
@@ -1543,7 +1591,7 @@ index ce9c747..8c43c67 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -649,7 +1948,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
+@@ -649,7 +1988,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
      NSWindow *window = self.windows[@(windowId)] ?: self.window;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
@@ -1553,7 +1601,7 @@ index ce9c747..8c43c67 100644
          if (it != self.browsers->end()) browser = it->second;
      }
      NSRect bounds = container.bounds;
-@@ -698,13 +1998,24 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -698,13 +2038,24 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
  }
  
  - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *)assetRoot entry:(NSString *)entry origin:(NSString *)origin spaFallback:(BOOL)spaFallback windowId:(uint64_t)windowId {
@@ -1580,7 +1628,7 @@ index ce9c747..8c43c67 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +2037,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +2077,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -1598,7 +1646,7 @@ index ce9c747..8c43c67 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +2055,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +2095,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -1611,7 +1659,7 @@ index ce9c747..8c43c67 100644
          return;
      }
  
-@@ -769,6 +2090,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +2130,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -1619,7 +1667,7 @@ index ce9c747..8c43c67 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -781,7 +2103,294 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
+@@ -781,7 +2143,302 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
  
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (self.browsers) (*self.browsers)[windowId] = browser;
@@ -1627,6 +1675,7 @@ index ce9c747..8c43c67 100644
 +    NSNumber *mainActiveKey = self.activeBrowserKeys[@1];
 +    uint64_t activeMain = mainActiveKey ? mainActiveKey.unsignedLongLongValue : 1;
 +    if (windowId == activeMain) self.browser = browser;
++    [self resizeNativeBrowserForKey:windowId];
 +}
 +
 +- (uint64_t)activeBrowserKeyForWindowId:(uint64_t)windowId {
@@ -1645,6 +1694,7 @@ index ce9c747..8c43c67 100644
 +    NSNumber *windowKey = @(windowId);
 +    self.activeBrowserKeys[windowKey] = @(browserKey);
 +    self.browserContainers[windowKey] = container;
++    self.browserKeyContainers[@(browserKey)] = container;
 +    if (windowId == 1) {
 +        self.browserContainer = container;
 +        if (self.browsers) {
@@ -1686,6 +1736,12 @@ index ce9c747..8c43c67 100644
 +    auto it = self.browsers->find(browserKey);
 +    if (it != self.browsers->end() && it->second) {
 +        it->second->GetHost()->WasResized();
++        NSView *container = self.browserKeyContainers[@(browserKey)] ?: self.browserContainers[@(browserKey)];
++        if (container) {
++            for (NSView *subview in container.subviews) {
++                subview.frame = container.bounds;
++            }
++        }
 +    }
 +}
 +
@@ -1915,15 +1971,16 @@ index ce9c747..8c43c67 100644
  }
  
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
-@@ -881,7 +2490,22 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -881,7 +2538,26 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  }
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
 -    [host_ setBrowser:browser windowId:window_id_];
 +    [host_ setBrowser:browser windowId:browser_key_];
 +    [host_ loadInlineHTMLIfNeededForWindowId:window_id_ browser:browser];
-+    [host_ loadPendingInitialURLForBrowserKey:browser_key_ browser:browser];
 +    ZeroNativeCmuxWorkbenchView *workbench = host_.nativeWorkbenchViews[@(window_id_)];
++    [workbench fitBrowserSurfaceForBrowserKey:browser_key_];
++    [host_ loadPendingInitialURLForBrowserKey:browser_key_ browser:browser];
 +    if (workbench.internalDevToolsVisible) {
 +        [host_ openNativeBrowserInternalDevToolsForWindowId:window_id_];
 +    }
@@ -1935,11 +1992,14 @@ index ce9c747..8c43c67 100644
 +    if (!frame || !frame->IsMain()) return;
 +    std::string url = frame->GetURL().ToString();
 +    NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
++    [host_ resizeNativeBrowserForKey:browser_key_];
++    ZeroNativeCmuxWorkbenchView *workbench = host_.nativeWorkbenchViews[@(window_id_)];
++    [workbench fitBrowserSurfaceForBrowserKey:browser_key_];
 +    [host_ updateNativeBrowserURLString:urlString browserKey:browser_key_ windowId:window_id_];
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +2528,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2580,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
@@ -1951,7 +2011,7 @@ index ce9c747..8c43c67 100644
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2550,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2602,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..b0fe294 100644
+index ce9c747..9aec1ae 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -314,7 +314,7 @@ index ce9c747..b0fe294 100644
  } // namespace
  
  @implementation ZeroNativeChromiumApplication
-@@ -305,20 +527,612 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -305,20 +527,860 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
@@ -751,10 +751,57 @@ index ce9c747..b0fe294 100644
 +    (void)processAlive;
 +}
 +
++@interface ZeroNativeCmuxBrowserTab : NSObject
++@property(nonatomic, copy) NSString *title;
++@property(nonatomic, copy) NSString *url;
+++ (instancetype)tabWithTitle:(NSString *)title url:(NSString *)url;
++@end
++
++@implementation ZeroNativeCmuxBrowserTab
++
+++ (instancetype)tabWithTitle:(NSString *)title url:(NSString *)url {
++    ZeroNativeCmuxBrowserTab *tab = [[ZeroNativeCmuxBrowserTab alloc] init];
++    tab.title = title.length > 0 ? title : @"Tab";
++    tab.url = url.length > 0 ? url : @"about:blank";
++    return tab;
++}
++
++@end
++
++@interface ZeroNativeCmuxWorkspace : NSObject
++@property(nonatomic, copy) NSString *title;
++@property(nonatomic, strong) NSColor *accentColor;
++@property(nonatomic, strong) NSMutableArray<ZeroNativeCmuxBrowserTab *> *tabs;
++@property(nonatomic, assign) NSInteger activeTabIndex;
+++ (instancetype)workspaceWithTitle:(NSString *)title color:(NSColor *)color tabs:(NSArray<ZeroNativeCmuxBrowserTab *> *)tabs;
++@end
++
++@implementation ZeroNativeCmuxWorkspace
++
+++ (instancetype)workspaceWithTitle:(NSString *)title color:(NSColor *)color tabs:(NSArray<ZeroNativeCmuxBrowserTab *> *)tabs {
++    ZeroNativeCmuxWorkspace *workspace = [[ZeroNativeCmuxWorkspace alloc] init];
++    workspace.title = title.length > 0 ? title : @"Workspace";
++    workspace.accentColor = color ?: NSColor.controlAccentColor;
++    workspace.tabs = [[NSMutableArray alloc] initWithArray:tabs ?: @[]];
++    if (workspace.tabs.count == 0) {
++        [workspace.tabs addObject:[ZeroNativeCmuxBrowserTab tabWithTitle:@"Home" url:@"https://zero-native.dev"]];
++    }
++    workspace.activeTabIndex = 0;
++    return workspace;
++}
++
++@end
++
 +@interface ZeroNativeCmuxWorkbenchView : NSView
 +@property(nonatomic, weak) id<ZeroNativeCmuxWorkbenchHost> host;
 +@property(nonatomic, assign) uint64_t windowId;
 +@property(nonatomic, assign) BOOL internalDevToolsVisible;
++@property(nonatomic, assign) NSInteger activeWorkspaceIndex;
++@property(nonatomic, strong) NSMutableArray<ZeroNativeCmuxWorkspace *> *workspaces;
++@property(nonatomic, strong) NSMutableArray<NSButton *> *workspaceButtons;
++@property(nonatomic, strong) NSMutableArray<NSButton *> *tabButtons;
++@property(nonatomic, strong) NSView *workspaceRail;
++@property(nonatomic, strong) NSView *tabStrip;
 +@property(nonatomic, strong) ZeroNativeCmuxGhosttySlotView *terminalSlot;
 +@property(nonatomic, strong) NSView *browserPane;
 +@property(nonatomic, strong) NSView *browserContainer;
@@ -765,6 +812,8 @@ index ce9c747..b0fe294 100644
 +@property(nonatomic, strong) NSButton *devToolsButton;
 +@property(nonatomic, strong) NSButton *devToolsWindowButton;
 +@property(nonatomic, strong) NSButton *addTerminalButton;
++@property(nonatomic, strong) NSButton *addWorkspaceButton;
++@property(nonatomic, strong) NSButton *addTabButton;
 +- (void)setBrowserURLString:(NSString *)urlString;
 +@end
 +
@@ -776,6 +825,33 @@ index ce9c747..b0fe294 100644
 +
 +    self.wantsLayer = YES;
 +    self.layer.backgroundColor = [NSColor separatorColor].CGColor;
++
++    _workspaces = [[NSMutableArray alloc] initWithArray:@[
++        [ZeroNativeCmuxWorkspace workspaceWithTitle:@"Main"
++                                             color:[NSColor colorWithCalibratedRed:0.18 green:0.52 blue:0.98 alpha:1.0]
++                                              tabs:@[
++            [ZeroNativeCmuxBrowserTab tabWithTitle:@"zero-native" url:@"https://zero-native.dev"],
++            [ZeroNativeCmuxBrowserTab tabWithTitle:@"GitHub" url:@"https://github.com/vercel-labs/zero-native"],
++        ]],
++        [ZeroNativeCmuxWorkspace workspaceWithTitle:@"Agents"
++                                             color:[NSColor colorWithCalibratedRed:0.40 green:0.78 blue:0.48 alpha:1.0]
++                                              tabs:@[
++            [ZeroNativeCmuxBrowserTab tabWithTitle:@"cmux" url:@"https://cmux.com"],
++        ]],
++        [ZeroNativeCmuxWorkspace workspaceWithTitle:@"Ops"
++                                             color:[NSColor colorWithCalibratedRed:0.96 green:0.58 blue:0.25 alpha:1.0]
++                                              tabs:@[
++            [ZeroNativeCmuxBrowserTab tabWithTitle:@"Vercel" url:@"https://vercel.com"],
++        ]],
++    ]];
++    _workspaceButtons = [[NSMutableArray alloc] init];
++    _tabButtons = [[NSMutableArray alloc] init];
++    _activeWorkspaceIndex = 0;
++
++    _workspaceRail = [[NSView alloc] initWithFrame:NSZeroRect];
++    _workspaceRail.wantsLayer = YES;
++    _workspaceRail.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.12 alpha:1.0].CGColor;
++    [self addSubview:_workspaceRail];
 +
 +    _terminalSlot = [[ZeroNativeCmuxGhosttySlotView alloc] initWithFrame:NSZeroRect];
 +    [self addSubview:_terminalSlot];
@@ -789,6 +865,11 @@ index ce9c747..b0fe294 100644
 +    _browserContainer.wantsLayer = YES;
 +    _browserContainer.layer.backgroundColor = NSColor.whiteColor.CGColor;
 +    [_browserPane addSubview:_browserContainer];
++
++    _tabStrip = [[NSView alloc] initWithFrame:NSZeroRect];
++    _tabStrip.wantsLayer = YES;
++    _tabStrip.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.15 alpha:1.0].CGColor;
++    [_browserPane addSubview:_tabStrip];
 +
 +    _devToolsContainer = [[NSView alloc] initWithFrame:NSZeroRect];
 +    _devToolsContainer.hidden = YES;
@@ -825,22 +906,38 @@ index ce9c747..b0fe294 100644
 +    _addTerminalButton.bezelStyle = NSBezelStyleRounded;
 +    [_browserPane addSubview:_addTerminalButton];
 +
++    _addWorkspaceButton = [NSButton buttonWithTitle:@"+" target:self action:@selector(addWorkspace:)];
++    _addWorkspaceButton.bezelStyle = NSBezelStyleRounded;
++    [_workspaceRail addSubview:_addWorkspaceButton];
++
++    _addTabButton = [NSButton buttonWithTitle:@"+" target:self action:@selector(addBrowserTab:)];
++    _addTabButton.bezelStyle = NSBezelStyleRounded;
++    [_tabStrip addSubview:_addTabButton];
++
++    [self rebuildWorkspaceButtons];
++    [self rebuildTabButtons];
++    [self updateChromeFromActiveTabNavigating:NO];
++
 +    return self;
 +}
 +
 +- (void)layout {
 +    [super layout];
 +
++    const CGFloat workspaceWidth = 148.0;
 +    const CGFloat minTerminalWidth = 320.0;
 +    const CGFloat maxTerminalFraction = 0.48;
-+    CGFloat terminalWidth = floor(self.bounds.size.width * 0.38);
-+    terminalWidth = MAX(minTerminalWidth, MIN(terminalWidth, floor(self.bounds.size.width * maxTerminalFraction)));
-+    if (self.bounds.size.width < 760) terminalWidth = floor(self.bounds.size.width * 0.42);
++    CGFloat contentWidth = MAX(0, self.bounds.size.width - workspaceWidth - 1);
++    CGFloat terminalWidth = floor(contentWidth * 0.36);
++    terminalWidth = MAX(minTerminalWidth, MIN(terminalWidth, floor(contentWidth * maxTerminalFraction)));
++    if (contentWidth < 760) terminalWidth = floor(contentWidth * 0.42);
 +
-+    self.terminalSlot.frame = NSMakeRect(0, 0, terminalWidth, self.bounds.size.height);
-+    self.browserPane.frame = NSMakeRect(terminalWidth + 1, 0, self.bounds.size.width - terminalWidth - 1, self.bounds.size.height);
++    self.workspaceRail.frame = NSMakeRect(0, 0, workspaceWidth, self.bounds.size.height);
++    self.terminalSlot.frame = NSMakeRect(workspaceWidth + 1, 0, terminalWidth, self.bounds.size.height);
++    self.browserPane.frame = NSMakeRect(workspaceWidth + terminalWidth + 2, 0, MAX(0, contentWidth - terminalWidth - 1), self.bounds.size.height);
 +
 +    const CGFloat chromeHeight = 40.0;
++    const CGFloat tabHeight = 34.0;
 +    const CGFloat padding = 8.0;
 +    self.titleLabel.frame = NSMakeRect(padding, self.browserPane.bounds.size.height - 28, 70, 20);
 +
@@ -858,7 +955,25 @@ index ce9c747..b0fe294 100644
 +    self.devToolsWindowButton.frame = NSMakeRect(NSMaxX(self.devToolsButton.frame) + padding, fieldY - 1, devToolsWindowWidth, 26);
 +    self.addTerminalButton.frame = NSMakeRect(NSMaxX(self.devToolsWindowButton.frame) + padding, fieldY - 1, newTerminalWidth, 26);
 +
-+    CGFloat contentHeight = MAX(0, self.browserPane.bounds.size.height - chromeHeight);
++    self.tabStrip.frame = NSMakeRect(0, self.browserPane.bounds.size.height - chromeHeight - tabHeight, self.browserPane.bounds.size.width, tabHeight);
++    CGFloat tabX = padding;
++    CGFloat tabY = 4.0;
++    CGFloat maxTabWidth = MAX(96.0, floor((self.tabStrip.bounds.size.width - padding * 4 - 34.0) / MAX(1, self.tabButtons.count)));
++    CGFloat tabWidth = MIN(150.0, maxTabWidth);
++    for (NSButton *button in self.tabButtons) {
++        button.frame = NSMakeRect(tabX, tabY, tabWidth, 26);
++        tabX += tabWidth + 6.0;
++    }
++    self.addTabButton.frame = NSMakeRect(tabX, tabY, 30.0, 26.0);
++
++    CGFloat workspaceY = self.workspaceRail.bounds.size.height - 42.0;
++    for (NSButton *button in self.workspaceButtons) {
++        button.frame = NSMakeRect(10.0, workspaceY, self.workspaceRail.bounds.size.width - 20.0, 30.0);
++        workspaceY -= 36.0;
++    }
++    self.addWorkspaceButton.frame = NSMakeRect(10.0, MAX(10.0, workspaceY), self.workspaceRail.bounds.size.width - 20.0, 28.0);
++
++    CGFloat contentHeight = MAX(0, self.browserPane.bounds.size.height - chromeHeight - tabHeight);
 +    if (self.internalDevToolsVisible) {
 +        CGFloat devToolsHeight = MAX(220.0, floor(contentHeight * 0.42));
 +        devToolsHeight = MIN(devToolsHeight, MAX(0, contentHeight - 160.0));
@@ -876,10 +991,24 @@ index ce9c747..b0fe294 100644
 +- (void)setBrowserURLString:(NSString *)urlString {
 +    if (urlString.length == 0) return;
 +    self.addressField.stringValue = urlString;
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    if (tab) {
++        tab.url = urlString;
++        tab.title = [self titleForURLString:urlString fallback:tab.title];
++        [self rebuildTabButtons];
++        [self setNeedsLayout:YES];
++    }
 +}
 +
 +- (void)go:(id)sender {
 +    (void)sender;
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    if (tab) {
++        tab.url = self.addressField.stringValue;
++        tab.title = [self titleForURLString:self.addressField.stringValue fallback:tab.title];
++        [self rebuildTabButtons];
++        [self setNeedsLayout:YES];
++    }
 +    [self.host navigateNativeBrowserToString:self.addressField.stringValue windowId:self.windowId];
 +}
 +
@@ -905,6 +1034,125 @@ index ce9c747..b0fe294 100644
 +    [self.host openNativeBrowserWindowDevToolsForWindowId:self.windowId];
 +}
 +
++- (ZeroNativeCmuxWorkspace *)activeWorkspace {
++    if (self.workspaces.count == 0) return nil;
++    self.activeWorkspaceIndex = MAX(0, MIN(self.activeWorkspaceIndex, (NSInteger)self.workspaces.count - 1));
++    return self.workspaces[(NSUInteger)self.activeWorkspaceIndex];
++}
++
++- (ZeroNativeCmuxBrowserTab *)activeBrowserTab {
++    ZeroNativeCmuxWorkspace *workspace = [self activeWorkspace];
++    if (!workspace) return nil;
++    if (workspace.tabs.count == 0) {
++        [workspace.tabs addObject:[ZeroNativeCmuxBrowserTab tabWithTitle:@"Home" url:@"https://zero-native.dev"]];
++    }
++    workspace.activeTabIndex = MAX(0, MIN(workspace.activeTabIndex, (NSInteger)workspace.tabs.count - 1));
++    return workspace.tabs[(NSUInteger)workspace.activeTabIndex];
++}
++
++- (NSString *)titleForURLString:(NSString *)urlString fallback:(NSString *)fallback {
++    NSURL *url = [NSURL URLWithString:urlString ?: @""];
++    NSString *host = url.host;
++    if (host.length == 0) return fallback.length > 0 ? fallback : @"Tab";
++    if ([host hasPrefix:@"www."]) host = [host substringFromIndex:4];
++    NSArray<NSString *> *parts = [host componentsSeparatedByString:@"."];
++    NSString *title = parts.count > 0 ? parts.firstObject : host;
++    return title.length > 0 ? title.capitalizedString : (fallback.length > 0 ? fallback : @"Tab");
++}
++
++- (void)rebuildWorkspaceButtons {
++    for (NSButton *button in self.workspaceButtons) {
++        [button removeFromSuperview];
++    }
++    [self.workspaceButtons removeAllObjects];
++
++    for (NSUInteger index = 0; index < self.workspaces.count; index += 1) {
++        ZeroNativeCmuxWorkspace *workspace = self.workspaces[index];
++        NSButton *button = [NSButton buttonWithTitle:workspace.title target:self action:@selector(workspaceButton:)];
++        button.bezelStyle = NSBezelStyleTexturedRounded;
++        button.buttonType = NSButtonTypeToggle;
++        button.tag = (NSInteger)index;
++        button.state = index == (NSUInteger)self.activeWorkspaceIndex ? NSControlStateValueOn : NSControlStateValueOff;
++        button.contentTintColor = index == (NSUInteger)self.activeWorkspaceIndex ? workspace.accentColor : NSColor.labelColor;
++        [self.workspaceRail addSubview:button];
++        [self.workspaceButtons addObject:button];
++    }
++}
++
++- (void)rebuildTabButtons {
++    for (NSButton *button in self.tabButtons) {
++        [button removeFromSuperview];
++    }
++    [self.tabButtons removeAllObjects];
++
++    ZeroNativeCmuxWorkspace *workspace = [self activeWorkspace];
++    for (NSUInteger index = 0; index < workspace.tabs.count; index += 1) {
++        ZeroNativeCmuxBrowserTab *tab = workspace.tabs[index];
++        NSButton *button = [NSButton buttonWithTitle:tab.title target:self action:@selector(tabButton:)];
++        button.bezelStyle = NSBezelStyleTexturedRounded;
++        button.buttonType = NSButtonTypeToggle;
++        button.tag = (NSInteger)index;
++        button.state = index == (NSUInteger)workspace.activeTabIndex ? NSControlStateValueOn : NSControlStateValueOff;
++        [self.tabStrip addSubview:button];
++        [self.tabButtons addObject:button];
++    }
++}
++
++- (void)updateChromeFromActiveTabNavigating:(BOOL)navigate {
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    if (!tab) return;
++    self.addressField.stringValue = tab.url;
++    if (navigate) [self.host navigateNativeBrowserToString:tab.url windowId:self.windowId];
++}
++
++- (void)workspaceButton:(NSButton *)sender {
++    if (sender.tag < 0 || sender.tag >= (NSInteger)self.workspaces.count) return;
++    self.activeWorkspaceIndex = sender.tag;
++    [self rebuildWorkspaceButtons];
++    [self rebuildTabButtons];
++    [self updateChromeFromActiveTabNavigating:YES];
++    [self setNeedsLayout:YES];
++    [self layoutSubtreeIfNeeded];
++}
++
++- (void)tabButton:(NSButton *)sender {
++    ZeroNativeCmuxWorkspace *workspace = [self activeWorkspace];
++    if (!workspace || sender.tag < 0 || sender.tag >= (NSInteger)workspace.tabs.count) return;
++    workspace.activeTabIndex = sender.tag;
++    [self rebuildTabButtons];
++    [self updateChromeFromActiveTabNavigating:YES];
++    [self setNeedsLayout:YES];
++    [self layoutSubtreeIfNeeded];
++}
++
++- (void)addWorkspace:(id)sender {
++    (void)sender;
++    NSUInteger number = self.workspaces.count + 1;
++    NSString *title = [NSString stringWithFormat:@"Space %lu", (unsigned long)number];
++    ZeroNativeCmuxWorkspace *workspace = [ZeroNativeCmuxWorkspace workspaceWithTitle:title
++                                                                              color:NSColor.controlAccentColor
++                                                                               tabs:@[
++        [ZeroNativeCmuxBrowserTab tabWithTitle:@"Home" url:@"https://zero-native.dev"],
++    ]];
++    [self.workspaces addObject:workspace];
++    self.activeWorkspaceIndex = (NSInteger)self.workspaces.count - 1;
++    [self rebuildWorkspaceButtons];
++    [self rebuildTabButtons];
++    [self updateChromeFromActiveTabNavigating:YES];
++    [self setNeedsLayout:YES];
++}
++
++- (void)addBrowserTab:(id)sender {
++    (void)sender;
++    ZeroNativeCmuxWorkspace *workspace = [self activeWorkspace];
++    if (!workspace) return;
++    [workspace.tabs addObject:[ZeroNativeCmuxBrowserTab tabWithTitle:@"New" url:@"https://zero-native.dev"]];
++    workspace.activeTabIndex = (NSInteger)workspace.tabs.count - 1;
++    [self rebuildTabButtons];
++    [self updateChromeFromActiveTabNavigating:YES];
++    [self setNeedsLayout:YES];
++}
++
 +@end
 +
  @interface ZeroNativeChromiumWindowDelegate : NSObject <NSWindowDelegate>
@@ -928,7 +1176,7 @@ index ce9c747..b0fe294 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +1149,13 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1397,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
@@ -943,7 +1191,7 @@ index ce9c747..b0fe294 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +1177,17 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1425,17 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
@@ -961,7 +1209,7 @@ index ce9c747..b0fe294 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -391,11 +1219,16 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1467,16 @@ - (void)windowWillClose:(NSNotification *)notification {
      (void)notification;
      [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
@@ -978,7 +1226,7 @@ index ce9c747..b0fe294 100644
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +1243,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1491,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -987,7 +1235,7 @@ index ce9c747..b0fe294 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,16 +1251,22 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1499,22 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
@@ -1010,7 +1258,7 @@ index ce9c747..b0fe294 100644
      self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
      self.allowedExternalURLs = @[];
      self.externalLinkAction = 0;
-@@ -519,6 +1358,8 @@ - (void)reload:(id)sender {
+@@ -519,6 +1606,8 @@ - (void)reload:(id)sender {
  - (void)dealloc {
      delete self.cefClients;
      delete self.browsers;
@@ -1019,7 +1267,7 @@ index ce9c747..b0fe294 100644
  }
  
  - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
-@@ -536,9 +1377,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -536,9 +1625,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -1044,7 +1292,7 @@ index ce9c747..b0fe294 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +1401,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1649,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -1052,7 +1300,7 @@ index ce9c747..b0fe294 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -601,14 +1455,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -601,14 +1703,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
  
@@ -1072,7 +1320,7 @@ index ce9c747..b0fe294 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -702,9 +1558,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -702,9 +1806,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      NSString *bridgeOrigin = nil;
      NSString *internalURLPrefix = nil;
      if (kind == 0) {
@@ -1084,7 +1332,7 @@ index ce9c747..b0fe294 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +1582,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +1830,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -1102,7 +1350,7 @@ index ce9c747..b0fe294 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +1600,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +1848,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -1115,7 +1363,7 @@ index ce9c747..b0fe294 100644
          return;
      }
  
-@@ -769,6 +1635,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +1883,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -1123,7 +1371,7 @@ index ce9c747..b0fe294 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -784,6 +1651,217 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
+@@ -784,6 +1899,217 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (windowId == 1) self.browser = browser;
  }
  
@@ -1341,7 +1589,7 @@ index ce9c747..b0fe294 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
      return self.fallbackURLs[@(windowId)];
  }
-@@ -882,6 +1960,11 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -882,6 +2208,11 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
      [host_ setBrowser:browser windowId:window_id_];
@@ -1353,7 +1601,7 @@ index ce9c747..b0fe294 100644
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +1987,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2235,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
@@ -1365,7 +1613,7 @@ index ce9c747..b0fe294 100644
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2009,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2257,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,0 +1,530 @@
+diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
+index ce9c747..07cb2e2 100644
+--- a/src/platform/macos/cef_host.mm
++++ b/src/platform/macos/cef_host.mm
+@@ -29,6 +29,10 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
+ @property(nonatomic, assign) BOOL handlingSendEvent;
+ @end
+ 
++@protocol ZeroNativeCmuxWorkbenchHost <NSObject>
++- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
++@end
++
+ namespace {
+ 
+ static const char *kBridgeMessageName = "zero_native_bridge";
+@@ -40,6 +44,10 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
+ static NSString *ZeroNativeAbsolutePath(NSString *path);
+ static NSString *ZeroNativeExistingPath(NSString *path);
+ static NSString *ZeroNativeCefFrameworkPath(void);
++static NSString *ZeroNativeBrowserSubprocessPath(void);
++static bool ZeroNativeIsCefHelperProcess(void);
++static bool ZeroNativeShouldUseHelperLoader(void);
++static void ZeroNativeRunCefSubprocessIfNeeded(void);
+ static NSString *ZeroNativeOriginForURL(NSURL *url);
+ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
+ 
+@@ -121,6 +129,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+ static CefScopedLibraryLoader g_cef_library_loader;
+ static bool g_cef_library_loaded = false;
+ 
++static void ZeroNativeRunCefSubprocessIfNeeded() {
++    if (!ZeroNativeShouldUseHelperLoader()) return;
++    if (!g_cef_library_loader.LoadInHelper()) {
++        fprintf(stderr, "failed to load Chromium Embedded Framework in helper\n");
++        exit(1);
++    }
++    CefMainArgs args(*_NSGetArgc(), *_NSGetArgv());
++    CefRefPtr<ZeroNativeCefApp> app = new ZeroNativeCefApp();
++    const int exit_code = CefExecuteProcess(args, app, nullptr);
++    exit(exit_code >= 0 ? exit_code : 1);
++}
++
+ static void shutdownCefIfNeeded() {
+     if (!g_cef_initialized || g_cef_shutdown) return;
+     CefShutdown();
+@@ -133,7 +153,8 @@ static void ensureCefInitialized() {
+     g_cef_shutdown = false;
+ 
+     if (!g_cef_library_loaded) {
+-        if (!g_cef_library_loader.LoadInMain()) {
++        const bool helper_process = ZeroNativeShouldUseHelperLoader();
++        if (!(helper_process ? g_cef_library_loader.LoadInHelper() : g_cef_library_loader.LoadInMain())) {
+             fprintf(stderr, "failed to load Chromium Embedded Framework\n");
+             return;
+         }
+@@ -154,7 +175,7 @@ static void ensureCefInitialized() {
+     NSString *cefDataRoot = [appSupport stringByAppendingPathComponent:@"zero-native/CEF"];
+     NSString *cefCachePath = [cefDataRoot stringByAppendingPathComponent:@"Default"];
+     [[NSFileManager defaultManager] createDirectoryAtPath:cefCachePath withIntermediateDirectories:YES attributes:nil error:nil];
+-    NSString *executablePath = [NSBundle mainBundle].executablePath ?: [[[NSProcessInfo processInfo] arguments] firstObject];
++    NSString *executablePath = ZeroNativeBrowserSubprocessPath();
+     CefString(&settings.framework_dir_path).FromString(frameworkPath.UTF8String);
+     CefString(&settings.resources_dir_path).FromString(resourcesPath.UTF8String);
+     CefString(&settings.root_cache_path).FromString(cefDataRoot.UTF8String);
+@@ -223,6 +244,33 @@ static void ensureCefInitialized() {
+     return [devRoot stringByAppendingPathComponent:@"Release/Chromium Embedded Framework.framework"];
+ }
+ 
++static NSString *ZeroNativeBrowserSubprocessPath(void) {
++    NSBundle *bundle = [NSBundle mainBundle];
++    NSString *executablePath = bundle.executablePath ?: [[[NSProcessInfo processInfo] arguments] firstObject];
++    NSString *executableName = executablePath.lastPathComponent;
++    if (executableName.length == 0) return executablePath;
++    NSString *helperName = [executableName stringByAppendingString:@" Helper"];
++    NSString *helperPath = [[[[bundle privateFrameworksPath] stringByAppendingPathComponent:[helperName stringByAppendingString:@".app"]] stringByAppendingPathComponent:@"Contents/MacOS"] stringByAppendingPathComponent:helperName];
++    if (ZeroNativeExistingPath(helperPath)) return helperPath;
++    return executablePath;
++}
++
++static bool ZeroNativeIsCefHelperProcess(void) {
++    int argc = *_NSGetArgc();
++    char **argv = *_NSGetArgv();
++    for (int index = 1; index < argc; index += 1) {
++        const char *arg = argv[index];
++        if (arg && strncmp(arg, "--type=", 7) == 0) return true;
++    }
++    return false;
++}
++
++static bool ZeroNativeShouldUseHelperLoader(void) {
++    if (!ZeroNativeIsCefHelperProcess()) return false;
++    NSString *bundleExtension = [NSBundle mainBundle].bundlePath.pathExtension.lowercaseString ?: @"";
++    return [bundleExtension isEqualToString:@"app"];
++}
++
+ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
+     NSScreen *screen = [NSScreen mainScreen];
+     if (!screen) return frame;
+@@ -305,20 +353,188 @@ - (void)sendEvent:(NSEvent *)event {
+ 
+ @end
+ 
++@interface ZeroNativeCmuxGhosttySlotView : NSView
++@property(nonatomic, assign) NSInteger terminalCount;
++- (void)incrementTerminalCount;
++@end
++
++@implementation ZeroNativeCmuxGhosttySlotView
++
++- (instancetype)initWithFrame:(NSRect)frameRect {
++    self = [super initWithFrame:frameRect];
++    if (!self) return nil;
++    _terminalCount = 1;
++    self.wantsLayer = YES;
++    self.layer.masksToBounds = YES;
++    return self;
++}
++
++- (BOOL)isOpaque {
++    return YES;
++}
++
++- (void)incrementTerminalCount {
++    self.terminalCount += 1;
++    self.needsDisplay = YES;
++}
++
++- (void)drawRect:(NSRect)dirtyRect {
++    (void)dirtyRect;
++    [[NSColor colorWithCalibratedWhite:0.055 alpha:1.0] setFill];
++    NSRectFill(self.bounds);
++
++    const CGFloat headerHeight = 38.0;
++    NSRect header = NSMakeRect(0, self.bounds.size.height - headerHeight, self.bounds.size.width, headerHeight);
++    [[NSColor colorWithCalibratedWhite:0.095 alpha:1.0] setFill];
++    NSRectFill(header);
++
++    NSDictionary *headerAttrs = @{
++        NSFontAttributeName: [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold],
++        NSForegroundColorAttributeName: [NSColor colorWithCalibratedWhite:0.92 alpha:1.0],
++    };
++    [@"Ghostty" drawInRect:NSInsetRect(header, 12, 10) withAttributes:headerAttrs];
++
++    NSDictionary *pillAttrs = @{
++        NSFontAttributeName: [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
++        NSForegroundColorAttributeName: [NSColor colorWithCalibratedWhite:0.68 alpha:1.0],
++    };
++    NSString *slot = [NSString stringWithFormat:@"native AppKit slot  %ld", (long)self.terminalCount];
++    [slot drawInRect:NSMakeRect(self.bounds.size.width - 150, header.origin.y + 11, 138, 18) withAttributes:pillAttrs];
++
++    NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
++    style.lineSpacing = 4;
++    NSDictionary *terminalAttrs = @{
++        NSFontAttributeName: [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular],
++        NSForegroundColorAttributeName: [NSColor colorWithCalibratedRed:0.82 green:0.89 blue:0.94 alpha:1.0],
++        NSParagraphStyleAttributeName: style,
++    };
++    NSString *body = @"$ zero-cmux native shell\n$ ghostty host = NSView\n$ chromium owns only browser content\n$ next step: mount live ghostty_surface_new here";
++    [body drawInRect:NSInsetRect(NSMakeRect(0, 0, self.bounds.size.width, self.bounds.size.height - headerHeight), 14, 16) withAttributes:terminalAttrs];
++}
++
++@end
++
++@interface ZeroNativeCmuxWorkbenchView : NSView
++@property(nonatomic, weak) id<ZeroNativeCmuxWorkbenchHost> host;
++@property(nonatomic, assign) uint64_t windowId;
++@property(nonatomic, strong) ZeroNativeCmuxGhosttySlotView *terminalSlot;
++@property(nonatomic, strong) NSView *browserPane;
++@property(nonatomic, strong) NSView *browserContainer;
++@property(nonatomic, strong) NSTextField *titleLabel;
++@property(nonatomic, strong) NSTextField *addressField;
++@property(nonatomic, strong) NSButton *goButton;
++@property(nonatomic, strong) NSButton *addTerminalButton;
++- (void)setBrowserURLString:(NSString *)urlString;
++@end
++
++@implementation ZeroNativeCmuxWorkbenchView
++
++- (instancetype)initWithFrame:(NSRect)frameRect {
++    self = [super initWithFrame:frameRect];
++    if (!self) return nil;
++
++    self.wantsLayer = YES;
++    self.layer.backgroundColor = [NSColor separatorColor].CGColor;
++
++    _terminalSlot = [[ZeroNativeCmuxGhosttySlotView alloc] initWithFrame:NSZeroRect];
++    [self addSubview:_terminalSlot];
++
++    _browserPane = [[NSView alloc] initWithFrame:NSZeroRect];
++    _browserPane.wantsLayer = YES;
++    _browserPane.layer.backgroundColor = NSColor.windowBackgroundColor.CGColor;
++    [self addSubview:_browserPane];
++
++    _browserContainer = [[NSView alloc] initWithFrame:NSZeroRect];
++    _browserContainer.wantsLayer = YES;
++    _browserContainer.layer.backgroundColor = NSColor.whiteColor.CGColor;
++    [_browserPane addSubview:_browserContainer];
++
++    _titleLabel = [NSTextField labelWithString:@"Chrome"];
++    _titleLabel.font = [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold];
++    _titleLabel.translatesAutoresizingMaskIntoConstraints = YES;
++    [_browserPane addSubview:_titleLabel];
++
++    _addressField = [[NSTextField alloc] initWithFrame:NSZeroRect];
++    _addressField.font = [NSFont systemFontOfSize:13];
++    _addressField.bezelStyle = NSTextFieldRoundedBezel;
++    _addressField.stringValue = @"https://zero-native.dev";
++    _addressField.target = self;
++    _addressField.action = @selector(go:);
++    [_browserPane addSubview:_addressField];
++
++    _goButton = [NSButton buttonWithTitle:@"Go" target:self action:@selector(go:)];
++    _goButton.bezelStyle = NSBezelStyleRounded;
++    [_browserPane addSubview:_goButton];
++
++    _addTerminalButton = [NSButton buttonWithTitle:@"+" target:self action:@selector(newTerminal:)];
++    _addTerminalButton.bezelStyle = NSBezelStyleRounded;
++    [_browserPane addSubview:_addTerminalButton];
++
++    return self;
++}
++
++- (void)layout {
++    [super layout];
++
++    const CGFloat minTerminalWidth = 320.0;
++    const CGFloat maxTerminalFraction = 0.48;
++    CGFloat terminalWidth = floor(self.bounds.size.width * 0.38);
++    terminalWidth = MAX(minTerminalWidth, MIN(terminalWidth, floor(self.bounds.size.width * maxTerminalFraction)));
++    if (self.bounds.size.width < 760) terminalWidth = floor(self.bounds.size.width * 0.42);
++
++    self.terminalSlot.frame = NSMakeRect(0, 0, terminalWidth, self.bounds.size.height);
++    self.browserPane.frame = NSMakeRect(terminalWidth + 1, 0, self.bounds.size.width - terminalWidth - 1, self.bounds.size.height);
++
++    const CGFloat chromeHeight = 40.0;
++    const CGFloat padding = 8.0;
++    self.titleLabel.frame = NSMakeRect(padding, self.browserPane.bounds.size.height - 28, 70, 20);
++
++    CGFloat buttonWidth = 42.0;
++    CGFloat newTerminalWidth = 30.0;
++    CGFloat fieldX = 82.0;
++    CGFloat fieldY = self.browserPane.bounds.size.height - 32.0;
++    CGFloat fieldWidth = MAX(120.0, self.browserPane.bounds.size.width - fieldX - buttonWidth - newTerminalWidth - padding * 4);
++    self.addressField.frame = NSMakeRect(fieldX, fieldY, fieldWidth, 24);
++
++    self.goButton.frame = NSMakeRect(NSMaxX(self.addressField.frame) + padding, fieldY - 1, buttonWidth, 26);
++    self.addTerminalButton.frame = NSMakeRect(NSMaxX(self.goButton.frame) + padding, fieldY - 1, newTerminalWidth, 26);
++
++    self.browserContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, MAX(0, self.browserPane.bounds.size.height - chromeHeight));
++}
++
++- (void)setBrowserURLString:(NSString *)urlString {
++    if (urlString.length == 0) return;
++    self.addressField.stringValue = urlString;
++}
++
++- (void)go:(id)sender {
++    (void)sender;
++    [self.host navigateNativeBrowserToString:self.addressField.stringValue windowId:self.windowId];
++}
++
++- (void)newTerminal:(id)sender {
++    (void)sender;
++    [self.terminalSlot incrementTerminalCount];
++}
++
++@end
++
+ @interface ZeroNativeChromiumWindowDelegate : NSObject <NSWindowDelegate>
+ @property(nonatomic, assign) ZeroNativeChromiumHost *host;
+ @property(nonatomic, assign) uint64_t windowId;
+ @end
+ 
+-@interface ZeroNativeChromiumHost : NSObject
++@interface ZeroNativeChromiumHost : NSObject <ZeroNativeCmuxWorkbenchHost>
+ @property(nonatomic, strong) NSWindow *window;
+ @property(nonatomic, strong) NSView *browserContainer;
+ @property(nonatomic, strong) ZeroNativeChromiumWindowDelegate *delegate;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *windows;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSView *> *browserContainers;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeCmuxWorkbenchView *> *nativeWorkbenchViews;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeChromiumWindowDelegate *> *delegates;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *bridgeOrigins;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *internalURLPrefixes;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *inlineHTMLSources;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
+ @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
+ @property(nonatomic, strong) NSTimer *timer;
+@@ -335,10 +551,11 @@ @interface ZeroNativeChromiumHost : NSObject
+ @property(nonatomic) CefRefPtr<CefBrowser> browser;
+ @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
+ @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
++@property(nonatomic, assign) BOOL cmuxNativeShellEnabled;
+ @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
+ @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
+ @property(nonatomic, assign) NSInteger externalLinkAction;
+-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height;
++- (instancetype)initWithAppName:(NSString *)appName bundleIdentifier:(NSString *)bundleIdentifier title:(NSString *)title width:(double)width height:(double)height;
+ - (void)configureApplication;
+ - (void)buildMenuBar;
+ - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
+@@ -360,6 +577,9 @@ - (BOOL)isInternalURL:(NSURL *)url;
+ - (BOOL)allowsNavigationURL:(NSURL *)url;
+ - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
+ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
++- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser;
++- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId;
++- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
+ - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
+ - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
+ - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
+@@ -393,9 +613,11 @@ - (void)windowWillClose:(NSNotification *)notification {
+     NSNumber *key = @(self.windowId);
+     [self.host.windows removeObjectForKey:key];
+     [self.host.browserContainers removeObjectForKey:key];
++    [self.host.nativeWorkbenchViews removeObjectForKey:key];
+     [self.host.delegates removeObjectForKey:key];
+     [self.host.bridgeOrigins removeObjectForKey:key];
+     [self.host.internalURLPrefixes removeObjectForKey:key];
++    [self.host.inlineHTMLSources removeObjectForKey:key];
+     [self.host.windowLabels removeObjectForKey:key];
+     [self.host.fallbackURLs removeObjectForKey:key];
+     if (self.host.browsers) self.host.browsers->erase(self.windowId);
+@@ -410,7 +632,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+ 
+ @implementation ZeroNativeChromiumHost
+ 
+-- (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title width:(double)width height:(double)height {
++- (instancetype)initWithAppName:(NSString *)appName bundleIdentifier:(NSString *)bundleIdentifier title:(NSString *)title width:(double)width height:(double)height {
+     self = [super init];
+     if (!self) return nil;
+ 
+@@ -418,12 +640,15 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+     ensureCefInitialized();
+     [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
+     self.appName = appName.length > 0 ? appName : @"zero-native";
++    self.cmuxNativeShellEnabled = [bundleIdentifier isEqualToString:@"com.cmux.zero-native"] || [self.appName isEqualToString:@"zero-cmux"];
+     [self configureApplication];
+     self.windows = [[NSMutableDictionary alloc] init];
+     self.browserContainers = [[NSMutableDictionary alloc] init];
++    self.nativeWorkbenchViews = [[NSMutableDictionary alloc] init];
+     self.delegates = [[NSMutableDictionary alloc] init];
+     self.bridgeOrigins = [[NSMutableDictionary alloc] init];
+     self.internalURLPrefixes = [[NSMutableDictionary alloc] init];
++    self.inlineHTMLSources = [[NSMutableDictionary alloc] init];
+     self.windowLabels = [[NSMutableDictionary alloc] init];
+     self.fallbackURLs = [[NSMutableDictionary alloc] init];
+     self.cefClients = new std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>>();
+@@ -536,9 +761,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+     [window setTitle:title.length > 0 ? title : @"zero-native"];
+     if (!restoreFrame) [window center];
+ 
+-    NSView *browserContainer = [[NSView alloc] initWithFrame:rect];
+-    browserContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
+-    window.contentView = browserContainer;
++    NSView *browserContainer = nil;
++    ZeroNativeCmuxWorkbenchView *workbenchView = nil;
++    if (self.cmuxNativeShellEnabled) {
++        workbenchView = [[ZeroNativeCmuxWorkbenchView alloc] initWithFrame:rect];
++        workbenchView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++        workbenchView.host = self;
++        workbenchView.windowId = windowId;
++        browserContainer = workbenchView.browserContainer;
++        window.contentView = workbenchView;
++        [workbenchView layoutSubtreeIfNeeded];
++    } else {
++        browserContainer = [[NSView alloc] initWithFrame:rect];
++        browserContainer.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++        window.contentView = browserContainer;
++    }
+ 
+     ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
+     delegate.host = self;
+@@ -548,6 +785,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+ 
+     self.windows[key] = window;
+     self.browserContainers[key] = browserContainer;
++    if (workbenchView) self.nativeWorkbenchViews[key] = workbenchView;
+     self.delegates[key] = delegate;
+     self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
+     (*self.cefClients)[windowId] = client;
+@@ -601,14 +839,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+     [self.window makeKeyAndOrderFront:nil];
+     [NSApp activateIgnoringOtherApps:YES];
+ 
+-    [self emitEvent:(zero_native_appkit_event_t){ .kind = ZERO_NATIVE_APPKIT_EVENT_START }];
+-    [self emitResize];
+-    [self emitWindowFrameForWindowId:1 open:YES];
+     self.timer = [NSTimer scheduledTimerWithTimeInterval:(1.0 / 60.0)
+                                                  target:self
+                                                selector:@selector(emitFrame)
+                                                userInfo:nil
+                                                 repeats:YES];
++    dispatch_async(dispatch_get_main_queue(), ^{
++        [self emitEvent:(zero_native_appkit_event_t){ .kind = ZERO_NATIVE_APPKIT_EVENT_START }];
++        [self emitResize];
++        [self emitWindowFrameForWindowId:1 open:YES];
++    });
+     [NSApp run];
+     shutdownCefIfNeeded();
+ }
+@@ -702,9 +942,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+     NSString *bridgeOrigin = nil;
+     NSString *internalURLPrefix = nil;
+     if (kind == 0) {
+-        urlString = temporaryHtmlUrl(source);
++        urlString = @"about:blank";
+         bridgeOrigin = @"zero://inline";
+-        internalURLPrefix = urlString;
++        internalURLPrefix = @"zero://inline/";
+     } else if (kind == 2) {
+         NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
+         NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
+@@ -726,11 +966,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+     } else {
+         [self.internalURLPrefixes removeObjectForKey:key];
+     }
++    if (kind == 0) {
++        self.inlineHTMLSources[key] = source ?: @"";
++    } else {
++        [self.inlineHTMLSources removeObjectForKey:key];
++    }
+     if (kind == 2 && spaFallback) {
+         self.fallbackURLs[key] = urlString;
+     } else {
+         [self.fallbackURLs removeObjectForKey:key];
+     }
++    [self updateNativeBrowserURLString:urlString windowId:windowId];
+     NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
+     CefRefPtr<CefBrowser> browser;
+     if (self.browsers) {
+@@ -738,7 +984,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+         if (browser_it != self.browsers->end()) browser = browser_it->second;
+     }
+     if (browser) {
+-        browser->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
++        if (kind == 0) {
++            [self loadInlineHTMLIfNeededForWindowId:windowId browser:browser];
++        } else {
++            browser->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
++        }
+         return;
+     }
+ 
+@@ -769,6 +1019,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+     NSString *scheme = url.scheme.lowercaseString ?: @"";
+     if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
+     if ([self isInternalURL:url]) return YES;
++    if (self.cmuxNativeShellEnabled && ([scheme isEqualToString:@"http"] || [scheme isEqualToString:@"https"])) return YES;
+     return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
+ }
+ 
+@@ -784,6 +1035,37 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
+     if (windowId == 1) self.browser = browser;
+ }
+ 
++- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId {
++    ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[@(windowId)];
++    [workbench setBrowserURLString:urlString];
++}
++
++- (NSString *)normalizedBrowserURLString:(NSString *)value {
++    NSString *trimmed = [value stringByTrimmingCharactersInSet:NSCharacterSet.whitespaceAndNewlineCharacterSet];
++    if (trimmed.length == 0) return @"about:blank";
++    NSURL *url = [NSURL URLWithString:trimmed];
++    if (url.scheme.length > 0) return trimmed;
++    return [@"https://" stringByAppendingString:trimmed];
++}
++
++- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId {
++    NSString *urlString = [self normalizedBrowserURLString:value ?: @""];
++    [self updateNativeBrowserURLString:urlString windowId:windowId];
++    if (!self.browsers) return;
++    auto it = self.browsers->find(windowId);
++    if (it == self.browsers->end() || !it->second) return;
++    it->second->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
++}
++
++- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser {
++    NSString *html = self.inlineHTMLSources[@(windowId)];
++    if (html.length == 0 || !browser) return;
++    NSData *htmlJSONData = [NSJSONSerialization dataWithJSONObject:@[ html ] options:0 error:nil];
++    NSString *htmlJSON = htmlJSONData ? [[NSString alloc] initWithData:htmlJSONData encoding:NSUTF8StringEncoding] : @"[\"\"]";
++    NSString *script = [NSString stringWithFormat:@"(function(){var html=%@;document.open();document.write(html[0]);document.close();})();", htmlJSON];
++    browser->GetMainFrame()->ExecuteJavaScript(std::string(script.UTF8String), "zero://inline/", 0);
++}
++
+ - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
+     return self.fallbackURLs[@(windowId)];
+ }
+@@ -882,6 +1164,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+ 
+ void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
+     [host_ setBrowser:browser windowId:window_id_];
++    [host_ loadInlineHTMLIfNeededForWindowId:window_id_ browser:browser];
+ }
+ 
+ void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
+@@ -904,7 +1187,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+     std::string url = request ? request->GetURL().ToString() : std::string();
+     NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
+     NSURL *nsURL = [NSURL URLWithString:urlString];
+-    if ([host_ allowsNavigationURL:nsURL]) return false;
++    if ([host_ allowsNavigationURL:nsURL]) {
++        [host_ updateNativeBrowserURLString:urlString windowId:window_id_];
++        return false;
++    }
+     if ([host_ openExternalURLIfAllowed:nsURL]) return true;
+     return true;
+ }
+@@ -926,16 +1212,16 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+ } // namespace
+ 
+ zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {
++    ZeroNativeRunCefSubprocessIfNeeded();
+     @autoreleasepool {
+-        (void)bundle_id;
+-        (void)bundle_id_len;
+         (void)icon_path;
+         (void)icon_path_len;
+         (void)window_label;
+         (void)window_label_len;
+         NSString *appNameString = [[NSString alloc] initWithBytes:app_name length:app_name_len encoding:NSUTF8StringEncoding] ?: @"zero-native";
++        NSString *bundleIdentifierString = [[NSString alloc] initWithBytes:bundle_id length:bundle_id_len encoding:NSUTF8StringEncoding] ?: @"";
+         NSString *titleString = [[NSString alloc] initWithBytes:window_title length:window_title_len encoding:NSUTF8StringEncoding] ?: appNameString;
+-        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString title:titleString width:width height:height];
++        ZeroNativeChromiumHost *host = [[ZeroNativeChromiumHost alloc] initWithAppName:appNameString bundleIdentifier:bundleIdentifierString title:titleString width:width height:height];
+         if (restore_frame) {
+             [host.window setFrame:ZeroNativeConstrainFrame(NSMakeRect(x, y, width, height)) display:NO];
+         }

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..ea78ee1 100644
+index ce9c747..e97dc57 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -24,7 +24,7 @@ index ce9c747..ea78ee1 100644
  #include "include/cef_app.h"
  #include "include/cef_browser.h"
  #include "include/cef_client.h"
-@@ -29,17 +38,40 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
+@@ -29,17 +38,42 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
  @property(nonatomic, assign) BOOL handlingSendEvent;
  @end
  
@@ -55,6 +55,8 @@ index ce9c747..ea78ee1 100644
 +static uint64_t ZeroNativeCmuxNextBrowserKey(void);
 +static NSData *ZeroNativeCmuxReadDevToolsJSON(void);
 +static NSString *ZeroNativeCmuxDevToolsFrontendURLForSourceURL(NSString *sourceURLString);
++static NSString *ZeroNativeCmuxDevToolsBootstrapURL(void);
++static NSString *ZeroNativeCmuxJSONString(NSString *value);
  static NSString *ZeroNativeAbsolutePath(NSString *path);
  static NSString *ZeroNativeExistingPath(NSString *path);
  static NSString *ZeroNativeCefFrameworkPath(void);
@@ -65,7 +67,7 @@ index ce9c747..ea78ee1 100644
  static NSString *ZeroNativeOriginForURL(NSURL *url);
  static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
  
-@@ -64,7 +96,8 @@ bool Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8Val
+@@ -64,7 +98,8 @@ bool Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8Val
  
  class ZeroNativeCefClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler, public CefRequestHandler {
  public:
@@ -75,7 +77,7 @@ index ce9c747..ea78ee1 100644
  
      CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
          return this;
-@@ -79,6 +112,7 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+@@ -79,6 +114,7 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
      }
  
      void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
@@ -83,7 +85,7 @@ index ce9c747..ea78ee1 100644
      void OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) override;
      bool OnBeforeBrowse(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefRefPtr<CefRequest> request, bool user_gesture, bool is_redirect) override;
      bool OnProcessMessageReceived(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, CefProcessId source_process, CefRefPtr<CefProcessMessage> message) override;
-@@ -86,9 +120,34 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+@@ -86,9 +122,37 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
  private:
      ZeroNativeChromiumHost *host_;
      uint64_t window_id_;
@@ -93,7 +95,8 @@ index ce9c747..ea78ee1 100644
  
 +class ZeroNativeCefDevToolsClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler {
 +public:
-+    explicit ZeroNativeCefDevToolsClient(ZeroNativeChromiumHost *host, uint64_t window_id, NSInteger mode) : host_(host), window_id_(window_id), mode_(mode) {}
++    explicit ZeroNativeCefDevToolsClient(ZeroNativeChromiumHost *host, uint64_t window_id, NSInteger mode, const std::string& frontend_url = std::string())
++        : host_(host), window_id_(window_id), mode_(mode), frontend_url_(frontend_url) {}
 +
 +    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
 +        return this;
@@ -112,13 +115,15 @@ index ce9c747..ea78ee1 100644
 +    ZeroNativeChromiumHost *host_;
 +    uint64_t window_id_;
 +    NSInteger mode_;
++    std::string frontend_url_;
++    bool did_bootstrap_ = false;
 +    IMPLEMENT_REFCOUNTING(ZeroNativeCefDevToolsClient);
 +};
 +
  class ZeroNativeCefApp final : public CefApp, public CefRenderProcessHandler {
  public:
      ZeroNativeCefApp() = default;
-@@ -97,6 +156,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
+@@ -97,6 +161,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
          (void)process_type;
          command_line->AppendSwitchWithValue("password-store", "basic");
          command_line->AppendSwitch("use-mock-keychain");
@@ -126,7 +131,7 @@ index ce9c747..ea78ee1 100644
      }
  
      CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
-@@ -121,6 +181,19 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+@@ -121,6 +186,19 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
  static CefScopedLibraryLoader g_cef_library_loader;
  static bool g_cef_library_loaded = false;
  
@@ -146,7 +151,7 @@ index ce9c747..ea78ee1 100644
  static void shutdownCefIfNeeded() {
      if (!g_cef_initialized || g_cef_shutdown) return;
      CefShutdown();
-@@ -133,7 +206,8 @@ static void ensureCefInitialized() {
+@@ -133,7 +211,8 @@ static void ensureCefInitialized() {
      g_cef_shutdown = false;
  
      if (!g_cef_library_loaded) {
@@ -156,7 +161,7 @@ index ce9c747..ea78ee1 100644
              fprintf(stderr, "failed to load Chromium Embedded Framework\n");
              return;
          }
-@@ -148,13 +222,14 @@ static void ensureCefInitialized() {
+@@ -148,13 +227,14 @@ static void ensureCefInitialized() {
      CefSettings settings;
      settings.no_sandbox = true;
      settings.multi_threaded_message_loop = false;
@@ -172,7 +177,7 @@ index ce9c747..ea78ee1 100644
      CefString(&settings.framework_dir_path).FromString(frameworkPath.UTF8String);
      CefString(&settings.resources_dir_path).FromString(resourcesPath.UTF8String);
      CefString(&settings.root_cache_path).FromString(cefDataRoot.UTF8String);
-@@ -223,6 +298,56 @@ static void ensureCefInitialized() {
+@@ -223,6 +303,56 @@ static void ensureCefInitialized() {
      return [devRoot stringByAppendingPathComponent:@"Release/Chromium Embedded Framework.framework"];
  }
  
@@ -229,7 +234,7 @@ index ce9c747..ea78ee1 100644
  static NSRect ZeroNativeConstrainFrame(NSRect frame) {
      NSScreen *screen = [NSScreen mainScreen];
      if (!screen) return frame;
-@@ -286,6 +411,141 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
+@@ -286,6 +416,153 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
          "})();";
  }
  
@@ -242,12 +247,15 @@ index ce9c747..ea78ee1 100644
 +    return ++nextBrowserKey;
 +}
 +
-+static BOOL ZeroNativeCmuxIsDevToolsTargetURL(NSString *urlString) {
++static BOOL ZeroNativeCmuxIsInspectableDevToolsTargetURL(NSString *urlString) {
 +    if (urlString.length == 0) return NO;
 +    NSString *lowercase = urlString.lowercaseString;
-+    if ([lowercase hasPrefix:@"devtools:"]) return YES;
-+    if ([lowercase containsString:@"/devtools/"]) return YES;
-+    return NO;
++    if ([lowercase hasPrefix:@"devtools:"]) return NO;
++    if ([lowercase containsString:@"/devtools/"]) return NO;
++    if ([lowercase hasPrefix:@"chrome:"]) return NO;
++    if ([lowercase hasPrefix:@"chrome-untrusted:"]) return NO;
++    if ([lowercase hasPrefix:@"about:"]) return NO;
++    return YES;
 +}
 +
 +static NSData *ZeroNativeCmuxReadDevToolsJSON(void) {
@@ -255,7 +263,7 @@ index ce9c747..ea78ee1 100644
 +    if (fd < 0) return nil;
 +
 +    struct timeval timeout = {};
-+    timeout.tv_sec = 2;
++    timeout.tv_usec = 500 * 1000;
 +    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
 +    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
 +
@@ -335,7 +343,7 @@ index ce9c747..ea78ee1 100644
 +        if (![type isEqualToString:@"page"]) continue;
 +
 +        NSString *targetURL = [target[@"url"] isKindOfClass:NSString.class] ? target[@"url"] : @"";
-+        if (ZeroNativeCmuxIsDevToolsTargetURL(targetURL)) continue;
++        if (!ZeroNativeCmuxIsInspectableDevToolsTargetURL(targetURL)) continue;
 +        if (!fallbackTarget) fallbackTarget = target;
 +        if (sourceURLString.length > 0 && [targetURL isEqualToString:sourceURLString]) {
 +            selectedTarget = target;
@@ -368,10 +376,19 @@ index ce9c747..ea78ee1 100644
 +    return [NSString stringWithFormat:@"%@/devtools/inspector.html?ws=%@", baseURLString, encodedWebSocketURL];
 +}
 +
++static NSString *ZeroNativeCmuxDevToolsBootstrapURL(void) {
++    return [NSString stringWithFormat:@"http://127.0.0.1:%d/json/version", kZeroNativeDevToolsPort];
++}
++
++static NSString *ZeroNativeCmuxJSONString(NSString *value) {
++    NSData *data = [NSJSONSerialization dataWithJSONObject:value ?: @"" options:NSJSONWritingFragmentsAllowed error:nil];
++    return data ? [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding] : @"\"\"";
++}
++
  } // namespace
  
  @implementation ZeroNativeChromiumApplication
-@@ -305,20 +565,1037 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -305,20 +582,1037 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
@@ -1410,7 +1427,7 @@ index ce9c747..ea78ee1 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +1612,13 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1629,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
@@ -1425,7 +1442,7 @@ index ce9c747..ea78ee1 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +1640,25 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1657,25 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
@@ -1451,7 +1468,7 @@ index ce9c747..ea78ee1 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -391,11 +1690,19 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1707,19 @@ - (void)windowWillClose:(NSNotification *)notification {
      (void)notification;
      [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
@@ -1471,7 +1488,7 @@ index ce9c747..ea78ee1 100644
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +1717,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1734,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -1480,7 +1497,7 @@ index ce9c747..ea78ee1 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,16 +1725,25 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1742,25 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
@@ -1506,7 +1523,7 @@ index ce9c747..ea78ee1 100644
      self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
      self.allowedExternalURLs = @[];
      self.externalLinkAction = 0;
-@@ -509,7 +1825,8 @@ - (void)reload:(id)sender {
+@@ -509,7 +1842,8 @@ - (void)reload:(id)sender {
          }
      }
      if (self.browsers) {
@@ -1516,7 +1533,7 @@ index ce9c747..ea78ee1 100644
          if (it != self.browsers->end() && it->second) {
              it->second->ReloadIgnoreCache();
          }
-@@ -519,6 +1836,8 @@ - (void)reload:(id)sender {
+@@ -519,6 +1853,8 @@ - (void)reload:(id)sender {
  - (void)dealloc {
      delete self.cefClients;
      delete self.browsers;
@@ -1525,7 +1542,7 @@ index ce9c747..ea78ee1 100644
  }
  
  - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
-@@ -536,9 +1855,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -536,9 +1872,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -1550,7 +1567,7 @@ index ce9c747..ea78ee1 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +1879,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1896,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -1558,7 +1575,7 @@ index ce9c747..ea78ee1 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -559,6 +1891,8 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -559,6 +1908,8 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      } else {
          [window makeKeyAndOrderFront:nil];
          [NSApp activateIgnoringOtherApps:YES];
@@ -1567,7 +1584,7 @@ index ce9c747..ea78ee1 100644
      }
      return YES;
  }
-@@ -600,15 +1934,20 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -600,15 +1951,20 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
  
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
@@ -1591,7 +1608,7 @@ index ce9c747..ea78ee1 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -649,7 +1988,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
+@@ -649,7 +2005,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
      NSWindow *window = self.windows[@(windowId)] ?: self.window;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
@@ -1601,7 +1618,7 @@ index ce9c747..ea78ee1 100644
          if (it != self.browsers->end()) browser = it->second;
      }
      NSRect bounds = container.bounds;
-@@ -698,13 +2038,24 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -698,13 +2055,24 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
  }
  
  - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *)assetRoot entry:(NSString *)entry origin:(NSString *)origin spaFallback:(BOOL)spaFallback windowId:(uint64_t)windowId {
@@ -1628,7 +1645,7 @@ index ce9c747..ea78ee1 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +2077,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +2094,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -1646,7 +1663,7 @@ index ce9c747..ea78ee1 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +2095,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +2112,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -1659,7 +1676,7 @@ index ce9c747..ea78ee1 100644
          return;
      }
  
-@@ -769,6 +2130,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +2147,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -1667,7 +1684,7 @@ index ce9c747..ea78ee1 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -781,7 +2143,312 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
+@@ -781,7 +2160,314 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
  
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (self.browsers) (*self.browsers)[windowId] = browser;
@@ -1905,14 +1922,16 @@ index ce9c747..ea78ee1 100644
 +    }
 +    if (!container) return;
 +
-+    CefRefPtr<ZeroNativeCefDevToolsClient> client = new ZeroNativeCefDevToolsClient(self, windowId, mode);
++    std::string frontendURLString(frontendURL.UTF8String);
++    CefRefPtr<ZeroNativeCefDevToolsClient> client = new ZeroNativeCefDevToolsClient(self, windowId, mode, mode == 1 ? frontendURLString : std::string());
 +    if (self.devToolsClients) (*self.devToolsClients)[devToolsKey] = client;
 +
 +    CefWindowInfo windowInfo;
 +    CefRect rect(0, 0, MAX(1, (int)container.bounds.size.width), MAX(1, (int)container.bounds.size.height));
 +    windowInfo.SetAsChild((__bridge void *)container, rect);
 +    CefBrowserSettings settings;
-+    const bool created = CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(frontendURL.UTF8String), settings, nullptr, nullptr);
++    NSString *initialURL = mode == 1 ? ZeroNativeCmuxDevToolsBootstrapURL() : frontendURL;
++    const bool created = CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(initialURL.UTF8String), settings, nullptr, nullptr);
 +    if (!created) {
 +        if (self.devToolsClients) self.devToolsClients->erase(devToolsKey);
 +        if (mode == 1) [self closeNativeBrowserDevToolsForWindowId:windowId mode:1 closeWindow:NO];
@@ -1981,7 +2000,7 @@ index ce9c747..ea78ee1 100644
  }
  
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
-@@ -881,7 +2548,26 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -881,7 +2567,26 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  }
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
@@ -2009,7 +2028,7 @@ index ce9c747..ea78ee1 100644
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +2590,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2609,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
@@ -2021,7 +2040,7 @@ index ce9c747..ea78ee1 100644
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2612,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2631,52 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  
@@ -2037,6 +2056,17 @@ index ce9c747..ea78ee1 100644
 +    (void)browser;
 +    (void)httpStatusCode;
 +    if (!frame || !frame->IsMain()) return;
++    if (mode_ != 1 || frontend_url_.empty() || did_bootstrap_) return;
++    did_bootstrap_ = true;
++
++    NSString *frontendURL = [[NSString alloc] initWithBytes:frontend_url_.data()
++                                                     length:frontend_url_.size()
++                                                   encoding:NSUTF8StringEncoding] ?: @"";
++    NSString *script = [NSString stringWithFormat:
++        @"try{localStorage.setItem('screencast-enabled','false');}catch(e){}"
++         "location.replace(%@);",
++        ZeroNativeCmuxJSONString(frontendURL)];
++    frame->ExecuteJavaScript(std::string(script.UTF8String), frame->GetURL(), 0);
 +}
 +
 +void ZeroNativeCefDevToolsClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..240ed51 100644
+index ce9c747..ea78ee1 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -1062,7 +1062,7 @@ index ce9c747..240ed51 100644
 +        if (tab.browserContainer) {
 +            NSRect frame = browserFrame;
 +            NSView *browserView = tab.browserContainer.subviews.firstObject;
-+            if (browserView && browserView.frame.size.height > browserFrame.size.height) {
++            if (!self.internalDevToolsVisible && browserView && browserView.frame.size.height > browserFrame.size.height) {
 +                frame.size.height = browserView.frame.size.height;
 +                frame.origin.y = NSMaxY(browserFrame) - frame.size.height;
 +            }
@@ -1127,7 +1127,7 @@ index ce9c747..240ed51 100644
 +    if (!tab.browserContainer) return;
 +    NSRect browserFrame = [self browserContentFrame];
 +    NSView *browserView = tab.browserContainer.subviews.firstObject;
-+    if (browserView && browserView.frame.size.height > browserFrame.size.height) {
++    if (!self.internalDevToolsVisible && browserView && browserView.frame.size.height > browserFrame.size.height) {
 +        browserFrame.size.height = browserView.frame.size.height;
 +        browserFrame.origin.y = NSMaxY([self browserContentFrame]) - browserFrame.size.height;
 +        tab.browserContainer.frame = browserFrame;
@@ -1667,7 +1667,7 @@ index ce9c747..240ed51 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -781,7 +2143,302 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
+@@ -781,7 +2143,312 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
  
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (self.browsers) (*self.browsers)[windowId] = browser;
@@ -1815,13 +1815,23 @@ index ce9c747..240ed51 100644
 +        auto existing = self.devToolsBrowsers->find(devToolsKey);
 +        if (existing != self.devToolsBrowsers->end() && existing->second) {
 +            if (mode == 2) {
-+                [self.devToolsWindows[windowKey] makeKeyAndOrderFront:nil];
-+                [NSApp activateIgnoringOtherApps:YES];
++                existing->second->GetHost()->SetFocus(true);
 +            } else {
 +                [self resizeNativeBrowserDevToolsForWindowId:windowId mode:mode];
 +            }
 +            return;
 +        }
++    }
++
++    if (mode == 2) {
++        CefRefPtr<ZeroNativeCefDevToolsClient> client = new ZeroNativeCefDevToolsClient(self, windowId, mode);
++        if (self.devToolsClients) (*self.devToolsClients)[devToolsKey] = client;
++
++        CefWindowInfo windowInfo;
++        windowInfo.runtime_style = CEF_RUNTIME_STYLE_CHROME;
++        CefBrowserSettings settings;
++        it->second->GetHost()->ShowDevTools(windowInfo, client.get(), settings, CefPoint());
++        return;
 +    }
 +
 +    NSString *sourceURLString = @"";
@@ -1971,7 +1981,7 @@ index ce9c747..240ed51 100644
  }
  
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
-@@ -881,7 +2538,26 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -881,7 +2548,26 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  }
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
@@ -1999,7 +2009,7 @@ index ce9c747..240ed51 100644
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +2580,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2590,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
@@ -2011,7 +2021,7 @@ index ce9c747..240ed51 100644
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2602,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2612,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..9aec1ae 100644
+index ce9c747..608a48f 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -2,12 +2,21 @@
@@ -24,12 +24,17 @@ index ce9c747..9aec1ae 100644
  #include "include/cef_app.h"
  #include "include/cef_browser.h"
  #include "include/cef_client.h"
-@@ -29,17 +38,34 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
+@@ -29,17 +38,40 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
  @property(nonatomic, assign) BOOL handlingSendEvent;
  @end
  
 +@protocol ZeroNativeCmuxWorkbenchHost <NSObject>
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
++- (void)setActiveNativeBrowserKey:(uint64_t)browserKey container:(NSView *)container windowId:(uint64_t)windowId;
++- (BOOL)hasNativeBrowserForKey:(uint64_t)browserKey;
++- (void)createNativeBrowserForKey:(uint64_t)browserKey container:(NSView *)container url:(NSString *)url ownerWindowId:(uint64_t)windowId;
++- (void)navigateNativeBrowserForKey:(uint64_t)browserKey toString:(NSString *)value ownerWindowId:(uint64_t)windowId;
++- (void)resizeNativeBrowserForKey:(uint64_t)browserKey;
 +- (void)openNativeBrowserInternalDevToolsForWindowId:(uint64_t)windowId;
 +- (void)openNativeBrowserWindowDevToolsForWindowId:(uint64_t)windowId;
 +- (void)createNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode frontendURL:(NSString *)frontendURL;
@@ -47,6 +52,7 @@ index ce9c747..9aec1ae 100644
  static NSURL *ZeroNativeAssetEntryFileURL(NSString *rootPath, NSString *entryPath);
  static NSArray<NSString *> *ZeroNativePolicyListFromBytes(const char *bytes, size_t len, NSArray<NSString *> *fallback);
 +static uint64_t ZeroNativeCmuxDevToolsKey(uint64_t windowId, NSInteger mode);
++static uint64_t ZeroNativeCmuxNextBrowserKey(void);
 +static NSData *ZeroNativeCmuxReadDevToolsJSON(void);
 +static NSString *ZeroNativeCmuxDevToolsFrontendURLForSourceURL(NSString *sourceURLString);
  static NSString *ZeroNativeAbsolutePath(NSString *path);
@@ -59,7 +65,21 @@ index ce9c747..9aec1ae 100644
  static NSString *ZeroNativeOriginForURL(NSURL *url);
  static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
  
-@@ -89,6 +115,30 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+@@ -64,7 +96,8 @@ bool Execute(const CefString& name, CefRefPtr<CefV8Value> object, const CefV8Val
+ 
+ class ZeroNativeCefClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler, public CefRequestHandler {
+ public:
+-    explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) : host_(host), window_id_(window_id) {}
++    explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id, uint64_t browser_key = 0)
++        : host_(host), window_id_(window_id), browser_key_(browser_key == 0 ? window_id : browser_key) {}
+ 
+     CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
+         return this;
+@@ -86,9 +119,34 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+ private:
+     ZeroNativeChromiumHost *host_;
+     uint64_t window_id_;
++    uint64_t browser_key_;
      IMPLEMENT_REFCOUNTING(ZeroNativeCefClient);
  };
  
@@ -90,7 +110,7 @@ index ce9c747..9aec1ae 100644
  class ZeroNativeCefApp final : public CefApp, public CefRenderProcessHandler {
  public:
      ZeroNativeCefApp() = default;
-@@ -97,6 +147,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
+@@ -97,6 +155,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
          (void)process_type;
          command_line->AppendSwitchWithValue("password-store", "basic");
          command_line->AppendSwitch("use-mock-keychain");
@@ -98,7 +118,7 @@ index ce9c747..9aec1ae 100644
      }
  
      CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
-@@ -121,6 +172,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+@@ -121,6 +180,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
  static CefScopedLibraryLoader g_cef_library_loader;
  static bool g_cef_library_loaded = false;
  
@@ -117,7 +137,7 @@ index ce9c747..9aec1ae 100644
  static void shutdownCefIfNeeded() {
      if (!g_cef_initialized || g_cef_shutdown) return;
      CefShutdown();
-@@ -133,7 +196,8 @@ static void ensureCefInitialized() {
+@@ -133,7 +204,8 @@ static void ensureCefInitialized() {
      g_cef_shutdown = false;
  
      if (!g_cef_library_loaded) {
@@ -127,7 +147,7 @@ index ce9c747..9aec1ae 100644
              fprintf(stderr, "failed to load Chromium Embedded Framework\n");
              return;
          }
-@@ -148,13 +212,14 @@ static void ensureCefInitialized() {
+@@ -148,13 +220,14 @@ static void ensureCefInitialized() {
      CefSettings settings;
      settings.no_sandbox = true;
      settings.multi_threaded_message_loop = false;
@@ -143,7 +163,7 @@ index ce9c747..9aec1ae 100644
      CefString(&settings.framework_dir_path).FromString(frameworkPath.UTF8String);
      CefString(&settings.resources_dir_path).FromString(resourcesPath.UTF8String);
      CefString(&settings.root_cache_path).FromString(cefDataRoot.UTF8String);
-@@ -223,6 +288,33 @@ static void ensureCefInitialized() {
+@@ -223,6 +296,33 @@ static void ensureCefInitialized() {
      return [devRoot stringByAppendingPathComponent:@"Release/Chromium Embedded Framework.framework"];
  }
  
@@ -177,12 +197,17 @@ index ce9c747..9aec1ae 100644
  static NSRect ZeroNativeConstrainFrame(NSRect frame) {
      NSScreen *screen = [NSScreen mainScreen];
      if (!screen) return frame;
-@@ -286,6 +378,136 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
+@@ -286,6 +386,141 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
          "})();";
  }
  
 +static uint64_t ZeroNativeCmuxDevToolsKey(uint64_t windowId, NSInteger mode) {
 +    return (windowId << 8) | (uint64_t)(mode & 0xff);
++}
++
++static uint64_t ZeroNativeCmuxNextBrowserKey(void) {
++    static uint64_t nextBrowserKey = 1000;
++    return ++nextBrowserKey;
 +}
 +
 +static BOOL ZeroNativeCmuxIsDevToolsTargetURL(NSString *urlString) {
@@ -314,7 +339,7 @@ index ce9c747..9aec1ae 100644
  } // namespace
  
  @implementation ZeroNativeChromiumApplication
-@@ -305,20 +527,860 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -305,20 +540,992 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
@@ -516,6 +541,7 @@ index ce9c747..9aec1ae 100644
 +@property(nonatomic, assign) ghostty_surface_t surface;
 +@property(nonatomic, strong) NSTextField *fallbackLabel;
 +- (void)incrementTerminalCount;
++- (void)setSurfaceActive:(BOOL)active;
 +@end
 +
 +@implementation ZeroNativeCmuxGhosttySlotView
@@ -540,6 +566,14 @@ index ce9c747..9aec1ae 100644
 +- (void)incrementTerminalCount {
 +    self.terminalCount += 1;
 +    if (self.surface) ghostty_surface_refresh(self.surface);
++}
++
++- (void)setSurfaceActive:(BOOL)active {
++    self.hidden = !active;
++    if (self.surface) {
++        ghostty_surface_set_focus(self.surface, active);
++        [self updateGhosttySurfaceGeometry];
++    }
 +}
 +
 +- (void)createSurfaceIfNeeded {
@@ -754,6 +788,10 @@ index ce9c747..9aec1ae 100644
 +@interface ZeroNativeCmuxBrowserTab : NSObject
 +@property(nonatomic, copy) NSString *title;
 +@property(nonatomic, copy) NSString *url;
++@property(nonatomic, assign) uint64_t browserKey;
++@property(nonatomic, assign) BOOL browserCreated;
++@property(nonatomic, strong) ZeroNativeCmuxGhosttySlotView *terminalView;
++@property(nonatomic, strong) NSView *browserContainer;
 ++ (instancetype)tabWithTitle:(NSString *)title url:(NSString *)url;
 +@end
 +
@@ -802,7 +840,7 @@ index ce9c747..9aec1ae 100644
 +@property(nonatomic, strong) NSMutableArray<NSButton *> *tabButtons;
 +@property(nonatomic, strong) NSView *workspaceRail;
 +@property(nonatomic, strong) NSView *tabStrip;
-+@property(nonatomic, strong) ZeroNativeCmuxGhosttySlotView *terminalSlot;
++@property(nonatomic, strong) NSView *terminalDeck;
 +@property(nonatomic, strong) NSView *browserPane;
 +@property(nonatomic, strong) NSView *browserContainer;
 +@property(nonatomic, strong) NSView *devToolsContainer;
@@ -814,7 +852,10 @@ index ce9c747..9aec1ae 100644
 +@property(nonatomic, strong) NSButton *addTerminalButton;
 +@property(nonatomic, strong) NSButton *addWorkspaceButton;
 +@property(nonatomic, strong) NSButton *addTabButton;
++- (void)configureForWindowId:(uint64_t)windowId;
++- (uint64_t)activeBrowserKey;
 +- (void)setBrowserURLString:(NSString *)urlString;
++- (void)setBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey;
 +@end
 +
 +@implementation ZeroNativeCmuxWorkbenchView
@@ -853,18 +894,15 @@ index ce9c747..9aec1ae 100644
 +    _workspaceRail.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.12 alpha:1.0].CGColor;
 +    [self addSubview:_workspaceRail];
 +
-+    _terminalSlot = [[ZeroNativeCmuxGhosttySlotView alloc] initWithFrame:NSZeroRect];
-+    [self addSubview:_terminalSlot];
++    _terminalDeck = [[NSView alloc] initWithFrame:NSZeroRect];
++    _terminalDeck.wantsLayer = YES;
++    _terminalDeck.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.055 alpha:1.0].CGColor;
++    [self addSubview:_terminalDeck];
 +
 +    _browserPane = [[NSView alloc] initWithFrame:NSZeroRect];
 +    _browserPane.wantsLayer = YES;
 +    _browserPane.layer.backgroundColor = NSColor.windowBackgroundColor.CGColor;
 +    [self addSubview:_browserPane];
-+
-+    _browserContainer = [[NSView alloc] initWithFrame:NSZeroRect];
-+    _browserContainer.wantsLayer = YES;
-+    _browserContainer.layer.backgroundColor = NSColor.whiteColor.CGColor;
-+    [_browserPane addSubview:_browserContainer];
 +
 +    _tabStrip = [[NSView alloc] initWithFrame:NSZeroRect];
 +    _tabStrip.wantsLayer = YES;
@@ -916,9 +954,116 @@ index ce9c747..9aec1ae 100644
 +
 +    [self rebuildWorkspaceButtons];
 +    [self rebuildTabButtons];
-+    [self updateChromeFromActiveTabNavigating:NO];
++    [self activateActiveTabCreatingBrowser:NO];
 +
 +    return self;
++}
++
++- (void)configureForWindowId:(uint64_t)windowId {
++    self.windowId = windowId;
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    if (tab && tab.browserKey == 0) {
++        tab.browserKey = windowId;
++        tab.browserCreated = YES;
++    }
++    [self activateActiveTabCreatingBrowser:NO];
++}
++
++- (NSArray<ZeroNativeCmuxBrowserTab *> *)allBrowserTabs {
++    NSMutableArray<ZeroNativeCmuxBrowserTab *> *tabs = [[NSMutableArray alloc] init];
++    for (ZeroNativeCmuxWorkspace *workspace in self.workspaces) {
++        [tabs addObjectsFromArray:workspace.tabs];
++    }
++    return tabs;
++}
++
++- (void)ensureViewsForTab:(ZeroNativeCmuxBrowserTab *)tab {
++    if (!tab) return;
++    if (!tab.terminalView) {
++        ZeroNativeCmuxGhosttySlotView *terminalView = [[ZeroNativeCmuxGhosttySlotView alloc] initWithFrame:NSZeroRect];
++        terminalView.hidden = YES;
++        [self.terminalDeck addSubview:terminalView];
++        tab.terminalView = terminalView;
++    }
++    if (!tab.browserContainer) {
++        NSView *container = [[NSView alloc] initWithFrame:NSZeroRect];
++        container.hidden = YES;
++        container.wantsLayer = YES;
++        container.layer.backgroundColor = NSColor.whiteColor.CGColor;
++        if (self.tabStrip.superview == self.browserPane) {
++            [self.browserPane addSubview:container positioned:NSWindowBelow relativeTo:self.tabStrip];
++        } else {
++            [self.browserPane addSubview:container];
++        }
++        tab.browserContainer = container;
++    }
++}
++
++- (NSRect)browserContentFrame {
++    const CGFloat chromeHeight = 40.0;
++    const CGFloat tabHeight = 34.0;
++    CGFloat contentHeight = MAX(0, self.browserPane.bounds.size.height - chromeHeight - tabHeight);
++    if (!self.internalDevToolsVisible) {
++        return NSMakeRect(0, 0, self.browserPane.bounds.size.width, contentHeight);
++    }
++
++    CGFloat devToolsHeight = MAX(220.0, floor(contentHeight * 0.42));
++    devToolsHeight = MIN(devToolsHeight, MAX(0, contentHeight - 160.0));
++    return NSMakeRect(0, devToolsHeight + 1, self.browserPane.bounds.size.width, MAX(0, contentHeight - devToolsHeight - 1));
++}
++
++- (void)layoutTabSurfaces {
++    NSRect browserFrame = [self browserContentFrame];
++    for (ZeroNativeCmuxBrowserTab *tab in [self allBrowserTabs]) {
++        if (tab.terminalView) tab.terminalView.frame = self.terminalDeck.bounds;
++        if (tab.browserContainer) tab.browserContainer.frame = browserFrame;
++    }
++}
++
++- (uint64_t)activeBrowserKey {
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    if (!tab) return self.windowId;
++    return tab.browserKey != 0 ? tab.browserKey : self.windowId;
++}
++
++- (ZeroNativeCmuxBrowserTab *)browserTabForBrowserKey:(uint64_t)browserKey {
++    if (browserKey == 0) return nil;
++    for (ZeroNativeCmuxBrowserTab *tab in [self allBrowserTabs]) {
++        if (tab.browserKey == browserKey) return tab;
++    }
++    return nil;
++}
++
++- (void)activateActiveTabCreatingBrowser:(BOOL)createBrowser {
++    ZeroNativeCmuxBrowserTab *active = [self activeBrowserTab];
++    if (!active) return;
++    [self ensureViewsForTab:active];
++    if (self.windowId != 0 && active.browserKey == 0) {
++        active.browserKey = ZeroNativeCmuxNextBrowserKey();
++    }
++
++    for (ZeroNativeCmuxBrowserTab *tab in [self allBrowserTabs]) {
++        BOOL isActive = tab == active;
++        if (tab.terminalView) [tab.terminalView setSurfaceActive:isActive];
++        if (tab.browserContainer) tab.browserContainer.hidden = !isActive;
++    }
++
++    self.browserContainer = active.browserContainer;
++    self.addressField.stringValue = active.url ?: @"about:blank";
++    [self layoutTabSurfaces];
++
++    if (!self.host || self.windowId == 0 || active.browserKey == 0) return;
++    [self.host setActiveNativeBrowserKey:active.browserKey container:active.browserContainer windowId:self.windowId];
++    if (!active.browserCreated) {
++        if ([self.host hasNativeBrowserForKey:active.browserKey]) {
++            active.browserCreated = YES;
++        } else if (createBrowser) {
++            [self.host createNativeBrowserForKey:active.browserKey container:active.browserContainer url:active.url ownerWindowId:self.windowId];
++            active.browserCreated = YES;
++        }
++    } else {
++        [self.host resizeNativeBrowserForKey:active.browserKey];
++    }
 +}
 +
 +- (void)layout {
@@ -933,7 +1078,7 @@ index ce9c747..9aec1ae 100644
 +    if (contentWidth < 760) terminalWidth = floor(contentWidth * 0.42);
 +
 +    self.workspaceRail.frame = NSMakeRect(0, 0, workspaceWidth, self.bounds.size.height);
-+    self.terminalSlot.frame = NSMakeRect(workspaceWidth + 1, 0, terminalWidth, self.bounds.size.height);
++    self.terminalDeck.frame = NSMakeRect(workspaceWidth + 1, 0, terminalWidth, self.bounds.size.height);
 +    self.browserPane.frame = NSMakeRect(workspaceWidth + terminalWidth + 2, 0, MAX(0, contentWidth - terminalWidth - 1), self.bounds.size.height);
 +
 +    const CGFloat chromeHeight = 40.0;
@@ -979,22 +1124,27 @@ index ce9c747..9aec1ae 100644
 +        devToolsHeight = MIN(devToolsHeight, MAX(0, contentHeight - 160.0));
 +        self.devToolsContainer.hidden = NO;
 +        self.devToolsContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, devToolsHeight);
-+        self.browserContainer.frame = NSMakeRect(0, devToolsHeight + 1, self.browserPane.bounds.size.width, MAX(0, contentHeight - devToolsHeight - 1));
 +        [self.host resizeNativeBrowserDevToolsForWindowId:self.windowId];
 +    } else {
 +        self.devToolsContainer.hidden = YES;
 +        self.devToolsContainer.frame = NSZeroRect;
-+        self.browserContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, contentHeight);
 +    }
++    [self layoutTabSurfaces];
++    uint64_t activeKey = [self activeBrowserKey];
++    if (activeKey != 0) [self.host resizeNativeBrowserForKey:activeKey];
 +}
 +
 +- (void)setBrowserURLString:(NSString *)urlString {
++    [self setBrowserURLString:urlString browserKey:[self activeBrowserKey]];
++}
++
++- (void)setBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey {
 +    if (urlString.length == 0) return;
-+    self.addressField.stringValue = urlString;
-+    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    ZeroNativeCmuxBrowserTab *tab = [self browserTabForBrowserKey:browserKey] ?: [self activeBrowserTab];
 +    if (tab) {
 +        tab.url = urlString;
 +        tab.title = [self titleForURLString:urlString fallback:tab.title];
++        if (tab == [self activeBrowserTab]) self.addressField.stringValue = urlString;
 +        [self rebuildTabButtons];
 +        [self setNeedsLayout:YES];
 +    }
@@ -1009,12 +1159,18 @@ index ce9c747..9aec1ae 100644
 +        [self rebuildTabButtons];
 +        [self setNeedsLayout:YES];
 +    }
-+    [self.host navigateNativeBrowserToString:self.addressField.stringValue windowId:self.windowId];
++    [self activateActiveTabCreatingBrowser:YES];
++    uint64_t browserKey = [self activeBrowserKey];
++    if (browserKey != 0) {
++        [self.host navigateNativeBrowserForKey:browserKey toString:self.addressField.stringValue ownerWindowId:self.windowId];
++    }
 +}
 +
 +- (void)newTerminal:(id)sender {
 +    (void)sender;
-+    [self.terminalSlot incrementTerminalCount];
++    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
++    [self ensureViewsForTab:tab];
++    [tab.terminalView incrementTerminalCount];
 +}
 +
 +- (void)devTools:(id)sender {
@@ -1098,11 +1254,11 @@ index ce9c747..9aec1ae 100644
 +    }
 +}
 +
-+- (void)updateChromeFromActiveTabNavigating:(BOOL)navigate {
++- (void)updateChromeFromActiveTabCreatingBrowser:(BOOL)createBrowser {
 +    ZeroNativeCmuxBrowserTab *tab = [self activeBrowserTab];
 +    if (!tab) return;
 +    self.addressField.stringValue = tab.url;
-+    if (navigate) [self.host navigateNativeBrowserToString:tab.url windowId:self.windowId];
++    [self activateActiveTabCreatingBrowser:createBrowser];
 +}
 +
 +- (void)workspaceButton:(NSButton *)sender {
@@ -1110,7 +1266,7 @@ index ce9c747..9aec1ae 100644
 +    self.activeWorkspaceIndex = sender.tag;
 +    [self rebuildWorkspaceButtons];
 +    [self rebuildTabButtons];
-+    [self updateChromeFromActiveTabNavigating:YES];
++    [self updateChromeFromActiveTabCreatingBrowser:YES];
 +    [self setNeedsLayout:YES];
 +    [self layoutSubtreeIfNeeded];
 +}
@@ -1120,7 +1276,7 @@ index ce9c747..9aec1ae 100644
 +    if (!workspace || sender.tag < 0 || sender.tag >= (NSInteger)workspace.tabs.count) return;
 +    workspace.activeTabIndex = sender.tag;
 +    [self rebuildTabButtons];
-+    [self updateChromeFromActiveTabNavigating:YES];
++    [self updateChromeFromActiveTabCreatingBrowser:YES];
 +    [self setNeedsLayout:YES];
 +    [self layoutSubtreeIfNeeded];
 +}
@@ -1138,7 +1294,7 @@ index ce9c747..9aec1ae 100644
 +    self.activeWorkspaceIndex = (NSInteger)self.workspaces.count - 1;
 +    [self rebuildWorkspaceButtons];
 +    [self rebuildTabButtons];
-+    [self updateChromeFromActiveTabNavigating:YES];
++    [self updateChromeFromActiveTabCreatingBrowser:YES];
 +    [self setNeedsLayout:YES];
 +}
 +
@@ -1149,7 +1305,7 @@ index ce9c747..9aec1ae 100644
 +    [workspace.tabs addObject:[ZeroNativeCmuxBrowserTab tabWithTitle:@"New" url:@"https://zero-native.dev"]];
 +    workspace.activeTabIndex = (NSInteger)workspace.tabs.count - 1;
 +    [self rebuildTabButtons];
-+    [self updateChromeFromActiveTabNavigating:YES];
++    [self updateChromeFromActiveTabCreatingBrowser:YES];
 +    [self setNeedsLayout:YES];
 +}
 +
@@ -1168,6 +1324,7 @@ index ce9c747..9aec1ae 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *windows;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *devToolsWindows;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSView *> *browserContainers;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSNumber *> *activeBrowserKeys;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeCmuxWorkbenchView *> *nativeWorkbenchViews;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeChromiumWindowDelegate *> *delegates;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *bridgeOrigins;
@@ -1176,7 +1333,7 @@ index ce9c747..9aec1ae 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +1397,13 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1542,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
@@ -1191,14 +1348,21 @@ index ce9c747..9aec1ae 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +1425,17 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1570,24 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
++- (uint64_t)activeBrowserKeyForWindowId:(uint64_t)windowId;
++- (BOOL)hasNativeBrowserForKey:(uint64_t)browserKey;
++- (void)setActiveNativeBrowserKey:(uint64_t)browserKey container:(NSView *)container windowId:(uint64_t)windowId;
++- (void)createNativeBrowserForKey:(uint64_t)browserKey container:(NSView *)container url:(NSString *)url ownerWindowId:(uint64_t)windowId;
++- (void)navigateNativeBrowserForKey:(uint64_t)browserKey toString:(NSString *)value ownerWindowId:(uint64_t)windowId;
++- (void)resizeNativeBrowserForKey:(uint64_t)browserKey;
 +- (void)setDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
 +- (void)clearDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
 +- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser;
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId;
++- (void)updateNativeBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey windowId:(uint64_t)windowId;
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
 +- (void)openNativeBrowserInternalDevToolsForWindowId:(uint64_t)windowId;
 +- (void)openNativeBrowserWindowDevToolsForWindowId:(uint64_t)windowId;
@@ -1209,7 +1373,7 @@ index ce9c747..9aec1ae 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -391,11 +1467,16 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1619,17 @@ - (void)windowWillClose:(NSNotification *)notification {
      (void)notification;
      [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
@@ -1218,6 +1382,7 @@ index ce9c747..9aec1ae 100644
      [self.host.windows removeObjectForKey:key];
 +    [self.host.devToolsWindows removeObjectForKey:key];
      [self.host.browserContainers removeObjectForKey:key];
++    [self.host.activeBrowserKeys removeObjectForKey:key];
 +    [self.host.nativeWorkbenchViews removeObjectForKey:key];
      [self.host.delegates removeObjectForKey:key];
      [self.host.bridgeOrigins removeObjectForKey:key];
@@ -1226,7 +1391,7 @@ index ce9c747..9aec1ae 100644
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +1491,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1644,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -1235,7 +1400,7 @@ index ce9c747..9aec1ae 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,16 +1499,22 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1652,23 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
@@ -1244,6 +1409,7 @@ index ce9c747..9aec1ae 100644
      self.windows = [[NSMutableDictionary alloc] init];
 +    self.devToolsWindows = [[NSMutableDictionary alloc] init];
      self.browserContainers = [[NSMutableDictionary alloc] init];
++    self.activeBrowserKeys = [[NSMutableDictionary alloc] init];
 +    self.nativeWorkbenchViews = [[NSMutableDictionary alloc] init];
      self.delegates = [[NSMutableDictionary alloc] init];
      self.bridgeOrigins = [[NSMutableDictionary alloc] init];
@@ -1258,7 +1424,17 @@ index ce9c747..9aec1ae 100644
      self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
      self.allowedExternalURLs = @[];
      self.externalLinkAction = 0;
-@@ -519,6 +1606,8 @@ - (void)reload:(id)sender {
+@@ -509,7 +1750,8 @@ - (void)reload:(id)sender {
+         }
+     }
+     if (self.browsers) {
+-        auto it = self.browsers->find(windowId);
++        uint64_t browserKey = [self activeBrowserKeyForWindowId:windowId];
++        auto it = self.browsers->find(browserKey);
+         if (it != self.browsers->end() && it->second) {
+             it->second->ReloadIgnoreCache();
+         }
+@@ -519,6 +1761,8 @@ - (void)reload:(id)sender {
  - (void)dealloc {
      delete self.cefClients;
      delete self.browsers;
@@ -1267,7 +1443,7 @@ index ce9c747..9aec1ae 100644
  }
  
  - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
-@@ -536,9 +1625,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -536,9 +1780,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -1280,7 +1456,7 @@ index ce9c747..9aec1ae 100644
 +        workbenchView = [[ZeroNativeCmuxWorkbenchView alloc] initWithFrame:rect];
 +        workbenchView.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
 +        workbenchView.host = self;
-+        workbenchView.windowId = windowId;
++        [workbenchView configureForWindowId:windowId];
 +        browserContainer = workbenchView.browserContainer;
 +        window.contentView = workbenchView;
 +        [workbenchView layoutSubtreeIfNeeded];
@@ -1292,7 +1468,7 @@ index ce9c747..9aec1ae 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +1649,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1804,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -1300,7 +1476,7 @@ index ce9c747..9aec1ae 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -601,14 +1703,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -601,14 +1858,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
  
@@ -1320,7 +1496,17 @@ index ce9c747..9aec1ae 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -702,9 +1806,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -649,7 +1908,8 @@ - (void)emitResizeForWindowId:(uint64_t)windowId {
+     NSWindow *window = self.windows[@(windowId)] ?: self.window;
+     CefRefPtr<CefBrowser> browser;
+     if (self.browsers) {
+-        auto it = self.browsers->find(windowId);
++        uint64_t browserKey = [self activeBrowserKeyForWindowId:windowId];
++        auto it = self.browsers->find(browserKey);
+         if (it != self.browsers->end()) browser = it->second;
+     }
+     NSRect bounds = container.bounds;
+@@ -702,9 +1962,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      NSString *bridgeOrigin = nil;
      NSString *internalURLPrefix = nil;
      if (kind == 0) {
@@ -1332,7 +1518,7 @@ index ce9c747..9aec1ae 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +1830,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +1986,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -1350,7 +1536,7 @@ index ce9c747..9aec1ae 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +1848,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +2004,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -1363,7 +1549,7 @@ index ce9c747..9aec1ae 100644
          return;
      }
  
-@@ -769,6 +1883,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +2039,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -1371,10 +1557,75 @@ index ce9c747..9aec1ae 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -784,6 +1899,217 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
-     if (windowId == 1) self.browser = browser;
- }
+@@ -781,7 +2052,284 @@ - (BOOL)openExternalURLIfAllowed:(NSURL *)url {
  
+ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
+     if (self.browsers) (*self.browsers)[windowId] = browser;
+-    if (windowId == 1) self.browser = browser;
++    NSNumber *mainActiveKey = self.activeBrowserKeys[@1];
++    uint64_t activeMain = mainActiveKey ? mainActiveKey.unsignedLongLongValue : 1;
++    if (windowId == activeMain) self.browser = browser;
++}
++
++- (uint64_t)activeBrowserKeyForWindowId:(uint64_t)windowId {
++    NSNumber *key = self.activeBrowserKeys[@(windowId)];
++    return key ? key.unsignedLongLongValue : windowId;
++}
++
++- (BOOL)hasNativeBrowserForKey:(uint64_t)browserKey {
++    if (!self.browsers) return NO;
++    auto it = self.browsers->find(browserKey);
++    return it != self.browsers->end() && it->second;
++}
++
++- (void)setActiveNativeBrowserKey:(uint64_t)browserKey container:(NSView *)container windowId:(uint64_t)windowId {
++    if (browserKey == 0 || !container) return;
++    NSNumber *windowKey = @(windowId);
++    self.activeBrowserKeys[windowKey] = @(browserKey);
++    self.browserContainers[windowKey] = container;
++    if (windowId == 1) {
++        self.browserContainer = container;
++        if (self.browsers) {
++            auto it = self.browsers->find(browserKey);
++            if (it != self.browsers->end()) self.browser = it->second;
++        }
++    }
++}
++
++- (void)createNativeBrowserForKey:(uint64_t)browserKey container:(NSView *)container url:(NSString *)url ownerWindowId:(uint64_t)windowId {
++    if (browserKey == 0 || !container || !self.browsers || !self.cefClients) return;
++    auto existing = self.browsers->find(browserKey);
++    if (existing != self.browsers->end() && existing->second) return;
++
++    [self setActiveNativeBrowserKey:browserKey container:container windowId:windowId];
++    NSString *urlString = [self normalizedBrowserURLString:url ?: @"about:blank"];
++    CefRefPtr<ZeroNativeCefClient> client = new ZeroNativeCefClient(self, windowId, browserKey);
++    (*self.cefClients)[browserKey] = client;
++
++    CefWindowInfo windowInfo;
++    CefRect rect(0, 0, MAX(1, (int)container.bounds.size.width), MAX(1, (int)container.bounds.size.height));
++    windowInfo.SetAsChild((__bridge void *)container, rect);
++    CefBrowserSettings browserSettings;
++    CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(urlString.UTF8String), browserSettings, nullptr, nullptr);
++}
++
++- (void)navigateNativeBrowserForKey:(uint64_t)browserKey toString:(NSString *)value ownerWindowId:(uint64_t)windowId {
++    NSString *urlString = [self normalizedBrowserURLString:value ?: @""];
++    [self updateNativeBrowserURLString:urlString browserKey:browserKey windowId:windowId];
++    if (!self.browsers) return;
++    auto it = self.browsers->find(browserKey);
++    if (it == self.browsers->end() || !it->second) return;
++    it->second->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
++}
++
++- (void)resizeNativeBrowserForKey:(uint64_t)browserKey {
++    if (!self.browsers || browserKey == 0) return;
++    auto it = self.browsers->find(browserKey);
++    if (it != self.browsers->end() && it->second) {
++        it->second->GetHost()->WasResized();
++    }
++}
++
 +- (void)setDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode {
 +    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
 +    if (self.devToolsBrowsers) (*self.devToolsBrowsers)[devToolsKey] = browser;
@@ -1393,8 +1644,16 @@ index ce9c747..9aec1ae 100644
 +}
 +
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId {
++    [self updateNativeBrowserURLString:urlString browserKey:[self activeBrowserKeyForWindowId:windowId] windowId:windowId];
++}
++
++- (void)updateNativeBrowserURLString:(NSString *)urlString browserKey:(uint64_t)browserKey windowId:(uint64_t)windowId {
 +    ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[@(windowId)];
-+    [workbench setBrowserURLString:urlString];
++    if (browserKey != 0) {
++        [workbench setBrowserURLString:urlString browserKey:browserKey];
++    } else {
++        [workbench setBrowserURLString:urlString];
++    }
 +}
 +
 +- (NSString *)normalizedBrowserURLString:(NSString *)value {
@@ -1406,12 +1665,7 @@ index ce9c747..9aec1ae 100644
 +}
 +
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId {
-+    NSString *urlString = [self normalizedBrowserURLString:value ?: @""];
-+    [self updateNativeBrowserURLString:urlString windowId:windowId];
-+    if (!self.browsers) return;
-+    auto it = self.browsers->find(windowId);
-+    if (it == self.browsers->end() || !it->second) return;
-+    it->second->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
++    [self navigateNativeBrowserForKey:[self activeBrowserKeyForWindowId:windowId] toString:value ownerWindowId:windowId];
 +}
 +
 +- (void)showNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode {
@@ -1419,9 +1673,10 @@ index ce9c747..9aec1ae 100644
 +        fprintf(stderr, "zero-native: DevTools requested before browser map exists mode=%ld\n", (long)mode);
 +        return;
 +    }
-+    auto it = self.browsers->find(windowId);
++    uint64_t browserKey = [self activeBrowserKeyForWindowId:windowId];
++    auto it = self.browsers->find(browserKey);
 +    if (it == self.browsers->end() || !it->second) {
-+        fprintf(stderr, "zero-native: DevTools requested before browser exists window=%llu mode=%ld\n", (unsigned long long)windowId, (long)mode);
++        fprintf(stderr, "zero-native: DevTools requested before browser exists window=%llu browser=%llu mode=%ld\n", (unsigned long long)windowId, (unsigned long long)browserKey, (long)mode);
 +        return;
 +    }
 +
@@ -1463,7 +1718,8 @@ index ce9c747..9aec1ae 100644
 +    }
 +
 +    if (!self.browsers) return;
-+    auto source = self.browsers->find(windowId);
++    uint64_t browserKey = [self activeBrowserKeyForWindowId:windowId];
++    auto source = self.browsers->find(browserKey);
 +    if (source == self.browsers->end() || !source->second) return;
 +
 +    NSNumber *windowKey = @(windowId);
@@ -1584,15 +1840,15 @@ index ce9c747..9aec1ae 100644
 +    NSString *htmlJSON = htmlJSONData ? [[NSString alloc] initWithData:htmlJSONData encoding:NSUTF8StringEncoding] : @"[\"\"]";
 +    NSString *script = [NSString stringWithFormat:@"(function(){var html=%@;document.open();document.write(html[0]);document.close();})();", htmlJSON];
 +    browser->GetMainFrame()->ExecuteJavaScript(std::string(script.UTF8String), "zero://inline/", 0);
-+}
-+
- - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
-     return self.fallbackURLs[@(windowId)];
  }
-@@ -882,6 +2208,11 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+ 
+ - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
+@@ -881,7 +2429,12 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+ }
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
-     [host_ setBrowser:browser windowId:window_id_];
+-    [host_ setBrowser:browser windowId:window_id_];
++    [host_ setBrowser:browser windowId:browser_key_];
 +    [host_ loadInlineHTMLIfNeededForWindowId:window_id_ browser:browser];
 +    ZeroNativeCmuxWorkbenchView *workbench = host_.nativeWorkbenchViews[@(window_id_)];
 +    if (workbench.internalDevToolsVisible) {
@@ -1601,19 +1857,19 @@ index ce9c747..9aec1ae 100644
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +2235,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +2457,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
 -    if ([host_ allowsNavigationURL:nsURL]) return false;
 +    if ([host_ allowsNavigationURL:nsURL]) {
-+        [host_ updateNativeBrowserURLString:urlString windowId:window_id_];
++        [host_ updateNativeBrowserURLString:urlString browserKey:browser_key_ windowId:window_id_];
 +        return false;
 +    }
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -923,19 +2257,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2479,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      return true;
  }
  

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,19 +1,54 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..74c1640 100644
+index ce9c747..b0fe294 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
-@@ -29,6 +29,10 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
+@@ -2,12 +2,21 @@
+ 
+ #import <AppKit/AppKit.h>
+ #import <CoreFoundation/CoreFoundation.h>
++#import <QuartzCore/QuartzCore.h>
+ #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
+ #include <crt_externs.h>
++#include <arpa/inet.h>
++#include <errno.h>
++#include <math.h>
++#include <netinet/in.h>
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/socket.h>
++#include <sys/time.h>
++#include <unistd.h>
+ 
++#include "ghostty.h"
+ #include "include/cef_app.h"
+ #include "include/cef_browser.h"
+ #include "include/cef_client.h"
+@@ -29,17 +38,34 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
  @property(nonatomic, assign) BOOL handlingSendEvent;
  @end
  
 +@protocol ZeroNativeCmuxWorkbenchHost <NSObject>
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
++- (void)openNativeBrowserInternalDevToolsForWindowId:(uint64_t)windowId;
++- (void)openNativeBrowserWindowDevToolsForWindowId:(uint64_t)windowId;
++- (void)createNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode frontendURL:(NSString *)frontendURL;
++- (void)closeNativeBrowserDevToolsForWindowId:(uint64_t)windowId;
++- (void)resizeNativeBrowserDevToolsForWindowId:(uint64_t)windowId;
 +@end
 +
  namespace {
  
  static const char *kBridgeMessageName = "zero_native_bridge";
-@@ -40,6 +44,10 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
++static constexpr int kZeroNativeDevToolsPort = 9233;
+ static const char *ZeroNativeCefBridgeScript();
+ static NSRect ZeroNativeConstrainFrame(NSRect frame);
+ static NSString *ZeroNativeResolvedAssetRoot(NSString *rootPath);
+ static NSURL *ZeroNativeAssetEntryFileURL(NSString *rootPath, NSString *entryPath);
+ static NSArray<NSString *> *ZeroNativePolicyListFromBytes(const char *bytes, size_t len, NSArray<NSString *> *fallback);
++static uint64_t ZeroNativeCmuxDevToolsKey(uint64_t windowId, NSInteger mode);
++static NSData *ZeroNativeCmuxReadDevToolsJSON(void);
++static NSString *ZeroNativeCmuxDevToolsFrontendURLForSourceURL(NSString *sourceURLString);
  static NSString *ZeroNativeAbsolutePath(NSString *path);
  static NSString *ZeroNativeExistingPath(NSString *path);
  static NSString *ZeroNativeCefFrameworkPath(void);
@@ -24,7 +59,46 @@ index ce9c747..74c1640 100644
  static NSString *ZeroNativeOriginForURL(NSURL *url);
  static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url);
  
-@@ -121,6 +129,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
+@@ -89,6 +115,30 @@ explicit ZeroNativeCefClient(ZeroNativeChromiumHost *host, uint64_t window_id) :
+     IMPLEMENT_REFCOUNTING(ZeroNativeCefClient);
+ };
+ 
++class ZeroNativeCefDevToolsClient final : public CefClient, public CefLifeSpanHandler, public CefLoadHandler {
++public:
++    explicit ZeroNativeCefDevToolsClient(ZeroNativeChromiumHost *host, uint64_t window_id, NSInteger mode) : host_(host), window_id_(window_id), mode_(mode) {}
++
++    CefRefPtr<CefLifeSpanHandler> GetLifeSpanHandler() override {
++        return this;
++    }
++
++    CefRefPtr<CefLoadHandler> GetLoadHandler() override {
++        return this;
++    }
++
++    void OnAfterCreated(CefRefPtr<CefBrowser> browser) override;
++    void OnBeforeClose(CefRefPtr<CefBrowser> browser) override;
++    void OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) override;
++    void OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) override;
++
++private:
++    ZeroNativeChromiumHost *host_;
++    uint64_t window_id_;
++    NSInteger mode_;
++    IMPLEMENT_REFCOUNTING(ZeroNativeCefDevToolsClient);
++};
++
+ class ZeroNativeCefApp final : public CefApp, public CefRenderProcessHandler {
+ public:
+     ZeroNativeCefApp() = default;
+@@ -97,6 +147,7 @@ void OnBeforeCommandLineProcessing(const CefString& process_type, CefRefPtr<CefC
+         (void)process_type;
+         command_line->AppendSwitchWithValue("password-store", "basic");
+         command_line->AppendSwitch("use-mock-keychain");
++        command_line->AppendSwitchWithValue("remote-allow-origins", "http://127.0.0.1:9233");
+     }
+ 
+     CefRefPtr<CefRenderProcessHandler> GetRenderProcessHandler() override {
+@@ -121,6 +172,18 @@ void OnContextCreated(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame,
  static CefScopedLibraryLoader g_cef_library_loader;
  static bool g_cef_library_loaded = false;
  
@@ -43,7 +117,7 @@ index ce9c747..74c1640 100644
  static void shutdownCefIfNeeded() {
      if (!g_cef_initialized || g_cef_shutdown) return;
      CefShutdown();
-@@ -133,7 +153,8 @@ static void ensureCefInitialized() {
+@@ -133,7 +196,8 @@ static void ensureCefInitialized() {
      g_cef_shutdown = false;
  
      if (!g_cef_library_loaded) {
@@ -53,7 +127,14 @@ index ce9c747..74c1640 100644
              fprintf(stderr, "failed to load Chromium Embedded Framework\n");
              return;
          }
-@@ -154,7 +175,7 @@ static void ensureCefInitialized() {
+@@ -148,13 +212,14 @@ static void ensureCefInitialized() {
+     CefSettings settings;
+     settings.no_sandbox = true;
+     settings.multi_threaded_message_loop = false;
++    settings.remote_debugging_port = kZeroNativeDevToolsPort;
+     NSString *frameworkPath = ZeroNativeCefFrameworkPath();
+     NSString *resourcesPath = [frameworkPath stringByAppendingPathComponent:@"Resources"];
+     NSString *appSupport = NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject ?: NSTemporaryDirectory();
      NSString *cefDataRoot = [appSupport stringByAppendingPathComponent:@"zero-native/CEF"];
      NSString *cefCachePath = [cefDataRoot stringByAppendingPathComponent:@"Default"];
      [[NSFileManager defaultManager] createDirectoryAtPath:cefCachePath withIntermediateDirectories:YES attributes:nil error:nil];
@@ -62,7 +143,7 @@ index ce9c747..74c1640 100644
      CefString(&settings.framework_dir_path).FromString(frameworkPath.UTF8String);
      CefString(&settings.resources_dir_path).FromString(resourcesPath.UTF8String);
      CefString(&settings.root_cache_path).FromString(cefDataRoot.UTF8String);
-@@ -223,6 +244,33 @@ static void ensureCefInitialized() {
+@@ -223,6 +288,33 @@ static void ensureCefInitialized() {
      return [devRoot stringByAppendingPathComponent:@"Release/Chromium Embedded Framework.framework"];
  }
  
@@ -96,23 +177,355 @@ index ce9c747..74c1640 100644
  static NSRect ZeroNativeConstrainFrame(NSRect frame) {
      NSScreen *screen = [NSScreen mainScreen];
      if (!screen) return frame;
-@@ -305,20 +353,188 @@ - (void)sendEvent:(NSEvent *)event {
+@@ -286,6 +378,136 @@ static NSRect ZeroNativeConstrainFrame(NSRect frame) {
+         "})();";
+ }
+ 
++static uint64_t ZeroNativeCmuxDevToolsKey(uint64_t windowId, NSInteger mode) {
++    return (windowId << 8) | (uint64_t)(mode & 0xff);
++}
++
++static BOOL ZeroNativeCmuxIsDevToolsTargetURL(NSString *urlString) {
++    if (urlString.length == 0) return NO;
++    NSString *lowercase = urlString.lowercaseString;
++    if ([lowercase hasPrefix:@"devtools:"]) return YES;
++    if ([lowercase containsString:@"/devtools/"]) return YES;
++    return NO;
++}
++
++static NSData *ZeroNativeCmuxReadDevToolsJSON(void) {
++    int fd = socket(AF_INET, SOCK_STREAM, 0);
++    if (fd < 0) return nil;
++
++    struct timeval timeout = {};
++    timeout.tv_sec = 2;
++    setsockopt(fd, SOL_SOCKET, SO_RCVTIMEO, &timeout, sizeof(timeout));
++    setsockopt(fd, SOL_SOCKET, SO_SNDTIMEO, &timeout, sizeof(timeout));
++
++    struct sockaddr_in address = {};
++    address.sin_family = AF_INET;
++    address.sin_port = htons(kZeroNativeDevToolsPort);
++    if (inet_pton(AF_INET, "127.0.0.1", &address.sin_addr) != 1) {
++        close(fd);
++        return nil;
++    }
++    if (connect(fd, (struct sockaddr *)&address, sizeof(address)) != 0) {
++        close(fd);
++        return nil;
++    }
++
++    const char *request = "GET /json HTTP/1.1\r\nHost: 127.0.0.1:9233\r\nConnection: close\r\n\r\n";
++    size_t requestLength = strlen(request);
++    size_t sent = 0;
++    while (sent < requestLength) {
++        ssize_t count = send(fd, request + sent, requestLength - sent, 0);
++        if (count <= 0) {
++            close(fd);
++            return nil;
++        }
++        sent += (size_t)count;
++    }
++
++    NSMutableData *response = [[NSMutableData alloc] init];
++    char buffer[4096];
++    while (true) {
++        ssize_t count = recv(fd, buffer, sizeof(buffer), 0);
++        if (count > 0) {
++            [response appendBytes:buffer length:(NSUInteger)count];
++            continue;
++        }
++        if (count == 0) break;
++        if (errno == EAGAIN || errno == EWOULDBLOCK) break;
++        close(fd);
++        return nil;
++    }
++    close(fd);
++    if (response.length == 0) return nil;
++
++    const unsigned char *bytes = (const unsigned char *)response.bytes;
++    NSUInteger bodyOffset = NSNotFound;
++    for (NSUInteger index = 0; index + 3 < response.length; index += 1) {
++        if (bytes[index] == '\r' && bytes[index + 1] == '\n' && bytes[index + 2] == '\r' && bytes[index + 3] == '\n') {
++            bodyOffset = index + 4;
++            break;
++        }
++    }
++    if (bodyOffset == NSNotFound || bodyOffset >= response.length) return nil;
++    return [response subdataWithRange:NSMakeRange(bodyOffset, response.length - bodyOffset)];
++}
++
++static NSString *ZeroNativeCmuxDevToolsFrontendURLForSourceURL(NSString *sourceURLString) {
++    NSString *baseURLString = [NSString stringWithFormat:@"http://127.0.0.1:%d", kZeroNativeDevToolsPort];
++    NSData *data = ZeroNativeCmuxReadDevToolsJSON();
++    if (!data) {
++        NSLog(@"zero-native: failed to read CEF DevTools endpoint");
++        return nil;
++    }
++
++    NSError *jsonError = nil;
++    id parsed = [NSJSONSerialization JSONObjectWithData:data options:0 error:&jsonError];
++    if (![parsed isKindOfClass:NSArray.class]) {
++        NSLog(@"zero-native: CEF DevTools endpoint returned invalid JSON: %@", jsonError);
++        return nil;
++    }
++
++    NSDictionary *selectedTarget = nil;
++    NSDictionary *fallbackTarget = nil;
++    for (id item in (NSArray *)parsed) {
++        if (![item isKindOfClass:NSDictionary.class]) continue;
++        NSDictionary *target = (NSDictionary *)item;
++        NSString *type = [target[@"type"] isKindOfClass:NSString.class] ? target[@"type"] : @"";
++        if (![type isEqualToString:@"page"]) continue;
++
++        NSString *targetURL = [target[@"url"] isKindOfClass:NSString.class] ? target[@"url"] : @"";
++        if (ZeroNativeCmuxIsDevToolsTargetURL(targetURL)) continue;
++        if (!fallbackTarget) fallbackTarget = target;
++        if (sourceURLString.length > 0 && [targetURL isEqualToString:sourceURLString]) {
++            selectedTarget = target;
++            break;
++        }
++    }
++
++    NSDictionary *target = selectedTarget ?: fallbackTarget;
++    if (!target) {
++        NSLog(@"zero-native: no CEF page target available for DevTools");
++        return nil;
++    }
++
++    NSString *webSocketDebuggerURL = [target[@"webSocketDebuggerUrl"] isKindOfClass:NSString.class] ? target[@"webSocketDebuggerUrl"] : @"";
++    if ([webSocketDebuggerURL hasPrefix:@"ws://"]) {
++        webSocketDebuggerURL = [webSocketDebuggerURL substringFromIndex:5];
++    } else if ([webSocketDebuggerURL hasPrefix:@"wss://"]) {
++        webSocketDebuggerURL = [webSocketDebuggerURL substringFromIndex:6];
++    }
++    if (webSocketDebuggerURL.length == 0) {
++        NSString *frontendURL = [target[@"devtoolsFrontendUrl"] isKindOfClass:NSString.class] ? target[@"devtoolsFrontendUrl"] : @"";
++        if ([frontendURL hasPrefix:@"http://"] || [frontendURL hasPrefix:@"https://"]) return frontendURL;
++        if ([frontendURL hasPrefix:@"/"]) return [baseURLString stringByAppendingString:frontendURL];
++        if (frontendURL.length > 0) return [NSString stringWithFormat:@"%@/%@", baseURLString, frontendURL];
++        NSLog(@"zero-native: CEF page target did not include a DevTools frontend URL");
++        return nil;
++    }
++
++    NSString *encodedWebSocketURL = [webSocketDebuggerURL stringByAddingPercentEncodingWithAllowedCharacters:NSCharacterSet.URLQueryAllowedCharacterSet] ?: webSocketDebuggerURL;
++    return [NSString stringWithFormat:@"%@/devtools/inspector.html?ws=%@", baseURLString, encodedWebSocketURL];
++}
++
+ } // namespace
+ 
+ @implementation ZeroNativeChromiumApplication
+@@ -305,20 +527,612 @@ - (void)sendEvent:(NSEvent *)event {
  
  @end
  
++static NSInteger ZeroNativeCmuxConfigFileSize(NSString *path) {
++    if (path.length == 0) return -1;
++    NSDictionary<NSFileAttributeKey, id> *attributes = [[NSFileManager defaultManager] attributesOfItemAtPath:path error:nil];
++    if (!attributes) return -1;
++    NSNumber *size = attributes[NSFileSize];
++    return size ? size.integerValue : -1;
++}
++
++static BOOL ZeroNativeCmuxIsNonEmptyConfigFile(NSString *path) {
++    return ZeroNativeCmuxConfigFileSize(path) > 0;
++}
++
++static BOOL ZeroNativeCmuxShouldLoadLegacyGhosttyConfig(NSString *newConfigPath, NSString *legacyConfigPath) {
++    return ZeroNativeCmuxConfigFileSize(newConfigPath) == 0 && ZeroNativeCmuxConfigFileSize(legacyConfigPath) > 0;
++}
++
++static NSString *ZeroNativeCmuxApplicationSupportDirectory(void) {
++    return NSSearchPathForDirectoriesInDomains(NSApplicationSupportDirectory, NSUserDomainMask, YES).firstObject;
++}
++
++static NSArray<NSString *> *ZeroNativeCmuxPreferredExistingConfigPaths(NSString *bundleIdentifier) {
++    NSString *appSupport = ZeroNativeCmuxApplicationSupportDirectory();
++    if (appSupport.length == 0 || bundleIdentifier.length == 0) return @[];
++
++    NSString *directory = [appSupport stringByAppendingPathComponent:bundleIdentifier];
++    NSString *configGhostty = [directory stringByAppendingPathComponent:@"config.ghostty"];
++    NSString *legacyConfig = [directory stringByAppendingPathComponent:@"config"];
++    if (ZeroNativeCmuxIsNonEmptyConfigFile(configGhostty)) return @[ configGhostty ];
++    if (ZeroNativeCmuxIsNonEmptyConfigFile(legacyConfig)) return @[ legacyConfig ];
++    return @[];
++}
++
++static NSArray<NSString *> *ZeroNativeCmuxAppSupportGhosttyConfigPaths(void) {
++    NSMutableArray<NSString *> *paths = [[NSMutableArray alloc] init];
++    NSMutableSet<NSString *> *seen = [[NSMutableSet alloc] init];
++    NSString *currentBundleIdentifier = NSBundle.mainBundle.bundleIdentifier ?: @"";
++    NSArray<NSString *> *candidateBundleIdentifiers = @[ currentBundleIdentifier, @"com.cmuxterm.app" ];
++    for (NSString *bundleIdentifier in candidateBundleIdentifiers) {
++        for (NSString *path in ZeroNativeCmuxPreferredExistingConfigPaths(bundleIdentifier)) {
++            if ([seen containsObject:path]) continue;
++            [paths addObject:path];
++            [seen addObject:path];
++        }
++        if (paths.count > 0) break;
++    }
++    return paths;
++}
++
++static void ZeroNativeCmuxLoadConfigFile(ghostty_config_t config, NSString *path) {
++    if (!config || path.length == 0) return;
++    ghostty_config_load_file(config, path.UTF8String);
++    fprintf(stderr, "zero-cmux: loaded Ghostty config %s\n", path.UTF8String);
++}
++
++static void ZeroNativeCmuxLoadInlineConfig(ghostty_config_t config, const char *contents, const char *syntheticPath) {
++    if (!config || !contents || !syntheticPath) return;
++    ghostty_config_load_string(config, contents, strlen(contents), syntheticPath);
++}
++
++static void ZeroNativeCmuxLoadGhosttyConfiguration(ghostty_config_t config) {
++    if (!config) return;
++
++    ghostty_config_load_default_files(config);
++
++    NSString *appSupport = ZeroNativeCmuxApplicationSupportDirectory();
++    NSString *ghosttyDir = [appSupport stringByAppendingPathComponent:@"com.mitchellh.ghostty"];
++    NSString *newGhosttyConfig = [ghosttyDir stringByAppendingPathComponent:@"config.ghostty"];
++    NSString *legacyGhosttyConfig = [ghosttyDir stringByAppendingPathComponent:@"config"];
++    if (ZeroNativeCmuxShouldLoadLegacyGhosttyConfig(newGhosttyConfig, legacyGhosttyConfig)) {
++        ZeroNativeCmuxLoadConfigFile(config, legacyGhosttyConfig);
++    }
++
++    for (NSString *path in ZeroNativeCmuxAppSupportGhosttyConfigPaths()) {
++        ZeroNativeCmuxLoadConfigFile(config, path);
++    }
++
++    ghostty_config_load_recursive_files(config);
++}
++
++@class ZeroNativeCmuxGhosttySlotView;
++
++@interface ZeroNativeCmuxGhosttyRuntime : NSObject
++@property(nonatomic, assign, readonly) ghostty_app_t app;
+++ (instancetype)sharedRuntime;
++- (BOOL)isReady;
++- (void)scheduleTick;
++- (void)tickNow;
++@end
++
++static void ZeroNativeCmuxGhosttyWakeup(void *userdata);
++static bool ZeroNativeCmuxGhosttyAction(ghostty_app_t app, ghostty_target_s target, ghostty_action_s action);
++static bool ZeroNativeCmuxGhosttyReadClipboard(void *userdata, ghostty_clipboard_e location, void *state);
++static void ZeroNativeCmuxGhosttyConfirmReadClipboard(void *userdata, const char *string, void *state, ghostty_clipboard_request_e request);
++static void ZeroNativeCmuxGhosttyWriteClipboard(void *userdata, ghostty_clipboard_e location, const ghostty_clipboard_content_s *content, size_t len, bool confirm);
++static void ZeroNativeCmuxGhosttyCloseSurface(void *userdata, bool processAlive);
++
++@interface ZeroNativeCmuxGhosttyRuntime ()
++@property(nonatomic, assign) ghostty_app_t app;
++@property(nonatomic, assign) ghostty_config_t config;
++@property(nonatomic, assign) BOOL tickScheduled;
++@end
++
++@implementation ZeroNativeCmuxGhosttyRuntime
++
+++ (instancetype)sharedRuntime {
++    static ZeroNativeCmuxGhosttyRuntime *runtime = nil;
++    static dispatch_once_t onceToken;
++    dispatch_once(&onceToken, ^{
++        runtime = [[ZeroNativeCmuxGhosttyRuntime alloc] init];
++    });
++    return runtime;
++}
++
++- (instancetype)init {
++    self = [super init];
++    if (!self) return nil;
++
++    if (getenv("NO_COLOR") != NULL) unsetenv("NO_COLOR");
++
++    const int initResult = ghostty_init((uintptr_t)*_NSGetArgc(), *_NSGetArgv());
++    if (initResult != GHOSTTY_SUCCESS) {
++        fprintf(stderr, "zero-cmux: ghostty_init failed: %d\n", initResult);
++        return self;
++    }
++
++    _config = ghostty_config_new();
++    if (!_config) {
++        fprintf(stderr, "zero-cmux: ghostty_config_new failed\n");
++        return self;
++    }
++    ZeroNativeCmuxLoadGhosttyConfiguration(_config);
++    ghostty_config_finalize(_config);
++
++    const uint32_t diagnosticCount = ghostty_config_diagnostics_count(_config);
++    for (uint32_t index = 0; index < diagnosticCount; index += 1) {
++        ghostty_diagnostic_s diagnostic = ghostty_config_get_diagnostic(_config, index);
++        if (diagnostic.message) fprintf(stderr, "zero-cmux: ghostty config: %s\n", diagnostic.message);
++    }
++
++    ghostty_runtime_config_s runtimeConfig = {};
++    runtimeConfig.userdata = (__bridge void *)self;
++    runtimeConfig.supports_selection_clipboard = false;
++    runtimeConfig.wakeup_cb = ZeroNativeCmuxGhosttyWakeup;
++    runtimeConfig.action_cb = ZeroNativeCmuxGhosttyAction;
++    runtimeConfig.read_clipboard_cb = ZeroNativeCmuxGhosttyReadClipboard;
++    runtimeConfig.confirm_read_clipboard_cb = ZeroNativeCmuxGhosttyConfirmReadClipboard;
++    runtimeConfig.write_clipboard_cb = ZeroNativeCmuxGhosttyWriteClipboard;
++    runtimeConfig.close_surface_cb = ZeroNativeCmuxGhosttyCloseSurface;
++
++    _app = ghostty_app_new(&runtimeConfig, _config);
++    if (!_app) {
++        fprintf(stderr, "zero-cmux: ghostty_app_new failed\n");
++        return self;
++    }
++    ghostty_app_set_focus(_app, NSApp.isActive);
++    return self;
++}
++
++- (BOOL)isReady {
++    return self.app != NULL;
++}
++
++- (void)scheduleTick {
++    if (!self.app) return;
++    @synchronized (self) {
++        if (self.tickScheduled) return;
++        self.tickScheduled = YES;
++    }
++    dispatch_async(dispatch_get_main_queue(), ^{
++        @synchronized (self) {
++            self.tickScheduled = NO;
++        }
++        [self tickNow];
++    });
++}
++
++- (void)tickNow {
++    if (self.app) ghostty_app_tick(self.app);
++}
++
++- (void)dealloc {
++    if (_app) {
++        ghostty_app_free(_app);
++        _app = NULL;
++    }
++    if (_config) {
++        ghostty_config_free(_config);
++        _config = NULL;
++    }
++}
++
++@end
++
 +@interface ZeroNativeCmuxGhosttySlotView : NSView
 +@property(nonatomic, assign) NSInteger terminalCount;
++@property(nonatomic, assign) ghostty_surface_t surface;
++@property(nonatomic, strong) NSTextField *fallbackLabel;
 +- (void)incrementTerminalCount;
 +@end
 +
 +@implementation ZeroNativeCmuxGhosttySlotView
 +
 +- (instancetype)initWithFrame:(NSRect)frameRect {
-+    self = [super initWithFrame:frameRect];
++    NSRect initialFrame = NSIsEmptyRect(frameRect) ? NSMakeRect(0, 0, 800, 600) : frameRect;
++    self = [super initWithFrame:initialFrame];
 +    if (!self) return nil;
 +    _terminalCount = 1;
-+    self.wantsLayer = YES;
-+    self.layer.masksToBounds = YES;
++    [self createSurfaceIfNeeded];
 +    return self;
 +}
 +
@@ -120,56 +533,237 @@ index ce9c747..74c1640 100644
 +    return YES;
 +}
 +
-+- (void)incrementTerminalCount {
-+    self.terminalCount += 1;
-+    self.needsDisplay = YES;
++- (BOOL)acceptsFirstResponder {
++    return YES;
 +}
 +
-+- (void)drawRect:(NSRect)dirtyRect {
-+    (void)dirtyRect;
-+    [[NSColor colorWithCalibratedWhite:0.055 alpha:1.0] setFill];
-+    NSRectFill(self.bounds);
++- (void)incrementTerminalCount {
++    self.terminalCount += 1;
++    if (self.surface) ghostty_surface_refresh(self.surface);
++}
 +
-+    const CGFloat headerHeight = 38.0;
-+    NSRect header = NSMakeRect(0, self.bounds.size.height - headerHeight, self.bounds.size.width, headerHeight);
-+    [[NSColor colorWithCalibratedWhite:0.095 alpha:1.0] setFill];
-+    NSRectFill(header);
++- (void)createSurfaceIfNeeded {
++    if (self.surface) return;
 +
-+    NSDictionary *headerAttrs = @{
-+        NSFontAttributeName: [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold],
-+        NSForegroundColorAttributeName: [NSColor colorWithCalibratedWhite:0.92 alpha:1.0],
-+    };
-+    [@"Ghostty" drawInRect:NSInsetRect(header, 12, 10) withAttributes:headerAttrs];
++    ZeroNativeCmuxGhosttyRuntime *runtime = [ZeroNativeCmuxGhosttyRuntime sharedRuntime];
++    if (!runtime.isReady) {
++        [self showFallbackLabel:@"Ghostty surface failed"];
++        return;
++    }
 +
-+    NSDictionary *pillAttrs = @{
-+        NSFontAttributeName: [NSFont systemFontOfSize:11 weight:NSFontWeightMedium],
-+        NSForegroundColorAttributeName: [NSColor colorWithCalibratedWhite:0.68 alpha:1.0],
-+    };
-+    NSString *slot = [NSString stringWithFormat:@"native AppKit slot  %ld", (long)self.terminalCount];
-+    [slot drawInRect:NSMakeRect(self.bounds.size.width - 150, header.origin.y + 11, 138, 18) withAttributes:pillAttrs];
++    ghostty_surface_config_s config = ghostty_surface_config_new();
++    config.userdata = (__bridge void *)self;
++    config.platform_tag = GHOSTTY_PLATFORM_MACOS;
++    config.platform.macos.nsview = (__bridge void *)self;
++    config.scale_factor = [self currentBackingScale];
++    config.font_size = 0;
++    const char *home = getenv("HOME");
++    config.working_directory = home ? home : "/";
++    config.wait_after_command = false;
++    config.context = GHOSTTY_SURFACE_CONTEXT_SPLIT;
++    config.io_mode = GHOSTTY_SURFACE_IO_EXEC;
 +
-+    NSMutableParagraphStyle *style = [[NSMutableParagraphStyle alloc] init];
-+    style.lineSpacing = 4;
-+    NSDictionary *terminalAttrs = @{
-+        NSFontAttributeName: [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular],
-+        NSForegroundColorAttributeName: [NSColor colorWithCalibratedRed:0.82 green:0.89 blue:0.94 alpha:1.0],
-+        NSParagraphStyleAttributeName: style,
-+    };
-+    NSString *body = @"$ zero-cmux native shell\n$ ghostty host = NSView\n$ chromium owns only browser content\n$ next step: mount live ghostty_surface_new here";
-+    [body drawInRect:NSInsetRect(NSMakeRect(0, 0, self.bounds.size.width, self.bounds.size.height - headerHeight), 14, 16) withAttributes:terminalAttrs];
++    self.surface = ghostty_surface_new(runtime.app, &config);
++    if (!self.surface) {
++        fprintf(stderr, "zero-cmux: ghostty_surface_new failed\n");
++        [self showFallbackLabel:@"Ghostty surface failed"];
++        return;
++    }
++
++    ghostty_surface_set_focus(self.surface, true);
++    [self updateGhosttySurfaceGeometry];
++    ghostty_surface_refresh(self.surface);
++}
++
++- (void)showFallbackLabel:(NSString *)message {
++    if (self.fallbackLabel) return;
++    self.wantsLayer = YES;
++    self.layer.backgroundColor = [NSColor colorWithCalibratedWhite:0.055 alpha:1.0].CGColor;
++    NSTextField *label = [NSTextField labelWithString:message];
++    label.font = [NSFont monospacedSystemFontOfSize:12 weight:NSFontWeightRegular];
++    label.textColor = [NSColor colorWithCalibratedRed:0.82 green:0.89 blue:0.94 alpha:1.0];
++    label.frame = NSInsetRect(self.bounds, 14, 16);
++    label.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++    [self addSubview:label];
++    self.fallbackLabel = label;
++}
++
++- (CGFloat)currentBackingScale {
++    NSScreen *screen = self.window.screen ?: NSScreen.mainScreen;
++    return screen ? screen.backingScaleFactor : 1.0;
++}
++
++- (void)updateGhosttySurfaceGeometry {
++    if (!self.surface) return;
++    if (self.bounds.size.width <= 0 || self.bounds.size.height <= 0) return;
++
++    const CGFloat scale = [self currentBackingScale];
++    NSSize backingSize = [self convertSizeToBacking:self.bounds.size];
++    uint32_t width = (uint32_t)MAX(1.0, ceil(backingSize.width));
++    uint32_t height = (uint32_t)MAX(1.0, ceil(backingSize.height));
++
++    [CATransaction begin];
++    [CATransaction setDisableActions:YES];
++    self.layer.contentsScale = scale;
++    [CATransaction commit];
++
++    ghostty_surface_set_content_scale(self.surface, scale, scale);
++    ghostty_surface_set_size(self.surface, width, height);
++    NSScreen *screen = self.window.screen;
++    NSNumber *screenNumber = screen.deviceDescription[@"NSScreenNumber"];
++    if (screenNumber) ghostty_surface_set_display_id(self.surface, screenNumber.unsignedIntValue);
++    ghostty_surface_set_occlusion(self.surface, self.window != nil && !self.hidden);
++    ghostty_surface_render_now(self.surface);
++}
++
++- (void)layout {
++    [super layout];
++    [self updateGhosttySurfaceGeometry];
++}
++
++- (void)setFrameSize:(NSSize)newSize {
++    [super setFrameSize:newSize];
++    [self updateGhosttySurfaceGeometry];
++}
++
++- (void)viewDidMoveToWindow {
++    [super viewDidMoveToWindow];
++    [self createSurfaceIfNeeded];
++    [self updateGhosttySurfaceGeometry];
++}
++
++- (void)viewDidChangeBackingProperties {
++    [super viewDidChangeBackingProperties];
++    [self updateGhosttySurfaceGeometry];
++}
++
++- (BOOL)becomeFirstResponder {
++    BOOL result = [super becomeFirstResponder];
++    if (result && self.surface) ghostty_surface_set_focus(self.surface, true);
++    return result;
++}
++
++- (BOOL)resignFirstResponder {
++    BOOL result = [super resignFirstResponder];
++    if (result && self.surface) ghostty_surface_set_focus(self.surface, false);
++    return result;
++}
++
++- (void)mouseDown:(NSEvent *)event {
++    (void)event;
++    [self.window makeFirstResponder:self];
++    if (self.surface) {
++        ghostty_surface_set_focus(self.surface, true);
++        ghostty_surface_mouse_button(self.surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
++    }
++}
++
++- (void)mouseUp:(NSEvent *)event {
++    (void)event;
++    if (self.surface) ghostty_surface_mouse_button(self.surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_LEFT, GHOSTTY_MODS_NONE);
++}
++
++- (void)keyDown:(NSEvent *)event {
++    if (!self.surface) {
++        [super keyDown:event];
++        return;
++    }
++    if ((event.modifierFlags & NSEventModifierFlagCommand) != 0) {
++        [super keyDown:event];
++        return;
++    }
++    NSString *characters = event.characters;
++    NSData *data = [characters dataUsingEncoding:NSUTF8StringEncoding];
++    if (data.length == 0) {
++        [super keyDown:event];
++        return;
++    }
++    ghostty_surface_text_input(self.surface, (const char *)data.bytes, data.length);
++}
++
++- (void)paste:(id)sender {
++    (void)sender;
++    if (!self.surface) return;
++    NSString *value = [NSPasteboard.generalPasteboard stringForType:NSPasteboardTypeString];
++    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
++    if (data.length > 0) ghostty_surface_text(self.surface, (const char *)data.bytes, data.length);
++}
++
++- (void)dealloc {
++    if (_surface) {
++        ghostty_surface_free(_surface);
++        _surface = NULL;
++    }
 +}
 +
 +@end
 +
++static void ZeroNativeCmuxGhosttyWakeup(void *userdata) {
++    if (!userdata) return;
++    ZeroNativeCmuxGhosttyRuntime *runtime = (__bridge ZeroNativeCmuxGhosttyRuntime *)userdata;
++    [runtime scheduleTick];
++}
++
++static bool ZeroNativeCmuxGhosttyAction(ghostty_app_t app, ghostty_target_s target, ghostty_action_s action) {
++    (void)app;
++    (void)target;
++    (void)action;
++    return false;
++}
++
++static bool ZeroNativeCmuxGhosttyReadClipboard(void *userdata, ghostty_clipboard_e location, void *state) {
++    (void)location;
++    ZeroNativeCmuxGhosttySlotView *view = (__bridge ZeroNativeCmuxGhosttySlotView *)userdata;
++    if (!view.surface) return false;
++    NSString *value = [NSPasteboard.generalPasteboard stringForType:NSPasteboardTypeString];
++    NSData *data = [value dataUsingEncoding:NSUTF8StringEncoding];
++    if (data.length == 0) return false;
++    ghostty_surface_complete_clipboard_request(view.surface, (const char *)data.bytes, state, false);
++    return true;
++}
++
++static void ZeroNativeCmuxGhosttyConfirmReadClipboard(void *userdata, const char *string, void *state, ghostty_clipboard_request_e request) {
++    (void)string;
++    (void)request;
++    ZeroNativeCmuxGhosttySlotView *view = (__bridge ZeroNativeCmuxGhosttySlotView *)userdata;
++    if (view.surface) ghostty_surface_complete_clipboard_request(view.surface, "", state, true);
++}
++
++static void ZeroNativeCmuxGhosttyWriteClipboard(void *userdata, ghostty_clipboard_e location, const ghostty_clipboard_content_s *content, size_t len, bool confirm) {
++    (void)userdata;
++    (void)location;
++    (void)confirm;
++    if (!content || len == 0) return;
++    for (size_t index = 0; index < len; index += 1) {
++        if (!content[index].mime || !content[index].data) continue;
++        if (strcmp(content[index].mime, "text/plain") != 0) continue;
++        NSString *value = [NSString stringWithUTF8String:content[index].data];
++        if (value.length == 0) continue;
++        NSPasteboard *pasteboard = NSPasteboard.generalPasteboard;
++        [pasteboard declareTypes:@[ NSPasteboardTypeString ] owner:nil];
++        [pasteboard setString:value forType:NSPasteboardTypeString];
++        return;
++    }
++}
++
++static void ZeroNativeCmuxGhosttyCloseSurface(void *userdata, bool processAlive) {
++    (void)userdata;
++    (void)processAlive;
++}
++
 +@interface ZeroNativeCmuxWorkbenchView : NSView
 +@property(nonatomic, weak) id<ZeroNativeCmuxWorkbenchHost> host;
 +@property(nonatomic, assign) uint64_t windowId;
++@property(nonatomic, assign) BOOL internalDevToolsVisible;
 +@property(nonatomic, strong) ZeroNativeCmuxGhosttySlotView *terminalSlot;
 +@property(nonatomic, strong) NSView *browserPane;
 +@property(nonatomic, strong) NSView *browserContainer;
++@property(nonatomic, strong) NSView *devToolsContainer;
 +@property(nonatomic, strong) NSTextField *titleLabel;
 +@property(nonatomic, strong) NSTextField *addressField;
 +@property(nonatomic, strong) NSButton *goButton;
++@property(nonatomic, strong) NSButton *devToolsButton;
++@property(nonatomic, strong) NSButton *devToolsWindowButton;
 +@property(nonatomic, strong) NSButton *addTerminalButton;
 +- (void)setBrowserURLString:(NSString *)urlString;
 +@end
@@ -196,6 +790,12 @@ index ce9c747..74c1640 100644
 +    _browserContainer.layer.backgroundColor = NSColor.whiteColor.CGColor;
 +    [_browserPane addSubview:_browserContainer];
 +
++    _devToolsContainer = [[NSView alloc] initWithFrame:NSZeroRect];
++    _devToolsContainer.hidden = YES;
++    _devToolsContainer.wantsLayer = YES;
++    _devToolsContainer.layer.backgroundColor = NSColor.blackColor.CGColor;
++    [_browserPane addSubview:_devToolsContainer];
++
 +    _titleLabel = [NSTextField labelWithString:@"Chrome"];
 +    _titleLabel.font = [NSFont systemFontOfSize:13 weight:NSFontWeightSemibold];
 +    _titleLabel.translatesAutoresizingMaskIntoConstraints = YES;
@@ -212,6 +812,14 @@ index ce9c747..74c1640 100644
 +    _goButton = [NSButton buttonWithTitle:@"Go" target:self action:@selector(go:)];
 +    _goButton.bezelStyle = NSBezelStyleRounded;
 +    [_browserPane addSubview:_goButton];
++
++    _devToolsButton = [NSButton buttonWithTitle:@"DevTools" target:self action:@selector(devTools:)];
++    _devToolsButton.bezelStyle = NSBezelStyleRounded;
++    [_browserPane addSubview:_devToolsButton];
++
++    _devToolsWindowButton = [NSButton buttonWithTitle:@"Popout" target:self action:@selector(devToolsWindow:)];
++    _devToolsWindowButton.bezelStyle = NSBezelStyleRounded;
++    [_browserPane addSubview:_devToolsWindowButton];
 +
 +    _addTerminalButton = [NSButton buttonWithTitle:@"+" target:self action:@selector(newTerminal:)];
 +    _addTerminalButton.bezelStyle = NSBezelStyleRounded;
@@ -237,16 +845,32 @@ index ce9c747..74c1640 100644
 +    self.titleLabel.frame = NSMakeRect(padding, self.browserPane.bounds.size.height - 28, 70, 20);
 +
 +    CGFloat buttonWidth = 42.0;
++    CGFloat devToolsWidth = 82.0;
++    CGFloat devToolsWindowWidth = 68.0;
 +    CGFloat newTerminalWidth = 30.0;
 +    CGFloat fieldX = 82.0;
 +    CGFloat fieldY = self.browserPane.bounds.size.height - 32.0;
-+    CGFloat fieldWidth = MAX(120.0, self.browserPane.bounds.size.width - fieldX - buttonWidth - newTerminalWidth - padding * 4);
++    CGFloat fieldWidth = MAX(120.0, self.browserPane.bounds.size.width - fieldX - buttonWidth - devToolsWidth - devToolsWindowWidth - newTerminalWidth - padding * 6);
 +    self.addressField.frame = NSMakeRect(fieldX, fieldY, fieldWidth, 24);
 +
 +    self.goButton.frame = NSMakeRect(NSMaxX(self.addressField.frame) + padding, fieldY - 1, buttonWidth, 26);
-+    self.addTerminalButton.frame = NSMakeRect(NSMaxX(self.goButton.frame) + padding, fieldY - 1, newTerminalWidth, 26);
++    self.devToolsButton.frame = NSMakeRect(NSMaxX(self.goButton.frame) + padding, fieldY - 1, devToolsWidth, 26);
++    self.devToolsWindowButton.frame = NSMakeRect(NSMaxX(self.devToolsButton.frame) + padding, fieldY - 1, devToolsWindowWidth, 26);
++    self.addTerminalButton.frame = NSMakeRect(NSMaxX(self.devToolsWindowButton.frame) + padding, fieldY - 1, newTerminalWidth, 26);
 +
-+    self.browserContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, MAX(0, self.browserPane.bounds.size.height - chromeHeight));
++    CGFloat contentHeight = MAX(0, self.browserPane.bounds.size.height - chromeHeight);
++    if (self.internalDevToolsVisible) {
++        CGFloat devToolsHeight = MAX(220.0, floor(contentHeight * 0.42));
++        devToolsHeight = MIN(devToolsHeight, MAX(0, contentHeight - 160.0));
++        self.devToolsContainer.hidden = NO;
++        self.devToolsContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, devToolsHeight);
++        self.browserContainer.frame = NSMakeRect(0, devToolsHeight + 1, self.browserPane.bounds.size.width, MAX(0, contentHeight - devToolsHeight - 1));
++        [self.host resizeNativeBrowserDevToolsForWindowId:self.windowId];
++    } else {
++        self.devToolsContainer.hidden = YES;
++        self.devToolsContainer.frame = NSZeroRect;
++        self.browserContainer.frame = NSMakeRect(0, 0, self.browserPane.bounds.size.width, contentHeight);
++    }
 +}
 +
 +- (void)setBrowserURLString:(NSString *)urlString {
@@ -264,6 +888,23 @@ index ce9c747..74c1640 100644
 +    [self.terminalSlot incrementTerminalCount];
 +}
 +
++- (void)devTools:(id)sender {
++    (void)sender;
++    self.internalDevToolsVisible = !self.internalDevToolsVisible;
++    [self setNeedsLayout:YES];
++    [self layoutSubtreeIfNeeded];
++    if (self.internalDevToolsVisible) {
++        [self.host openNativeBrowserInternalDevToolsForWindowId:self.windowId];
++    } else {
++        [self.host closeNativeBrowserDevToolsForWindowId:self.windowId];
++    }
++}
++
++- (void)devToolsWindow:(id)sender {
++    (void)sender;
++    [self.host openNativeBrowserWindowDevToolsForWindowId:self.windowId];
++}
++
 +@end
 +
  @interface ZeroNativeChromiumWindowDelegate : NSObject <NSWindowDelegate>
@@ -277,6 +918,7 @@ index ce9c747..74c1640 100644
  @property(nonatomic, strong) NSView *browserContainer;
  @property(nonatomic, strong) ZeroNativeChromiumWindowDelegate *delegate;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *windows;
++@property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSWindow *> *devToolsWindows;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSView *> *browserContainers;
 +@property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeCmuxWorkbenchView *> *nativeWorkbenchViews;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, ZeroNativeChromiumWindowDelegate *> *delegates;
@@ -286,10 +928,12 @@ index ce9c747..74c1640 100644
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *windowLabels;
  @property(nonatomic, strong) NSMutableDictionary<NSNumber *, NSString *> *fallbackURLs;
  @property(nonatomic, strong) NSTimer *timer;
-@@ -335,10 +551,11 @@ @interface ZeroNativeChromiumHost : NSObject
+@@ -335,10 +1149,13 @@ @interface ZeroNativeChromiumHost : NSObject
  @property(nonatomic) CefRefPtr<CefBrowser> browser;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>> *cefClients;
  @property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *browsers;
++@property(nonatomic, assign) std::map<uint64_t, CefRefPtr<ZeroNativeCefDevToolsClient>> *devToolsClients;
++@property(nonatomic, assign) std::map<uint64_t, CefRefPtr<CefBrowser>> *devToolsBrowsers;
 +@property(nonatomic, assign) BOOL cmuxNativeShellEnabled;
  @property(nonatomic, strong) NSArray<NSString *> *allowedNavigationOrigins;
  @property(nonatomic, strong) NSArray<NSString *> *allowedExternalURLs;
@@ -299,19 +943,32 @@ index ce9c747..74c1640 100644
  - (void)configureApplication;
  - (void)buildMenuBar;
  - (NSMenuItem *)menuItem:(NSString *)title action:(SEL)action key:(NSString *)key modifiers:(NSEventModifierFlags)modifiers;
-@@ -360,6 +577,9 @@ - (BOOL)isInternalURL:(NSURL *)url;
+@@ -360,6 +1177,17 @@ - (BOOL)isInternalURL:(NSURL *)url;
  - (BOOL)allowsNavigationURL:(NSURL *)url;
  - (BOOL)openExternalURLIfAllowed:(NSURL *)url;
  - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId;
++- (void)setDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
++- (void)clearDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode;
 +- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser;
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId;
 +- (void)navigateNativeBrowserToString:(NSString *)value windowId:(uint64_t)windowId;
++- (void)openNativeBrowserInternalDevToolsForWindowId:(uint64_t)windowId;
++- (void)openNativeBrowserWindowDevToolsForWindowId:(uint64_t)windowId;
++- (void)closeNativeBrowserDevToolsForWindowId:(uint64_t)windowId;
++- (void)closeNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode closeWindow:(BOOL)closeWindow;
++- (void)resizeNativeBrowserDevToolsForWindowId:(uint64_t)windowId;
++- (void)resizeNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode;
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId;
  - (NSString *)bridgeOriginForWindowId:(uint64_t)windowId sourceURL:(NSString *)sourceURL;
  - (void)receiveBridgePayload:(NSString *)payload origin:(NSString *)origin windowId:(uint64_t)windowId;
-@@ -393,9 +613,11 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -391,11 +1219,16 @@ - (void)windowWillClose:(NSNotification *)notification {
+     (void)notification;
+     [self.host emitWindowFrameForWindowId:self.windowId open:NO];
      NSNumber *key = @(self.windowId);
++    [self.host closeNativeBrowserDevToolsForWindowId:self.windowId mode:1 closeWindow:NO];
++    [self.host closeNativeBrowserDevToolsForWindowId:self.windowId mode:2 closeWindow:YES];
      [self.host.windows removeObjectForKey:key];
++    [self.host.devToolsWindows removeObjectForKey:key];
      [self.host.browserContainers removeObjectForKey:key];
 +    [self.host.nativeWorkbenchViews removeObjectForKey:key];
      [self.host.delegates removeObjectForKey:key];
@@ -321,7 +978,7 @@ index ce9c747..74c1640 100644
      [self.host.windowLabels removeObjectForKey:key];
      [self.host.fallbackURLs removeObjectForKey:key];
      if (self.host.browsers) self.host.browsers->erase(self.windowId);
-@@ -410,7 +632,7 @@ - (void)windowWillClose:(NSNotification *)notification {
+@@ -410,7 +1243,7 @@ - (void)windowWillClose:(NSNotification *)notification {
  
  @implementation ZeroNativeChromiumHost
  
@@ -330,13 +987,14 @@ index ce9c747..74c1640 100644
      self = [super init];
      if (!self) return nil;
  
-@@ -418,12 +640,15 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
+@@ -418,16 +1251,22 @@ - (instancetype)initWithAppName:(NSString *)appName title:(NSString *)title widt
      ensureCefInitialized();
      [NSApp setActivationPolicy:NSApplicationActivationPolicyRegular];
      self.appName = appName.length > 0 ? appName : @"zero-native";
 +    self.cmuxNativeShellEnabled = [bundleIdentifier isEqualToString:@"com.cmux.zero-native"] || [self.appName isEqualToString:@"zero-cmux"];
      [self configureApplication];
      self.windows = [[NSMutableDictionary alloc] init];
++    self.devToolsWindows = [[NSMutableDictionary alloc] init];
      self.browserContainers = [[NSMutableDictionary alloc] init];
 +    self.nativeWorkbenchViews = [[NSMutableDictionary alloc] init];
      self.delegates = [[NSMutableDictionary alloc] init];
@@ -346,7 +1004,22 @@ index ce9c747..74c1640 100644
      self.windowLabels = [[NSMutableDictionary alloc] init];
      self.fallbackURLs = [[NSMutableDictionary alloc] init];
      self.cefClients = new std::map<uint64_t, CefRefPtr<ZeroNativeCefClient>>();
-@@ -536,9 +761,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+     self.browsers = new std::map<uint64_t, CefRefPtr<CefBrowser>>();
++    self.devToolsClients = new std::map<uint64_t, CefRefPtr<ZeroNativeCefDevToolsClient>>();
++    self.devToolsBrowsers = new std::map<uint64_t, CefRefPtr<CefBrowser>>();
+     self.allowedNavigationOrigins = @[ @"zero://app", @"zero://inline" ];
+     self.allowedExternalURLs = @[];
+     self.externalLinkAction = 0;
+@@ -519,6 +1358,8 @@ - (void)reload:(id)sender {
+ - (void)dealloc {
+     delete self.cefClients;
+     delete self.browsers;
++    delete self.devToolsClients;
++    delete self.devToolsBrowsers;
+ }
+ 
+ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSString *)label x:(double)x y:(double)y width:(double)width height:(double)height restoreFrame:(BOOL)restoreFrame makeMain:(BOOL)makeMain {
+@@ -536,9 +1377,21 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
      [window setTitle:title.length > 0 ? title : @"zero-native"];
      if (!restoreFrame) [window center];
  
@@ -371,7 +1044,7 @@ index ce9c747..74c1640 100644
  
      ZeroNativeChromiumWindowDelegate *delegate = [[ZeroNativeChromiumWindowDelegate alloc] init];
      delegate.host = self;
-@@ -548,6 +785,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
+@@ -548,6 +1401,7 @@ - (BOOL)createWindowWithId:(uint64_t)windowId title:(NSString *)title label:(NSS
  
      self.windows[key] = window;
      self.browserContainers[key] = browserContainer;
@@ -379,7 +1052,7 @@ index ce9c747..74c1640 100644
      self.delegates[key] = delegate;
      self.windowLabels[key] = label.length > 0 ? label : (makeMain ? @"main" : @"");
      (*self.cefClients)[windowId] = client;
-@@ -601,14 +839,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
+@@ -601,14 +1455,16 @@ - (void)runWithCallback:(zero_native_appkit_event_callback_t)callback context:(v
      [self.window makeKeyAndOrderFront:nil];
      [NSApp activateIgnoringOtherApps:YES];
  
@@ -399,7 +1072,7 @@ index ce9c747..74c1640 100644
      [NSApp run];
      shutdownCefIfNeeded();
  }
-@@ -702,9 +942,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -702,9 +1558,9 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      NSString *bridgeOrigin = nil;
      NSString *internalURLPrefix = nil;
      if (kind == 0) {
@@ -411,7 +1084,7 @@ index ce9c747..74c1640 100644
      } else if (kind == 2) {
          NSString *resolvedRoot = ZeroNativeResolvedAssetRoot(assetRoot ?: @"");
          NSString *assetEntry = entry.length > 0 ? entry : @"index.html";
-@@ -726,11 +966,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -726,11 +1582,17 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
      } else {
          [self.internalURLPrefixes removeObjectForKey:key];
      }
@@ -429,7 +1102,7 @@ index ce9c747..74c1640 100644
      NSView *container = self.browserContainers[@(windowId)] ?: self.browserContainer;
      CefRefPtr<CefBrowser> browser;
      if (self.browsers) {
-@@ -738,7 +984,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
+@@ -738,7 +1600,11 @@ - (void)loadSource:(NSString *)source kind:(NSInteger)kind assetRoot:(NSString *
          if (browser_it != self.browsers->end()) browser = browser_it->second;
      }
      if (browser) {
@@ -442,7 +1115,7 @@ index ce9c747..74c1640 100644
          return;
      }
  
-@@ -769,6 +1019,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
+@@ -769,6 +1635,7 @@ - (BOOL)allowsNavigationURL:(NSURL *)url {
      NSString *scheme = url.scheme.lowercaseString ?: @"";
      if (scheme.length == 0 || [scheme isEqualToString:@"about"]) return YES;
      if ([self isInternalURL:url]) return YES;
@@ -450,10 +1123,27 @@ index ce9c747..74c1640 100644
      return ZeroNativePolicyListMatches(self.allowedNavigationOrigins, url);
  }
  
-@@ -784,6 +1035,37 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
+@@ -784,6 +1651,217 @@ - (void)setBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId {
      if (windowId == 1) self.browser = browser;
  }
  
++- (void)setDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode {
++    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
++    if (self.devToolsBrowsers) (*self.devToolsBrowsers)[devToolsKey] = browser;
++    [self resizeNativeBrowserDevToolsForWindowId:windowId mode:mode];
++}
++
++- (void)clearDevToolsBrowser:(CefRefPtr<CefBrowser>)browser windowId:(uint64_t)windowId mode:(NSInteger)mode {
++    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
++    if (self.devToolsBrowsers) {
++        auto it = self.devToolsBrowsers->find(devToolsKey);
++        if (it != self.devToolsBrowsers->end() && (!browser || it->second->IsSame(browser))) {
++            self.devToolsBrowsers->erase(it);
++        }
++    }
++    if (self.devToolsClients) self.devToolsClients->erase(devToolsKey);
++}
++
 +- (void)updateNativeBrowserURLString:(NSString *)urlString windowId:(uint64_t)windowId {
 +    ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[@(windowId)];
 +    [workbench setBrowserURLString:urlString];
@@ -476,6 +1166,169 @@ index ce9c747..74c1640 100644
 +    it->second->GetMainFrame()->LoadURL(std::string(urlString.UTF8String));
 +}
 +
++- (void)showNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode {
++    if (!self.browsers) {
++        fprintf(stderr, "zero-native: DevTools requested before browser map exists mode=%ld\n", (long)mode);
++        return;
++    }
++    auto it = self.browsers->find(windowId);
++    if (it == self.browsers->end() || !it->second) {
++        fprintf(stderr, "zero-native: DevTools requested before browser exists window=%llu mode=%ld\n", (unsigned long long)windowId, (long)mode);
++        return;
++    }
++
++    NSNumber *windowKey = @(windowId);
++    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
++    if (self.devToolsBrowsers) {
++        auto existing = self.devToolsBrowsers->find(devToolsKey);
++        if (existing != self.devToolsBrowsers->end() && existing->second) {
++            if (mode == 2) {
++                [self.devToolsWindows[windowKey] makeKeyAndOrderFront:nil];
++                [NSApp activateIgnoringOtherApps:YES];
++            } else {
++                [self resizeNativeBrowserDevToolsForWindowId:windowId mode:mode];
++            }
++            return;
++        }
++    }
++
++    NSString *sourceURLString = @"";
++    if (it->second->GetMainFrame()) {
++        std::string sourceURL = it->second->GetMainFrame()->GetURL().ToString();
++        sourceURLString = [[NSString alloc] initWithBytes:sourceURL.data()
++                                                   length:sourceURL.size()
++                                                 encoding:NSUTF8StringEncoding] ?: @"";
++    }
++
++    dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
++        NSString *frontendURL = ZeroNativeCmuxDevToolsFrontendURLForSourceURL(sourceURLString);
++        dispatch_async(dispatch_get_main_queue(), ^{
++            [self createNativeBrowserDevToolsForWindowId:windowId mode:mode frontendURL:frontendURL];
++        });
++    });
++}
++
++- (void)createNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode frontendURL:(NSString *)frontendURL {
++    if (frontendURL.length == 0) {
++        if (mode == 1) [self closeNativeBrowserDevToolsForWindowId:windowId mode:1 closeWindow:NO];
++        return;
++    }
++
++    if (!self.browsers) return;
++    auto source = self.browsers->find(windowId);
++    if (source == self.browsers->end() || !source->second) return;
++
++    NSNumber *windowKey = @(windowId);
++    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
++    if (self.devToolsBrowsers) {
++        auto existing = self.devToolsBrowsers->find(devToolsKey);
++        if (existing != self.devToolsBrowsers->end() && existing->second) return;
++    }
++
++    NSView *container = nil;
++    if (mode == 1) {
++        ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[windowKey];
++        if (!workbench) return;
++        if (!workbench.internalDevToolsVisible) return;
++        workbench.internalDevToolsVisible = YES;
++        workbench.devToolsContainer.hidden = NO;
++        [workbench setNeedsLayout:YES];
++        [workbench layoutSubtreeIfNeeded];
++        container = workbench.devToolsContainer;
++    } else if (mode == 2) {
++        NSWindow *devToolsWindow = self.devToolsWindows[windowKey];
++        if (!devToolsWindow) {
++            NSRect frame = NSMakeRect(0, 0, 1100, 720);
++            devToolsWindow = [[NSWindow alloc] initWithContentRect:frame
++                                                         styleMask:(NSWindowStyleMaskTitled |
++                                                                    NSWindowStyleMaskClosable |
++                                                                    NSWindowStyleMaskResizable |
++                                                                    NSWindowStyleMaskMiniaturizable)
++                                                           backing:NSBackingStoreBuffered
++                                                             defer:NO];
++            devToolsWindow.title = @"Chrome DevTools";
++            devToolsWindow.releasedWhenClosed = NO;
++            NSView *content = [[NSView alloc] initWithFrame:frame];
++            content.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
++            content.wantsLayer = YES;
++            content.layer.backgroundColor = NSColor.blackColor.CGColor;
++            devToolsWindow.contentView = content;
++            [devToolsWindow center];
++            self.devToolsWindows[windowKey] = devToolsWindow;
++        }
++        [devToolsWindow makeKeyAndOrderFront:nil];
++        [NSApp activateIgnoringOtherApps:YES];
++        container = devToolsWindow.contentView;
++    }
++    if (!container) return;
++
++    CefRefPtr<ZeroNativeCefDevToolsClient> client = new ZeroNativeCefDevToolsClient(self, windowId, mode);
++    if (self.devToolsClients) (*self.devToolsClients)[devToolsKey] = client;
++
++    CefWindowInfo windowInfo;
++    CefRect rect(0, 0, MAX(1, (int)container.bounds.size.width), MAX(1, (int)container.bounds.size.height));
++    windowInfo.SetAsChild((__bridge void *)container, rect);
++    CefBrowserSettings settings;
++    const bool created = CefBrowserHost::CreateBrowser(windowInfo, client.get(), std::string(frontendURL.UTF8String), settings, nullptr, nullptr);
++    fprintf(stderr, "zero-native: create DevTools browser mode=%ld url=%s created=%d\n", (long)mode, frontendURL.UTF8String, created ? 1 : 0);
++    if (!created) {
++        if (self.devToolsClients) self.devToolsClients->erase(devToolsKey);
++        if (mode == 1) [self closeNativeBrowserDevToolsForWindowId:windowId mode:1 closeWindow:NO];
++    }
++}
++
++- (void)openNativeBrowserInternalDevToolsForWindowId:(uint64_t)windowId {
++    [self showNativeBrowserDevToolsForWindowId:windowId mode:1];
++}
++
++- (void)openNativeBrowserWindowDevToolsForWindowId:(uint64_t)windowId {
++    [self showNativeBrowserDevToolsForWindowId:windowId mode:2];
++}
++
++- (void)closeNativeBrowserDevToolsForWindowId:(uint64_t)windowId {
++    [self closeNativeBrowserDevToolsForWindowId:windowId mode:1 closeWindow:NO];
++}
++
++- (void)closeNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode closeWindow:(BOOL)closeWindow {
++    uint64_t devToolsKey = ZeroNativeCmuxDevToolsKey(windowId, mode);
++    CefRefPtr<CefBrowser> browser;
++    if (self.devToolsBrowsers) {
++        auto it = self.devToolsBrowsers->find(devToolsKey);
++        if (it != self.devToolsBrowsers->end()) browser = it->second;
++    }
++    if (browser) {
++        browser->GetHost()->CloseBrowser(true);
++    } else if (self.devToolsClients) {
++        self.devToolsClients->erase(devToolsKey);
++    }
++
++    NSNumber *windowKey = @(windowId);
++    if (mode == 1) {
++        ZeroNativeCmuxWorkbenchView *workbench = self.nativeWorkbenchViews[windowKey];
++        if (workbench && workbench.internalDevToolsVisible) {
++            workbench.internalDevToolsVisible = NO;
++            [workbench setNeedsLayout:YES];
++            [workbench layoutSubtreeIfNeeded];
++        }
++    } else if (mode == 2 && closeWindow) {
++        NSWindow *devToolsWindow = self.devToolsWindows[windowKey];
++        if (devToolsWindow) [devToolsWindow close];
++        [self.devToolsWindows removeObjectForKey:windowKey];
++    }
++}
++
++- (void)resizeNativeBrowserDevToolsForWindowId:(uint64_t)windowId {
++    [self resizeNativeBrowserDevToolsForWindowId:windowId mode:1];
++}
++
++- (void)resizeNativeBrowserDevToolsForWindowId:(uint64_t)windowId mode:(NSInteger)mode {
++    if (!self.devToolsBrowsers) return;
++    auto it = self.devToolsBrowsers->find(ZeroNativeCmuxDevToolsKey(windowId, mode));
++    if (it != self.devToolsBrowsers->end() && it->second) {
++        it->second->GetHost()->WasResized();
++    }
++}
++
 +- (void)loadInlineHTMLIfNeededForWindowId:(uint64_t)windowId browser:(CefRefPtr<CefBrowser>)browser {
 +    NSString *html = self.inlineHTMLSources[@(windowId)];
 +    if (html.length == 0 || !browser) return;
@@ -488,15 +1341,19 @@ index ce9c747..74c1640 100644
  - (NSString *)fallbackURLForWindowId:(uint64_t)windowId {
      return self.fallbackURLs[@(windowId)];
  }
-@@ -882,6 +1164,7 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -882,6 +1960,11 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
  
  void ZeroNativeCefClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
      [host_ setBrowser:browser windowId:window_id_];
 +    [host_ loadInlineHTMLIfNeededForWindowId:window_id_ browser:browser];
++    ZeroNativeCmuxWorkbenchView *workbench = host_.nativeWorkbenchViews[@(window_id_)];
++    if (workbench.internalDevToolsVisible) {
++        [host_ openNativeBrowserInternalDevToolsForWindowId:window_id_];
++    }
  }
  
  void ZeroNativeCefClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
-@@ -904,7 +1187,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -904,7 +1987,10 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
      std::string url = request ? request->GetURL().ToString() : std::string();
      NSString *urlString = [[NSString alloc] initWithBytes:url.data() length:url.size() encoding:NSUTF8StringEncoding] ?: @"";
      NSURL *nsURL = [NSURL URLWithString:urlString];
@@ -508,7 +1365,32 @@ index ce9c747..74c1640 100644
      if ([host_ openExternalURLIfAllowed:nsURL]) return true;
      return true;
  }
-@@ -926,16 +1212,16 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+@@ -923,19 +2009,41 @@ static BOOL ZeroNativePolicyListMatches(NSArray<NSString *> *values, NSURL *url)
+     return true;
+ }
+ 
++void ZeroNativeCefDevToolsClient::OnAfterCreated(CefRefPtr<CefBrowser> browser) {
++    [host_ setDevToolsBrowser:browser windowId:window_id_ mode:mode_];
++}
++
++void ZeroNativeCefDevToolsClient::OnBeforeClose(CefRefPtr<CefBrowser> browser) {
++    [host_ clearDevToolsBrowser:browser windowId:window_id_ mode:mode_];
++}
++
++void ZeroNativeCefDevToolsClient::OnLoadEnd(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, int httpStatusCode) {
++    if (!frame || !frame->IsMain()) return;
++    std::string url = frame->GetURL().ToString();
++    fprintf(stderr, "zero-native: DevTools load end mode=%ld status=%d url=%s\n", (long)mode_, httpStatusCode, url.c_str());
++}
++
++void ZeroNativeCefDevToolsClient::OnLoadError(CefRefPtr<CefBrowser> browser, CefRefPtr<CefFrame> frame, ErrorCode errorCode, const CefString& errorText, const CefString& failedUrl) {
++    (void)browser;
++    if (!frame || !frame->IsMain()) return;
++    std::string error = errorText.ToString();
++    std::string url = failedUrl.ToString();
++    fprintf(stderr, "zero-native: DevTools load error mode=%ld code=%d error=%s url=%s\n", (long)mode_, (int)errorCode, error.c_str(), url.c_str());
++}
++
  } // namespace
  
  zero_native_appkit_host_t *zero_native_appkit_create(const char *app_name, size_t app_name_len, const char *window_title, size_t window_title_len, const char *bundle_id, size_t bundle_id_len, const char *icon_path, size_t icon_path_len, const char *window_label, size_t window_label_len, double x, double y, double width, double height, int restore_frame) {

--- a/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
+++ b/experiments/zero-native-cmux/patches/zero-native-cef-native-shell.patch
@@ -1,5 +1,5 @@
 diff --git a/src/platform/macos/cef_host.mm b/src/platform/macos/cef_host.mm
-index ce9c747..07cb2e2 100644
+index ce9c747..74c1640 100644
 --- a/src/platform/macos/cef_host.mm
 +++ b/src/platform/macos/cef_host.mm
 @@ -29,6 +29,10 @@ @interface ZeroNativeChromiumApplication : NSApplication <CefAppProtocol>
@@ -89,8 +89,8 @@ index ce9c747..07cb2e2 100644
 +
 +static bool ZeroNativeShouldUseHelperLoader(void) {
 +    if (!ZeroNativeIsCefHelperProcess()) return false;
-+    NSString *bundleExtension = [NSBundle mainBundle].bundlePath.pathExtension.lowercaseString ?: @"";
-+    return [bundleExtension isEqualToString:@"app"];
++    NSString *executableName = [NSBundle mainBundle].executablePath.lastPathComponent ?: @"";
++    return [executableName hasSuffix:@" Helper"];
 +}
 +
  static NSRect ZeroNativeConstrainFrame(NSRect frame) {

--- a/experiments/zero-native-cmux/scripts/package-app.sh
+++ b/experiments/zero-native-cmux/scripts/package-app.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+OUTPUT="$ROOT/zig-out/package/zero-cmux.app"
+APP_NAME="zero-cmux"
+BUNDLE_ID="com.cmux.zero-native"
+BINARY="$ROOT/zig-out/bin/zero-cmux"
+CEF_DIR="$ROOT/third_party/cef/macos"
+SIGN=1
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/package-app.sh [options]
+
+Options:
+  --output <path>      Output .app path.
+  --name <name>        App and executable display name.
+  --bundle-id <id>     Main bundle identifier.
+  --binary <path>      Built zero-cmux executable.
+  --cef-dir <path>     CEF runtime directory.
+  --no-sign            Skip ad-hoc signing.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --output)
+      OUTPUT="${2:?}"
+      shift 2
+      ;;
+    --name)
+      APP_NAME="${2:?}"
+      shift 2
+      ;;
+    --bundle-id)
+      BUNDLE_ID="${2:?}"
+      shift 2
+      ;;
+    --binary)
+      BINARY="${2:?}"
+      shift 2
+      ;;
+    --cef-dir)
+      CEF_DIR="${2:?}"
+      shift 2
+      ;;
+    --no-sign)
+      SIGN=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "error: unknown option $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+CEF_FRAMEWORK="$CEF_DIR/Release/Chromium Embedded Framework.framework"
+if [[ ! -x "$BINARY" ]]; then
+  echo "error: missing executable: $BINARY" >&2
+  exit 1
+fi
+if [[ ! -d "$CEF_FRAMEWORK" ]]; then
+  echo "error: missing CEF framework: $CEF_FRAMEWORK" >&2
+  exit 1
+fi
+
+sanitize_id_component() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g'
+}
+
+plist_add() {
+  local plist="$1"
+  local key="$2"
+  local type="$3"
+  local value="$4"
+  /usr/libexec/PlistBuddy -c "Add :${key} ${type} ${value}" "$plist" >/dev/null
+}
+
+write_plist() {
+  local plist="$1"
+  local executable="$2"
+  local bundle_id="$3"
+  local name="$4"
+  local background="${5:-0}"
+  plutil -create xml1 "$plist"
+  plist_add "$plist" CFBundleExecutable string "$executable"
+  plist_add "$plist" CFBundleIdentifier string "$bundle_id"
+  plist_add "$plist" CFBundleName string "$name"
+  plist_add "$plist" CFBundleDisplayName string "$name"
+  plist_add "$plist" CFBundlePackageType string APPL
+  plist_add "$plist" CFBundleVersion string 1
+  plist_add "$plist" CFBundleShortVersionString string 0.1.0
+  plist_add "$plist" NSHighResolutionCapable bool YES
+  if [[ "$background" == "1" ]]; then
+    plist_add "$plist" LSBackgroundOnly bool YES
+  fi
+}
+
+copy_runtime_siblings() {
+  local destination="$1"
+  mkdir -p "$destination"
+  for item in libEGL.dylib libGLESv2.dylib libvk_swiftshader.dylib libvulkan.1.dylib vk_swiftshader_icd.json; do
+    if [[ -e "$CEF_FRAMEWORK/Libraries/$item" ]]; then
+      cp -f "$CEF_FRAMEWORK/Libraries/$item" "$destination/$item"
+    fi
+  done
+}
+
+install_helper() {
+  local helper_name="$1"
+  local helper_suffix="$2"
+  local helper_app="$OUTPUT/Contents/Frameworks/${helper_name}.app"
+  local helper_macos="$helper_app/Contents/MacOS"
+  local helper_frameworks="$helper_app/Contents/Frameworks"
+  local helper_plist="$helper_app/Contents/Info.plist"
+
+  mkdir -p "$helper_macos" "$helper_frameworks" "$helper_app/Contents/Resources"
+  cp -f "$BINARY" "$helper_macos/$helper_name"
+  chmod +x "$helper_macos/$helper_name"
+  ln -sfn "../../../Chromium Embedded Framework.framework" "$helper_frameworks/Chromium Embedded Framework.framework"
+  copy_runtime_siblings "$helper_macos"
+  write_plist "$helper_plist" "$helper_name" "${BUNDLE_ID}.${helper_suffix}" "$helper_name" 1
+}
+
+rm -rf "$OUTPUT"
+mkdir -p "$OUTPUT/Contents/MacOS" "$OUTPUT/Contents/Frameworks" "$OUTPUT/Contents/Resources"
+
+cp -f "$BINARY" "$OUTPUT/Contents/MacOS/$APP_NAME"
+chmod +x "$OUTPUT/Contents/MacOS/$APP_NAME"
+cp -R "$CEF_FRAMEWORK" "$OUTPUT/Contents/Frameworks/Chromium Embedded Framework.framework"
+copy_runtime_siblings "$OUTPUT/Contents/MacOS"
+write_plist "$OUTPUT/Contents/Info.plist" "$APP_NAME" "$BUNDLE_ID" "$APP_NAME" 0
+printf 'APPL????' > "$OUTPUT/Contents/PkgInfo"
+
+install_helper "$APP_NAME Helper" "helper"
+install_helper "$APP_NAME Helper (GPU)" "helper.$(sanitize_id_component GPU)"
+install_helper "$APP_NAME Helper (Plugin)" "helper.$(sanitize_id_component Plugin)"
+install_helper "$APP_NAME Helper (Renderer)" "helper.$(sanitize_id_component Renderer)"
+
+if [[ "$SIGN" == "1" ]]; then
+  find "$OUTPUT/Contents/Frameworks" -maxdepth 1 -type d -name "*.app" -print0 |
+    while IFS= read -r -d '' helper_app; do
+      /usr/bin/codesign --force --deep --sign - --timestamp=none "$helper_app" >/dev/null 2>&1
+    done
+  /usr/bin/codesign --force --deep --sign - --timestamp=none "$OUTPUT" >/dev/null 2>&1
+fi
+
+echo "App path:"
+echo "  $OUTPUT"

--- a/experiments/zero-native-cmux/scripts/setup.sh
+++ b/experiments/zero-native-cmux/scripts/setup.sh
@@ -8,6 +8,21 @@ if [ ! -d "$ZERO_NATIVE_DIR/.git" ]; then
   git clone --depth 1 https://github.com/vercel-labs/zero-native.git "$ZERO_NATIVE_DIR"
 fi
 
+shopt -s nullglob
+PATCHES=("$ROOT"/patches/*.patch)
+shopt -u nullglob
+
+for PATCH in "${PATCHES[@]}"; do
+  if git -C "$ZERO_NATIVE_DIR" apply --check "$PATCH" >/dev/null 2>&1; then
+    git -C "$ZERO_NATIVE_DIR" apply "$PATCH"
+  elif git -C "$ZERO_NATIVE_DIR" apply --reverse --check "$PATCH" >/dev/null 2>&1; then
+    :
+  else
+    echo "Failed to apply Zero Native patch: ${PATCH##*/}" >&2
+    exit 1
+  fi
+done
+
 if command -v zero-native >/dev/null 2>&1; then
   ZERO_NATIVE_CLI=(zero-native)
 else

--- a/experiments/zero-native-cmux/scripts/setup.sh
+++ b/experiments/zero-native-cmux/scripts/setup.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ZERO_NATIVE_DIR="$ROOT/third_party/zero-native"
+
+if [ ! -d "$ZERO_NATIVE_DIR/.git" ]; then
+  git clone --depth 1 https://github.com/vercel-labs/zero-native.git "$ZERO_NATIVE_DIR"
+fi
+
+if command -v zero-native >/dev/null 2>&1; then
+  ZERO_NATIVE_CLI=(zero-native)
+else
+  npm install --prefix "$ZERO_NATIVE_DIR/packages/zero-native"
+  ZERO_NATIVE_CLI=(node "$ZERO_NATIVE_DIR/packages/zero-native/bin/zero-native.js")
+fi
+
+"${ZERO_NATIVE_CLI[@]}" cef install --dir "$ROOT/third_party/cef/macos"
+
+echo "Ready. Run:"
+echo "  cd experiments/zero-native-cmux"
+echo "  zig build run"

--- a/experiments/zero-native-cmux/src/ghostty_contract.zig
+++ b/experiments/zero-native-cmux/src/ghostty_contract.zig
@@ -1,0 +1,40 @@
+const std = @import("std");
+
+const c = @cImport({
+    @cInclude("ghostty.h");
+});
+
+pub const Contract = struct {
+    terminal_engine: []const u8,
+    host_platform: []const u8,
+    surface_context: []const u8,
+    io_mode: []const u8,
+};
+
+pub fn current() Contract {
+    return .{
+        .terminal_engine = "ghostty",
+        .host_platform = "macos-nsview",
+        .surface_context = "split",
+        .io_mode = "exec",
+    };
+}
+
+pub fn assertCompileTimeSurfaceContract() void {
+    _ = c.GHOSTTY_PLATFORM_MACOS;
+    _ = c.GHOSTTY_SURFACE_CONTEXT_SPLIT;
+    _ = c.GHOSTTY_SURFACE_IO_EXEC;
+    _ = c.ghostty_surface_config_s;
+}
+
+test "Ghostty C API exposes the native macOS surface contract" {
+    assertCompileTimeSurfaceContract();
+    var config = std.mem.zeroes(c.ghostty_surface_config_s);
+    config.platform_tag = c.GHOSTTY_PLATFORM_MACOS;
+    config.context = c.GHOSTTY_SURFACE_CONTEXT_SPLIT;
+    config.io_mode = c.GHOSTTY_SURFACE_IO_EXEC;
+
+    try std.testing.expectEqual(c.GHOSTTY_PLATFORM_MACOS, config.platform_tag);
+    try std.testing.expectEqual(c.GHOSTTY_SURFACE_CONTEXT_SPLIT, config.context);
+    try std.testing.expectEqual(c.GHOSTTY_SURFACE_IO_EXEC, config.io_mode);
+}

--- a/experiments/zero-native-cmux/src/main.zig
+++ b/experiments/zero-native-cmux/src/main.zig
@@ -1,0 +1,397 @@
+const std = @import("std");
+const runner = @import("runner");
+const zero_native = @import("zero-native");
+const ghostty_contract = @import("ghostty-contract");
+
+pub const panic = std.debug.FullPanic(zero_native.debug.capturePanic);
+
+const html =
+    \\<!doctype html>
+    \\<html>
+    \\<head>
+    \\  <meta charset="utf-8">
+    \\  <meta name="viewport" content="width=device-width, initial-scale=1">
+    \\  <meta http-equiv="Content-Security-Policy" content="default-src 'self' zero://inline zero://app https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src https: http: data:;">
+    \\  <style>
+    \\    :root { color-scheme: light dark; --bg:#f6f7f8; --panel:#ffffff; --ink:#17191c; --muted:#68707a; --line:#d9dde3; --active:#1463ff; --terminal:#101214; --terminal-ink:#e8edf2; }
+    \\    @media (prefers-color-scheme: dark) { :root { --bg:#111316; --panel:#191c20; --ink:#eff2f5; --muted:#99a1ad; --line:#2a3038; --active:#6ba4ff; --terminal:#08090a; --terminal-ink:#dfe7ee; } }
+    \\    * { box-sizing: border-box; }
+    \\    body { margin:0; height:100vh; overflow:hidden; background:var(--bg); color:var(--ink); font:13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0; }
+    \\    button, input { font:inherit; }
+    \\    .app { height:100vh; display:grid; grid-template-columns:230px 1fr; grid-template-rows:40px 1fr; }
+    \\    .top { grid-column:1 / -1; display:flex; align-items:center; gap:10px; padding:0 12px; border-bottom:1px solid var(--line); background:var(--panel); }
+    \\    .brand { font-weight:650; }
+    \\    .pill { border:1px solid var(--line); border-radius:999px; padding:3px 8px; color:var(--muted); white-space:nowrap; }
+    \\    .spacer { flex:1; }
+    \\    .sidebar { border-right:1px solid var(--line); background:var(--panel); padding:10px; overflow:auto; }
+    \\    .workspace { width:100%; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:9px 10px; text-align:left; }
+    \\    .workspace + .workspace { margin-top:8px; }
+    \\    .main { min-width:0; min-height:0; display:grid; grid-template-rows:38px 1fr; }
+    \\    .tabs { display:flex; gap:6px; align-items:center; padding:6px 8px; border-bottom:1px solid var(--line); background:var(--panel); overflow:auto; }
+    \\    .tab { height:26px; border:1px solid var(--line); border-radius:7px; background:transparent; color:var(--ink); padding:0 10px; display:flex; align-items:center; gap:7px; white-space:nowrap; }
+    \\    .tab.active { border-color:color-mix(in srgb, var(--active) 45%, var(--line)); background:color-mix(in srgb, var(--active) 11%, transparent); }
+    \\    .tool { height:26px; width:30px; border:1px solid var(--line); border-radius:7px; background:transparent; color:var(--ink); }
+    \\    .content { min-width:0; min-height:0; display:grid; grid-template-columns:minmax(360px, 0.95fr) minmax(420px, 1.05fr); gap:1px; background:var(--line); }
+    \\    .pane { min-width:0; min-height:0; background:var(--panel); display:grid; grid-template-rows:34px 1fr; }
+    \\    .pane-head { display:flex; align-items:center; gap:8px; min-width:0; padding:0 8px; border-bottom:1px solid var(--line); }
+    \\    .pane-title { font-weight:600; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+    \\    .address { flex:1; min-width:80px; height:24px; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:0 8px; }
+    \\    .go { height:24px; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:0 9px; }
+    \\    .terminal { background:var(--terminal); color:var(--terminal-ink); padding:14px; font:12px ui-monospace, SFMono-Regular, Menlo, monospace; overflow:auto; }
+    \\    .terminal .muted { color:#8f9aa5; }
+    \\    iframe { width:100%; height:100%; border:0; background:white; }
+    \\    .empty { display:grid; place-items:center; color:var(--muted); }
+    \\  </style>
+    \\</head>
+    \\<body>
+    \\  <div class="app">
+    \\    <div class="top">
+    \\      <div class="brand">cmux zero</div>
+    \\      <div class="pill" id="browser-engine">browser</div>
+    \\      <div class="pill" id="terminal-engine">terminal</div>
+    \\      <div class="spacer"></div>
+    \\      <button class="tool" id="new-terminal" title="New terminal">+</button>
+    \\      <button class="tool" id="new-browser" title="New browser">B</button>
+    \\    </div>
+    \\    <aside class="sidebar" id="workspaces"></aside>
+    \\    <main class="main">
+    \\      <div class="tabs" id="tabs"></div>
+    \\      <div class="content" id="content"></div>
+    \\    </main>
+    \\  </div>
+    \\  <script>
+    \\    const state = { panes: [], selectedPaneId: 0 };
+    \\    const q = (s) => document.querySelector(s);
+    \\    async function invoke(command, payload = {}) {
+    \\      return await window.zero.invoke(command, payload);
+    \\    }
+    \\    function paneIcon(kind) { return kind === "terminal" ? "T" : "B"; }
+    \\    function browserPane() { return state.panes.find((p) => p.kind === "browser") || state.panes[0]; }
+    \\    function terminalPane() { return state.panes.find((p) => p.kind === "terminal") || state.panes[0]; }
+    \\    function render() {
+    \\      q("#browser-engine").textContent = state.browserEngine;
+    \\      q("#terminal-engine").textContent = state.terminalEngine;
+    \\      q("#workspaces").innerHTML = `<button class="workspace">main<br><span style="color:var(--muted)">${state.panes.length} panes</span></button>`;
+    \\      q("#tabs").innerHTML = state.panes.map((p) => `<button class="tab ${p.id === state.selectedPaneId ? "active" : ""}" data-pane="${p.id}"><span>${paneIcon(p.kind)}</span><span>${p.title}</span></button>`).join("");
+    \\      for (const tab of document.querySelectorAll(".tab")) {
+    \\        tab.onclick = async () => {
+    \\          Object.assign(state, await invoke("workbench.focusPane", { paneId: Number(tab.dataset.pane) }));
+    \\          render();
+    \\        };
+    \\      }
+    \\      const terminal = terminalPane();
+    \\      const browser = browserPane();
+    \\      q("#content").innerHTML = `
+    \\        <section class="pane">
+    \\          <div class="pane-head"><div class="pane-title">${terminal ? terminal.title : "Terminal"}</div><div class="pill">Ghostty</div></div>
+    \\          <div class="terminal" data-native-slot="${terminal ? "ghostty:" + terminal.id : ""}">
+    \\            <div class="muted">$ native-slot ${terminal ? terminal.id : "none"}</div>
+    \\            <div>$ ${terminal ? terminal.cwd : "~"}</div>
+    \\            <div class="muted">surface=${terminal ? terminal.host : "ghostty"} context=split io=exec</div>
+    \\          </div>
+    \\        </section>
+    \\        <section class="pane">
+    \\          <div class="pane-head">
+    \\            <div class="pane-title">${browser ? browser.title : "Browser"}</div>
+    \\            <input class="address" id="address" value="${browser ? browser.url : ""}">
+    \\            <button class="go" id="go">Go</button>
+    \\          </div>
+    \\          ${browser ? `<iframe src="${browser.url}"></iframe>` : `<div class="empty">No browser pane</div>`}
+    \\        </section>`;
+    \\      const go = q("#go");
+    \\      if (go && browser) {
+    \\        go.onclick = async () => {
+    \\          Object.assign(state, await invoke("workbench.navigateBrowser", { paneId: browser.id, url: q("#address").value }));
+    \\          render();
+    \\        };
+    \\      }
+    \\    }
+    \\    async function refresh() {
+    \\      Object.assign(state, await invoke("workbench.snapshot"));
+    \\      render();
+    \\    }
+    \\    q("#new-terminal").onclick = async () => { Object.assign(state, await invoke("workbench.addTerminal")); render(); };
+    \\    q("#new-browser").onclick = async () => { Object.assign(state, await invoke("workbench.addBrowser")); render(); };
+    \\    refresh().catch((error) => {
+    \\      q("#content").innerHTML = `<div class="empty">${error.code || "error"}: ${error.message}</div>`;
+    \\    });
+    \\  </script>
+    \\</body>
+    \\</html>
+;
+
+const MaxPanes = 8;
+const MaxTitle = 80;
+const MaxURL = 512;
+
+const PaneKind = enum {
+    terminal,
+    browser,
+
+    fn jsonName(self: PaneKind) []const u8 {
+        return switch (self) {
+            .terminal => "terminal",
+            .browser => "browser",
+        };
+    }
+};
+
+const Pane = struct {
+    id: u32 = 0,
+    kind: PaneKind = .terminal,
+    host: []const u8 = "ghostty",
+    title: [MaxTitle]u8 = undefined,
+    title_len: usize = 0,
+    url: [MaxURL]u8 = undefined,
+    url_len: usize = 0,
+    cwd: []const u8 = "~",
+
+    fn titleSlice(self: *const Pane) []const u8 {
+        return self.title[0..self.title_len];
+    }
+
+    fn urlSlice(self: *const Pane) []const u8 {
+        return self.url[0..self.url_len];
+    }
+
+    fn setTitle(self: *Pane, value: []const u8) void {
+        self.title_len = copyBounded(&self.title, value);
+    }
+
+    fn setURL(self: *Pane, value: []const u8) void {
+        self.url_len = copyBounded(&self.url, value);
+    }
+};
+
+const NavigatePayload = struct {
+    paneId: u32 = 0,
+    url: []const u8 = "",
+};
+
+const bridge_policies = [_]zero_native.BridgeCommandPolicy{
+    .{ .name = "workbench.snapshot" },
+    .{ .name = "workbench.addTerminal" },
+    .{ .name = "workbench.addBrowser" },
+    .{ .name = "workbench.focusPane" },
+    .{ .name = "workbench.navigateBrowser" },
+};
+
+const allowed_origins = [_][]const u8{ "zero://inline", "zero://app" };
+
+const WorkbenchApp = struct {
+    panes: [MaxPanes]Pane = undefined,
+    pane_count: usize = 0,
+    next_pane_id: u32 = 1,
+    selected_pane_id: u32 = 0,
+    bridge_handlers: [bridge_policies.len]zero_native.BridgeHandler = undefined,
+
+    fn init() WorkbenchApp {
+        var self = WorkbenchApp{};
+        self.addPane(.terminal, "Ghostty", "") catch unreachable;
+        self.addPane(.browser, "Zero Native", "https://zero-native.dev") catch unreachable;
+        return self;
+    }
+
+    fn app(self: *@This()) zero_native.App {
+        return .{
+            .context = self,
+            .name = "zero-cmux",
+            .source = zero_native.WebViewSource.html(html),
+        };
+    }
+
+    fn bridge(self: *@This()) zero_native.BridgeDispatcher {
+        self.bridge_handlers = .{
+            .{ .name = "workbench.snapshot", .context = self, .invoke_fn = snapshot },
+            .{ .name = "workbench.addTerminal", .context = self, .invoke_fn = addTerminal },
+            .{ .name = "workbench.addBrowser", .context = self, .invoke_fn = addBrowser },
+            .{ .name = "workbench.focusPane", .context = self, .invoke_fn = focusPane },
+            .{ .name = "workbench.navigateBrowser", .context = self, .invoke_fn = navigateBrowser },
+        };
+        return .{
+            .policy = .{ .enabled = true, .commands = &bridge_policies },
+            .registry = .{ .handlers = &self.bridge_handlers },
+        };
+    }
+
+    fn addPane(self: *@This(), kind: PaneKind, title: []const u8, url: []const u8) !void {
+        if (self.pane_count >= MaxPanes) return error.TooManyPanes;
+        var pane = Pane{
+            .id = self.next_pane_id,
+            .kind = kind,
+            .host = if (kind == .terminal) "ghostty" else "chromium-cef",
+        };
+        pane.setTitle(title);
+        pane.setURL(url);
+        self.panes[self.pane_count] = pane;
+        self.pane_count += 1;
+        self.next_pane_id += 1;
+        self.selected_pane_id = pane.id;
+    }
+
+    fn findPane(self: *@This(), pane_id: u32) ?*Pane {
+        for (self.panes[0..self.pane_count]) |*pane| {
+            if (pane.id == pane_id) return pane;
+        }
+        return null;
+    }
+
+    fn snapshot(context: *anyopaque, invocation: zero_native.bridge.Invocation, output: []u8) anyerror![]const u8 {
+        _ = invocation;
+        const self: *@This() = @ptrCast(@alignCast(context));
+        return self.writeSnapshot(output);
+    }
+
+    fn addTerminal(context: *anyopaque, invocation: zero_native.bridge.Invocation, output: []u8) anyerror![]const u8 {
+        _ = invocation;
+        const self: *@This() = @ptrCast(@alignCast(context));
+        var title_buffer: [MaxTitle]u8 = undefined;
+        const title = try std.fmt.bufPrint(&title_buffer, "Terminal {d}", .{self.next_pane_id});
+        try self.addPane(.terminal, title, "");
+        return self.writeSnapshot(output);
+    }
+
+    fn addBrowser(context: *anyopaque, invocation: zero_native.bridge.Invocation, output: []u8) anyerror![]const u8 {
+        _ = invocation;
+        const self: *@This() = @ptrCast(@alignCast(context));
+        var title_buffer: [MaxTitle]u8 = undefined;
+        const title = try std.fmt.bufPrint(&title_buffer, "Browser {d}", .{self.next_pane_id});
+        try self.addPane(.browser, title, "https://zero-native.dev");
+        return self.writeSnapshot(output);
+    }
+
+    fn focusPane(context: *anyopaque, invocation: zero_native.bridge.Invocation, output: []u8) anyerror![]const u8 {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        const pane_id = std.json.parseFromSlice(struct { paneId: u32 = 0 }, std.heap.page_allocator, invocation.request.payload, .{
+            .ignore_unknown_fields = true,
+        }) catch return error.InvalidPane;
+        defer pane_id.deinit();
+        if (self.findPane(pane_id.value.paneId) == null) return error.InvalidPane;
+        self.selected_pane_id = pane_id.value.paneId;
+        return self.writeSnapshot(output);
+    }
+
+    fn navigateBrowser(context: *anyopaque, invocation: zero_native.bridge.Invocation, output: []u8) anyerror![]const u8 {
+        const self: *@This() = @ptrCast(@alignCast(context));
+        const parsed = try std.json.parseFromSlice(NavigatePayload, std.heap.page_allocator, invocation.request.payload, .{
+            .ignore_unknown_fields = true,
+        });
+        defer parsed.deinit();
+        const pane = self.findPane(parsed.value.paneId) orelse return error.InvalidPane;
+        if (pane.kind != .browser) return error.InvalidPane;
+        var normalized_buffer: [MaxURL]u8 = undefined;
+        const normalized = try normalizeURL(parsed.value.url, &normalized_buffer);
+        pane.setURL(normalized);
+        pane.setTitle(normalized);
+        self.selected_pane_id = pane.id;
+        return self.writeSnapshot(output);
+    }
+
+    fn writeSnapshot(self: *@This(), output: []u8) ![]const u8 {
+        const contract = ghostty_contract.current();
+        var writer = std.Io.Writer.fixed(output);
+        try writer.writeAll("{\"browserEngine\":\"chromium-cef\",\"terminalEngine\":");
+        try writeJsonString(&writer, contract.terminal_engine);
+        try writer.writeAll(",\"ghostty\":{\"hostPlatform\":");
+        try writeJsonString(&writer, contract.host_platform);
+        try writer.writeAll(",\"surfaceContext\":");
+        try writeJsonString(&writer, contract.surface_context);
+        try writer.writeAll(",\"ioMode\":");
+        try writeJsonString(&writer, contract.io_mode);
+        try writer.writeAll("},\"selectedPaneId\":");
+        try writer.print("{d}", .{self.selected_pane_id});
+        try writer.writeAll(",\"panes\":[");
+        for (self.panes[0..self.pane_count], 0..) |*pane, index| {
+            if (index > 0) try writer.writeByte(',');
+            try writer.writeAll("{\"id\":");
+            try writer.print("{d}", .{pane.id});
+            try writer.writeAll(",\"kind\":");
+            try writeJsonString(&writer, pane.kind.jsonName());
+            try writer.writeAll(",\"host\":");
+            try writeJsonString(&writer, pane.host);
+            try writer.writeAll(",\"title\":");
+            try writeJsonString(&writer, pane.titleSlice());
+            try writer.writeAll(",\"url\":");
+            try writeJsonString(&writer, pane.urlSlice());
+            try writer.writeAll(",\"cwd\":");
+            try writeJsonString(&writer, pane.cwd);
+            try writer.writeByte('}');
+        }
+        try writer.writeAll("]}");
+        return writer.buffered();
+    }
+};
+
+pub fn main(init_value: std.process.Init) !void {
+    ghostty_contract.assertCompileTimeSurfaceContract();
+    var workbench = WorkbenchApp.init();
+    try runner.runWithOptions(workbench.app(), .{
+        .app_name = "cmux Zero Native",
+        .window_title = "cmux Zero Native",
+        .bundle_id = "com.cmux.zero-native",
+        .bridge = workbench.bridge(),
+        .security = .{
+            .navigation = .{ .allowed_origins = &allowed_origins },
+        },
+    }, init_value);
+}
+
+fn normalizeURL(input: []const u8, output: []u8) ![]const u8 {
+    const trimmed = std.mem.trim(u8, input, " \n\r\t");
+    if (trimmed.len == 0) return error.InvalidURL;
+    if (std.mem.startsWith(u8, trimmed, "https://") or
+        std.mem.startsWith(u8, trimmed, "http://") or
+        std.mem.startsWith(u8, trimmed, "file://") or
+        std.mem.startsWith(u8, trimmed, "about:"))
+    {
+        return trimmed;
+    }
+    return std.fmt.bufPrint(output, "https://{s}", .{trimmed});
+}
+
+fn copyBounded(destination: []u8, source: []const u8) usize {
+    const count = @min(destination.len, source.len);
+    @memcpy(destination[0..count], source[0..count]);
+    return count;
+}
+
+fn writeJsonString(writer: anytype, value: []const u8) !void {
+    try writer.writeByte('"');
+    for (value) |ch| {
+        switch (ch) {
+            '"' => try writer.writeAll("\\\""),
+            '\\' => try writer.writeAll("\\\\"),
+            '\n' => try writer.writeAll("\\n"),
+            '\r' => try writer.writeAll("\\r"),
+            '\t' => try writer.writeAll("\\t"),
+            0...8, 11...12, 14...0x1f => try writer.print("\\u{x:0>4}", .{ch}),
+            else => try writer.writeByte(ch),
+        }
+    }
+    try writer.writeByte('"');
+}
+
+test "snapshot declares chromium browser panes and Ghostty terminal host" {
+    var app = WorkbenchApp.init();
+    var dispatcher = app.bridge();
+    var output: [4096]u8 = undefined;
+    const response = dispatcher.dispatch(
+        \\{"id":"1","command":"workbench.snapshot","payload":{}}
+    , .{ .origin = "zero://inline" }, &output);
+
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "chromium-cef") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "ghostty") != null);
+}
+
+test "browser navigation normalizes hostnames" {
+    var app = WorkbenchApp.init();
+    var dispatcher = app.bridge();
+    var output: [4096]u8 = undefined;
+    const response = dispatcher.dispatch(
+        \\{"id":"1","command":"workbench.navigateBrowser","payload":{"paneId":2,"url":"example.com"}}
+    , .{ .origin = "zero://inline" }, &output);
+
+    try std.testing.expect(std.mem.indexOf(u8, response, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "https://example.com") != null);
+}

--- a/experiments/zero-native-cmux/src/main.zig
+++ b/experiments/zero-native-cmux/src/main.zig
@@ -5,124 +5,10 @@ const ghostty_contract = @import("ghostty-contract");
 
 pub const panic = std.debug.FullPanic(zero_native.debug.capturePanic);
 
-const html =
-    \\<!doctype html>
-    \\<html>
-    \\<head>
-    \\  <meta charset="utf-8">
-    \\  <meta name="viewport" content="width=device-width, initial-scale=1">
-    \\  <meta http-equiv="Content-Security-Policy" content="default-src 'self' zero://inline zero://app https: data:; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; frame-src https: http: data:;">
-    \\  <style>
-    \\    :root { color-scheme: light dark; --bg:#f6f7f8; --panel:#ffffff; --ink:#17191c; --muted:#68707a; --line:#d9dde3; --active:#1463ff; --terminal:#101214; --terminal-ink:#e8edf2; }
-    \\    @media (prefers-color-scheme: dark) { :root { --bg:#111316; --panel:#191c20; --ink:#eff2f5; --muted:#99a1ad; --line:#2a3038; --active:#6ba4ff; --terminal:#08090a; --terminal-ink:#dfe7ee; } }
-    \\    * { box-sizing: border-box; }
-    \\    body { margin:0; height:100vh; overflow:hidden; background:var(--bg); color:var(--ink); font:13px -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; letter-spacing:0; }
-    \\    button, input { font:inherit; }
-    \\    .app { height:100vh; display:grid; grid-template-columns:230px 1fr; grid-template-rows:40px 1fr; }
-    \\    .top { grid-column:1 / -1; display:flex; align-items:center; gap:10px; padding:0 12px; border-bottom:1px solid var(--line); background:var(--panel); }
-    \\    .brand { font-weight:650; }
-    \\    .pill { border:1px solid var(--line); border-radius:999px; padding:3px 8px; color:var(--muted); white-space:nowrap; }
-    \\    .spacer { flex:1; }
-    \\    .sidebar { border-right:1px solid var(--line); background:var(--panel); padding:10px; overflow:auto; }
-    \\    .workspace { width:100%; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:9px 10px; text-align:left; }
-    \\    .workspace + .workspace { margin-top:8px; }
-    \\    .main { min-width:0; min-height:0; display:grid; grid-template-rows:38px 1fr; }
-    \\    .tabs { display:flex; gap:6px; align-items:center; padding:6px 8px; border-bottom:1px solid var(--line); background:var(--panel); overflow:auto; }
-    \\    .tab { height:26px; border:1px solid var(--line); border-radius:7px; background:transparent; color:var(--ink); padding:0 10px; display:flex; align-items:center; gap:7px; white-space:nowrap; }
-    \\    .tab.active { border-color:color-mix(in srgb, var(--active) 45%, var(--line)); background:color-mix(in srgb, var(--active) 11%, transparent); }
-    \\    .tool { height:26px; width:30px; border:1px solid var(--line); border-radius:7px; background:transparent; color:var(--ink); }
-    \\    .content { min-width:0; min-height:0; display:grid; grid-template-columns:minmax(360px, 0.95fr) minmax(420px, 1.05fr); gap:1px; background:var(--line); }
-    \\    .pane { min-width:0; min-height:0; background:var(--panel); display:grid; grid-template-rows:34px 1fr; }
-    \\    .pane-head { display:flex; align-items:center; gap:8px; min-width:0; padding:0 8px; border-bottom:1px solid var(--line); }
-    \\    .pane-title { font-weight:600; min-width:0; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
-    \\    .address { flex:1; min-width:80px; height:24px; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:0 8px; }
-    \\    .go { height:24px; border:1px solid var(--line); border-radius:7px; background:var(--bg); color:var(--ink); padding:0 9px; }
-    \\    .terminal { background:var(--terminal); color:var(--terminal-ink); padding:14px; font:12px ui-monospace, SFMono-Regular, Menlo, monospace; overflow:auto; }
-    \\    .terminal .muted { color:#8f9aa5; }
-    \\    iframe { width:100%; height:100%; border:0; background:white; }
-    \\    .empty { display:grid; place-items:center; color:var(--muted); }
-    \\  </style>
-    \\</head>
-    \\<body>
-    \\  <div class="app">
-    \\    <div class="top">
-    \\      <div class="brand">cmux zero</div>
-    \\      <div class="pill" id="browser-engine">browser</div>
-    \\      <div class="pill" id="terminal-engine">terminal</div>
-    \\      <div class="spacer"></div>
-    \\      <button class="tool" id="new-terminal" title="New terminal">+</button>
-    \\      <button class="tool" id="new-browser" title="New browser">B</button>
-    \\    </div>
-    \\    <aside class="sidebar" id="workspaces"></aside>
-    \\    <main class="main">
-    \\      <div class="tabs" id="tabs"></div>
-    \\      <div class="content" id="content"></div>
-    \\    </main>
-    \\  </div>
-    \\  <script>
-    \\    const state = { panes: [], selectedPaneId: 0 };
-    \\    const q = (s) => document.querySelector(s);
-    \\    async function invoke(command, payload = {}) {
-    \\      return await window.zero.invoke(command, payload);
-    \\    }
-    \\    function paneIcon(kind) { return kind === "terminal" ? "T" : "B"; }
-    \\    function browserPane() { return state.panes.find((p) => p.kind === "browser") || state.panes[0]; }
-    \\    function terminalPane() { return state.panes.find((p) => p.kind === "terminal") || state.panes[0]; }
-    \\    function render() {
-    \\      q("#browser-engine").textContent = state.browserEngine;
-    \\      q("#terminal-engine").textContent = state.terminalEngine;
-    \\      q("#workspaces").innerHTML = `<button class="workspace">main<br><span style="color:var(--muted)">${state.panes.length} panes</span></button>`;
-    \\      q("#tabs").innerHTML = state.panes.map((p) => `<button class="tab ${p.id === state.selectedPaneId ? "active" : ""}" data-pane="${p.id}"><span>${paneIcon(p.kind)}</span><span>${p.title}</span></button>`).join("");
-    \\      for (const tab of document.querySelectorAll(".tab")) {
-    \\        tab.onclick = async () => {
-    \\          Object.assign(state, await invoke("workbench.focusPane", { paneId: Number(tab.dataset.pane) }));
-    \\          render();
-    \\        };
-    \\      }
-    \\      const terminal = terminalPane();
-    \\      const browser = browserPane();
-    \\      q("#content").innerHTML = `
-    \\        <section class="pane">
-    \\          <div class="pane-head"><div class="pane-title">${terminal ? terminal.title : "Terminal"}</div><div class="pill">Ghostty</div></div>
-    \\          <div class="terminal" data-native-slot="${terminal ? "ghostty:" + terminal.id : ""}">
-    \\            <div class="muted">$ native-slot ${terminal ? terminal.id : "none"}</div>
-    \\            <div>$ ${terminal ? terminal.cwd : "~"}</div>
-    \\            <div class="muted">surface=${terminal ? terminal.host : "ghostty"} context=split io=exec</div>
-    \\          </div>
-    \\        </section>
-    \\        <section class="pane">
-    \\          <div class="pane-head">
-    \\            <div class="pane-title">${browser ? browser.title : "Browser"}</div>
-    \\            <input class="address" id="address" value="${browser ? browser.url : ""}">
-    \\            <button class="go" id="go">Go</button>
-    \\          </div>
-    \\          ${browser ? `<iframe src="${browser.url}"></iframe>` : `<div class="empty">No browser pane</div>`}
-    \\        </section>`;
-    \\      const go = q("#go");
-    \\      if (go && browser) {
-    \\        go.onclick = async () => {
-    \\          Object.assign(state, await invoke("workbench.navigateBrowser", { paneId: browser.id, url: q("#address").value }));
-    \\          render();
-    \\        };
-    \\      }
-    \\    }
-    \\    async function refresh() {
-    \\      Object.assign(state, await invoke("workbench.snapshot"));
-    \\      render();
-    \\    }
-    \\    q("#new-terminal").onclick = async () => { Object.assign(state, await invoke("workbench.addTerminal")); render(); };
-    \\    q("#new-browser").onclick = async () => { Object.assign(state, await invoke("workbench.addBrowser")); render(); };
-    \\    refresh().catch((error) => {
-    \\      q("#content").innerHTML = `<div class="empty">${error.code || "error"}: ${error.message}</div>`;
-    \\    });
-    \\  </script>
-    \\</body>
-    \\</html>
-;
-
 const MaxPanes = 8;
 const MaxTitle = 80;
 const MaxURL = 512;
+const initial_browser_url = "https://zero-native.dev";
 
 const PaneKind = enum {
     terminal,
@@ -176,7 +62,7 @@ const bridge_policies = [_]zero_native.BridgeCommandPolicy{
     .{ .name = "workbench.navigateBrowser" },
 };
 
-const allowed_origins = [_][]const u8{ "zero://inline", "zero://app" };
+const allowed_origins = [_][]const u8{ "zero://inline", "zero://app", "https://zero-native.dev" };
 
 const WorkbenchApp = struct {
     panes: [MaxPanes]Pane = undefined,
@@ -196,7 +82,7 @@ const WorkbenchApp = struct {
         return .{
             .context = self,
             .name = "zero-cmux",
-            .source = zero_native.WebViewSource.html(html),
+            .source = zero_native.WebViewSource.url(initial_browser_url),
         };
     }
 
@@ -290,7 +176,7 @@ const WorkbenchApp = struct {
     fn writeSnapshot(self: *@This(), output: []u8) ![]const u8 {
         const contract = ghostty_contract.current();
         var writer = std.Io.Writer.fixed(output);
-        try writer.writeAll("{\"browserEngine\":\"chromium-cef\",\"terminalEngine\":");
+        try writer.writeAll("{\"browserEngine\":\"chromium-cef\",\"layoutOwner\":\"appkit-native\",\"terminalEngine\":");
         try writeJsonString(&writer, contract.terminal_engine);
         try writer.writeAll(",\"ghostty\":{\"hostPlatform\":");
         try writeJsonString(&writer, contract.host_platform);
@@ -380,8 +266,17 @@ test "snapshot declares chromium browser panes and Ghostty terminal host" {
     , .{ .origin = "zero://inline" }, &output);
 
     try std.testing.expect(std.mem.indexOf(u8, response, "\"ok\":true") != null);
+    try std.testing.expect(std.mem.indexOf(u8, response, "appkit-native") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "chromium-cef") != null);
     try std.testing.expect(std.mem.indexOf(u8, response, "ghostty") != null);
+}
+
+test "app loads the Chromium browser URL instead of a terminal HTML shell" {
+    var app_state = WorkbenchApp.init();
+    const app_value = app_state.app();
+
+    try std.testing.expectEqual(zero_native.WebViewSourceKind.url, app_value.source.kind);
+    try std.testing.expectEqualStrings(initial_browser_url, app_value.source.bytes);
 }
 
 test "browser navigation normalizes hostnames" {

--- a/experiments/zero-native-cmux/src/runner.zig
+++ b/experiments/zero-native-cmux/src/runner.zig
@@ -59,20 +59,15 @@ fn runMacos(app: zero_native.App, options: RunOptions, init: std.process.Init) !
     );
     defer mac_platform.deinit();
 
-    var trace_sink = StdoutTraceSink{};
     var log_buffers: zero_native.debug.LogPathBuffers = .{};
     const log_setup = zero_native.debug.setupLogging(init.io, init.environ_map, app_info.bundle_id, &log_buffers) catch null;
     if (log_setup) |setup| zero_native.debug.installPanicCapture(init.io, setup.paths);
 
     var file_trace_sink: zero_native.debug.FileTraceSink = undefined;
-    var fanout_sinks: [2]zero_native.trace.Sink = undefined;
-    var fanout_sink: zero_native.debug.FanoutTraceSink = undefined;
-    var runtime_trace_sink = trace_sink.sink();
+    var runtime_trace_sink: ?zero_native.trace.Sink = null;
     if (log_setup) |setup| {
         file_trace_sink = zero_native.debug.FileTraceSink.init(init.io, setup.paths.log_dir, setup.paths.log_file, setup.format);
-        fanout_sinks = .{ trace_sink.sink(), file_trace_sink.sink() };
-        fanout_sink = .{ .sinks = &fanout_sinks };
-        runtime_trace_sink = fanout_sink.sink();
+        runtime_trace_sink = file_trace_sink.sink();
     }
 
     var runtime = zero_native.Runtime.init(.{

--- a/experiments/zero-native-cmux/src/runner.zig
+++ b/experiments/zero-native-cmux/src/runner.zig
@@ -1,0 +1,108 @@
+const std = @import("std");
+const build_options = @import("build_options");
+const zero_native = @import("zero-native");
+
+pub const RunOptions = struct {
+    app_name: []const u8,
+    window_title: []const u8,
+    bundle_id: []const u8,
+    icon_path: []const u8 = "",
+    bridge: ?zero_native.BridgeDispatcher = null,
+    builtin_bridge: zero_native.BridgePolicy = .{},
+    security: zero_native.SecurityPolicy = .{},
+
+    fn appInfo(self: RunOptions) zero_native.AppInfo {
+        return .{
+            .app_name = self.app_name,
+            .window_title = self.window_title,
+            .bundle_id = self.bundle_id,
+            .icon_path = self.icon_path,
+            .main_window = .{
+                .label = "main",
+                .title = self.window_title,
+                .default_frame = zero_native.geometry.RectF.init(0, 0, 1240, 780),
+                .restore_state = true,
+            },
+        };
+    }
+};
+
+pub fn runWithOptions(app: zero_native.App, options: RunOptions, init: std.process.Init) !void {
+    if (comptime std.mem.eql(u8, build_options.platform, "macos")) {
+        try runMacos(app, options, init);
+    } else {
+        try runNull(app, options, init);
+    }
+}
+
+fn runNull(app: zero_native.App, options: RunOptions, init: std.process.Init) !void {
+    const app_info = options.appInfo();
+    var null_platform = zero_native.NullPlatform.initWithOptions(.{}, webEngine(), app_info);
+    var trace_sink = StdoutTraceSink{};
+    var runtime = zero_native.Runtime.init(.{
+        .platform = null_platform.platform(),
+        .trace_sink = trace_sink.sink(),
+        .bridge = options.bridge,
+        .builtin_bridge = options.builtin_bridge,
+        .security = options.security,
+    });
+    _ = init;
+    try runtime.run(app);
+}
+
+fn runMacos(app: zero_native.App, options: RunOptions, init: std.process.Init) !void {
+    const app_info = options.appInfo();
+    var mac_platform = try zero_native.platform.macos.MacPlatform.initWithOptions(
+        zero_native.geometry.SizeF.init(1240, 780),
+        webEngine(),
+        app_info,
+    );
+    defer mac_platform.deinit();
+
+    var trace_sink = StdoutTraceSink{};
+    var log_buffers: zero_native.debug.LogPathBuffers = .{};
+    const log_setup = zero_native.debug.setupLogging(init.io, init.environ_map, app_info.bundle_id, &log_buffers) catch null;
+    if (log_setup) |setup| zero_native.debug.installPanicCapture(init.io, setup.paths);
+
+    var file_trace_sink: zero_native.debug.FileTraceSink = undefined;
+    var fanout_sinks: [2]zero_native.trace.Sink = undefined;
+    var fanout_sink: zero_native.debug.FanoutTraceSink = undefined;
+    var runtime_trace_sink = trace_sink.sink();
+    if (log_setup) |setup| {
+        file_trace_sink = zero_native.debug.FileTraceSink.init(init.io, setup.paths.log_dir, setup.paths.log_file, setup.format);
+        fanout_sinks = .{ trace_sink.sink(), file_trace_sink.sink() };
+        fanout_sink = .{ .sinks = &fanout_sinks };
+        runtime_trace_sink = fanout_sink.sink();
+    }
+
+    var runtime = zero_native.Runtime.init(.{
+        .platform = mac_platform.platform(),
+        .trace_sink = runtime_trace_sink,
+        .log_path = if (log_setup) |setup| setup.paths.log_file else null,
+        .bridge = options.bridge,
+        .builtin_bridge = options.builtin_bridge,
+        .security = options.security,
+    });
+
+    try runtime.run(app);
+}
+
+fn webEngine() zero_native.WebEngine {
+    if (comptime std.mem.eql(u8, build_options.web_engine, "chromium")) return .chromium;
+    return .system;
+}
+
+pub const StdoutTraceSink = struct {
+    pub fn sink(self: *StdoutTraceSink) zero_native.trace.Sink {
+        return .{ .context = self, .write_fn = write };
+    }
+
+    fn write(context: *anyopaque, record: zero_native.trace.Record) zero_native.trace.WriteError!void {
+        _ = context;
+        if (!std.mem.startsWith(u8, record.name, "runtime.") and !std.mem.startsWith(u8, record.name, "bridge.")) return;
+        var buffer: [1024]u8 = undefined;
+        var writer = std.Io.Writer.fixed(&buffer);
+        zero_native.trace.formatText(record, &writer) catch return error.OutOfSpace;
+        std.debug.print("{s}\n", .{writer.buffered()});
+    }
+};


### PR DESCRIPTION
## Summary
- Adds a standalone zero-native cmux prototype under experiments/zero-native-cmux.
- Defaults browser panes to Chromium/CEF and keeps terminal panes tied to the Ghostty C API contract.
- Adds setup/build docs and ignores local zero-native/CEF downloads.

## Testing
- /tmp/zig-0.16/zig build test -Dplatform=null -Dzero-native-path=/tmp/zero-native
- /tmp/zig-0.16/zig build -Dplatform=macos -Dweb-engine=system -Dzero-native-path=/tmp/zero-native
- ./experiments/zero-native-cmux/scripts/setup.sh
- /tmp/zig-0.16/zig build -Dplatform=macos -Dweb-engine=chromium -Dzero-native-path=third_party/zero-native
- ./scripts/reload.sh --tag zchrome

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Scoped to `experiments/zero-native-cmux`, but introduces substantial native build/packaging logic plus a large patch to `zero-native`’s CEF macOS host, which could be brittle to upstream changes and tricky to debug on macOS.
> 
> **Overview**
> Adds a new standalone experiment, `experiments/zero-native-cmux`, that prototypes a cmux-style workbench using `vercel-labs/zero-native` with a **native AppKit split**: a Ghostty `NSView` terminal surface alongside a Chromium/CEF browser pane.
> 
> Includes Zig build tooling and scripts to fetch/patch `zero-native`, install CEF, copy required CEF runtime bits for local runs, and package a clickable macOS `.app` with CEF helper apps. The included `zero-native` patch adds multi-browser key routing, embedded + pop-out DevTools via remote debugging, and Ghostty surface/config loading to support the native split UI.
> 
> Updates `.gitignore` to ignore the experiment’s downloaded `third_party` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8294abd249b9cb7b5e0ca27ea9c26dc50872b74c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a standalone cmux prototype on `vercel-labs/zero-native` with a native AppKit workbench (Ghostty terminal beside a Chromium/CEF browser). Also fixes Chromium rendering and viewport clipping in a packaged macOS `.app`, switches pop‑out DevTools to native CEF windows, and fixes the internal DevTools screencast.

- **New Features**
  - Prototype under `experiments/zero-native-cmux` with an AppKit split view: Ghostty `NSView` terminal next to a CEF browser; workspace rail, per-workspace tabs, persistent surfaces, simple browser chrome and URL normalization, `zero://inline`, and docked/native pop‑out DevTools.
  - JS bridge commands: `workbench.snapshot`, `workbench.addTerminal`, `workbench.addBrowser`, `workbench.focusPane`, `workbench.navigateBrowser`.
  - Build/run/packaging: Zig tooling, `scripts/setup.sh` to fetch/patch `zero-native` and CEF, and `scripts/package-app.sh` to produce a clickable `.app` with bundled CEF and ad‑hoc signing.

- **Bug Fixes**
  - Chromium DevTools now work reliably via CEF remote debugging (port 9233), with automatic target selection, proper split-pane resizing, and native CEF pop‑out windows.
  - Fixed the internal DevTools screencast so the docked DevTools shows a live, correctly sized page preview.
  - Fixed Chromium rendering in a macOS `.app` bundle and browser viewport clipping in split view by bundling required CEF frameworks, adjusting launch configuration, and correcting view insets.

<sup>Written for commit 8294abd249b9cb7b5e0ca27ea9c26dc50872b74c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Experimental zero-native cmux workbench: native terminal pane beside a browser pane, address field, navigation controls, URL normalization, integrated DevTools (inline and pop-out), and macOS-native window behavior.
  * Build/run support for macOS including optional Chromium engine handling and runtime CEF provisioning.

* **Documentation**
  * Added README with setup, build, run and test instructions for the prototype.

* **Chores**
  * Updated ignore rules to skip local tmp/ and experiment third-party artifacts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3774)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->