### PR TITLE
feat: add native text input bar for terminal (mouse-click cursor positioning)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -239,6 +239,7 @@
 		B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3770BA00000000000000002 /* BrowserAutomation.swift */; };
 		D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */; };
 		A5001403 /* TerminalPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001413 /* TerminalPanelView.swift */; };
+		A5TB82727B9A2A39435BAC7C /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5TB4B3C5011665A440B808F /* TextBoxInput.swift */; };
 		A5001404 /* BrowserPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001414 /* BrowserPanelView.swift */; };
 		B0A500000000000000000001 /* BrowserOmnibarPerformanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
@@ -735,6 +736,7 @@
 		B3770BA00000000000000002 /* BrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAutomation.swift; sourceTree = "<group>"; };
 		D7AB00000000000000000008 /* BrowserPanel+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserPanel+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		A5001413 /* TerminalPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelView.swift; sourceTree = "<group>"; };
+		A5TB4B3C5011665A440B808F /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
 		A5001414 /* BrowserPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPanelView.swift; sourceTree = "<group>"; };
 		B0A500000000000000000002 /* BrowserOmnibarPerformanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserOmnibarPerformanceSupport.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
@@ -1173,6 +1175,7 @@
 				A5001417 /* WorkspaceContentView.swift */,
 				E30760000000000000000001 /* TmuxWorkspacePaneOverlayView.swift */,
 				A5001014 /* GhosttyConfig.swift */,
+				A5TB4B3C5011665A440B808F /* TextBoxInput.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
 				C13519000000000000000002 /* TerminalStartupEnvironment.swift */,
 				C13519000000000000000006 /* RestorableAgentTypes.swift */,
@@ -1879,6 +1882,7 @@
 				D7AB00000000000000000007 /* BrowserPanel+MoveTabToNewWorkspace.swift in Sources */,
 				A500RG01 /* ReactGrab.swift in Sources */,
 				A5001403 /* TerminalPanelView.swift in Sources */,
+				A5TB82727B9A2A39435BAC7C /* TextBoxInput.swift in Sources */,
 				A5001404 /* BrowserPanelView.swift in Sources */,
 				B0A500000000000000000001 /* BrowserOmnibarPerformanceSupport.swift in Sources */,
 				A5007420 /* BrowserPopupWindowController.swift in Sources */,

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -40,6 +40,9 @@ final class TerminalPanel: Panel, ObservableObject {
 
     var onRequestWorkspacePaneFlash: ((WorkspaceAttentionFlashReason) -> Void)?
 
+    // [TextBox] Text content for the bottom input bar.
+    @Published var textBoxContent: String = ""
+
     private var cancellables = Set<AnyCancellable>()
 
     var displayTitle: String {

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -21,25 +21,38 @@ struct TerminalPanelView: View {
     var body: some View {
         // Layering contract: terminal find UI is mounted in GhosttySurfaceScrollView (AppKit portal layer)
         // via `searchState`. Rendering `SurfaceSearchOverlay` in this SwiftUI container can hide it.
-        GhosttyTerminalView(
-            terminalSurface: panel.surface,
-            paneId: paneId,
-            isActive: isFocused,
-            isVisibleInUI: isVisibleInUI,
-            portalZPriority: portalPriority,
-            showsInactiveOverlay: isSplit && !isFocused,
-            showsUnreadNotificationRing: hasUnreadNotification && notificationPaneRingEnabled,
-            inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
-            inactiveOverlayOpacity: appearance.unfocusedOverlayOpacity,
-            searchState: panel.searchState,
-            reattachToken: panel.viewReattachToken,
-            onFocus: { _ in onFocus() },
-            onTriggerFlash: onTriggerFlash
-        )
-        // Keep the NSViewRepresentable identity stable across bonsplit structural updates.
-        // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
-        .id(panel.id)
-        .background(Color.clear)
+        VStack(spacing: 0) {
+            GhosttyTerminalView(
+                terminalSurface: panel.surface,
+                paneId: paneId,
+                isActive: isFocused,
+                isVisibleInUI: isVisibleInUI,
+                portalZPriority: portalPriority,
+                showsInactiveOverlay: isSplit && !isFocused,
+                showsUnreadNotificationRing: hasUnreadNotification && notificationPaneRingEnabled,
+                inactiveOverlayColor: appearance.unfocusedOverlayNSColor,
+                inactiveOverlayOpacity: appearance.unfocusedOverlayOpacity,
+                searchState: panel.searchState,
+                reattachToken: panel.viewReattachToken,
+                onFocus: { _ in onFocus() },
+                onTriggerFlash: onTriggerFlash
+            )
+            // Keep the NSViewRepresentable identity stable across bonsplit structural updates.
+            // This prevents transient teardown/recreate that can momentarily detach the hosted terminal view.
+            .id(panel.id)
+            .background(Color.clear)
+
+            // [TextBox] Native text input bar below the terminal.
+            TextBoxInputContainer(
+                text: $panel.textBoxContent,
+                surface: panel.surface,
+                backgroundColor: appearance.backgroundColor,
+                foregroundColor: appearance.foregroundColor,
+                font: NSFont.monospacedSystemFont(
+                    ofType: GhosttyConfig.load().fontSize, weight: .regular
+                )
+            )
+        }
     }
 }
 

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -48,9 +48,7 @@ struct TerminalPanelView: View {
                 surface: panel.surface,
                 backgroundColor: appearance.backgroundColor,
                 foregroundColor: appearance.foregroundColor,
-                font: NSFont.monospacedSystemFont(
-                    ofType: GhosttyConfig.load().fontSize, weight: .regular
-                )
+                font: appearance.font
             )
         }
     }
