### PR TITLE
Revert "Fix McBopomofo Bopomofo candidate opening"

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -107,14 +107,12 @@ extension GhosttyNSView {
         }
     }
 
-    func isBopomofoInputSource(_ sourceId: String?) -> Bool {
+    func isTraditionalZhuyinInputSource(_ sourceId: String?) -> Bool {
         guard let sourceId else { return false }
-        // Apple's source IDs use "Zhuyin"; McBopomofo/OpenVanilla use "Bopomofo".
-        return sourceId.localizedCaseInsensitiveContains("Zhuyin")
-            || sourceId.localizedCaseInsensitiveContains("Bopomofo")
+        return sourceId.localizedCaseInsensitiveContains("TCIM.Zhuyin")
     }
 
-    func shouldOpenBopomofoCandidatesWithSyntheticSpace(
+    func shouldOpenZhuyinCandidatesWithSyntheticSpace(
         event: NSEvent,
         inputSourceId: String?,
         markedTextBefore: Bool,
@@ -127,7 +125,7 @@ extension GhosttyNSView {
         guard !candidateOpenAlreadyRequested,
               markedTextBefore,
               accumulatedText.isEmpty,
-              isBopomofoInputSource(inputSourceId),
+              isTraditionalZhuyinInputSource(inputSourceId),
               Int(event.keyCode) == kVK_DownArrow,
               commandSelector == #selector(NSResponder.moveDown(_:)),
               before.text == after.text,
@@ -137,7 +135,7 @@ extension GhosttyNSView {
         return true
     }
 
-    func shouldRememberBopomofoCandidateInteraction(
+    func shouldRememberZhuyinCandidateInteraction(
         event: NSEvent,
         inputSourceId: String?,
         markedTextBefore: Bool,
@@ -145,7 +143,7 @@ extension GhosttyNSView {
     ) -> Bool {
         guard markedTextBefore,
               accumulatedText.isEmpty,
-              isBopomofoInputSource(inputSourceId) else {
+              isTraditionalZhuyinInputSource(inputSourceId) else {
             return false
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7031,7 +7031,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             desiredFocus = false
             terminalSurface?.recordExternalFocusState(false)
             imeSuppressedKeyUpKeyCodes.removeAll()
-            bopomofoCandidateOpenRequested = false
+            zhuyinCandidateOpenRequested = false
         }
         if result, let surface = surface {
             let now = CACurrentMediaTime()
@@ -7051,7 +7051,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     var numpadIMECommitDeduplicator = NumpadIMECommitDeduplicator()
     private var imeSuppressedKeyUpKeyCodes: Set<UInt16> = []
     private var textInputCommandSelectorDuringKeyDown: Selector?
-    private var bopomofoCandidateOpenRequested = false
+    private var zhuyinCandidateOpenRequested = false
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -7066,16 +7066,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     func setIMETransientStateForTesting(
         suppressedKeyUpKeyCodes: Set<UInt16>,
-        bopomofoCandidateOpenRequested: Bool
+        zhuyinCandidateOpenRequested: Bool
     ) {
         imeSuppressedKeyUpKeyCodes = suppressedKeyUpKeyCodes
-        self.bopomofoCandidateOpenRequested = bopomofoCandidateOpenRequested
+        self.zhuyinCandidateOpenRequested = zhuyinCandidateOpenRequested
     }
     var imeSuppressedKeyUpKeyCodesForTesting: Set<UInt16> {
         imeSuppressedKeyUpKeyCodes
     }
-    var bopomofoCandidateOpenRequestedForTesting: Bool {
-        bopomofoCandidateOpenRequested
+    var zhuyinCandidateOpenRequestedForTesting: Bool {
+        zhuyinCandidateOpenRequested
     }
     func shouldSuppressShiftSpaceFallbackTextForTesting(event: NSEvent, markedTextBefore: Bool) -> Bool {
         shouldSuppressShiftSpaceFallbackText(event: event, markedTextBefore: markedTextBefore)
@@ -7530,7 +7530,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         var accumulatedText = keyTextAccumulator ?? []
         var markedStateAfter = (markedText.string, markedSelectedRange)
-        if shouldOpenBopomofoCandidatesWithSyntheticSpace(
+        if shouldOpenZhuyinCandidatesWithSyntheticSpace(
             event: translationEvent,
             inputSourceId: keyboardIdBefore,
             markedTextBefore: markedTextBefore,
@@ -7538,23 +7538,23 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             after: markedStateAfter,
             accumulatedText: accumulatedText,
             commandSelector: textInputCommandSelectorDuringKeyDown,
-            candidateOpenAlreadyRequested: bopomofoCandidateOpenRequested
+            candidateOpenAlreadyRequested: zhuyinCandidateOpenRequested
         ) {
-            bopomofoCandidateOpenRequested = true
+            zhuyinCandidateOpenRequested = true
             textInputCommandSelectorDuringKeyDown = nil
-            _ = handleTextInputKeyEvent(bopomofoCandidateOpenSpaceEvent(from: translationEvent))
+            _ = handleTextInputKeyEvent(zhuyinCandidateOpenSpaceEvent(from: translationEvent))
             syncPreedit(clearIfNeeded: markedTextBefore)
             accumulatedText = keyTextAccumulator ?? []
             markedStateAfter = (markedText.string, markedSelectedRange)
-        } else if shouldRememberBopomofoCandidateInteraction(
+        } else if shouldRememberZhuyinCandidateInteraction(
             event: translationEvent,
             inputSourceId: keyboardIdBefore,
             markedTextBefore: markedTextBefore,
             accumulatedText: accumulatedText
         ) {
-            bopomofoCandidateOpenRequested = true
-        } else if markedTextBefore, isBopomofoInputSource(keyboardIdBefore) {
-            bopomofoCandidateOpenRequested = false
+            zhuyinCandidateOpenRequested = true
+        } else if markedTextBefore, isTraditionalZhuyinInputSource(keyboardIdBefore) {
+            zhuyinCandidateOpenRequested = false
         }
 
         if shouldSuppressGhosttyKeyForwardingAfterIMEHandling(
@@ -7763,7 +7763,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return inputContext.handleEvent(event)
     }
 
-    private func bopomofoCandidateOpenSpaceEvent(from event: NSEvent) -> NSEvent {
+    private func zhuyinCandidateOpenSpaceEvent(from event: NSEvent) -> NSEvent {
         NSEvent.keyEvent(
             with: event.type,
             location: event.locationInWindow,
@@ -12847,7 +12847,7 @@ extension GhosttyNSView: NSTextInputClient {
 #endif
         markedText.mutableString.setString("")
         markedSelectedRange = NSRange(location: NSNotFound, length: 0)
-        bopomofoCandidateOpenRequested = false
+        zhuyinCandidateOpenRequested = false
 
         if hadMarkedText {
             syncPreedit()

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -548,86 +548,6 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         XCTAssertEqual(forwardedReleaseKeyCodes, [])
     }
 
-    func testMcBopomofoDownArrowRequestsCandidatesViaSpaceCommandFallback() throws {
-        let hostedTerminal = try makeHostedTerminalWindow()
-        let terminalSurface = hostedTerminal.surface
-        let window = hostedTerminal.window
-        let surfaceView = hostedTerminal.surfaceView
-        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
-        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
-        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
-        defer {
-            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
-            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
-            cjkIMEInterpretKeyEventsHook = previousInterpretHook
-            window.orderOut(nil)
-            withExtendedLifetime(terminalSurface) {}
-        }
-
-        surfaceView.setMarkedText(
-            "ㄋㄧˇ",
-            selectedRange: NSRange(location: 3, length: 0),
-            replacementRange: NSRange(location: NSNotFound, length: 0)
-        )
-        KeyboardLayout.debugInputSourceIdOverride = "org.openvanilla.inputmethod.McBopomofo.McBopomofo.Bopomofo"
-        installCJKIMEInterpretKeyEventsSwizzle()
-
-        var sawDownCommand = false
-        var syntheticSpaceCount = 0
-        cjkIMEInterpretKeyEventsHook = { candidateView, events in
-            guard candidateView === surfaceView, let event = events.first else { return false }
-            if Int(event.keyCode) == kVK_DownArrow {
-                sawDownCommand = true
-                candidateView.doCommand(by: #selector(NSResponder.moveDown(_:)))
-                return false
-            }
-            if Int(event.keyCode) == kVK_Space {
-                syntheticSpaceCount += 1
-                return true
-            }
-            return false
-        }
-
-        var forwardedPressKeyCodes: [UInt32] = []
-        var forwardedReleaseKeyCodes: [UInt32] = []
-        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
-            previousKeyEventObserver?(keyEvent)
-            if keyEvent.action == GHOSTTY_ACTION_PRESS {
-                forwardedPressKeyCodes.append(keyEvent.keycode)
-            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
-                forwardedReleaseKeyCodes.append(keyEvent.keycode)
-            }
-        }
-
-        let keyDown = try keyEvent(
-            text: "\u{F701}",
-            keyCode: UInt16(kVK_DownArrow),
-            windowNumber: window.windowNumber
-        )
-        let keyUp = try keyEvent(
-            type: .keyUp,
-            text: "\u{F701}",
-            keyCode: UInt16(kVK_DownArrow),
-            windowNumber: window.windowNumber
-        )
-
-        window.makeFirstResponder(surfaceView)
-        withExtendedLifetime(terminalSurface) {
-            surfaceView.keyDown(with: keyDown)
-            surfaceView.keyUp(with: keyUp)
-        }
-
-        XCTAssertTrue(sawDownCommand)
-        XCTAssertEqual(
-            syntheticSpaceCount,
-            1,
-            "McBopomofo Bopomofo should share Zhuyin's candidate-opening path"
-        )
-        XCTAssertTrue(surfaceView.hasMarkedText())
-        XCTAssertEqual(forwardedPressKeyCodes, [])
-        XCTAssertEqual(forwardedReleaseKeyCodes, [])
-    }
-
     func testNumberCandidateSelectionStillCommitsTextDuringZhuyinComposition() throws {
         let hostedTerminal = try makeHostedTerminalWindow()
         let terminalSurface = hostedTerminal.surface
@@ -845,7 +765,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let view = GhosttyNSView(frame: .zero)
         view.setIMETransientStateForTesting(
             suppressedKeyUpKeyCodes: [UInt16(kVK_DownArrow)],
-            bopomofoCandidateOpenRequested: true
+            zhuyinCandidateOpenRequested: true
         )
 
         view.unmarkText()
@@ -853,7 +773,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         XCTAssertFalse(view.hasMarkedText())
         XCTAssertEqual(view.markedRange(), NSRange(location: NSNotFound, length: 0))
         XCTAssertEqual(view.imeSuppressedKeyUpKeyCodesForTesting, [UInt16(kVK_DownArrow)])
-        XCTAssertFalse(view.bopomofoCandidateOpenRequestedForTesting)
+        XCTAssertFalse(view.zhuyinCandidateOpenRequestedForTesting)
     }
 
     func testSuppressesInputMethodHandledKeyWithoutMarkedText() throws {


### PR DESCRIPTION
Reverts manaflow-ai/cmux#3836

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS IME key handling and candidate-window heuristics; could regress candidate opening/navigation for non-Apple Zhuyin/Bopomofo input sources while improving correctness for the built-in Traditional Chinese Zhuyin IME.
> 
> **Overview**
> Reverts the prior expansion of the Zhuyin/Bopomofo candidate-opening workaround by **scoping it only to Apple’s Traditional Chinese Zhuyin input source** (`com.apple.inputmethod.TCIM.Zhuyin`).
> 
> Renames the internal state/helpers from *Bopomofo* to *Zhuyin* and updates detection to match `TCIM.Zhuyin` specifically, which stops triggering the synthetic-space candidate-open path for third-party Bopomofo IMEs. The test suite is updated accordingly by removing the McBopomofo coverage and renaming related debug/test accessors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808e1a9325edcac270e77c53a9a7f575b5517afe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the McBopomofo candidate-opening logic and restores handling to only support Apple's Traditional Zhuyin (`TCIM.Zhuyin`). Removes the McBopomofo test and renames internal bopomofo identifiers to zhuyin to match the scope.

<sup>Written for commit 808e1a9325edcac270e77c53a9a7f575b5517afe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced Traditional Chinese input support by refining the Zhuyin input method's candidate window behavior, improving keyboard event handling for character selection, and better tracking of user interactions with candidate windows.

* **Tests**
  * Updated test suite to validate changes to input method composition behavior and candidate window interactions for Traditional Chinese input.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3845)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->