### PR TITLE
Fix Escape command palette dismissal

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10782,7 +10782,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 }
                 clearCommandPalettePendingOpen(for: paletteWindow)
                 beginCommandPaletteEscapeSuppression(for: paletteWindow)
-                NotificationCenter.default.post(name: .commandPaletteToggleRequested, object: paletteWindow)
+                NotificationCenter.default.post(name: .commandPaletteDismissRequested, object: paletteWindow)
 #if DEBUG
                 cmuxDebugLog("shortcut.escape paletteDismiss consumed=1 target={\(debugWindowToken(paletteWindow))}")
 #endif

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -3544,10 +3544,10 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             appDelegate.setCommandPaletteVisible(false, for: window)
         }
 
-        let dismissExpectation = expectation(description: "Expected command palette toggle notification for Escape dismiss")
+        let dismissExpectation = expectation(description: "Expected command palette dismiss notification for Escape")
         var observedDismissWindow: NSWindow?
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -3609,7 +3609,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         )
         dismissExpectation.isInverted = true
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -3660,7 +3660,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "Expected command palette dismiss notification for Escape")
         var observedDismissWindow: NSWindow?
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -3866,7 +3866,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "Escape should dismiss stale-state command palette after delay")
         var observedDismissWindow: NSWindow?
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -3926,7 +3926,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "Escape should dismiss stale-state command palette after extended delay")
         var observedDismissWindow: NSWindow?
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -3988,7 +3988,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "No dismiss notification for expired pending-open state")
         dismissExpectation.isInverted = true
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { _ in
@@ -4053,7 +4053,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "Expected command palette dismiss notification for menu-triggered stale visibility")
         var observedDismissWindow: NSWindow?
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { notification in
@@ -4253,7 +4253,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         let dismissExpectation = expectation(description: "Escape in another window should not dismiss palette")
         dismissExpectation.isInverted = true
         let dismissToken = NotificationCenter.default.addObserver(
-            forName: .commandPaletteToggleRequested,
+            forName: .commandPaletteDismissRequested,
             object: nil,
             queue: nil
         ) { _ in

--- a/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
+++ b/cmuxUITests/BrowserPaneNavigationKeybindUITests.swift
@@ -493,6 +493,48 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
     }
 
+    func testEscapeDismissesCommandPaletteOpenedByCmdShiftP() {
+        let app = XCUIApplication()
+        app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
+        app.launchEnvironment["CMUX_TAG"] = "ui-esc-\(UUID().uuidString.prefix(8))"
+        launchAndEnsureForeground(app)
+
+        let window = app.windows.firstMatch
+        _ = window.waitForExistence(timeout: 2.0)
+        XCTAssertTrue(waitForSocketPong(timeout: 12.0), "Expected control socket at \(socketPath)")
+
+        guard let workspace = currentWorkspaceContext() else {
+            XCTFail("Expected current workspace context before opening the command palette")
+            return
+        }
+
+        let paletteSearchField = app.textFields["CommandPaletteSearchField"].firstMatch
+        app.typeKey("p", modifierFlags: [.command, .shift])
+        XCTAssertTrue(
+            paletteSearchField.waitForExistence(timeout: 5.0),
+            "Expected Cmd+Shift+P to open the command palette"
+        )
+        XCTAssertNotNil(
+            waitForCommandPaletteSnapshot(
+                windowId: workspace.windowId,
+                mode: "commands",
+                query: ">",
+                timeout: 5.0
+            ),
+            "Expected command palette debug state to report visible commands mode"
+        )
+
+        app.typeKey(XCUIKeyboardKey.escape.rawValue, modifierFlags: [])
+        XCTAssertTrue(
+            waitForNonExistence(paletteSearchField, timeout: 5.0),
+            "Expected Escape to dismiss the command palette opened by Cmd+Shift+P"
+        )
+        XCTAssertTrue(
+            waitForCommandPaletteVisibility(windowId: workspace.windowId, visible: false, timeout: 5.0),
+            "Expected command palette debug state to report hidden after Escape"
+        )
+    }
+
     func testCmdDSplitsRightWhenWebViewFocused() {
         let app = XCUIApplication()
         app.launchEnvironment["CMUX_SOCKET_PATH"] = socketPath
@@ -1392,6 +1434,16 @@ final class BrowserPaneNavigationKeybindUITests: XCTestCase {
         )
         guard let ok = envelope?["ok"] as? Bool, ok else { return nil }
         return envelope?["result"] as? [String: Any]
+    }
+
+    private func waitForCommandPaletteVisibility(
+        windowId: String,
+        visible: Bool,
+        timeout: TimeInterval
+    ) -> Bool {
+        waitForCondition(timeout: timeout) {
+            (self.commandPaletteSnapshot(windowId: windowId)?["visible"] as? Bool) == visible
+        }
     }
 
     private var autofocusRacePageURL: String {


### PR DESCRIPTION
Summary
- Send Escape through the command palette dismiss notification instead of the toggle notification.
- Add red/green AppDelegate coverage for the dismiss route.
- Add a UI regression for Cmd+Shift+P followed by Escape and debug-state hidden verification.

Tests
- M4 red check: 062c83754 fails cmuxTests/AppDelegateShortcutRoutingTests/testEscapeDismissesVisibleCommandPaletteAndIsConsumed.
- M4 green check: 268d0f0cc passes cmuxTests/AppDelegateShortcutRoutingTests/testEscapeDismissesVisibleCommandPaletteAndIsConsumed.
- M4 green check: 268d0f0cc passes cmuxUITests/BrowserPaneNavigationKeybindUITests/testEscapeDismissesCommandPaletteOpenedByCmdShiftP.
- Local tagged reload: ./scripts/reload.sh --tag escpal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, localized change to Escape shortcut routing plus updated/added tests; behavior is covered by unit and UI regression tests.
> 
> **Overview**
> Escape dismissal of the command palette is now routed via `Notification.Name.commandPaletteDismissRequested` instead of the toggle notification, aligning the shortcut path with the explicit dismiss handler.
> 
> Updates `AppDelegateShortcutRoutingTests` to assert the new notification name, and adds a UI regression test that opens the palette with Cmd+Shift+P, presses Escape, and verifies (via debug snapshot) that the palette becomes hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 268d0f0cc7ce5c1b0517f13af6211bb839c9f897. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Escape so it dismisses the command palette by posting `commandPaletteDismissRequested` instead of toggling. Adds tests to prevent regressions and verify UI behavior.

- **Bug Fixes**
  - Post `.commandPaletteDismissRequested` on Escape from AppDelegate.
  - Update unit tests to observe dismiss notifications.
  - Add UI test: Cmd+Shift+P opens the palette; Escape closes it and debug state reports hidden.

<sup>Written for commit 268d0f0cc7ce5c1b0517f13af6211bb839c9f897. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command palette Escape key behavior to consistently dismiss the palette instead of toggling its visibility.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3823)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->