### PR TITLE
Close Web Inspector before browser host teardown

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -627,7 +627,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         #endif
 
-        func windowShouldClose(_ sender: NSWindow) -> Bool { shouldClose?() ?? true }
+        func windowShouldClose(_ sender: NSWindow) -> Bool {
+            let shouldClose = shouldClose?() ?? true
+            if shouldClose {
+                WebViewInspectorTeardown.closeAllInspectors(in: sender)
+            }
+            return shouldClose
+        }
     }
 
     struct ScriptableMainWindowState {
@@ -1482,18 +1488,21 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         // Tagged DEV builds are ephemeral, skip quit confirmation entirely.
         if SocketControlSettings.isTaggedDevBuild() {
+            closeAllWebInspectorsBeforeAppTeardown()
             return .terminateNow
         }
 
         // If the user already confirmed via the Cmd+Q shortcut warning dialog
         // (handleQuitShortcutWarning), skip the check to avoid a second alert.
         if isQuitWarningConfirmed {
+            closeAllWebInspectorsBeforeAppTeardown()
             return .terminateNow
         }
 
         // Respect the "Warn Before Quit" setting even when Cmd+Q arrives via
         // the Cmd+Tab app switcher, bypassing handleCustomShortcut.
         guard QuitWarningSettings.isEnabled() else {
+            closeAllWebInspectorsBeforeAppTeardown()
             return .terminateNow
         }
 
@@ -1517,6 +1526,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             let shouldQuit = response == .alertFirstButtonReturn
             if shouldQuit {
                 self.isQuitWarningConfirmed = true
+                self.closeAllWebInspectorsBeforeAppTeardown()
             } else {
                 // Reset so that the next quit attempt can show the dialog again.
                 self.isTerminatingApp = false
@@ -1526,8 +1536,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return .terminateLater
     }
 
+    @discardableResult
+    private func closeAllWebInspectorsBeforeAppTeardown() -> Int {
+        WebViewInspectorTeardown.closeAllInspectors(in: NSApp.windows)
+    }
+
     func applicationWillTerminate(_ notification: Notification) {
         isTerminatingApp = true
+        closeAllWebInspectorsBeforeAppTeardown()
         _ = saveSessionSnapshot(includeScrollback: true, removeWhenEmpty: false)
         stopSessionAutosaveTimer()
         CloudVMActionLauncher.shared.terminateAll()

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3448,6 +3448,8 @@ final class BrowserPanel: Panel, ObservableObject {
     }
 
     func close() {
+        closeDeveloperToolsForTeardown()
+
         // Ensure we don't keep a hidden WKWebView (or its content view) as first responder while
         // bonsplit/SwiftUI reshuffles views during close.
         unfocus()
@@ -4742,6 +4744,22 @@ extension BrowserPanel {
         return true
     }
 
+    @discardableResult
+    func closeDeveloperToolsForTeardown() -> Bool {
+        developerToolsTransitionSettleWorkItem?.cancel()
+        developerToolsTransitionSettleWorkItem = nil
+        pendingDeveloperToolsTransitionTargetVisible = nil
+        developerToolsTransitionTargetVisible = nil
+        developerToolsDetachedOpenGraceDeadline = nil
+        developerToolsLastKnownVisibleAt = nil
+        forceDeveloperToolsRefreshOnNextAttach = false
+        cancelDeveloperToolsRestoreRetry()
+
+        let closed = WebViewInspectorTeardown.closeInspector(for: webView)
+        setPreferredDeveloperToolsVisible(false)
+        return closed
+    }
+
     /// Called before WKWebView detaches so manual inspector closes are respected.
     func syncDeveloperToolsPreferenceFromInspector(preserveVisibleIntent: Bool = false) {
         guard let inspector = webView.cmuxInspectorObject() else { return }
@@ -5877,6 +5895,86 @@ extension WKWebView {
             return nil
         }
         return inspectorWebView
+    }
+}
+
+enum WebViewInspectorTeardown {
+    @discardableResult
+    static func closeAllInspectors(in window: NSWindow) -> Int {
+        assert(Thread.isMainThread)
+
+        return webViews(in: window).reduce(0) { count, webView in
+            closeInspector(for: webView) ? count + 1 : count
+        }
+    }
+
+    @discardableResult
+    static func closeAllInspectors(in windows: [NSWindow]) -> Int {
+        windows.reduce(0) { count, window in
+            count + closeAllInspectors(in: window)
+        }
+    }
+
+    @discardableResult
+    static func closeInspector(for webView: WKWebView) -> Bool {
+        assert(Thread.isMainThread)
+
+        guard !isInspectorFrontendWebView(webView),
+              let inspector = webView.cmuxInspectorObject() else {
+            return false
+        }
+
+        let isVisibleSelector = NSSelectorFromString("isVisible")
+        let isAttachedSelector = NSSelectorFromString("isAttached")
+        let isVisible = inspector.cmuxCallBool(selector: isVisibleSelector)
+        let isAttached = inspector.cmuxCallBool(selector: isAttachedSelector)
+        let shouldClose = (isVisible == true)
+            || (isAttached == true)
+            || (isVisible == nil && isAttached == nil)
+        guard shouldClose else { return false }
+
+        // cmux already opens Web Inspector through WebKit's `_inspector` object
+        // because the deployable SDK surface does not expose a stable close API.
+        // Keep teardown on the same auditable SPI path so WebKit unregisters the
+        // inspector window observers before the parent AppKit close cascade runs.
+        let closeSelector = NSSelectorFromString("close")
+        guard inspector.responds(to: closeSelector) else { return false }
+        inspector.cmuxCallVoid(selector: closeSelector)
+        return true
+    }
+
+    private static func webViews(in window: NSWindow) -> [WKWebView] {
+        var seen = Set<ObjectIdentifier>()
+        var result: [WKWebView] = []
+        let roots = [window.contentView, window.contentView?.superview].compactMap { $0 }
+        for root in roots {
+            collectWebViews(in: root, seen: &seen, result: &result)
+        }
+        return result
+    }
+
+    private static func collectWebViews(
+        in view: NSView,
+        seen: inout Set<ObjectIdentifier>,
+        result: inout [WKWebView]
+    ) {
+        if let webView = view as? WKWebView,
+           !isInspectorFrontendWebView(webView) {
+            let id = ObjectIdentifier(webView)
+            if !seen.contains(id) {
+                seen.insert(id)
+                result.append(webView)
+            }
+        }
+
+        for subview in view.subviews {
+            collectWebViews(in: subview, seen: &seen, result: &result)
+        }
+    }
+
+    private static func isInspectorFrontendWebView(_ webView: WKWebView) -> Bool {
+        let className = NSStringFromClass(type(of: webView))
+        return className.contains("WKInspector") || className.contains("WebInspector")
     }
 }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -5898,6 +5898,7 @@ extension WKWebView {
     }
 }
 
+@MainActor
 enum WebViewInspectorTeardown {
     @discardableResult
     static func closeAllInspectors(in window: NSWindow) -> Int {

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -279,11 +279,17 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
 
     // MARK: - NSWindowDelegate
 
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        WebViewInspectorTeardown.closeAllInspectors(in: sender)
+        return true
+    }
+
     func windowWillClose(_ notification: Notification) {
         #if DEBUG
         cmuxDebugLog("popup.close depth=\(nestingDepth)")
         #endif
 
+        WebViewInspectorTeardown.closeInspector(for: webView)
         closeAllChildPopups()
 
         // Invalidate observations

--- a/Sources/Panels/BrowserPopupWindowController.swift
+++ b/Sources/Panels/BrowserPopupWindowController.swift
@@ -265,6 +265,7 @@ final class BrowserPopupWindowController: NSObject, NSWindowDelegate {
     // MARK: - Popup lifecycle
 
     func closePopup() {
+        WebViewInspectorTeardown.closeAllInspectors(in: panel)
         panel.close() // triggers windowWillClose
     }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2141,11 +2141,6 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         installCmuxUnitTestInspectorOverride()
     }
 
-    override func setUp() {
-        super.setUp()
-        setenv("NSZombieEnabled", "YES", 1)
-    }
-
     private func makePanelWithInspector(
         hideBehavior: FakeInspector.HideBehavior = .unsupported
     ) -> (BrowserPanel, FakeInspector) {
@@ -2200,9 +2195,10 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         XCTAssertEqual(inspector.closeCount, 0)
 
         panel.close()
-        spinRunLoopOneTick()
 
         XCTAssertEqual(inspector.closeCount, 1)
+        spinRunLoopOneTick()
+
         XCTAssertFalse(panel.isDeveloperToolsVisible())
     }
 

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2141,6 +2141,11 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         installCmuxUnitTestInspectorOverride()
     }
 
+    override func setUp() {
+        super.setUp()
+        setenv("NSZombieEnabled", "YES", 1)
+    }
+
     private func makePanelWithInspector(
         hideBehavior: FakeInspector.HideBehavior = .unsupported
     ) -> (BrowserPanel, FakeInspector) {
@@ -2148,6 +2153,15 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
         let inspector = FakeInspector(hideBehavior: hideBehavior)
         panel.webView.cmuxSetUnitTestInspector(inspector)
         return (panel, inspector)
+    }
+
+    private func spinRunLoopOneTick() {
+        RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.01))
+    }
+
+    private func window(withId windowId: UUID) -> NSWindow? {
+        let identifier = "cmux.main.\(windowId.uuidString)"
+        return NSApp.windows.first(where: { $0.identifier?.rawValue == identifier })
     }
 
     private func findHostContainerView(in root: NSView) -> WebViewRepresentable.HostContainerView? {
@@ -2176,6 +2190,64 @@ final class BrowserDeveloperToolsVisibilityPersistenceTests: XCTestCase {
             }
         }
         return nil
