### PR TITLE
Gate minimal-mode chrome and sidebar on focusPaneOnFirstClick

### DIFF
--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Darwin
 import Foundation
 
@@ -89,6 +90,37 @@ enum PaneFirstClickFocusSettings {
 
     static func isEnabled(defaults: UserDefaults = .standard) -> Bool {
         defaults.object(forKey: enabledKey) as? Bool ?? defaultEnabled
+    }
+}
+
+@MainActor
+enum PaneFirstClickGate {
+    private static let graceInterval: TimeInterval = 0.2
+    private static var lastBecameActiveAt: TimeInterval = 0
+    private static var installed = false
+
+    static func install() {
+        guard !installed else { return }
+        installed = true
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated {
+                lastBecameActiveAt = ProcessInfo.processInfo.systemUptime
+            }
+        }
+    }
+
+    static func shouldSwallowFirstClick(now: TimeInterval = ProcessInfo.processInfo.systemUptime) -> Bool {
+        if PaneFirstClickFocusSettings.isEnabled() { return false }
+        let elapsed = now - lastBecameActiveAt
+        return elapsed >= 0 && elapsed < graceInterval
+    }
+
+    static func markActivatedForTesting(at time: TimeInterval = ProcessInfo.processInfo.systemUptime) {
+        lastBecameActiveAt = time
     }
 }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -996,6 +996,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isRunningUnderXCTest = isRunningUnderXCTest(env)
         let telemetryEnabled = TelemetrySettings.enabledForCurrentLaunch
         AppIconLaunchState.markDidFinishLaunching()
+        PaneFirstClickGate.install()
         if isRunningUnderXCTest {
             NSApp.setActivationPolicy(.regular)
         } else {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12612,6 +12612,7 @@ private struct TabItemView: View, Equatable {
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex
         ))
         .onTapGesture {
+            if PaneFirstClickGate.shouldSwallowFirstClick() { return }
             updateSelection()
         }
         .safeHelp(workspaceSnapshot.title)

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -357,7 +357,11 @@ struct TitlebarControlButton<Content: View>: View {
     @State private var isHovering = false
 
     var body: some View {
-        let baseButton = Button(action: action) {
+        let gatedAction: () -> Void = {
+            if PaneFirstClickGate.shouldSwallowFirstClick() { return }
+            action()
+        }
+        let baseButton = Button(action: gatedAction) {
             content()
                 .frame(width: config.buttonSize, height: config.buttonSize)
                 .contentShape(Rectangle())

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -123,6 +123,9 @@ final class WindowDecorationsController {
                isHovering,
                controlsAreRevealed,
                let slot = actionSlot {
+                if MainActor.assumeIsolated({ PaneFirstClickGate.shouldSwallowFirstClick() }) {
+                    return nil
+                }
                 MinimalModeSidebarChromeHoverState.shared.setHovering(true, windowNumber: window.windowNumber)
                 self.performMinimalModeSidebarControlAction(
                     slot,
@@ -187,6 +190,9 @@ final class WindowDecorationsController {
         #endif
 
         guard isHovering, controlsAreRevealed, let actionSlot else { return false }
+        if MainActor.assumeIsolated({ PaneFirstClickGate.shouldSwallowFirstClick() }) {
+            return true
+        }
         MinimalModeSidebarChromeHoverState.shared.setHovering(true, windowNumber: window.windowNumber)
         performMinimalModeSidebarControlAction(
             actionSlot,

--- a/cmuxTests/InactivePaneFirstClickFocusTests.swift
+++ b/cmuxTests/InactivePaneFirstClickFocusTests.swift
@@ -69,4 +69,29 @@ final class InactivePaneFirstClickFocusTests: XCTestCase {
 
         XCTAssertFalse(view.acceptsFirstMouse(for: nil))
     }
+
+    func testPaneFirstClickGateSwallowsWithinGraceWhenSettingDisabled() {
+        UserDefaults.standard.set(false, forKey: settingsKey)
+        let now = ProcessInfo.processInfo.systemUptime
+        PaneFirstClickGate.markActivatedForTesting(at: now)
+
+        XCTAssertTrue(PaneFirstClickGate.shouldSwallowFirstClick(now: now + 0.05))
+        XCTAssertTrue(PaneFirstClickGate.shouldSwallowFirstClick(now: now + 0.19))
+    }
+
+    func testPaneFirstClickGateAllowsAfterGrace() {
+        UserDefaults.standard.set(false, forKey: settingsKey)
+        let now = ProcessInfo.processInfo.systemUptime
+        PaneFirstClickGate.markActivatedForTesting(at: now)
+
+        XCTAssertFalse(PaneFirstClickGate.shouldSwallowFirstClick(now: now + 1.0))
+    }
+
+    func testPaneFirstClickGateAllowsWhenSettingEnabled() {
+        UserDefaults.standard.set(true, forKey: settingsKey)
+        let now = ProcessInfo.processInfo.systemUptime
+        PaneFirstClickGate.markActivatedForTesting(at: now)
+
+        XCTAssertFalse(PaneFirstClickGate.shouldSwallowFirstClick(now: now + 0.05))
+    }
 }


### PR DESCRIPTION
Closes #3856.

## Summary

With `app.focusPaneOnFirstClick: false`, clicks on cmux chrome while the window was inactive still fired actions on first click. The setting was already honoured for pane content (terminal, web view, markdown observer) but bypassed for chrome and sidebar via five separate code paths that I traced with a temporary instrumented build:

- `TitlebarControlButton` SwiftUI `Button`s in the titlebar (bell, sidebar toggle, `+`)
- The `NSEvent.addLocalMonitor` in `WindowDecorationsController` that resolves minimal-mode chrome clicks via the hit-region registry and calls `performMinimalModeSidebarControlAction` directly (this one bypasses every view-level check, including any `acceptsFirstMouse` override)
- The per-window send-event hook in the same controller
- The sidebar workspace row's `.onTapGesture`, which switched workspaces on first click — the most surprising symptom

## Approach

Adds `PaneFirstClickGate` next to `PaneFirstClickFocusSettings` in `WorkspaceRuntimeSettings.swift`. It observes `NSApplication.didBecomeActiveNotification` and exposes `shouldSwallowFirstClick(now:)`, which returns `true` for 200 ms after activation when the setting is disabled. The four action sites consult the gate before firing.

The grace-window approach is necessary because by the time these SwiftUI actions and event-monitor callbacks run, `NSApp.isActive` is already `true` — there's no other reliable per-click signal. 200 ms is short enough that a deliberate second click is well past the window and long enough that the activation click reliably falls inside it.

## Test plan

- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/InactivePaneFirstClickFocusTests test` — all 9 tests pass (6 existing + 3 new gate-behaviour cases)
- Manual on a tagged Debug build with `focusPaneOnFirstClick: false` and `minimalMode: true`, cmux unfocused:
  - Bell / sidebar toggle / `+` button: first click only activates cmux, second click fires the action
  - Click workspace 2 from workspace 1: first click only activates cmux, second click switches workspace
  - With `focusPaneOnFirstClick: true`: all four still fire on first click as before

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-click protection: the app now ignores the first click for a short grace period (~0.2s) after the app becomes active to prevent accidental actions. This applies to sidebar rows, titlebar controls, and minimal-mode sidebar chrome, and can be toggled in settings.
* **Tests**
  * Added automated tests validating the timing and behavior of the first-click gating.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3857)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->