@@ -60,6 +58,7 @@ struct TerminalPanelView: View {
 struct PanelAppearance {
     let backgroundColor: NSColor
     let foregroundColor: NSColor
+    let font: NSFont
     let dividerColor: Color
     let unfocusedOverlayNSColor: NSColor
     let unfocusedOverlayOpacity: Double
@@ -71,6 +70,7 @@ struct PanelAppearance {
                 opacity: config.backgroundOpacity
             ),
             foregroundColor: config.foregroundColor,
+            font: NSFont.monospacedSystemFont(ofSize: config.fontSize, weight: .regular),
             dividerColor: Color(nsColor: config.resolvedSplitDividerColor),
             unfocusedOverlayNSColor: config.unfocusedSplitOverlayFill,
             unfocusedOverlayOpacity: config.unfocusedSplitOverlayOpacity

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -37,8 +37,6 @@ private enum TextBoxSubmit {
         if !trimmed.isEmpty {
             surface.sendText(trimmed)
         }
-        // Send Return as a separate write so bracket-paste-aware shells
-        // (zsh, Claude CLI) execute the pasted text.
         surface.sendText("\r")
     }
 }
@@ -263,9 +261,10 @@ final class InputTextView: NSTextView {
     }
 
     private func updateBorder(focused: Bool) {
-        guard let sv = superview?.superview else { return }
+        // container = the border-drawing NSView from makeNSView
+        guard let container = enclosingScrollView?.superview else { return }
         let opacity = focused ? Layout.focusedBorderOpacity : Layout.borderOpacity
-        sv.layer?.borderColor = (textColor ?? .white)
+        container.layer?.borderColor = (textColor ?? .white)
             .withAlphaComponent(opacity).cgColor
     }
 
@@ -298,7 +297,10 @@ final class InputTextView: NSTextView {
             }
         }
         if selector == #selector(NSResponder.cancelOperation(_:)) {
