### PR TITLE
Fix re-entrant view hierarchy crash in onDidMoveToWindow

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -13335,29 +13335,41 @@ struct GhosttyTerminalView: NSViewRepresentable {
             host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }
                 guard coordinator.attachGeneration == generation else { return }
-                guard terminalSurface.claimPortalHost(
-                    hostId: ObjectIdentifier(host),
-                    paneId: paneId,
-                    instanceSerial: host.instanceSerial,
-                    inWindow: host.window != nil,
-                    bounds: host.bounds,
-                    reason: "didMoveToWindow"
-                ) else { return }
                 guard host.window != nil else { return }
                 guard portalBindingStillLive() else { return }
-                TerminalWindowPortalRegistry.bind(
-                    hostedView: hostedView,
-                    to: host,
-                    visibleInUI: coordinator.desiredIsVisibleInUI,
-                    zPriority: coordinator.desiredPortalZPriority,
-                    expectedSurfaceId: portalExpectedSurfaceId,
-                    expectedGeneration: portalExpectedGeneration
-                )
-                coordinator.lastBoundHostId = ObjectIdentifier(host)
-                coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
-                hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
-                hostedView.setActive(coordinator.desiredIsActive)
-                hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                // Defer to next RunLoop iteration to avoid re-entrant view
+                // hierarchy modification during AppKit's _setWindow:
+                // propagation. viewDidMoveToWindow fires inside _setWindow:'s
+                // recursive traversal; calling addSubview() synchronously
+                // corrupts AppKit's internal state (crash: EXC_BREAKPOINT in
+                // insertObject:atIndex:).
+                DispatchQueue.main.async { [weak host, weak hostedView, weak coordinator] in
+                    guard let host, let hostedView, let coordinator else { return }
+                    guard coordinator.attachGeneration == generation else { return }
+                    guard terminalSurface.claimPortalHost(
+                        hostId: ObjectIdentifier(host),
+                        paneId: paneId,
+                        instanceSerial: host.instanceSerial,
+                        inWindow: host.window != nil,
+                        bounds: host.bounds,
+                        reason: "didMoveToWindow"
+                    ) else { return }
+                    guard host.window != nil else { return }
+                    guard portalBindingStillLive() else { return }
+                    TerminalWindowPortalRegistry.bind(
+                        hostedView: hostedView,
+                        to: host,
+                        visibleInUI: coordinator.desiredIsVisibleInUI,
+                        zPriority: coordinator.desiredPortalZPriority,
+                        expectedSurfaceId: portalExpectedSurfaceId,
+                        expectedGeneration: portalExpectedGeneration
+                    )
+                    coordinator.lastBoundHostId = ObjectIdentifier(host)
+                    coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                    hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
+                    hostedView.setActive(coordinator.desiredIsActive)
+                    hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
+                }
             }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1194,6 +1194,9 @@ final class WindowTerminalPortal: NSObject {
         hostedView.reconcileGeometryNow()
 
         if hostedView.superview !== hostView {
+            // Guard: never add subviews if the host isn't in a window yet
+            // (defense-in-depth against re-entrant _setWindow: crashes).
+            guard hostView.window != nil else { return }
 #if DEBUG
             cmuxDebugLog(
                 "portal.reparent hosted=\(portalDebugToken(hostedView)) " +
@@ -1205,6 +1208,7 @@ final class WindowTerminalPortal: NSObject {
             // Refresh z-order only when a view becomes visible or gets a higher priority.
             // Anchor-only churn is common during split tree updates; forcing remove/add there
             // causes transient inWindow=0 -> 1 bounces that can flash black.
+            guard hostView.window != nil else { return }
 #if DEBUG
             cmuxDebugLog(
                 "portal.reparent hosted=\(portalDebugToken(hostedView)) reason=raise " +


### PR DESCRIPTION
# Crash: EXC_BREAKPOINT in `insertObject:atIndex:` due to re-entrant view hierarchy modification during `_setWindow:` propagation

## Bug Report

**Severity:** High — application termination with no recovery
**Reproducibility:** Intermittent (timing-dependent)
**Affected versions:** Current main (commit b046b32b)
**Occurrences:** 2 crashes on 2026-05-09, identical call stacks

---

## Summary

cmux crashes with `EXC_BREAKPOINT (SIGTRAP)` in `-[__NSArrayM insertObject:atIndex:]`. The root cause is a re-entrant view hierarchy modification: `HostContainerView.viewDidMoveToWindow()` synchronously calls `TerminalWindowPortalRegistry.bind()` → `addSubview()` during AppKit's `_setWindow:` recursive propagation, corrupting AppKit's internal subview array.

---

## Crash Logs

**Incident 1:** 2026-05-09 11:53:45 — `EXC_BREAKPOINT (SIGTRAP)` at `-[__NSArrayM insertObject:atIndex:]`
**Incident 2:** 2026-05-09 14:11 — Same exception, identical call stack

Both crashes share the same stack trace (key frames):

```
Thread 0 Crashed:
0  CoreFoundation       -[__NSArrayM insertObject:atIndex:] + 1668
1  AppKit                -[NSView _addSubview:positioned:relativeTo:]
2  AppKit                -[NSView addSubview:positioned:relativeTo:]
3  cmux                  WindowTerminalPortal.bind()              // TerminalWindowPortal.swift:1203
4  cmux                  @objc HostContainerView.onDidMoveToWindow // GhosttyTerminalView.swift:13348
5  cmux                  HostContainerView.viewDidMoveToWindow()  // GhosttyTerminalView.swift:13138
6  AppKit                -[NSView _setWindow:]                   // recursive propagation
...
N  AppKit                -[NSHostingView _setWindow:]
N+1 SwiftUI              swiftui_addRenderedSubview
```

---

## Root Cause

In `GhosttyTerminalView.swift`, the `onDidMoveToWindow` callback (line 13335) executes `TerminalWindowPortalRegistry.bind()` **synchronously** when `viewDidMoveToWindow()` fires:

```swift
host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
    // ... guards ...
    TerminalWindowPortalRegistry.bind(          // ← SYNCHRONOUS — dangerous
        hostedView: hostedView,
        to: host,
        // ...
    )
}
```

`viewDidMoveToWindow()` is called by AppKit during `_setWindow:` recursive propagation. When `bind()` calls `hostView.addSubview()` inside this propagation, it mutates the view hierarchy while AppKit is iterating over it, corrupting the internal subview array.

This is a well-known AppKit re-entrancy anti-pattern. The crash is intermittent because it requires a specific timing: SwiftUI's display cycle must trigger `swiftui_addRenderedSubview` → `_setWindow:` propagation while a `HostContainerView` is in the view tree.

---

## Proposed Fix

### 1. Defer `bind()` in `onDidMoveToWindow` (primary fix)

Wrap the closure body in `DispatchQueue.main.async` to move the `addSubview` out of the `_setWindow:` propagation:

```swift
host.onDidMoveToWindow = { [weak host, weak hostedView, weak coordinator] in
    guard let host, let hostedView, let coordinator else { return }
    guard coordinator.attachGeneration == generation else { return }
    guard host.window != nil else { return }
    guard portalBindingStillLive() else { return }
    // Defer to next RunLoop iteration to avoid re-entrant view hierarchy
    // modification during AppKit's _setWindow: propagation.
    DispatchQueue.main.async { [weak host, weak hostedView, weak coordinator] in
        guard let host, let hostedView, let coordinator else { return }
        guard coordinator.attachGeneration == generation else { return }
        guard terminalSurface.claimPortalHost(
            hostId: ObjectIdentifier(host),
            paneId: paneId,
            instanceSerial: host.instanceSerial,
            inWindow: host.window != nil,
            bounds: host.bounds,
            reason: "didMoveToWindow"
        ) else { return }
        guard host.window != nil else { return }
        guard portalBindingStillLive() else { return }
        TerminalWindowPortalRegistry.bind(
            hostedView: hostedView,
            to: host,
            visibleInUI: coordinator.desiredIsVisibleInUI,
            zPriority: coordinator.desiredPortalZPriority,
            expectedSurfaceId: portalExpectedSurfaceId,
            expectedGeneration: portalExpectedGeneration
        )
        coordinator.lastBoundHostId = ObjectIdentifier(host)
        coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
        hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
        hostedView.setActive(coordinator.desiredIsActive)
        hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
    }
}
```

**File:** `Sources/GhosttyTerminalView.swift`, lines 13335-13361

### 2. Guard `addSubview` in `bind()` (defense-in-depth)

Add `hostView.window != nil` checks before both `addSubview` calls in `WindowTerminalPortal.bind()`:

```swift
if hostedView.superview !== hostView {
    guard hostView.window != nil else { return }  // ← added
    hostView.addSubview(hostedView, positioned: .above, relativeTo: nil)
} else if (becameVisible || priorityIncreased), hostView.subviews.last !== hostedView {
    guard hostView.window != nil else { return }  // ← added
    hostView.addSubview(hostedView, positioned: .above, relativeTo: nil)
}
```

**File:** `Sources/TerminalWindowPortal.swift`, lines 1196-1216

---

## Consistency with Existing Code

The codebase already uses `DispatchQueue.main.async` to defer view hierarchy operations:

- `scheduleExternalGeometrySynchronize` (TerminalWindowPortal.swift:770) — defers geometry sync
- `scheduleDeferredFullSynchronizeAll` (TerminalWindowPortal.swift:1255) — defers full synchronize
- `updateNSView` deferred bind path (GhosttyTerminalView.swift:13444) — already handles deferred `bind()`

This fix follows the same pattern.

---

## Risk Assessment

- **Visual impact**: Terminal surface may not appear in the portal for one frame (~16ms). Same trade-off already accepted in existing deferred operations.
- **Correctness**: The `updateNSView` direct `bind()` call (line 13428) runs during SwiftUI's layout pass but NOT inside `_setWindow:`, so it remains synchronous and unaffected.
- **Merge conflict risk**: Minimal — changes are confined to the `onDidMoveToWindow` closure body and two guard statements in `bind()`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes an intermittent crash caused by re-entrant view hierarchy changes during AppKit `_setWindow:` by deferring portal binding out of `viewDidMoveToWindow`. Adds safety checks to avoid `addSubview` when the host isn’t in a window.

- **Bug Fixes**
  - Defer `TerminalWindowPortalRegistry.bind()` in `HostContainerView.onDidMoveToWindow` via `DispatchQueue.main.async` to avoid synchronous `addSubview` during `_setWindow:`.
  - Guard `addSubview` in `WindowTerminalPortal.bind()` with `hostView.window != nil` (defense-in-depth).

<sup>Written for commit ca1426cdff836eeaab17c0a56b2335532e76ad79. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of terminal view initialization and window management during app lifecycle transitions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3793)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->