### PR TITLE
PortScanner: replace `ps`/`lsof` subprocesses with libproc

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -259,6 +259,7 @@
 		A5001532 /* TerminalWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001531 /* TerminalWindowPortal.swift */; };
 		A5001534 /* BrowserWindowPortal.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001533 /* BrowserWindowPortal.swift */; };
 		A5001540 /* PortScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001541 /* PortScanner.swift */; };
+		A5001550 /* ProcessScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001551 /* ProcessScanner.swift */; };
 		C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A501000000000000000001 /* CmuxTopSnapshot.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
 		C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */; };
@@ -375,6 +376,7 @@
 		C13519000000000000000007 /* ClaudeConfigDirectoryPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */; };
 		F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */; };
 		F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */; };
+		F4100002A1B2C3D4E5F60718 /* ProcessScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4100003A1B2C3D4E5F60718 /* ProcessScannerTests.swift */; };
 		F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
 		F5410000A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */; };
@@ -747,6 +749,7 @@
 		D0B10003A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarPassThrough.swift; sourceTree = "<group>"; };
 		D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarDebug.swift; sourceTree = "<group>"; };
 		A5001541 /* PortScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScanner.swift; sourceTree = "<group>"; };
+		A5001551 /* ProcessScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessScanner.swift; sourceTree = "<group>"; };
 		A5001544 /* TerminalImageTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalImageTransfer.swift; sourceTree = "<group>"; };
 		A5001545 /* TerminalSSHSessionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSSHSessionDetector.swift; sourceTree = "<group>"; };
 		A5001600 /* SentryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryHelper.swift; sourceTree = "<group>"; };
@@ -849,6 +852,7 @@
 		C13519000000000000000008 /* ClaudeConfigDirectoryPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeConfigDirectoryPathTests.swift; sourceTree = "<group>"; };
 		F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearanceSnapshotTests.swift; sourceTree = "<group>"; };
 		F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortScannerTests.swift; sourceTree = "<group>"; };
+		F4100003A1B2C3D4E5F60718 /* ProcessScannerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessScannerTests.swift; sourceTree = "<group>"; };
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
 		F5410001A1B2C3D4E5F60718 /* RestorableAgentHookProviderResumeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableAgentHookProviderResumeTests.swift; sourceTree = "<group>"; };
@@ -1171,6 +1175,7 @@
 				C7A503000000000000000001 /* TaskManagerSnapshot.swift */,
 				C7A504000000000000000001 /* TaskManagerTypes.swift */,
 				A5001541 /* PortScanner.swift */,
+				A5001551 /* ProcessScanner.swift */,
 				A5001544 /* TerminalImageTransfer.swift */,
 				A5001545 /* TerminalSSHSessionDetector.swift */,
 				A5001225 /* SocketControlSettings.swift */,
@@ -1325,6 +1330,7 @@
 				A11EAF000000000000000001 /* GhosttyNotificationDispatcherTests.swift */,
 				F4200001A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift */,
 					F4100001A1B2C3D4E5F60718 /* PortScannerTests.swift */,
+					F4100003A1B2C3D4E5F60718 /* ProcessScannerTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
 					B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */,
 					D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */,
@@ -1791,6 +1797,7 @@
 				C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */,
 				C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */,
 				A5001540 /* PortScanner.swift in Sources */,
+				A5001550 /* ProcessScanner.swift in Sources */,
 				A5001542 /* TerminalImageTransfer.swift in Sources */,
 				A5001543 /* TerminalSSHSessionDetector.swift in Sources */,
 				A5001226 /* SocketControlSettings.swift in Sources */,
@@ -1985,6 +1992,7 @@
 				A11EAF000000000000000000 /* GhosttyNotificationDispatcherTests.swift in Sources */,
 				F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */,
 					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,
+					F4100002A1B2C3D4E5F60718 /* ProcessScannerTests.swift in Sources */,
 					F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 					D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */,

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -264,12 +264,19 @@ nonisolated final class CmuxTopProcessSnapshot: @unchecked Sendable {
                 return []
             }
 
