### PR TITLE
Add mobile terminal snapshot core

### DIFF
--- a/Packages/CMUXMobileSyncCore/Package.swift
+++ b/Packages/CMUXMobileSyncCore/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.1
+
+import PackageDescription
+
+let package = Package(
+    name: "CMUXMobileSyncCore",
+    platforms: [
+        .iOS(.v17),
+        .macOS(.v10_13),
+    ],
+    products: [
+        .library(
+            name: "CMUXMobileSyncCore",
+            targets: ["CMUXMobileSyncCore"]
+        ),
+    ],
+    targets: [
+        .target(name: "CMUXMobileSyncCore"),
+        .testTarget(
+            name: "CMUXMobileSyncCoreTests",
+            dependencies: ["CMUXMobileSyncCore"]
+        ),
+    ]
+)

--- a/Packages/CMUXMobileSyncCore/Sources/CMUXMobileSyncCore/MobileTerminalGhosttySnapshot.swift
+++ b/Packages/CMUXMobileSyncCore/Sources/CMUXMobileSyncCore/MobileTerminalGhosttySnapshot.swift
@@ -1,0 +1,348 @@
+import Foundation
+
+public struct MobileTerminalGridSize: Codable, Equatable, Sendable {
+    public var columns: Int
+    public var rows: Int
+
+    public init(columns: Int, rows: Int) throws {
+        guard columns > 0, rows > 0 else {
+            throw MobileTerminalGhosttySnapshotError.invalidGridSize
+        }
+        self.columns = columns
+        self.rows = rows
+    }
+}
+
+public enum MobileTerminalGhosttyScreen: String, Codable, Equatable, Sendable {
+    case primary
+    case alternate
+}
+
+public struct MobileTerminalGhosttyColor: Codable, Equatable, Sendable {
+    public var red: UInt8
+    public var green: UInt8
+    public var blue: UInt8
+
+    public init(red: UInt8, green: UInt8, blue: UInt8) {
+        self.red = red
+        self.green = green
+        self.blue = blue
+    }
+}
+
+public enum MobileTerminalGhosttyUnderline: String, Codable, Equatable, Sendable {
+    case none
+    case single
+    case double
+    case curly
+    case dotted
+    case dashed
+}
+
+public enum MobileTerminalGhosttyCellWidth: String, Codable, Equatable, Sendable {
+    case narrow
+    case wide
+    case spacerTail
+    case spacerHead
+}
+
+public struct MobileTerminalGhosttyCellStyle: Codable, Equatable, Sendable {
+    public var foreground: MobileTerminalGhosttyColor?
+    public var background: MobileTerminalGhosttyColor?
+    public var bold: Bool
+    public var italic: Bool
+    public var dim: Bool
+    public var inverse: Bool
+    public var underline: MobileTerminalGhosttyUnderline
+
+    public init(
+        foreground: MobileTerminalGhosttyColor? = nil,
+        background: MobileTerminalGhosttyColor? = nil,
+        bold: Bool = false,
+        italic: Bool = false,
+        dim: Bool = false,
+        inverse: Bool = false,
+        underline: MobileTerminalGhosttyUnderline = .none
+    ) {
+        self.foreground = foreground
+        self.background = background
+        self.bold = bold
+        self.italic = italic
+        self.dim = dim
+        self.inverse = inverse
+        self.underline = underline
+    }
+}
+
+public struct MobileTerminalGhosttyCell: Codable, Equatable, Sendable {
+    public var text: String
+    public var width: MobileTerminalGhosttyCellWidth
+    public var style: MobileTerminalGhosttyCellStyle
+    public var hyperlinkURI: String?
+
+    public init(
+        text: String = "",
+        width: MobileTerminalGhosttyCellWidth = .narrow,
+        style: MobileTerminalGhosttyCellStyle = MobileTerminalGhosttyCellStyle(),
+        hyperlinkURI: String? = nil
+    ) {
+        self.text = text
+        self.width = width
+        self.style = style
+        self.hyperlinkURI = hyperlinkURI
+    }
+
+    public static let blank = MobileTerminalGhosttyCell()
+}
+
+public struct MobileTerminalGhosttyRow: Codable, Equatable, Sendable {
+    public var cells: [MobileTerminalGhosttyCell]
+    public var isWrapped: Bool
+
+    public init(cells: [MobileTerminalGhosttyCell], isWrapped: Bool = false) {
+        self.cells = cells
+        self.isWrapped = isWrapped
+    }
+
+    public var plainText: String {
+        cells.map { cell in
+            switch cell.width {
+            case .spacerHead, .spacerTail:
+                return ""
+            case .narrow, .wide:
+                return cell.text.isEmpty ? " " : cell.text
+            }
+        }
+        .joined()
+    }
+
+    public var trimmedPlainText: String {
+        plainText.trimmingTerminalPadding()
+    }
+}
+
+public struct MobileTerminalGhosttyCursor: Codable, Equatable, Sendable {
+    public enum Style: String, Codable, Equatable, Sendable {
+        case block
+        case hollowBlock
+        case bar
+        case underline
+    }
+
+    public var column: Int
+    public var row: Int
+    public var isVisible: Bool
+    public var style: Style
+
+    public init(
+        column: Int,
+        row: Int,
+        isVisible: Bool = true,
+        style: Style = .block
+    ) {
+        self.column = column
+        self.row = row
+        self.isVisible = isVisible
+        self.style = style
+    }
+}
+
+private extension String {
+    func trimmingTerminalPadding() -> String {
+        var result = self
+        while result.last == " " || result.last == "\t" {
+            result.removeLast()
+        }
+        return result
+    }
+}
+
+public struct MobileTerminalGhosttyModes: Codable, Equatable, Sendable {
+    public var bracketedPaste: Bool
+    public var applicationCursorKeys: Bool
+    public var applicationKeypad: Bool
+    public var mouseTracking: Bool
+    public var cursorVisible: Bool
+
+    public init(
+        bracketedPaste: Bool = false,
+        applicationCursorKeys: Bool = false,
+        applicationKeypad: Bool = false,
+        mouseTracking: Bool = false,
+        cursorVisible: Bool = true
+    ) {
+        self.bracketedPaste = bracketedPaste
+        self.applicationCursorKeys = applicationCursorKeys
+        self.applicationKeypad = applicationKeypad
+        self.mouseTracking = mouseTracking
+        self.cursorVisible = cursorVisible
+    }
+}
+
+public struct MobileTerminalGhosttySnapshot: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public var schemaVersion: Int
+    public var terminalID: String
+    public var gridSize: MobileTerminalGridSize
+    public var activeScreen: MobileTerminalGhosttyScreen
+    public var scrollbackRows: [MobileTerminalGhosttyRow]
+    public var visibleRows: [MobileTerminalGhosttyRow]
+    public var cursor: MobileTerminalGhosttyCursor
+    public var modes: MobileTerminalGhosttyModes
+    public var streamOffset: UInt64
+    public var generatedAt: Date
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        terminalID: String,
+        gridSize: MobileTerminalGridSize,
+        activeScreen: MobileTerminalGhosttyScreen,
+        scrollbackRows: [MobileTerminalGhosttyRow],
+        visibleRows: [MobileTerminalGhosttyRow],
+        cursor: MobileTerminalGhosttyCursor,
+        modes: MobileTerminalGhosttyModes,
+        streamOffset: UInt64,
+        generatedAt: Date = Date()
+    ) throws {
+        self.schemaVersion = schemaVersion
+        self.terminalID = terminalID
+        self.gridSize = gridSize
+        self.activeScreen = activeScreen
+        self.scrollbackRows = scrollbackRows
+        self.visibleRows = visibleRows
+        self.cursor = cursor
+        self.modes = modes
+        self.streamOffset = streamOffset
+        self.generatedAt = generatedAt
+        try validate()
+    }
+
+    public func validate() throws {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw MobileTerminalGhosttySnapshotError.unsupportedSchemaVersion(schemaVersion)
+        }
+        guard gridSize.columns > 0, gridSize.rows > 0 else {
+            throw MobileTerminalGhosttySnapshotError.invalidGridSize
+        }
+        guard visibleRows.count == gridSize.rows else {
+            throw MobileTerminalGhosttySnapshotError.invalidVisibleRowCount(
+                expected: gridSize.rows,
+                actual: visibleRows.count
+            )
+        }
+        try validateRows(scrollbackRows, kind: .scrollback)
+        try validateRows(visibleRows, kind: .visible)
+        guard (0..<gridSize.columns).contains(cursor.column),
+              (0..<gridSize.rows).contains(cursor.row) else {
+            throw MobileTerminalGhosttySnapshotError.cursorOutOfBounds
+        }
+    }
+
+    public func encodedValidatedJSON() throws -> Data {
+        try validate()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return try encoder.encode(self)
+    }
+
+    public static func decodeValidatedJSON(_ data: Data) throws -> MobileTerminalGhosttySnapshot {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let snapshot = try decoder.decode(MobileTerminalGhosttySnapshot.self, from: data)
+        try snapshot.validate()
+        return snapshot
+    }
+
+    public var renderedVisibleLines: [String] {
+        visibleRows.map(\.trimmedPlainText)
+    }
+
+    public static func fixture(
+        terminalID: String,
+        columns: Int = 32,
+        rows: Int = 6,
+        scrollbackLines: [String] = [],
+        visibleLines: [String],
+        activeScreen: MobileTerminalGhosttyScreen = .primary,
+        modes: MobileTerminalGhosttyModes = MobileTerminalGhosttyModes(),
+        cursor: MobileTerminalGhosttyCursor? = nil,
+        streamOffset: UInt64 = 0,
+        generatedAt: Date = Date(timeIntervalSince1970: 0)
+    ) throws -> MobileTerminalGhosttySnapshot {
+        let gridSize = try MobileTerminalGridSize(columns: columns, rows: rows)
+        let visible = paddedRows(lines: visibleLines, columns: columns, rows: rows)
+        let resolvedCursor = cursor ?? MobileTerminalGhosttyCursor(
+            column: min(columns - 1, visibleLines.last?.count ?? 0),
+            row: max(0, min(rows - 1, visibleLines.count - 1)),
+            isVisible: modes.cursorVisible
+        )
+        return try MobileTerminalGhosttySnapshot(
+            terminalID: terminalID,
+            gridSize: gridSize,
+            activeScreen: activeScreen,
+            scrollbackRows: scrollbackLines.map { row(from: $0, columns: columns) },
+            visibleRows: visible,
+            cursor: resolvedCursor,
+            modes: modes,
+            streamOffset: streamOffset,
+            generatedAt: generatedAt
+        )
+    }
+
+    private enum RowKind {
+        case scrollback
+        case visible
+    }
+
+    private func validateRows(_ rows: [MobileTerminalGhosttyRow], kind: RowKind) throws {
+        for (index, row) in rows.enumerated() where row.cells.count != gridSize.columns {
+            switch kind {
+            case .scrollback:
+                throw MobileTerminalGhosttySnapshotError.invalidScrollbackRowWidth(
+                    row: index,
+                    expected: gridSize.columns,
+                    actual: row.cells.count
+                )
+            case .visible:
+                throw MobileTerminalGhosttySnapshotError.invalidVisibleRowWidth(
+                    row: index,
+                    expected: gridSize.columns,
+                    actual: row.cells.count
+                )
+            }
+        }
+    }
+
+    private static func paddedRows(
+        lines: [String],
+        columns: Int,
+        rows: Int
+    ) -> [MobileTerminalGhosttyRow] {
+        var padded = lines.prefix(rows).map { row(from: $0, columns: columns) }
+        while padded.count < rows {
+            padded.append(row(from: "", columns: columns))
+        }
+        return padded
+    }
+
+    private static func row(from line: String, columns: Int) -> MobileTerminalGhosttyRow {
+        var cells = Array(line).prefix(columns).map { character in
+            MobileTerminalGhosttyCell(text: String(character))
+        }
+        while cells.count < columns {
+            cells.append(.blank)
+        }
+        return MobileTerminalGhosttyRow(cells: cells)
+    }
+}
+
+public enum MobileTerminalGhosttySnapshotError: Error, Equatable, Sendable {
+    case unsupportedSchemaVersion(Int)
+    case invalidGridSize
+    case invalidVisibleRowCount(expected: Int, actual: Int)
+    case invalidVisibleRowWidth(row: Int, expected: Int, actual: Int)
+    case invalidScrollbackRowWidth(row: Int, expected: Int, actual: Int)
+    case cursorOutOfBounds
+}

