### PR TITLE
Add split cycle terminal rendering regression test

### DIFF
--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -7,6 +7,40 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         let windowId: String
     }
 
+    private struct TerminalSurfaceInfo: CustomStringConvertible {
+        let id: String
+        let index: Int
+        let focused: Bool
+
+        var description: String {
+            "TerminalSurfaceInfo(id: \(id), index: \(index), focused: \(focused))"
+        }
+    }
+
+    private struct TerminalRenderStats: CustomStringConvertible {
+        let presentCount: Int
+        let drawCount: Int
+        let inWindow: Bool
+        let windowOcclusionVisible: Bool
+        let layerClass: String
+        let layerContentsKey: String
+
+        var description: String {
+            "TerminalRenderStats(presentCount: \(presentCount), drawCount: \(drawCount), inWindow: \(inWindow), windowOcclusionVisible: \(windowOcclusionVisible), layerClass: \(layerClass), layerContentsKey: \(layerContentsKey))"
+        }
+    }
+
+    private struct PanelSnapshotInfo: CustomStringConvertible {
+        let changedPixels: Int
+        let width: Int
+        let height: Int
+        let path: String
+
+        var description: String {
+            "PanelSnapshotInfo(changedPixels: \(changedPixels), width: \(width), height: \(height), path: \(path))"
+        }
+    }
+
     private var dataPath = ""
     private var socketPath = ""
 
@@ -838,6 +872,65 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
     }
 
+    func testRepeatedCmdDSplitAndCtrlDExitKeepsLeftmostTerminalRendering() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchEnvironment["CMUX_UI_TEST_SOCKET_SANITY"] = "1"
+        launchAndEnsureForeground(app)
+
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
+        guard let initialSurfaceId = waitForSingleTerminalSurface(timeout: 12.0)?.id else {
+            XCTFail("Expected exactly one terminal surface after launch. surfaces=\(terminalSurfaces())")
+            return
+        }
+
+        assertSurfaceRendersNewMarker(
+            surfaceId: initialSurfaceId,
+            marker: "cmux-left-render-start",
+            context: "Initial left terminal"
+        )
+
+        for cycle in 1...10 {
+            app.typeKey("d", modifierFlags: [.command])
+            XCTAssertTrue(
+                waitForTerminalSurfaceCount(2, timeout: 6.0),
+                "Cycle \(cycle): expected first Cmd+D to create a second terminal. surfaces=\(terminalSurfaces())"
+            )
+
+            app.typeKey("d", modifierFlags: [.command])
+            XCTAssertTrue(
+                waitForTerminalSurfaceCount(3, timeout: 6.0),
+                "Cycle \(cycle): expected second Cmd+D to create a third terminal. surfaces=\(terminalSurfaces())"
+            )
+
+            app.typeKey("d", modifierFlags: [.control])
+            XCTAssertTrue(
+                waitForTerminalSurfaceCount(2, timeout: 8.0),
+                "Cycle \(cycle): expected first Ctrl+D to close only the focused split. surfaces=\(terminalSurfaces())"
+            )
+
+            app.typeKey("d", modifierFlags: [.control])
+            XCTAssertTrue(
+                waitForTerminalSurfaceCount(1, timeout: 8.0),
+                "Cycle \(cycle): expected second Ctrl+D to leave one terminal. surfaces=\(terminalSurfaces())"
+            )
+
+            let remaining = terminalSurfaces()
+            XCTAssertEqual(
+                remaining.first?.id,
+                initialSurfaceId,
+                "Cycle \(cycle): expected the original leftmost terminal to survive the Cmd+D/Ctrl+D churn. surfaces=\(remaining)"
+            )
+
+            assertSurfaceRendersNewMarker(
+                surfaceId: initialSurfaceId,
+                marker: "cmux-left-render-\(cycle)",
+                context: "Cycle \(cycle) left terminal"
+            )
+        }
+    }
+
     func testCmdOptionPaneSwitchPreservesFindFieldFocus() {
         runFindFocusPersistenceScenario(route: .cmdOptionArrows, useAutofocusRacePage: false)
     }
@@ -1317,6 +1410,217 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         waitForCondition(timeout: timeout) {
             self.socketCommand("ping") == "PONG"
         }