-            window?.resignFirstResponder()
+            // Release focus so the terminal's GhosttyNSView can reclaim it.
+            // makeFirstResponder(nil) resigns current first responder;
+            // clicking the terminal will then naturally restore focus there.
+            window?.makeFirstResponder(nil)
             return
         }
         super.doCommand(by: selector)

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -1,0 +1,339 @@
+/*
+ TextBoxInput.swift
+
+ Minimal native text input below the terminal.
+ Mouse click to position cursor, standard macOS editing, Enter to send.
+
+ The terminal's existing focus guards (`firstResponder is NSText` checks in
+ GhosttySurfaceScrollView) already skip stealing focus from NSTextView subclasses,
+ so no additional focus guard code is needed in upstream files.
+*/
+
+import AppKit
+import SwiftUI
+
+// MARK: - Layout
+
+private enum Layout {
+    static let padding: CGFloat = 6
+    static let contentSpacing: CGFloat = 4
+    static let sendButtonSize: CGFloat = 16
+    static let borderWidth: CGFloat = 1
+    static let cornerRadius: CGFloat = 5
+    static let borderOpacity: CGFloat = 0.3
+    static let focusedBorderOpacity: CGFloat = 0.55
+    static let textInset = NSSize(width: 4, height: 4)
+    static let minLines: Int = 1
+    static let maxLines: Int = 6
+    static let lineSpacing: CGFloat = 2
+    static let placeholderOpacity: CGFloat = 0.35
+}
+
+// MARK: - Submit
+
+private enum TextBoxSubmit {
+    static func send(_ text: String, via surface: TerminalSurface) {
+        let trimmed = text.trimmingCharacters(in: .newlines)
+        if !trimmed.isEmpty {
+            surface.sendText(trimmed)
+        }
+        // Send Return as a separate write so bracket-paste-aware shells
+        // (zsh, Claude CLI) execute the pasted text.
+        surface.sendText("\r")
+    }
+}
+
+// MARK: - Container View
+
+struct TextBoxInputContainer: View {
+    @Binding var text: String
+    let surface: TerminalSurface
+    let backgroundColor: NSColor
+    let foregroundColor: NSColor
+    let font: NSFont
+    @State private var textViewHeight: CGFloat = 0
+
+    private var adjustedFont: NSFont {
+        NSFont.monospacedSystemFont(
+            ofSize: max(1, font.pointSize + 1),
+            weight: .regular
+        )
+    }
+
+    private func heightForLines(_ count: Int) -> CGFloat {
+        let lineHeight = adjustedFont.ascender - adjustedFont.descender
+            + adjustedFont.leading + Layout.lineSpacing
+        return lineHeight * CGFloat(count) + Layout.textInset.height * 2
+    }
+
+    var body: some View {
+        let minH = heightForLines(Layout.minLines)
+        let maxH = heightForLines(Layout.maxLines)
+        let clamped = max(minH, min(maxH, textViewHeight))
+
+        HStack(alignment: .bottom, spacing: Layout.contentSpacing) {
+            TextBoxInputView(
+                text: $text,
+                textViewHeight: $textViewHeight,
+                font: adjustedFont,
+                foregroundColor: foregroundColor,
+                backgroundColor: backgroundColor,
+                onSubmit: { submit() }
+            )
+            .frame(height: clamped)
+
+            Button(action: submit) {
+                Image(systemName: "paperplane.fill")
+                    .font(.system(size: Layout.sendButtonSize))
+            }
+            .buttonStyle(SendButtonStyle(fg: Color(nsColor: foregroundColor)))
+            .help("Send")
+        }
+        .padding(.horizontal, Layout.padding)
+        .padding(.vertical, Layout.padding)
+        .background(Color(nsColor: backgroundColor))
+    }
+
+    private func submit() {
+        TextBoxSubmit.send(text, via: surface)
+        text = ""
+        textViewHeight = 0
+    }
+}
+
+// MARK: - NSViewRepresentable
+
+struct TextBoxInputView: NSViewRepresentable {
+    @Binding var text: String
+    @Binding var textViewHeight: CGFloat
+    let font: NSFont
+    let foregroundColor: NSColor
+    let backgroundColor: NSColor
+    let onSubmit: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(self) }
+
+    func makeNSView(context: Context) -> NSView {
+        let container = NSView()
+        container.wantsLayer = true
+        container.layer?.borderWidth = Layout.borderWidth
+        container.layer?.borderColor = foregroundColor
+            .withAlphaComponent(Layout.borderOpacity).cgColor
+        container.layer?.cornerRadius = Layout.cornerRadius
+        container.layer?.masksToBounds = true
+
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.borderType = .noBorder
+        scrollView.drawsBackground = false
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+
+        let tv = InputTextView()
+        tv.isRichText = false
+        tv.allowsUndo = true
+        tv.isEditable = true
+        tv.isSelectable = true
+        tv.usesFindPanel = false
+        tv.isVerticallyResizable = true
+        tv.isHorizontallyResizable = false
+        tv.autoresizingMask = [.width]
+        tv.minSize = NSSize(width: 0, height: 0)
+        tv.maxSize = NSSize(width: .greatestFiniteMagnitude, height: .greatestFiniteMagnitude)
+        tv.textContainerInset = Layout.textInset
+        tv.delegate = context.coordinator
+        tv.onSubmit = onSubmit
+
+        tv.drawsBackground = false
+        tv.insertionPointColor = foregroundColor
+        tv.textColor = foregroundColor
+        tv.selectedTextAttributes = [
+            .backgroundColor: foregroundColor,
+            .foregroundColor: backgroundColor.withAlphaComponent(1.0),
+        ]
+        tv.font = font
+        tv.typingAttributes = [
+            .font: font,
+            .foregroundColor: foregroundColor,
+        ]
+
+        if let tc = tv.textContainer {
+            tc.widthTracksTextView = true
+            tc.containerSize = NSSize(width: 0, height: .greatestFiniteMagnitude)
+        }
+
+        scrollView.documentView = tv
+        context.coordinator.textView = tv
+        context.coordinator.container = container
+
+        container.addSubview(scrollView)
+        NSLayoutConstraint.activate([
+            scrollView.topAnchor.constraint(equalTo: container.topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+            scrollView.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+        ])
+
+        return container
+    }
+
+    func updateNSView(_ container: NSView, context: Context) {
+        guard let scrollView = container.subviews.first as? NSScrollView,
+              let tv = scrollView.documentView as? InputTextView else { return }
+        context.coordinator.parent = self
+
+        if !tv.hasMarkedText(), tv.string != text {
+            tv.string = text
+            context.coordinator.recalcHeight(tv)
+        }
+
+        tv.onSubmit = onSubmit
+        tv.insertionPointColor = foregroundColor
+        tv.textColor = foregroundColor
+        tv.selectedTextAttributes = [
+            .backgroundColor: foregroundColor,
+            .foregroundColor: backgroundColor.withAlphaComponent(1.0),
+        ]
+        tv.typingAttributes = [
+            .font: font,
+            .foregroundColor: foregroundColor,
+        ]
+
+        let focused = tv.window?.firstResponder === tv
+        let opacity = focused ? Layout.focusedBorderOpacity : Layout.borderOpacity
+        container.layer?.borderColor = foregroundColor
+            .withAlphaComponent(opacity).cgColor
+    }
+
+    static func dismantleNSView(_ container: NSView, coordinator: Coordinator) {
+        guard let scrollView = container.subviews.first as? NSScrollView,
+              let tv = scrollView.documentView as? InputTextView else { return }
+        tv.undoManager?.removeAllActions(withTarget: tv)
+    }
+
+    // MARK: Coordinator
+
+    final class Coordinator: NSObject, NSTextViewDelegate {
+        var parent: TextBoxInputView
+        weak var textView: NSTextView?
+        weak var container: NSView?
+
+        init(_ parent: TextBoxInputView) { self.parent = parent }
+
+        func textDidChange(_ notification: Notification) {
+            guard let tv = notification.object as? NSTextView else { return }
+            parent.text = tv.string
+            recalcHeight(tv)
+        }
+
+        func recalcHeight(_ tv: NSTextView) {
+            guard let lm = tv.layoutManager, let tc = tv.textContainer else { return }
+            lm.ensureLayout(for: tc)
+            let h = lm.usedRect(for: tc).height + tv.textContainerInset.height * 2
+            parent.textViewHeight = h
+        }
+    }
+}
+
+// MARK: - InputTextView
+
+final class InputTextView: NSTextView {
+    var onSubmit: (() -> Void)?
+
+    deinit { undoManager?.removeAllActions(withTarget: self) }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    override func mouseDown(with event: NSEvent) {
+        window?.makeFirstResponder(self)
+        super.mouseDown(with: event)
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let r = super.becomeFirstResponder()
+        if r { updateBorder(focused: true) }
+        return r
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let r = super.resignFirstResponder()
+        if r { updateBorder(focused: false) }
+        return r
+    }
+
+    private func updateBorder(focused: Bool) {
+        guard let sv = superview?.superview else { return }
+        let opacity = focused ? Layout.focusedBorderOpacity : Layout.borderOpacity
+        sv.layer?.borderColor = (textColor ?? .white)
+            .withAlphaComponent(opacity).cgColor
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        if string.isEmpty {
+            let placeholder = "Commands or prompts here\u{2026}"
+            let color = (insertionPointColor ?? .white)
+                .withAlphaComponent(Layout.placeholderOpacity)
+            let attrs: [NSAttributedString.Key: Any] = [
+                .font: font ?? NSFont.systemFont(ofSize: 13),
+                .foregroundColor: color,
+            ]
+            let inset = textContainerInset
+            let origin = NSPoint(
+                x: inset.width + (textContainer?.lineFragmentPadding ?? 0),
+                y: inset.height
+            )
+            NSString(string: placeholder).draw(at: origin, withAttributes: attrs)
+        }
+    }
+
+    override func doCommand(by selector: Selector) {
+        if selector == #selector(NSResponder.insertNewline(_:)) ||
+           selector == #selector(NSResponder.insertNewlineIgnoringFieldEditor(_:)) {
+            let shifted = NSApp.currentEvent?.modifierFlags.contains(.shift) ?? false
+            if !shifted {
+                onSubmit?()
+                return
+            }
+        }
+        if selector == #selector(NSResponder.cancelOperation(_:)) {
+            window?.resignFirstResponder()
+            return
+        }
+        super.doCommand(by: selector)
+    }
+}
+
+// MARK: - Send Button Style
+
+private struct SendButtonStyle: ButtonStyle {
+    let fg: Color
+    func makeBody(configuration: Configuration) -> some View {
+        SendButtonBody(configuration: configuration, fg: fg)
+    }
+}
+
+private struct SendButtonBody: View {
+    let configuration: SendButtonStyle.Configuration
+    let fg: Color
+    @State private var hovered = false
+
+    private var bgOpacity: Double {
+        if configuration.isPressed { return 0.16 }
+        if hovered { return 0.08 }
+        return 0.0
+    }
+
+    var body: some View {
+        configuration.label
+            .foregroundColor(fg)
+            .padding(4)
+            .background(
+                RoundedRectangle(cornerRadius: 5, style: .continuous)
+                    .fill(fg.opacity(bgOpacity))
+            )
+            .onHover { hovered = $0 }
+            .animation(.easeOut(duration: 0.12), value: hovered)
+    }
+}