--- a/Packages/CMUXMobileSyncCore/Tests/CMUXMobileSyncCoreTests/MobileTerminalGhosttySnapshotTests.swift
+++ b/Packages/CMUXMobileSyncCore/Tests/CMUXMobileSyncCoreTests/MobileTerminalGhosttySnapshotTests.swift
@@ -1,0 +1,162 @@
+import Foundation
+import Testing
+@testable import CMUXMobileSyncCore
+
+@Test func snapshotRoundTripsNormalScreenWithScrollback() throws {
+    let snapshot = try MobileTerminalGhosttySnapshot.fixture(
+        terminalID: "terminal-build",
+        columns: 24,
+        rows: 4,
+        scrollbackLines: [
+            "$ swift test",
+            "Test Suite passed",
+        ],
+        visibleLines: [
+            "$ cmux ios status",
+            "Mobile Sync: enabled",
+            "Listener: stopped",
+            "Tailscale: available",
+        ],
+        streamOffset: 42
+    )
+
+    let encoded = try snapshot.encodedValidatedJSON()
+    let decoded = try MobileTerminalGhosttySnapshot.decodeValidatedJSON(encoded)
+
+    #expect(decoded == snapshot)
+    #expect(decoded.scrollbackRows.count == 2)
+    #expect(decoded.renderedVisibleLines == [
+        "$ cmux ios status",
+        "Mobile Sync: enabled",
+        "Listener: stopped",
+        "Tailscale: available",
+    ])
+    #expect(decoded.streamOffset == 42)
+}
+
+@Test func snapshotPreservesAlternateScreenTUIState() throws {
+    let modes = MobileTerminalGhosttyModes(
+        bracketedPaste: true,
+        applicationCursorKeys: true,
+        applicationKeypad: true,
+        mouseTracking: true,
+        cursorVisible: false
+    )
+    let snapshot = try MobileTerminalGhosttySnapshot.fixture(
+        terminalID: "terminal-tui",
+        columns: 20,
+        rows: 3,
+        visibleLines: [
+            "LAZYGIT",
+            "files branches log",
+            "q quit",
+        ],
+        activeScreen: .alternate,
+        modes: modes,
+        cursor: MobileTerminalGhosttyCursor(column: 2, row: 1, isVisible: false, style: .bar),
+        streamOffset: 9001
+    )
+
+    #expect(snapshot.activeScreen == .alternate)
+    #expect(snapshot.modes == modes)
+    #expect(snapshot.cursor == MobileTerminalGhosttyCursor(column: 2, row: 1, isVisible: false, style: .bar))
+    #expect(snapshot.renderedVisibleLines[0] == "LAZYGIT")
+    #expect(snapshot.streamOffset == 9001)
+}
+
+@Test func renderedLinesPreserveLeadingWhitespace() throws {
+    let snapshot = try MobileTerminalGhosttySnapshot.fixture(
+        terminalID: "terminal-indented",
+        columns: 16,
+        rows: 2,
+        visibleLines: [
+            "  indented",
+            "    nested",
+        ]
+    )
+
+    #expect(snapshot.renderedVisibleLines == [
+        "  indented",
+        "    nested",
+    ])
+}
+
+@Test func snapshotPreservesStyledCellsAndLinks() throws {
+    var cells = Array(repeating: MobileTerminalGhosttyCell.blank, count: 8)
+    cells[0] = MobileTerminalGhosttyCell(
+        text: "c",
+        style: MobileTerminalGhosttyCellStyle(
+            foreground: MobileTerminalGhosttyColor(red: 72, green: 199, blue: 142),
+            background: MobileTerminalGhosttyColor(red: 16, green: 24, blue: 32),
+            bold: true,
+            underline: .single
+        ),
+        hyperlinkURI: "https://cmux.dev"
+    )
+    cells[1] = MobileTerminalGhosttyCell(text: "m", style: cells[0].style)
+    cells[2] = MobileTerminalGhosttyCell(text: "u", style: cells[0].style)
+    cells[3] = MobileTerminalGhosttyCell(text: "x", style: cells[0].style)
+    let styledRow = MobileTerminalGhosttyRow(cells: cells)
+    let blankRow = MobileTerminalGhosttyRow(cells: Array(repeating: .blank, count: 8))
+    let snapshot = try MobileTerminalGhosttySnapshot(
+        terminalID: "terminal-styled",
+        gridSize: try MobileTerminalGridSize(columns: 8, rows: 2),
+        activeScreen: .primary,
+        scrollbackRows: [],
+        visibleRows: [styledRow, blankRow],
+        cursor: MobileTerminalGhosttyCursor(column: 4, row: 0),
+        modes: MobileTerminalGhosttyModes(),
+        streamOffset: 10,
+        generatedAt: Date(timeIntervalSince1970: 0)
+    )
+
+    let decoded = try MobileTerminalGhosttySnapshot.decodeValidatedJSON(
+        try snapshot.encodedValidatedJSON()
+    )
+
+    #expect(decoded.visibleRows[0].cells[0].style.bold)
+    #expect(decoded.visibleRows[0].cells[0].style.foreground == MobileTerminalGhosttyColor(red: 72, green: 199, blue: 142))
+    #expect(decoded.visibleRows[0].cells[0].hyperlinkURI == "https://cmux.dev")
+    #expect(decoded.visibleRows[0].trimmedPlainText == "cmux")
+}
+
+@Test func decodeRejectsIncompatibleSnapshotVersion() throws {
+    let snapshot = try MobileTerminalGhosttySnapshot.fixture(
+        terminalID: "terminal-old",
+        columns: 10,
+        rows: 1,
+        visibleLines: ["old"]
+    )
+    var object = try JSONSerialization.jsonObject(with: try snapshot.encodedValidatedJSON()) as! [String: Any]
+    object["schemaVersion"] = 999
+    let data = try JSONSerialization.data(withJSONObject: object)
+
+    #expect(throws: MobileTerminalGhosttySnapshotError.unsupportedSchemaVersion(999)) {
+        try MobileTerminalGhosttySnapshot.decodeValidatedJSON(data)
+    }
+}
+
+@Test func validationRejectsMalformedRowsAndCursor() throws {
+    #expect(throws: MobileTerminalGhosttySnapshotError.invalidVisibleRowCount(expected: 2, actual: 1)) {
+        _ = try MobileTerminalGhosttySnapshot(
+            terminalID: "terminal-short",
+            gridSize: try MobileTerminalGridSize(columns: 4, rows: 2),
+            activeScreen: .primary,
+            scrollbackRows: [],
+            visibleRows: [MobileTerminalGhosttyRow(cells: Array(repeating: .blank, count: 4))],
+            cursor: MobileTerminalGhosttyCursor(column: 0, row: 0),
+            modes: MobileTerminalGhosttyModes(),
+            streamOffset: 0
+        )
+    }
+
+    #expect(throws: MobileTerminalGhosttySnapshotError.cursorOutOfBounds) {
+        _ = try MobileTerminalGhosttySnapshot.fixture(
+            terminalID: "terminal-cursor",
+            columns: 4,
+            rows: 2,
+            visibleLines: ["ok"],
+            cursor: MobileTerminalGhosttyCursor(column: 4, row: 0)
+        )
+    }
+}

