### PR TITLE
Fix right sidebar shortcut defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ For more info on how to configure cmux, [head over to our docs](https://cmux.com
 | ⌥ ⌘ E | Edit workspace description |
 | ⌘ B | Toggle sidebar |
 | ⌥ ⌘ B | Toggle right sidebar |
-| ⌘ ⇧ E | Open file explorer |
+| ⌘ ⇧ E | Toggle right sidebar focus |
 
 ### Surfaces
 

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -104878,19 +104878,19 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toggle Right Sidebar"
+            "value": "Toggle Right Sidebar Focus"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "右サイドバーを切り替え"
+            "value": "右サイドバーのフォーカスを切替"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "오른쪽 사이드바 전환"
+            "value": "오른쪽 사이드바 포커스 전환"
           }
         }
       }
@@ -105010,19 +105010,19 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Toggle Right Sidebar"
+            "value": "Toggle Right Sidebar Focus"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "右サイドバーを切り替え"
+            "value": "右サイドバーのフォーカスを切替"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "오른쪽 사이드바 전환"
+            "value": "오른쪽 사이드바 포커스 전환"
           }
         }
       }

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -159,7 +159,7 @@ enum KeyboardShortcutSettings {
             case .sendFeedback: return String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback")
             case .showNotifications: return String(localized: "shortcut.showNotifications.label", defaultValue: "Show Notifications")
             case .jumpToUnread: return String(localized: "shortcut.jumpToUnread.label", defaultValue: "Jump to Latest Unread")
-            case .focusRightSidebar: return String(localized: "shortcut.focusRightSidebar.label", defaultValue: "Toggle Right Sidebar")
+            case .focusRightSidebar: return String(localized: "shortcut.focusRightSidebar.label", defaultValue: "Toggle Right Sidebar Focus")
             case .switchRightSidebarToFiles: return String(localized: "shortcut.switchRightSidebarToFiles.label", defaultValue: "Show Sidebar Files")
             case .switchRightSidebarToFind: return String(localized: "shortcut.switchRightSidebarToFind.label", defaultValue: "Show Sidebar Find")
             case .switchRightSidebarToSessions: return String(localized: "shortcut.switchRightSidebarToSessions.label", defaultValue: "Show Sidebar Vault")
@@ -271,7 +271,7 @@ enum KeyboardShortcutSettings {
             case .jumpToUnread:
                 return StoredShortcut(key: "u", command: true, shift: true, option: false, control: false)
             case .focusRightSidebar:
-                return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
+                return StoredShortcut(key: "e", command: true, shift: true, option: false, control: false)
             case .switchRightSidebarToFiles,
                  .switchRightSidebarToFind,
                  .switchRightSidebarToSessions,
@@ -330,7 +330,7 @@ enum KeyboardShortcutSettings {
             case .selectWorkspaceByNumber:
                 return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
             case .toggleFileExplorer:
-                return StoredShortcut(key: "e", command: true, shift: true, option: false, control: false)
+                return StoredShortcut(key: "b", command: true, shift: false, option: true, control: false)
             case .saveFilePreview:
                 return StoredShortcut(key: "s", command: true, shift: false, option: false, control: false)
             case .openBrowser:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -642,7 +642,7 @@ struct cmuxApp: App {
                 }
             }
 
-            splitCommandButton(title: String(localized: "menu.view.focusRightSidebar", defaultValue: "Toggle Right Sidebar"), shortcut: menuShortcut(for: .focusRightSidebar)) {
+            splitCommandButton(title: String(localized: "menu.view.focusRightSidebar", defaultValue: "Toggle Right Sidebar Focus"), shortcut: menuShortcut(for: .focusRightSidebar)) {
                 if AppDelegate.shared?.toggleRightSidebarKeyboardFocusInActiveMainWindow() != true {
                     if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
                         preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -4433,15 +4433,15 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let cases: [(action: KeyboardShortcutSettings.Action, modifiers: NSEvent.ModifierFlags, key: String, keyCode: UInt16)] = [
             (
                 .toggleFileExplorer,
-                [.command, .shift],
-                "e",
-                14
-            ),
-            (
-                .focusRightSidebar,
                 [.command, .option],
                 "b",
                 11
+            ),
+            (
+                .focusRightSidebar,
+                [.command, .shift],
+                "e",
+                14
             ),
             (
                 .findInDirectory,

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -331,21 +331,21 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
     }
 
     func testRightSidebarAndFindShortcutDefaultsMatchSettingsSurface() {
-        XCTAssertEqual(KeyboardShortcutSettings.Action.focusRightSidebar.label, "Toggle Right Sidebar")
-        XCTAssertEqual(KeyboardShortcutSettings.Action.toggleFileExplorer.label, "Open File Explorer")
+        XCTAssertEqual(KeyboardShortcutSettings.Action.focusRightSidebar.label, "Toggle Right Sidebar Focus")
+        XCTAssertEqual(KeyboardShortcutSettings.Action.toggleFileExplorer.label, "Toggle Right Sidebar")
 
         let toggleFileExplorer = KeyboardShortcutSettings.Action.toggleFileExplorer.defaultShortcut
-        XCTAssertEqual(toggleFileExplorer.key, "e")
+        XCTAssertEqual(toggleFileExplorer.key, "b")
         XCTAssertTrue(toggleFileExplorer.command)
-        XCTAssertTrue(toggleFileExplorer.shift)
-        XCTAssertFalse(toggleFileExplorer.option)
+        XCTAssertFalse(toggleFileExplorer.shift)
+        XCTAssertTrue(toggleFileExplorer.option)
         XCTAssertFalse(toggleFileExplorer.control)
 
         let focusRightSidebar = KeyboardShortcutSettings.Action.focusRightSidebar.defaultShortcut
-        XCTAssertEqual(focusRightSidebar.key, "b")
+        XCTAssertEqual(focusRightSidebar.key, "e")
         XCTAssertTrue(focusRightSidebar.command)
-        XCTAssertFalse(focusRightSidebar.shift)
-        XCTAssertTrue(focusRightSidebar.option)
+        XCTAssertTrue(focusRightSidebar.shift)
+        XCTAssertFalse(focusRightSidebar.option)
         XCTAssertFalse(focusRightSidebar.control)
 
         let findInDirectory = KeyboardShortcutSettings.Action.findInDirectory.defaultShortcut
@@ -391,7 +391,7 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
         ]
 
         guard let startIndex = visibleActions.firstIndex(of: .focusRightSidebar) else {
-            XCTFail("Toggle Right Sidebar should be visible in keyboard shortcut settings")
+            XCTFail("Toggle Right Sidebar Focus should be visible in keyboard shortcut settings")
             return
         }
 

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -75,8 +75,8 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "selectWorkspaceByNumber", combos: [["⌘", "1…9"]], description: { en: "Select workspace 1…9", ja: "ワークスペース1…9を選択" } },
       { id: "renameWorkspace", combos: [["⌘", "⇧", "R"]], description: { en: "Rename workspace", ja: "ワークスペース名を変更" } },
       { id: "editWorkspaceDescription", combos: [["⌥", "⌘", "E"]], description: { en: "Edit workspace description", ja: "ワークスペースの説明を編集" } },
-      { id: "focusRightSidebar", combos: [["⌥", "⌘", "B"]], description: { en: "Toggle right sidebar", ja: "右サイドバーを切り替え" } },
-      { id: "toggleFileExplorer", combos: [["⌘", "⇧", "E"]], description: { en: "Open file explorer", ja: "ファイルエクスプローラを開く" } },
+      { id: "focusRightSidebar", combos: [["⌘", "⇧", "E"]], description: { en: "Toggle right-sidebar focus", ja: "右サイドバーのフォーカスを切り替え" } },
+      { id: "toggleFileExplorer", combos: [["⌥", "⌘", "B"]], description: { en: "Toggle right sidebar", ja: "右サイドバーを切り替え" } },
       {
         id: "navigateRightSidebarRows",
         combos: [["J / K"], ["⌃", "N / P"], ["H / L"]],


### PR DESCRIPTION
## Summary
- make Cmd+Option+B the right sidebar visibility toggle
- make Cmd+Shift+E the right sidebar focus toggle
- update shortcut labels, docs, localization, and shortcut routing/default tests

## Verification
- jq empty Resources/Localizable.xcstrings
- CMUX_SKIP_ZIG_BUILD=1 xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-rsswap-unit -only-testing:cmuxTests/WorkspaceRenameShortcutDefaultsTests/testRightSidebarAndFindShortcutDefaultsMatchSettingsSurface -only-testing:cmuxTests/AppDelegateShortcutRoutingTests/testExampleShortcutRoutingConsultsConfiguredShortcutSettings test
- ./scripts/reload.sh --tag rsswap

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a shortcut default/label swap with corresponding doc/localization/test updates, with minimal impact beyond keyboard routing and UI text.
> 
> **Overview**
> Swaps the default keybindings for right-sidebar actions: **visibility toggle** is now `⌥⌘B`, and **right-sidebar focus toggle** is now `⌘⇧E`.
> 
> Updates the associated labels/menu titles and localizations (including `Localizable.xcstrings`), plus refreshes shortcut routing/unit tests and the documented shortcut lists (README and web shortcuts data) to match the new defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a85b446d525df0c53f746aaa35bdf1483e3235a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated right-sidebar keyboard shortcuts: ⌥⌘B now toggles the right sidebar; ⌘⇧E toggles right-sidebar focus. Synced menu/setting labels, localization, README and `web/data/cmux-shortcuts.ts`, and unit tests; verified shortcut routing matches the new defaults.

<sup>Written for commit a85b446d525df0c53f746aaa35bdf1483e3235a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Reassigned keyboard shortcuts and refined action labels for workspace management operations to enhance clarity.

* **Localization**
  * Updated keyboard shortcut descriptions and action labels across all supported languages (English, Japanese, Korean) for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->