### PR TITLE
Fix SSH multi-image image drops

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1538,6 +1538,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         CloudVMActionLauncher.shared.terminateAll()
         CmuxSSHURLProcessLauncher.shared.terminateAll()
         TerminalController.shared.stop()
+        GhosttyPasteboardHelper.cleanupAllOwnedTemporaryImageFiles()
         VSCodeServeWebController.shared.stop()
         BrowserProfileStore.shared.flushPendingSaves()
         if TelemetrySettings.enabledForCurrentLaunch {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -299,6 +299,12 @@ enum GhosttyPasteboardHelper {
         case rejectedImagePayload
     }
 
+    enum ImageFileListMaterializationResult {
+        case saved([URL])
+        case noDecodableImagePayload
+        case rejectedImagePayload
+    }
+
     private static let selectionPasteboard = NSPasteboard(
         name: NSPasteboard.Name("com.mitchellh.ghostty.selection")
     )
@@ -493,20 +499,34 @@ enum GhosttyPasteboardHelper {
         )
     }
 
-    private static func rtfdAttachmentImageRepresentation(
-        in pasteboard: NSPasteboard
-    ) -> (data: Data, fileExtension: String)? {
-        guard let attributed = attributedString(
-            from: pasteboard,
-            type: .rtfd,
-            documentType: .rtfd
-        ) else { return nil }
+    private static func attributedString(
+        from item: NSPasteboardItem,
+        type: NSPasteboard.PasteboardType,
+        documentType: NSAttributedString.DocumentType
+    ) -> NSAttributedString? {
+        let data =
+            item.data(forType: type)
+            ?? item.string(forType: type)?.data(using: .utf8)
+        guard let data else { return nil }
 
-        var result: (data: Data, fileExtension: String)?
+        return try? NSAttributedString(
+            data: data,
+            options: [
+                .documentType: documentType,
+                .characterEncoding: String.Encoding.utf8.rawValue
+            ],
+            documentAttributes: nil
+        )
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        from attributed: NSAttributedString
+    ) -> [(data: Data, fileExtension: String)] {
+        var results: [(data: Data, fileExtension: String)] = []
         attributed.enumerateAttribute(
             .attachment,
             in: NSRange(location: 0, length: attributed.length)
-        ) { value, _, stop in
+        ) { value, _, _ in
             guard let attachment = value as? NSTextAttachment else { return }
 
             if let fileWrapper = attachment.fileWrapper,
@@ -515,12 +535,33 @@ enum GhosttyPasteboardHelper {
                 data: data,
                 preferredFilename: fileWrapper.preferredFilename
                ) {
-                result = imageRepresentation
-                stop.pointee = true
+                results.append(imageRepresentation)
             }
         }
 
-        return result
+        return results
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        in pasteboard: NSPasteboard
+    ) -> [(data: Data, fileExtension: String)] {
+        guard let attributed = attributedString(
+            from: pasteboard,
+            type: .rtfd,
+            documentType: .rtfd
+        ) else { return [] }
+        return rtfdAttachmentImageRepresentations(from: attributed)
+    }
+
+    private static func rtfdAttachmentImageRepresentations(
+        in item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        guard let attributed = attributedString(
+            from: item,
+            type: .rtfd,
+            documentType: .rtfd
+        ) else { return [] }
+        return rtfdAttachmentImageRepresentations(from: attributed)
     }
 
     private static func imageAttachmentRepresentation(
@@ -533,6 +574,9 @@ enum GhosttyPasteboardHelper {
         if let type = !pathExtension.isEmpty ? UTType(filenameExtension: pathExtension) : nil,
            type.conforms(to: .image),
            let fileExtension = type.preferredFilenameExtension ?? nonEmpty(pathExtension) {
+            if isTIFFType(type) {
+                return normalizedPNGRepresentation(from: data)
+            }
             return (data, fileExtension)
         }
 
@@ -541,7 +585,36 @@ enum GhosttyPasteboardHelper {
               let type = UTType(typeIdentifier),
               type.conforms(to: .image),
               let fileExtension = type.preferredFilenameExtension else { return nil }
+        if isTIFFType(type) {
+            return normalizedPNGRepresentation(from: data)
+        }
         return (data, fileExtension)
+    }
+
+    private static func imageDataRepresentation(
+        data: Data,
+        type: NSPasteboard.PasteboardType
+    ) -> (data: Data, fileExtension: String)? {
+        guard let utType = UTType(type.rawValue),
+              utType.conforms(to: .image),
+              let fileExtension = utType.preferredFilenameExtension,
+              !fileExtension.isEmpty else { return nil }
+        if isTIFFType(utType) {
+            return normalizedPNGRepresentation(from: data)
+        }
+        return (data, fileExtension)
+    }
+
+    private static func isTIFFType(_ type: UTType) -> Bool {
+        type == .tiff || type.conforms(to: .tiff)
+    }
+
+    private static func normalizedPNGRepresentation(from data: Data) -> (data: Data, fileExtension: String)? {
+        guard let image = NSImage(data: data),
+              let tiffData = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiffData),
+              let pngData = bitmap.representation(using: .png, properties: [:]) else { return nil }
+        return (pngData, "png")
     }
 
     private static func nonEmpty(_ value: String) -> String? {
@@ -570,16 +643,182 @@ enum GhosttyPasteboardHelper {
 
         for type in pasteboard.types ?? [] {
             guard type != .png,
-                  type != .tiff,
-                  let utType = UTType(type.rawValue),
-                  utType.conforms(to: .image),
                   let imageData = pasteboard.data(forType: type),
-                  let fileExtension = utType.preferredFilenameExtension,
-                  !fileExtension.isEmpty else { continue }
-            return (imageData, fileExtension)
+                  let representation = imageDataRepresentation(data: imageData, type: type) else { continue }
+            return representation
         }
 
         return nil
+    }
+
+    private static func directImageRepresentation(
+        in item: NSPasteboardItem
+    ) -> (data: Data, fileExtension: String)? {
+        if let pngData = item.data(forType: .png) {
+            return (pngData, "png")
+        }
+
+        for type in item.types {
+            guard type != .png,
+                  let imageData = item.data(forType: type),
+                  let representation = imageDataRepresentation(data: imageData, type: type) else { continue }
+            return representation
+        }
+
+        return nil
+    }
+
+    private static func fallbackImageRepresentation(
+        in item: NSPasteboardItem
+    ) -> (data: Data, fileExtension: String)? {
+        for type in item.types {
+            guard let utType = UTType(type.rawValue),
+                  utType.conforms(to: .image),
+                  let data = item.data(forType: type),
+                  let normalized = normalizedPNGRepresentation(from: data) else { continue }
+            return normalized
+        }
+        return nil
+    }
+
+    private static func fallbackImageRepresentation(
+        in pasteboard: NSPasteboard
+    ) -> (data: Data, fileExtension: String)? {
+        guard hasImageData(in: pasteboard),
+              let tiffData = NSImage(pasteboard: pasteboard)?.tiffRepresentation else { return nil }
+        return normalizedPNGRepresentation(from: tiffData)
+    }
+
+    private static func imageRepresentations(
+        in item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        if let directImage = directImageRepresentation(in: item) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: item)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: item) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func pasteboardFallbackImageRepresentations(
+        for item: NSPasteboardItem
+    ) -> [(data: Data, fileExtension: String)] {
+        guard let copiedItem = copiedPasteboardItem(from: item) else { return [] }
+
+        let pasteboard = NSPasteboard(name: .init("cmux-single-image-item-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        defer {
+            pasteboard.clearContents()
+            pasteboard.releaseGlobally()
+        }
+        guard pasteboard.writeObjects([copiedItem]) else { return [] }
+
+        if let directImage = directImageRepresentation(in: pasteboard) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: pasteboard)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: pasteboard) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func copiedPasteboardItem(from item: NSPasteboardItem) -> NSPasteboardItem? {
+        let copiedItem = NSPasteboardItem()
+        var copiedAnyType = false
+
+        for type in item.types {
+            if let data = item.data(forType: type) {
+                copiedAnyType = copiedItem.setData(data, forType: type) || copiedAnyType
+                continue
+            }
+
+            if let string = item.string(forType: type) {
+                copiedAnyType = copiedItem.setString(string, forType: type) || copiedAnyType
+            }
+        }
+
+        return copiedAnyType ? copiedItem : nil
+    }
+
+    private static func imageRepresentations(
+        in pasteboard: NSPasteboard
+    ) -> [(data: Data, fileExtension: String)] {
+        let itemRepresentations = (pasteboard.pasteboardItems ?? [])
+            .flatMap { item in
+                let representations = imageRepresentations(in: item)
+                if !representations.isEmpty {
+                    return representations
+                }
+                return pasteboardFallbackImageRepresentations(for: item)
+            }
+        if !itemRepresentations.isEmpty {
+            return itemRepresentations
+        }
+        if let directImage = directImageRepresentation(in: pasteboard) {
+            return [directImage]
+        }
+        let rtfdAttachments = rtfdAttachmentImageRepresentations(in: pasteboard)
+        if !rtfdAttachments.isEmpty {
+            return rtfdAttachments
+        }
+        if let fallbackImage = fallbackImageRepresentation(in: pasteboard) {
+            return [fallbackImage]
+        }
+        return []
+    }
+
+    private static func materializeImageFileURLs(
+        from representations: [(data: Data, fileExtension: String)]
+    ) -> ImageFileListMaterializationResult {
+        guard !representations.isEmpty else { return .noDecodableImagePayload }
+
+        let maxClipboardImageSize = 10 * 1024 * 1024  // 10 MB
+        var fileURLs: [URL] = []
+        for representation in representations {
+            guard representation.data.count <= maxClipboardImageSize else {
+#if DEBUG
+                cmuxDebugLog("terminal.paste.image.rejected reason=tooLarge bytes=\(representation.data.count)")
+#endif
+                cleanupTransferredTemporaryImageFiles(fileURLs)
+                return .rejectedImagePayload
+            }
+
+            let fileURL = temporaryImageFileURL(fileExtension: representation.fileExtension)
+
+            do {
+                try representation.data.write(to: fileURL)
+            } catch {
+#if DEBUG
+                cmuxDebugLog("terminal.paste.image.writeFailed error=\(error.localizedDescription)")
+#endif
+                try? FileManager.default.removeItem(at: fileURL)
+                cleanupTransferredTemporaryImageFiles(fileURLs)
+                return .rejectedImagePayload
+            }
+
+            registerOwnedTemporaryImageFile(fileURL)
+            fileURLs.append(fileURL)
+        }
+
+        return .saved(fileURLs)
+    }
+
+    private static func temporaryImageFileURL(fileExtension: String) -> URL {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        let timestamp = formatter.string(from: Date())
+        let filename = "\(temporaryImageFilenamePrefix)\(timestamp)-\(UUID().uuidString.prefix(8)).\(fileExtension)"
+        return FileManager.default.temporaryDirectory.appendingPathComponent(filename)
     }
 
     /// Attempts to materialize a decodable pasteboard image into a temporary file.
@@ -588,52 +827,34 @@ enum GhosttyPasteboardHelper {
     static func materializeImageFileURLIfNeeded(
         from pasteboard: NSPasteboard = .general
     ) -> ImageFileMaterializationResult {
-        let imageData: Data
-        let fileExtension: String
-        if let directImage = directImageRepresentation(in: pasteboard) {
-            imageData = directImage.data
-            fileExtension = directImage.fileExtension
-        } else if let rtfdAttachment = rtfdAttachmentImageRepresentation(in: pasteboard) {
-            imageData = rtfdAttachment.data
-            fileExtension = rtfdAttachment.fileExtension
-        } else {
-            guard hasImageData(in: pasteboard),
-                  let image = NSImage(pasteboard: pasteboard),
-                  let tiffData = image.tiffRepresentation,
-                  let bitmap = NSBitmapImageRep(data: tiffData),
-                  let pngData = bitmap.representation(using: .png, properties: [:]) else {
-                return .noDecodableImagePayload
-            }
-            imageData = pngData
-            fileExtension = "png"
-        }
-
-        let maxClipboardImageSize = 10 * 1024 * 1024  // 10 MB
-        guard imageData.count <= maxClipboardImageSize else {
-#if DEBUG
-            cmuxDebugLog("terminal.paste.image.rejected reason=tooLarge bytes=\(imageData.count)")
-#endif
+        let representations = Array(imageRepresentations(in: pasteboard).prefix(1))
+        switch materializeImageFileURLs(from: representations) {
+        case .saved(let fileURLs):
+            guard let fileURL = fileURLs.first else { return .noDecodableImagePayload }
+            return .saved(fileURL)
+        case .noDecodableImagePayload:
+            return .noDecodableImagePayload
+        case .rejectedImagePayload:
             return .rejectedImagePayload
         }
+    }
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd-HHmmss"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        let timestamp = formatter.string(from: Date())
-        let filename = "\(temporaryImageFilenamePrefix)\(timestamp)-\(UUID().uuidString.prefix(8)).\(fileExtension)"
-        let fileURL = FileManager.default.temporaryDirectory.appendingPathComponent(filename)
+    static func materializeImageFileURLsIfNeeded(
+        from pasteboard: NSPasteboard = .general
+    ) -> ImageFileListMaterializationResult {
+        materializeImageFileURLs(from: imageRepresentations(in: pasteboard))
+    }
 
-        do {
-            try imageData.write(to: fileURL)
-        } catch {
-#if DEBUG
-            cmuxDebugLog("terminal.paste.image.writeFailed error=\(error.localizedDescription)")
-#endif
-            return .rejectedImagePayload
+    static func saveImageFileURLsIfNeeded(
+        from pasteboard: NSPasteboard = .general,
+        assumeNoText: Bool = false
+    ) -> [URL] {
+        if !assumeNoText && stringContents(from: pasteboard) != nil { return [] }
+
+        guard case .saved(let fileURLs) = materializeImageFileURLsIfNeeded(from: pasteboard) else {
+            return []
         }
-
-        registerOwnedTemporaryImageFile(fileURL)
-        return .saved(fileURL)
+        return fileURLs
     }
 
     /// When the clipboard contains only image data (or rich text that resolves to
@@ -670,6 +891,17 @@ enum GhosttyPasteboardHelper {
                 continue
             }
             try? FileManager.default.removeItem(at: normalizedURL)
+        }
+    }
+
+    static func cleanupAllOwnedTemporaryImageFiles() {
+        temporaryImageOwnershipLock.lock()
+        let paths = ownedTemporaryImagePaths
+        ownedTemporaryImagePaths.removeAll()
+        temporaryImageOwnershipLock.unlock()
+
+        for path in paths {
+            try? FileManager.default.removeItem(at: URL(fileURLWithPath: path))
         }
     }
 
@@ -9373,15 +9605,44 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
 #if DEBUG
+    fileprivate enum DebugDropPayloadKind {
+        case fileURLs
+        case imageData
+    }
+
     @discardableResult
-    fileprivate func debugSimulateFileDrop(paths: [String]) -> Bool {
+    fileprivate func debugSimulateFileDrop(
+        paths: [String],
+        asImageData: Bool = false
+    ) -> Bool {
         guard !paths.isEmpty else { return false }
-        let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
         let pbName = NSPasteboard.Name("cmux.debug.drop.\(UUID().uuidString)")
         let pasteboard = NSPasteboard(name: pbName)
         pasteboard.clearContents()
-        pasteboard.writeObjects(urls)
+        switch asImageData ? DebugDropPayloadKind.imageData : .fileURLs {
+        case .fileURLs:
+            let urls = paths.map { URL(fileURLWithPath: $0) as NSURL }
+            pasteboard.writeObjects(urls)
+        case .imageData:
+            let items = paths.compactMap { path -> NSPasteboardItem? in
+                let url = URL(fileURLWithPath: path)
+                guard let data = try? Data(contentsOf: url),
+                      let type = debugImagePasteboardType(for: url) else { return nil }
+                let item = NSPasteboardItem()
+                item.setData(data, forType: type)
+                return item
+            }
+            guard items.count == paths.count else { return false }
+            pasteboard.writeObjects(items)
+        }
         return insertDroppedPasteboard(pasteboard)
+    }
+
+    private func debugImagePasteboardType(for url: URL) -> NSPasteboard.PasteboardType? {
+        let pathExtension = url.pathExtension.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let utType = UTType(filenameExtension: pathExtension),
+              utType.conforms(to: .image) else { return nil }
+        return NSPasteboard.PasteboardType(utType.identifier)
     }
 
     fileprivate func debugRegisteredDropTypes() -> [String] {
@@ -11248,8 +11509,8 @@ final class GhosttySurfaceScrollView: NSView {
 
 #if DEBUG
     @discardableResult
-    func debugSimulateFileDrop(paths: [String]) -> Bool {
-        surfaceView.debugSimulateFileDrop(paths: paths)
+    func debugSimulateFileDrop(paths: [String], asImageData: Bool = false) -> Bool {
+        surfaceView.debugSimulateFileDrop(paths: paths, asImageData: asImageData)
     }
 
     func debugPendingSurfaceSize() -> CGSize? {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12541,6 +12541,10 @@ class TerminalController {
             case terminal
             case textDestination
         }
+        enum TerminalFileDropSimulationPayload {
+            case fileURLs
+            case imageData
+        }
         let simulationRoute: TerminalFileDropSimulationRoute
         switch route {
         case "terminal", "direct":
@@ -12550,6 +12554,20 @@ class TerminalController {
         default:
             return .err(code: "invalid_params", message: "Unknown route", data: [
                 "route": route
+            ])
+        }
+        let payload = (v2String(params, "payload") ?? "file_urls")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let simulationPayload: TerminalFileDropSimulationPayload
+        switch payload {
+        case "file", "files", "file_url", "file_urls":
+            simulationPayload = .fileURLs
+        case "image", "image_data", "images":
+            simulationPayload = .imageData
+        default:
+            return .err(code: "invalid_params", message: "Unknown payload", data: [
+                "payload": payload
             ])
         }
 
@@ -12563,11 +12581,21 @@ class TerminalController {
 
             switch simulationRoute {
             case .terminal:
-                let handled = panel.hostedView.debugSimulateFileDrop(paths: paths)
+                let handled = panel.hostedView.debugSimulateFileDrop(
+                    paths: paths,
+                    asImageData: simulationPayload == .imageData
+                )
                 result = handled
-                    ? .ok(["handled": true, "route": "terminal"])
+                    ? .ok(["handled": true, "route": "terminal", "payload": payload])
                     : .err(code: "internal_error", message: "Terminal drop simulation failed", data: nil)
             case .textDestination:
+                guard simulationPayload == .fileURLs else {
+                    result = .err(code: "invalid_params", message: "Image data payload requires terminal route", data: [
+                        "route": route,
+                        "payload": payload
+                    ])
+                    return
+                }
                 guard let workspace = tabManager.tabs.first(where: { $0.id == panel.workspaceId }) else {
                     result = .err(code: "not_found", message: "Workspace not found", data: [
                         "workspace_id": panel.workspaceId.uuidString
@@ -12583,7 +12611,7 @@ class TerminalController {
                     window: panel.hostedView.window
                 )
                 result = handled
-                    ? .ok(["handled": true, "route": "text_destination"])
+                    ? .ok(["handled": true, "route": "text_destination", "payload": payload])
                     : .err(code: "internal_error", message: "Text destination drop simulation failed", data: nil)
             }
         }

--- a/Sources/TerminalImageTransfer.swift
+++ b/Sources/TerminalImageTransfer.swift
@@ -355,10 +355,7 @@ enum TerminalImageTransferPlanner {
         if !urls.isEmpty {
             return urls
         }
-        if let imageURL = GhosttyPasteboardHelper.saveImageFileURLIfNeeded(from: pasteboard, assumeNoText: true) {
-            return [imageURL]
-        }
-        return []
+        return GhosttyPasteboardHelper.saveImageFileURLsIfNeeded(from: pasteboard, assumeNoText: true)
     }
 
     private static func fileURLs(from pasteboard: NSPasteboard) -> [URL] {

--- a/cmuxTests/FinderFileDropRegressionTests.swift
+++ b/cmuxTests/FinderFileDropRegressionTests.swift
@@ -235,6 +235,32 @@ final class FinderFileDropRegressionTests: XCTestCase {
         )
     }
 
+    func testImagePasteboardDropMaterializesEveryImageForRemoteUpload() throws {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-multi-image-remote-drop-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+        let items = try [
+            makeImagePasteboardItem(color: .systemRed),
+            makeImagePasteboardItem(color: .systemGreen),
+        ]
+        XCTAssertTrue(pasteboard.writeObjects(items))
+
+        let plan = GhosttyNSView.dropPlanForTesting(
+            pasteboard: pasteboard,
+            isRemoteTerminalSurface: true
+        )
+
+        guard case .uploadFiles(let urls) = plan else {
+            return XCTFail("expected remote image upload plan, got \(plan)")
+        }
+        defer {
+            GhosttyPasteboardHelper.cleanupTransferredTemporaryImageFiles(urls)
+        }
+
+        XCTAssertEqual(urls.count, 2)
+        XCTAssertTrue(urls.allSatisfy { $0.lastPathComponent.hasPrefix("clipboard-") && $0.pathExtension == "png" })
+        XCTAssertTrue(urls.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+    }
+
     func testSuccessfulPanelTextDropFocusesDestinationPanel() {
         let workspace = Workspace(title: "Tests")
         guard let terminalId = workspace.focusedPanelId,
@@ -403,5 +429,11 @@ final class FinderFileDropRegressionTests: XCTestCase {
             ),
             "Sources/App.swift"
         )
+    }
+
+    private func makeImagePasteboardItem(color: NSColor) throws -> NSPasteboardItem {
+        let item = NSPasteboardItem()
+        item.setData(try make1x1PNG(color: color), forType: .png)
+        return item
     }
 }

--- a/tests_v2/cmux.py
+++ b/tests_v2/cmux.py
@@ -985,13 +985,20 @@ class cmux:
         panel: Union[str, int],
         paths: list[str],
         route: str = "text_destination",
-    ) -> None:
+        payload: str = "file_urls",
+    ) -> dict:
         sid = self._resolve_surface_id(panel)
-        self._call(
+        res = self._call(
             "debug.terminal.simulate_file_drop",
-            {"surface_id": sid, "paths": [str(path) for path in paths], "route": route},
+            {
+                "surface_id": sid,
+                "paths": [str(path) for path in paths],
+                "route": route,
+                "payload": payload,
+            },
             timeout_s=30.0,
         )
+        return dict(res or {})
 
     def read_terminal_text(self, panel: Union[str, int, None] = None) -> str:
         params: Dict[str, Any] = {}

--- a/tests_v2/test_ssh_remote_image_drop_upload.py
+++ b/tests_v2/test_ssh_remote_image_drop_upload.py
@@ -183,17 +183,23 @@ def _focused_surface_id(client: cmux) -> str:
     return surface_id
 
 
-def _wait_for_remote_drop_path(client: cmux, surface_id: str, timeout: float = 20.0) -> str:
+def _wait_for_remote_drop_paths(client: cmux, surface_id: str, expected_count: int, timeout: float = 20.0) -> list[str]:
     pattern = re.compile(r"/tmp/cmux-drop-[0-9a-f-]+\.png")
     deadline = time.time() + timeout
     last = ""
     while time.time() < deadline:
         last = client.read_terminal_text(surface_id)
-        match = pattern.search(last)
-        if match:
-            return match.group(0)
+        search_text = last.replace("\r", "").replace("\n", "")
+        remote_paths: list[str] = []
+        for match in pattern.findall(search_text):
+            if match not in remote_paths:
+                remote_paths.append(match)
+        if len(remote_paths) >= expected_count:
+            return remote_paths[:expected_count]
         time.sleep(0.25)
-    raise cmuxError(f"Timed out waiting for remote drop path in terminal text: {last[-1000:]!r}")
+    raise cmuxError(
+        f"Timed out waiting for {expected_count} remote drop paths in terminal text: {last[-1000:]!r}"
+    )
 
 
 def main() -> int:
@@ -248,27 +254,46 @@ def main() -> int:
             _wait_remote_ready(client, workspace_id)
             client.select_workspace(workspace_id)
 
-            image_path = temp_dir / "dragged-image.png"
-            image_path.write_bytes(base64.b64decode(
+            first_image_path = temp_dir / "dragged-image-one.png"
+            second_image_path = temp_dir / "dragged-image-two.png"
+            first_image_path.write_bytes(base64.b64decode(
                 "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAFgwJ/lS2cWQAAAABJRU5ErkJggg=="
             ))
-            local_sha = hashlib.sha256(image_path.read_bytes()).hexdigest()
+            second_image_path.write_bytes(base64.b64decode(
+                "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg=="
+            ))
+            local_shas = [
+                hashlib.sha256(first_image_path.read_bytes()).hexdigest(),
+                hashlib.sha256(second_image_path.read_bytes()).hexdigest(),
+            ]
 
             surface_id = _focused_surface_id(client)
-            client.simulate_terminal_file_drop(surface_id, [str(image_path)], route="text_destination")
-            remote_path = _wait_for_remote_drop_path(client, surface_id)
+            response = client.simulate_terminal_file_drop(
+                surface_id,
+                [str(first_image_path), str(second_image_path)],
+                route="terminal",
+                payload="image_data",
+            )
+            _must(
+                response.get("payload") == "image_data",
+                f"debug terminal drop did not honor image_data payload: {response}",
+            )
+            remote_paths = _wait_for_remote_drop_paths(client, surface_id, expected_count=2)
 
-        remote_sha = _ssh_run(
-            host,
-            host_ssh_port,
-            key_path,
-            f"sha256sum {_shell_single_quote(remote_path)}",
-        ).stdout.split()[0]
+        remote_shas = [
+            _ssh_run(
+                host,
+                host_ssh_port,
+                key_path,
+                f"sha256sum {_shell_single_quote(remote_path)}",
+            ).stdout.split()[0]
+            for remote_path in remote_paths
+        ]
         _must(
-            remote_sha == local_sha,
-            f"Uploaded file hash mismatch local={local_sha} remote={remote_sha} path={remote_path}",
+            sorted(remote_shas) == sorted(local_shas),
+            f"Uploaded file hashes mismatch local={sorted(local_shas)} remote={sorted(remote_shas)} paths={remote_paths}",
         )
-        print(f"PASS: ssh image drop uploaded {remote_path}")
+        print(f"PASS: ssh image drop uploaded {len(remote_paths)} files: {', '.join(remote_paths)}")
         return 0
     finally:
         if workspace_id:


### PR DESCRIPTION
Split out the SSH-safe part from https://github.com/manaflow-ai/cmux/pull/3769 while the local Claude drag path is still under investigation.

Changes:
- Add a regression for two image-data drops into a cmux-ssh terminal.
- Teach the debug socket drop helper to simulate image-data pasteboard items.
- Materialize every image item and upload the full list to the remote terminal.

Verification:
- Red before fix: `FinderFileDropRegressionTests/testImagePasteboardDropMaterializesEveryImageForRemoteUpload` failed with `1` URL instead of `2`.
- Green after fix: focused XCTest passed.
- Tagged socket regression passed: `tests_v2/test_ssh_remote_image_drop_upload.py` uploaded 2 remote files and hash-checked both.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes pasteboard image materialization and temporary-file lifecycle, which directly affects drag/drop behavior and remote SSH uploads. Failures could lead to missing uploads or leaked temp files across sessions.
> 
> **Overview**
> Fixes remote (SSH) image drops to **upload every image** when the pasteboard contains multiple image items, instead of only materializing a single image.
> 
> Refactors `GhosttyPasteboardHelper` to extract image representations per `NSPasteboardItem`, normalize TIFF payloads to PNG, add APIs for multi-image materialization (`materializeImageFileURLsIfNeeded`/`saveImageFileURLsIfNeeded`), and ensure owned temporary clipboard images are cleaned up on app termination.
> 
> Extends the debug socket drop simulation to support an `image_data` payload (in addition to `file_urls`) and updates both XCTest and v2 Python regression tests to validate two-image remote upload behavior end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99aea35dc3ab401657437443c26f475cc0596557. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSH multi-image drops by materializing every image from the pasteboard and uploading the full set to the remote terminal. Adds a regression test and debug simulation for image-data drops.

- **Bug Fixes**
  - Materialize all pasteboard images (direct types, RTFD attachments, TIFF→PNG) and upload the full list over SSH.
  - Enforce per-image size limit (10 MB) and avoid falling back to text/URLs when a real image is rejected.
  - Upload planner now returns all image file URLs, not just the first.
  - Clean up temporary image files after transfer and on app exit.

- **New Features**
  - Debug drop simulation supports image-data payloads with a new `payload` param (`image_data` or `file_urls`) and returns `route` and `payload`.

<sup>Written for commit 99aea35dc3ab401657437443c26f475cc0596557. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for handling multiple images in drag-and-drop and paste operations.
  * Images are now automatically normalized to PNG format for consistency.

* **Bug Fixes**
  * Temporary clipboard image files are properly cleaned up on app shutdown.
  * Improved image drop and upload reliability for remote terminal connections.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3795)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->