--- a/ios/cmuxMobilePackage/Package.swift
+++ b/ios/cmuxMobilePackage/Package.swift
@@ -12,14 +12,19 @@ let package = Package(
             targets: ["cmuxMobileFeature"]
         ),
     ],
+    dependencies: [
+        .package(path: "../../Packages/CMUXMobileSyncCore"),
+    ],
     targets: [
         .target(
-            name: "cmuxMobileFeature"
+            name: "cmuxMobileFeature",
+            dependencies: ["CMUXMobileSyncCore"]
         ),
         .testTarget(
             name: "cmuxMobileFeatureTests",
             dependencies: [
-                "cmuxMobileFeature"
+                "cmuxMobileFeature",
+                "CMUXMobileSyncCore",
             ]
         ),
     ]

--- a/ios/cmuxMobilePackage/Sources/cmuxMobileFeature/CMUXMobileFeature.swift
+++ b/ios/cmuxMobilePackage/Sources/cmuxMobileFeature/CMUXMobileFeature.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CMUXMobileSyncCore
 import Observation
 import SwiftUI
 
@@ -305,15 +306,20 @@ struct TerminalPreviewSurface: View {
     let terminal: MobileTerminalPreview?
     let workspace: MobileWorkspacePreview
 
+    private var snapshot: MobileTerminalGhosttySnapshot? {
+        terminal?.snapshot
+    }
+
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: 6) {
-                ForEach((terminal?.lines ?? []).indices, id: \.self) { index in
-                    Text(terminal?.lines[index] ?? "")
+                ForEach((snapshot?.renderedVisibleLines ?? []).indices, id: \.self) { index in
+                    Text(snapshot?.renderedVisibleLines[index] ?? "")
                         .font(.system(.body, design: .monospaced))
                         .foregroundStyle(index == 0 ? .green : .white)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
+                        .accessibilityIdentifier("MobileTerminalRow-\(index)")
                 }
             }
             .padding(16)

--- a/ios/cmuxMobilePackage/Sources/cmuxMobileFeature/MobileShellStore.swift
+++ b/ios/cmuxMobilePackage/Sources/cmuxMobileFeature/MobileShellStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CMUXMobileSyncCore
 import Observation
 
 public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
@@ -40,12 +41,25 @@ public struct MobileTerminalPreview: Identifiable, Equatable, Sendable {
 
     public var id: ID
     public var name: String
-    public var lines: [String]
+    public var snapshot: MobileTerminalGhosttySnapshot
+
+    public init(id: ID, name: String, snapshot: MobileTerminalGhosttySnapshot) {
+        self.id = id
+        self.name = name
+        self.snapshot = snapshot
+    }
 
     public init(id: ID, name: String, lines: [String]) {
         self.id = id
         self.name = name
-        self.lines = lines
+        self.snapshot = PreviewMobileHost.snapshot(
+            terminalID: id.rawValue,
+            lines: lines
+        )
+    }
+
+    public var lines: [String] {
+        snapshot.renderedVisibleLines
     }
 }
 
@@ -223,6 +237,28 @@ enum PreviewMobileHost {
                         "Test Suite passed",
                     ]
                 ),