### PR DESCRIPTION
## Summary

Adds a minimal native text input bar below each terminal surface. This solves the problem where terminal input cannot be positioned with mouse clicks — users currently must use arrow keys to move the cursor for editing.

## Approach

Minimal-invasive — only **4 files changed** (+378/-19 lines) vs PR #2051's 12 files (+2203/-19 lines).

| File | Change |
|------|--------|
| `Sources/TextBoxInput.swift` | **New** (339 lines): NSTextView subclass, NSViewRepresentable bridge, send button |
| `Sources/Panels/TerminalPanel.swift` | +3 lines: `textBoxContent` property |
| `Sources/Panels/TerminalPanelView.swift` | +20/-19 lines: VStack wrapper + TextBoxInputContainer |
| `GhosttyTabs.xcodeproj/project.pbxproj` | +4 lines: file reference |

**No changes needed to:** GhosttyTerminalView, cmuxApp, Workspace, AppDelegate, ContentView, KeyboardShortcutSettings — leverages existing `sendText()` API and `firstResponder is NSText` focus guards.

## Features

- Mouse click to position cursor
- Standard macOS editing (Cmd+C/V/X/A/Z, Option+Arrow, double/triple-click)
- Enter to send, Shift+Enter for newline
- Auto-grow (1–6 lines)
- Theme sync with terminal colors/font
- Placeholder and send button
- Escape returns focus to terminal

