### PR TITLE
Fix modified Backspace with omnibar inline completions

### DIFF
--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1916,6 +1916,8 @@ struct BrowserPanelView: View {
 
     private func handleInlineClearTypedPrefix() {
         guard inlineCompletion != nil else { return }
+        // Modified Backspace dismisses the current inline suggestion instead of
+        // refetching suggestions for the shorter prefix.
         _ = omnibarReduce(state: &omnibarState, event: .bufferChanged(""))
         omnibarSelectionRange = NSRange(location: 0, length: 0)
         hideSuggestions()
@@ -1924,10 +1926,11 @@ struct BrowserPanelView: View {
     private func handleInlineDeleteWordBackward() {
         guard let completion = inlineCompletion else { return }
         let updated = omnibarPrefixAfterDeletingTrailingWord(from: completion.typedText)
-        let effects = omnibarReduce(state: &omnibarState, event: .bufferChanged(updated))
-        applyOmnibarEffects(effects)
+        // Modified Backspace dismisses the current inline suggestion instead of
+        // refetching suggestions for the shorter prefix.
+        _ = omnibarReduce(state: &omnibarState, event: .bufferChanged(updated))
         omnibarSelectionRange = NSRange(location: updated.utf16.count, length: 0)
-        refreshInlineCompletion()
+        hideSuggestions()
     }
 
     private func deleteSelectedSuggestionIfPossible() {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1219,8 +1219,12 @@ struct BrowserPanelView: View {
                 onDeleteBackwardWithInlineSelection: {
                     handleInlineBackspace()
                 },
-                onClearTypedPrefixWithInlineSelection: {},
-                onDeleteWordBackwardWithInlineSelection: {},
+                onClearTypedPrefixWithInlineSelection: {
+                    handleInlineClearTypedPrefix()
+                },
+                onDeleteWordBackwardWithInlineSelection: {
+                    handleInlineDeleteWordBackward()
+                },
                 onSelectionChanged: { selectionRange, hasMarkedText in
                     handleOmnibarSelectionChange(range: selectionRange, hasMarkedText: hasMarkedText)
                 },
@@ -1904,6 +1908,22 @@ struct BrowserPanelView: View {
         let prefix = completion.typedText
         guard !prefix.isEmpty else { return }
         let updated = String(prefix.dropLast())
+        let effects = omnibarReduce(state: &omnibarState, event: .bufferChanged(updated))
+        applyOmnibarEffects(effects)
+        omnibarSelectionRange = NSRange(location: updated.utf16.count, length: 0)
+        refreshInlineCompletion()
+    }
+
+    private func handleInlineClearTypedPrefix() {
+        guard inlineCompletion != nil else { return }
+        _ = omnibarReduce(state: &omnibarState, event: .bufferChanged(""))
+        omnibarSelectionRange = NSRange(location: 0, length: 0)
+        hideSuggestions()
+    }
+
+    private func handleInlineDeleteWordBackward() {
+        guard let completion = inlineCompletion else { return }
+        let updated = omnibarPrefixAfterDeletingTrailingWord(from: completion.typedText)
         let effects = omnibarReduce(state: &omnibarState, event: .bufferChanged(updated))
         applyOmnibarEffects(effects)
         omnibarSelectionRange = NSRange(location: updated.utf16.count, length: 0)
@@ -2823,6 +2843,17 @@ func omnibarInlineCompletionIfBufferMatchesTypedPrefix(
     return inlineCompletion
 }
 
+func omnibarPrefixAfterDeletingTrailingWord(from text: String) -> String {
+    let nsText = text as NSString
+    let fullRange = NSRange(location: 0, length: nsText.length)
+    var deletionStart = nsText.length
+    nsText.enumerateSubstrings(in: fullRange, options: [.byWords, .reverse]) { _, range, _, stop in
+        deletionStart = range.location
+        stop.pointee = true
+    }
+    return nsText.substring(to: deletionStart)
+}
+
 private func typedQueryHasExplicitPathOrQuery(_ typedQuery: String) -> Bool {
     var normalized = typedQuery.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
     if normalized.hasPrefix("https://") {
@@ -3703,6 +3734,25 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                     return true
                 }
                 return false
+            case #selector(NSResponder.deleteToBeginningOfLine(_:)),
+                 #selector(NSResponder.deleteToBeginningOfParagraph(_:)):
+                if inlineCompletionSelectionIsActive(textView, inline: parent.inlineCompletion) {
+                    parent.onClearTypedPrefixWithInlineSelection()
+#if DEBUG
+                    handled = true
+#endif
+                    return true
+                }
+                return false
+            case #selector(NSResponder.deleteWordBackward(_:)):
+                if inlineCompletionSelectionIsActive(textView, inline: parent.inlineCompletion) {
+                    parent.onDeleteWordBackwardWithInlineSelection()
+#if DEBUG
+                    handled = true
+#endif
+                    return true
+                }
+                return false
             default:
                 return false
             }
@@ -3782,18 +3832,22 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
             }
         }
 
-    private func suffixSelectionMatchesInline(_ editor: NSTextView?, inline: OmnibarInlineCompletion?) -> Bool {
-        guard let editor, let inline else { return false }
-        let selected = editor.selectedRange()
-        return NSEqualRanges(selected, inline.suffixRange)
-    }
+        private func inlineCompletionSelectionIsActive(_ editor: NSTextView?, inline: OmnibarInlineCompletion?) -> Bool {
+            suffixSelectionMatchesInline(editor, inline: inline) || selectionIsTypedPrefixBoundary(editor, inline: inline)
+        }
 
-    private func selectionIsTypedPrefixBoundary(_ editor: NSTextView?, inline: OmnibarInlineCompletion?) -> Bool {
-        guard let editor, let inline else { return false }
-        let selected = editor.selectedRange()
-        let typedCount = inline.typedText.utf16.count
-        return selected.location == typedCount && selected.length == 0
-    }
+        private func suffixSelectionMatchesInline(_ editor: NSTextView?, inline: OmnibarInlineCompletion?) -> Bool {
+            guard let editor, let inline else { return false }
+            let selected = editor.selectedRange()
+            return NSEqualRanges(selected, inline.suffixRange)
+        }
+
+        private func selectionIsTypedPrefixBoundary(_ editor: NSTextView?, inline: OmnibarInlineCompletion?) -> Bool {
+            guard let editor, let inline else { return false }
+            let selected = editor.selectedRange()
+            let typedCount = inline.typedText.utf16.count
+            return selected.location == typedCount && selected.length == 0
+        }
 
         func handleKeyEvent(_ event: NSEvent, editor: NSTextView?) -> Bool {
 #if DEBUG
@@ -3884,8 +3938,11 @@ struct OmnibarTextFieldRepresentable: NSViewRepresentable {
                     return true
                 }
             case 51: // Backspace
+                if modifiers.contains(.command) || modifiers.contains(.option) {
+                    return false
+                }
                 if let inline = parent.inlineCompletion,
-                   (suffixSelectionMatchesInline(editor, inline: inline) || selectionIsTypedPrefixBoundary(editor, inline: inline)) {
+                   inlineCompletionSelectionIsActive(editor, inline: inline) {
                     parent.onDeleteBackwardWithInlineSelection()
 #if DEBUG
                     handled = true

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -1219,6 +1219,8 @@ struct BrowserPanelView: View {
                 onDeleteBackwardWithInlineSelection: {
                     handleInlineBackspace()
                 },
+                onClearTypedPrefixWithInlineSelection: {},
+                onDeleteWordBackwardWithInlineSelection: {},
                 onSelectionChanged: { selectionRange, hasMarkedText in
                     handleOmnibarSelectionChange(range: selectionRange, hasMarkedText: hasMarkedText)
                 },
@@ -3213,7 +3215,7 @@ func browserOmnibarShouldReacquireFocusAfterEndEditing(
     desiredOmnibarFocus && !nextResponderIsOtherTextField
 }
 
-private final class OmnibarNativeTextField: NSTextField {
+final class OmnibarNativeTextField: NSTextField {
     var panelId: UUID?
     var onPointerDown: (() -> Void)?
     var onHandleKeyEvent: ((NSEvent, NSTextView?) -> Bool)?
@@ -3377,7 +3379,7 @@ private final class OmnibarNativeTextField: NSTextField {
     }
 }
 
-private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
+struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     let panelId: UUID
     @Binding var text: String
     @Binding var isFocused: Bool
@@ -3392,6 +3394,8 @@ private struct OmnibarTextFieldRepresentable: NSViewRepresentable {
     let onDeleteSelectedSuggestion: () -> Void
     let onAcceptInlineCompletion: () -> Void
     let onDeleteBackwardWithInlineSelection: () -> Void
+    let onClearTypedPrefixWithInlineSelection: () -> Void
+    let onDeleteWordBackwardWithInlineSelection: () -> Void
     let onSelectionChanged: (NSRange, Bool) -> Void
     let shouldSuppressWebViewFocus: () -> Bool
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -566,6 +566,7 @@ final class OmnibarStateMachineTests: XCTestCase {
 
         XCTAssertEqual(harness.state.buffer, "gmail account ")
         XCTAssertNil(harness.inlineCompletion)
+        XCTAssertTrue(harness.state.suggestions.isEmpty)
     }
 
     @MainActor
@@ -681,16 +682,13 @@ private final class OmnibarInlineDeletionHarness {
     }
 
     private func clearTypedPrefix() {
-        replaceTypedPrefix(with: "")
-        let effects = omnibarReduce(state: &state, event: .suggestionsUpdated([]))
-        XCTAssertFalse(effects.shouldRefreshSuggestions)
-        inlineCompletion = nil
+        replaceTypedPrefixAndDismissSuggestions(with: "")
     }
 
     private func deleteWordBeforeInlineCompletion() {
         guard let inlineCompletion else { return }
         let updated = omnibarPrefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
-        replaceTypedPrefix(with: updated)
+        replaceTypedPrefixAndDismissSuggestions(with: updated)
     }
 
     private func replaceTypedPrefix(with updated: String) {
@@ -703,6 +701,13 @@ private final class OmnibarInlineDeletionHarness {
             selectionRange: NSRange(location: updated.utf16.count, length: 0),
             hasMarkedText: false
         )
+    }
+
+    private func replaceTypedPrefixAndDismissSuggestions(with updated: String) {
+        _ = omnibarReduce(state: &state, event: .bufferChanged(updated))
+        let effects = omnibarReduce(state: &state, event: .suggestionsUpdated([]))
+        XCTAssertFalse(effects.shouldRefreshSuggestions)
+        inlineCompletion = nil
     }
 
 }

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -528,6 +528,193 @@ final class OmnibarStateMachineTests: XCTestCase {
         XCTAssertTrue(omnibarSuggestionSupportsAutocompletion(query: "gm", suggestion: state.suggestions[state.selectedSuggestionIndex]))
         XCTAssertEqual(state.suggestions[state.selectedSuggestionIndex].completion, "https://gmail.com/")
     }
+
+    @MainActor
+    func testCommandBackspaceClearsInlineCompletionTypedPrefix() throws {
+        let harness = OmnibarInlineDeletionHarness(
+            typedText: "gma",
+            displayText: "gmail.com",
+            suggestions: [
+                .history(url: "https://gmail.com/", title: "Gmail"),
+            ]
+        )
+
+        try harness.dispatchBackspace(
+            modifiers: [.command],
+            fallbackCommand: #selector(NSResponder.deleteToBeginningOfLine(_:))
+        )
+
+        XCTAssertEqual(harness.state.buffer, "")
+        XCTAssertNil(harness.inlineCompletion)
+        XCTAssertTrue(harness.state.suggestions.isEmpty)
+    }
+
+    @MainActor
+    func testOptionBackspaceDeletesWordBeforeInlineCompletion() throws {
+        let harness = OmnibarInlineDeletionHarness(
+            typedText: "gmail account info",
+            displayText: "gmail account information",
+            suggestions: [
+                .remoteSearchSuggestion("gmail account information"),
+            ]
+        )
+
+        try harness.dispatchBackspace(
+            modifiers: [.option],
+            fallbackCommand: #selector(NSResponder.deleteWordBackward(_:))
+        )
+
+        XCTAssertEqual(harness.state.buffer, "gmail account ")
+        XCTAssertNil(harness.inlineCompletion)
+    }
+
+    @MainActor
+    func testPlainBackspaceStillDeletesSingleCharacterWithInlineCompletion() throws {
+        let harness = OmnibarInlineDeletionHarness(
+            typedText: "gma",
+            displayText: "gmail.com",
+            suggestions: [
+                .history(url: "https://gmail.com/", title: "Gmail"),
+            ]
+        )
+
+        try harness.dispatchBackspace(modifiers: [], fallbackCommand: #selector(NSResponder.deleteBackward(_:)))
+
+        XCTAssertEqual(harness.state.buffer, "gm")
+        XCTAssertEqual(harness.inlineCompletion?.typedText, "gm")
+        XCTAssertEqual(harness.inlineCompletion?.displayText, "gmail.com")
+    }
+}
+
+@MainActor
+private final class OmnibarInlineDeletionHarness {
+    var state = OmnibarState()
+    var inlineCompletion: OmnibarInlineCompletion?
+
+    init(
+        typedText: String,
+        displayText: String,
+        suggestions: [OmnibarSuggestion]
+    ) {
+        state.isFocused = true
+        state.currentURLString = ""
+        state.buffer = typedText
+        state.suggestions = suggestions
+        inlineCompletion = OmnibarInlineCompletion(
+            typedText: typedText,
+            displayText: displayText,
+            acceptedText: displayText
+        )
+    }
+
+    func dispatchBackspace(
+        modifiers: NSEvent.ModifierFlags,
+        fallbackCommand: Selector,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let coordinator = makeCoordinator()
+        let editor = NSTextView()
+        editor.string = inlineCompletion?.displayText ?? state.buffer
+        if let inlineCompletion {
+            editor.setSelectedRange(inlineCompletion.suffixRange)
+        }
+
+        let event = try XCTUnwrap(
+            NSEvent.keyEvent(
+                with: .keyDown,
+                location: .zero,
+                modifierFlags: modifiers,
+                timestamp: ProcessInfo.processInfo.systemUptime,
+                windowNumber: 0,
+                context: nil,
+                characters: "\u{7F}",
+                charactersIgnoringModifiers: "\u{7F}",
+                isARepeat: false,
+                keyCode: 51
+            ),
+            file: file,
+            line: line
+        )
+
+        let handledInKeyDown = coordinator.handleKeyEvent(event, editor: editor)
+        if !handledInKeyDown {
+            _ = coordinator.control(NSTextField(), textView: editor, doCommandBy: fallbackCommand)
+        }
+    }
+
+    private func makeCoordinator() -> OmnibarTextFieldRepresentable.Coordinator {
+        OmnibarTextFieldRepresentable.Coordinator(
+            parent: OmnibarTextFieldRepresentable(
+                panelId: UUID(),
+                text: Binding(
+                    get: { self.state.buffer },
+                    set: { self.state.buffer = $0 }
+                ),
+                isFocused: Binding(
+                    get: { self.state.isFocused },
+                    set: { self.state.isFocused = $0 }
+                ),
+                selectAllRequestId: 0,
+                inlineCompletion: inlineCompletion,
+                placeholder: "",
+                onTap: {},
+                onSubmit: {},
+                onEscape: {},
+                onFieldLostFocus: {},
+                onMoveSelection: { _ in },
+                onDeleteSelectedSuggestion: {},
+                onAcceptInlineCompletion: {},
+                onDeleteBackwardWithInlineSelection: { self.deleteSingleCharacterBeforeInlineCompletion() },
+                onClearTypedPrefixWithInlineSelection: { self.clearTypedPrefix() },
+                onDeleteWordBackwardWithInlineSelection: { self.deleteWordBeforeInlineCompletion() },
+                onSelectionChanged: { _, _ in },
+                shouldSuppressWebViewFocus: { false }
+            )
+        )
+    }
+
+    private func deleteSingleCharacterBeforeInlineCompletion() {
+        guard let inlineCompletion else { return }
+        let updated = String(inlineCompletion.typedText.dropLast())
+        replaceTypedPrefix(with: updated)
+    }
+
+    private func clearTypedPrefix() {
+        replaceTypedPrefix(with: "")
+        let effects = omnibarReduce(state: &state, event: .suggestionsUpdated([]))
+        XCTAssertFalse(effects.shouldRefreshSuggestions)
+        inlineCompletion = nil
+    }
+
+    private func deleteWordBeforeInlineCompletion() {
+        guard let inlineCompletion else { return }
+        let updated = Self.prefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
+        replaceTypedPrefix(with: updated)
+    }
+
+    private func replaceTypedPrefix(with updated: String) {
+        let effects = omnibarReduce(state: &state, event: .bufferChanged(updated))
+        XCTAssertTrue(effects.shouldRefreshSuggestions)
+        inlineCompletion = omnibarInlineCompletionForDisplay(
+            typedText: state.buffer,
+            suggestions: state.suggestions,
+            isFocused: state.isFocused,
+            selectionRange: NSRange(location: updated.utf16.count, length: 0),
+            hasMarkedText: false
+        )
+    }
+
+    private static func prefixAfterDeletingTrailingWord(from text: String) -> String {
+        let nsText = text as NSString
+        let fullRange = NSRange(location: 0, length: nsText.length)
+        var deletionStart = nsText.length
+        nsText.enumerateSubstrings(in: fullRange, options: [.byWords, .reverse]) { _, range, _, stop in
+            deletionStart = range.location
+            stop.pointee = true
+        }
+        return nsText.substring(to: deletionStart)
+    }
 }
 
 

--- a/cmuxTests/OmnibarAndToolsTests.swift
+++ b/cmuxTests/OmnibarAndToolsTests.swift
@@ -689,7 +689,7 @@ private final class OmnibarInlineDeletionHarness {
 
     private func deleteWordBeforeInlineCompletion() {
         guard let inlineCompletion else { return }
-        let updated = Self.prefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
+        let updated = omnibarPrefixAfterDeletingTrailingWord(from: inlineCompletion.typedText)
         replaceTypedPrefix(with: updated)
     }
 
@@ -705,16 +705,6 @@ private final class OmnibarInlineDeletionHarness {
         )
     }
 
-    private static func prefixAfterDeletingTrailingWord(from text: String) -> String {
-        let nsText = text as NSString
-        let fullRange = NSRange(location: 0, length: nsText.length)
-        var deletionStart = nsText.length
-        nsText.enumerateSubstrings(in: fullRange, options: [.byWords, .reverse]) { _, range, _, stop in
-            deletionStart = range.location
-            stop.pointee = true
-        }
-        return nsText.substring(to: deletionStart)
-    }
 }
 
 


### PR DESCRIPTION
Fixes #3841.\n\n## Summary\n- keeps plain Backspace on the inline-completion single-character route\n- lets Command/Option Backspace reach AppKit command-selector routing\n- handles delete-to-beginning and delete-word-backward selectors against the typed prefix while dismissing inline completion\n- keeps the regression-policy two-commit structure: failing tests first, fix second\n\n## Verification\n- ./scripts/reload.sh --tag issue-3841-omnibar-cmd-backspace\n\n## Not run\n- Local XCTest execution, per repo testing policy; committed regression tests should run in CI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches omnibar key-command routing and inline-completion deletion behavior, which can subtly affect text editing UX and suggestion state transitions. Changes are localized and covered by new regression tests, reducing risk.
> 
> **Overview**
> Fixes modified Backspace handling when an omnibar inline completion is active.
> 
> Cmd-Backspace and Opt-Backspace are no longer consumed by the raw key handler; they flow through AppKit command selectors and are explicitly handled to **clear the typed prefix** or **delete the previous word** while dismissing the inline suggestion (without refetching suggestions). Plain Backspace continues to delete a single character and refresh inline completion.
> 
> Adds `omnibarPrefixAfterDeletingTrailingWord` plus a small test harness and new XCTest cases covering Cmd/Opt/plain Backspace behaviors; makes `OmnibarNativeTextField` and `OmnibarTextFieldRepresentable` non-`private` to enable testing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60182a71074ac8ac6c4d7d0127fe42e611f1c741. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes modified Backspace handling in the omnibar with inline completions. Cmd-Backspace and Option-Backspace now invoke AppKit delete-to-beginning/delete-word and dismiss inline suggestions; plain Backspace still deletes one character. Fixes #3841.

- **Bug Fixes**
  - Do not consume Backspace (keyCode 51) with Command/Option in the raw key handler; let AppKit route to selectors.
  - When the inline-completion selection is active, handle `deleteToBeginningOfLine`/`deleteToBeginningOfParagraph` and `deleteWordBackward` by updating the typed prefix and dismissing suggestions.
  - Add `inlineCompletionSelectionIsActive` and `omnibarPrefixAfterDeletingTrailingWord` helpers.
  - Add tests via `OmnibarInlineDeletionHarness` for Cmd-Backspace (clears prefix, dismisses suggestions), Option-Backspace (deletes previous word, dismisses suggestions), and plain Backspace (deletes one char); expose `OmnibarNativeTextField`/`OmnibarTextFieldRepresentable` for the harness.

<sup>Written for commit 60182a71074ac8ac6c4d7d0127fe42e611f1c741. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced omnibar keyboard editing during autocomplete: Command+Backspace clears the typed prefix and suggestions, Option+Backspace deletes the previous word and dismisses suggestions, and Backspace now behaves more predictably when an inline completion is active.

* **Tests**
  * Added focused tests validating Backspace behaviors with modifiers and inline-completion interactions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3842)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->