+                MobileTerminalPreview(
+                    id: "terminal-tui",
+                    name: "TUI",
+                    snapshot: snapshot(
+                        terminalID: "terminal-tui",
+                        lines: [
+                            "LAZYGIT",
+                            "files branches log",
+                            "main feat-ios clean",
+                            "q quit",
+                        ],
+                        activeScreen: .alternate,
+                        modes: MobileTerminalGhosttyModes(
+                            bracketedPaste: true,
+                            applicationCursorKeys: true,
+                            applicationKeypad: true,
+                            mouseTracking: true,
+                            cursorVisible: false
+                        ),
+                        streamOffset: 128
+                    )
+                ),
             ]
         ),
         MobileWorkspacePreview(
@@ -240,4 +276,28 @@ enum PreviewMobileHost {
             ]
         ),
     ]
+
+    static func snapshot(
+        terminalID: String,
+        lines: [String],
+        scrollbackLines: [String] = [],
+        activeScreen: MobileTerminalGhosttyScreen = .primary,
+        modes: MobileTerminalGhosttyModes = MobileTerminalGhosttyModes(),
+        streamOffset: UInt64 = 0
+    ) -> MobileTerminalGhosttySnapshot {
+        do {
+            return try MobileTerminalGhosttySnapshot.fixture(
+                terminalID: terminalID,
+                columns: 48,
+                rows: 6,
+                scrollbackLines: scrollbackLines,
+                visibleLines: lines,
+                activeScreen: activeScreen,
+                modes: modes,
+                streamOffset: streamOffset
+            )
+        } catch {
+            preconditionFailure("Invalid mobile terminal preview snapshot: \(error)")
+        }
+    }
 }

