### PR TITLE
Fix McBopomofo Bopomofo candidate opening

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -114,7 +114,7 @@ extension GhosttyNSView {
             || sourceId.localizedCaseInsensitiveContains("Bopomofo")
     }
 
-    func shouldOpenZhuyinCandidatesWithSyntheticSpace(
+    func shouldOpenBopomofoCandidatesWithSyntheticSpace(
         event: NSEvent,
         inputSourceId: String?,
         markedTextBefore: Bool,
@@ -137,7 +137,7 @@ extension GhosttyNSView {
         return true
     }
 
-    func shouldRememberZhuyinCandidateInteraction(
+    func shouldRememberBopomofoCandidateInteraction(
         event: NSEvent,
         inputSourceId: String?,
         markedTextBefore: Bool,

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -107,9 +107,11 @@ extension GhosttyNSView {
         }
     }
 
-    func isTraditionalZhuyinInputSource(_ sourceId: String?) -> Bool {
+    func isBopomofoInputSource(_ sourceId: String?) -> Bool {
         guard let sourceId else { return false }
-        return sourceId.localizedCaseInsensitiveContains("TCIM.Zhuyin")
+        // Apple's source IDs use "Zhuyin"; McBopomofo/OpenVanilla use "Bopomofo".
+        return sourceId.localizedCaseInsensitiveContains("Zhuyin")
+            || sourceId.localizedCaseInsensitiveContains("Bopomofo")
     }
 
     func shouldOpenZhuyinCandidatesWithSyntheticSpace(
@@ -125,7 +127,7 @@ extension GhosttyNSView {
         guard !candidateOpenAlreadyRequested,
               markedTextBefore,
               accumulatedText.isEmpty,
-              isTraditionalZhuyinInputSource(inputSourceId),
+              isBopomofoInputSource(inputSourceId),
               Int(event.keyCode) == kVK_DownArrow,
               commandSelector == #selector(NSResponder.moveDown(_:)),
               before.text == after.text,
@@ -143,7 +145,7 @@ extension GhosttyNSView {
     ) -> Bool {
         guard markedTextBefore,
               accumulatedText.isEmpty,
-              isTraditionalZhuyinInputSource(inputSourceId) else {
+              isBopomofoInputSource(inputSourceId) else {
             return false
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7027,7 +7027,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             desiredFocus = false
             terminalSurface?.recordExternalFocusState(false)
             imeSuppressedKeyUpKeyCodes.removeAll()
-            zhuyinCandidateOpenRequested = false
+            bopomofoCandidateOpenRequested = false
         }
         if result, let surface = surface {
             let now = CACurrentMediaTime()
@@ -7047,7 +7047,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var numpadIMECommitDeduplicator = NumpadIMECommitDeduplicator()
     private var imeSuppressedKeyUpKeyCodes: Set<UInt16> = []
     private var textInputCommandSelectorDuringKeyDown: Selector?
-    private var zhuyinCandidateOpenRequested = false
+    private var bopomofoCandidateOpenRequested = false
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -7062,16 +7062,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     func setIMETransientStateForTesting(
         suppressedKeyUpKeyCodes: Set<UInt16>,
-        zhuyinCandidateOpenRequested: Bool
+        bopomofoCandidateOpenRequested: Bool
     ) {
         imeSuppressedKeyUpKeyCodes = suppressedKeyUpKeyCodes
-        self.zhuyinCandidateOpenRequested = zhuyinCandidateOpenRequested
+        self.bopomofoCandidateOpenRequested = bopomofoCandidateOpenRequested
     }
     var imeSuppressedKeyUpKeyCodesForTesting: Set<UInt16> {
         imeSuppressedKeyUpKeyCodes
     }
-    var zhuyinCandidateOpenRequestedForTesting: Bool {
-        zhuyinCandidateOpenRequested
+    var bopomofoCandidateOpenRequestedForTesting: Bool {
+        bopomofoCandidateOpenRequested
     }
     func shouldSuppressShiftSpaceFallbackTextForTesting(event: NSEvent, markedTextBefore: Bool) -> Bool {
         shouldSuppressShiftSpaceFallbackText(event: event, markedTextBefore: markedTextBefore)
@@ -7526,7 +7526,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         var accumulatedText = keyTextAccumulator ?? []
         var markedStateAfter = (markedText.string, markedSelectedRange)
-        if shouldOpenZhuyinCandidatesWithSyntheticSpace(
+        if shouldOpenBopomofoCandidatesWithSyntheticSpace(
             event: translationEvent,
             inputSourceId: keyboardIdBefore,
             markedTextBefore: markedTextBefore,
@@ -7534,23 +7534,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             after: markedStateAfter,
             accumulatedText: accumulatedText,
             commandSelector: textInputCommandSelectorDuringKeyDown,
-            candidateOpenAlreadyRequested: zhuyinCandidateOpenRequested
+            candidateOpenAlreadyRequested: bopomofoCandidateOpenRequested
         ) {
-            zhuyinCandidateOpenRequested = true
+            bopomofoCandidateOpenRequested = true
             textInputCommandSelectorDuringKeyDown = nil
-            _ = handleTextInputKeyEvent(zhuyinCandidateOpenSpaceEvent(from: translationEvent))
+            _ = handleTextInputKeyEvent(bopomofoCandidateOpenSpaceEvent(from: translationEvent))
             syncPreedit(clearIfNeeded: markedTextBefore)
             accumulatedText = keyTextAccumulator ?? []
             markedStateAfter = (markedText.string, markedSelectedRange)
-        } else if shouldRememberZhuyinCandidateInteraction(
+        } else if shouldRememberBopomofoCandidateInteraction(
             event: translationEvent,
             inputSourceId: keyboardIdBefore,
             markedTextBefore: markedTextBefore,
             accumulatedText: accumulatedText
         ) {
-            zhuyinCandidateOpenRequested = true
+            bopomofoCandidateOpenRequested = true
         } else if markedTextBefore, isBopomofoInputSource(keyboardIdBefore) {
-            zhuyinCandidateOpenRequested = false
+            bopomofoCandidateOpenRequested = false
         }
 
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
@@ -7759,7 +7759,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return inputContext.handleEvent(event)
     }
 
-    private func zhuyinCandidateOpenSpaceEvent(from event: NSEvent) -> NSEvent {
+    private func bopomofoCandidateOpenSpaceEvent(from event: NSEvent) -> NSEvent {
         NSEvent.keyEvent(
             with: event.type,
             location: event.locationInWindow,
@@ -12843,7 +12843,7 @@ extension GhosttyNSView: NSTextInputClient {
 #endif
         markedText.mutableString.setString("")
         markedSelectedRange = NSRange(location: NSNotFound, length: 0)
-        zhuyinCandidateOpenRequested = false
+        bopomofoCandidateOpenRequested = false
 
         if hadMarkedText {
             syncPreedit()

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7564,7 +7564,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             accumulatedText: accumulatedText
         ) {
             zhuyinCandidateOpenRequested = true
-        } else if markedTextBefore, isTraditionalZhuyinInputSource(keyboardIdBefore) {
+        } else if markedTextBefore, isBopomofoInputSource(keyboardIdBefore) {
             zhuyinCandidateOpenRequested = false
         }
 

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -548,6 +548,86 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         XCTAssertEqual(forwardedReleaseKeyCodes, [])
     }
 
+    func testMcBopomofoDownArrowRequestsCandidatesViaSpaceCommandFallback() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        surfaceView.setMarkedText(
+            "ㄋㄧˇ",
+            selectedRange: NSRange(location: 3, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        KeyboardLayout.debugInputSourceIdOverride = "org.openvanilla.inputmethod.McBopomofo.McBopomofo.Bopomofo"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var sawDownCommand = false
+        var syntheticSpaceCount = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, events in
+            guard candidateView === surfaceView, let event = events.first else { return false }
+            if Int(event.keyCode) == kVK_DownArrow {
+                sawDownCommand = true
+                candidateView.doCommand(by: #selector(NSResponder.moveDown(_:)))
+                return false
+            }
+            if Int(event.keyCode) == kVK_Space {
+                syntheticSpaceCount += 1
+                return true
+            }
+            return false
+        }
+
+        var forwardedPressKeyCodes: [UInt32] = []
+        var forwardedReleaseKeyCodes: [UInt32] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressKeyCodes.append(keyEvent.keycode)
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseKeyCodes.append(keyEvent.keycode)
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertTrue(sawDownCommand)
+        XCTAssertEqual(
+            syntheticSpaceCount,
+            1,
+            "McBopomofo Bopomofo should share Zhuyin's candidate-opening path"
+        )
+        XCTAssertTrue(surfaceView.hasMarkedText())
+        XCTAssertEqual(forwardedPressKeyCodes, [])
+        XCTAssertEqual(forwardedReleaseKeyCodes, [])
+    }
+
     func testNumberCandidateSelectionStillCommitsTextDuringZhuyinComposition() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -845,7 +845,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let view = GhosttyNSView(frame: .zero)
         view.setIMETransientStateForTesting(
             suppressedKeyUpKeyCodes: [UInt16(kVK_DownArrow)],
-            zhuyinCandidateOpenRequested: true
+            bopomofoCandidateOpenRequested: true
         )
 
         view.unmarkText()
@@ -853,7 +853,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         XCTAssertFalse(view.hasMarkedText())
         XCTAssertEqual(view.markedRange(), NSRange(location: NSNotFound, length: 0))
         XCTAssertEqual(view.imeSuppressedKeyUpKeyCodesForTesting, [UInt16(kVK_DownArrow)])
-        XCTAssertFalse(view.zhuyinCandidateOpenRequestedForTesting)
+        XCTAssertFalse(view.bopomofoCandidateOpenRequestedForTesting)
     }
 
     func testSuppressesInputMethodHandledKeyWithoutMarkedText() throws {


### PR DESCRIPTION
Closes #3825.

## Design memo
cmux already routes IME-owned command keys through `NSTextInputContext` before terminal forwarding, and the recent #3691 fix added a Bopomofo/Zhuyin-specific candidate-open fallback for the `moveDown:`/no-output path. The root issue here was that the fallback classified only Apple's `TCIM.Zhuyin` input source, while McBopomofo/OpenVanilla advertises Bopomofo in its TIS identifiers and follows the same AppKit text-input behavior. This keeps the `NSTextInputClient` implementation generic and moves the family decision into one IME composition predicate shared by the existing fallback and interaction tracking.

## Regression test
Added `testMcBopomofoDownArrowRequestsCandidatesViaSpaceCommandFallback`, which hosts a `GhosttyNSView`, sets active Bopomofo marked text, simulates McBopomofo's input-source ID, and asserts that a Down-key `moveDown:` command requests the same synthetic Space candidate-open path without forwarding Down press/release events to Ghostty.

## Manual verification
The reporter confirmed they cannot build from source, so this PR no longer depends on external manual verification before merge. I could not perform a real McBopomofo candidate-window repro locally because this machine has Apple Zhuyin enabled but does not have McBopomofo available in the input-source setup.

## Files changed
- `Sources/GhosttyNSView+IMEComposition.swift`
- `Sources/GhosttyTerminalView.swift`
- `cmuxTests/CJKIMEMarkedSelectionTests.swift`

## Validation
- `git diff --check origin/main...HEAD`
- `./scripts/reload.sh --tag issue-3825-mcbopomofo-candidate-window`
- PR CI green after merging latest `origin/main`: GitHub checks, Vercel deploy checks, CircleCI macOS debug/release builds, CircleCI macOS unit tests, activation-session, Greptile, Cursor Bugbot, Socket Security.
- CodeRabbit status passed; latest run was skipped by the service.
