### PR TITLE
Fix Claude/agent session restore across cmux relaunches

### DIFF
--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,11 +1,11 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-20550	CLI/cmux.swift
-17317	Sources/TerminalController.swift
+20900	CLI/cmux.swift
+17460	Sources/TerminalController.swift
 15956	Sources/ContentView.swift
 14636	Sources/AppDelegate.swift
-14020	Sources/Workspace.swift
+14030	Sources/Workspace.swift
 13458	Sources/GhosttyTerminalView.swift
 10607	Sources/Panels/BrowserPanel.swift
 8285	Sources/cmuxApp.swift
@@ -25,8 +25,8 @@
 2863	cmuxTests/WindowAndDragTests.swift
 2609	Sources/SessionIndexView.swift
 2472	Sources/Panels/CmuxWebView.swift
+2400	cmuxTests/SessionPersistenceTests.swift
 2317	cmuxTests/TabManagerUnitTests.swift
-2300	cmuxTests/SessionPersistenceTests.swift
 2179	Sources/KeyboardShortcutSettings.swift
 2172	Sources/TerminalWindowPortal.swift
 2153	Sources/Update/UpdateTitlebarAccessory.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -25,7 +25,7 @@
 2863	cmuxTests/WindowAndDragTests.swift
 2609	Sources/SessionIndexView.swift
 2472	Sources/Panels/CmuxWebView.swift
-2400	cmuxTests/SessionPersistenceTests.swift
+2410	cmuxTests/SessionPersistenceTests.swift
 2317	cmuxTests/TabManagerUnitTests.swift
 2179	Sources/KeyboardShortcutSettings.swift
 2172	Sources/TerminalWindowPortal.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,11 +1,11 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-20530	CLI/cmux.swift
+20550	CLI/cmux.swift
 17317	Sources/TerminalController.swift
 15956	Sources/ContentView.swift
 14636	Sources/AppDelegate.swift
-13975	Sources/Workspace.swift
+14000	Sources/Workspace.swift
 13458	Sources/GhosttyTerminalView.swift
 10607	Sources/Panels/BrowserPanel.swift
 8285	Sources/cmuxApp.swift
@@ -26,9 +26,9 @@
 2609	Sources/SessionIndexView.swift
 2472	Sources/Panels/CmuxWebView.swift
 2317	cmuxTests/TabManagerUnitTests.swift
+2220	cmuxTests/SessionPersistenceTests.swift
 2179	Sources/KeyboardShortcutSettings.swift
 2172	Sources/TerminalWindowPortal.swift
-2170	cmuxTests/SessionPersistenceTests.swift
 2153	Sources/Update/UpdateTitlebarAccessory.swift
 2026	cmuxTests/CJKIMEInputTests.swift
 1949	Sources/Panels/BrowserWebAuthnSupport.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -25,7 +25,7 @@
 2863	cmuxTests/WindowAndDragTests.swift
 2609	Sources/SessionIndexView.swift
 2472	Sources/Panels/CmuxWebView.swift
-2410	cmuxTests/SessionPersistenceTests.swift
+2470	cmuxTests/SessionPersistenceTests.swift
 2317	cmuxTests/TabManagerUnitTests.swift
 2179	Sources/KeyboardShortcutSettings.swift
 2172	Sources/TerminalWindowPortal.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -1,8 +1,8 @@
 # cmux-owned Swift file length budget.
 # Format: max_lines<TAB>relative path
 # Reduce counts as files shrink. CI fails if tracked files exceed this budget.
-20900	CLI/cmux.swift
-17460	Sources/TerminalController.swift
+20970	CLI/cmux.swift
+17500	Sources/TerminalController.swift
 15956	Sources/ContentView.swift
 14636	Sources/AppDelegate.swift
 14030	Sources/Workspace.swift

--- a/.github/swift-file-length-budget.tsv
+++ b/.github/swift-file-length-budget.tsv
@@ -5,7 +5,7 @@
 17317	Sources/TerminalController.swift
 15956	Sources/ContentView.swift
 14636	Sources/AppDelegate.swift
-14000	Sources/Workspace.swift
+14020	Sources/Workspace.swift
 13458	Sources/GhosttyTerminalView.swift
 10607	Sources/Panels/BrowserPanel.swift
 8285	Sources/cmuxApp.swift
@@ -26,7 +26,7 @@
 2609	Sources/SessionIndexView.swift
 2472	Sources/Panels/CmuxWebView.swift
 2317	cmuxTests/TabManagerUnitTests.swift
