### PR TITLE
Fix stale terminal foreground after theme switch

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */; };
 		F57072635F25EBCA741E125D /* SidebarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */; };
 		A8CBA43C2DA5AB9E3A1E65A4 /* CommandPaletteSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */; };
+		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */; };
 		A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */; };
 		E8BA79E246754A8B99A0B823 /* ScreenIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */; };
@@ -612,6 +613,7 @@
 		A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackdropController.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
 		38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette/CommandPaletteSearch.swift; sourceTree = "<group>"; };
+		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalDirectoryOpenSupport.swift; sourceTree = "<group>"; };
 		8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxCLIPathInstaller.swift; sourceTree = "<group>"; };
 		47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ScreenIdentity.swift; sourceTree = "<group>"; };
@@ -1118,6 +1120,7 @@
 				A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */,
 				D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */,
 				38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */,
+				9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */,
 				6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */,
 				8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */,
 				47D5AA7D29C94F5CA865B2BF /* ScreenIdentity.swift */,
@@ -1748,6 +1751,7 @@
 				A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
 				A8CBA43C2DA5AB9E3A1E65A4 /* CommandPaletteSearch.swift in Sources */,
+				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,
 				0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */,
 				A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */,
 				E8BA79E246754A8B99A0B823 /* ScreenIdentity.swift in Sources */,