+    }
+
+    func testPaneCloseClosesVisibleInspectorSynchronouslyBeforeWebViewTeardown() {
+        let (panel, inspector) = makePanelWithInspector()
+
+        XCTAssertTrue(panel.showDeveloperTools())
+        XCTAssertTrue(panel.isDeveloperToolsVisible())
+        XCTAssertEqual(inspector.closeCount, 0)
+
+        panel.close()
+        spinRunLoopOneTick()
+
+        XCTAssertEqual(inspector.closeCount, 1)
+        XCTAssertFalse(panel.isDeveloperToolsVisible())
+    }
+
+    func testWindowCloseClosesContainedBrowserInspectorBeforeWindowWillClose() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let windowId = appDelegate.createMainWindow()
+        guard let window = window(withId: windowId),
+              let manager = appDelegate.tabManagerFor(windowId: windowId),
+              let workspace = manager.selectedWorkspace,
+              let browserPanelId = manager.openBrowser(inWorkspace: workspace.id, preferSplitRight: true),
+              let browserPanel = workspace.browserPanel(for: browserPanelId) else {
+            XCTFail("Expected main window with browser panel")
+            return
+        }
+
+        let inspector = FakeInspector()
+        browserPanel.webView.cmuxSetUnitTestInspector(inspector)
+        if browserPanel.webView.superview == nil {
+            browserPanel.webView.frame = window.contentView?.bounds ?? .zero
+            window.contentView?.addSubview(browserPanel.webView)
+        }
+
+        XCTAssertTrue(browserPanel.showDeveloperTools())
+        XCTAssertTrue(browserPanel.isDeveloperToolsVisible())
+
+        var closeCountObservedAtWillClose: Int?
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: nil
+        ) { _ in
+            closeCountObservedAtWillClose = inspector.closeCount
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        window.performClose(nil)
+        spinRunLoopOneTick()
+
+        XCTAssertEqual(closeCountObservedAtWillClose, 1)
+        XCTAssertEqual(inspector.closeCount, 1)
+        XCTAssertFalse(browserPanel.isDeveloperToolsVisible())
     }
 
     func testRestoreReopensInspectorAfterAttachWhenPreferredVisible() {


### PR DESCRIPTION
Fixes #3828

## Crash signature

cmux 0.64.3 can crash on the main thread when closing a window or pane containing a browser `WKWebView` whose Web Inspector is open:

```text
EXC_BAD_ACCESS (KERN_INVALID_ADDRESS at 0x170)
0  WebKit -[WKWebInspectorUIProxyObjCAdapter inspectorViewControllerDidBecomeActive:] + 88
1  WebKit -[WKInspectorViewController inspectorWKWebViewDidBecomeActive:] + 60
2  WebKit -[WKInspectorWKWebView _handleWindowDidBecomeKey:] + 92
...
22 WebKit -[WKWebInspectorUIProxyObjCAdapter windowWillClose:] + 52
30 AppKit -[NSWindow __close] + 376
31 AppKit -[NSApplication(NSResponder) sendAction:to:from:]
...
44 cmux   NSWindow.cmux_sendEvent(_:) + 788
```

## Repro notes

Attempted the requested baseline command before code changes: `./scripts/reload.sh --tag issue-3828-web-inspector-crash-baseline --launch`. The first attempt was interrupted by the shared build queue before launch; a retry was still waiting on the global reload lock, so I stopped only that queued retry before editing to avoid it launching a non-baseline build after changes. A fresh local crash report at `~/Library/Logs/DiagnosticReports/cmux-2026-05-10-164628.ips` matched the exact signature above, including the `0x170` read, `WKInspectorWKWebView _handleWindowDidBecomeKey`, and `NSWindow.cmux_sendEvent` frame.

Manual repro sequence used for the live smoke path:

1. Open browser pane.
2. Open Web Inspector via the production DevTools toolbar button.
3. Exercise inspector/window close behavior and check `DiagnosticReports` for a new crash.

## Design memo

The fix closes Web Inspector synchronously before AppKit starts tearing down the parent host. `WebViewInspectorTeardown.closeAllInspectors(in:)` walks the closing window's view tree for production `WKWebView` instances and closes any visible or attached inspector through the same WebKit `_inspector` object cmux already uses for DevTools. The helper is called from `windowShouldClose` for main windows, pane teardown, popup teardown, and app termination. It does not schedule `DispatchQueue`, `Task`, or delayed retries, because the failing observer must be removed on the same runloop turn before `windowWillClose:` and key-window notifications cascade through WebKit.

`NSWindow.cmux_sendEvent` audit: the swizzle only performs event routing, focus guard context, key timing, and folder-drag/window-move suppression before forwarding to AppKit. It does not perform synchronous teardown or pre-empt normal close ordering, so the fix belongs in the close lifecycle rather than the event swizzle.

## Regression tests

Two-commit structure:

1. `8d43a77f3` adds failing regression coverage only.
2. `228390fa7` adds the synchronous inspector teardown fix.

Added `@MainActor` tests in `BrowserDeveloperToolsVisibilityPersistenceTests` that use the production `BrowserPanel`/`CmuxWebView` path and the same inspector SPI hook used by existing DevTools tests:

- `testPaneCloseClosesVisibleInspectorSynchronouslyBeforeWebViewTeardown`
- `testWindowCloseClosesContainedBrowserInspectorBeforeWindowWillClose`

Local unit tests were not run because this issue forbids direct `xcodebuild`; CI is the validation path.

## Manual verification

| Case | Result | Notes |
| --- | --- | --- |
| Browser pane + Web Inspector, close cmux window | Not run manually | Covered by new regression test + CircleCI macOS unit tests; UI automation could not reliably target the parent window behind the detached inspector without disrupting the final launch requirement |
| Browser pane + Web Inspector, close pane | Not run manually | Covered by new regression test + CircleCI macOS unit tests |
| Web Inspector open, Cmd+Q app | Not run manually | Code path covered by `applicationShouldTerminate`/`applicationWillTerminate` hook; not exercised manually to preserve final launched dev app |
| Close inspector window itself | Pass | Opened real Web Inspector from the production DevTools toolbar button, clicked inspector close button, parent browser window remained open |
| Reload WKWebView URL, then close window | Not run manually | Not completed in UI smoke pass |
| Repeat timing-sensitive cases 3-5x | Not run manually | Not completed in UI smoke pass |
| Check `~/Library/Logs/DiagnosticReports/cmux-*.ips` | Pass | No crash report newer than the pre-fix `cmux-2026-05-10-164628.ips` after launch/smoke interaction |

## Validation

- `git diff --check` passed.
- GitHub Actions checks passed: `workflow-guard-tests`, `remote-daemon-tests`, `web-typecheck`, `web-db-migrations`, `activation-session`.
- CircleCI passed: `macos-debug-build`, `macos-release-build`, `macos-unit-tests`.
- Vercel production/staging preview deploy contexts passed.
- Branch pushed to `origin` (`manaflow-ai/cmux`) only.
- `./scripts/reload.sh --tag issue-3828-web-inspector-crash --launch` succeeded after freeing this issue's stale baseline DerivedData and launched `cmux DEV issue-3828-web-inspector-crash`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window-close and app-termination paths and relies on WebKit private inspector SPI; incorrect ordering could regress close behavior or DevTools state, but changes are localized and covered by new tests.
> 
> **Overview**
> Closes any open WebKit Web Inspector *synchronously* before AppKit begins tearing down windows, panes, or popups to prevent a crash during close.
> 
> Introduces `WebViewInspectorTeardown` to walk a window’s view tree, find non-inspector `WKWebView`s, and invoke the inspector `close` SPI when visible/attached. This teardown is now triggered from main window `windowShouldClose`, `BrowserPanel.close()`, popup close/delegate hooks, and app quit/terminate (`applicationShouldTerminate`/`applicationWillTerminate`).
> 
> Adds unit tests asserting inspectors are closed before `WKWebView` teardown and before `NSWindow.willClose` fires during window close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1c31b8d73abda09a632773f115db47b866c1040. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Developer tools are now properly closed and cleaned up when windows close or during application shutdown
  * Enhanced shutdown sequence to ensure inspector state is fully released before app termination

* **Tests**
  * Added lifecycle tests verifying proper developer tools cleanup during window closure and panel shutdown scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3835)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->