-2220	cmuxTests/SessionPersistenceTests.swift
+2300	cmuxTests/SessionPersistenceTests.swift
 2179	Sources/KeyboardShortcutSettings.swift
 2172	Sources/TerminalWindowPortal.swift
 2153	Sources/Update/UpdateTitlebarAccessory.swift

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14329,10 +14329,12 @@ struct CMUXCLI {
                 // Tell the live app to drop the restored-agent snapshot for this
                 // panel so the next session save does not re-embed it. Without
                 // this, the next cmux launch tries to resume a session that
-                // was already ended in this lifetime.
-                if !surfaceId.isEmpty {
+                // was already ended in this lifetime. The sessionId scopes the
+                // clear so a late hook for session A can't wipe a freshly-
+                // started session B that has reused the same panel.
+                if !surfaceId.isEmpty, !consumedSession.sessionId.isEmpty {
                     _ = try? sendV1Command(
-                        "agent_session_ended --tab=\(workspaceId) --surface=\(surfaceId)",
+                        "agent_session_ended --tab=\(workspaceId) --surface=\(surfaceId) --session=\(consumedSession.sessionId)",
                         client: client
                     )
                 }
@@ -17427,10 +17429,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 )
                 // Drop the restored-agent snapshot for this panel so the next
                 // session save does not re-embed it. See the matching
-                // `agent_session_ended` block in `claude-hook session-end`.
-                if !mapped.surfaceId.isEmpty {
+                // `agent_session_ended` block in `claude-hook session-end`
+                // for the sessionId-scoping rationale.
+                if !mapped.surfaceId.isEmpty, !mapped.sessionId.isEmpty {
                     _ = try? sendV1Command(
-                        "agent_session_ended --tab=\(mapped.workspaceId) --surface=\(mapped.surfaceId)",
+                        "agent_session_ended --tab=\(mapped.workspaceId) --surface=\(mapped.surfaceId) --session=\(mapped.sessionId)",
                         client: client
                     )
                 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14319,12 +14319,23 @@ struct CMUXCLI {
             )
             if let consumedSession {
                 let workspaceId = consumedSession.workspaceId
+                let surfaceId = consumedSession.surfaceId
                 sendClaudeFeedTelemetry(workspaceId: workspaceId)
                 _ = try? sendV1Command(
                     "clear_agent_pid claude_code --tab=\(workspaceId)\(socketPanelOption(consumedSession.surfaceId)) --clear-status",
                     client: client
                 )
                 _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
+                // Tell the live app to drop the restored-agent snapshot for this
+                // panel so the next session save does not re-embed it. Without
+                // this, the next cmux launch tries to resume a session that
+                // was already ended in this lifetime.
+                if !surfaceId.isEmpty {
+                    _ = try? sendV1Command(
+                        "agent_session_ended --tab=\(workspaceId) --surface=\(surfaceId)",
+                        client: client
+                    )
+                }
             }
             print("OK")
 
@@ -17414,6 +17425,15 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     "clear_agent_pid \(pidKey) --tab=\(mapped.workspaceId)\(socketPanelOption(mapped.surfaceId)) --clear-status",
                     client: client
                 )
+                // Drop the restored-agent snapshot for this panel so the next
+                // session save does not re-embed it. See the matching
+                // `agent_session_ended` block in `claude-hook session-end`.
+                if !mapped.surfaceId.isEmpty {
+                    _ = try? sendV1Command(
+                        "agent_session_ended --tab=\(mapped.workspaceId) --surface=\(mapped.surfaceId)",
+                        client: client
+                    )
+                }
             }
 
         case .noop:

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -50,13 +50,18 @@ enum AgentResumeCommandBuilder {
             ? nil
             : normalized(workingDirectory ?? launchCommand?.workingDirectory)
         if let cwd {
-            // Don't resume into a dead working directory. The captured `cd`
-            // would fail at restore time, `&&` would short-circuit before the
-            // agent runs, and the user would see a dead "no such file or
-            // directory" prompt with no way back. Returning nil tells the
-            // caller (`resumeStartupInput`) to skip auto-resume entirely so
-            // the panel opens as a fresh shell instead.
-            guard FileManager.default.fileExists(atPath: cwd) else { return nil }
+            // Don't resume into a dead working directory or one that's not a
+            // directory at all. `fileExists(atPath:)` alone returns true for
+            // regular files too, so a path that points at a leftover file
+            // would let `cd <file>` fail at runtime — the exact failure mode
+            // the guard exists to prevent. Returning nil tells the caller
+            // (`resumeStartupInput`) to skip auto-resume entirely so the
+            // panel opens as a fresh shell instead.
+            var isDirectory: ObjCBool = false
+            guard FileManager.default.fileExists(atPath: cwd, isDirectory: &isDirectory),
+                  isDirectory.boolValue else {
+                return nil
+            }
             shellCommand = "cd \(shellSingleQuoted(cwd)) && \(shellCommand)"
         }
         return shellCommand
@@ -607,11 +612,21 @@ struct RestorableAgentSessionIndex: Sendable {
             resolved[key] = detected
         }
 
-        var byPanelId: [UUID: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval)] = [:]
-        for (key, value) in resolved {
-            if let existing = byPanelId[key.panelId], existing.updatedAt > value.updatedAt {
-                continue
+        // Sort the resolved entries before folding by panelId so equal
+        // `updatedAt` ties resolve identically across launches. Without the
+        // sort, `Dictionary` iteration order is unspecified and a panel with
+        // two stale records sharing a timestamp would flap between the two
+        // sessions on different cmux launches. Primary key: newer
+        // `updatedAt` wins; secondary tie-break: lexicographically larger
+        // `sessionId` wins (arbitrary but stable).
+        let rankedResolved = resolved.sorted { lhs, rhs in
+            if lhs.value.updatedAt != rhs.value.updatedAt {
+                return lhs.value.updatedAt > rhs.value.updatedAt
             }
+            return lhs.value.snapshot.sessionId > rhs.value.snapshot.sessionId
+        }
+        var byPanelId: [UUID: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval)] = [:]
+        for (key, value) in rankedResolved where byPanelId[key.panelId] == nil {
             byPanelId[key.panelId] = value
         }
 

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -725,19 +725,34 @@ struct RestorableAgentSessionIndex: Sendable {
         )
     }
 
+    /// Cached regex for `lineDeclaresConversationEvent`. Compiled once so the
+    /// per-line scan stays cheap. Tolerates any whitespace around the colon
+    /// (valid JSON), which a fixed-substring check would miss for inputs like
+    /// `"type" : "assistant"`.
+    private static let conversationEventRegex: NSRegularExpression = {
+        // swiftlint:disable:next force_try
+        try! NSRegularExpression(
+            pattern: #""type"\s*:\s*"(?:user|assistant)""#,
+            options: []
+        )
+    }()
+
     private static func lineDeclaresConversationEvent(_ line: Data) -> Bool {
-        // Cheap probe: a line that mentions `"type":"user"` or
-        // `"type":"assistant"` is a real conversation event. Metadata-only
-        // lines (`custom-title`, `agent-name`, `permission-mode`, etc.) don't
-        // match. We avoid full JSON parsing per line for hot-path performance.
+        // A line carrying a top-level `"type": "user"` or `"type": "assistant"`
+        // is a real conversation event. Metadata-only lines (`custom-title`,
+        // `agent-name`, `permission-mode`, etc.) don't match. We avoid full
+        // JSON parsing per line for hot-path performance — the regex still
+        // costs <1 µs per line with a precompiled NSRegularExpression.
         guard !line.isEmpty,
               let text = String(data: line, encoding: .utf8) else {
             return false
         }
-        return text.contains("\"type\":\"user\"")
-            || text.contains("\"type\":\"assistant\"")
-            || text.contains("\"type\": \"user\"")
-            || text.contains("\"type\": \"assistant\"")
+        let nsLength = (text as NSString).length
+        return conversationEventRegex.firstMatch(
+            in: text,
+            options: [],
+            range: NSRange(location: 0, length: nsLength)
+        ) != nil
     }
 
     private init(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -561,6 +561,22 @@ struct RestorableAgentSessionIndex: Sendable {
                     continue
                 }
 
+                // Claude `--resume <id>` rejects sessions whose transcript only
+                // contains metadata events (e.g. `/rename` immediately after
+                // SessionStart, before the user typed anything) with
+                // "No conversation found with session ID …". Drop those hook
+                // records so cmux doesn't auto-resume them.
+                if kind == .claude,
+                   let cwd = record.cwd,
+                   !claudeTranscriptHasConversation(
+                       cwd: cwd,
+                       sessionId: normalizedSessionId,
+                       claudeConfigDir: claudeConfigDir(in: record.launchCommand?.environment),
+                       fileManager: fileManager
+                   ) {
+                    continue
+                }
+
                 let snapshot = SessionRestorableAgentSnapshot(
                     kind: kind,
                     sessionId: normalizedSessionId,
@@ -603,6 +619,99 @@ struct RestorableAgentSessionIndex: Sendable {
             return nil
         }
         return rawValue
+    }
+
+    /// Resolve the directory under which Claude stores its session
+    /// transcripts (defaults to `~/.claude`). If the launch environment
+    /// pinned a `CLAUDE_CONFIG_DIR`, use that — running it through the
+    /// subrouter→codex-accounts redirect that the Claude wrapper applies.
+    /// Exposed for callers that need to look up transcripts at restoration
+    /// time without re-importing `CMUXAgentLaunch`.
+    static func claudeConfigDir(in environment: [String: String]?) -> String {
+        if let raw = environment?["CLAUDE_CONFIG_DIR"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty {
+            return ClaudeConfigDirectoryPath.preferredPath(raw)
+        }
+        return (NSString(string: "~/.claude").expandingTildeInPath as String)
+    }
+
+    /// Returns true if Claude's session transcript at
+    /// `<claudeConfigDir>/projects/<encoded-cwd>/<sessionId>.jsonl` contains at
+    /// least one `user` or `assistant` event. Returns true (do not skip) when
+    /// the transcript is unreadable or absent — letting Claude itself produce
+    /// the canonical error if it's truly broken at resume time.
+    static func claudeTranscriptHasConversation(
+        cwd: String,
+        sessionId: String,
+        claudeConfigDir: String,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        let trimmedCwd = cwd.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedCwd.isEmpty else { return true }
+        // Claude encodes a project dir as `cwd.replacingOccurrences("/", with: "-")`
+        // on the raw cwd Claude saw at startup — no symlink resolution. The leading
+        // `/` in an absolute path becomes the leading `-`, so an absolute cwd
+        // `/private/tmp/aaa` maps to `-private-tmp-aaa`. Do NOT standardize the
+        // path: macOS's `NSString.standardizingPath` collapses `/private/tmp` →
+        // `/tmp`, which would point at the wrong project directory.
+        let encodedProject = trimmedCwd.replacingOccurrences(of: "/", with: "-")
+        let projectsRoot = (claudeConfigDir as NSString).appendingPathComponent("projects")
+        let projectDir = (projectsRoot as NSString).appendingPathComponent(encodedProject)
+        let transcript = (projectDir as NSString)
+            .appendingPathComponent("\(sessionId).jsonl")
+
+        guard fileManager.fileExists(atPath: transcript) else {
+            // Unknown — let Claude error if needed; do not pre-emptively drop.
+            return true
+        }
+        guard let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: transcript)) else {
+            return true
+        }
+        defer { try? handle.close() }
+        // Scan the file in chunks; the "user" / "assistant" `type` field
+        // appears near the start of each line in Claude's JSONL.
+        var leftover = Data()
+        let chunkSize = 64 * 1024
+        var totalRead = 0
+        let maxScan = 1 * 1024 * 1024 // 1 MB cap; transcripts with content cross this trivially.
+        while totalRead < maxScan {
+            let chunk: Data
+            do {
+                chunk = try handle.read(upToCount: chunkSize) ?? Data()
+            } catch {
+                return true
+            }
+            if chunk.isEmpty { break }
+            totalRead += chunk.count
+            leftover.append(chunk)
+            while let newlineIndex = leftover.firstIndex(of: 0x0A) {
+                let line = leftover.subdata(in: leftover.startIndex..<newlineIndex)
+                leftover.removeSubrange(leftover.startIndex...newlineIndex)
+                if lineDeclaresConversationEvent(line) {
+                    return true
+                }
+            }
+        }
+        if !leftover.isEmpty, lineDeclaresConversationEvent(leftover) {
+            return true
+        }
+        return false
+    }
+
+    private static func lineDeclaresConversationEvent(_ line: Data) -> Bool {
+        // Cheap probe: a line that mentions `"type":"user"` or
+        // `"type":"assistant"` is a real conversation event. Metadata-only
+        // lines (`custom-title`, `agent-name`, `permission-mode`, etc.) don't
+        // match. We avoid full JSON parsing per line for hot-path performance.
+        guard !line.isEmpty,
+              let text = String(data: line, encoding: .utf8) else {
+            return false
+        }
+        return text.contains("\"type\":\"user\"")
+            || text.contains("\"type\":\"assistant\"")
+            || text.contains("\"type\": \"user\"")
+            || text.contains("\"type\": \"assistant\"")
     }
 
     private init(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -565,15 +565,16 @@ struct RestorableAgentSessionIndex: Sendable {
                 // contains metadata events (e.g. `/rename` immediately after
                 // SessionStart, before the user typed anything) with
                 // "No conversation found with session ID …". Drop those hook
-                // records so cmux doesn't auto-resume them.
-                if kind == .claude,
-                   let cwd = record.cwd,
-                   !claudeTranscriptHasConversation(
-                       cwd: cwd,
-                       sessionId: normalizedSessionId,
-                       claudeConfigDir: claudeConfigDir(in: record.launchCommand?.environment),
-                       fileManager: fileManager
-                   ) {
+                // records so cmux doesn't auto-resume them. Same helper is
+                // reused by `Workspace.createPanel` for snapshots already
+                // embedded in `SessionPanelSnapshot.terminal.agent`.
+                if !claudeAgentIsRestorable(
+                    kind: kind,
+                    sessionId: normalizedSessionId,
+                    cwd: record.cwd,
+                    environment: record.launchCommand?.environment,
+                    fileManager: fileManager
+                ) {
                     continue
                 }
 
@@ -601,7 +602,7 @@ struct RestorableAgentSessionIndex: Sendable {
 
         var byPanelId: [UUID: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval)] = [:]
         for (key, value) in resolved {
-            if let existing = byPanelId[key.panelId], existing.updatedAt >= value.updatedAt {
+            if let existing = byPanelId[key.panelId], existing.updatedAt > value.updatedAt {
                 continue
             }
             byPanelId[key.panelId] = value
@@ -697,6 +698,31 @@ struct RestorableAgentSessionIndex: Sendable {
             return true
         }
         return false
+    }
+
+    /// Single eligibility check shared by the load loop and `Workspace.createPanel`
+    /// for whether a candidate Claude/agent session can be auto-resumed.
+    /// Non-Claude agents pass through (they don't share Claude's metadata-only
+    /// failure mode). Empty/missing cwd fails open — let Claude itself produce
+    /// the canonical error if it's truly broken at resume time. Centralising
+    /// here keeps both surfaces in sync if Claude's transcript rules change.
+    static func claudeAgentIsRestorable(
+        kind: RestorableAgentKind,
+        sessionId: String,
+        cwd: String?,
+        environment: [String: String]?,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard kind == .claude else { return true }
+        guard let cwd, !cwd.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return true
+        }
+        return claudeTranscriptHasConversation(
+            cwd: cwd,
+            sessionId: sessionId,
+            claudeConfigDir: claudeConfigDir(in: environment),
+            fileManager: fileManager
+        )
     }
 
     private static func lineDeclaresConversationEvent(_ line: Data) -> Bool {

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -474,7 +474,7 @@ private struct RestorableAgentHookSessionStoreFile: Codable, Sendable {
 }
 
 struct RestorableAgentSessionIndex: Sendable {
-    static let empty = RestorableAgentSessionIndex(snapshotsByPanel: [:])
+    static let empty = RestorableAgentSessionIndex(snapshotsByPanel: [:], snapshotsByPanelId: [:])
 
     struct PanelKey: Hashable, Sendable {
         let workspaceId: UUID
@@ -482,9 +482,18 @@ struct RestorableAgentSessionIndex: Sendable {
     }
 
     private let snapshotsByPanel: [PanelKey: SessionRestorableAgentSnapshot]
+    // Workspace UUIDs are regenerated on every cmux launch, so a hook record
+    // saved as (workspaceA, panelA) won't match a lookup with (workspaceB, panelA)
+    // after relaunch even though it's the same panel. Panel UUIDs (== surface IDs
+    // == CMUX_SURFACE_ID) are stable per snapshot save and unique enough across
+    // the hook records, so this fallback recovers the agent for that panel.
+    private let snapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot]
 
     func snapshot(workspaceId: UUID, panelId: UUID) -> SessionRestorableAgentSnapshot? {
-        snapshotsByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)]
+        if let exact = snapshotsByPanel[PanelKey(workspaceId: workspaceId, panelId: panelId)] {
+            return exact
+        }
+        return snapshotsByPanelId[panelId]
     }
 
     static func load(
@@ -574,7 +583,18 @@ struct RestorableAgentSessionIndex: Sendable {
             resolved[key] = detected
         }
 
-        return RestorableAgentSessionIndex(snapshotsByPanel: resolved.mapValues(\.snapshot))
+        var byPanelId: [UUID: (snapshot: SessionRestorableAgentSnapshot, updatedAt: TimeInterval)] = [:]
+        for (key, value) in resolved {
+            if let existing = byPanelId[key.panelId], existing.updatedAt >= value.updatedAt {
+                continue
+            }
+            byPanelId[key.panelId] = value
+        }
+
+        return RestorableAgentSessionIndex(
+            snapshotsByPanel: resolved.mapValues(\.snapshot),
+            snapshotsByPanelId: byPanelId.mapValues(\.snapshot)
+        )
     }
 
     private static func normalizedWorkingDirectory(_ rawValue: String?) -> String? {
@@ -585,7 +605,11 @@ struct RestorableAgentSessionIndex: Sendable {
         return rawValue
     }
 
-    private init(snapshotsByPanel: [PanelKey: SessionRestorableAgentSnapshot]) {
+    private init(
+        snapshotsByPanel: [PanelKey: SessionRestorableAgentSnapshot],
+        snapshotsByPanelId: [UUID: SessionRestorableAgentSnapshot]
+    ) {
         self.snapshotsByPanel = snapshotsByPanel
+        self.snapshotsByPanelId = snapshotsByPanelId
     }
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -50,6 +50,13 @@ enum AgentResumeCommandBuilder {
             ? nil
             : normalized(workingDirectory ?? launchCommand?.workingDirectory)
         if let cwd {
+            // Don't resume into a dead working directory. The captured `cd`
+            // would fail at restore time, `&&` would short-circuit before the
+            // agent runs, and the user would see a dead "no such file or
+            // directory" prompt with no way back. Returning nil tells the
+            // caller (`resumeStartupInput`) to skip auto-resume entirely so
+            // the panel opens as a fresh shell instead.
+            guard FileManager.default.fileExists(atPath: cwd) else { return nil }
             shellCommand = "cd \(shellSingleQuoted(cwd)) && \(shellCommand)"
         }
         return shellCommand

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -16340,12 +16340,12 @@ class TerminalController {
 
     /// Mark the restorable agent for a panel as ended so the next session
     /// snapshot save does not embed it. Usage:
-    ///   agent_session_ended --tab=<workspaceId> --surface=<panelUUID>
+    ///   agent_session_ended --tab=<workspaceId> --surface=<panelUUID> --session=<sessionId>
     /// Called by `cmux claude-hook session-end` (and other agents' SessionEnd
-    /// hooks) once the on-disk hook record has been consumed. Without this,
-    /// `Workspace.restoredAgentSnapshotsByPanelId` keeps the post-restoration
-    /// snapshot in memory after the agent exits, and the next cmux launch
-    /// auto-resumes a session that was already finished.
+    /// hooks) once the on-disk hook record has been consumed. The sessionId
+    /// scopes the clear: if the panel is now hosting a different session
+    /// (panel reused after a fresh `claude` start), the clear is a no-op so
+    /// the new session's restored-agent state is preserved.
     private func agentSessionEnded(_ args: String) -> String {
         let parsed = parseOptions(args)
         let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
@@ -16354,13 +16354,17 @@ class TerminalController {
         }
         guard let surfaceRaw = parsed.options["surface"]?.trimmingCharacters(in: .whitespacesAndNewlines),
               !surfaceRaw.isEmpty else {
-            return "ERROR: Usage: agent_session_ended --tab=<id> --surface=<panel-uuid>"
+            return "ERROR: Usage: agent_session_ended --tab=<id> --surface=<panel-uuid> --session=<sessionId>"
         }
         guard let panelId = UUID(uuidString: surfaceRaw) else {
             return "ERROR: --surface must be a UUID, got: \(surfaceRaw)"
         }
+        guard let sessionId = parsed.options["session"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !sessionId.isEmpty else {
+            return "ERROR: Usage: agent_session_ended --tab=<id> --surface=<panel-uuid> --session=<sessionId>"
+        }
         scheduleSidebarMutation(target: target) { _, tab in
-            tab.markRestorableAgentSessionEnded(panelId: panelId)
+            tab.markRestorableAgentSessionEnded(panelId: panelId, sessionId: sessionId)
         }
         return "OK"
     }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -2127,6 +2127,9 @@ class TerminalController {
         case "clear_agent_pid":
             return clearAgentPID(args)
 
+        case "agent_session_ended":
+            return agentSessionEnded(args)
+
         case "clear_meta":
             return clearMeta(args)
 
@@ -16331,6 +16334,33 @@ class TerminalController {
                 return
             }
             tab.recordAgentPID(key: key, pid: pid, panelId: panelResolution.panelId)
+        }
+        return "OK"
+    }
+
+    /// Mark the restorable agent for a panel as ended so the next session
+    /// snapshot save does not embed it. Usage:
+    ///   agent_session_ended --tab=<workspaceId> --surface=<panelUUID>
+    /// Called by `cmux claude-hook session-end` (and other agents' SessionEnd
+    /// hooks) once the on-disk hook record has been consumed. Without this,
+    /// `Workspace.restoredAgentSnapshotsByPanelId` keeps the post-restoration
+    /// snapshot in memory after the agent exits, and the next cmux launch
+    /// auto-resumes a session that was already finished.
+    private func agentSessionEnded(_ args: String) -> String {
+        let parsed = parseOptions(args)
+        let targetResolution = parseSidebarMutationTabTarget(options: parsed.options)
+        guard let target = targetResolution.target else {
+            return targetResolution.error ?? "ERROR: No tab selected"
+        }
+        guard let surfaceRaw = parsed.options["surface"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !surfaceRaw.isEmpty else {
+            return "ERROR: Usage: agent_session_ended --tab=<id> --surface=<panel-uuid>"
+        }
+        guard let panelId = UUID(uuidString: surfaceRaw) else {
+            return "ERROR: --surface must be a UUID, got: \(surfaceRaw)"
+        }
+        scheduleSidebarMutation(target: target) { _, tab in
+            tab.markRestorableAgentSessionEnded(panelId: panelId)
         }
         return "OK"
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8475,8 +8475,14 @@ final class Workspace: Identifiable, ObservableObject {
     /// persists in `restoredAgentSnapshotsByPanelId` after the underlying
     /// session has been consumed from disk, and the next cmux launch tries to
     /// resume a session that no longer exists.
-    func markRestorableAgentSessionEnded(panelId: UUID) {
-        guard let restored = restoredAgentSnapshotsByPanelId[panelId] else { return }
+    ///
+    /// `sessionId` scopes the clear: a late or duplicate SessionEnd event for
+    /// session A must not wipe a freshly-started session B that has reused
+    /// the same panel. We no-op unless the currently-restored snapshot's
+    /// sessionId matches the ended one.
+    func markRestorableAgentSessionEnded(panelId: UUID, sessionId: String) {
+        guard let restored = restoredAgentSnapshotsByPanelId[panelId],
+              restored.sessionId == sessionId else { return }
         invalidatedRestoredAgentFingerprintsByPanelId[panelId] = TabManager.restorableAgentSnapshotFingerprint(restored)
         restoredAgentSnapshotsByPanelId.removeValue(forKey: panelId)
         restoredAgentAutoResumePendingPanelIds.remove(panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -737,25 +737,18 @@ extension Workspace {
             let localWorkingDirectory = remoteTerminalStartupCommand() == nil ? workingDirectory : nil
             // Drop a Claude agent embedded in the snapshot if its transcript is
             // missing real conversation events (only metadata like `/rename`
-            // before any user prompt). Claude rejects `--resume <id>` for those
-            // with "No conversation found", so auto-resume would error.
-            // See `RestorableAgentSession.swift` for the same filter applied
-            // during fresh hook-record load.
+            // before any user prompt). Shares the same eligibility helper as
+            // the fresh-load path in `RestorableAgentSession.swift`.
             let restorableAgent: SessionRestorableAgentSnapshot? = {
                 guard let candidate = snapshot.terminal?.agent else { return nil }
-                if candidate.kind != .claude { return candidate }
                 let cwd = candidate.workingDirectory
                     ?? candidate.launchCommand?.workingDirectory
-                guard let cwd, !cwd.isEmpty else { return candidate }
-                let configDir = RestorableAgentSessionIndex.claudeConfigDir(
-                    in: candidate.launchCommand?.environment
-                )
-                let hasConversation = RestorableAgentSessionIndex.claudeTranscriptHasConversation(
-                    cwd: cwd,
+                return RestorableAgentSessionIndex.claudeAgentIsRestorable(
+                    kind: candidate.kind,
                     sessionId: candidate.sessionId,
-                    claudeConfigDir: configDir
-                )
-                return hasConversation ? candidate : nil
+                    cwd: cwd,
+                    environment: candidate.launchCommand?.environment
+                ) ? candidate : nil
             }()
             let restorableTmuxStartCommand = restorableAgent == nil
                 ? Self.restorableTmuxStartCommand(snapshot.terminal?.tmuxStartCommand)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -735,7 +735,28 @@ extension Workspace {
                 ?? snapshot.directory
                 ?? currentDirectory
             let localWorkingDirectory = remoteTerminalStartupCommand() == nil ? workingDirectory : nil
-            let restorableAgent = snapshot.terminal?.agent
+            // Drop a Claude agent embedded in the snapshot if its transcript is
+            // missing real conversation events (only metadata like `/rename`
+            // before any user prompt). Claude rejects `--resume <id>` for those
+            // with "No conversation found", so auto-resume would error.
+            // See `RestorableAgentSession.swift` for the same filter applied
+            // during fresh hook-record load.
+            let restorableAgent: SessionRestorableAgentSnapshot? = {
+                guard let candidate = snapshot.terminal?.agent else { return nil }
+                if candidate.kind != .claude { return candidate }
+                let cwd = candidate.workingDirectory
+                    ?? candidate.launchCommand?.workingDirectory
+                guard let cwd, !cwd.isEmpty else { return candidate }
+                let configDir = RestorableAgentSessionIndex.claudeConfigDir(
+                    in: candidate.launchCommand?.environment
+                )
+                let hasConversation = RestorableAgentSessionIndex.claudeTranscriptHasConversation(
+                    cwd: cwd,
+                    sessionId: candidate.sessionId,
+                    claudeConfigDir: configDir
+                )
+                return hasConversation ? candidate : nil
+            }()
             let restorableTmuxStartCommand = restorableAgent == nil
                 ? Self.restorableTmuxStartCommand(snapshot.terminal?.tmuxStartCommand)
                 : nil

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8455,6 +8455,25 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    /// Mark the restorable agent for `panelId` as ended, so the next snapshot
+    /// save does not embed it. Called when an agent's hook reports SessionEnd
+    /// (claude exits, codex resume completes, etc.). Without this, the agent
+    /// persists in `restoredAgentSnapshotsByPanelId` after the underlying
+    /// session has been consumed from disk, and the next cmux launch tries to
+    /// resume a session that no longer exists.
+    func markRestorableAgentSessionEnded(panelId: UUID) {
+        guard let restored = restoredAgentSnapshotsByPanelId[panelId] else { return }
+        invalidatedRestoredAgentFingerprintsByPanelId[panelId] = TabManager.restorableAgentSnapshotFingerprint(restored)
+        restoredAgentSnapshotsByPanelId.removeValue(forKey: panelId)
+        restoredAgentAutoResumePendingPanelIds.remove(panelId)
+#if DEBUG
+        cmuxDebugLog(
+            "session.restore.agent.session-ended panel=\(panelId.uuidString.prefix(5)) " +
+            "kind=\(restored.kind.rawValue) session=\(restored.sessionId.prefix(8))"
+        )
+#endif
+    }
+
     func updatePanelShellActivityState(panelId: UUID, state: PanelShellActivityState) {
         guard panels[panelId] != nil else { return }
         let previousState = panelShellActivityStates[panelId] ?? .unknown

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -759,6 +759,26 @@ final class SessionPersistenceTests: XCTestCase {
             ),
             "a missing transcript should NOT be filtered out — let Claude error if it's truly broken at resume"
         )
+
+        // Same setup verifies the higher-level `claudeAgentIsRestorable`
+        // helper that both the load loop and `Workspace.createPanel` route
+        // through. Non-Claude agents bypass the filter entirely.
+        let env: [String: String] = ["CLAUDE_CONFIG_DIR": tmp.path]
+        XCTAssertTrue(
+            RestorableAgentSessionIndex.claudeAgentIsRestorable(
+                kind: .codex, sessionId: metadataOnlyId, cwd: cwd, environment: env),
+            "non-Claude agents bypass the Claude-specific filter"
+        )
+        XCTAssertFalse(
+            RestorableAgentSessionIndex.claudeAgentIsRestorable(
+                kind: .claude, sessionId: metadataOnlyId, cwd: cwd, environment: env),
+            "metadata-only Claude transcripts must be filtered by the helper"
+        )
+        XCTAssertTrue(
+            RestorableAgentSessionIndex.claudeAgentIsRestorable(
+                kind: .claude, sessionId: realSessionId, cwd: cwd, environment: env),
+            "Claude transcripts with conversation events should pass"
+        )
     }
 
     @MainActor

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -661,6 +661,44 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNotEqual(firstFingerprint, secondFingerprint)
     }
 
+    func testRestorableAgentIndexFallsBackToPanelIdAfterWorkspaceUUIDRegenerates() throws {
+        // Workspace UUIDs are regenerated on every cmux launch. The hook record
+        // captures (workspaceId, surfaceId) from CMUX_WORKSPACE_ID/CMUX_SURFACE_ID
+        // at SessionStart time, but on the next launch the live workspace.id is a
+        // different UUID. The strict (workspaceId, panelId) lookup misses, so the
+        // autosave drops the agent field and the next relaunch can't resume.
+        // The index should fall back to a panelId-only lookup so the agent stays
+        // attached to the panel across launches.
+        let recordedWorkspaceId = UUID()
+        let panelId = UUID()
+        let index = try makeRestorableAgentIndex(
+            kind: .claude,
+            workspaceId: recordedWorkspaceId,
+            panelId: panelId,
+            sessionId: "claude-session-restore",
+            arguments: [
+                "/usr/local/bin/claude",
+                "--model",
+                "sonnet",
+            ]
+        )
+
+        // Same lifetime: strict match still works.
+        let strict = try XCTUnwrap(index.snapshot(workspaceId: recordedWorkspaceId, panelId: panelId))
+        XCTAssertEqual(strict.sessionId, "claude-session-restore")
+
+        // Post-relaunch: workspace UUID is regenerated, panel UUID is the new one
+        // assigned to the restored panel. The index should still resolve via
+        // the panelId fallback.
+        let regeneratedWorkspaceId = UUID()
+        let resolved = try XCTUnwrap(index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: panelId))
+        XCTAssertEqual(resolved.sessionId, "claude-session-restore")
+        XCTAssertEqual(resolved.kind, .claude)
+
+        // Unknown panelId still misses (no false positives).
+        XCTAssertNil(index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: UUID()))
+    }
+
     func testResolvedWindowFramePrefersSavedDisplayIdentity() {
         let savedFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
         let savedDisplay = SessionDisplaySnapshot(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -699,6 +699,18 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: UUID()))
     }
 
+    @MainActor
+    func testMarkRestorableAgentSessionEndedNoopsWithoutEntry() {
+        // The CLI calls Workspace.markRestorableAgentSessionEnded for any panel
+        // whose agent SessionEnd hook fires, including panels that never had a
+        // restored snapshot (fresh sessions started in this lifetime). Make
+        // sure the call is safe — no crash, no spurious side effects.
+        let workspace = Workspace(title: "Tests")
+        workspace.markRestorableAgentSessionEnded(panelId: UUID())
+        // No assertion needed beyond "did not crash"; the method is called
+        // from a sidebar mutation closure and must tolerate missing entries.
+    }
+
     func testResolvedWindowFramePrefersSavedDisplayIdentity() {
         let savedFrame = SessionRectSnapshot(x: 1_200, y: 100, width: 600, height: 400)
         let savedDisplay = SessionDisplaySnapshot(

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -861,6 +861,35 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testResumeCommandIsNilWhenWorkingDirectoryDoesNotExist() {
+        // If the user deletes the project dir between sessions, the captured
+        // `cd '<cwd>' && '<agent>' --resume <id>` would fail at `cd`, the `&&`
+        // would short-circuit, and the panel would sit at a dead "no such file
+        // or directory" prompt. Returning nil from `resumeCommand` skips
+        // auto-resume entirely so the panel opens to a fresh shell instead.
+        let missingCwd = "/this/path/definitely/does/not/exist/\(UUID().uuidString)"
+        XCTAssertFalse(FileManager.default.fileExists(atPath: missingCwd))
+        let snapshot = SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "abandoned-session",
+            workingDirectory: missingCwd,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: ["/usr/local/bin/claude"],
+                workingDirectory: missingCwd,
+                environment: nil,
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+        XCTAssertNil(
+            snapshot.resumeCommand,
+            "resumeCommand must be nil when the captured cwd no longer exists, " +
+            "so the caller skips auto-resume rather than typing a `cd` that fails"
+        )
+    }
+
     @MainActor
     func testMarkRestorableAgentSessionEndedNoopsWithoutEntry() {
         // The CLI calls Workspace.markRestorableAgentSessionEnded for any panel

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -699,6 +699,69 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: UUID()))
     }
 
+    func testRestorableAgentIndexFallbackPicksMostRecentRecordPerPanelId() throws {
+        // The panelId fallback may resolve from multiple hook records sharing
+        // a panelId — e.g. the user ended a session and started a new one in
+        // the same panel before relaunch. The fold must return the most-recent
+        // record per panelId so resume lands on the right session, not an
+        // arbitrary one.
+        let panelId = UUID()
+        let oldWorkspaceId = UUID()
+        let newWorkspaceId = UUID()
+        let now = Date().timeIntervalSince1970
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-agent-recency-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = RestorableAgentKind.claude.hookStoreFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        func record(sessionId: String, workspaceId: UUID, updatedAt: TimeInterval) -> [String: Any] {
+            return [
+                "sessionId": sessionId,
+                "workspaceId": workspaceId.uuidString,
+                "surfaceId": panelId.uuidString,
+                "cwd": "/tmp/repo",
+                "updatedAt": updatedAt,
+                "launchCommand": [
+                    "launcher": "claude",
+                    "executablePath": "/usr/local/bin/claude",
+                    "arguments": ["/usr/local/bin/claude"],
+                    "workingDirectory": "/tmp/repo",
+                    "environment": ["CLAUDE_CONFIG_DIR": "/tmp/claude"],
+                    "capturedAt": updatedAt,
+                    "source": "process",
+                ],
+            ]
+        }
+        let payload: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                "old-session": record(sessionId: "old-session", workspaceId: oldWorkspaceId, updatedAt: now - 100),
+                "new-session": record(sessionId: "new-session", workspaceId: newWorkspaceId, updatedAt: now),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        try data.write(to: storeURL, options: .atomic)
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: home.path)
+
+        // Strict (workspaceId, panelId) lookups still return their own records.
+        XCTAssertEqual(index.snapshot(workspaceId: oldWorkspaceId, panelId: panelId)?.sessionId, "old-session")
+        XCTAssertEqual(index.snapshot(workspaceId: newWorkspaceId, panelId: panelId)?.sessionId, "new-session")
+
+        // Post-relaunch: a regenerated workspace UUID hits the panelId fallback,
+        // which must return the most-recent record (newer updatedAt wins).
+        let regeneratedWorkspaceId = UUID()
+        XCTAssertEqual(
+            index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: panelId)?.sessionId,
+            "new-session",
+            "panelId fallback must return the most-recent record across the panel's history"
+        )
+    }
+
     func testClaudeTranscriptHasConversationFiltersMetadataOnlyTranscripts() throws {
         // Claude rejects `--resume <id>` for sessions whose .jsonl only
         // contains metadata events (e.g. `custom-title`, `agent-name`,
@@ -735,6 +798,15 @@ final class SessionPersistenceTests: XCTestCase {
         {"type":"assistant","sessionId":"\(realSessionId)","message":{"role":"assistant","content":"hi"}}
         """.write(to: realSession, atomically: true, encoding: .utf8)
 
+        // Whitespace variant: JSON permits arbitrary whitespace around `:`.
+        // Claude's writer is stable today, but the probe should still match
+        // valid JSON forms like `"type" : "user"` instead of dropping them.
+        let whitespaceId = "44444444-4444-4444-4444-444444444444"
+        let whitespaceSession = projectDir.appendingPathComponent("\(whitespaceId).jsonl")
+        try """
+        {"type" : "user","sessionId":"\(whitespaceId)","message":{"role":"user","content":"hi"}}
+        """.write(to: whitespaceSession, atomically: true, encoding: .utf8)
+
         XCTAssertFalse(
             RestorableAgentSessionIndex.claudeTranscriptHasConversation(
                 cwd: cwd,
@@ -758,6 +830,14 @@ final class SessionPersistenceTests: XCTestCase {
                 claudeConfigDir: tmp.path
             ),
             "a missing transcript should NOT be filtered out — let Claude error if it's truly broken at resume"
+        )
+        XCTAssertTrue(
+            RestorableAgentSessionIndex.claudeTranscriptHasConversation(
+                cwd: cwd,
+                sessionId: whitespaceId,
+                claudeConfigDir: tmp.path
+            ),
+            "JSON whitespace around the `:` should not cause valid conversation events to be dropped"
         )
 
         // Same setup verifies the higher-level `claudeAgentIsRestorable`
@@ -788,7 +868,7 @@ final class SessionPersistenceTests: XCTestCase {
         // restored snapshot (fresh sessions started in this lifetime). Make
         // sure the call is safe — no crash, no spurious side effects.
         let workspace = Workspace(title: "Tests")
-        workspace.markRestorableAgentSessionEnded(panelId: UUID())
+        workspace.markRestorableAgentSessionEnded(panelId: UUID(), sessionId: "any-session")
         // No assertion needed beyond "did not crash"; the method is called
         // from a sidebar mutation closure and must tolerate missing entries.
     }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -699,6 +699,68 @@ final class SessionPersistenceTests: XCTestCase {
         XCTAssertNil(index.snapshot(workspaceId: regeneratedWorkspaceId, panelId: UUID()))
     }
 
+    func testClaudeTranscriptHasConversationFiltersMetadataOnlyTranscripts() throws {
+        // Claude rejects `--resume <id>` for sessions whose .jsonl only
+        // contains metadata events (e.g. `custom-title`, `agent-name`,
+        // `permission-mode`) with "No conversation found with session ID".
+        // This happens when a user runs `/rename` immediately after Claude
+        // starts, before sending any user message — the SessionStart hook
+        // fires and cmux records the session, but the transcript never gets
+        // a real exchange. The index loader should drop those records so
+        // cmux doesn't auto-resume into that error.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-claude-conv-\(UUID().uuidString)", isDirectory: true)
+        let projects = tmp.appendingPathComponent("projects", isDirectory: true)
+        try FileManager.default.createDirectory(at: projects, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let cwd = "/private/tmp/aaa"
+        let encoded = "-private-tmp-aaa"
+        let projectDir = projects.appendingPathComponent(encoded, isDirectory: true)
+        try FileManager.default.createDirectory(at: projectDir, withIntermediateDirectories: true)
+
+        let metadataOnlyId = "11111111-1111-1111-1111-111111111111"
+        let metadataOnly = projectDir.appendingPathComponent("\(metadataOnlyId).jsonl")
+        try """
+        {"type":"custom-title","customTitle":"renamed","sessionId":"\(metadataOnlyId)"}
+        {"type":"agent-name","agentName":"renamed","sessionId":"\(metadataOnlyId)"}
+        {"type":"permission-mode","permissionMode":"acceptEdits","sessionId":"\(metadataOnlyId)"}
+        """.write(to: metadataOnly, atomically: true, encoding: .utf8)
+
+        let realSessionId = "22222222-2222-2222-2222-222222222222"
+        let realSession = projectDir.appendingPathComponent("\(realSessionId).jsonl")
+        try """
+        {"type":"permission-mode","permissionMode":"acceptEdits","sessionId":"\(realSessionId)"}
+        {"type":"user","sessionId":"\(realSessionId)","message":{"role":"user","content":"hello"}}
+        {"type":"assistant","sessionId":"\(realSessionId)","message":{"role":"assistant","content":"hi"}}
+        """.write(to: realSession, atomically: true, encoding: .utf8)
+
+        XCTAssertFalse(
+            RestorableAgentSessionIndex.claudeTranscriptHasConversation(
+                cwd: cwd,
+                sessionId: metadataOnlyId,
+                claudeConfigDir: tmp.path
+            ),
+            "metadata-only transcripts should be treated as having no conversation"
+        )
+        XCTAssertTrue(
+            RestorableAgentSessionIndex.claudeTranscriptHasConversation(
+                cwd: cwd,
+                sessionId: realSessionId,
+                claudeConfigDir: tmp.path
+            ),
+            "transcripts with at least one user/assistant event should pass"
+        )
+        XCTAssertTrue(
+            RestorableAgentSessionIndex.claudeTranscriptHasConversation(
+                cwd: cwd,
+                sessionId: "33333333-3333-3333-3333-333333333333",
+                claudeConfigDir: tmp.path
+            ),
+            "a missing transcript should NOT be filtered out — let Claude error if it's truly broken at resume"
+        )
+    }
+
     @MainActor
     func testMarkRestorableAgentSessionEndedNoopsWithoutEntry() {
         // The CLI calls Workspace.markRestorableAgentSessionEnded for any panel

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -762,6 +762,59 @@ final class SessionPersistenceTests: XCTestCase {
         )
     }
 
+    func testRestorableAgentIndexFallbackTieBreakIsDeterministic() throws {
+        // When two hook records share a panelId AND `updatedAt`, the panelId
+        // fallback must resolve identically across cmux launches. The fold
+        // sorts by `(updatedAt desc, sessionId desc)` so the lexicographically
+        // greater sessionId wins on tie, regardless of dictionary iteration
+        // order.
+        let panelId = UUID()
+        let timestamp = Date().timeIntervalSince1970
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-tiebreak-\(UUID().uuidString)", isDirectory: true)
+        let storeURL = RestorableAgentKind.claude.hookStoreFileURL(homeDirectory: home.path)
+        try FileManager.default.createDirectory(
+            at: storeURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        func record(sessionId: String) -> [String: Any] {
+            return [
+                "sessionId": sessionId,
+                "workspaceId": UUID().uuidString,
+                "surfaceId": panelId.uuidString,
+                "cwd": "/tmp/repo",
+                "updatedAt": timestamp,
+                "launchCommand": [
+                    "launcher": "claude",
+                    "executablePath": "/usr/local/bin/claude",
+                    "arguments": ["/usr/local/bin/claude"],
+                    "workingDirectory": "/tmp/repo",
+                    "environment": ["CLAUDE_CONFIG_DIR": "/tmp/claude"],
+                    "capturedAt": timestamp,
+                    "source": "process",
+                ],
+            ]
+        }
+        let payload: [String: Any] = [
+            "version": 1,
+            "sessions": [
+                "aaa-session": record(sessionId: "aaa-session"),
+                "zzz-session": record(sessionId: "zzz-session"),
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [])
+        try data.write(to: storeURL, options: .atomic)
+
+        let index = RestorableAgentSessionIndex.load(homeDirectory: home.path)
+        XCTAssertEqual(
+            index.snapshot(workspaceId: UUID(), panelId: panelId)?.sessionId,
+            "zzz-session",
+            "tie-break must be deterministic; lexicographically greater sessionId wins"
+        )
+    }
+
     func testClaudeTranscriptHasConversationFiltersMetadataOnlyTranscripts() throws {
         // Claude rejects `--resume <id>` for sessions whose .jsonl only
         // contains metadata events (e.g. `custom-title`, `agent-name`,


### PR DESCRIPTION
## Summary

Fixes three independent bugs that prevent Claude/Codex/etc. session
auto-resume from working after a cmux relaunch.

- **Commit 1 — index lookup misses across launches.**
  `RestorableAgentSessionIndex` is keyed by `(workspaceId, panelId)`,
  but `Workspace.id` is regenerated as a fresh `UUID()` on every cmux
  launch (`Sources/Workspace.swift:7682`). After the first relaunch, the
  saved hook record's `workspaceId` no longer matches the live workspace,
  the strict index lookup misses, and autosave persists the panel
  snapshot with `agent: nil`. From then on agents never auto-resume.
  The fix adds a panel-id-only fallback. Strict `(workspaceId, panelId)`
  still wins; only fall back to `panelId`-only when the strict key
  misses, picking the most recent record per panel.

- **Commit 2 — in-lifetime SessionEnd doesn't clear in-memory state.**
  After commit 1, restoration reliably populates
  `restoredAgentSnapshotsByPanelId[panelId]`. When the user `/exit`s
  claude in the same lifetime, `claude-hook session-end` consumes the
  on-disk record but doesn't clear the in-memory entry, so the next
  save re-embeds the stale agent and the next launch tries to resume a
  session that already exited. The fix adds a new `agent_session_ended`
  v1 control command and wires `claude-hook session-end` (plus the
  generic-agent SessionEnd path used by Codex, Gemini, etc.) to call
  it alongside the existing `clear_agent_pid` / `clear_status` calls.

- **Commit 3 — auto-resume into "No conversation found" after rename.**
  When a user runs `/rename <name>` immediately after Claude starts,
  before sending any prompt, Claude writes only metadata events
  (`custom-title`, `agent-name`, `permission-mode`) to the transcript.
  `claude --resume <id>` rejects metadata-only transcripts with
  `No conversation found with session ID: …`. The fix derives Claude's
  transcript path from the hook record's `cwd` and `sessionId` and
  filters out metadata-only records during index load. Fail-open: if
  the transcript is missing or unreadable, the record is kept so
  Claude can produce its own canonical error.

## Why

Empirical: on a machine with active Claude sessions,
`~/.cmuxterm/claude-hook-sessions.json` carried 16 active records, but
`~/Library/Application Support/cmux/session-com.cmuxterm.app.json` had
zero panels with an `agent` field. 7 panel UUIDs in the snapshot
matched `surfaceId` entries in the hook file — the data was there, the
lookup just couldn't connect them across the workspace-UUID
regeneration. Bugs 2 and 3 were observed during the same investigation.

Closes #2941
Refs #3342
Refs #3322

## Testing

- `xcodebuild test` against the real `cmuxTests` target (Xcode 26.2,
  macOS 26.x, Apple Silicon). All 3 new tests pass:
  - `testRestorableAgentIndexFallsBackToPanelIdAfterWorkspaceUUIDRegenerates`
  - `testMarkRestorableAgentSessionEndedNoopsWithoutEntry`
  - `testClaudeTranscriptHasConversationFiltersMetadataOnlyTranscripts`
- Reverting `Sources/RestorableAgentSession.swift` to pre-fix while
  keeping the test file shows the regression tests fail with
  `XCTUnwrap failed: expected non-nil value` and an assertion mismatch
  on metadata-only transcripts — i.e. the tests catch the bugs and the
  fixes are causally responsible.
- Manual repro of bug 1: built a debug app via `./scripts/reload.sh
  --tag fix-restore --launch`, started a Claude session, Cmd+Q'd,
  relaunched. The restored panel auto-typed
  `cd '<cwd>' && 'claude' '--resume' '<id>'` and Claude reattached.
- Manual repro of bug 3: ran `/rename test` in a fresh Claude session
  before any prompt, exited, restarted, observed `No conversation found
  with session ID: <id>` from the auto-resume. With the fix, the
  hook record is filtered out during load and the panel restores as a
  fresh shell instead.
- Swift file length budget check still passes
  (`python3 scripts/swift_file_length_budget.py
  --budget .github/swift-file-length-budget.tsv` → exit 0).

Local repro command:
```
CMUX_SKIP_ZIG_BUILD=1 \
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer \
xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit \
  -configuration Debug -destination 'platform=macOS' \
  -only-testing:cmuxTests/SessionPersistenceTests/testRestorableAgentIndexFallsBackToPanelIdAfterWorkspaceUUIDRegenerates \
  -only-testing:cmuxTests/SessionPersistenceTests/testMarkRestorableAgentSessionEndedNoopsWithoutEntry \
  test
```

## Demo Video

https://github.com/user-attachments/assets/0a1713d7-ca8a-41de-9772-aad45e81a37d

## Checklist

- [x] I tested the change locally (xcodebuild test + manual relaunch repro)
- [x] I added or updated tests for behavior changes (3 new regression tests)
- [ ] I updated docs/changelog if needed (no doc changes — implementation detail)
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI can be notified to mark specific restored-agent sessions ended (scoped to panel/surface and session) so panels update immediately.
  * Restoration skips auto-resume when the agent's working directory is missing or invalid.

* **Bug Fixes**
  * Metadata-only transcripts are excluded from auto-resume; only sessions with conversation events restore.
  * Restoration falls back to panel-only matching when workspace identifiers change.

* **Tests**
  * Added tests for fallback resolution, transcript filtering, deterministic tie-breaking, and safe session-end handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3805)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->