### PR TITLE
Enable Feed by default

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -64938,10 +64938,7 @@
     "settings.betaFeatures.dock": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Dock" } }, "ja": { "stringUnit": { "state": "translated", "value": "Dock" } } } },
     "settings.betaFeatures.dock.subtitleOff": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Hides Dock from the right sidebar until you enable it here." } }, "ja": { "stringUnit": { "state": "translated", "value": "ここで有効にするまで、Dock を右サイドバーから隠します。" } } } },
     "settings.betaFeatures.dock.subtitleOn": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Shows Dock in the right sidebar mode switcher for custom terminal controls." } }, "ja": { "stringUnit": { "state": "translated", "value": "Dock を右サイドバーのモード切り替えに表示し、カスタム端末コントロールを使えるようにします。" } } } },
-    "settings.betaFeatures.feed": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Feed" } }, "ja": { "stringUnit": { "state": "translated", "value": "Feed" } } } },
-    "settings.betaFeatures.feed.subtitleOff": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Hides Feed from the right sidebar until you enable it here." } }, "ja": { "stringUnit": { "state": "translated", "value": "ここで有効にするまで、Feed を右サイドバーから隠します。" } } } },
-    "settings.betaFeatures.feed.subtitleOn": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Shows Feed in the right sidebar mode switcher for inline agent decisions." } }, "ja": { "stringUnit": { "state": "translated", "value": "Feed を右サイドバーのモード切り替えに表示し、エージェントの判断をインラインで扱えるようにします。" } } } },
-    "settings.betaFeatures.warning": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "These features are unstable and may change or break. Enable them only when you are testing them." } }, "ja": { "stringUnit": { "state": "translated", "value": "これらの機能は不安定で、変更されたり壊れたりする可能性があります。テストする場合だけ有効にしてください。" } } } },
+    "settings.betaFeatures.warning": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Dock is unstable and may change or break. Enable it only when you are testing it." } }, "ja": { "stringUnit": { "state": "translated", "value": "Dock は不安定で、変更されたり壊れたりする可能性があります。テストする場合だけ有効にしてください。" } } } },
     "settings.browser.enabled": {
       "extractionState": "manual",
       "localizations": {
@@ -110295,13 +110292,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Activity"
+            "value": "All Activity"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "アクティビティ"
+            "value": "すべてのアクティビティ"
           }
         }
       }

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -153,16 +153,9 @@ enum AgentSessionAutoResumeSettings {
 }
 
 enum RightSidebarBetaFeatureSettings {
-    static let feedEnabledKey = "rightSidebar.beta.feed.enabled"
     static let dockEnabledKey = "rightSidebar.beta.dock.enabled"
 
-    static let defaultFeedEnabled = false
     static let defaultDockEnabled = false
-
-    nonisolated static func isFeedEnabled(defaults: UserDefaults = .standard) -> Bool {
-        guard defaults.object(forKey: feedEnabledKey) != nil else { return defaultFeedEnabled }
-        return defaults.bool(forKey: feedEnabledKey)
-    }
 
     nonisolated static func isDockEnabled(defaults: UserDefaults = .standard) -> Bool {
         guard defaults.object(forKey: dockEnabledKey) != nil else { return defaultDockEnabled }

--- a/Sources/BetaFeaturesSettingsView.swift
+++ b/Sources/BetaFeaturesSettingsView.swift
@@ -1,21 +1,7 @@
 import SwiftUI
 
 struct BetaFeaturesSettingsView: View {
-    @Binding var feedEnabled: Bool
     @Binding var dockEnabled: Bool
-
-    private var feedSubtitle: String {
-        if feedEnabled {
-            return String(
-                localized: "settings.betaFeatures.feed.subtitleOn",
-                defaultValue: "Shows Feed in the right sidebar mode switcher for inline agent decisions."
-            )
-        }
-        return String(
-            localized: "settings.betaFeatures.feed.subtitleOff",
-            defaultValue: "Hides Feed from the right sidebar until you enable it here."
-        )
-    }
 
     private var dockSubtitle: String {
         if dockEnabled {
@@ -37,26 +23,9 @@ struct BetaFeaturesSettingsView: View {
             BetaFeaturesWarningNote(
                 String(
                     localized: "settings.betaFeatures.warning",
-                    defaultValue: "These features are unstable and may change or break. Enable them only when you are testing them."
+                    defaultValue: "Dock is unstable and may change or break. Enable it only when you are testing it."
                 )
             )
-
-            SettingsCardDivider()
-
-            SettingsCardRow(
-                configurationReview: .settingsOnly,
-                String(localized: "settings.betaFeatures.feed", defaultValue: "Feed"),
-                subtitle: feedSubtitle,
-                searchAnchorID: SettingsSearchIndex.settingID(for: .betaFeatures, idSuffix: "feed")
-            ) {
-                Toggle("", isOn: $feedEnabled)
-                    .labelsHidden()
-                    .controlSize(.small)
-                    .accessibilityIdentifier("SettingsBetaFeedToggle")
-                    .accessibilityLabel(
-                        String(localized: "settings.betaFeatures.feed", defaultValue: "Feed")
-                    )
-            }
 
             SettingsCardDivider()
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -60,7 +60,7 @@ struct FeedPanelView: View {
             case .actionable:
                 return String(localized: "feed.filter.actionable", defaultValue: "Actionable")
             case .activity:
-                return String(localized: "feed.filter.activity", defaultValue: "Activity")
+                return String(localized: "feed.filter.activity", defaultValue: "All Activity")
             }
         }
         var symbolName: String {
@@ -108,7 +108,7 @@ struct FeedPanelView: View {
 
     private var controlBarContent: some View {
         HStack(spacing: 6) {
-            ForEach([Filter.actionable]) { f in
+            ForEach(Filter.allCases) { f in
                 FeedSecondaryFilterButton(
                     filter: f,
                     isSelected: filter == f
@@ -226,29 +226,11 @@ private struct FeedListView: View {
                 actions: actions
             )
         case .activity:
-            let stable = snapshots.filter(prefersStableSurface)
-            let history = snapshots.filter { !prefersStableSurface($0) }
-            if history.isEmpty && !hasMorePersistedItems {
-                stableScrollSurface(
-                    snapshots: stable,
-                    actions: actions
-                )
-            } else {
-                VStack(spacing: 0) {
-                    if !stable.isEmpty {
-                        stableRows(
-                            snapshots: stable,
-                            actions: actions
-                        )
-                        rowSeparator
-                    }
-                    historyList(
-                        snapshots: history,
-                        actions: actions,
-                        showsLoadMore: hasMorePersistedItems
-                    )
-                }
-            }
+            activityScrollSurface(
+                snapshots: snapshots,
+                actions: actions,
+                showsLoadMore: hasMorePersistedItems
+            )
         }
     }
 
@@ -272,36 +254,34 @@ private struct FeedListView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
     }
 
-    private func stableRows(
-        snapshots: [FeedItemSnapshot],
-        actions: FeedRowActions
-    ) -> some View {
-        VStack(spacing: 0) {
-            ForEach(Array(snapshots.enumerated()), id: \.element.id) { idx, snapshot in
-                rowSurface(
-                    snapshot: snapshot,
-                    actions: actions,
-                    showsDivider: idx < snapshots.count - 1
-                )
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    private func historyList(
+    private func activityScrollSurface(
         snapshots: [FeedItemSnapshot],
         actions: FeedRowActions,
         showsLoadMore: Bool
     ) -> some View {
-        List {
-            // Single chronological history stream. The plain List keeps
-            // virtualization for older feed rows while active decision
-            // surfaces live above it in a stable stack.
-            ForEach(Array(snapshots.enumerated()), id: \.element.id) { idx, snapshot in
+        let groups = activitySnapshotGroups(snapshots)
+        return List {
+            ForEach(Array(groups.stable.enumerated()), id: \.element.id) { idx, snapshot in
                 rowSurface(
                     snapshot: snapshot,
                     actions: actions,
-                    showsDivider: idx < snapshots.count - 1
+                    showsDivider: idx < groups.stable.count - 1
+                )
+                .listRowInsets(EdgeInsets())
+                .listRowSeparator(.hidden)
+                .listRowBackground(Color.clear)
+            }
+            if !groups.stable.isEmpty && (!groups.history.isEmpty || showsLoadMore) {
+                rowSeparator
+                    .listRowInsets(EdgeInsets())
+                    .listRowSeparator(.hidden)
+                    .listRowBackground(Color.clear)
+            }
+            ForEach(Array(groups.history.enumerated()), id: \.element.id) { idx, snapshot in
+                rowSurface(
+                    snapshot: snapshot,
+                    actions: actions,
+                    showsDivider: idx < groups.history.count - 1
                 )
                 .listRowInsets(EdgeInsets())
                 .listRowSeparator(.hidden)
@@ -322,6 +302,23 @@ private struct FeedListView: View {
         .feedZeroScrollContentMargins()
         .environment(\.defaultMinListRowHeight, 0)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func activitySnapshotGroups(
+        _ snapshots: [FeedItemSnapshot]
+    ) -> (stable: [FeedItemSnapshot], history: [FeedItemSnapshot]) {
+        var stable: [FeedItemSnapshot] = []
+        var history: [FeedItemSnapshot] = []
+        stable.reserveCapacity(snapshots.count)
+        history.reserveCapacity(snapshots.count)
+        for snapshot in snapshots {
+            if prefersStableSurface(snapshot) {
+                stable.append(snapshot)
+            } else {
+                history.append(snapshot)
+            }
+        }
+        return (stable, history)
     }
 
     private func rowSurface(

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -3302,6 +3302,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         var parent: FeedInlineTextField
         var isProgrammaticMutation = false
         weak var view: FeedInlineTextEditorView?
+        var lastRenderedIsFocused: Bool?
 
         init(parent: FeedInlineTextField) {
             self.parent = parent
@@ -3410,9 +3411,18 @@ private struct FeedInlineTextField: NSViewRepresentable {
         guard let window = nsView.window else { return }
         let firstResponder = window.firstResponder
         let isFirstResponder = firstResponder === nsView.textView
+        let didRequestFocus = isFocused && context.coordinator.lastRenderedIsFocused != true
+        defer {
+            context.coordinator.lastRenderedIsFocused = isFocused
+        }
 
         if isFocused, isEnabled, !isFirstResponder {
-            nsView.focusIfNeeded()
+            let ownsSidebarFocus = firstResponder.map {
+                AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.ownsRightSidebarFocus($0) == true
+            } ?? true
+            if didRequestFocus || ownsSidebarFocus {
+                nsView.focusIfNeeded()
+            }
         } else if !isEnabled, isFirstResponder {
             window.makeFirstResponder(nil)
         }

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -2845,7 +2845,8 @@ private struct QuestionActionArea: View {
             isEnabled: status.isPending,
             font: font,
             onFocus: onFocus,
-            onBlur: onBlur
+            onBlur: onBlur,
+            onSubmit: nil
         )
         .frame(
             maxWidth: .infinity,
@@ -3043,6 +3044,7 @@ private final class FeedInlineNativeTextView: NSTextView, FeedKeyboardFocusRespo
 
     var onActivate: (() -> Void)?
     var onEscape: (() -> Void)?
+    var onSubmit: (() -> Void)?
 
     static func blurActiveEditor() {
         guard let activeEditor else { return }
@@ -3081,6 +3083,17 @@ private final class FeedInlineNativeTextView: NSTextView, FeedKeyboardFocusRespo
             return true
         }
         return super.performKeyEquivalent(with: event)
+    }
+
+    override func keyDown(with event: NSEvent) {
+        let normalizedFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+        let shouldSubmit = (event.keyCode == 36 || event.keyCode == 76)
+            && normalizedFlags.intersection([.shift, .option, .command, .control]).isEmpty
+        if shouldSubmit, let onSubmit {
+            onSubmit()
+            return
+        }
+        super.keyDown(with: event)
     }
 
     override func resetCursorRects() {
@@ -3283,6 +3296,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
     let font: NSFont
     let onFocus: () -> Void
     let onBlur: () -> Void
+    let onSubmit: (() -> Void)?
 
     final class Coordinator: NSObject, NSTextViewDelegate {
         var parent: FeedInlineTextField
@@ -3370,6 +3384,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         view.textView.onEscape = { [weak coordinator = context.coordinator] in
             coordinator?.blurField()
         }
+        view.textView.onSubmit = onSubmit
         configure(view)
         context.coordinator.view = view
         return view
@@ -3384,6 +3399,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         nsView.textView.onEscape = { [weak coordinator = context.coordinator] in
             coordinator?.blurField()
         }
+        nsView.textView.onSubmit = onSubmit
         configure(nsView)
 
         if nsView.textView.string != text, !nsView.textView.hasMarkedText() {
@@ -3439,6 +3455,7 @@ private struct FeedInlineTextField: NSViewRepresentable {
         nsView.textView.delegate = nil
         nsView.textView.onActivate = nil
         nsView.textView.onEscape = nil
+        nsView.textView.onSubmit = nil
     }
 }
 
@@ -3553,12 +3570,13 @@ private struct StopActionArea: View {
     let onSend: (String) -> Void
 
     @State private var reply: String = ""
-    @FocusState private var replyFocused: Bool
+    @State private var replyFocused: Bool = false
 
     private var trimmed: String {
         reply.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     private var canSend: Bool { !trimmed.isEmpty }
+    private var replyFont: NSFont { NSFont.systemFont(ofSize: 12) }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -3570,23 +3588,23 @@ private struct StopActionArea: View {
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(.secondary)
             }
-            TextField(
-                String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
+            FeedInlineTextField(
                 text: $reply,
-                axis: .vertical
+                isFocused: $replyFocused,
+                placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
+                isEnabled: true,
+                font: replyFont,
+                onFocus: onFocusRow,
+                onBlur: onBlurRow,
+                onSubmit: sendReply
             )
-            .textFieldStyle(.plain)
-            .font(.system(size: 12))
-            .focused($replyFocused)
-            .onChange(of: replyFocused) { _, focused in
-                if focused {
-                    onFocusRow()
-                } else {
-                    onBlurRow()
-                }
-            }
-            .lineLimit(1...5)
-            .padding(10)
+            .frame(
+                maxWidth: .infinity,
+                minHeight: FeedInlineTextEditorView.minimumHeight(for: replyFont),
+                alignment: .leading
+            )
+            .padding(.horizontal, 10)
+            .padding(.vertical, 9)
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .fill(Color.primary.opacity(0.06))
@@ -3595,11 +3613,11 @@ private struct StopActionArea: View {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .stroke(Color.primary.opacity(canSend ? 0.25 : 0.10), lineWidth: 1)
             )
-            .onSubmit {
-                if canSend {
-                    onSend(trimmed)
-                    reply = ""
-                }
+            .contentShape(Rectangle())
+            .feedIBeamCursorOnHover(enabled: true)
+            .onTapGesture {
+                onFocusRow()
+                replyFocused = true
             }
             FeedButton(
                 label: String(localized: "feed.stop.send", defaultValue: "Send to Claude"),
@@ -3609,9 +3627,9 @@ private struct StopActionArea: View {
                 fullWidth: true,
                 dimmed: !canSend
             ) {
+                guard canSend else { return }
                 onFocusRow()
-                onSend(trimmed)
-                reply = ""
+                sendReply()
             }
         }
         .onChange(of: isRowSelected) { _, selected in
@@ -3619,6 +3637,12 @@ private struct StopActionArea: View {
                 replyFocused = false
             }
         }
+    }
+
+    private func sendReply() {
+        guard canSend else { return }
+        onSend(trimmed)
+        reply = ""
     }
 }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -333,7 +333,7 @@ private struct FeedListView: View {
             isFocusActive: focusSnapshot.isKeyboardActive && focusSnapshot.selectedItemId == snapshot.id,
             showsDivider: showsDivider,
             onPressSelect: {
-                selectRow(snapshot.id, focusFeed: true)
+                selectRow(snapshot.id, focusFeed: false)
             },
             onControlFocus: {
                 selectRow(snapshot.id, focusFeed: false)
@@ -1208,8 +1208,6 @@ struct FeedItemRow: View, Equatable {
             )
         case .stop:
             StopActionArea(
-                workstreamId: snapshot.workstreamId,
-                isRowSelected: isSelected,
                 onFocusRow: onControlFocus,
                 onBlurRow: onControlBlur,
                 onSend: { text in actions.sendText(snapshot.workstreamId, text) }
@@ -2552,7 +2550,8 @@ private struct QuestionActionArea: View {
     // non-empty, wins over preset option selections for that
     // question — mirrors Claude's TUI fallback.
     @State private var freeTexts: [String: String] = [:]
-    @State private var focusedCustomAnswerId: String?
+    @State private var customAnswerFocusKey: String?
+    @State private var customAnswerFocusRequest = 0
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -2709,7 +2708,7 @@ private struct QuestionActionArea: View {
                 )
             customAnswerField(
                 text: customAnswerBinding(questionId: questionId, multi: multi),
-                isFocused: customAnswerFocusBinding(focusKey),
+                focusRequest: focusRequest(forCustomAnswerKey: focusKey),
                 font: font,
                 onFocus: {
                     onFocusRow()
@@ -2738,7 +2737,7 @@ private struct QuestionActionArea: View {
             guard status.isPending else { return }
             onFocusRow()
             selectCustomAnswer(questionId: questionId, multi: multi)
-            focusedCustomAnswerId = focusKey
+            requestCustomAnswerFocus(focusKey)
         }
         .feedIBeamCursorOnHover(enabled: status.isPending)
         .disabled(!status.isPending)
@@ -2802,7 +2801,7 @@ private struct QuestionActionArea: View {
         let font = NSFont.systemFont(ofSize: 11)
         return customAnswerField(
             text: customAnswerBinding(questionId: questionId, multi: multi),
-            isFocused: customAnswerFocusBinding(focusKey),
+            focusRequest: focusRequest(forCustomAnswerKey: focusKey),
             font: font,
             onFocus: {
                 onFocusRow()
@@ -2826,20 +2825,20 @@ private struct QuestionActionArea: View {
             guard status.isPending else { return }
             onFocusRow()
             selectCustomAnswer(questionId: questionId, multi: multi)
-            focusedCustomAnswerId = focusKey
+            requestCustomAnswerFocus(focusKey)
         }
     }
 
     private func customAnswerField(
         text: Binding<String>,
-        isFocused: Binding<Bool>,
+        focusRequest: Int?,
         font: NSFont,
         onFocus: @escaping () -> Void,
         onBlur: @escaping () -> Void
     ) -> some View {
         FeedInlineTextField(
             text: text,
-            isFocused: isFocused,
+            focusRequest: focusRequest,
             placeholder: String(localized: "feed.question.typeSomething",
                                 defaultValue: "Type something..."),
             isEnabled: status.isPending,
@@ -2874,21 +2873,17 @@ private struct QuestionActionArea: View {
         )
     }
 
-    private func customAnswerFocusBinding(_ focusKey: String) -> Binding<Bool> {
-        Binding<Bool>(
-            get: { focusedCustomAnswerId == focusKey },
-            set: { focused in
-                if focused {
-                    focusedCustomAnswerId = focusKey
-                } else if focusedCustomAnswerId == focusKey {
-                    focusedCustomAnswerId = nil
-                }
-            }
-        )
-    }
-
     private func customAnswerFocusKey(_ questionId: String) -> String {
         "\(questionId)::custom"
+    }
+
+    private func focusRequest(forCustomAnswerKey focusKey: String) -> Int? {
+        customAnswerFocusKey == focusKey ? customAnswerFocusRequest : nil
+    }
+
+    private func requestCustomAnswerFocus(_ focusKey: String) {
+        customAnswerFocusKey = focusKey
+        customAnswerFocusRequest += 1
     }
 
     private func selectCustomAnswer(questionId: String, multi: Bool) {
@@ -2902,7 +2897,7 @@ private struct QuestionActionArea: View {
     }
 
     private func clearCustomAnswerFocus() {
-        focusedCustomAnswerId = nil
+        customAnswerFocusKey = nil
     }
 
     private func optionPill(
@@ -3289,8 +3284,8 @@ private final class FeedInlineTextEditorView: NSView {
 
 private struct FeedInlineTextField: NSViewRepresentable {
     @Binding var text: String
-    @Binding var isFocused: Bool
 
+    let focusRequest: Int?
     let placeholder: String
     let isEnabled: Bool
     let font: NSFont
@@ -3302,10 +3297,11 @@ private struct FeedInlineTextField: NSViewRepresentable {
         var parent: FeedInlineTextField
         var isProgrammaticMutation = false
         weak var view: FeedInlineTextEditorView?
-        var lastRenderedIsFocused: Bool?
+        var lastAppliedFocusRequest: Int?
 
         init(parent: FeedInlineTextField) {
             self.parent = parent
+            self.lastAppliedFocusRequest = parent.focusRequest
         }
 
         func activateField() {
@@ -3313,15 +3309,9 @@ private struct FeedInlineTextField: NSViewRepresentable {
             dlog("feed.editor.activateField")
 #endif
             parent.onFocus()
-            if !parent.isFocused {
-                parent.isFocused = true
-            }
         }
 
         func blurField() {
-            if parent.isFocused {
-                parent.isFocused = false
-            }
             guard let view, let window = view.window, window.firstResponder === view.textView else {
                 return
             }
@@ -3353,9 +3343,6 @@ private struct FeedInlineTextField: NSViewRepresentable {
         func textDidEndEditing(_ notification: Notification) {
             if !isProgrammaticMutation, let textView = notification.object as? NSTextView {
                 parent.text = textView.string
-            }
-            if parent.isFocused {
-                parent.isFocused = false
             }
             guard let window = view?.window else {
                 parent.onBlur()
@@ -3409,20 +3396,15 @@ private struct FeedInlineTextField: NSViewRepresentable {
         }
 
         guard let window = nsView.window else { return }
-        let firstResponder = window.firstResponder
-        let isFirstResponder = firstResponder === nsView.textView
-        let didRequestFocus = isFocused && context.coordinator.lastRenderedIsFocused != true
-        defer {
-            context.coordinator.lastRenderedIsFocused = isFocused
-        }
-
-        if isFocused, isEnabled, !isFirstResponder {
-            let ownsSidebarFocus = firstResponder.map {
-                AppDelegate.shared?.keyboardFocusCoordinator(for: window)?.ownsRightSidebarFocus($0) == true
-            } ?? true
-            if didRequestFocus || ownsSidebarFocus {
-                nsView.focusIfNeeded()
+        let isFirstResponder = window.firstResponder === nsView.textView
+        if let focusRequest,
+           focusRequest != context.coordinator.lastAppliedFocusRequest {
+            guard isEnabled else {
+                context.coordinator.lastAppliedFocusRequest = focusRequest
+                return
             }
+            context.coordinator.lastAppliedFocusRequest = focusRequest
+            nsView.focusIfNeeded()
         } else if !isEnabled, isFirstResponder {
             window.makeFirstResponder(nil)
         }
@@ -3553,14 +3535,12 @@ private struct FlowLayout: Layout {
 /// types the reply into the agent's terminal surface and presses
 /// Return — so the user can reply without switching focus.
 private struct StopActionArea: View {
-    let workstreamId: String
-    let isRowSelected: Bool
     let onFocusRow: () -> Void
     let onBlurRow: () -> Void
     let onSend: (String) -> Void
 
     @State private var reply: String = ""
-    @State private var replyFocused: Bool = false
+    @State private var replyFocusRequest = 0
 
     private var trimmed: String {
         reply.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -3580,7 +3560,7 @@ private struct StopActionArea: View {
             }
             FeedInlineTextField(
                 text: $reply,
-                isFocused: $replyFocused,
+                focusRequest: replyFocusRequest == 0 ? nil : replyFocusRequest,
                 placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
                 isEnabled: true,
                 font: replyFont,
@@ -3607,7 +3587,7 @@ private struct StopActionArea: View {
             .feedIBeamCursorOnHover(enabled: true)
             .onTapGesture {
                 onFocusRow()
-                replyFocused = true
+                requestReplyFocus()
             }
             FeedButton(
                 label: String(localized: "feed.stop.send", defaultValue: "Send to Claude"),
@@ -3622,11 +3602,10 @@ private struct StopActionArea: View {
                 sendReply()
             }
         }
-        .onChange(of: isRowSelected) { _, selected in
-            if !selected {
-                replyFocused = false
-            }
-        }
+    }
+
+    private func requestReplyFocus() {
+        replyFocusRequest += 1
     }
 
     private func sendReply() {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -338,6 +338,9 @@ private struct FeedListView: View {
             onControlFocus: {
                 selectRow(snapshot.id, focusFeed: false)
             },
+            onControlAction: {
+                selectRow(snapshot.id, focusFeed: true)
+            },
             onControlBlur: {
                 syncFeedFocusSnapshot()
             },
@@ -417,7 +420,7 @@ private struct FeedListView: View {
             "frBefore=\(feedDebugResponderSummary(window?.firstResponder))"
         )
 #endif
-        if focusFeed || selectionChanged {
+        if focusFeed {
             FeedInlineNativeTextView.blurActiveEditor()
         }
         let optimisticSnapshot = FeedFocusSnapshot(selectedItemId: id, isKeyboardActive: true)
@@ -579,6 +582,7 @@ private struct FeedRowSurface: View {
     let showsDivider: Bool
     let onPressSelect: () -> Void
     let onControlFocus: () -> Void
+    let onControlAction: () -> Void
     let onControlBlur: () -> Void
     let onActivate: () -> Void
 
@@ -592,6 +596,7 @@ private struct FeedRowSurface: View {
                 isSelected: isFocusActive,
                 onPressSelect: onPressSelect,
                 onControlFocus: onControlFocus,
+                onControlAction: onControlAction,
                 onControlBlur: onControlBlur,
                 onActivate: onActivate
             )
@@ -947,6 +952,7 @@ struct FeedItemRow: View, Equatable {
     let isSelected: Bool
     let onPressSelect: () -> Void
     let onControlFocus: () -> Void
+    let onControlAction: () -> Void
     let onControlBlur: () -> Void
     let onActivate: () -> Void
 
@@ -1177,6 +1183,7 @@ struct FeedItemRow: View, Equatable {
                 toolInputJSON: toolInputJSON,
                 source: snapshot.source,
                 status: snapshot.status,
+                onActionRow: onControlAction,
                 onApprove: { mode in
                     actions.approvePermission(snapshot.id, mode)
                 }
@@ -1188,6 +1195,7 @@ struct FeedItemRow: View, Equatable {
                 status: snapshot.status,
                 isRowSelected: isSelected,
                 onFocusRow: onControlFocus,
+                onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
                 onApprove: { mode, feedback in
                     actions.approveExitPlan(snapshot.id, mode, feedback)
@@ -1200,6 +1208,7 @@ struct FeedItemRow: View, Equatable {
                 status: snapshot.status,
                 isRowSelected: isSelected,
                 onFocusRow: onControlFocus,
+                onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
                 context: displayContext,
                 onReply: { selections in
@@ -1209,6 +1218,7 @@ struct FeedItemRow: View, Equatable {
         case .stop:
             StopActionArea(
                 onFocusRow: onControlFocus,
+                onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
                 onSend: { text in actions.sendText(snapshot.workstreamId, text) }
             )
@@ -1366,6 +1376,7 @@ private struct PermissionActionArea: View {
     let toolInputJSON: String
     let source: WorkstreamSource
     let status: WorkstreamStatus
+    let onActionRow: () -> Void
     let onApprove: (WorkstreamPermissionMode) -> Void
 
     var body: some View {
@@ -1375,19 +1386,31 @@ private struct PermissionActionArea: View {
             if status.isPending {
                 HStack(spacing: 6) {
                     FeedButton(label: String(localized: "feed.permission.deny", defaultValue: "Deny"),
-                               kind: .dark, size: .medium, fullWidth: true) { onApprove(.deny) }
+                               kind: .dark, size: .medium, fullWidth: true) {
+                        onActionRow()
+                        onApprove(.deny)
+                    }
                         .accessibilityIdentifier("FeedPermissionDenyButton")
                     FeedButton(label: String(localized: "feed.permission.once", defaultValue: "Allow Once"),
-                               kind: .light, size: .medium, fullWidth: true) { onApprove(.once) }
+                               kind: .light, size: .medium, fullWidth: true) {
+                        onActionRow()
+                        onApprove(.once)
+                    }
                         .accessibilityIdentifier("FeedPermissionAllowOnceButton")
                     if FeedPermissionActionPolicy.supportsPersistentPermissionModes(source: source) {
                         FeedButton(label: String(localized: "feed.permission.always", defaultValue: "Always Allow"),
-                                   kind: .primary, size: .medium, fullWidth: true) { onApprove(.always) }
+                                   kind: .primary, size: .medium, fullWidth: true) {
+                            onActionRow()
+                            onApprove(.always)
+                        }
                             .accessibilityIdentifier("FeedPermissionAlwaysAllowButton")
                     }
                     if FeedPermissionActionPolicy.supportsBypassPermissions(source: source) {
                         FeedButton(label: String(localized: "feed.permission.bypass", defaultValue: "Bypass"),
-                                   kind: .destructive, size: .medium, fullWidth: true) { onApprove(.bypass) }
+                                   kind: .destructive, size: .medium, fullWidth: true) {
+                            onActionRow()
+                            onApprove(.bypass)
+                        }
                             .accessibilityIdentifier("FeedPermissionBypassButton")
                     }
                 }
@@ -2130,6 +2153,7 @@ private struct ExitPlanActionArea: View {
     let status: WorkstreamStatus
     let isRowSelected: Bool
     let onFocusRow: () -> Void
+    let onActionRow: () -> Void
     let onBlurRow: () -> Void
     let onApprove: (WorkstreamExitPlanMode, String?) -> Void
 
@@ -2199,7 +2223,8 @@ private struct ExitPlanActionArea: View {
                         kind: hasFeedback ? .primary : .soft,
                         size: .medium, fullWidth: true
                     ) {
-                        onFocusRow()
+                        feedbackFocused = false
+                        onActionRow()
                         // Feedback always wins over mode; hook translates
                         // non-empty feedback into block+reason.
                         onApprove(hasFeedback ? .manual : .ultraplan, hasFeedback ? trimmedFeedback : nil)
@@ -2211,7 +2236,8 @@ private struct ExitPlanActionArea: View {
                         size: .medium, fullWidth: true,
                         dimmed: hasFeedback
                     ) {
-                        onFocusRow()
+                        feedbackFocused = false
+                        onActionRow()
                         onApprove(.manual, hasFeedback ? trimmedFeedback : nil)
                     }
                     FeedButton(
@@ -2221,7 +2247,8 @@ private struct ExitPlanActionArea: View {
                         size: .medium, fullWidth: true,
                         dimmed: hasFeedback
                     ) {
-                        onFocusRow()
+                        feedbackFocused = false
+                        onActionRow()
                         onApprove(.autoAccept, hasFeedback ? trimmedFeedback : nil)
                     }
                 }
@@ -2537,6 +2564,7 @@ private struct QuestionActionArea: View {
     let status: WorkstreamStatus
     let isRowSelected: Bool
     let onFocusRow: () -> Void
+    let onActionRow: () -> Void
     let onBlurRow: () -> Void
     let context: WorkstreamContext?
     let onReply: ([String]) -> Void
@@ -2633,7 +2661,7 @@ private struct QuestionActionArea: View {
         let selected = selections[questionId]?.contains(option.id) == true
         return Button {
             guard status.isPending else { return }
-            onFocusRow()
+            onActionRow()
             clearCustomAnswerFocus()
             var current = selections[questionId] ?? []
             if multi {
@@ -2918,7 +2946,7 @@ private struct QuestionActionArea: View {
             dimmed: !status.isPending
         ) {
             guard status.isPending else { return }
-            onFocusRow()
+            onActionRow()
             clearCustomAnswerFocus()
             var current = selections[questionId] ?? []
             if multi {
@@ -3007,7 +3035,7 @@ private struct QuestionActionArea: View {
             fullWidth: true,
             dimmed: !enabled
         ) {
-            onFocusRow()
+            onActionRow()
             // Selections carry human-readable answer strings (one per
             // answered question) so the hook can feed them straight
             // back to the agent as the user's reply.
@@ -3024,7 +3052,7 @@ private struct QuestionActionArea: View {
             size: .medium,
             fullWidth: true
         ) {
-            onFocusRow()
+            onActionRow()
             onReply([Self.skipInterviewAndPlanAnswer])
         }
     }
@@ -3536,6 +3564,7 @@ private struct FlowLayout: Layout {
 /// Return — so the user can reply without switching focus.
 private struct StopActionArea: View {
     let onFocusRow: () -> Void
+    let onActionRow: () -> Void
     let onBlurRow: () -> Void
     let onSend: (String) -> Void
 
@@ -3598,7 +3627,7 @@ private struct StopActionArea: View {
                 dimmed: !canSend
             ) {
                 guard canSend else { return }
-                onFocusRow()
+                onActionRow()
                 sendReply()
             }
         }

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -164,6 +164,8 @@ private struct FeedListView: View {
 
     var body: some View {
         let snapshots = visibleSnapshots(items)
+        let activityGroups = filter == .activity ? activitySnapshotGroups(snapshots) : nil
+        let focusSnapshots = activityGroups?.ordered ?? snapshots
         let rowActions = FeedRowActions.bound()
         ScrollViewReader { proxy in
             Group {
@@ -172,6 +174,7 @@ private struct FeedListView: View {
                 } else {
                     contentBody(
                         snapshots: snapshots,
+                        activityGroups: activityGroups,
                         actions: rowActions
                     )
                 }
@@ -190,13 +193,13 @@ private struct FeedListView: View {
                         syncFeedFocusSnapshot(window: window)
                     },
                     onMoveSelection: { delta in
-                        moveSelection(in: snapshots, delta: delta)
+                        moveSelection(in: focusSnapshots, delta: delta)
                     },
                     onActivateSelection: {
-                        activateSelection(in: snapshots, actions: rowActions)
+                        activateSelection(in: focusSnapshots, actions: rowActions)
                     },
                     onFocusFirstItemRequested: {
-                        focusFirstVisibleItem(in: snapshots, focusHost: false)
+                        focusFirstVisibleItem(in: focusSnapshots, focusHost: false)
                     },
                     onFocusChanged: { focused in
                         let window = activeFeedWindow()
@@ -217,6 +220,7 @@ private struct FeedListView: View {
     @ViewBuilder
     private func contentBody(
         snapshots: [FeedItemSnapshot],
+        activityGroups: ActivitySnapshotGroups?,
         actions: FeedRowActions
     ) -> some View {
         switch filter {
@@ -227,7 +231,7 @@ private struct FeedListView: View {
             )
         case .activity:
             activityScrollSurface(
-                snapshots: snapshots,
+                groups: activityGroups ?? activitySnapshotGroups(snapshots),
                 actions: actions,
                 showsLoadMore: hasMorePersistedItems
             )
@@ -255,12 +259,11 @@ private struct FeedListView: View {
     }
 
     private func activityScrollSurface(
-        snapshots: [FeedItemSnapshot],
+        groups: ActivitySnapshotGroups,
         actions: FeedRowActions,
         showsLoadMore: Bool
     ) -> some View {
-        let groups = activitySnapshotGroups(snapshots)
-        return List {
+        List {
             ForEach(Array(groups.stable.enumerated()), id: \.element.id) { idx, snapshot in
                 rowSurface(
                     snapshot: snapshot,
@@ -273,6 +276,7 @@ private struct FeedListView: View {
             }
             if !groups.stable.isEmpty && (!groups.history.isEmpty || showsLoadMore) {
                 rowSeparator
+                    .id("feed.activity.separator")
                     .listRowInsets(EdgeInsets())
                     .listRowSeparator(.hidden)
                     .listRowBackground(Color.clear)
@@ -304,9 +308,13 @@ private struct FeedListView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private func activitySnapshotGroups(
-        _ snapshots: [FeedItemSnapshot]
-    ) -> (stable: [FeedItemSnapshot], history: [FeedItemSnapshot]) {
+    private struct ActivitySnapshotGroups {
+        let stable: [FeedItemSnapshot]
+        let history: [FeedItemSnapshot]
+        let ordered: [FeedItemSnapshot]
+    }
+
+    private func activitySnapshotGroups(_ snapshots: [FeedItemSnapshot]) -> ActivitySnapshotGroups {
         var stable: [FeedItemSnapshot] = []
         var history: [FeedItemSnapshot] = []
         stable.reserveCapacity(snapshots.count)
@@ -318,7 +326,7 @@ private struct FeedListView: View {
                 history.append(snapshot)
             }
         }
-        return (stable, history)
+        return ActivitySnapshotGroups(stable: stable, history: history, ordered: stable + history)
     }
 
     private func rowSurface(
@@ -3112,7 +3120,7 @@ private final class FeedInlineNativeTextView: NSTextView, FeedKeyboardFocusRespo
         let normalizedFlags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
         let shouldSubmit = (event.keyCode == 36 || event.keyCode == 76)
             && normalizedFlags.intersection([.shift, .option, .command, .control]).isEmpty
-        if shouldSubmit, let onSubmit {
+        if shouldSubmit, !hasMarkedText(), let onSubmit {
             onSubmit()
             return
         }
@@ -3283,8 +3291,11 @@ private final class FeedInlineTextEditorView: NSView {
         )
         layoutManager.ensureLayout(for: textContainer)
         let usedRect = layoutManager.usedRect(for: textContainer)
+        let extraLineHeight = layoutManager.extraLineFragmentTextContainer == textContainer
+            ? layoutManager.extraLineFragmentRect.height
+            : 0
         let lineHeight = ceil(currentFont.ascender - currentFont.descender + currentFont.leading)
-        let contentHeight = max(lineHeight, ceil(usedRect.height))
+        let contentHeight = max(lineHeight, ceil(usedRect.height + extraLineHeight))
         return max(
             Self.minimumHeight(for: currentFont),
             ceil(contentHeight + Self.textInset.height * 2)
@@ -3427,15 +3438,26 @@ private struct FeedInlineTextField: NSViewRepresentable {
         let isFirstResponder = window.firstResponder === nsView.textView
         if let focusRequest,
            focusRequest != context.coordinator.lastAppliedFocusRequest {
-            guard isEnabled else {
-                context.coordinator.lastAppliedFocusRequest = focusRequest
-                return
-            }
             context.coordinator.lastAppliedFocusRequest = focusRequest
-            nsView.focusIfNeeded()
+            if isEnabled {
+                nsView.focusIfNeeded()
+            } else if isFirstResponder {
+                moveFocusToFeedHost(in: window)
+            }
         } else if !isEnabled, isFirstResponder {
-            window.makeFirstResponder(nil)
+            moveFocusToFeedHost(in: window)
         }
+    }
+
+    private func moveFocusToFeedHost(in window: NSWindow) {
+        if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
+            mode: .feed,
+            focusFirstItem: false,
+            preferredWindow: window
+        ) == true {
+            return
+        }
+        window.makeFirstResponder(nil)
     }
 
     private func configure(_ view: FeedInlineTextEditorView) {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -161,6 +161,7 @@ private struct FeedListView: View {
     @State private var focusSnapshot = FeedFocusSnapshot()
     @State private var scrollRequest: FeedScrollRequest?
     @State private var scrollRequestSequence = 0
+    @State private var stopDrafts: [UUID: FeedStopDraft] = [:]
 
     var body: some View {
         let snapshots = visibleSnapshots(items)
@@ -340,6 +341,7 @@ private struct FeedListView: View {
             isSelected: focusSnapshot.selectedItemId == snapshot.id,
             isFocusActive: focusSnapshot.isKeyboardActive && focusSnapshot.selectedItemId == snapshot.id,
             showsDivider: showsDivider,
+            stopDraft: stopDraftBinding(for: snapshot.id),
             onPressSelect: {
                 selectRow(snapshot.id, focusFeed: false)
             },
@@ -358,6 +360,19 @@ private struct FeedListView: View {
             }
         )
         .id(snapshot.id)
+    }
+
+    private func stopDraftBinding(for id: UUID) -> Binding<FeedStopDraft> {
+        Binding(
+            get: { stopDrafts[id] ?? FeedStopDraft() },
+            set: { draft in
+                if draft.isPristine {
+                    stopDrafts.removeValue(forKey: id)
+                } else {
+                    stopDrafts[id] = draft
+                }
+            }
+        )
     }
 
     /// Walks the full items list (not just the filtered visible set),
@@ -582,12 +597,22 @@ private struct FeedScrollRequest: Equatable {
     let sequence: Int
 }
 
+struct FeedStopDraft: Equatable {
+    var reply = ""
+    var focusRequest = 0
+
+    var isPristine: Bool {
+        reply.isEmpty && focusRequest == 0
+    }
+}
+
 private struct FeedRowSurface: View {
     let snapshot: FeedItemSnapshot
     let actions: FeedRowActions
     let isSelected: Bool
     let isFocusActive: Bool
     let showsDivider: Bool
+    @Binding var stopDraft: FeedStopDraft
     let onPressSelect: () -> Void
     let onControlFocus: () -> Void
     let onControlAction: () -> Void
@@ -606,7 +631,9 @@ private struct FeedRowSurface: View {
                 onControlFocus: onControlFocus,
                 onControlAction: onControlAction,
                 onControlBlur: onControlBlur,
-                onActivate: onActivate
+                onActivate: onActivate,
+                stopDraft: $stopDraft,
+                stopDraftValue: stopDraft
             )
             .equatable()
             if showsDivider {
@@ -963,12 +990,15 @@ struct FeedItemRow: View, Equatable {
     let onControlAction: () -> Void
     let onControlBlur: () -> Void
     let onActivate: () -> Void
+    @Binding var stopDraft: FeedStopDraft
+    let stopDraftValue: FeedStopDraft
 
     @State private var didHandlePressSelection = false
 
     static func == (lhs: FeedItemRow, rhs: FeedItemRow) -> Bool {
         lhs.snapshot == rhs.snapshot
             && lhs.isSelected == rhs.isSelected
+            && lhs.stopDraftValue == rhs.stopDraftValue
     }
 
     var body: some View {
@@ -1225,6 +1255,7 @@ struct FeedItemRow: View, Equatable {
             )
         case .stop:
             StopActionArea(
+                draft: $stopDraft,
                 onFocusRow: onControlFocus,
                 onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
@@ -3585,19 +3616,24 @@ private struct FlowLayout: Layout {
 /// types the reply into the agent's terminal surface and presses
 /// Return — so the user can reply without switching focus.
 private struct StopActionArea: View {
+    @Binding var draft: FeedStopDraft
+
     let onFocusRow: () -> Void
     let onActionRow: () -> Void
     let onBlurRow: () -> Void
     let onSend: (String) -> Void
 
-    @State private var reply: String = ""
-    @State private var replyFocusRequest = 0
-
     private var trimmed: String {
-        reply.trimmingCharacters(in: .whitespacesAndNewlines)
+        draft.reply.trimmingCharacters(in: .whitespacesAndNewlines)
     }
     private var canSend: Bool { !trimmed.isEmpty }
     private var replyFont: NSFont { NSFont.systemFont(ofSize: 12) }
+    private var replyBinding: Binding<String> {
+        Binding(
+            get: { draft.reply },
+            set: { draft.reply = $0 }
+        )
+    }
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -3610,8 +3646,8 @@ private struct StopActionArea: View {
                     .foregroundColor(.secondary)
             }
             FeedInlineTextField(
-                text: $reply,
-                focusRequest: replyFocusRequest == 0 ? nil : replyFocusRequest,
+                text: replyBinding,
+                focusRequest: draft.focusRequest == 0 ? nil : draft.focusRequest,
                 placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
                 isEnabled: true,
                 font: replyFont,
@@ -3656,13 +3692,13 @@ private struct StopActionArea: View {
     }
 
     private func requestReplyFocus() {
-        replyFocusRequest += 1
+        draft.focusRequest += 1
     }
 
     private func sendReply() {
         guard canSend else { return }
         onSend(trimmed)
-        reply = ""
+        draft = FeedStopDraft()
     }
 }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -599,7 +599,6 @@ private struct FeedScrollRequest: Equatable {
 
 struct FeedStopDraft: Equatable {
     var reply = ""
-    var focusRequest = 0
 
     var isPristine: Bool {
         reply.isEmpty
@@ -620,6 +619,7 @@ private struct FeedRowSurface: View {
     let onActivate: () -> Void
 
     @State private var isHovered = false
+    @State private var stopReplyFocusRequest = 0
 
     var body: some View {
         VStack(spacing: 0) {
@@ -633,7 +633,9 @@ private struct FeedRowSurface: View {
                 onControlBlur: onControlBlur,
                 onActivate: onActivate,
                 stopDraft: $stopDraft,
-                stopDraftValue: stopDraft
+                stopDraftValue: stopDraft,
+                stopFocusRequest: $stopReplyFocusRequest,
+                stopFocusRequestValue: stopReplyFocusRequest
             )
             .equatable()
             if showsDivider {
@@ -992,6 +994,8 @@ struct FeedItemRow: View, Equatable {
     let onActivate: () -> Void
     @Binding var stopDraft: FeedStopDraft
     let stopDraftValue: FeedStopDraft
+    @Binding var stopFocusRequest: Int
+    let stopFocusRequestValue: Int
 
     @State private var didHandlePressSelection = false
 
@@ -999,6 +1003,7 @@ struct FeedItemRow: View, Equatable {
         lhs.snapshot == rhs.snapshot
             && lhs.isSelected == rhs.isSelected
             && lhs.stopDraftValue == rhs.stopDraftValue
+            && lhs.stopFocusRequestValue == rhs.stopFocusRequestValue
     }
 
     var body: some View {
@@ -1256,6 +1261,7 @@ struct FeedItemRow: View, Equatable {
         case .stop:
             StopActionArea(
                 draft: $stopDraft,
+                focusRequest: $stopFocusRequest,
                 onFocusRow: onControlFocus,
                 onActionRow: onControlAction,
                 onBlurRow: onControlBlur,
@@ -3622,6 +3628,7 @@ private struct FlowLayout: Layout {
 /// Return — so the user can reply without switching focus.
 private struct StopActionArea: View {
     @Binding var draft: FeedStopDraft
+    @Binding var focusRequest: Int
 
     let onFocusRow: () -> Void
     let onActionRow: () -> Void
@@ -3652,7 +3659,7 @@ private struct StopActionArea: View {
             }
             FeedInlineTextField(
                 text: replyBinding,
-                focusRequest: draft.focusRequest == 0 ? nil : draft.focusRequest,
+                focusRequest: focusRequest == 0 ? nil : focusRequest,
                 placeholder: String(localized: "feed.stop.placeholder", defaultValue: "Reply to Claude…"),
                 isEnabled: true,
                 font: replyFont,
@@ -3697,7 +3704,7 @@ private struct StopActionArea: View {
     }
 
     private func requestReplyFocus() {
-        draft.focusRequest += 1
+        focusRequest += 1
     }
 
     private func sendReply() {

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -3302,7 +3302,6 @@ private struct FeedInlineTextField: NSViewRepresentable {
         var parent: FeedInlineTextField
         var isProgrammaticMutation = false
         weak var view: FeedInlineTextEditorView?
-        var pendingFocusRequest: Bool?
 
         init(parent: FeedInlineTextField) {
             self.parent = parent
@@ -3319,7 +3318,6 @@ private struct FeedInlineTextField: NSViewRepresentable {
         }
 
         func blurField() {
-            pendingFocusRequest = nil
             if parent.isFocused {
                 parent.isFocused = false
             }
@@ -3413,28 +3411,10 @@ private struct FeedInlineTextField: NSViewRepresentable {
         let firstResponder = window.firstResponder
         let isFirstResponder = firstResponder === nsView.textView
 
-        if isFocused, isEnabled, !isFirstResponder, context.coordinator.pendingFocusRequest != true {
-            context.coordinator.pendingFocusRequest = true
-            DispatchQueue.main.async { [weak nsView, weak coordinator = context.coordinator] in
-                coordinator?.pendingFocusRequest = nil
-                guard let coordinator, coordinator.parent.isFocused, coordinator.parent.isEnabled else { return }
-                nsView?.focusIfNeeded()
-            }
-        } else if (!isFocused || !isEnabled), isFirstResponder, context.coordinator.pendingFocusRequest != false {
-            context.coordinator.pendingFocusRequest = false
-            Task { @MainActor [weak nsView, weak coordinator = context.coordinator] in
-                coordinator?.pendingFocusRequest = nil
-                guard let nsView, let window = nsView.window else { return }
-                let stillFocused = window.firstResponder === nsView.textView
-                guard stillFocused else { return }
-                if AppDelegate.shared?.focusRightSidebarInActiveMainWindow(
-                    mode: .feed,
-                    focusFirstItem: false,
-                    preferredWindow: window
-                ) != true {
-                    window.makeFirstResponder(nil)
-                }
-            }
+        if isFocused, isEnabled, !isFirstResponder {
+            nsView.focusIfNeeded()
+        } else if !isEnabled, isFirstResponder {
+            window.makeFirstResponder(nil)
         }
     }
 

--- a/Sources/Feed/FeedPanelView.swift
+++ b/Sources/Feed/FeedPanelView.swift
@@ -602,7 +602,7 @@ struct FeedStopDraft: Equatable {
     var focusRequest = 0
 
     var isPristine: Bool {
-        reply.isEmpty && focusRequest == 0
+        reply.isEmpty
     }
 }
 
@@ -3475,6 +3475,11 @@ private struct FeedInlineTextField: NSViewRepresentable {
             } else if isFirstResponder {
                 moveFocusToFeedHost(in: window)
             }
+        } else if focusRequest == nil {
+            context.coordinator.lastAppliedFocusRequest = nil
+            if !isEnabled, isFirstResponder {
+                moveFocusToFeedHost(in: window)
+            }
         } else if !isEnabled, isFirstResponder {
             moveFocusToFeedHost(in: window)
         }
@@ -3698,7 +3703,7 @@ private struct StopActionArea: View {
     private func sendReply() {
         guard canSend else { return }
         onSend(trimmed)
-        draft = FeedStopDraft()
+        draft.reply = ""
     }
 }
 

--- a/Sources/Feed/FeedPanelViewModel.swift
+++ b/Sources/Feed/FeedPanelViewModel.swift
@@ -57,8 +57,6 @@ struct FeedHistoryLoadMoreRow: View {
     let isLoading: Bool
     let action: () -> Void
 
-    @State private var isVisible = false
-
     var body: some View {
         Button(action: action) {
             HStack(spacing: 6) {
@@ -77,17 +75,6 @@ struct FeedHistoryLoadMoreRow: View {
         }
         .buttonStyle(.plain)
         .disabled(isLoading)
-        .onAppear {
-            isVisible = true
-            requestLoadIfVisible()
-        }
-        .onDisappear {
-            isVisible = false
-        }
-        .onChange(of: isLoading) { _, loading in
-            guard !loading else { return }
-            requestLoadIfVisible()
-        }
     }
 
     private var label: String {
@@ -97,8 +84,4 @@ struct FeedHistoryLoadMoreRow: View {
         return String(localized: "feed.history.loadOlder", defaultValue: "Load older activity")
     }
 
-    private func requestLoadIfVisible() {
-        guard isVisible, !isLoading else { return }
-        action()
-    }
 }

--- a/Sources/Feed/FeedPreviewWindowController.swift
+++ b/Sources/Feed/FeedPreviewWindowController.swift
@@ -129,6 +129,7 @@ private struct FeedPreviewCardHost: View {
             isSelected: false,
             onPressSelect: {},
             onControlFocus: {},
+            onControlAction: {},
             onControlBlur: {},
             onActivate: {}
         )

--- a/Sources/Feed/FeedPreviewWindowController.swift
+++ b/Sources/Feed/FeedPreviewWindowController.swift
@@ -119,6 +119,8 @@ private struct FeedPreviewRootView: View {
 private struct FeedPreviewCardHost: View {
     let item: WorkstreamItem
 
+    @State private var stopDraft = FeedStopDraft()
+
     var body: some View {
         FeedItemRow(
             snapshot: FeedItemSnapshot(
@@ -131,7 +133,9 @@ private struct FeedPreviewCardHost: View {
             onControlFocus: {},
             onControlAction: {},
             onControlBlur: {},
-            onActivate: {}
+            onActivate: {},
+            stopDraft: $stopDraft,
+            stopDraftValue: stopDraft
         )
     }
 }

--- a/Sources/Feed/FeedPreviewWindowController.swift
+++ b/Sources/Feed/FeedPreviewWindowController.swift
@@ -120,6 +120,7 @@ private struct FeedPreviewCardHost: View {
     let item: WorkstreamItem
 
     @State private var stopDraft = FeedStopDraft()
+    @State private var stopFocusRequest = 0
 
     var body: some View {
         FeedItemRow(
@@ -135,7 +136,9 @@ private struct FeedPreviewCardHost: View {
             onControlBlur: {},
             onActivate: {},
             stopDraft: $stopDraft,
-            stopDraftValue: stopDraft
+            stopDraftValue: stopDraft,
+            stopFocusRequest: $stopFocusRequest,
+            stopFocusRequestValue: stopFocusRequest
         )
     }
 }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7021,6 +7021,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             if let displayID = window?.screen?.displayID, displayID != 0 {
                 ghostty_surface_set_display_id(surface, displayID)
             }
+            terminalSurface?.forceRefresh(reason: "focus.firstResponder")
         }
         return result
     }

--- a/Sources/RightSidebarMode+Availability.swift
+++ b/Sources/RightSidebarMode+Availability.swift
@@ -2,29 +2,21 @@ import Foundation
 
 extension RightSidebarMode {
     static func availableModes(defaults: UserDefaults = .standard) -> [RightSidebarMode] {
-        availableModes(
-            feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
-            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults)
-        )
+        availableModes(dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults))
     }
 
-    static func availableModes(feedEnabled: Bool, dockEnabled: Bool) -> [RightSidebarMode] {
-        allCases.filter { $0.isAvailable(feedEnabled: feedEnabled, dockEnabled: dockEnabled) }
+    static func availableModes(dockEnabled: Bool) -> [RightSidebarMode] {
+        allCases.filter { $0.isAvailable(dockEnabled: dockEnabled) }
     }
 
     func isAvailable(defaults: UserDefaults = .standard) -> Bool {
-        isAvailable(
-            feedEnabled: RightSidebarBetaFeatureSettings.isFeedEnabled(defaults: defaults),
-            dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults)
-        )
+        isAvailable(dockEnabled: RightSidebarBetaFeatureSettings.isDockEnabled(defaults: defaults))
     }
 
-    func isAvailable(feedEnabled: Bool, dockEnabled: Bool) -> Bool {
+    func isAvailable(dockEnabled: Bool) -> Bool {
         switch self {
-        case .files, .find, .sessions:
+        case .files, .find, .sessions, .feed:
             return true
-        case .feed:
-            return feedEnabled
         case .dock:
             return dockEnabled
         }

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -163,8 +163,6 @@ struct RightSidebarPanelView: View {
     private let closeShortcutHintYOffset = ShortcutHintDebugSettings.defaultRightSidebarCloseHintY
     private let focusShortcutHintXOffset = ShortcutHintDebugSettings.defaultRightSidebarFocusHintX
     private let focusShortcutHintYOffset = ShortcutHintDebugSettings.defaultRightSidebarFocusHintY
-    @AppStorage(RightSidebarBetaFeatureSettings.feedEnabledKey)
-    private var feedEnabled = RightSidebarBetaFeatureSettings.defaultFeedEnabled
     @AppStorage(RightSidebarBetaFeatureSettings.dockEnabledKey)
     private var dockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
 
@@ -176,7 +174,7 @@ struct RightSidebarPanelView: View {
     }
 
     private var availableModes: [RightSidebarMode] {
-        RightSidebarMode.availableModes(feedEnabled: feedEnabled, dockEnabled: dockEnabled)
+        RightSidebarMode.availableModes(dockEnabled: dockEnabled)
     }
 
     var body: some View {
@@ -216,7 +214,6 @@ struct RightSidebarPanelView: View {
             if mode != .dock { dockStore.deactivate() }
         }
         .onChange(of: fileExplorerState.isVisible) { _, visible in if !visible { dockStore.deactivate() } }
-        .onChange(of: feedEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
         .onChange(of: dockEnabled) { _, _ in refreshModeAvailabilityAndFocusIfNeeded() }
     }
 

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -329,7 +329,6 @@ enum SettingsSearchIndex {
         setting(.sidebarAppearance, "show-log", String(localized: "settings.app.showLog", defaultValue: "Show Latest Log in Sidebar"), "status message"),
         setting(.sidebarAppearance, "show-progress", String(localized: "settings.app.showProgress", defaultValue: "Show Progress in Sidebar"), "progress bar"),
         setting(.sidebarAppearance, "show-metadata", String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar"), "report meta status block"),
-        setting(.betaFeatures, "feed", String(localized: "settings.betaFeatures.feed", defaultValue: "Feed"), "feed right sidebar agent decisions permissions questions"),
         setting(.betaFeatures, "dock", String(localized: "settings.betaFeatures.dock", defaultValue: "Dock"), "dock right sidebar terminal controls tui"),
         setting(.automation, "socket-mode", String(localized: "settings.automation.socketMode", defaultValue: "Socket Control Mode"), "unix socket api access password auth"),
         setting(.automation, "socket-password", String(localized: "settings.automation.socketPassword", defaultValue: "Socket Password"), "socket auth credential"),
@@ -372,7 +371,6 @@ enum SettingsSearchIndex {
     )
 
     private static let settingsPathAnchorIDs: [String: String] = [
-        "rightSidebar.beta.feed.enabled": settingID(for: .betaFeatures, idSuffix: "feed"),
         "rightSidebar.beta.dock.enabled": settingID(for: .betaFeatures, idSuffix: "dock"),
         "app.language": settingID(for: .app, idSuffix: "language"),
         "app.appearance": settingID(for: .app, idSuffix: "appearance"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -10,7 +10,7 @@ enum SettingsSearchAliasIndex {
         case .sidebarAppearance:
             return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "sidebar left rail navigation details branches badges material terminal background")
         case .betaFeatures:
-            return localized("settings.search.alias.section.betaFeatures", defaultValue: "beta experimental unstable preview feed dock right sidebar")
+            return localized("settings.search.alias.section.betaFeatures", defaultValue: "beta experimental unstable preview dock right sidebar")
         case .automation:
             return localized("settings.search.alias.section.automation", defaultValue: "api cli control socket mcp agents hooks ports")
         case .browser:
@@ -78,7 +78,6 @@ enum SettingsSearchAliasIndex {
         "sidebarAppearance:show-log": localized("settings.search.alias.setting.app.show-log", defaultValue: "sidebar.showLog log status latest message imperative"),
         "sidebarAppearance:show-progress": localized("settings.search.alias.setting.app.show-progress", defaultValue: "sidebar.showProgress progress bar percent status set_progress"),
         "sidebarAppearance:show-metadata": localized("settings.search.alias.setting.app.show-metadata", defaultValue: "sidebar.showCustomMetadata metadata meta report_meta status custom block"),
-        "betaFeatures:feed": localized("settings.search.alias.setting.betaFeatures.feed", defaultValue: "feed right sidebar agent decisions permissions questions approval beta unstable"),
         "betaFeatures:dock": localized("settings.search.alias.setting.betaFeatures.dock", defaultValue: "dock right sidebar terminal controls tui beta unstable"),
         "automation:socket-mode": localized("settings.search.alias.setting.automation.socket-mode", defaultValue: "automation.socketControlMode api socket unix domain control server auth allow password disabled"),
         "automation:socket-password": localized("settings.search.alias.setting.automation.socket-password", defaultValue: "automation.socketPassword auth token credential secret password access key"),

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -5043,8 +5043,6 @@ struct SettingsView: View {
     @AppStorage("sidebarTintHexDark") private var sidebarTintHexDark: String?
     @AppStorage("sidebarTintOpacity") private var sidebarTintOpacity = SidebarTintDefaults.opacity
     @AppStorage("sidebarMatchTerminalBackground") private var sidebarMatchTerminalBackground = false
-    @AppStorage(RightSidebarBetaFeatureSettings.feedEnabledKey)
-    private var rightSidebarFeedEnabled = RightSidebarBetaFeatureSettings.defaultFeedEnabled
     @AppStorage(RightSidebarBetaFeatureSettings.dockEnabledKey)
     private var rightSidebarDockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
 
@@ -6326,7 +6324,6 @@ struct SettingsView: View {
                     }
 
                     BetaFeaturesSettingsView(
-                        feedEnabled: $rightSidebarFeedEnabled,
                         dockEnabled: $rightSidebarDockEnabled
                     )
 
@@ -7209,7 +7206,6 @@ struct SettingsView: View {
         browserImportHintVariantRaw = BrowserImportHintSettings.defaultVariant.rawValue
         showBrowserImportHintOnBlankTabs = BrowserImportHintSettings.defaultShowOnBlankTabs
         isBrowserImportHintDismissed = BrowserImportHintSettings.defaultDismissed
-        rightSidebarFeedEnabled = RightSidebarBetaFeatureSettings.defaultFeedEnabled
         rightSidebarDockEnabled = RightSidebarBetaFeatureSettings.defaultDockEnabled
         openTerminalLinksInCmuxBrowser = BrowserLinkOpenSettings.defaultOpenTerminalLinksInCmuxBrowser
         interceptTerminalOpenCommandInCmuxBrowser = BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser

--- a/cmuxTests/FileExplorerStateModePersistenceTests.swift
+++ b/cmuxTests/FileExplorerStateModePersistenceTests.swift
@@ -9,27 +9,12 @@ import XCTest
 
 final class FileExplorerStateModePersistenceTests: XCTestCase {
     private let modeKey = "rightSidebar.mode"
-    private let feedEnabledKey = RightSidebarBetaFeatureSettings.feedEnabledKey
     private let dockEnabledKey = RightSidebarBetaFeatureSettings.dockEnabledKey
 
-    func testDisabledFeedStoredModeFallsBackToFiles() {
+    func testFeedStoredModeSurvivesByDefault() {
         withSavedRightSidebarModeDefaults {
             let defaults = UserDefaults.standard
             defaults.set(RightSidebarMode.feed.rawValue, forKey: modeKey)
-            defaults.set(false, forKey: feedEnabledKey)
-
-            let state = FileExplorerState()
-
-            XCTAssertEqual(state.mode, .files)
-            XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.files.rawValue)
-        }
-    }
-
-    func testEnabledFeedStoredModeSurvives() {
-        withSavedRightSidebarModeDefaults {
-            let defaults = UserDefaults.standard
-            defaults.set(RightSidebarMode.feed.rawValue, forKey: modeKey)
-            defaults.set(true, forKey: feedEnabledKey)
 
             let state = FileExplorerState()
 
@@ -41,13 +26,12 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
     func testModeSetterClampsUnavailableBetaModes() {
         withSavedRightSidebarModeDefaults {
             let defaults = UserDefaults.standard
-            defaults.set(false, forKey: feedEnabledKey)
             defaults.set(false, forKey: dockEnabledKey)
             let state = FileExplorerState()
 
             state.mode = .feed
-            XCTAssertEqual(state.mode, .files)
-            XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.files.rawValue)
+            XCTAssertEqual(state.mode, .feed)
+            XCTAssertEqual(defaults.string(forKey: modeKey), RightSidebarMode.feed.rawValue)
 
             defaults.set(true, forKey: dockEnabledKey)
             state.mode = .dock
@@ -64,11 +48,9 @@ final class FileExplorerStateModePersistenceTests: XCTestCase {
     private func withSavedRightSidebarModeDefaults(_ body: () -> Void) {
         let defaults = UserDefaults.standard
         let previousMode = defaults.object(forKey: modeKey)
-        let previousFeedEnabled = defaults.object(forKey: feedEnabledKey)
         let previousDockEnabled = defaults.object(forKey: dockEnabledKey)
         defer {
             restore(previousMode, forKey: modeKey)
-            restore(previousFeedEnabled, forKey: feedEnabledKey)
             restore(previousDockEnabled, forKey: dockEnabledKey)
         }
         body()

--- a/cmuxTests/RightSidebarCommandPaletteTests.swift
+++ b/cmuxTests/RightSidebarCommandPaletteTests.swift
@@ -11,7 +11,6 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
     func testCommandPaletteIncludesDefaultRightSidebarModes() throws {
         try withSavedBetaFeatureDefaults {
             let defaults = UserDefaults.standard
-            defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             defaults.removeObject(forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
             let contributions = ContentView.commandPaletteRightSidebarModeCommandContributions()
             let contributionsByID = Dictionary(uniqueKeysWithValues: contributions.map { ($0.commandId, $0) })
@@ -36,8 +35,8 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
                 XCTAssertTrue(contribution.enablement(context))
             }
 
-            XCTAssertEqual(contributions.count, 3)
-            XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.feed)])
+            XCTAssertEqual(contributions.count, 4)
+            XCTAssertNotNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.feed)])
             XCTAssertNil(contributionsByID[ContentView.commandPaletteRightSidebarModeCommandID(.dock)])
         }
     }
@@ -45,7 +44,6 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
     func testCommandPaletteRightSidebarActionsUseModeShortcutActions() {
         withSavedBetaFeatureDefaults {
             let defaults = UserDefaults.standard
-            defaults.set(true, forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             defaults.set(true, forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
 
             for mode in RightSidebarMode.allCases {
@@ -61,10 +59,8 @@ final class RightSidebarCommandPaletteTests: XCTestCase {
 
     private func withSavedBetaFeatureDefaults(_ body: () throws -> Void) rethrows {
         let defaults = UserDefaults.standard
-        let previousFeed = defaults.object(forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
         let previousDock = defaults.object(forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
         defer {
-            restore(previousFeed, forKey: RightSidebarBetaFeatureSettings.feedEnabledKey)
             restore(previousDock, forKey: RightSidebarBetaFeatureSettings.dockEnabledKey)
         }
         try body()

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2108,6 +2108,59 @@ final class TerminalNotificationDirectInteractionTests: XCTestCase {
         throw XCTSkip("Debug-only regression test")
 #endif
     }
+
+    func testDirectFirstResponderFocusRefreshesCursorStateAfterForeignResponder() throws {
+#if DEBUG
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        let otherResponder = FocusProbeView(frame: NSRect(x: 0, y: 0, width: 40, height: 40))
+        contentView.addSubview(otherResponder)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let surfaceView = surfaceView(in: hostedView) as? GhosttyNSView else {
+            XCTFail("Expected terminal surface view")
+            return
+        }
+        XCTAssertNotNil(surface.surface, "Expected runtime surface before measuring focus redraws")
+        XCTAssertTrue(window.makeFirstResponder(surfaceView))
+        XCTAssertTrue(window.makeFirstResponder(otherResponder))
+
+        surface.resetDebugForceRefreshCount()
+        XCTAssertTrue(window.makeFirstResponder(surfaceView))
+
+        XCTAssertGreaterThan(
+            surface.debugForceRefreshCount(),
+            0,
+            "Clicking back into the terminal should redraw immediately so the cursor reflects focused input"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
 }
 
 

--- a/cmuxUITests/RightSidebarChromeHeightUITests.swift
+++ b/cmuxUITests/RightSidebarChromeHeightUITests.swift
@@ -13,7 +13,6 @@ final class RightSidebarChromeHeightUITests: XCTestCase {
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_TAB_DRAG_PATH"] = dataPath
         app.launchEnvironment["CMUX_UI_TEST_BONSPLIT_SHOW_RIGHT_SIDEBAR"] = "1"
         app.launchArguments += ["-workspacePresentationMode", "minimal"]
-        app.launchArguments += ["-rightSidebar.beta.feed.enabled", "YES"]
         let options = XCTExpectedFailure.Options()
         options.isStrict = false
         XCTExpectFailure("App activation may fail on headless CI runners", options: options) {
@@ -77,15 +76,18 @@ final class RightSidebarChromeHeightUITests: XCTestCase {
 
         let feedControlHeightKeys = [
             "rightSidebarSecondaryControl_feed_actionableHeight",
+            "rightSidebarSecondaryControl_feed_activityHeight",
         ]
         guard let feedGeometry = waitForJSONNumbers(feedControlHeightKeys, greaterThan: 1, atPath: dataPath, timeout: 5),
               let feedSecondaryBarHeight = Double(feedGeometry["rightSidebarSecondaryBarHeight"] ?? ""),
-              let actionableControlHeight = Double(feedGeometry["rightSidebarSecondaryControl_feed_actionableHeight"] ?? "") else {
+              let actionableControlHeight = Double(feedGeometry["rightSidebarSecondaryControl_feed_actionableHeight"] ?? ""),
+              let activityControlHeight = Double(feedGeometry["rightSidebarSecondaryControl_feed_activityHeight"] ?? "") else {
             XCTFail("Timed out waiting for feed secondary bar geometry. data=\(loadJSON(atPath: dataPath) ?? [:])")
             return
         }
         XCTAssertEqual(feedSecondaryBarHeight, modeBarHeight, accuracy: 0.5, "Expected feed secondary bar to match the mode bar. geometry=\(feedGeometry)")
         XCTAssertEqual(actionableControlHeight, modeControlHeight, accuracy: 0.5, "Expected Feed Actionable pill to match mode button height. geometry=\(feedGeometry)")
+        XCTAssertEqual(activityControlHeight, modeControlHeight, accuracy: 0.5, "Expected Feed All Activity pill to match mode button height. geometry=\(feedGeometry)")
     }
 
     private func waitForJSONNumbers(_ keys: [String], greaterThan threshold: Double, atPath path: String, timeout: TimeInterval) -> [String: String]? {


### PR DESCRIPTION
Summary:
- Promote Feed to an always-available right-sidebar mode and remove its beta setting/search/config gating.
- Restore the All Activity filter and render it in one virtualized scroll surface.
- Make older Activity history loading explicit so switching filters cannot auto-page through sparse history.

Verification:
- ./scripts/reload.sh --tag feedon
- jq empty Resources/Localizable.xcstrings
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: refactors Feed panel filtering, scrolling virtualization, and keyboard/focus handling, which could introduce regressions in right-sidebar navigation and inline editor behavior.
> 
> **Overview**
> Promotes **Feed** to an always-available right sidebar mode by removing the `feed` beta flag, its settings toggle/search entries, and related mode-availability gating; the beta warning copy now applies to **Dock only**.
> 
> Restores the *All Activity* filter and updates the Feed UI to render both actionable + activity filters, with Activity shown in a single virtualized list and **explicit** "Load older activity" paging (no auto-load on appearance).
> 
> Improves Feed interaction ergonomics: action buttons now explicitly focus the feed row, row presses don’t steal focus, Stop replies keep per-row drafts and support Enter-to-submit, and inline editors switch to one-shot focus requests with better height calculation. Terminal focus now forces an immediate refresh on first-responder changes, with updated/added regression UI/unit tests to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81b9e3675e5b1bb3cbad2c8cb053a80ef9320739. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Feed by default in the right sidebar and command palette. Restores “All Activity” as a single virtualized stream with an explicit “Load older,” and tightens editor focus so replies are fast and predictable.

- **New Features**
  - Feed is always available; removed Feed beta toggle and settings/search entries. Only `dock` remains gated; warning copy now mentions Dock only.
  - Secondary filter shows Actionable and All Activity. Activity renders as one scroll surface (active above history with a separator) and loads older items only on click.

- **Bug Fixes**
  - Keyboard navigation follows All Activity order; row clicks don’t steal focus; action buttons focus the Feed.
  - Inline editors use one‑shot focus requests with Enter‑to‑submit; reply drafts persist across recycling; stop replies and custom answers keep separate focus state to prevent refocus loops.
  - Terminal cursor redraws immediately on first‑responder focus; added a debug regression test to verify the refresh.

<sup>Written for commit 81b9e3675e5b1bb3cbad2c8cb053a80ef9320739. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Feed mode is now available by default without a beta opt-in.

* **Bug Fixes & Improvements**
  * Activity filter label changed to "All Activity".
  * Beta warning copy now references Dock specifically.
  * Removed Feed toggle and search/navigation entry from Beta Features.
  * Reply input: Enter submits replies; load-more requires explicit user action.
  * Terminal focus now forces an immediate redraw on regain.

* **Tests**
  * Added regression test verifying immediate terminal focus refresh.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3854)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->