### PR TITLE
Fix Files find result aggregation

### DIFF
--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -332,8 +332,8 @@ final class FileSearchController: FileSearchControlling {
             let stdoutHandle = stdout.fileHandleForReading
             let stderrHandle = stderr.fileHandleForReading
             searchTask = Task { [weak self, pipeline, terminationSignal] in
-                // Result completeness is defined by stdout. Stderr is diagnostic-only, so
-                // drain it without letting an empty/error stream block final result publication.
+                // Result completeness is defined by stdout. Stderr stays diagnostic-only:
+                // successful searches do not wait on it, failed searches do before formatting the error.
                 let stderrTask = Task {
                     await Self.streamStderr(from: stderrHandle, pipeline: pipeline)
                 }
@@ -352,6 +352,9 @@ final class FileSearchController: FileSearchControlling {
                 guard let status = await terminationSignal.wait() else { return }
                 await stdoutDone
                 guard !Task.isCancelled else { return }
+                if status != 0 && status != 1 {
+                    await stderrTask.value
+                }
                 let update = await pipeline.finish(status: status)
                 self?.finish(generation: searchGeneration, update: update)
             }

--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -332,6 +332,14 @@ final class FileSearchController: FileSearchControlling {
             let stdoutHandle = stdout.fileHandleForReading
             let stderrHandle = stderr.fileHandleForReading
             searchTask = Task { [weak self, pipeline, terminationSignal] in
+                // Result completeness is defined by stdout. Stderr is diagnostic-only, so
+                // drain it without letting an empty/error stream block final result publication.
+                let stderrTask = Task {
+                    await Self.streamStderr(from: stderrHandle, pipeline: pipeline)
+                }
+                defer {
+                    stderrTask.cancel()
+                }
                 let applyUpdate: @Sendable (FileSearchPipelineUpdate, Int) async -> Void = { [weak self] update, generation in
                     await self?.applyPipelineUpdate(update, generation: generation)
                 }
@@ -341,9 +349,8 @@ final class FileSearchController: FileSearchControlling {
                     generation: searchGeneration,
                     applyUpdate: applyUpdate
                 )
-                async let stderrDone: Void = Self.streamStderr(from: stderrHandle, pipeline: pipeline)
                 guard let status = await terminationSignal.wait() else { return }
-                _ = await (stdoutDone, stderrDone)
+                await stdoutDone
                 guard !Task.isCancelled else { return }
                 let update = await pipeline.finish(status: status)
                 self?.finish(generation: searchGeneration, update: update)

--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -133,6 +133,7 @@ private actor FileSearchOutputPipeline {
     private let rootPath: String
     private let maxResults: Int
     private let snapshotInterval: TimeInterval
+    private var stdoutBuffer = Data()
     private var stderrBuffer = Data()
     private var results: [FileSearchResult] = []
     private var lastSnapshotEmissionDate = Date.distantPast
@@ -144,13 +145,43 @@ private actor FileSearchOutputPipeline {
         self.snapshotInterval = snapshotInterval
     }
 
-    func consumeStdoutLine(_ line: String) -> FileSearchPipelineUpdate? {
-        guard !isFinished,
+    func consumeStdout(_ data: Data) -> FileSearchPipelineUpdate? {
+        guard !isFinished else { return nil }
+        stdoutBuffer.append(data)
+        return consumeBufferedStdout(includeTrailingLine: false)
+    }
+
+    private func consumeBufferedStdout(includeTrailingLine: Bool) -> FileSearchPipelineUpdate? {
+        var latestUpdate: FileSearchPipelineUpdate?
+        while let newlineIndex = stdoutBuffer.firstIndex(of: 10) {
+            let lineData = stdoutBuffer[..<newlineIndex]
+            stdoutBuffer.removeSubrange(...newlineIndex)
+            guard let update = consumeStdoutLine(lineData) else { continue }
+            latestUpdate = update
+            if update.shouldStopProcess {
+                return update
+            }
+        }
+
+        if includeTrailingLine, !stdoutBuffer.isEmpty {
+            let lineData = stdoutBuffer
+            stdoutBuffer.removeAll(keepingCapacity: true)
+            if let update = consumeStdoutLine(lineData) {
+                latestUpdate = update
+            }
+        }
+
+        return latestUpdate
+    }
+
+    private func consumeStdoutLine(_ lineData: Data) -> FileSearchPipelineUpdate? {
+        guard let line = String(data: lineData, encoding: .utf8),
               let result = FileSearchRipgrepParser.parseMatchLine(line, rootPath: rootPath) else {
             return nil
         }
         results.append(result)
         if results.count >= maxResults {
+            isFinished = true
             return FileSearchPipelineUpdate(
                 results: results,
                 status: .limited(maxResults),
@@ -187,6 +218,9 @@ private actor FileSearchOutputPipeline {
     }
 
     func finish(status: Int32) -> FileSearchPipelineUpdate {
+        if !isFinished {
+            _ = consumeBufferedStdout(includeTrailingLine: true)
+        }
         isFinished = true
         if status == 0 || status == 1 {
             return FileSearchPipelineUpdate(
@@ -329,34 +363,37 @@ final class FileSearchController: FileSearchControlling {
         do {
             try process.run()
             self.process = process
-            let stdoutHandle = stdout.fileHandleForReading
-            let stderrHandle = stderr.fileHandleForReading
-            searchTask = Task { [weak self, pipeline, terminationSignal] in
+            let stdoutFileDescriptor = stdout.fileHandleForReading.fileDescriptor
+            let stderrFileDescriptor = stderr.fileHandleForReading.fileDescriptor
+            searchTask = Task.detached(priority: .userInitiated) { [weak self, pipeline, terminationSignal] in
                 // Result completeness is defined by stdout. Stderr stays diagnostic-only:
                 // successful searches do not wait on it, failed searches do before formatting the error.
-                let stderrTask = Task {
-                    await Self.streamStderr(from: stderrHandle, pipeline: pipeline)
-                }
-                defer {
-                    stderrTask.cancel()
+                let stderrTask = Task.detached(priority: .utility) {
+                    await Self.streamStderr(from: stderrFileDescriptor, pipeline: pipeline)
                 }
                 let applyUpdate: @Sendable (FileSearchPipelineUpdate, Int) async -> Void = { [weak self] update, generation in
                     await self?.applyPipelineUpdate(update, generation: generation)
                 }
-                async let stdoutDone: Void = Self.streamStdout(
-                    from: stdoutHandle,
-                    pipeline: pipeline,
-                    generation: searchGeneration,
-                    applyUpdate: applyUpdate
-                )
+                let stdoutTask = Task.detached(priority: .userInitiated) {
+                    await Self.streamStdout(
+                        from: stdoutFileDescriptor,
+                        pipeline: pipeline,
+                        generation: searchGeneration,
+                        applyUpdate: applyUpdate
+                    )
+                }
+                defer {
+                    stderrTask.cancel()
+                    stdoutTask.cancel()
+                }
                 guard let status = await terminationSignal.wait() else { return }
-                await stdoutDone
+                await stdoutTask.value
                 guard !Task.isCancelled else { return }
                 if status != 0 && status != 1 {
                     await stderrTask.value
                 }
                 let update = await pipeline.finish(status: status)
-                self?.finish(generation: searchGeneration, update: update)
+                await self?.finish(generation: searchGeneration, update: update)
             }
         } catch {
             process.standardOutput = nil
@@ -418,47 +455,52 @@ final class FileSearchController: FileSearchControlling {
         }
     }
 
-#if compiler(>=6.2)
-    @concurrent
-#endif
     private nonisolated static func streamStdout(
-        from handle: FileHandle,
+        from fileDescriptor: Int32,
         pipeline: FileSearchOutputPipeline,
         generation: Int,
         applyUpdate: @Sendable (FileSearchPipelineUpdate, Int) async -> Void
     ) async {
-        do {
-            for try await line in handle.bytes.lines {
-                try Task.checkCancellation()
-                guard let update = await pipeline.consumeStdoutLine(line) else { continue }
-                await applyUpdate(update, generation)
-                if update.shouldStopProcess {
-                    return
-                }
+        var buffer = [UInt8](repeating: 0, count: 32 * 1024)
+        while !Task.isCancelled {
+            let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
+                Darwin.read(fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            await pipeline.consumeStderrLine(error.localizedDescription)
+            if bytesRead > 0 {
+                let data = Data(buffer.prefix(bytesRead))
+                guard let update = await pipeline.consumeStdout(data) else { continue }
+                await applyUpdate(update, generation)
+                if update.shouldStopProcess { return }
+            } else if bytesRead == 0 {
+                return
+            } else if errno == EINTR {
+                continue
+            } else {
+                await pipeline.consumeStderrLine(String(cString: strerror(errno)))
+                return
+            }
         }
     }
 
-#if compiler(>=6.2)
-    @concurrent
-#endif
     private nonisolated static func streamStderr(
-        from handle: FileHandle,
+        from fileDescriptor: Int32,
         pipeline: FileSearchOutputPipeline
     ) async {
-        do {
-            for try await line in handle.bytes.lines {
-                try Task.checkCancellation()
-                await pipeline.consumeStderrLine(line)
+        var buffer = [UInt8](repeating: 0, count: 8 * 1024)
+        while !Task.isCancelled {
+            let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
+                Darwin.read(fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
             }
-        } catch is CancellationError {
-            return
-        } catch {
-            await pipeline.consumeStderrLine(error.localizedDescription)
+            if bytesRead > 0 {
+                await pipeline.consumeStderr(Data(buffer.prefix(bytesRead)))
+            } else if bytesRead == 0 {
+                return
+            } else if errno == EINTR {
+                continue
+            } else {
+                await pipeline.consumeStderrLine(String(cString: strerror(errno)))
+                return
+            }
         }
     }
 

--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -138,6 +138,7 @@ actor FileSearchOutputPipeline {
     private var results: [FileSearchResult] = []
     private var lastSnapshotEmissionDate = Date.distantPast
     private var isFinished = false
+    private var terminalUpdate: FileSearchPipelineUpdate?
 
     init(rootPath: String, maxResults: Int, snapshotInterval: TimeInterval) {
         self.rootPath = rootPath
@@ -181,13 +182,15 @@ actor FileSearchOutputPipeline {
         }
         results.append(result)
         if results.count >= maxResults {
-            isFinished = true
-            return FileSearchPipelineUpdate(
+            let update = FileSearchPipelineUpdate(
                 results: results,
                 status: .limited(maxResults),
                 isSearching: false,
                 shouldStopProcess: true
             )
+            isFinished = true
+            terminalUpdate = update
+            return update
         }
 
         let now = Date()
@@ -218,6 +221,9 @@ actor FileSearchOutputPipeline {
     }
 
     func finish(status: Int32) -> FileSearchPipelineUpdate {
+        if let terminalUpdate {
+            return terminalUpdate
+        }
         let trailingUpdate: FileSearchPipelineUpdate?
         if !isFinished {
             trailingUpdate = consumeBufferedStdout(includeTrailingLine: true)

--- a/Sources/FileExplorerSearchController.swift
+++ b/Sources/FileExplorerSearchController.swift
@@ -74,7 +74,7 @@ protocol FileSearchControlling: AnyObject {
     func cancel(clear: Bool)
 }
 
-private struct FileSearchPipelineUpdate: Sendable {
+struct FileSearchPipelineUpdate: Sendable {
     let results: [FileSearchResult]
     let status: FileSearchSnapshot.Status
     let isSearching: Bool
@@ -129,7 +129,7 @@ private actor FileSearchTerminationSignal {
     }
 }
 
-private actor FileSearchOutputPipeline {
+actor FileSearchOutputPipeline {
     private let rootPath: String
     private let maxResults: Int
     private let snapshotInterval: TimeInterval
@@ -218,8 +218,14 @@ private actor FileSearchOutputPipeline {
     }
 
     func finish(status: Int32) -> FileSearchPipelineUpdate {
+        let trailingUpdate: FileSearchPipelineUpdate?
         if !isFinished {
-            _ = consumeBufferedStdout(includeTrailingLine: true)
+            trailingUpdate = consumeBufferedStdout(includeTrailingLine: true)
+        } else {
+            trailingUpdate = nil
+        }
+        if let trailingUpdate, trailingUpdate.shouldStopProcess {
+            return trailingUpdate
         }
         isFinished = true
         if status == 0 || status == 1 {
@@ -243,6 +249,51 @@ private actor FileSearchOutputPipeline {
             isSearching: false,
             shouldStopProcess: false
         )
+    }
+}
+
+private final class FileSearchReadHandle: @unchecked Sendable {
+    private let fileHandle: FileHandle
+
+    init(_ fileHandle: FileHandle) {
+        self.fileHandle = fileHandle
+    }
+
+    var fileDescriptor: Int32 {
+        fileHandle.fileDescriptor
+    }
+}
+
+private enum FileSearchPipeReadResult: Sendable {
+    case chunk(Data)
+    case endOfFile
+    case failure(Int32)
+}
+
+private enum FileSearchPipeReader {
+    private static let queue = DispatchQueue(
+        label: "com.cmux.file-search.pipe-read",
+        qos: .userInitiated,
+        attributes: .concurrent
+    )
+
+    static func read(from readHandle: FileSearchReadHandle, maxByteCount: Int) async -> FileSearchPipeReadResult {
+        await withCheckedContinuation { continuation in
+            queue.async {
+                var buffer = [UInt8](repeating: 0, count: maxByteCount)
+                let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
+                    // Keep blocking pipe reads off Swift's cooperative executor.
+                    Darwin.read(readHandle.fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
+                }
+                if bytesRead > 0 {
+                    continuation.resume(returning: .chunk(Data(buffer.prefix(bytesRead))))
+                } else if bytesRead == 0 {
+                    continuation.resume(returning: .endOfFile)
+                } else {
+                    continuation.resume(returning: .failure(errno))
+                }
+            }
+        }
     }
 }
 
@@ -363,20 +414,20 @@ final class FileSearchController: FileSearchControlling {
         do {
             try process.run()
             self.process = process
-            let stdoutFileDescriptor = stdout.fileHandleForReading.fileDescriptor
-            let stderrFileDescriptor = stderr.fileHandleForReading.fileDescriptor
-            searchTask = Task.detached(priority: .userInitiated) { [weak self, pipeline, terminationSignal] in
+            let stdoutReadHandle = FileSearchReadHandle(stdout.fileHandleForReading)
+            let stderrReadHandle = FileSearchReadHandle(stderr.fileHandleForReading)
+            searchTask = Task.detached(priority: .userInitiated) { [weak self, pipeline, terminationSignal, stdoutReadHandle, stderrReadHandle] in
                 // Result completeness is defined by stdout. Stderr stays diagnostic-only:
                 // successful searches do not wait on it, failed searches do before formatting the error.
-                let stderrTask = Task.detached(priority: .utility) {
-                    await Self.streamStderr(from: stderrFileDescriptor, pipeline: pipeline)
+                let stderrTask = Task.detached(priority: .utility) { [stderrReadHandle, pipeline] in
+                    await Self.streamStderr(from: stderrReadHandle, pipeline: pipeline)
                 }
                 let applyUpdate: @Sendable (FileSearchPipelineUpdate, Int) async -> Void = { [weak self] update, generation in
                     await self?.applyPipelineUpdate(update, generation: generation)
                 }
-                let stdoutTask = Task.detached(priority: .userInitiated) {
+                let stdoutTask = Task.detached(priority: .userInitiated) { [stdoutReadHandle, pipeline, searchGeneration, applyUpdate] in
                     await Self.streamStdout(
-                        from: stdoutFileDescriptor,
+                        from: stdoutReadHandle,
                         pipeline: pipeline,
                         generation: searchGeneration,
                         applyUpdate: applyUpdate
@@ -456,49 +507,46 @@ final class FileSearchController: FileSearchControlling {
     }
 
     private nonisolated static func streamStdout(
-        from fileDescriptor: Int32,
+        from readHandle: FileSearchReadHandle,
         pipeline: FileSearchOutputPipeline,
         generation: Int,
         applyUpdate: @Sendable (FileSearchPipelineUpdate, Int) async -> Void
     ) async {
-        var buffer = [UInt8](repeating: 0, count: 32 * 1024)
         while !Task.isCancelled {
-            let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
-                Darwin.read(fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
-            }
-            if bytesRead > 0 {
-                let data = Data(buffer.prefix(bytesRead))
+            let readResult = await FileSearchPipeReader.read(from: readHandle, maxByteCount: 32 * 1024)
+            guard !Task.isCancelled else { return }
+            switch readResult {
+            case .chunk(let data):
                 guard let update = await pipeline.consumeStdout(data) else { continue }
                 await applyUpdate(update, generation)
                 if update.shouldStopProcess { return }
-            } else if bytesRead == 0 {
+            case .endOfFile:
                 return
-            } else if errno == EINTR {
+            case .failure(let errorNumber) where errorNumber == EINTR:
                 continue
-            } else {
-                await pipeline.consumeStderrLine(String(cString: strerror(errno)))
+            case .failure(let errorNumber):
+                await pipeline.consumeStderrLine(String(cString: strerror(errorNumber)))
                 return
             }
         }
     }
 
     private nonisolated static func streamStderr(
-        from fileDescriptor: Int32,
+        from readHandle: FileSearchReadHandle,
         pipeline: FileSearchOutputPipeline
     ) async {
-        var buffer = [UInt8](repeating: 0, count: 8 * 1024)
         while !Task.isCancelled {
-            let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
-                Darwin.read(fileDescriptor, rawBuffer.baseAddress, rawBuffer.count)
-            }
-            if bytesRead > 0 {
-                await pipeline.consumeStderr(Data(buffer.prefix(bytesRead)))
-            } else if bytesRead == 0 {
+            let readResult = await FileSearchPipeReader.read(from: readHandle, maxByteCount: 8 * 1024)
+            guard !Task.isCancelled else { return }
+            switch readResult {
+            case .chunk(let data):
+                await pipeline.consumeStderr(data)
+            case .endOfFile:
                 return
-            } else if errno == EINTR {
+            case .failure(let errorNumber) where errorNumber == EINTR:
                 continue
-            } else {
-                await pipeline.consumeStderrLine(String(cString: strerror(errno)))
+            case .failure(let errorNumber):
+                await pipeline.consumeStderrLine(String(cString: strerror(errorNumber)))
                 return
             }
         }

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -1185,7 +1185,7 @@ final class FileExplorerContainerView: NSView {
     private func statusText(for snapshot: FileSearchSnapshot) -> String {
         switch snapshot.status {
         case .idle:
-            return String(localized: "fileExplorer.search.empty", defaultValue: "Type to search")
+            return ""
         case .unsupported:
             return String(localized: "fileExplorer.search.unsupported", defaultValue: "Local folders only")
         case .searching:

--- a/Sources/FileExplorerView.swift
+++ b/Sources/FileExplorerView.swift
@@ -603,10 +603,12 @@ final class FileExplorerContainerView: NSView {
     private let searchDebounceSubject = PassthroughSubject<Int, Never>()
     private var searchDebounceCancellable: AnyCancellable?
     private var searchDebounceGeneration = 0
+    private var pendingSearchRefreshAfterSettled = false
     private var isSearchVisible = false {
         didSet {
             if !isSearchVisible {
                 cancelPendingSearchRefresh()
+                pendingSearchRefreshAfterSettled = false
             }
         }
     }
@@ -887,16 +889,19 @@ final class FileExplorerContainerView: NSView {
         let nextRootPath = store.rootPath
         let nextProviderIsLocal = store.provider is LocalFileExplorerProvider
         let nextContentRevision = store.contentRevision
-        let shouldRefreshSearch = nextRootPath != currentRootPath ||
-            nextProviderIsLocal != currentProviderIsLocal ||
-            nextContentRevision != currentContentRevision
+        let searchScopeChanged = nextRootPath != currentRootPath ||
+            nextProviderIsLocal != currentProviderIsLocal
+        let contentRevisionChanged = nextContentRevision != currentContentRevision
 
         currentRootPath = nextRootPath
         currentProviderIsLocal = nextProviderIsLocal
         currentContentRevision = nextContentRevision
         headerView.update(displayPath: store.displayRootPath)
-        if shouldRefreshSearch {
+        if searchScopeChanged {
+            pendingSearchRefreshAfterSettled = false
             refreshSearchIfNeeded()
+        } else if contentRevisionChanged {
+            refreshSearchAfterContentRevisionIfNeeded()
         }
     }
 
@@ -909,7 +914,6 @@ final class FileExplorerContainerView: NSView {
             if presentation == .find {
                 isSearchVisible = true
                 updateSearchLayout()
-                refreshSearchIfNeeded()
             }
             return
         }
@@ -1049,6 +1053,25 @@ final class FileExplorerContainerView: NSView {
         )
     }
 
+    private func refreshSearchAfterContentRevisionIfNeeded() {
+        guard isSearchVisible else {
+            pendingSearchRefreshAfterSettled = false
+            return
+        }
+        guard searchSnapshot.isSearching else {
+            pendingSearchRefreshAfterSettled = false
+            refreshSearchIfNeeded()
+            return
+        }
+        pendingSearchRefreshAfterSettled = true
+#if DEBUG
+        dlog(
+            "file.search.contentRevision.defer queryLen=\(searchField.stringValue.count) " +
+            "revision=\(currentContentRevision) results=\(searchSnapshot.results.count)"
+        )
+#endif
+    }
+
     private func configureSearchDebounce() {
         searchDebounceCancellable = searchDebounceSubject
             .debounce(for: .milliseconds(searchDebounceDelayMilliseconds), scheduler: RunLoop.main)
@@ -1070,6 +1093,7 @@ final class FileExplorerContainerView: NSView {
 
     private func scheduleSearchRefresh() {
         guard isSearchVisible else { return }
+        pendingSearchRefreshAfterSettled = false
         searchDebounceGeneration += 1
         let debounceGeneration = searchDebounceGeneration
 #if DEBUG
@@ -1116,11 +1140,21 @@ final class FileExplorerContainerView: NSView {
         )
 #endif
 
-        guard !snapshot.results.isEmpty else { return }
-        let selectedRow = previousSelectedRow >= 0
-            ? min(previousSelectedRow, snapshot.results.count - 1)
-            : 0
-        searchResultsView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
+        let shouldRunDeferredContentRefresh = !snapshot.isSearching && pendingSearchRefreshAfterSettled
+        if shouldRunDeferredContentRefresh {
+            pendingSearchRefreshAfterSettled = false
+        }
+
+        if !snapshot.results.isEmpty {
+            let selectedRow = previousSelectedRow >= 0
+                ? min(previousSelectedRow, snapshot.results.count - 1)
+                : 0
+            searchResultsView.selectRowIndexes(IndexSet(integer: selectedRow), byExtendingSelection: false)
+        }
+
+        if shouldRunDeferredContentRefresh {
+            refreshSearchIfNeeded()
+        }
     }
 
     private func applySearchResultsUpdate(previousResults: [FileSearchResult], nextResults: [FileSearchResult]) {
@@ -1275,6 +1309,7 @@ final class FileExplorerContainerView: NSView {
         if presentation == .find {
             let hadQuery = !searchField.stringValue.isEmpty
             cancelPendingSearchRefresh()
+            pendingSearchRefreshAfterSettled = false
             searchController.cancel(clear: true)
             searchField.stringValue = ""
             applySearchSnapshot(.empty)
@@ -1293,6 +1328,7 @@ final class FileExplorerContainerView: NSView {
         isSearchVisible = false
         searchController.cancel(clear: true)
         searchField.stringValue = ""
+        pendingSearchRefreshAfterSettled = false
         searchSnapshot = .empty
         searchResultsView.reloadData()
         updateSearchLayout()

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -720,9 +720,8 @@ final class FileSearchControllerTests: XCTestCase {
         searchField.stringValue = "needle"
         container.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: searchField))
 
-        try await waitFor("initial find search request") {
-            searchController.searchRequests.count == 1
-        }
+        try await waitForSearchRequestCount(1, in: searchController)
+        XCTAssertEqual(searchController.searchRequests.count, 1)
 
         searchController.publish(FileSearchSnapshot(
             query: "needle",
@@ -761,6 +760,28 @@ final class FileSearchControllerTests: XCTestCase {
             columnNumber: 1,
             preview: "needle"
         )
+    }
+
+    private func waitForSearchRequestCount(
+        _ expectedCount: Int,
+        in searchController: SpyFileSearchController,
+        timeout: TimeInterval = 1,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) async throws {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if searchController.searchRequests.count >= expectedCount {
+                return
+            }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTFail(
+            "Timed out waiting for \(expectedCount) file search requests",
+            file: file,
+            line: line
+        )
+        throw WaitTimeout()
     }
 
     private func waitForSettledSearchSnapshot(

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -603,6 +603,33 @@ final class FileSearchControllerTests: XCTestCase {
         XCTAssertEqual(finalSnapshot.results.count, matchingFiles.count)
     }
 
+    func testSearchLimitsHighVolumeResultsWithoutWaitingForRipgrepExit() async throws {
+        try XCTSkipUnless(Self.hasRipgrep(), "ripgrep is required for file search behavior tests")
+
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+
+        for index in 0..<650 {
+            try "needle \(index)\n".write(
+                to: rootURL.appendingPathComponent(String(format: "match-%04d.txt", index)),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+
+        let controller = FileSearchController()
+        var snapshots: [FileSearchSnapshot] = []
+        controller.onSnapshotChanged = { snapshots.append($0) }
+
+        controller.search(query: "needle", rootPath: rootURL.path, isLocal: true)
+        let finalSnapshot = try await waitForSettledSearchSnapshot { snapshots.last }
+
+        XCTAssertEqual(finalSnapshot.status, .limited(500))
+        XCTAssertEqual(finalSnapshot.results.count, 500)
+    }
+
     func testSearchRefreshesWhenContentRevisionChanges() async throws {
         try XCTSkipUnless(Self.hasRipgrep(), "ripgrep is required for file search behavior tests")
 

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -563,6 +563,46 @@ final class FileSearchControllerTests: XCTestCase {
         XCTAssertFalse(finalSnapshot.results.contains { $0.relativePath.hasPrefix("DerivedData/") })
     }
 
+    func testSearchPublishesAllMatchingFilesInFolder() async throws {
+        try XCTSkipUnless(Self.hasRipgrep(), "ripgrep is required for file search behavior tests")
+
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        let nestedURL = rootURL.appendingPathComponent("Nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nestedURL, withIntermediateDirectories: true)
+
+        let matchingFiles = [
+            "Alpha.swift",
+            "Beta.swift",
+            "Nested/Gamma.swift",
+        ]
+        for relativePath in matchingFiles {
+            try "issue3817Token \(relativePath)\n".write(
+                to: rootURL.appendingPathComponent(relativePath),
+                atomically: true,
+                encoding: .utf8
+            )
+        }
+        try "no matching content\n".write(
+            to: rootURL.appendingPathComponent("Other.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let controller = FileSearchController()
+        var snapshots: [FileSearchSnapshot] = []
+        controller.onSnapshotChanged = { snapshots.append($0) }
+
+        controller.search(query: "issue3817Token", rootPath: rootURL.path, isLocal: true)
+        let finalSnapshot = try await waitForSettledSearchSnapshot { snapshots.last }
+
+        XCTAssertEqual(finalSnapshot.status, .matches)
+        XCTAssertEqual(Set(finalSnapshot.results.map(\.relativePath)), Set(matchingFiles))
+        XCTAssertEqual(finalSnapshot.results.count, matchingFiles.count)
+    }
+
     func testSearchRefreshesWhenContentRevisionChanges() async throws {
         try XCTSkipUnless(Self.hasRipgrep(), "ripgrep is required for file search behavior tests")
 

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -734,6 +734,7 @@ final class FileSearchControllerTests: XCTestCase {
 
         store.reload()
         container.updateHeader(store: store)
+        container.updatePresentation(.find)
 
         XCTAssertEqual(
             searchController.searchRequests.count,

--- a/cmuxTests/FileExplorerStoreTests.swift
+++ b/cmuxTests/FileExplorerStoreTests.swift
@@ -697,6 +697,71 @@ final class FileSearchControllerTests: XCTestCase {
         XCTAssertEqual(searchController.searchRequests.last?.query, "private")
     }
 
+    func testContentRevisionChangeDoesNotRestartActiveFindSearch() async throws {
+        let store = FileExplorerStore()
+        let state = FileExplorerState()
+        let searchController = SpyFileSearchController()
+        let coordinator = FileExplorerPanelView.Coordinator(
+            store: store,
+            state: state,
+            onOpenFilePreview: { _ in }
+        )
+        let container = FileExplorerContainerView(
+            coordinator: coordinator,
+            presentation: .find,
+            searchController: searchController
+        )
+        store.provider = MockFileExplorerProvider(homePath: "/tmp")
+        store.setRootPath("/tmp/cmux-find-content-revision-test")
+        container.updateHeader(store: store)
+        container.updatePresentation(.find)
+
+        let searchField = try XCTUnwrap(Self.findSearchField(in: container))
+        searchField.stringValue = "needle"
+        container.controlTextDidChange(Notification(name: NSControl.textDidChangeNotification, object: searchField))
+
+        try await waitFor("initial find search request") {
+            searchController.searchRequests.count == 1
+        }
+
+        searchController.publish(FileSearchSnapshot(
+            query: "needle",
+            results: [Self.searchResult(relativePath: "first.txt")],
+            status: .searching,
+            isSearching: true
+        ))
+        let originalRequestCount = searchController.searchRequests.count
+
+        store.reload()
+        container.updateHeader(store: store)
+
+        XCTAssertEqual(
+            searchController.searchRequests.count,
+            originalRequestCount,
+            "A content revision while a search is active should not cancel and restart the result stream."
+        )
+
+        searchController.publish(FileSearchSnapshot(
+            query: "needle",
+            results: [Self.searchResult(relativePath: "first.txt")],
+            status: .matches,
+            isSearching: false
+        ))
+
+        XCTAssertEqual(searchController.searchRequests.count, originalRequestCount + 1)
+        XCTAssertEqual(searchController.searchRequests.last?.contentRevision, store.contentRevision)
+    }
+
+    private static func searchResult(relativePath: String) -> FileSearchResult {
+        FileSearchResult(
+            path: "/tmp/cmux-find-content-revision-test/\(relativePath)",
+            relativePath: relativePath,
+            lineNumber: 1,
+            columnNumber: 1,
+            preview: "needle"
+        )
+    }
+
     private func waitForSettledSearchSnapshot(
         timeout: TimeInterval = 5,
         _ snapshot: @MainActor @escaping () -> FileSearchSnapshot?
@@ -759,6 +824,10 @@ final class FileSearchControllerTests: XCTestCase {
                 isLocal: isLocal,
                 contentRevision: contentRevision
             ))
+        }
+
+        func publish(_ snapshot: FileSearchSnapshot) {
+            onSnapshotChanged?(snapshot)
         }
 
         func cancel(clear: Bool) {

--- a/cmuxTests/FileSearchRipgrepParserTests.swift
+++ b/cmuxTests/FileSearchRipgrepParserTests.swift
@@ -138,6 +138,26 @@ final class FileSearchOutputPipelineTests: XCTestCase {
         XCTAssertTrue(finalUpdate.shouldStopProcess)
     }
 
+    func testFinishKeepsEarlierLimitedStatusAfterStreamingLimit() async throws {
+        let pipeline = FileSearchOutputPipeline(
+            rootPath: "/tmp/project",
+            maxResults: 1,
+            snapshotInterval: 60
+        )
+        let line = try makeMatchLine(relativePath: "Sources/App.swift") + "\n"
+
+        let streamingUpdate = try XCTUnwrap(await pipeline.consumeStdout(Data(line.utf8)))
+        XCTAssertEqual(streamingUpdate.status, .limited(1))
+        XCTAssertTrue(streamingUpdate.shouldStopProcess)
+
+        let finalUpdate = await pipeline.finish(status: 0)
+
+        XCTAssertEqual(finalUpdate.status, .limited(1))
+        XCTAssertEqual(finalUpdate.results.map(\.relativePath), ["Sources/App.swift"])
+        XCTAssertFalse(finalUpdate.isSearching)
+        XCTAssertTrue(finalUpdate.shouldStopProcess)
+    }
+
     private func makeMatchLine(relativePath: String) throws -> String {
         let object: [String: Any] = [
             "type": "match",

--- a/cmuxTests/FileSearchRipgrepParserTests.swift
+++ b/cmuxTests/FileSearchRipgrepParserTests.swift
@@ -117,3 +117,48 @@ final class FileSearchRipgrepParserTests: XCTestCase {
         return String(decoding: data, as: UTF8.self)
     }
 }
+
+final class FileSearchOutputPipelineTests: XCTestCase {
+    func testFinishPreservesLimitedStatusFromTrailingBufferedLine() async throws {
+        let pipeline = FileSearchOutputPipeline(
+            rootPath: "/tmp/project",
+            maxResults: 1,
+            snapshotInterval: 60
+        )
+        let line = try makeMatchLine(relativePath: "Sources/App.swift")
+
+        let streamingUpdate = await pipeline.consumeStdout(Data(line.utf8))
+        XCTAssertNil(streamingUpdate, "A match without a trailing newline should remain buffered until finish.")
+
+        let finalUpdate = await pipeline.finish(status: 0)
+
+        XCTAssertEqual(finalUpdate.status, .limited(1))
+        XCTAssertEqual(finalUpdate.results.map(\.relativePath), ["Sources/App.swift"])
+        XCTAssertFalse(finalUpdate.isSearching)
+        XCTAssertTrue(finalUpdate.shouldStopProcess)
+    }
+
+    private func makeMatchLine(relativePath: String) throws -> String {
+        let object: [String: Any] = [
+            "type": "match",
+            "data": [
+                "path": [
+                    "text": "/tmp/project/\(relativePath)",
+                ],
+                "lines": [
+                    "text": "let title = \"Search files\"\n",
+                ],
+                "line_number": 7,
+                "submatches": [
+                    [
+                        "match": ["text": "title"],
+                        "start": 4,
+                        "end": 9,
+                    ],
+                ],
+            ],
+        ]
+        let data = try JSONSerialization.data(withJSONObject: object)
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/cmuxTests/FileSearchRipgrepParserTests.swift
+++ b/cmuxTests/FileSearchRipgrepParserTests.swift
@@ -146,7 +146,8 @@ final class FileSearchOutputPipelineTests: XCTestCase {
         )
         let line = try makeMatchLine(relativePath: "Sources/App.swift") + "\n"
 
-        let streamingUpdate = try XCTUnwrap(await pipeline.consumeStdout(Data(line.utf8)))
+        let maybeStreamingUpdate = await pipeline.consumeStdout(Data(line.utf8))
+        let streamingUpdate = try XCTUnwrap(maybeStreamingUpdate)
         XCTAssertEqual(streamingUpdate.status, .limited(1))
         XCTAssertTrue(streamingUpdate.shouldStopProcess)
 


### PR DESCRIPTION
## Summary
- Adds a regression test proving Files find publishes every match from a folder with three matching files.
- Fixes result finalization so stdout, the match stream, gates the final accumulated snapshot while stderr remains diagnostic-only.
- Preserves the typing-lag optimization: the query input stays debounced and result parsing stays off the input path.
- Removes the redundant idle Find prompt under the search field before a query is typed.

## Regressing Commit
Regression from [`52db9e358f9073526de98c10ba424275751c06fe`](https://github.com/manaflow-ai/cmux/commit/52db9e358f9073526de98c10ba424275751c06fe) (`Fix right sidebar Find typing lag (#3739)`).

## Testing
- Built and launched main repro with `./scripts/reload.sh --tag repro-3817-main --launch`.
- Confirmed the Find panel can be revealed/focused in the launched repro build via the tagged debug socket (`debug.right_sidebar.focus` returned visible/focused true). Local AX/screen-capture access was unavailable, so direct visual row-count capture could not be collected from this environment.
- `git diff --check -- cmuxTests/FileExplorerStoreTests.swift`
- `git diff --check -- Sources/FileExplorerSearchController.swift cmuxTests/FileExplorerStoreTests.swift`

## Not Tested
- Local XCTest execution, per repo policy.
- XCUITests, per repo policy.

## Checklist
- [x] Regression coverage added for multi-match folder searches.
- [x] Tagged dogfood build completed with `./scripts/reload.sh --tag issue-3817-find-in-folder-one-result`.
- [x] PR branch merged with latest `origin/main`.
- [ ] User dogfood approval before merge.

Fixes https://github.com/manaflow-ai/cmux/issues/3817

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the ripgrep process I/O/concurrency path and search refresh scheduling; mistakes could cause hangs, missed results, or extra process churn, but changes are localized and covered by new tests.
> 
> **Overview**
> Fixes Files Find result aggregation by switching ripgrep output handling to chunked POSIX pipe reads with stdout line buffering/flush-on-finish, preserving the terminal `.limited` update and treating stderr as diagnostic-only (only awaited on error exits).
> 
> Adjusts Find refresh behavior so root/provider scope changes still refresh immediately, but *content revision* changes during an active search are deferred until the current stream settles; also removes the idle “Type to search” prompt. Adds regression tests for multi-file/nested match completeness, early limiting to 500 results, pipeline finish behavior with buffered trailing lines, and avoiding mid-stream restarts on content revision changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 741ff5a7cdead8c72bfcf0f4bc18e9bd639e99ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Files Find to publish all matches and prevent stalls or lost results during folder searches and content refreshes. Completion is now gated on ripgrep stdout, drained independently; same-query content refreshes run after the current search settles, and the terminal limited state is preserved on finish.

- **Bug Fixes**
  - Drain stdout via retained read handles and POSIX reads on a dedicated queue; frame lines in an actor, flush a trailing line on finish, remember the terminal limited update, gate completion on stdout, and await stderr only on non‑0/1 exits.
  - Defer same‑query content refreshes until the current search settles (scope changes still refresh immediately). Add tests for multi‑file/nested results, high‑volume limit publication, terminal limited‑state preservation, and avoiding restarts on content revisions; fix a test by removing async from `XCTUnwrap`. Remove the redundant idle Find prompt. Fixes #3817.

<sup>Written for commit 741ff5a7cdead8c72bfcf0f4bc18e9bd639e99ed. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Ensure all search matches are captured by flushing trailing output and handling diagnostic/error output without blocking final results.

* **Behavior**
  * Defer refreshes while search results stream; content-revision changes mid-search wait until streaming settles. Hiding or closing search cancels pending refreshes; scheduled debounces clear pending flags.

* **Tests**
  * Added tests for accurate match results (including nested folders) and ensuring active searches are not restarted by reloads.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3818)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
