### PR TITLE
Revert duplicate browser pane drop zone overlay fix

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -468,15 +468,11 @@ final class WindowBrowserHostView: NSView {
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {
-        performHitTest(at: point, currentEvent: NSApp.currentEvent)
-    }
-
-    func performHitTest(at point: NSPoint, currentEvent: NSEvent?) -> NSView? {
         let dividerHit = splitDividerHit(at: point)
         let hostedInspectorHit = dividerHit == nil ? hostedInspectorDividerHit(at: point) : nil
         updateDividerCursor(at: point, dividerHit: dividerHit, hostedInspectorHit: hostedInspectorHit)
 
-        let eventType = currentEvent?.type
+        let eventType = NSApp.currentEvent?.type
         let titlebarPassThrough = shouldPassThroughToTitlebar(at: point)
         let tabStripPassThrough = shouldPassThroughToPaneTabBar(at: point, eventType: eventType)
         let sidebarPassThrough = shouldPassThroughToSidebarResizer(
@@ -539,22 +535,13 @@ final class WindowBrowserHostView: NSView {
             return nil
         }
         // Mirror terminal portal routing: while tab-reorder drags are active,
-        // prefer pane-local drop targets owned by the portal slot. Fall through
-        // to SwiftUI targets only when the browser pane itself is not the target.
+        // pass through to SwiftUI drop targets behind the portal host.
         // Browser hover routing also arrives as cursor/enter events and may not
         // report a pressed-button state, so include that path here.
-        let dragPasteboardTypes = NSPasteboard(name: .drag).types
         if Self.shouldPassThroughToDragTargets(
-            pasteboardTypes: dragPasteboardTypes,
-            eventType: eventType
+            pasteboardTypes: NSPasteboard(name: .drag).types,
+            eventType: NSApp.currentEvent?.type
         ) {
-            if let paneDropTarget = paneDropTargetForDrag(
-                at: point,
-                pasteboardTypes: dragPasteboardTypes,
-                eventType: eventType
-            ) {
-                return paneDropTarget
-            }
             return nil
         }
 
@@ -596,36 +583,6 @@ final class WindowBrowserHostView: NSView {
         )
 #endif
         return hitView === self ? nil : hitView
-    }
-
-    private func paneDropTargetForDrag(
-        at point: NSPoint,
-        pasteboardTypes: [NSPasteboard.PasteboardType]?,
-        eventType: NSEvent.EventType?
-    ) -> BrowserPaneDropTargetView? {
-        guard BrowserPaneDropTargetView.shouldCaptureHitTesting(
-            pasteboardTypes: pasteboardTypes,
-            eventType: eventType
-        ) else {
-            return nil
-        }
-
-        return browserPaneDropTarget(at: point)
-    }
-
-    func browserPaneDropTarget(at point: NSPoint) -> BrowserPaneDropTargetView? {
-        for slot in subviews.reversed() {
-            guard let slot = slot as? WindowBrowserSlotView,
-                  !slot.isHidden,
-                  slot.alphaValue > 0,
-                  slot.frame.contains(point) else { continue }
-            let pointInSlot = slot.convert(point, from: self)
-            if let target = slot.paneDropTargetForDrop(at: pointInSlot) {
-                return target
-            }
-        }
-
-        return nil
     }
 
     override func mouseDown(with event: NSEvent) {
@@ -1459,9 +1416,6 @@ enum BrowserPaneDropRouting {
 }
 
 final class WindowBrowserSlotView: NSView {
-    private static let dropZoneOverlayFadeInAnimationKey = "cmux.browser.dropZoneOverlay.fadeIn"
-    private static let dropZoneOverlayFadeInDuration: CFTimeInterval = 0.25
-
     override var isOpaque: Bool { false }
     override var isHidden: Bool {
         didSet {
@@ -1882,10 +1836,14 @@ final class WindowBrowserSlotView: NSView {
 
         if dropZoneOverlayView.isHidden {
             applyDropZoneOverlayFrame(targetFrame)
-            dropZoneOverlayView.alphaValue = 1
+            dropZoneOverlayView.alphaValue = 0
             dropZoneOverlayView.isHidden = false
             bringInteractionLayersToFrontIfNeeded()
-            animateDropZoneOverlayFadeIn()
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.18
+                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+                dropZoneOverlayView.animator().alphaValue = 1
+            }
             return
         }
 
@@ -1900,30 +1858,6 @@ final class WindowBrowserSlotView: NSView {
                 dropZoneOverlayView.animator().alphaValue = 1
             }
         }
-    }
-
-    private func animateDropZoneOverlayFadeIn() {
-        guard let layer = dropZoneOverlayView.layer else {
-            dropZoneOverlayView.alphaValue = 0
-            NSAnimationContext.runAnimationGroup { context in
-                context.duration = Self.dropZoneOverlayFadeInDuration
-                context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-                dropZoneOverlayView.animator().alphaValue = 1
-            }
-            return
-        }
-
-        CATransaction.begin()
-        CATransaction.setDisableActions(true)
-        layer.opacity = 1
-        CATransaction.commit()
-
-        let animation = CABasicAnimation(keyPath: "opacity")
-        animation.fromValue = 0.0
-        animation.toValue = 1.0
-        animation.duration = Self.dropZoneOverlayFadeInDuration
-        animation.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
-        layer.add(animation, forKey: Self.dropZoneOverlayFadeInAnimationKey)
     }
 
     private func interactionLayerPriority(of view: NSView) -> Int {
@@ -3835,7 +3769,14 @@ final class WindowBrowserPortal: NSObject {
     func browserPaneDropTargetAtWindowPoint(_ windowPoint: NSPoint) -> BrowserPaneDropTargetView? {
         guard ensureInstalled() else { return nil }
         let point = hostView.convert(windowPoint, from: nil)
-        return hostView.browserPaneDropTarget(at: point)
+        for subview in hostView.subviews.reversed() {
+            guard let container = subview as? WindowBrowserSlotView else { continue }
+            guard !container.isHidden else { continue }
+            guard container.frame.contains(point) else { continue }
+            let pointInContainer = container.convert(point, from: hostView)
+            return container.paneDropTargetForDrop(at: pointInContainer)
+        }
+        return nil
     }
 }
 

--- a/cmuxTests/BrowserPaneDropRoutingTests.swift
+++ b/cmuxTests/BrowserPaneDropRoutingTests.swift
@@ -255,54 +255,6 @@ final class BrowserPaneDropRoutingTests: XCTestCase {
         XCTAssertTrue(syntheticTransfer.isFilePreview)
     }
 
-    func testBrowserPortalRoutesTabTransferDragToPaneDropTargetBeforeSwiftUIDropLayer() throws {
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
-            styleMask: [.titled, .closable],
-            backing: .buffered,
-            defer: false
-        )
-        defer {
-            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
-            window.orderOut(nil)
-        }
-
-        let host = WindowBrowserHostView(frame: window.contentView?.bounds ?? NSRect(x: 0, y: 0, width: 360, height: 240))
-        host.autoresizingMask = [.width, .height]
-        window.contentView = host
-
-        let slot = WindowBrowserSlotView(frame: NSRect(x: 20, y: 20, width: 260, height: 160))
-        host.addSubview(slot)
-        slot.setPaneDropContext(BrowserPaneDropContext(
-            workspaceId: UUID(),
-            panelId: UUID(),
-            paneId: PaneID(id: UUID())
-        ))
-        slot.layoutSubtreeIfNeeded()
-
-        let dragPasteboard = NSPasteboard(name: .drag)
-        dragPasteboard.clearContents()
-        dragPasteboard.setString("{}", forType: DragOverlayRoutingPolicy.bonsplitTabTransferType)
-        defer { dragPasteboard.clearContents() }
-
-        let pointInHost = NSPoint(x: slot.frame.midX, y: slot.frame.midY)
-        let dragEvent = try XCTUnwrap(NSEvent.mouseEvent(
-            with: .leftMouseDragged,
-            location: host.convert(pointInHost, to: nil),
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 1,
-            clickCount: 1,
-            pressure: 1
-        ))
-        let hitView = host.performHitTest(at: pointInHost, currentEvent: dragEvent)
-        let expectedTarget = try XCTUnwrap(slot.paneDropTargetForDrop(at: NSPoint(x: slot.bounds.midX, y: slot.bounds.midY)))
-
-        XCTAssertTrue(hitView === expectedTarget)
-    }
-
     func testBrowserPaneFileDropDefaultUsesHostedWebViewLifecycle() throws {
         let defaults = UserDefaults.standard
         let savedDefaultBehavior = defaults.object(forKey: FileDropBehaviorSettings.defaultBehaviorKey)

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2007,12 +2007,6 @@ final class WindowBrowserSlotViewTests: XCTestCase {
         RunLoop.current.run(until: Date().addingTimeInterval(0.25))
     }
 
-    private func opacityAnimation(in view: NSView) -> CABasicAnimation? {
-        view.layer?.animationKeys()?
-            .compactMap { view.layer?.animation(forKey: $0) as? CABasicAnimation }
-            .first { $0.keyPath == "opacity" }
-    }
-
     func testDropZoneOverlayStaysAboveContentWithoutBlockingHits() {
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
         let slot = WindowBrowserSlotView(frame: container.bounds)
@@ -2043,30 +2037,6 @@ final class WindowBrowserSlotViewTests: XCTestCase {
         slot.setDropZoneOverlay(zone: nil)
         advanceAnimations()
         XCTAssertTrue(overlay.isHidden, "Clearing the drop zone should hide the overlay")
-    }
-
-    func testDropZoneOverlayFadesInWhenShown() {
-        let container = NSView(frame: NSRect(x: 0, y: 0, width: 200, height: 100))
-        let slot = WindowBrowserSlotView(frame: container.bounds)
-        container.addSubview(slot)
-
-        slot.setDropZoneOverlay(zone: .left)
-        container.layoutSubtreeIfNeeded()
-
-        guard let overlay = container.subviews.first(where: {
-            $0 !== slot && String(describing: type(of: $0)).contains("BrowserDropZoneOverlayView")
-        }) else {
-            XCTFail("Expected browser slot drop-zone overlay")
-            return
-        }
-
-        guard let animation = opacityAnimation(in: overlay) else {
-            XCTFail("Showing the portal drop overlay should install an opacity animation")
-            return
-        }
-        XCTAssertEqual((animation.fromValue as? NSNumber)?.doubleValue ?? -1, 0, accuracy: 0.001)
-        XCTAssertEqual((animation.toValue as? NSNumber)?.doubleValue ?? -1, 1, accuracy: 0.001)
-        XCTAssertGreaterThanOrEqual(animation.duration, 0.2)
     }
 
     func testTopDropZoneOverlayUsesFullBrowserContentHeight() {


### PR DESCRIPTION
Reverts https://github.com/manaflow-ai/cmux/pull/3782 at user request after merge.

Summary:
- Removes the browser drop-zone overlay changes from https://github.com/manaflow-ai/cmux/pull/3782.
- Restores the previous Bonsplit submodule pointer.

Testing:
- `./scripts/reload.sh --tag rev3782` succeeded.
- GitHub and CircleCI checks passed on this PR, including `ci/circleci: macos-unit-tests`, `ci/circleci: macos-debug-build`, and `ci/circleci: macos-release-build`.

Review notes:
- Greptile and Cursor flagged the existing drop-target loop. I verified the same loop existed before https://github.com/manaflow-ai/cmux/pull/3782 and replied on both threads, leaving it unchanged to keep this an exact undo.

Checklist:
- [x] Tagged build completed.
- [x] CI passed.
- [x] Review feedback checked.