-            var processes = Array(repeating: kinfo_proc(), count: max(1, (length / stride) + 32))
+            let capacity = max(1, (length / stride) + 32)
+            var processes = Array(repeating: kinfo_proc(), count: capacity)
+            // sysctl uses `oldlenp` as both input (declared buffer size) and
+            // output (bytes actually written). Declare the full allocation —
+            // not the probed size — so the 32-entry slack absorbs process-
+            // table growth between probe and read instead of triggering a
+            // spurious ENOMEM.
+            var bufferLength = capacity * stride
             let result = processes.withUnsafeMutableBufferPointer { buffer in
-                sysctl(&mib, u_int(mib.count), buffer.baseAddress, &length, nil, 0)
+                sysctl(&mib, u_int(mib.count), buffer.baseAddress, &bufferLength, nil, 0)
             }
             if result == 0 {
-                let count = min(processes.count, length / stride)
+                let count = min(processes.count, bufferLength / stride)
                 let sampledProcesses = Array(processes.prefix(count))
                 let activeScopeKeys = Set(sampledProcesses.map { scopeCacheKey(from: $0) })
                 let sampledAtNanoseconds = cpuSampleClockNanoseconds()

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -4,7 +4,9 @@ import Foundation
 ///
 /// Each shell sends a lightweight `report_tty` + `ports_kick` over the socket.
 /// PortScanner coalesces kicks across all panels, then runs a single
-/// `ps -t <ttys>` + `lsof -p <pids>` covering every panel that needs scanning.
+/// libproc sweep (TTY→pids + per-pid listening TCP ports) covering every
+/// panel that needs scanning. See `ProcessScanner` for the subprocess-free
+/// replacements for `ps -t` / `ps -ax` / `lsof -iTCP -sTCP:LISTEN`.
 ///
 /// Kick → coalesce → burst flow:
 /// 1. `kick()` adds panel to `pendingKicks` set
@@ -534,80 +536,25 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func runPS(ttyList: String) -> [Int: String] {
-        // `ps -t tty1,tty2,... -o pid=,tty=` — targeted scan, much cheaper than -ax.
-        guard let output = Self.captureStandardOutput(
-            executablePath: "/bin/ps",
-            arguments: ["-t", ttyList, "-o", "pid=,tty="]
-        ) else {
-            return [:]
-        }
-
-        var mapping: [Int: String] = [:]
-        for line in output.split(separator: "\n") {
-            let parts = line.split(whereSeparator: \.isWhitespace)
-            guard parts.count >= 2,
-                  let pid = Int(parts[0]) else { continue }
-            mapping[pid] = String(parts[1])
-        }
-        return mapping
+        // Subprocess-free replacement for `ps -t <ttys> -o pid=,tty=`. Every
+        // exec() was logged by endpoint-security tools (FortiDLP, CrowdStrike),
+        // and the burst/agent rescan path ran this many thousands of times a
+        // day per workspace. See `ProcessScanner`.
+        ProcessScanner.pidsByTTY(ttyList: ttyList)
     }
 
     private func runAllProcesses() -> [Int: Int] {
-        guard let output = Self.captureStandardOutput(
-            executablePath: "/bin/ps",
-            arguments: ["-ax", "-o", "pid=,ppid="]
-        ) else {
-            return [:]
-        }
-
-        var mapping: [Int: Int] = [:]
-        for line in output.split(separator: "\n") {
-            let parts = line.split(whereSeparator: \.isWhitespace)
-            guard parts.count >= 2,
-                  let pid = Int(parts[0]),
-                  let parentPid = Int(parts[1]) else { continue }
-            mapping[pid] = parentPid
-        }
-        return mapping
+        // Subprocess-free replacement for `ps -ax -o pid=,ppid=`.
+        ProcessScanner.parentByPid()
     }
 
     private func runLsof(pidsCsv: String) -> [Int: Set<Int>] {
-        // `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -F pn`
-        guard let output = Self.captureStandardOutput(
-            executablePath: "/usr/sbin/lsof",
-            arguments: ["-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"]
-        ) else {
-            return [:]
-        }
-
-        // Parse lsof -F output: lines starting with 'p' = PID, 'n' = name (host:port).
-        var result: [Int: Set<Int>] = [:]
-        var currentPid: Int?
-        for line in output.split(separator: "\n") {
-            guard let first = line.first else { continue }
-            switch first {
-            case "p":
-                currentPid = Int(line.dropFirst())
-            case "n":
-                guard let pid = currentPid else { continue }
-                var name = String(line.dropFirst())
-                // Strip remote endpoint if present.
-                if let arrowIdx = name.range(of: "->") {
-                    name = String(name[..<arrowIdx.lowerBound])
-                }
-                // Port is after the last colon.
-                if let colonIdx = name.lastIndex(of: ":") {
-                    let portStr = name[name.index(after: colonIdx)...]
-                    // Strip anything non-numeric.
-                    let cleaned = portStr.prefix(while: \.isNumber)
-                    if let port = Int(cleaned), port > 0, port <= 65535 {
-                        result[pid, default: []].insert(port)
-                    }
-                }
-            default:
-                break
-            }
-        }
-        return result
+        // Subprocess-free replacement for
+        // `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn`.
+        let pids = pidsCsv
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .compactMap { Int($0) }
+        guard !pids.isEmpty else { return [:] }
+        return ProcessScanner.listeningTCPPorts(forPIDs: pids)
     }
 }

