### PR TITLE
Fix Claude resume cwd

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2449,7 +2449,7 @@ struct ContentView: View {
     }
 
     private func resumeSession(entry: SessionEntry) {
-        guard let resumeCommand = entry.resumeCommandWithCwd else { return }
+        guard let resumeCommand = entry.resumeCommand else { return }
         let inputWithReturn = resumeCommand + "\n"
         let targetCwd = entry.resumeWorkingDirectory
 

--- a/Sources/SessionIndexModels.swift
+++ b/Sources/SessionIndexModels.swift
@@ -222,6 +222,14 @@ struct SessionEntry: Identifiable, Hashable {
     /// Shell command that resumes this session in a new terminal, with the agent's
     /// known per-session settings injected as CLI flags.
     var resumeCommand: String? {
+        guard let command = resumeCommandWithoutWorkingDirectory else { return nil }
+        guard let cwd = resumeWorkingDirectory else {
+            return command
+        }
+        return "cd \(Self.shellQuote(cwd)) && \(command)"
+    }
+
+    private var resumeCommandWithoutWorkingDirectory: String? {
         switch specifics {
         case let .claude(model, permissionMode):
             var parts = ["claude --resume \(sessionId)"]
@@ -289,14 +297,6 @@ struct SessionEntry: Identifiable, Hashable {
             }
             return nil
         }
-    }
-
-    var resumeCommandWithCwd: String? {
-        guard let resumeCommand else { return nil }
-        guard let cwd = resumeWorkingDirectory else {
-            return resumeCommand
-        }
-        return "cd \(Self.shellQuote(cwd)) && \(resumeCommand)"
     }
 
     private var claudeConfigDirectoryForResume: String? {

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -639,7 +639,7 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
             Text(String(localized: "sessionIndex.row.copyPath", defaultValue: "Copy File Path"))
         }
     }
-    if let resumeCommand = entry.resumeCommandWithCwd {
+    if let resumeCommand = entry.resumeCommand {
         Button {
             let pb = NSPasteboard.general
             pb.clearContents()

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -152,7 +152,7 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         )
 
         XCTAssertNil(entry.resumeWorkingDirectory)
-        XCTAssertEqual(entry.resumeCommandWithCwd, "'acme-agent' '--session' 'session-123'")
+        XCTAssertEqual(entry.resumeCommand, "'acme-agent' '--session' 'session-123'")
     }
 
     func testRegisteredAgentJSONLNativeSessionIDOverridesPathFallback() async throws {

--- a/cmuxTests/RovoDevSessionIndexTests.swift
+++ b/cmuxTests/RovoDevSessionIndexTests.swift
@@ -40,9 +40,8 @@ final class RovoDevSessionIndexTests: XCTestCase {
         XCTAssertEqual(entry.title, "Ship Rovo Dev support")
         XCTAssertEqual(entry.cwd, "/tmp/rovo repo")
         XCTAssertEqual(entry.fileURL?.lastPathComponent, "session_context.json")
-        XCTAssertEqual(entry.resumeCommand, "acli rovodev run --restore 'session with space'")
         XCTAssertEqual(
-            entry.resumeCommandWithCwd,
+            entry.resumeCommand,
             "cd '/tmp/rovo repo' && acli rovodev run --restore 'session with space'"
         )
     }

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -1653,6 +1653,28 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    func testSessionEntryClaudeResumeCommandChangesToSessionCwdBeforeResume() {
+        let entry = SessionEntry(
+            id: "claude:a22293b7-bcef-4707-8439-2f538c8517a4",
+            agent: .claude,
+            sessionId: "a22293b7-bcef-4707-8439-2f538c8517a4",
+            title: "resume me",
+            cwd: "/Users/tiffanysun/fun",
+            gitBranch: nil,
+            pullRequest: nil,
+            modified: Date(timeIntervalSince1970: 0),
+            fileURL: URL(
+                fileURLWithPath: "/Users/tiffanysun/.claude/projects/-Users-tiffanysun-fun/a22293b7-bcef-4707-8439-2f538c8517a4.jsonl"
+            ),
+            specifics: .claude(model: nil, permissionMode: nil)
+        )
+
+        XCTAssertEqual(
+            entry.resumeCommand,
+            "cd /Users/tiffanysun/fun && env CLAUDE_CONFIG_DIR=/Users/tiffanysun/.claude CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1 CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS=CLAUDE_CONFIG_DIR claude --resume a22293b7-bcef-4707-8439-2f538c8517a4"
+        )
+    }
+
     func testRestorableAgentStartupInputUsesInlineCommandWhenShort() {
         let snapshot = SessionRestorableAgentSnapshot(
             kind: .claude,


### PR DESCRIPTION
Summary:
- Make session-index resume commands change into the recorded session cwd before invoking the agent resume command.
- Route resume and copy-resume entrypoints through the cwd-safe command.
- Keep cwd-ignored registered agents unchanged.

Testing:
- Reproduced on ssh cmux-macmini: the same Claude session ID was found from its original cwd and failed with "No conversation found" from a different cwd.
- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-3815-unit '-only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testSessionEntryClaudeResumeCommandChangesToSessionCwdBeforeResume'
- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-3815-unit '-only-testing:cmuxTests/PiVaultAgentPersistenceTests/testRegisteredAgentCWDIgnoreSuppressesResumeWorkingDirectory' '-only-testing:cmuxTests/RovoDevSessionIndexTests/testRovoDevSessionIndexReadsMetadataAndResumeCommand'
- ./scripts/reload.sh --tag 3815cwd

Closes https://github.com/manaflow-ai/cmux/issues/3815

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavior change limited to how session resume commands are constructed and used; main risk is altering quoting/`cd` prefix semantics for some agents’ resume flows.
> 
> **Overview**
> Fixes session-index resume failures (notably for **Claude**) by making `SessionEntry.resumeCommand` include `cd <recorded cwd> && …` when a `resumeWorkingDirectory` is available, and removing the separate `resumeCommandWithCwd` variant.
> 
> Routes both the UI resume action (`ContentView`) and “Copy Resume Command” menu item (`SessionIndexView`) through the updated `resumeCommand`, and updates/adds unit tests to validate cwd-changing behavior while keeping registered agents with `cwd == .ignore` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f917cef187897d10204943d85ad301ff23327699. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes resume failures for Claude when run from a different directory by cd-ing into the session’s recorded cwd before invoking the agent; both Resume and Copy Resume now use this cwd-safe command and agents marked to ignore cwd are unchanged. Fixes #3815.

- **Bug Fixes**
  - `SessionEntry.resumeCommand` now prefixes `cd <cwd> &&` when `resumeWorkingDirectory` is set; removed `resumeCommandWithCwd`.
  - Updated Resume and Copy Resume entrypoints to use the cwd-safe `resumeCommand`.
  - Tests added/updated to cover Claude cwd behavior and ensure CWD-ignored agents keep prior behavior.

<sup>Written for commit f917cef187897d10204943d85ad301ff23327699. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Session resume commands now automatically prepend working directory changes, ensuring sessions restore to the correct location. The "Copy Resume Command" feature will now copy the complete, fully-formed command including directory setup.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3816)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->