--- a/Sources/App/GhosttySurfaceConfigurationRefresh.swift
+++ b/Sources/App/GhosttySurfaceConfigurationRefresh.swift
@@ -1,6 +1,6 @@
 @MainActor
 enum GhosttySurfaceConfigurationRefresh {
-    static let forceRefreshReason = "appDelegate.refreshAfterGhosttyConfigReload"
+    nonisolated static let forceRefreshReason = "appDelegate.refreshAfterGhosttyConfigReload"
 
     static func applyAfterAppConfigReload(
         to surface: ghostty_surface_t?,
@@ -9,6 +9,9 @@ enum GhosttySurfaceConfigurationRefresh {
         refreshHostBackground: () -> Void,
         forceRefresh: (String) -> Void
     ) {
+        if let surface {
+            reloadSurfaceConfiguration(surface, true, source)
+        }
         refreshHostBackground()
         forceRefresh(forceRefreshReason)
     }

--- a/Sources/App/GhosttySurfaceConfigurationRefresh.swift
+++ b/Sources/App/GhosttySurfaceConfigurationRefresh.swift
@@ -1,0 +1,15 @@
+@MainActor
+enum GhosttySurfaceConfigurationRefresh {
+    static let forceRefreshReason = "appDelegate.refreshAfterGhosttyConfigReload"
+
+    static func applyAfterAppConfigReload(
+        to surface: ghostty_surface_t?,
+        source: String,
+        reloadSurfaceConfiguration: (ghostty_surface_t, Bool, String) -> Void,
+        refreshHostBackground: () -> Void,
+        forceRefresh: (String) -> Void
+    ) {
+        refreshHostBackground()
+        forceRefresh(forceRefreshReason)
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4790,8 +4790,22 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func refreshTerminalSurfacesAfterGhosttyConfigReload(source: String) {
         var refreshedCount = 0
         forEachTerminalPanel { terminalPanel in
-            terminalPanel.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
-            terminalPanel.surface.forceRefresh(reason: "appDelegate.refreshAfterGhosttyConfigReload")
+            let liveSurface = terminalPanel.surface.liveSurfaceForGhosttyAccess(
+                reason: "appDelegate.refreshAfterGhosttyConfigReload"
+            )
+            GhosttySurfaceConfigurationRefresh.applyAfterAppConfigReload(
+                to: liveSurface,
+                source: source,
+                reloadSurfaceConfiguration: { surface, soft, source in
+                    GhosttyApp.shared.reloadSurfaceConfiguration(surface, soft: soft, source: source)
+                },
+                refreshHostBackground: {
+                    terminalPanel.hostedView.refreshHostBackgroundAfterGhosttyConfigReload()
+                },
+                forceRefresh: { reason in
+                    terminalPanel.surface.forceRefresh(reason: reason)
+                }
+            )
             refreshedCount += 1
         }
 #if DEBUG

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -10,6 +10,56 @@ import SwiftUI
 
 @MainActor
 final class AppearanceSettingsTests: XCTestCase {
+    func testAppConfigReloadRefreshUpdatesSurfaceConfigBeforeRedraw() throws {
+        let fakeSurface = try XCTUnwrap(UnsafeMutableRawPointer(bitPattern: 0x3851))
+        var events: [String] = []
+
+        GhosttySurfaceConfigurationRefresh.applyAfterAppConfigReload(
+            to: fakeSurface,
+            source: "appearanceSync:test",
+            reloadSurfaceConfiguration: { surface, soft, source in
+                XCTAssertEqual(surface, fakeSurface)
+                XCTAssertTrue(soft)
+                events.append("reload:\(source)")
+            },
+            refreshHostBackground: {
+                events.append("host-background")
+            },
+            forceRefresh: { reason in
+                events.append("force-refresh:\(reason)")
+            }
+        )
+
+        XCTAssertEqual(events, [
+            "reload:appearanceSync:test",
+            "host-background",
+            "force-refresh:\(GhosttySurfaceConfigurationRefresh.forceRefreshReason)"
+        ])
+    }
+
+    func testAppConfigReloadRefreshSkipsSurfaceConfigUpdateWhenSurfaceIsUnavailable() {
+        var events: [String] = []
+
+        GhosttySurfaceConfigurationRefresh.applyAfterAppConfigReload(
+            to: nil,
+            source: "appearanceSync:teardown",
+            reloadSurfaceConfiguration: { _, _, _ in
+                events.append("reload")
+            },
+            refreshHostBackground: {
+                events.append("host-background")
+            },
+            forceRefresh: { reason in
+                events.append("force-refresh:\(reason)")
+            }
+        )
+
+        XCTAssertEqual(events, [
+            "host-background",
+            "force-refresh:\(GhosttySurfaceConfigurationRefresh.forceRefreshReason)"
+        ])
+    }
+
     func testResolvedModeDefaultsToSystemWhenUnset() {
         let suiteName = "AppearanceSettingsTests.Default.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {


### PR DESCRIPTION
## Summary
- Fixes https://github.com/manaflow-ai/cmux/issues/3851.
- App-level Ghostty config reloads now push the already-loaded config into each live terminal surface with a soft per-surface reload before repainting.
- Keeps the existing hosted-background refresh and force redraw after the config update so old scrollback is repainted with the new palette.

## Testing
- Added a regression test for the app-config-reload surface refresh sequence.
- Not run locally per task instruction; CI will run the regression.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal surface refresh behavior during Ghostty config reload; incorrect ordering or nil-surface handling could cause missed updates or visual regressions across all open terminals.
> 
> **Overview**
> Fixes stale terminal colors after theme/config reload by **pushing the reloaded Ghostty config into each live terminal surface before repainting**.
> 
> Introduces `GhosttySurfaceConfigurationRefresh.applyAfterAppConfigReload` to enforce the sequence *soft per-surface config reload → hosted background refresh → forced surface redraw*, and updates `AppDelegate.refreshTerminalSurfacesAfterGhosttyConfigReload` to use a live-surface guard.
> 
> Adds unit tests verifying the call order and the behavior when the surface is unavailable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecaf2e18e8d4e77535327619e4227894329521d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3851 by soft-reloading each live terminal surface with the app’s reloaded Ghostty config before repaint to prevent stale foreground colors after theme switches. The surface update, host background refresh, and redraw now run in one ordered pass.

- **Bug Fixes**
  - Added a helper to run: soft per-surface config reload → host background refresh → force redraw; used in AppDelegate via `liveSurfaceForGhosttyAccess`.
  - Added regression tests for call ordering and the unavailable-surface path.

<sup>Written for commit ecaf2e18e8d4e77535327619e4227894329521d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal surface refresh after Ghostty config reload: uses the live-surface access path to ensure background, styling, and visual updates are consistently applied across open terminal panels, even when a live surface is unavailable.

* **Tests**
  * Added unit tests verifying refresh behavior both when surfaces are present and when they are nil.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3852)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->