--- a/ios/cmuxMobilePackage/Tests/cmuxMobileFeatureTests/cmuxMobileFeatureTests.swift
+++ b/ios/cmuxMobilePackage/Tests/cmuxMobileFeatureTests/cmuxMobileFeatureTests.swift
@@ -52,8 +52,8 @@ import Testing
     store.createTerminal()
 
     #expect(store.selectedWorkspace?.id.rawValue == "workspace-main")
-    #expect(store.selectedWorkspace?.terminals.count == 3)
-    #expect(store.selectedTerminalID?.rawValue == "workspace-main-terminal-3")
+    #expect(store.selectedWorkspace?.terminals.count == 4)
+    #expect(store.selectedTerminalID?.rawValue == "workspace-main-terminal-4")
 }
 
 @MainActor
@@ -68,4 +68,17 @@ import Testing
 
     #expect(store.selectedWorkspace?.id.rawValue == "workspace-docs")
     #expect(store.selectedTerminalID?.rawValue == "terminal-notes")
+}
+
+@MainActor
+@Test func previewHostIncludesAlternateScreenSnapshotTerminal() {
+    let store = CMUXMobileShellStore.preview()
+    let workspace = store.workspaces.first { $0.id.rawValue == "workspace-main" }
+    let terminal = workspace?.terminals.first { $0.id.rawValue == "terminal-tui" }
+
+    #expect(terminal?.snapshot.activeScreen == .alternate)
+    #expect(terminal?.snapshot.modes.mouseTracking == true)
+    #expect(terminal?.snapshot.modes.bracketedPaste == true)
+    #expect(terminal?.lines.first == "LAZYGIT")
+    #expect(terminal?.snapshot.streamOffset == 128)
 }