--- a/Sources/ProcessScanner.swift
+++ b/Sources/ProcessScanner.swift
@@ -149,11 +149,17 @@ enum ProcessScanner {
 
             let capacity = max(1, (length / stride) + 32)
             var processes = Array(repeating: kinfo_proc(), count: capacity)
+            // sysctl uses `oldlenp` as both input (declared buffer size) and
+            // output (bytes actually written). Declare the full allocation —
+            // not the probed size — so the 32-entry slack absorbs process-
+            // table growth between probe and read instead of triggering a
+            // spurious ENOMEM.
+            var bufferLength = capacity * stride
             let result = processes.withUnsafeMutableBufferPointer { buffer -> Int32 in
-                sysctl(&mib, u_int(mib.count), buffer.baseAddress, &length, nil, 0)
+                sysctl(&mib, u_int(mib.count), buffer.baseAddress, &bufferLength, nil, 0)
             }
             if result == 0 {
-                let count = min(processes.count, length / stride)
+                let count = min(processes.count, bufferLength / stride)
                 for i in 0..<count {
                     body(processes[i])
                 }

--- a/Sources/ProcessScanner.swift
+++ b/Sources/ProcessScanner.swift
@@ -1,0 +1,165 @@
+import Darwin
+import Foundation
+
+/// Subprocess-free replacement for the `ps`/`lsof` helpers that PortScanner
+/// previously shelled out to. Uses `sysctl(KERN_PROC_ALL)` for the process
+/// table (pid, ppid, tty device) and `proc_pidinfo(PROC_PIDLISTFDS)` plus
+/// `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` for each pid's listening TCP ports.
+///
+/// This exists because every `ps`/`lsof` exec is visible to macOS endpoint
+/// security monitors (FortiDLP, CrowdStrike, etc.) which log every process
+/// launch. The shell-kick + 2s agent rescan loop in PortScanner was spawning
+/// thousands of short-lived subprocesses per day per workspace; libproc does
+/// the same queries via syscall only.
+enum ProcessScanner {
+    /// Maps a comma-separated TTY name list (the same format `ps -t` accepts,
+    /// e.g. `"ttys001,ttys003"`) to `[pid: tty_name]` for every process whose
+    /// controlling terminal matches one of the listed names.
+    static func pidsByTTY(ttyList: String) -> [Int: String] {
+        let names = ttyList
+            .split(separator: ",", omittingEmptySubsequences: true)
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        guard !names.isEmpty else { return [:] }
+
+        var deviceToName: [Int64: String] = [:]
+        for name in names {
+            guard let dev = ttyDeviceID(forName: name) else { continue }
+            deviceToName[dev] = name
+        }
+        guard !deviceToName.isEmpty else { return [:] }
+
+        var mapping: [Int: String] = [:]
+        forEachProcess { kinfo in
+            let dev = Int64(kinfo.kp_eproc.e_tdev)
+            guard dev > 0, let name = deviceToName[dev] else { return }
+            let pid = Int(kinfo.kp_proc.p_pid)
+            guard pid > 0 else { return }
+            mapping[pid] = name
+        }
+        return mapping
+    }
+
+    /// Returns `[pid: ppid]` for every process in the system — the subprocess-
+    /// free equivalent of `ps -ax -o pid=,ppid=`. Used to walk agent-owned
+    /// descendant process trees.
+    static func parentByPid() -> [Int: Int] {
+        var mapping: [Int: Int] = [:]
+        forEachProcess { kinfo in
+            let pid = Int(kinfo.kp_proc.p_pid)
+            let ppid = Int(kinfo.kp_eproc.e_ppid)
+            guard pid > 0 else { return }
+            mapping[pid] = ppid
+        }
+        return mapping
+    }
+
+    /// Returns `[pid: set<listening_tcp_port>]` — the subprocess-free
+    /// equivalent of `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` filtered
+    /// by the caller-supplied pid set.
+    static func listeningTCPPorts(forPIDs pids: [Int]) -> [Int: Set<Int>] {
+        var result: [Int: Set<Int>] = [:]
+        for pid in pids where pid > 0 {
+            let ports = listeningTCPPorts(forPID: pid)
+            guard !ports.isEmpty else { continue }
+            result[pid] = ports
+        }
+        return result
+    }
+
+    // MARK: - Internals
+
+    private static func listeningTCPPorts(forPID pid: Int) -> Set<Int> {
+        var bufferSize: Int32 = 0
+        // First probe to size the fd list.
+        let probe = proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, nil, 0)
+        guard probe > 0 else { return [] }
+        bufferSize = probe
+
+        let fdSize = Int32(MemoryLayout<proc_fdinfo>.stride)
+        // Allocate with a little slack so FDs opened between the size probe
+        // and the real call don't truncate us.
+        let slack: Int32 = fdSize * 16
+        let capacity = Int(bufferSize + slack)
+        guard capacity >= Int(fdSize) else { return [] }
+
+        let entryCount = capacity / Int(fdSize)
+        var fds = [proc_fdinfo](repeating: proc_fdinfo(), count: entryCount)
+        let bytes = Int32(entryCount) * fdSize
+
+        let written = fds.withUnsafeMutableBufferPointer { buf -> Int32 in
+            proc_pidinfo(pid_t(pid), PROC_PIDLISTFDS, 0, buf.baseAddress, bytes)
+        }
+        guard written > 0 else { return [] }
+        let count = Int(written) / Int(fdSize)
+
+        var ports: Set<Int> = []
+        for i in 0..<count {
+            let fd = fds[i]
+            guard fd.proc_fdtype == UInt32(PROX_FDTYPE_SOCKET) else { continue }
+            if let port = listenPort(forPID: pid, fd: fd.proc_fd) {
+                ports.insert(port)
+            }
+        }
+        return ports
+    }
+
+    private static func listenPort(forPID pid: Int, fd: Int32) -> Int? {
+        var info = socket_fdinfo()
+        let expected = Int32(MemoryLayout<socket_fdinfo>.stride)
+        let written = proc_pidfdinfo(pid_t(pid), fd, PROC_PIDFDSOCKETINFO, &info, expected)
+        guard written == expected else { return nil }
+
+        let psi = info.psi
+        guard Int(psi.soi_kind) == SOCKINFO_TCP else { return nil }
+        guard psi.soi_proto.pri_tcp.tcpsi_state == TSI_S_LISTEN else { return nil }
+
+        // insi_lport is stored in network byte order; convert to host order.
+        let rawPort = psi.soi_proto.pri_tcp.tcpsi_ini.insi_lport
+        let port = Int(UInt16(bigEndian: UInt16(truncatingIfNeeded: rawPort)))
+        guard port > 0, port <= 65535 else { return nil }
+        return port
+    }
+
+    /// Resolve a TTY *name* (as reported by `tty(1)` with `/dev/` stripped,
+    /// e.g. `ttys001`) to the `st_rdev` device ID that `kinfo_proc.kp_eproc.e_tdev`
+    /// stores. Returns nil for non-tty strings.
+    private static func ttyDeviceID(forName name: String) -> Int64? {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, trimmed != "not a tty" else { return nil }
+
+        let path = trimmed.hasPrefix("/dev/") ? trimmed : "/dev/\(trimmed)"
+        var statInfo = stat()
+        guard stat(path, &statInfo) == 0 else { return nil }
+        return Int64(statInfo.st_rdev)
+    }
+
+    /// Enumerates every process on the system once via `sysctl(KERN_PROC_ALL)`
+    /// and invokes `body` with each `kinfo_proc`. Retries on ENOMEM to handle
+    /// the table growing between the size probe and the read.
+    private static func forEachProcess(_ body: (kinfo_proc) -> Void) {
+        var mib: [Int32] = [CTL_KERN, KERN_PROC, KERN_PROC_ALL, 0]
+        let stride = MemoryLayout<kinfo_proc>.stride
+
+        for _ in 0..<3 {
+            var length = 0
+            guard sysctl(&mib, u_int(mib.count), nil, &length, nil, 0) == 0, length > 0 else {
+                return
+            }
+
+            let capacity = max(1, (length / stride) + 32)
+            var processes = Array(repeating: kinfo_proc(), count: capacity)
+            let result = processes.withUnsafeMutableBufferPointer { buffer -> Int32 in
+                sysctl(&mib, u_int(mib.count), buffer.baseAddress, &length, nil, 0)
+            }
+            if result == 0 {
+                let count = min(processes.count, length / stride)
+                for i in 0..<count {
+                    body(processes[i])
+                }
+                return
+            }
+            guard errno == ENOMEM else { return }
+        }
+    }
+}

--- a/cmuxTests/ProcessScannerTests.swift
+++ b/cmuxTests/ProcessScannerTests.swift
@@ -1,0 +1,113 @@
+import Darwin
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class ProcessScannerTests: XCTestCase {
+    func testParentByPidIncludesSelfWithMatchingParent() {
+        let mapping = ProcessScanner.parentByPid()
+        let selfPid = Int(getpid())
+        let selfParent = Int(getppid())
+
+        XCTAssertFalse(mapping.isEmpty, "expected to enumerate at least one process")
+        XCTAssertEqual(mapping[selfPid], selfParent,
+                       "self pid should map to getppid() result")
+    }
+
+    func testPidsByTTYResolvesSelfsControllingTerminal() throws {
+        guard let (ttyName, _) = currentTerminalName() else {
+            throw XCTSkip("Test runner has no controlling tty; skipping.")
+        }
+        let mapping = ProcessScanner.pidsByTTY(ttyList: ttyName)
+        // We don't assert which specific pid is present — the test runner's
+        // own pid may or may not be attached to this tty depending on the
+        // harness — only that SOMETHING on that tty is returned.
+        XCTAssertFalse(mapping.isEmpty,
+                       "expected at least one pid on tty \(ttyName)")
+        for (_, resolved) in mapping {
+            XCTAssertEqual(resolved, ttyName)
+        }
+    }
+
+    func testPidsByTTYReturnsEmptyForBogusName() {
+        XCTAssertTrue(ProcessScanner.pidsByTTY(ttyList: "ttys-does-not-exist").isEmpty)
+        XCTAssertTrue(ProcessScanner.pidsByTTY(ttyList: "").isEmpty)
+        XCTAssertTrue(ProcessScanner.pidsByTTY(ttyList: "not a tty").isEmpty)
+    }
+
+    func testListeningTCPPortsDetectsBoundSocket() throws {
+        let sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else {
+            throw XCTSkip("socket() failed; skipping.")
+        }
+        defer { close(sock) }
+
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_addr.s_addr = INADDR_ANY.bigEndian
+        addr.sin_port = 0
+
+        let bindResult = withUnsafePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { raw in
+                Darwin.bind(sock, raw, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        try XCTSkipIf(bindResult != 0, "bind() failed; skipping.")
+        try XCTSkipIf(listen(sock, 16) != 0, "listen() failed; skipping.")
+
+        var actualLen = socklen_t(MemoryLayout<sockaddr_in>.size)
+        let getResult = withUnsafeMutablePointer(to: &addr) { ptr -> Int32 in
+            ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { raw in
+                getsockname(sock, raw, &actualLen)
+            }
+        }
+        try XCTSkipIf(getResult != 0, "getsockname() failed; skipping.")
+
+        let expectedPort = Int(UInt16(bigEndian: addr.sin_port))
+        XCTAssertGreaterThan(expectedPort, 0)
+
+        let selfPid = Int(getpid())
+        let ports = ProcessScanner.listeningTCPPorts(forPIDs: [selfPid])
+        XCTAssertTrue(ports[selfPid]?.contains(expectedPort) ?? false,
+                      "expected libproc to report port \(expectedPort) on self pid \(selfPid); got \(ports)")
+    }
+
+    func testListeningTCPPortsIgnoresNonListeningSockets() throws {
+        // A plain unbound socket should not produce a listening port entry.
+        let sock = socket(AF_INET, SOCK_STREAM, 0)
+        guard sock >= 0 else {
+            throw XCTSkip("socket() failed; skipping.")
+        }
+        defer { close(sock) }
+
+        let ports = ProcessScanner.listeningTCPPorts(forPIDs: [Int(getpid())])
+        // We can't assert the result is empty because the test harness itself
+        // may hold listening sockets; just assert that nothing looks like our
+        // unbound fd (port 0).
+        for (_, set) in ports {
+            XCTAssertFalse(set.contains(0))
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Returns (basename, fd) for the process's controlling terminal if one
+    /// exists. Checks stdin, stdout, stderr.
+    private func currentTerminalName() -> (String, Int32)? {
+        for fd: Int32 in [0, 1, 2] {
+            guard isatty(fd) != 0 else { continue }
+            guard let cStr = ttyname(fd) else { continue }
+            let path = String(cString: cStr)
+            let basename = (path as NSString).lastPathComponent
+            if !basename.isEmpty && basename != "not a tty" {
+                return (basename, fd)
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

This PR replaces the three subprocess call sites in `PortScanner` (`/bin/ps -t`, `/bin/ps -ax`, `/usr/sbin/lsof -iTCP -sTCP:LISTEN`) with direct `sysctl(KERN_PROC_ALL)` + `proc_pidinfo(PROC_PIDLISTFDS)` + `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` calls in a new `ProcessScanner` enum. The kick/coalesce/burst pipeline behavior is unchanged.

Related to #2540. Complementary to #3199 (throttle `preexec` kicks): That PR reduces the rate of execs; this one removes them entirely.

## Motivation

PortScanner runs `ps` + `lsof` in two hot paths:

1. **Kick burst:** every `preexec` `ports_kick` triggers 6 scans at offsets `[0.5, 1.5, 3, 5, 7.5, 10]s`. Up to 12 `posix_spawn` calls per shell command.
2. **Agent rescan timer:** a repeating 2s `DispatchSourceTimer` runs `ps -ax` + `lsof` for as long as any agent PID is tracked — roughly 86k execs/day per active workspace, even when fully idle (`Sources/PortScanner.swift:54`, `agentRescanInterval`).

For users running endpoint-security tools (FortiDLP Reveal, CrowdStrike Falcon, etc.) that hook `exec()`, each of those launches is logged by the monitoring agent. On a real user's machine, cmux idling with a couple of Claude Code panels was producing enough `ps`/`lsof` events to drive significant CPU usage in the security monitor — a cost that doesn't show up in cmux's own CPU sample but is still caused by cmux.

Closing `ps`/`lsof` out entirely removes that externality. It also cuts the ~14% idle CPU figure `sghael` attributed to PortScanner in the #2540 sample analysis, since there's no spawn/wait/pipe-read round-trip anymore.

## Approach

`Sources/ProcessScanner.swift` (new, ~160 LOC) provides three entry points:

| Old subprocess | New call |
|---|---|
| `ps -t <ttys> -o pid=,tty=` | `ProcessScanner.pidsByTTY(ttyList:)` |
| `ps -ax -o pid=,ppid=` | `ProcessScanner.parentByPid()` |
| `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -Fpn` | `ProcessScanner.listeningTCPPorts(forPIDs:)` |

- Process enumeration via `sysctl(CTL_KERN, KERN_PROC, KERN_PROC_ALL)` with ENOMEM retry. Same pattern `CmuxTopSnapshot.swift` already uses for its task-manager snapshots.
- TTY name → `st_rdev` conversion via a `stat("/dev/<name>")` per unique TTY, then matched against `kinfo_proc.kp_eproc.e_tdev`.
- Listening ports via `proc_pidinfo(PROC_PIDLISTFDS)` to enumerate each pid's fds, then `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` on each socket fd, filtered by `soi_kind == SOCKINFO_TCP` and `tcpsi_state == TSI_S_LISTEN`. Port extracted from `insi_lport` (network byte order → host).

`PortScanner`'s three helpers (`runPS`, `runAllProcesses`, `runLsof`) become thin wrappers that call into `ProcessScanner`. `captureStandardOutput` is kept for now since the existing `PortScannerTests` regression test (the fd-leak test from #2893) still exercises it through `/usr/bin/printf`.

## Commit structure

Two commits:

1. `Add ProcessScanner: subprocess-free ps/lsof replacement` — scanner + unit tests + Xcode project wiring. New tests verify process enumeration, TTY resolution, and bound-listening-socket detection against real libproc calls.
2. `PortScanner: replace ps/lsof subprocesses with ProcessScanner` — the rewire.

Keeping the scanner and its tests in a separate commit means the tests compile against the new type without the rewire, and the second commit is a pure diff of the subprocess call sites going away.

## Validation

- `swiftc -typecheck` clean on both new files against the command-line-tools SDK.
- Runtime smoke tests of the two primary APIs, outside Xcode:
  - `parentByPid()` enumerated 1162 processes and correctly mapped `getpid()` → `getppid()`.
  - `listeningTCPPorts(forPIDs: [self])` detected an ephemeral port immediately after a locally-bound `listen()` — exact port match.
- New XCTest cases cover: self-PID/parent-PID mapping, TTY-keyed pid resolution, empty/invalid TTY inputs, bound-listening-socket detection, and non-listening-fd rejection.
- Did not run local Xcode builds or Python socket tests per repo testing policy. CI should build the tagged debug app and run the unit + python suites.

## Related

- #2540 — CPU usage ~15% when idle; `sghael`'s sample analysis names PortScanner as the top contributor
- #3199 — throttle `preexec` `ports_kick` (complementary; reduces kick rate instead of per-exec cost)
- #2893 — fd-leak fix for `PortScanner.captureStandardOutput` (still used by tests; helper retained)
- #2562 — introduced the 2s agent rescan timer this PR is neutralizing from an exec-cost standpoint
- #100 — original PR that built PortScanner with shell subprocesses

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `ps`/`lsof` subprocesses in PortScanner with a libproc-based `ProcessScanner` to remove all exec() calls in the scan paths. Also fixed `sysctl` buffer sizing to prevent ENOMEM and silent empty scans; task manager process listing uses the same fix. No behavior change.

- **Refactors**
  - Added `ProcessScanner` using `sysctl(KERN_PROC_ALL)`, `proc_pidinfo(PROC_PIDLISTFDS)`, and `proc_pidfdinfo(PROC_PIDFDSOCKETINFO)` with `pidsByTTY(ttyList:)`, `parentByPid()`, and `listeningTCPPorts(forPIDs:)`; rewired `PortScanner` to use it. Tests included. Related: #2540; complements #3199.

- **Bug Fixes**
  - Corrected `sysctl oldlenp` handling in `ProcessScanner.forEachProcess` to declare the full buffer, avoiding ENOMEM and empty port scans.
  - Applied the same `oldlenp` fix to `CmuxTopSnapshot` to prevent an empty task-manager process list.

<sup>Written for commit aad31315767fb0729258b57570bf4f900f69d01a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced subprocess-free process inspection for terminal and TCP port discovery on macOS.

* **Tests**
  * Added comprehensive tests covering process scanning, terminal-to-PID mapping, and TCP listening socket detection.

* **Refactor**
  * Replaced external command parsing with native system inspection for process and port lookups.

* **Chores**
  * Project configuration updated to include the new scanner and its tests.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3801)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->