### PR TITLE
Fix Zhuyin candidate-window arrow navigation (#3691), with guardrails

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -1,6 +1,60 @@
 import AppKit
+import Carbon.HIToolbox
 
 extension GhosttyNSView {
+    private static let appleTraditionalZhuyinInputSourceId = "com.apple.inputmethod.TCIM.Zhuyin"
+
+    private func isAppleTraditionalZhuyinInputSource(_ id: String?) -> Bool {
+        guard let id else { return false }
+        return id.compare(Self.appleTraditionalZhuyinInputSourceId, options: [.caseInsensitive]) == .orderedSame
+    }
+
+    /// Returns true for the narrow #3691 path where AppKit's Zhuyin candidate UI owns the arrow.
+    func shouldRouteKeyToZhuyinCandidateInsteadOfTerminal(
+        event: NSEvent,
+        inputSourceId: String?
+    ) -> Bool {
+        guard hasMarkedText() else { return false }
+        guard isAppleTraditionalZhuyinInputSource(inputSourceId) else { return false }
+
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        guard flags.isEmpty else { return false }
+
+        switch Int(event.keyCode) {
+        case kVK_DownArrow, kVK_UpArrow:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// Returns true when a plain Zhuyin Down arrow reached AppKit text input but did not mutate
+    /// composition state, so the OS input method still needs the candidate-list expansion gesture.
+    func shouldExpandZhuyinCandidatesAfterTextInterpretation(
+        event: NSEvent,
+        inputSourceId: String?,
+        before: (text: String, selection: NSRange),
+        after: (text: String, selection: NSRange),
+        accumulatedText: [String],
+        commandSelector: Selector?
+    ) -> Bool {
+        guard !before.text.isEmpty else { return false }
+        guard hasMarkedText() else { return false }
+        guard isAppleTraditionalZhuyinInputSource(inputSourceId) else { return false }
+
+        let flags = event.modifierFlags
+            .intersection(.deviceIndependentFlagsMask)
+            .subtracting([.numericPad, .function, .capsLock])
+        guard flags.isEmpty else { return false }
+        guard Int(event.keyCode) == kVK_DownArrow else { return false }
+        guard commandSelector == #selector(NSResponder.moveDown(_:)) else { return false }
+        guard accumulatedText.isEmpty else { return false }
+
+        return before.text == after.text && before.selection == after.selection
+    }
+
     /// Clamps AppKit's marked-text selection into the active preedit buffer.
     func normalizedMarkedSelectionRange(_ range: NSRange, markedLength: Int) -> NSRange {
         guard markedLength > 0 else {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8237,7 +8237,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return sourceId.range(of: "korean", options: .caseInsensitive) != nil
     }
 
-    private func zhuyinCandidateExpansionEvent(from event: NSEvent) -> NSEvent {
+    private func zhuyinCandidateExpansionEvent(from event: NSEvent) -> NSEvent? {
         NSEvent.keyEvent(
             with: event.type,
             location: event.locationInWindow,
@@ -8249,12 +8249,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             charactersIgnoringModifiers: " ",
             isARepeat: event.isARepeat,
             keyCode: UInt16(kVK_Space)
-        ) ?? event
+        )
     }
 
     @discardableResult
     private func requestZhuyinCandidateExpansion(from event: NSEvent) -> Bool {
-        let expansionEvent = zhuyinCandidateExpansionEvent(from: event)
+        guard let expansionEvent = zhuyinCandidateExpansionEvent(from: event) else { return false }
 #if DEBUG
         if let debugZhuyinCandidateExpansionEventHandler = Self.debugZhuyinCandidateExpansionEventHandler {
             return debugZhuyinCandidateExpansionEventHandler(self, expansionEvent)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5938,6 +5938,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return UserDefaults.standard.bool(forKey: "cmuxKeyLatencyProbe")
     }()
     static var debugGhosttySurfaceKeyEventObserver: ((ghostty_input_key_s) -> Void)?
+    static var debugZhuyinCandidateExpansionEventHandler: ((GhosttyNSView, NSEvent) -> Bool)?
 #endif
     private var eventMonitor: Any?
     private var trackingArea: NSTrackingArea?
@@ -7047,6 +7048,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private var lastPerformKeyEvent: TimeInterval?
     private(set) var externalCommittedTextDepth = 0
     var numpadIMECommitDeduplicator = NumpadIMECommitDeduplicator()
+    private var commandObservedDuringTextInterpretation: Selector?
     private struct SelectionSnapshot {
         let range: NSRange
         let string: String
@@ -7079,6 +7081,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     // Prevents NSBeep for unimplemented actions from interpretKeyEvents
     override func doCommand(by selector: Selector) {
+        commandObservedDuringTextInterpretation = selector
         // Intentionally empty - prevents system beep on unhandled key commands
     }
 
@@ -7460,6 +7463,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
         let markedTextBefore = markedText.length > 0
         let markedStateBefore = (markedText.string, markedSelectedRange)
+        let zhuyinCandidateInputSourceId: String? = {
+            guard markedTextBefore else { return nil }
+            switch Int(event.keyCode) {
+            case kVK_DownArrow, kVK_UpArrow:
+                return KeyboardLayout.id
+            default:
+                return nil
+            }
+        }()
 
         // Capture the keyboard layout ID before interpretation so we can
         // detect if an IME changed it (e.g. toggling input methods).
@@ -7475,15 +7487,60 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let interpretTimingStart = CmuxTypingTiming.start()
         let interpretPhaseStart = ProcessInfo.processInfo.systemUptime
 #endif
-        interpretKeyEvents([translationEvent])
-#if DEBUG
-        interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
-        CmuxTypingTiming.logDuration(
-            path: "terminal.keyDown.interpretKeyEvents",
-            startedAt: interpretTimingStart,
-            event: event
+        commandObservedDuringTextInterpretation = nil
+        let handledByZhuyinCandidateContext = shouldRouteKeyToZhuyinCandidateInsteadOfTerminal(
+            event: event,
+            inputSourceId: zhuyinCandidateInputSourceId
         )
+        if handledByZhuyinCandidateContext {
+            interpretKeyEvents([event])
+            let commandSelector = commandObservedDuringTextInterpretation
+#if DEBUG
+            interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
+            CmuxTypingTiming.logDuration(
+                path: "terminal.keyDown.zhuyinCandidateInterpretKeyEvents",
+                startedAt: interpretTimingStart,
+                event: event
+            )
 #endif
+            // A candidate arrow normally only moves the AppKit IME UI. If
+            // interpretKeyEvents synchronously commits text, reuse the normal
+            // accumulated-text send path.
+            let hasAccumulatedText = keyTextAccumulator?.isEmpty == false
+            if !hasAccumulatedText {
+                let markedStateAfter = (markedText.string, markedSelectedRange)
+                if shouldExpandZhuyinCandidatesAfterTextInterpretation(
+                    event: event,
+                    inputSourceId: zhuyinCandidateInputSourceId,
+                    before: markedStateBefore,
+                    after: markedStateAfter,
+                    accumulatedText: keyTextAccumulator ?? [],
+                    commandSelector: commandSelector
+                ) {
+                    let didRequestCandidates = requestZhuyinCandidateExpansion(from: event)
+#if DEBUG
+                    cmuxDebugLog(
+                        "terminal.keyDown.zhuyinCandidateExpansion " +
+                        "keyCode=\(event.keyCode) requested=\(didRequestCandidates ? 1 : 0)"
+                    )
+#endif
+                }
+                syncPreedit(clearIfNeeded: markedTextBefore)
+                if keyTextAccumulator?.isEmpty != false {
+                    return
+                }
+            }
+        } else {
+            interpretKeyEvents([translationEvent])
+#if DEBUG
+            interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
+            CmuxTypingTiming.logDuration(
+                path: "terminal.keyDown.interpretKeyEvents",
+                startedAt: interpretTimingStart,
+                event: event
+            )
+#endif
+        }
 
         // If the keyboard layout changed, an input method grabbed the event.
         // Sync preedit and return without sending the key to Ghostty.
@@ -7946,6 +8003,37 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Only send the extra Return key for Korean input sources.
         guard let sourceId = KeyboardLayout.id else { return false }
         return sourceId.range(of: "korean", options: .caseInsensitive) != nil
+    }
+
+    private func zhuyinCandidateExpansionEvent(from event: NSEvent) -> NSEvent {
+        NSEvent.keyEvent(
+            with: event.type,
+            location: event.locationInWindow,
+            modifierFlags: [],
+            timestamp: event.timestamp,
+            windowNumber: event.windowNumber,
+            context: nil,
+            characters: " ",
+            charactersIgnoringModifiers: " ",
+            isARepeat: event.isARepeat,
+            keyCode: UInt16(kVK_Space)
+        ) ?? event
+    }
+
+    @discardableResult
+    private func requestZhuyinCandidateExpansion(from event: NSEvent) -> Bool {
+        let expansionEvent = zhuyinCandidateExpansionEvent(from: event)
+#if DEBUG
+        if let debugZhuyinCandidateExpansionEventHandler = Self.debugZhuyinCandidateExpansionEventHandler {
+            return debugZhuyinCandidateExpansionEventHandler(self, expansionEvent)
+        }
+#endif
+
+        guard let inputContext else {
+            interpretKeyEvents([expansionEvent])
+            return false
+        }
+        return inputContext.handleEvent(expansionEvent)
     }
 
     private func ghosttyKeyEvent(for event: NSEvent, surface: ghostty_surface_t) -> ghostty_input_key_s {

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import Carbon.HIToolbox
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -55,11 +56,16 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
-    private func keyEvent(text: String, keyCode: UInt16, windowNumber: Int) throws -> NSEvent {
+    private func keyEvent(
+        text: String,
+        keyCode: UInt16,
+        modifiers: NSEvent.ModifierFlags = [],
+        windowNumber: Int
+    ) throws -> NSEvent {
         try XCTUnwrap(NSEvent.keyEvent(
             with: .keyDown,
             location: .zero,
-            modifierFlags: [],
+            modifierFlags: modifiers,
             timestamp: ProcessInfo.processInfo.systemUptime,
             windowNumber: windowNumber,
             context: nil,
@@ -68,6 +74,140 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             isARepeat: false,
             keyCode: keyCode
         ))
+    }
+
+    private struct ForwardedKeyCase {
+        let name: String
+        let keyCode: UInt16
+        let text: String
+    }
+
+    private var terminalNavigationKeyCases: [ForwardedKeyCase] {
+        [
+            ForwardedKeyCase(name: "Left", keyCode: UInt16(kVK_LeftArrow), text: ""),
+            ForwardedKeyCase(name: "Right", keyCode: UInt16(kVK_RightArrow), text: ""),
+            ForwardedKeyCase(name: "Up", keyCode: UInt16(kVK_UpArrow), text: ""),
+            ForwardedKeyCase(name: "Down", keyCode: UInt16(kVK_DownArrow), text: ""),
+            ForwardedKeyCase(name: "PageUp", keyCode: UInt16(kVK_PageUp), text: ""),
+            ForwardedKeyCase(name: "PageDown", keyCode: UInt16(kVK_PageDown), text: ""),
+            ForwardedKeyCase(name: "Home", keyCode: UInt16(kVK_Home), text: ""),
+            ForwardedKeyCase(name: "End", keyCode: UInt16(kVK_End), text: ""),
+            ForwardedKeyCase(name: "Space", keyCode: UInt16(kVK_Space), text: " "),
+        ]
+    }
+
+    private func assertPlainNavigationKeysReachShell(
+        inputSourceId: String?,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = inputSourceId
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt16] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedPressKeyCodes.append(UInt16(keyEvent.keycode))
+        }
+
+        window.makeFirstResponder(surfaceView)
+        for keyCase in terminalNavigationKeyCases {
+            surfaceView.unmarkText()
+            forwardedPressKeyCodes.removeAll()
+
+            let event = try keyEvent(
+                text: keyCase.text,
+                keyCode: keyCase.keyCode,
+                windowNumber: window.windowNumber
+            )
+
+            withExtendedLifetime(terminalSurface) {
+                surfaceView.keyDown(with: event)
+            }
+
+            XCTAssertTrue(
+                forwardedPressKeyCodes.contains(keyCase.keyCode),
+                "\(keyCase.name) should reach Ghostty for input source \(inputSourceId ?? "nil")",
+                file: file,
+                line: line
+            )
+        }
+    }
+
+    private func assertZhuyinCandidateArrowDoesNotReachShell(
+        keyCode: UInt16,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt16] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedPressKeyCodes.append(UInt16(keyEvent.keycode))
+        }
+
+        surfaceView.setMarkedText(
+            "ㄋ",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        let event = try keyEvent(text: "", keyCode: keyCode, windowNumber: window.windowNumber)
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertTrue(surfaceView.hasMarkedText(), "Zhuyin composition should remain active", file: file, line: line)
+        XCTAssertFalse(
+            forwardedPressKeyCodes.contains(keyCode),
+            "Zhuyin candidate arrow must stay in AppKit text input instead of reaching Ghostty",
+            file: file,
+            line: line
+        )
     }
 
     func testSelectedRangeReturnsEmptyRangeWithoutSelectionOrMarkedText() {
@@ -205,6 +345,38 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             0,
             "AppKit-consumed Zhuyin marked-text changes must not forward a duplicate Ghostty key"
         )
+    }
+
+    func testKoreanInputSourceArrowKeysAlwaysReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.inputmethod.Korean.2SetKorean")
+    }
+
+    func testJapaneseInputSourceArrowKeysAlwaysReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.inputmethod.Kotoeri.Japanese")
+    }
+
+    func testSimplifiedChinesePinyinArrowKeysAlwaysReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.inputmethod.SCIM.ITABC")
+    }
+
+    func testCangjieArrowKeysAlwaysReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.inputmethod.TCIM.Cangjie")
+    }
+
+    func testNonIMELayoutArrowKeysAlwaysReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.keylayout.ABC")
+    }
+
+    func testZhuyinArrowKeysOutsideCompositionReachShell() throws {
+        try assertPlainNavigationKeysReachShell(inputSourceId: "com.apple.inputmethod.TCIM.Zhuyin")
+    }
+
+    func testZhuyinDownArrowDuringCompositionOpensCandidates() throws {
+        try assertZhuyinCandidateArrowDoesNotReachShell(keyCode: UInt16(kVK_DownArrow))
+    }
+
+    func testZhuyinUpArrowDuringCompositionMovesCandidateSelection() throws {
+        try assertZhuyinCandidateArrowDoesNotReachShell(keyCode: UInt16(kVK_UpArrow))
     }
 
     func testSuppressesTerminalForwardingWhenZhuyinMarkedTextChanges() {

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -80,14 +80,27 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let name: String
         let keyCode: UInt16
         let text: String
+        let modifiers: NSEvent.ModifierFlags
+
+        init(
+            name: String,
+            keyCode: UInt16,
+            text: String,
+            modifiers: NSEvent.ModifierFlags = []
+        ) {
+            self.name = name
+            self.keyCode = keyCode
+            self.text = text
+            self.modifiers = modifiers
+        }
     }
 
     private var terminalNavigationKeyCases: [ForwardedKeyCase] {
         [
-            ForwardedKeyCase(name: "Left", keyCode: UInt16(kVK_LeftArrow), text: "\u{F702}"),
-            ForwardedKeyCase(name: "Right", keyCode: UInt16(kVK_RightArrow), text: "\u{F703}"),
-            ForwardedKeyCase(name: "Up", keyCode: UInt16(kVK_UpArrow), text: "\u{F700}"),
-            ForwardedKeyCase(name: "Down", keyCode: UInt16(kVK_DownArrow), text: "\u{F701}"),
+            ForwardedKeyCase(name: "Left", keyCode: UInt16(kVK_LeftArrow), text: "\u{F702}", modifiers: [.numericPad]),
+            ForwardedKeyCase(name: "Right", keyCode: UInt16(kVK_RightArrow), text: "\u{F703}", modifiers: [.numericPad]),
+            ForwardedKeyCase(name: "Up", keyCode: UInt16(kVK_UpArrow), text: "\u{F700}", modifiers: [.numericPad]),
+            ForwardedKeyCase(name: "Down", keyCode: UInt16(kVK_DownArrow), text: "\u{F701}", modifiers: [.numericPad]),
             ForwardedKeyCase(name: "PageUp", keyCode: UInt16(kVK_PageUp), text: "\u{F72C}"),
             ForwardedKeyCase(name: "PageDown", keyCode: UInt16(kVK_PageDown), text: "\u{F72D}"),
             ForwardedKeyCase(name: "Home", keyCode: UInt16(kVK_Home), text: "\u{F729}"),
@@ -98,6 +111,10 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
 
     private func navigationKeyText(for keyCode: UInt16) -> String {
         terminalNavigationKeyCases.first { $0.keyCode == keyCode }?.text ?? ""
+    }
+
+    private func navigationKeyModifiers(for keyCode: UInt16) -> NSEvent.ModifierFlags {
+        terminalNavigationKeyCases.first { $0.keyCode == keyCode }?.modifiers ?? []
     }
 
     private func assertPlainNavigationKeysReachShell(
@@ -144,6 +161,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             let event = try keyEvent(
                 text: keyCase.text,
                 keyCode: keyCase.keyCode,
+                modifiers: keyCase.modifiers,
                 windowNumber: window.windowNumber
             )
 
@@ -202,6 +220,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let event = try keyEvent(
             text: navigationKeyText(for: keyCode),
             keyCode: keyCode,
+            modifiers: navigationKeyModifiers(for: keyCode),
             windowNumber: window.windowNumber
         )
         var interpretedKeyCodes: [UInt16] = []
@@ -312,7 +331,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let event = try keyEvent(
             text: navigationKeyText(for: keyCode),
             keyCode: keyCode,
-            modifiers: [.shift],
+            modifiers: navigationKeyModifiers(for: keyCode).union(.shift),
             windowNumber: window.windowNumber
         )
 
@@ -571,6 +590,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let event = try keyEvent(
             text: navigationKeyText(for: keyCode),
             keyCode: keyCode,
+            modifiers: navigationKeyModifiers(for: keyCode),
             windowNumber: window.windowNumber
         )
 

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -84,16 +84,20 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
 
     private var terminalNavigationKeyCases: [ForwardedKeyCase] {
         [
-            ForwardedKeyCase(name: "Left", keyCode: UInt16(kVK_LeftArrow), text: ""),
-            ForwardedKeyCase(name: "Right", keyCode: UInt16(kVK_RightArrow), text: ""),
-            ForwardedKeyCase(name: "Up", keyCode: UInt16(kVK_UpArrow), text: ""),
-            ForwardedKeyCase(name: "Down", keyCode: UInt16(kVK_DownArrow), text: ""),
-            ForwardedKeyCase(name: "PageUp", keyCode: UInt16(kVK_PageUp), text: ""),
-            ForwardedKeyCase(name: "PageDown", keyCode: UInt16(kVK_PageDown), text: ""),
-            ForwardedKeyCase(name: "Home", keyCode: UInt16(kVK_Home), text: ""),
-            ForwardedKeyCase(name: "End", keyCode: UInt16(kVK_End), text: ""),
+            ForwardedKeyCase(name: "Left", keyCode: UInt16(kVK_LeftArrow), text: "\u{F702}"),
+            ForwardedKeyCase(name: "Right", keyCode: UInt16(kVK_RightArrow), text: "\u{F703}"),
+            ForwardedKeyCase(name: "Up", keyCode: UInt16(kVK_UpArrow), text: "\u{F700}"),
+            ForwardedKeyCase(name: "Down", keyCode: UInt16(kVK_DownArrow), text: "\u{F701}"),
+            ForwardedKeyCase(name: "PageUp", keyCode: UInt16(kVK_PageUp), text: "\u{F72C}"),
+            ForwardedKeyCase(name: "PageDown", keyCode: UInt16(kVK_PageDown), text: "\u{F72D}"),
+            ForwardedKeyCase(name: "Home", keyCode: UInt16(kVK_Home), text: "\u{F729}"),
+            ForwardedKeyCase(name: "End", keyCode: UInt16(kVK_End), text: "\u{F72B}"),
             ForwardedKeyCase(name: "Space", keyCode: UInt16(kVK_Space), text: " "),
         ]
+    }
+
+    private func navigationKeyText(for keyCode: UInt16) -> String {
+        terminalNavigationKeyCases.first { $0.keyCode == keyCode }?.text ?? ""
     }
 
     private func assertPlainNavigationKeysReachShell(
@@ -108,10 +112,12 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousCandidateExpansionHandler = GhosttyNSView.debugZhuyinCandidateExpansionEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = previousCandidateExpansionHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }
@@ -156,6 +162,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
 
     private func assertZhuyinCandidateArrowDoesNotReachShell(
         keyCode: UInt16,
+        expectCandidateExpansion: Bool,
         file: StaticString = #filePath,
         line: UInt = #line
     ) throws {
@@ -166,20 +173,18 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousCandidateExpansionHandler = GhosttyNSView.debugZhuyinCandidateExpansionEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = previousCandidateExpansionHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }
 
         KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
         installCJKIMEInterpretKeyEventsSwizzle()
-        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
-            guard candidateView === surfaceView else { return false }
-            return true
-        }
 
         var forwardedPressKeyCodes: [UInt16] = []
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
@@ -194,7 +199,33 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             replacementRange: NSRange(location: NSNotFound, length: 0)
         )
 
-        let event = try keyEvent(text: "", keyCode: keyCode, windowNumber: window.windowNumber)
+        let event = try keyEvent(
+            text: navigationKeyText(for: keyCode),
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+        var interpretedKeyCodes: [UInt16] = []
+        var interpretedOriginalEvent = false
+        var candidateExpansionKeyCodes: [UInt16] = []
+        GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = { candidateView, expansionEvent in
+            guard candidateView === surfaceView else { return false }
+            candidateExpansionKeyCodes.append(UInt16(expansionEvent.keyCode))
+            return true
+        }
+        cjkIMEInterpretKeyEventsHook = { candidateView, eventArray in
+            guard candidateView === surfaceView else { return false }
+            interpretedKeyCodes.append(contentsOf: eventArray.map { UInt16($0.keyCode) })
+            interpretedOriginalEvent = eventArray.count == 1 && eventArray.first === event
+            switch keyCode {
+            case UInt16(kVK_DownArrow):
+                candidateView.doCommand(by: #selector(NSResponder.moveDown(_:)))
+            case UInt16(kVK_UpArrow):
+                candidateView.doCommand(by: #selector(NSResponder.moveUp(_:)))
+            default:
+                break
+            }
+            return true
+        }
 
         window.makeFirstResponder(surfaceView)
         withExtendedLifetime(terminalSurface) {
@@ -202,9 +233,105 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         }
 
         XCTAssertTrue(surfaceView.hasMarkedText(), "Zhuyin composition should remain active", file: file, line: line)
+        XCTAssertEqual(
+            interpretedKeyCodes,
+            [keyCode],
+            "Zhuyin candidate arrow must be handed to interpretKeyEvents so AppKit can open or navigate the candidate UI",
+            file: file,
+            line: line
+        )
+        XCTAssertTrue(
+            interpretedOriginalEvent,
+            "Zhuyin candidate arrow should use the original key event for AppKit text input",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            candidateExpansionKeyCodes,
+            expectCandidateExpansion ? [UInt16(kVK_Space)] : [],
+            "Only plain Zhuyin Down should ask the input context to expand the candidate list",
+            file: file,
+            line: line
+        )
         XCTAssertFalse(
             forwardedPressKeyCodes.contains(keyCode),
             "Zhuyin candidate arrow must stay in AppKit text input instead of reaching Ghostty",
+            file: file,
+            line: line
+        )
+    }
+
+    private func assertModifiedZhuyinCandidateArrowReachesShell(
+        keyCode: UInt16,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousCandidateExpansionHandler = GhosttyNSView.debugZhuyinCandidateExpansionEventHandler
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = previousCandidateExpansionHandler
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            return true
+        }
+
+        var forwardedPressKeyCodes: [UInt16] = []
+        var candidateExpansionKeyCodes: [UInt16] = []
+        GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = { candidateView, expansionEvent in
+            guard candidateView === surfaceView else { return false }
+            candidateExpansionKeyCodes.append(UInt16(expansionEvent.keyCode))
+            return true
+        }
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            forwardedPressKeyCodes.append(UInt16(keyEvent.keycode))
+        }
+
+        surfaceView.setMarkedText(
+            "ㄋ",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        let event = try keyEvent(
+            text: navigationKeyText(for: keyCode),
+            keyCode: keyCode,
+            modifiers: [.shift],
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertTrue(surfaceView.hasMarkedText(), "Zhuyin composition should remain active", file: file, line: line)
+        XCTAssertTrue(
+            forwardedPressKeyCodes.contains(keyCode),
+            "Modified Zhuyin arrows should keep reaching Ghostty",
+            file: file,
+            line: line
+        )
+        XCTAssertEqual(
+            candidateExpansionKeyCodes,
+            [],
+            "Modified Zhuyin arrows must not open the candidate list",
             file: file,
             line: line
         )
@@ -305,10 +432,12 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousCandidateExpansionHandler = GhosttyNSView.debugZhuyinCandidateExpansionEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = previousCandidateExpansionHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }
@@ -372,11 +501,94 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
     }
 
     func testZhuyinDownArrowDuringCompositionOpensCandidates() throws {
-        try assertZhuyinCandidateArrowDoesNotReachShell(keyCode: UInt16(kVK_DownArrow))
+        try assertZhuyinCandidateArrowDoesNotReachShell(
+            keyCode: UInt16(kVK_DownArrow),
+            expectCandidateExpansion: true
+        )
     }
 
     func testZhuyinUpArrowDuringCompositionMovesCandidateSelection() throws {
-        try assertZhuyinCandidateArrowDoesNotReachShell(keyCode: UInt16(kVK_UpArrow))
+        try assertZhuyinCandidateArrowDoesNotReachShell(
+            keyCode: UInt16(kVK_UpArrow),
+            expectCandidateExpansion: false
+        )
+    }
+
+    func testZhuyinCandidateArrowCommitFromInterpretKeyEventsReachesShell() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousCandidateExpansionHandler = GhosttyNSView.debugZhuyinCandidateExpansionEventHandler
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = previousCandidateExpansionHandler
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        let keyCode = UInt16(kVK_DownArrow)
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        installCJKIMEInterpretKeyEventsSwizzle()
+        var interpretedKeyCodes: [UInt16] = []
+        cjkIMEInterpretKeyEventsHook = { candidateView, eventArray in
+            guard candidateView === surfaceView else { return false }
+            interpretedKeyCodes.append(contentsOf: eventArray.map { UInt16($0.keyCode) })
+            guard eventArray.count == 1, UInt16(eventArray[0].keyCode) == keyCode else { return false }
+            surfaceView.insertText("你", replacementRange: NSRange(location: NSNotFound, length: 0))
+            return true
+        }
+
+        var forwardedText: [String] = []
+        var forwardedBareArrow = false
+        var candidateExpansionKeyCodes: [UInt16] = []
+        GhosttyNSView.debugZhuyinCandidateExpansionEventHandler = { candidateView, expansionEvent in
+            guard candidateView === surfaceView else { return false }
+            candidateExpansionKeyCodes.append(UInt16(expansionEvent.keyCode))
+            return true
+        }
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS else { return }
+            if let text = keyEvent.text {
+                forwardedText.append(String(cString: text))
+            } else if UInt16(keyEvent.keycode) == keyCode {
+                forwardedBareArrow = true
+            }
+        }
+
+        surfaceView.setMarkedText(
+            "ㄋ",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+
+        let event = try keyEvent(
+            text: navigationKeyText(for: keyCode),
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: event)
+        }
+
+        XCTAssertFalse(surfaceView.hasMarkedText(), "Committed text should clear Zhuyin composition")
+        XCTAssertEqual(interpretedKeyCodes, [keyCode])
+        XCTAssertEqual(forwardedText, ["你"])
+        XCTAssertFalse(forwardedBareArrow, "Committed candidate text must not also leak a bare Down arrow")
+        XCTAssertEqual(candidateExpansionKeyCodes, [], "Committed candidate text must not also expand the candidate list")
+    }
+
+    func testZhuyinModifiedCandidateArrowsDuringCompositionReachShell() throws {
+        try assertModifiedZhuyinCandidateArrowReachesShell(keyCode: UInt16(kVK_DownArrow))
+        try assertModifiedZhuyinCandidateArrowReachesShell(keyCode: UInt16(kVK_UpArrow))
     }
 
     func testSuppressesTerminalForwardingWhenZhuyinMarkedTextChanges() {


### PR DESCRIPTION
## Summary

Fixes #3691 for the narrow Apple Zhuyin path: `com.apple.inputmethod.TCIM.Zhuyin`, active marked text, plain Down/Up only.

The previous pushed attempt stopped the shell leak but did not show the candidate menu. That path asked private AppKit candidate-panel selectors to present candidates; Austin dogfooded it and Down still did nothing. This revision removes that non-working presenter path. The current flow first gives the original Down/Up to AppKit text input; if exact plain Apple Zhuyin Down reports `moveDown:`, produces no committed text, and leaves marked text unchanged, it replays a plain Space key event into the active `NSTextInputContext` to trigger Zhuyin's candidate-list expansion. Up remains consume-only for navigating an already-open list.

This replaces PR #3694, which was reverted by #3849 after broad IME/window-level routing broke arrows globally for IME users. This PR does not recreate the reverted framework: no window reroute, no keyUp suppression set, no broad IME predicate, and no PageUp/PageDown/Home/End/Space suppression case list. McBopomofo/OpenVanilla remain out of scope.

## #3691 Guardrails Confirmation

Citing the mandatory "Guardrails for the next fix attempt" section from #3691:

1. **Only `TCIM.Zhuyin`: satisfied.** The source predicate is an exact case-insensitive compare against `com.apple.inputmethod.TCIM.Zhuyin`.
2. **No no-marked-text suppression: satisfied.** The routing predicate starts with `hasMarkedText() == true`; Zhuyin outside composition falls through to Ghostty.
3. **Only Down/Up: satisfied.** Suppression is limited to `kVK_DownArrow` and `kVK_UpArrow`. Candidate expansion is narrower: Down only, after unchanged `moveDown:` handling.
4. **No window-level reroute: satisfied.** No `AppDelegate.performKeyEquivalent` changes; the hook lives in the focused `GhosttyNSView.keyDown` path.
5. **No keyUp suppression changes: satisfied.** `keyUp` is untouched and no `Set<UInt16>` lifecycle was added.
6. **All four gates: satisfied.** Marked text, exact Apple Zhuyin source, empty normalized modifiers, and Down/Up are all required before terminal forwarding is suppressed.
7. **Regression guards: satisfied.** Commit 1 adds the required Korean, Japanese, Pinyin, Cangjie, Latin/ABC, Zhuyin-outside-composition, and Zhuyin marked-text tests.
8. **Neighboring suites listed below.** Focused marked-selection suite is green after this revision; the neighboring CJK input selectors were run earlier and are listed under Verification.
9. **Two commits: satisfied.** Commit 1 (`216da0338`) is test-only. Commit 2 (`2c9695e3`) lands the fix.
10. **Manual repro capture included.** Current-main repro is below. Latest post-fix reload/manual dogfood is intentionally left to Austin per the latest request not to reload locally.

Implementation note: the issue guardrails are satisfied. The later implementation sketch said not to synthesize Space; dogfood proved the private candidate-panel path did not show Apple Zhuyin's menu. The Space replay here is therefore intentionally narrower than #3694: it is only an input-context event after exact Down + Apple Zhuyin + active marked text + unchanged `moveDown:` no-op, and it does not add any of #3694's broad state/routing machinery.

## Manual Repro Capture

Pre-fix tagged current-main build:

- Ran `./scripts/reload.sh --tag repro-3691-main --launch` from post-revert base behavior.
- App launched as `cmux DEV repro-3691-main`.
- In a terminal pane running `cat -v`, selected `com.apple.inputmethod.TCIM.Zhuyin`.
- Pressed a Zhuyin composition key, then Space.
- Pressed Down: no candidate navigation was visible and `cat -v` printed `^[[B`.
- Pressed Up: `cat -v` printed `^[[A`.

Latest branch dogfood before `2c9695e3`: Down no longer visibly leaked to the shell, but the expected Zhuyin candidate menu still did not appear. This revision replaces that failed presenter path with input-context candidate expansion.

## Regression-Guard Test Diff

```diff
+func testKoreanInputSourceArrowKeysAlwaysReachShell()
+func testJapaneseInputSourceArrowKeysAlwaysReachShell()
+func testSimplifiedChinesePinyinArrowKeysAlwaysReachShell()
+func testCangjieArrowKeysAlwaysReachShell()
+func testNonIMELayoutArrowKeysAlwaysReachShell()
+func testZhuyinArrowKeysOutsideCompositionReachShell()
```

Each forwarding guard synthesizes Left/Right/Up/Down/PageUp/PageDown/Home/End/Space with empty modifiers and asserts the key reaches Ghostty.

## Zhuyin-Specific Test Diff

```diff
+func testZhuyinDownArrowDuringCompositionOpensCandidates()
+func testZhuyinUpArrowDuringCompositionMovesCandidateSelection()
+func testZhuyinCandidateArrowCommitFromInterpretKeyEventsReachesShell()
+func testZhuyinModifiedCandidateArrowsDuringCompositionReachShell()
```

The positive helper asserts the original arrow goes through AppKit text input, composition remains active, no bare Up/Down reaches Ghostty, and only plain Down asks the input context to expand candidates via a plain Space event. Modified arrows and synchronous committed candidate text do not use the expansion fallback.

## Verification

Commit 1 red proof:

- `./scripts/test-unit.sh test -only-testing:cmuxTests/CJKIMEMarkedSelectionTests`
- Result on commit 1: exactly the two Zhuyin marked-text arrow tests fail; non-Zhuyin regression guards pass.

Post-fix focused proof:

- `./scripts/test-unit.sh test -only-testing:cmuxTests/CJKIMEMarkedSelectionTests`
- Result after `2c9695e3`: 20 tests, 0 failures.

Passing `CJKIMEMarkedSelectionTests` names:

- `testAttributedSubstringReturnsMarkedTextSegment`
- `testCangjieArrowKeysAlwaysReachShell`
- `testDoesNotSuppressCommittedIMEInsertText`
- `testDoesNotSuppressNormalTerminalKeyWhenIMEDidNothing`
- `testJapaneseInputSourceArrowKeysAlwaysReachShell`
- `testKeyDownDoesNotForwardWhenZhuyinStartsMarkedText`
- `testKoreanInputSourceArrowKeysAlwaysReachShell`
- `testNonIMELayoutArrowKeysAlwaysReachShell`
- `testSelectedRangeReturnsEmptyRangeAfterCompositionEnds`
- `testSelectedRangeReturnsEmptyRangeWithoutSelectionOrMarkedText`
- `testSelectedRangeTracksMarkedTextSelection`
- `testSimplifiedChinesePinyinArrowKeysAlwaysReachShell`
- `testSuppressesTerminalForwardingWhenZhuyinMarkedTextChanges`
- `testSuppressesTerminalForwardingWhenZhuyinStartsMarkedText`
- `testTraditionalChineseZhuyinMarkedTextSelectionAndSubstring`
- `testZhuyinArrowKeysOutsideCompositionReachShell`
- `testZhuyinCandidateArrowCommitFromInterpretKeyEventsReachesShell`
- `testZhuyinDownArrowDuringCompositionOpensCandidates`
- `testZhuyinModifiedCandidateArrowsDuringCompositionReachShell`
- `testZhuyinUpArrowDuringCompositionMovesCandidateSelection`

Neighboring file run:

- `./scripts/test-unit.sh test` with the XCTestCase selectors from `cmuxTests/CJKIMEInputTests.swift` was run earlier on this branch.
- Result: IME-focused classes passed; unrelated existing key-equivalent failures were outside this PR's path.

Static checks:

- `git diff --check` passed.
- Reverted-symbol scan passed: no `isInputMethodSource`, `shouldRouteTextInputKeyEquivalentToKeyDown`, `shouldKeepIMECompositionCommandInsideTextInput`, `shouldOpenZhuyinCandidatesWithSyntheticSpace`, `imeSuppressedKeyUpKeyCodes`, `zhuyinCandidateOpenRequested`, `debugTextInputEventHandler`, `shouldAllowDeferredNumpadIMEFallback`, `shouldRememberZhuyinCandidateInteraction`, or `isTraditionalZhuyinInputSource`.

## Retest Plan for yoonkeee@gmail.com

After CI/nightly is available, send the build to `yoonkeee@gmail.com` (`ko-KR`, M4 Pro, macOS 26.4) and ask them to verify Korean 2-Set Hangul with Left/Right/Up/Down/PageUp/PageDown/Home/End/Space in an active terminal session. Expected result: all keys still reach the shell when not composing.

Additional manual dogfood for this branch:

- Korean 2-Set arrows work.
- Japanese Hiragana arrows work.
- Simplified Pinyin arrows work.
- Latin/ABC arrows work.
- Zhuyin arrows outside composition work.
- Zhuyin Down during composition opens the candidate window.
- Zhuyin Up during composition navigates candidates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `keyDown`/IME event path and synthesizes an extra input-context event, so regressions could affect key handling during composition, though the behavior is tightly gated to Apple Zhuyin + marked text + plain Up/Down and is covered by new tests.
> 
> **Overview**
> Fixes the narrow Apple Traditional Zhuyin IME case where plain Up/Down arrows during active marked text should control the candidate UI instead of leaking to the terminal.
> 
> `GhosttyTerminalView.keyDown` now detects this gated scenario, routes the *original* arrow event through `interpretKeyEvents`, observes the resulting `doCommand` selector, and if Down results in no composition/commit change, sends a synthetic Space event to the `NSTextInputContext` to request candidate-list expansion (with a DEBUG hook for tests).
> 
> Adds helper predicates in `GhosttyNSView+IMEComposition` and expands `CJKIMEMarkedSelectionTests` with regression guards ensuring navigation keys still reach the shell for other input sources, plus Zhuyin-specific tests for arrow suppression/expansion behavior, modified-arrow passthrough, and commit-on-interpret handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22da5256ed1846029d37857c4796d9d12574c530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->