--- a/ios/cmuxMobileUITests/cmuxMobileUITests.swift
+++ b/ios/cmuxMobileUITests/cmuxMobileUITests.swift
@@ -58,6 +58,21 @@ final class cmuxMobileUITests: XCTestCase {
     }
 
     @MainActor
+    func testTerminalDropdownSwitchesToAlternateScreenSnapshot() throws {
+        let app = launchApp()
+        try connect(app)
+
+        app.buttons["MobileTerminalDropdown"].tap()
+        let tuiTerminal = app.buttons["MobileTerminalMenuItem-terminal-tui"]
+        XCTAssertTrue(tuiTerminal.waitForExistence(timeout: 4))
+        tuiTerminal.tap()
+
+        XCTAssertTrue(app.staticTexts["LAZYGIT"].waitForExistence(timeout: 4))
+        XCTAssertTrue(app.staticTexts["files branches log"].exists)
+        XCTAssertTrue(app.staticTexts["q quit"].exists)
+    }
+
+    @MainActor
     func testIPadShowsWorkspaceListAndTerminalTogether() throws {
         guard UIDevice.current.userInterfaceIdiom == .pad else {
             throw XCTSkip("iPad-only split view check")


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/3775.

Summary:
- Add `CMUXMobileSyncCore`, a shared Swift package for validated Ghostty terminal snapshots.
- Model visible rows, scrollback rows, alternate-screen state, cursor, modes, styles, links, and stream offsets.
- Teach the iOS shell preview to render snapshot rows and add an alternate-screen TUI fixture in the terminal dropdown.
- Add focused snapshot unit tests and an iOS UI test for switching to the alternate-screen snapshot terminal.

Verification:
- `swift test --package-path Packages/CMUXMobileSyncCore` passed, 6 tests.
- XcodeBuildMCP `build_sim` passed for `iPhone 17`.
- XcodeBuildMCP `build_sim` passed for `iPad Pro 13-inch (M5)`.
- `./scripts/reload.sh --tag iosm5` passed.
- `ios/scripts/reload.sh --tag ios5` passed on `iPhone 17` simulator.
- Physical iPhone reload was attempted against `Lawrence’s iPhone`, but Xcode blocked it because no account/provisioning profile exists for `dev.cmux.ios.ios5`.

Scope note:
- This adds the production Swift snapshot contract and iOS consumption path. The live Ghostty embedded-surface exporter/importer belongs in the next stacked PR so this phase stays reviewable.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new shared snapshot schema/validation layer and switches the iOS terminal preview to consume it, which could impact future terminal rendering/serialization behavior. Changes are mostly additive and covered by new unit/UI tests, but the new contract is foundational for sync.
> 
> **Overview**
> Adds a new Swift package, `CMUXMobileSyncCore`, defining a **versioned, validated Ghostty terminal snapshot** model (grid, screens, scrollback/visible rows, cursor, modes, cell styles/links) with JSON encode/decode helpers and fixtures.
> 
> Updates the iOS `cmuxMobileFeature` package to depend on this core and changes the terminal preview surface to render `snapshot.renderedVisibleLines` (with new row accessibility IDs), plus adds a preview "TUI" terminal using an **alternate-screen** snapshot and expands unit/UI tests to cover snapshot round-tripping/validation and switching to the alternate-screen terminal.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b470c223e048ec8f80dfb3e9031b99540b107c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `CMUXMobileSyncCore` to define and validate Ghostty terminal snapshots, and update the iOS terminal preview to render snapshot rows including an alternate-screen TUI option. This establishes the mobile snapshot contract and wires it into `cmuxMobileFeature`.

- New Features
  - Introduced `CMUXMobileSyncCore`: models grid, visible/scrollback rows, active screen, cursor, modes, styles/links; JSON encode/decode with strict validation and fixtures.
  - iOS preview now renders `snapshot.renderedVisibleLines`; added an alternate-screen TUI fixture in the terminal dropdown with row accessibility IDs.
  - Added focused unit tests for snapshot validation/encoding and a UI test that switches to the alternate-screen snapshot.

- Dependencies
  - Added `CMUXMobileSyncCore` as a dependency of `cmuxMobileFeature` and its tests.

<sup>Written for commit 3b470c223e048ec8f80dfb3e9031b99540b107c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

