### PR TITLE
Fix duplicate browser pane drop zone overlay

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -539,13 +539,22 @@ final class WindowBrowserHostView: NSView {
             return nil
         }
         // Mirror terminal portal routing: while tab-reorder drags are active,
-        // pass through to SwiftUI drop targets behind the portal host.
+        // prefer pane-local drop targets owned by the portal slot. Fall through
+        // to SwiftUI targets only when the browser pane itself is not the target.
         // Browser hover routing also arrives as cursor/enter events and may not
         // report a pressed-button state, so include that path here.
+        let dragPasteboardTypes = NSPasteboard(name: .drag).types
         if Self.shouldPassThroughToDragTargets(
-            pasteboardTypes: NSPasteboard(name: .drag).types,
+            pasteboardTypes: dragPasteboardTypes,
             eventType: eventType
         ) {
+            if let paneDropTarget = paneDropTargetForDrag(
+                at: point,
+                pasteboardTypes: dragPasteboardTypes,
+                eventType: eventType
+            ) {
+                return paneDropTarget
+            }
             return nil
         }
 
@@ -587,6 +596,32 @@ final class WindowBrowserHostView: NSView {
         )
 #endif
         return hitView === self ? nil : hitView
+    }
+
+    private func paneDropTargetForDrag(
+        at point: NSPoint,
+        pasteboardTypes: [NSPasteboard.PasteboardType]?,
+        eventType: NSEvent.EventType?
+    ) -> BrowserPaneDropTargetView? {
+        guard BrowserPaneDropTargetView.shouldCaptureHitTesting(
+            pasteboardTypes: pasteboardTypes,
+            eventType: eventType
+        ) else {
+            return nil
+        }
+
+        for slot in subviews.reversed() {
+            guard let slot = slot as? WindowBrowserSlotView,
+                  !slot.isHidden,
+                  slot.alphaValue > 0,
+                  slot.frame.contains(point) else { continue }
+            let pointInSlot = slot.convert(point, from: self)
+            if let target = slot.paneDropTargetForDrop(at: pointInSlot) {
+                return target
+            }
+        }
+
+        return nil
     }
 
     override func mouseDown(with event: NSEvent) {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -610,6 +610,10 @@ final class WindowBrowserHostView: NSView {
             return nil
         }
 
+        return browserPaneDropTarget(at: point)
+    }
+
+    func browserPaneDropTarget(at point: NSPoint) -> BrowserPaneDropTargetView? {
         for slot in subviews.reversed() {
             guard let slot = slot as? WindowBrowserSlotView,
                   !slot.isHidden,
@@ -3831,14 +3835,7 @@ final class WindowBrowserPortal: NSObject {
     func browserPaneDropTargetAtWindowPoint(_ windowPoint: NSPoint) -> BrowserPaneDropTargetView? {
         guard ensureInstalled() else { return nil }
         let point = hostView.convert(windowPoint, from: nil)
-        for subview in hostView.subviews.reversed() {
-            guard let container = subview as? WindowBrowserSlotView else { continue }
-            guard !container.isHidden else { continue }
-            guard container.frame.contains(point) else { continue }
-            let pointInContainer = container.convert(point, from: hostView)
-            return container.paneDropTargetForDrop(at: pointInContainer)
-        }
-        return nil
+        return hostView.browserPaneDropTarget(at: point)
     }
 }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -468,11 +468,15 @@ final class WindowBrowserHostView: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
+        performHitTest(at: point, currentEvent: NSApp.currentEvent)
+    }
+
+    func performHitTest(at point: NSPoint, currentEvent: NSEvent?) -> NSView? {
         let dividerHit = splitDividerHit(at: point)
         let hostedInspectorHit = dividerHit == nil ? hostedInspectorDividerHit(at: point) : nil
         updateDividerCursor(at: point, dividerHit: dividerHit, hostedInspectorHit: hostedInspectorHit)
 
-        let eventType = NSApp.currentEvent?.type
+        let eventType = currentEvent?.type
         let titlebarPassThrough = shouldPassThroughToTitlebar(at: point)
         let tabStripPassThrough = shouldPassThroughToPaneTabBar(at: point, eventType: eventType)
         let sidebarPassThrough = shouldPassThroughToSidebarResizer(
@@ -540,7 +544,7 @@ final class WindowBrowserHostView: NSView {
         // report a pressed-button state, so include that path here.
         if Self.shouldPassThroughToDragTargets(
             pasteboardTypes: NSPasteboard(name: .drag).types,
-            eventType: NSApp.currentEvent?.type
+            eventType: eventType
         ) {
             return nil
         }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1455,6 +1455,9 @@ enum BrowserPaneDropRouting {
 }
 
 final class WindowBrowserSlotView: NSView {
+    private static let dropZoneOverlayFadeInAnimationKey = "cmux.browser.dropZoneOverlay.fadeIn"
+    private static let dropZoneOverlayFadeInDuration: CFTimeInterval = 0.25
+
     override var isOpaque: Bool { false }
     override var isHidden: Bool {
         didSet {
@@ -1875,14 +1878,10 @@ final class WindowBrowserSlotView: NSView {
 
         if dropZoneOverlayView.isHidden {
             applyDropZoneOverlayFrame(targetFrame)
-            dropZoneOverlayView.alphaValue = 0
+            dropZoneOverlayView.alphaValue = 1
             dropZoneOverlayView.isHidden = false
             bringInteractionLayersToFrontIfNeeded()
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = 0.18
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                dropZoneOverlayView.animator().alphaValue = 1
-            }
+            animateDropZoneOverlayFadeIn()
             return
         }
 
@@ -1897,6 +1896,30 @@ final class WindowBrowserSlotView: NSView {
                 dropZoneOverlayView.animator().alphaValue = 1
             }
         }
+    }
+
+    private func animateDropZoneOverlayFadeIn() {
+        guard let layer = dropZoneOverlayView.layer else {
+            dropZoneOverlayView.alphaValue = 0
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = Self.dropZoneOverlayFadeInDuration
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                dropZoneOverlayView.animator().alphaValue = 1
+            }
+            return
+        }
+
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        layer.opacity = 1
+        CATransaction.commit()
+
+        let animation = CABasicAnimation(keyPath: "opacity")
+        animation.fromValue = 0.0
+        animation.toValue = 1.0
+        animation.duration = Self.dropZoneOverlayFadeInDuration
+        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        layer.add(animation, forKey: Self.dropZoneOverlayFadeInAnimationKey)
     }
 
     private func interactionLayerPriority(of view: NSView) -> Int {

--- a/cmuxTests/BrowserPaneDropRoutingTests.swift
+++ b/cmuxTests/BrowserPaneDropRoutingTests.swift
@@ -255,6 +255,54 @@ final class BrowserPaneDropRoutingTests: XCTestCase {
         XCTAssertTrue(syntheticTransfer.isFilePreview)
     }
 
+    func testBrowserPortalRoutesTabTransferDragToPaneDropTargetBeforeSwiftUIDropLayer() throws {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        let host = WindowBrowserHostView(frame: window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 360, height: 240))
+        host.autoresizingMask = [.width, .height]
+        window.contentView = host
+
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
+        host.addSubview(slot)
+        slot.setPaneDropContext(BrowserPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        slot.layoutSubtreeIfNeeded()
+
+        let dragPasteboard = NSPasteboard(name: .drag)
+        dragPasteboard.clearContents()
+        dragPasteboard.setString("{}", forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
+        defer { dragPasteboard.clearContents() }
+
+        let pointInHost = NSPoint(x: slot.frame.midX, y: slot.frame.midY)
+        let dragEvent = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDragged,
+            location: host.convert(pointInHost, to: nil),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let hitView = host.performHitTest(at: pointInHost, currentEvent: dragEvent)
+        let expectedTarget = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
+
+        XCTAssertTrue(hitView === expectedTarget)
+    }
+
     func testBrowserPaneFileDropDefaultUsesHostedWebViewLifecycle() throws {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2007,6 +2007,12 @@ final class WindowBrowserSlotViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.25))
     }
 
+    private func opacityAnimation(in view: NSView) -> CABasicAnimation? {
+        view.layer?.animationKeys()?
+            .compactMap { view.layer?.animation(forKey: $0) as? CABasicAnimation }
+            .first { $0.keyPath == "opacity" }
+    }
+
     func testDropZoneOverlayStaysAboveContentWithoutBlockingHits() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
         let slot = WindowBrowserSlotView(frame: container.bounds)
@@ -2037,6 +2043,30 @@ final class WindowBrowserSlotViewTests: XCTestCase {
         slot.setDropZoneOverlay(zone: nil)
         advanceAnimations()
         XCTAssertTrue(overlay.isHidden, "Clearing the drop zone should hide the overlay")
+    }
+
+    func testDropZoneOverlayFadesInWhenShown() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
+        let slot = WindowBrowserSlotView(frame: container.bounds)
+        container.addSubview(slot)
+
+        slot.setDropZoneOverlay(zone: .left)
+        container.layoutSubtreeIfNeeded()
+
+        guard let overlay = container.subviews.first(where: {
+            $0 !== slot && String(describing: type(of: $0)).contains("BrowserDropZoneOverlayView")
+        }) else {
+            XCTFail("Expected browser slot drop-zone overlay")
+            return
+        }
+
+        guard let animation = opacityAnimation(in: overlay) else {
+            XCTFail("Showing the portal drop overlay should install an opacity animation")
+            return
+        }
+        XCTAssertEqual((animation.fromValue as? NSNumber)?.doubleValue ?? -1, 0, accuracy: 0.001)
+        XCTAssertEqual((animation.toValue as? NSNumber)?.doubleValue ?? -1, 1, accuracy: 0.001)
+        XCTAssertGreaterThanOrEqual(animation.duration, 0.2)
     }
 
     func testTopDropZoneOverlayUsesFullBrowserContentHeight() {


### PR DESCRIPTION
## Summary
- Keep Bonsplit as the single tab-drag lifecycle owner, but suppress Bonsplit's inline drop placeholder for portal-hosted tab kinds.
- Add `portalDropOverlayTabKinds` to Bonsplit configuration, defaulting to `terminal` and `browser`, so terminal/browser content can draw the drop overlay from `paneDropZone` above AppKit portals.
- Restore the portal-owned overlay fade-in with an explicit layer opacity animation now that the portal is the only renderer.
- Keep browser portal drag-target routing coverage for the AppKit path.

## Dogfood evidence
- `/tmp/cmux-debug-bdroptrace.log` showed the real duplicate owner split: `pane.dropEntered zone=left`, `browser.dropTrace.portalUpdate old=none new=left`, and `browser.dropTrace.slot event=overlay.show displayed=left` for the same hover.
- No `browser.dropTrace.paneTarget` owned the reproduced hover, so the previous hit-test-only fix did not address the active path.
- After `bdropown`, dogfood reported the duplicate was gone but the visible fade-in was gone, because the old SwiftUI placeholder had been the animated renderer.
- Bonsplit PR: https://github.com/manaflow-ai/bonsplit/pull/117
- Bonsplit submodule commit: https://github.com/manaflow-ai/bonsplit/commit/5b38ac9a049ce1b6216c041d7ac8316958c45781
- Temporary debug lines removed: yes.

## Testing
- `swift test` in `vendor/bonsplit`, 114 tests passed.
- `xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-bdropfade-unit -only-testing:cmuxTests/WindowBrowserSlotViewTests/testDropZoneOverlayFadesInWhenShown` passed.
- `./scripts/reload.sh --tag bdropfade` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AppKit `hitTest` routing for browser portals during drag sessions and rewrites the drop-zone overlay fade-in animation, which could affect drag-and-drop behavior and pointer event handling in browser panes.
> 
> **Overview**
> Fixes browser portal drag routing so tab-transfer drags hit the pane-local `BrowserPaneDropTargetView` first and only fall through to underlying SwiftUI drop targets when the pane itself isn’t the target.
> 
> Restores/standardizes the browser pane drop-zone overlay fade-in by switching to an explicit layer opacity animation (with shared duration/key), and updates portal APIs to reuse the same pane drop-target lookup. Adds unit coverage for both the drag hit-testing priority and the overlay opacity animation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 852a3aa0802d9a36e4a9abee1effd9003a00e799. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved drag-and-drop routing to prioritize pane-local drop targets before falling back to other handlers.
  * Refined drop-zone overlay fade-in with consistent timing and a reliable fallback.

* **Tests**
  * Added a UI routing test verifying tab-transfer drag reaches pane-local drop targets first.
  * Added an animation test validating drop-zone overlay fade-in behaviour.

* **Chores**
  * Updated bundled vendor dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->