### PR TITLE
Fix Sentry CLI crashes and termination hang

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -25,6 +25,67 @@ struct CLIError: Error, CustomStringConvertible {
     var description: String { message }
 }
 
+private struct CLIOutputClosed: Error {
+    let streamName: String
+}
+
+private struct CLISocketNotFound: Error, CustomStringConvertible {
+    let path: String
+
+    var description: String {
+        "Socket not found at \(path)"
+    }
+}
+
+private struct CLIOutputWriteError: Error, CustomStringConvertible {
+    let streamName: String
+    let errnoCode: Int32
+
+    var description: String {
+        "Failed to write \(streamName): \(String(cString: strerror(errnoCode)))"
+    }
+}
+
+private enum CLIOutput {
+    static func writeStdout(_ data: Data) throws {
+        try write(data, fd: STDOUT_FILENO, streamName: "stdout")
+    }
+
+    static func writeStderr(_ data: Data) throws {
+        try write(data, fd: STDERR_FILENO, streamName: "stderr")
+    }
+
+    static func writeStderrBestEffort(_ text: String) {
+        try? writeStderr(Data(text.utf8))
+    }
+
+    private static func write(_ data: Data, fd: Int32, streamName: String) throws {
+        guard !data.isEmpty else { return }
+
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.baseAddress else { return }
+            var offset = 0
+
+            while offset < data.count {
+                let written = Darwin.write(fd, baseAddress.advanced(by: offset), data.count - offset)
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+
+                if written < 0, errno == EINTR {
+                    continue
+                }
+                if written < 0, errno == EPIPE {
+                    throw CLIOutputClosed(streamName: streamName)
+                }
+
+                throw CLIOutputWriteError(streamName: streamName, errnoCode: written < 0 ? errno : EIO)
+            }
+        }
+    }
+}
+
 private enum CLISocketEnvironment {
     static func socketPath(in environment: [String: String]) throws -> String? {
         let socketPath = normalized(environment["CMUX_SOCKET_PATH"])
@@ -1332,7 +1393,7 @@ final class SocketClient {
         // Verify socket is owned by the current user to prevent fake-socket attacks.
         var st = stat()
         guard stat(path, &st) == 0 else {
-            throw CLIError(message: "Socket not found at \(path)")
+            throw CLISocketNotFound(path: path)
         }
         guard (st.st_mode & mode_t(S_IFMT)) == mode_t(S_IFSOCK) else {
             throw CLIError(message: "Path exists at \(path) but is not a Unix socket")
@@ -1986,9 +2047,20 @@ struct CMUXCLI {
     private static let vmAttachResponseTimeoutSeconds: TimeInterval = 16 * 60
 
     private func captureSocketTransportError(telemetry: CLISocketSentryTelemetry, stage: String, error: Error, client: SocketClient) {
-        if client.hasUnfinishedOperationTelemetry() {
+        if shouldCaptureSocketTransportError(error, client: client) {
             telemetry.captureError(stage: stage, error: error, data: client.operationTelemetryContext())
         }
+    }
+
+    private func shouldCaptureSocketTransportError(_ error: Error, client: SocketClient) -> Bool {
+        guard !(error is CLIOutputClosed) else {
+            return false
+        }
+        return client.hasUnfinishedOperationTelemetry()
+    }
+
+    private func shouldCaptureSocketConnectError(_ error: Error) -> Bool {
+        !(error is CLISocketNotFound)
     }
 
     private struct VMCreateIdempotencyStore: Codable {
@@ -2688,7 +2760,9 @@ struct CMUXCLI {
             cliTelemetry.breadcrumb("socket.connect.success", data: ["path": resolvedSocketPath])
         } catch {
             cliTelemetry.breadcrumb("socket.connect.failure", data: ["path": resolvedSocketPath])
-            cliTelemetry.captureError(stage: "socket_connect", error: error)
+            if shouldCaptureSocketConnectError(error) {
+                cliTelemetry.captureError(stage: "socket_connect", error: error)
+            }
             throw error
         }
         defer { client.close() }
@@ -3001,11 +3075,16 @@ struct CMUXCLI {
                     }
                     break
                 }
-                if !stdout.isEmpty { print(stdout, terminator: stdout.hasSuffix("\n") ? "" : "\n") }
+                if !stdout.isEmpty {
+                    try CLIOutput.writeStdout(Data(stdout.utf8))
+                    if !stdout.hasSuffix("\n") {
+                        try CLIOutput.writeStdout(Data("\n".utf8))
+                    }
+                }
                 if !stderr.isEmpty {
-                    FileHandle.standardError.write(Data(stderr.utf8))
+                    try CLIOutput.writeStderr(Data(stderr.utf8))
                     if !stderr.hasSuffix("\n") {
-                        FileHandle.standardError.write(Data("\n".utf8))
+                        try CLIOutput.writeStderr(Data("\n".utf8))
                     }
                 }
                 if exitCode != 0 {
@@ -5468,7 +5547,7 @@ struct CMUXCLI {
                 _ = try client.sendV2(method: "workspace.close", params: ["workspace_id": workspaceId])
             } catch {
                 let warning = "Warning: failed to rollback workspace \(workspaceId): \(error)\n"
-                FileHandle.standardError.write(Data(warning.utf8))
+                CLIOutput.writeStderrBestEffort(warning)
             }
             throw error
         }
@@ -6778,7 +6857,7 @@ struct CMUXCLI {
                 _ = try client.sendV2(method: "workspace.close", params: ["workspace_id": workspaceId])
             } catch {
                 let warning = "Warning: failed to rollback workspace \(workspaceId): \(error)\n"
-                FileHandle.standardError.write(Data(warning.utf8))
+                CLIOutput.writeStderrBestEffort(warning)
             }
             throw error
         }
@@ -7054,7 +7133,7 @@ struct CMUXCLI {
             while let message = try receiveSync(delegate: delegate) {
                 switch message {
                 case .data(let data):
-                    FileHandle.standardOutput.write(data)
+                    try CLIOutput.writeStdout(data)
                 case .string:
                     continue
                 @unknown default:
@@ -14971,7 +15050,7 @@ struct CMUXCLI {
         if !fm.fileExists(atPath: pluginPackageDir.path) {
             let installDir = shadowDir
             if let bunPath = resolveExecutableInPath("bun") {
-                FileHandle.standardError.write("Installing oh-my-opencode plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
+                CLIOutput.writeStderrBestEffort("Installing oh-my-opencode plugin (this may take a minute on first run)...\n")
                 let installArguments = ["add", Self.omoPluginName]
                 let firstAttemptStatus = try omoRunPackageInstall(
                     executablePath: bunPath,
@@ -14979,7 +15058,7 @@ struct CMUXCLI {
                     currentDirectoryURL: installDir
                 )
                 if firstAttemptStatus != 0 {
-                    FileHandle.standardError.write("Retrying oh-my-opencode install with a clean shadow package state...\n".data(using: .utf8)!)
+                    CLIOutput.writeStderrBestEffort("Retrying oh-my-opencode install with a clean shadow package state...\n")
                     try? fm.removeItem(at: shadowBunLockURL)
                     try? fm.removeItem(at: shadowNodeModules)
                     try omoEnsureShadowNodeModulesSymlink(shadowNodeModules: shadowNodeModules, userNodeModules: userNodeModules)
@@ -14993,7 +15072,7 @@ struct CMUXCLI {
                     }
                 }
             } else if let npmPath = resolveExecutableInPath("npm") {
-                FileHandle.standardError.write("Installing oh-my-opencode plugin (this may take a minute on first run)...\n".data(using: .utf8)!)
+                CLIOutput.writeStderrBestEffort("Installing oh-my-opencode plugin (this may take a minute on first run)...\n")
                 let status = try omoRunPackageInstall(
                     executablePath: npmPath,
                     arguments: ["install", Self.omoPluginName],
@@ -15005,7 +15084,7 @@ struct CMUXCLI {
             } else {
                 throw CLIError(message: "Neither bun nor npm found in PATH. Install oh-my-opencode manually: bunx oh-my-opencode install")
             }
-            FileHandle.standardError.write("oh-my-opencode plugin installed\n".data(using: .utf8)!)
+            CLIOutput.writeStderrBestEffort("oh-my-opencode plugin installed\n")
         }
 
         // Ensure tmux mode is enabled in oh-my-opencode config.
@@ -24296,32 +24375,6 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 #endif
 }
 
-private enum CMUXCLIOutput {
-    static func writeStandardError(_ message: String) {
-        write(Data(message.utf8), to: STDERR_FILENO)
-    }
-
-    private static func write(_ data: Data, to fd: Int32) {
-        data.withUnsafeBytes { rawBuffer in
-            guard let baseAddress = rawBuffer.baseAddress else {
-                return
-            }
-
-            var offset = 0
-            while offset < data.count {
-                let bytesWritten = Darwin.write(fd, baseAddress.advanced(by: offset), data.count - offset)
-                if bytesWritten > 0 {
-                    offset += bytesWritten
-                } else if bytesWritten == -1, errno == EINTR {
-                    continue
-                } else {
-                    return
-                }
-            }
-        }
-    }
-}
-
 @main
 struct CMUXTermMain {
     static func main() {
@@ -24330,8 +24383,10 @@ struct CMUXTermMain {
         let cli = CMUXCLI(args: CommandLine.arguments)
         do {
             try cli.run()
+        } catch let error as CLIOutputClosed {
+            exit(error.streamName == "stdout" ? 0 : 1)
         } catch {
-            CMUXCLIOutput.writeStandardError("Error: \(error)\n")
+            CLIOutput.writeStderrBestEffort("Error: \(error)\n")
             let exitCode = (error as? CLIError)?.exitCode ?? 1
             exit(exitCode)
         }

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -4,6 +4,7 @@ import PostHog
 
 final class PostHogAnalytics {
     static let shared = PostHogAnalytics()
+    private static let terminationFlushTimeout: DispatchTimeInterval = .seconds(2)
 
     // The PostHog project API key is intentionally embedded in the app (it's a public key).
     private let apiKey = "phc_opOVu7oFzR9wD3I6ZahFGOV2h3mqGpl5EHyQvmHciDP"
@@ -74,10 +75,20 @@ final class PostHogAnalytics {
     }
 
     func flush() {
-        dispatchSyncOnWorkQueue {
+        if DispatchQueue.getSpecific(key: workQueueSpecificKey) != nil {
             guard didStart else { return }
             PostHogSDK.shared.flush()
+            return
         }
+
+        let group = DispatchGroup()
+        group.enter()
+        workQueue.async { [weak self] in
+            defer { group.leave() }
+            guard let self, self.didStart else { return }
+            PostHogSDK.shared.flush()
+        }
+        _ = group.wait(timeout: .now() + Self.terminationFlushTimeout)
     }
 
     private func startIfNeededOnWorkQueue() {
@@ -188,14 +199,6 @@ final class PostHogAnalytics {
             return
         }
         workQueue.async(execute: block)
-    }
-
-    private func dispatchSyncOnWorkQueue(_ block: () -> Void) {
-        if DispatchQueue.getSpecific(key: workQueueSpecificKey) != nil {
-            block()
-            return
-        }
-        workQueue.sync(execute: block)
     }
 
     private func utcHourString(_ date: Date) -> String {


### PR DESCRIPTION
Fixes Sentry regressions seen on the latest release:

- https://manaflow.sentry.io/issues/7464454913/ by avoiding Foundation FileHandle writes for raw CLI stdout/stderr output and treating closed output pipes as a normal CLI exit.
- https://manaflow.sentry.io/issues/7290136228/ by suppressing expected missing-socket connect errors from Sentry capture.
- https://manaflow.sentry.io/issues/7392351523/ by making PostHog termination flush non-blocking on the main thread.

Verification:
- ./scripts/reload.sh --tag sentryfix
- git diff --check
- built CLI version command
- missing-socket CLI error path
- closed stdout pipeline

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core CLI output/error paths and telemetry capture, which can affect process exit behavior (e.g., piping) and error reporting. Changes are localized but could regress output/exit codes or hide unexpected connect issues if misclassified.
> 
> **Overview**
> Improves CLI robustness when writing output by replacing `print`/`FileHandle` writes with a `Darwin.write`-based `CLIOutput` that retries on `EINTR`, throws on `EPIPE`, and treats closed stdout pipes as a normal exit.
> 
> Reduces Sentry noise by introducing `CLISocketNotFound` and skipping capture for expected missing-socket connect failures and for `CLIOutputClosed` transport errors.
> 
> Prevents shutdown hangs in analytics by making `PostHogAnalytics.flush()` avoid synchronous main-thread blocking, instead flushing on the work queue with a short timeout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7bb3b3bc239761d9a0788f5ecdefeed9f5d3e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents CLI crashes and shutdown hangs by using a resilient stdout/stderr writer, treating closed pipes as safe exits, and bounding analytics flush to avoid blocking. Also reduces Sentry noise by skipping expected missing-socket and output-closed errors.

- **Bug Fixes**
  - Route stdout/stderr through `CLIOutput` using `Darwin.write`, retry on `EINTR`, and map `EPIPE` to `CLIOutputClosed`.
  - On `EPIPE`, exit 0 for stdout and 1 for stderr; don’t capture these as errors.
  - Capture socket transport errors only when there’s unfinished telemetry; skip `CLIOutputClosed`.
  - Skip socket connect error capture for `CLISocketNotFound`; still capture other connect failures.
  - Make `PostHog` flush run on its queue with a 2s timeout to prevent termination hangs.
  - Switch stderr warnings and top-level errors to best-effort logging.

<sup>Written for commit ec7bb3b3bc239761d9a0788f5ecdefeed9f5d3e4. Summary will update on new commits. <a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/3855?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and output reliability in CLI output streams.
  * Enhanced socket transport telemetry capture logic to prevent duplicate reporting.

* **Refactor**
  * Optimized analytics flush operation for better queue management and reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3855)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->