## Test plan

- [ ] Mouse click positions cursor in input bar
- [ ] Enter sends text to terminal and executes
- [ ] Cmd+C/V/X/A — copy/paste/select all work
- [ ] Option+Arrow — word-level navigation
- [ ] Double-click selects word, triple-click selects line
- [ ] Terminal scrolling, split panes, tab switching unaffected
- [ ] Click terminal area — focus returns to terminal

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native text input bar below each terminal for precise editing with a real `NSTextView`. Uses the existing `sendText()` path and avoids changes to core terminal components.

- **New Features**
  - Click to position the cursor.
  - Standard macOS editing: Cmd+C/V/X/A/Z, Option+Arrows, double/triple-click.
  - Enter sends; Shift+Enter inserts a newline.
  - Auto-expands from 1 to 6 lines.
  - Matches terminal font and colors.
  - Placeholder and a send button.
  - Escape returns focus to the terminal.

- **Bug Fixes**
  - Fixed `NSFont.monospacedSystemFont(ofSize:)` compile error.
  - Moved font into `PanelAppearance` to avoid loading config in the view body.
  - Escape now uses `makeFirstResponder(nil)` to reliably drop focus.
  - Border highlight updates from the correct container view.
  - Empty submit sends only `\r` to match terminal Enter behavior.

<sup>Written for commit bee0785545b99a42927fabea083cf59258db6403. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a text input bar at the bottom of terminal panels for direct text submission.
  * Input bar auto-sizes with content, shows placeholder when empty, and indicates focus visually.
  * Press Enter to submit (Shift+Enter for newline); Escape cancels input. A Send button is also available.
  * Terminal appearance now respects the configured monospace font and size.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3861)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->