+    }
+
+    private func waitForSingleTerminalSurface(timeout: TimeInterval) -> TerminalSurfaceInfo? {
+        var matchedSurface: TerminalSurfaceInfo?
+        let matched = waitForCondition(timeout: timeout) {
+            let surfaces = self.terminalSurfaces()
+            guard surfaces.count == 1, let surface = surfaces.first else {
+                return false
+            }
+            matchedSurface = surface
+            return true
+        }
+        return matched ? matchedSurface : nil
+    }
+
+    private func waitForTerminalSurfaceCount(_ expectedCount: Int, timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            self.terminalSurfaces().count == expectedCount
+        }
+    }
+
+    private func terminalSurfaces() -> [TerminalSurfaceInfo] {
+        guard let result = socketResult(method: "surface.list"),
+              let surfaces = result["surfaces"] as? [[String: Any]] else {
+            return []
+        }
+
+        return surfaces.compactMap { item in
+            guard (item["type"] as? String) == "terminal",
+                  let id = item["id"] as? String else {
+                return nil
+            }
+            return TerminalSurfaceInfo(
+                id: id,
+                index: intValue(item["index"]) ?? -1,
+                focused: boolValue(item["focused"]) ?? false
+            )
+        }
+    }
+
+    private func assertSurfaceRendersNewMarker(surfaceId: String, marker: String, context: String) {
+        guard let baselineStats = waitForTerminalRenderStats(surfaceId: surfaceId, timeout: 6.0) else {
+            XCTFail("\(context): missing baseline render stats for \(surfaceId)")
+            return
+        }
+        XCTAssertTrue(baselineStats.inWindow, "\(context): expected left terminal to be attached to a window. stats=\(baselineStats)")
+        XCTAssertTrue(
+            baselineStats.windowOcclusionVisible,
+            "\(context): expected left terminal window to be visible. stats=\(baselineStats)"
+        )
+
+        _ = socketResult(method: "debug.panel_snapshot.reset", params: ["surface_id": surfaceId])
+        guard let baselineSnapshot = waitForPanelSnapshot(
+            surfaceId: surfaceId,
+            label: "render-\(marker)-baseline",
+            timeout: 6.0
+        ) else {
+            XCTFail("\(context): could not capture baseline panel snapshot for \(surfaceId)")
+            return
+        }
+
+        XCTAssertGreaterThan(baselineSnapshot.width, 0, "\(context): baseline panel snapshot has invalid width. snapshot=\(baselineSnapshot)")
+        XCTAssertGreaterThan(baselineSnapshot.height, 0, "\(context): baseline panel snapshot has invalid height. snapshot=\(baselineSnapshot)")
+
+        let command = "printf '\(marker)\\n'\n"
+        guard sendText(surfaceId: surfaceId, text: command) else {
+            XCTFail("\(context): failed to send marker command to left terminal \(surfaceId)")
+            return
+        }
+
+        XCTAssertTrue(
+            waitForSurfaceText(surfaceId: surfaceId, contains: marker, timeout: 6.0),
+            "\(context): terminal model did not contain marker \(marker). text=\(surfaceText(surfaceId: surfaceId) ?? "<nil>")"
+        )
+
+        let rendered = waitForCondition(timeout: 6.0) {
+            guard let stats = self.terminalRenderStats(surfaceId: surfaceId) else {
+                return false
+            }
+            return stats.presentCount > baselineStats.presentCount
+                || stats.drawCount > baselineStats.drawCount
+        }
+        XCTAssertTrue(
+            rendered,
+            "\(context): render counters did not advance after marker \(marker). baseline=\(baselineStats) current=\(terminalRenderStats(surfaceId: surfaceId).map { String(describing: $0) } ?? "<nil>")"
+        )
+
+        guard let markerSnapshot = waitForPanelSnapshot(
+            surfaceId: surfaceId,
+            label: "render-\(marker)-after",
+            timeout: 6.0
+        ) else {
+            XCTFail("\(context): could not capture marker panel snapshot for \(surfaceId)")
+            return
+        }
+
+        XCTAssertGreaterThan(
+            markerSnapshot.changedPixels,
+            20,
+            "\(context): left terminal text changed but panel pixels barely changed after \(marker). baseline=\(baselineSnapshot) after=\(markerSnapshot)"
+        )
+    }
+
+    private func waitForTerminalRenderStats(surfaceId: String, timeout: TimeInterval) -> TerminalRenderStats? {
+        var matchedStats: TerminalRenderStats?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let stats = self.terminalRenderStats(surfaceId: surfaceId) else {
+                return false
+            }
+            matchedStats = stats
+            return stats.inWindow
+        }
+        return matched ? matchedStats : nil
+    }
+
+    private func terminalRenderStats(surfaceId: String) -> TerminalRenderStats? {
+        guard let result = socketResult(
+            method: "debug.terminal.render_stats",
+            params: ["surface_id": surfaceId]
+        ),
+        let stats = result["stats"] as? [String: Any] else {
+            return nil
+        }
+
+        return TerminalRenderStats(
+            presentCount: intValue(stats["presentCount"]) ?? 0,
+            drawCount: intValue(stats["drawCount"]) ?? 0,
+            inWindow: boolValue(stats["inWindow"]) ?? false,
+            windowOcclusionVisible: boolValue(stats["windowOcclusionVisible"]) ?? false,
+            layerClass: stats["layerClass"] as? String ?? "",
+            layerContentsKey: stats["layerContentsKey"] as? String ?? ""
+        )
+    }
+
+    private func waitForPanelSnapshot(surfaceId: String, label: String, timeout: TimeInterval) -> PanelSnapshotInfo? {
+        var matchedSnapshot: PanelSnapshotInfo?
+        let matched = waitForCondition(timeout: timeout) {
+            guard let snapshot = self.panelSnapshot(surfaceId: surfaceId, label: label) else {
+                return false
+            }
+            matchedSnapshot = snapshot
+            return snapshot.width > 0 && snapshot.height > 0
+        }
+        return matched ? matchedSnapshot : nil
+    }
+
+    private func panelSnapshot(surfaceId: String, label: String) -> PanelSnapshotInfo? {
+        guard let result = socketResult(
+            method: "debug.panel_snapshot",
+            params: ["surface_id": surfaceId, "label": label]
+        ) else {
+            return nil
+        }
+        return PanelSnapshotInfo(
+            changedPixels: intValue(result["changed_pixels"]) ?? -1,
+            width: intValue(result["width"]) ?? 0,
+            height: intValue(result["height"]) ?? 0,
+            path: result["path"] as? String ?? ""
+        )
+    }
+
+    private func sendText(surfaceId: String, text: String) -> Bool {
+        socketResult(
+            method: "surface.send_text",
+            params: ["surface_id": surfaceId, "text": text]
+        ) != nil
+    }
+
+    private func waitForSurfaceText(surfaceId: String, contains marker: String, timeout: TimeInterval) -> Bool {
+        waitForCondition(timeout: timeout) {
+            self.surfaceText(surfaceId: surfaceId)?.contains(marker) == true
+        }
+    }
+
+    private func surfaceText(surfaceId: String) -> String? {
+        guard let result = socketResult(
+            method: "surface.read_text",
+            params: ["surface_id": surfaceId, "scrollback": true, "lines": 80]
+        ) else {
+            return nil
+        }
+        return result["text"] as? String
+    }
+
+    private func socketResult(method: String, params: [String: Any] = [:]) -> [String: Any]? {
+        guard let envelope = socketJSON(method: method, params: params),
+              let ok = envelope["ok"] as? Bool,
+              ok else {
+            return nil
+        }
+        return envelope["result"] as? [String: Any]
+    }
+
+    private func intValue(_ value: Any?) -> Int? {
+        if let value = value as? Int { return value }
+        if let value = value as? NSNumber { return value.intValue }
+        if let value = value as? String { return Int(value) }
+        return nil
+    }
+
+    private func boolValue(_ value: Any?) -> Bool? {
+        if let value = value as? Bool { return value }
+        if let value = value as? NSNumber { return value.boolValue }
+        if let value = value as? String {
+            switch value.lowercased() {
+            case "1", "true", "yes": return true
+            case "0", "false", "no": return false
+            default: return nil
+            }
+        }
+        return nil
     }
 
     private func currentWorkspaceContext() -> WorkspaceContext? {


### PR DESCRIPTION
## Summary
- Adds an XCUITest that repeats Cmd+D, Cmd+D, Ctrl+D, Ctrl+D ten times.
- Verifies the original leftmost Ghostty terminal remains the only surviving terminal and keeps rendering new marker output after every cycle.

## Testing
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-splitrender build-for-testing -only-testing:cmuxUITests/BrowserPaneNavigationKeybindUITests/testRepeatedCmdDSplitAndCtrlDExitKeepsLeftmostTerminalRendering` passed.\n- `test-e2e.yml` passed for `BrowserPaneNavigationKeybindUITests/testRepeatedCmdDSplitAndCtrlDExitKeepsLeftmostTerminalRendering`: https://github.com/manaflow-ai/cmux/actions/runs/25593148882\n\n## Task\n- Regression coverage for repeated split and terminal exit churn making the leftmost Ghostty terminal fail to render.