### PR TITLE
feat: add capture-pane --follow for continuous terminal output streaming

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9649,6 +9649,7 @@ struct CMUXCLI {
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let (linesArg, rem2) = parseOption(rem1, name: "--lines")
+            let sawIntervalFlag = rem2.contains("--interval")
             let (intervalArg, rem3) = parseOption(rem2, name: "--interval")
             let workspaceArg = wsArg ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = sfArg ?? (wsArg == nil && windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
@@ -9678,6 +9679,9 @@ struct CMUXCLI {
                     throw CLIError(message: "--json is not supported with --follow; use plain text output for streaming")
                 }
                 // Continuous streaming: poll surface, print only new content
+                if sawIntervalFlag && intervalArg == nil {
+                    throw CLIError(message: "--interval requires a value")
+                }
                 guard let intervalValue = Double(intervalArg ?? "0.5"), intervalValue > 0 else {
                     throw CLIError(message: "--interval must be a positive number")
                 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9674,6 +9674,9 @@ struct CMUXCLI {
             let followMode = rem3.contains("--follow")
 
             if followMode {
+                guard !jsonOutput else {
+                    throw CLIError(message: "--json is not supported with --follow; use plain text output for streaming")
+                }
                 // Continuous streaming: poll surface, print only new content
                 let interval = Double(intervalArg ?? "0.5") ?? 0.5
                 guard interval > 0 else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9678,11 +9678,15 @@ struct CMUXCLI {
                     throw CLIError(message: "--json is not supported with --follow; use plain text output for streaming")
                 }
                 // Continuous streaming: poll surface, print only new content
-                let interval = Double(intervalArg ?? "0.5") ?? 0.5
-                guard interval > 0 else {
-                    throw CLIError(message: "--interval must be greater than 0")
+                guard let intervalValue = Double(intervalArg ?? "0.5"), intervalValue > 0 else {
+                    throw CLIError(message: "--interval must be a positive number")
                 }
+                let interval = intervalValue
                 var previousText = ""
+
+                // Follow mode always needs scrollback so the viewport doesn't
+                // shrink as the terminal scrolls, breaking the append heuristic.
+                params["scrollback"] = true
 
                 // Ignore SIGPIPE so writes return EPIPE instead of killing the process;
                 // we detect broken pipes via fflush(stdout) return value below
@@ -9706,11 +9710,11 @@ struct CMUXCLI {
                                 // Content changed completely (screen refresh) — print separator + all
                                 print("\n---\n\(currentText)", terminator: "")
                             }
-                            // Check for broken pipe (EPIPE) — reader disconnected
-                            if fflush(stdout) != 0 {
-                                break
-                            }
                             previousText = currentText
+                        }
+                        // Always flush to detect broken pipe (EPIPE), even when content unchanged
+                        if fflush(stdout) != 0 {
+                            break
                         }
                     } catch {
                         // Socket died — close and reconnect before retrying

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9676,30 +9676,37 @@ struct CMUXCLI {
             if followMode {
                 // Continuous streaming: poll surface, print only new content
                 let interval = Double(intervalArg ?? "0.5") ?? 0.5
+                guard interval > 0 else {
+                    throw CLIError(message: "--interval must be greater than 0")
+                }
                 var previousText = ""
 
                 // Ignore SIGPIPE so we exit cleanly when the reader disconnects
                 signal(SIGPIPE, SIG_IGN)
 
                 while true {
-                    let payload = try client.sendV2(method: "surface.read_text", params: params)
-                    let currentText = (payload["text"] as? String) ?? ""
+                    do {
+                        let payload = try client.sendV2(method: "surface.read_text", params: params)
+                        let currentText = (payload["text"] as? String) ?? ""
 
-                    if currentText != previousText {
-                        if previousText.isEmpty {
-                            // First read — print everything
-                            print(currentText, terminator: "")
-                        } else if currentText.count > previousText.count,
-                                  currentText.hasPrefix(String(previousText.prefix(100))) {
-                            // Text grew — print only the new part
-                            let newText = String(currentText.dropFirst(previousText.count))
-                            print(newText, terminator: "")
-                        } else {
-                            // Content changed completely (screen refresh) — print separator + all
-                            print("\n---\n\(currentText)", terminator: "")
+                        if currentText != previousText {
+                            if previousText.isEmpty {
+                                // First read — print everything
+                                print(currentText, terminator: "")
+                            } else if currentText.count > previousText.count,
+                                      currentText.hasPrefix(previousText) {
+                                // Text grew — print only the new part
+                                let newText = String(currentText.dropFirst(previousText.count))
+                                print(newText, terminator: "")
+                            } else {
+                                // Content changed completely (screen refresh) — print separator + all
+                                print("\n---\n\(currentText)", terminator: "")
+                            }
+                            fflush(stdout)
+                            previousText = currentText
                         }
-                        fflush(stdout)
-                        previousText = currentText
+                    } catch {
+                        // Transient error — retry after interval
                     }
 
                     Thread.sleep(forTimeInterval: interval)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9681,7 +9681,8 @@ struct CMUXCLI {
                 }
                 var previousText = ""
 
-                // Ignore SIGPIPE so we exit cleanly when the reader disconnects
+                // Ignore SIGPIPE so writes return EPIPE instead of killing the process;
+                // we detect broken pipes via fflush(stdout) return value below
                 signal(SIGPIPE, SIG_IGN)
 
                 while true {
@@ -9702,11 +9703,21 @@ struct CMUXCLI {
                                 // Content changed completely (screen refresh) — print separator + all
                                 print("\n---\n\(currentText)", terminator: "")
                             }
-                            fflush(stdout)
+                            // Check for broken pipe (EPIPE) — reader disconnected
+                            if fflush(stdout) != 0 {
+                                break
+                            }
                             previousText = currentText
                         }
                     } catch {
-                        // Transient error — retry after interval
+                        // Socket died — close and reconnect before retrying
+                        client.close()
+                        do {
+                            try client.connect()
+                        } catch {
+                            // Can't reconnect — exit
+                            break
+                        }
                     }
 
                     Thread.sleep(forTimeInterval: interval)
@@ -11127,7 +11138,7 @@ struct CMUXCLI {
           simulate-app-active
 
           # tmux compatibility commands
-          capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
+          capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>] [--follow [--interval <s>]]
           resize-pane --pane <id|ref> [--workspace <id|ref>] (-L|-R|-U|-D) [--amount <n>]
           pipe-pane --command <shell-command> [--workspace <id|ref>] [--surface <id|ref>]
           wait-for [-S|--signal] <name> [--timeout <seconds>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6462,18 +6462,21 @@ struct CMUXCLI {
             """
         case "capture-pane":
             return """
-            Usage: cmux capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>]
+            Usage: cmux capture-pane [--workspace <id|ref>] [--surface <id|ref>] [--scrollback] [--lines <n>] [--follow [--interval <s>]]
 
-            tmux-compatible alias for reading terminal text from a pane.
+            Read terminal text from a pane. With --follow, streams new output continuously.
 
             Flags:
               --workspace <id|ref>   Workspace context (default: $CMUX_WORKSPACE_ID)
               --surface <id|ref>     Surface context (default: $CMUX_SURFACE_ID)
               --scrollback           Include scrollback
               --lines <n>            Return only the last N lines (implies --scrollback)
+              --follow               Continuously stream new terminal output (Ctrl+C to stop)
+              --interval <s>         Poll interval in seconds for --follow (default: 0.5)
 
             Example:
-              cmux capture-pane --workspace workspace:2 --surface surface:1 --scrollback --lines 200
+              cmux capture-pane --workspace workspace:2 --scrollback --lines 200
+              cmux capture-pane --follow --interval 0.3 --workspace workspace:2
             """
         case "resize-pane":
             return """
@@ -9646,6 +9649,7 @@ struct CMUXCLI {
             let (wsArg, rem0) = parseOption(commandArgs, name: "--workspace")
             let (sfArg, rem1) = parseOption(rem0, name: "--surface")
             let (linesArg, rem2) = parseOption(rem1, name: "--lines")
+            let (intervalArg, rem3) = parseOption(rem2, name: "--interval")
             let workspaceArg = wsArg ?? (windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
             let surfaceArg = sfArg ?? (wsArg == nil && windowOverride == nil ? ProcessInfo.processInfo.environment["CMUX_SURFACE_ID"] : nil)
 
@@ -9655,7 +9659,7 @@ struct CMUXCLI {
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId)
             if let sfId { params["surface_id"] = sfId }
 
-            let includeScrollback = rem2.contains("--scrollback")
+            let includeScrollback = rem3.contains("--scrollback")
             if includeScrollback {
                 params["scrollback"] = true
             }
@@ -9667,11 +9671,47 @@ struct CMUXCLI {
                 params["scrollback"] = true
             }
 
-            let payload = try client.sendV2(method: "surface.read_text", params: params)
-            if jsonOutput {
-                print(jsonString(payload))
+            let followMode = rem3.contains("--follow")
+
+            if followMode {
+                // Continuous streaming: poll surface, print only new content
+                let interval = Double(intervalArg ?? "0.5") ?? 0.5
+                var previousText = ""
+
+                // Ignore SIGPIPE so we exit cleanly when the reader disconnects
+                signal(SIGPIPE, SIG_IGN)
+
+                while true {
+                    let payload = try client.sendV2(method: "surface.read_text", params: params)
+                    let currentText = (payload["text"] as? String) ?? ""
+
+                    if currentText != previousText {
+                        if previousText.isEmpty {
+                            // First read — print everything
+                            print(currentText, terminator: "")
+                        } else if currentText.count > previousText.count,
+                                  currentText.hasPrefix(String(previousText.prefix(100))) {
+                            // Text grew — print only the new part
+                            let newText = String(currentText.dropFirst(previousText.count))
+                            print(newText, terminator: "")
+                        } else {
+                            // Content changed completely (screen refresh) — print separator + all
+                            print("\n---\n\(currentText)", terminator: "")
+                        }
+                        fflush(stdout)
+                        previousText = currentText
+                    }
+
+                    Thread.sleep(forTimeInterval: interval)
+                }
             } else {
-                print((payload["text"] as? String) ?? "")
+                // One-shot capture (original behavior)
+                let payload = try client.sendV2(method: "surface.read_text", params: params)
+                if jsonOutput {
+                    print(jsonString(payload))
+                } else {
+                    print((payload["text"] as? String) ?? "")
+                }
             }
 
         case "resize-pane":


### PR DESCRIPTION
## Summary

Adds a `--follow` flag to `capture-pane` that continuously streams terminal content changes at a configurable interval (default 0.5s).

Uses diff-based output: only prints new content when the screen changes. Handles three cases:
- **Text grew (append)**: prints only the new portion
- **Screen refreshed completely**: prints separator + full content
- **No change**: skips (no output)

Ignores SIGPIPE for clean exit when reader disconnects.

## Usage

```bash
cmux capture-pane --follow --workspace workspace:2
cmux capture-pane --follow --interval 0.3 --surface surface:1
```

## Motivation

This is needed for the claude-agent workspace bridge to stream terminal output to Emacs buffers in real-time, replacing the previous `pipe-pane --command cat` approach that had no diff-based deduplication.

## Test plan

- [ ] `cmux capture-pane --follow --workspace <id>` streams output continuously
- [ ] `Ctrl+C` cleanly exits without errors
- [ ] `--interval 0.3` changes poll rate
- [ ] No output when screen hasn't changed
- [ ] Append-only output for growing text (no full reprints)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `--follow` to `cmux capture-pane` to stream new pane output with diff-based printing and a configurable `--interval` (default 0.5s). Follow mode rejects `--json` and streams plain text only.

- **New Features**
  - `--follow` streams output; `--interval <s>` sets poll rate (default 0.5s). Help text updated in command and top-level `cmux --help`.
  - Diff-based printing: only new text; on full refresh prints separator + full content; no output when unchanged; uses full hasPrefix check for appends.
  - Robustness: auto-enables scrollback; validates `--interval` is numeric and > 0; flushes every poll to detect broken pipes; ignores SIGPIPE and exits cleanly; reconnects on transient errors; one-shot (incl. JSON) unchanged.

- **Bug Fixes**
  - Clear errors when `--json` is used with `--follow`, and when `--interval` is provided without a value.

<sup>Written for commit d8f0a7ea4869db1f3f70f4d9c08e082dc565e353. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--follow` streaming mode to continuously monitor capture-pane output.
  * Added `--interval <s>` to configure polling frequency for follow mode.
  * Follow mode shows only newly appended text or a refreshed snapshot when content changes; one-shot behavior (including JSON output) is preserved.

* **Documentation**
  * Updated capture-pane usage and examples to cover the new streaming mode.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3858)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->