### PR TITLE
Narrow IME candidate key suppression

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -46,7 +46,6 @@ extension GhosttyNSView {
         guard hadMarkedTextBefore || hasMarkedTextAfter else {
             guard textInputHandledEvent, isBopomofoInputSource(inputSourceId) else { return false }
             return shouldKeepNoMarkedIMECommandInsideTextInput(event)
-                && !shouldAllowDeferredNumpadIMEFallback(event)
         }
 
         if before.text != after.text {
@@ -123,19 +122,6 @@ extension GhosttyNSView {
         default:
             return false
         }
-    }
-
-    func shouldAllowDeferredNumpadIMEFallback(_ event: NSEvent?) -> Bool {
-        guard let event,
-              let text = event.characters,
-              !text.isEmpty,
-              text.allSatisfy(\.isNumber) else {
-            return false
-        }
-        let flags = event.modifierFlags
-            .intersection(.deviceIndependentFlagsMask)
-            .subtracting([.function, .capsLock])
-        return flags == [.numericPad]
     }
 
 #if DEBUG

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -101,10 +101,12 @@ extension GhosttyNSView {
 
     func shouldRouteTextInputKeyEquivalentToKeyDown(_ event: NSEvent, inputSourceId: String?) -> Bool {
         guard event.type == .keyDown else { return false }
+        let resolvedInputSourceId = inputSourceId ?? KeyboardLayout.id
         if hasMarkedText() {
-            return shouldKeepIMECompositionCommandInsideTextInput(event)
+            return isInputMethodSource(resolvedInputSourceId)
+                && shouldKeepIMECompositionCommandInsideTextInput(event)
         }
-        return isBopomofoInputSource(inputSourceId ?? KeyboardLayout.id)
+        return isBopomofoInputSource(resolvedInputSourceId)
             && shouldKeepNoMarkedIMECommandInsideTextInput(event)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7757,6 +7757,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return
         }
 
+        // A forwarded keyDown owns its keyUp. Clear any stale IME suppression
+        // entry left by an earlier suppressed repeat for the same physical key.
+        imeSuppressedKeyUpKeyCodes.remove(event.keyCode)
+
         // Build the key event
         var keyEvent = ghostty_input_key_s()
         keyEvent.action = action

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7725,6 +7725,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // If the keyboard layout changed, an input method grabbed the event.
         // Sync preedit and return without sending the key to Ghostty.
         if !markedTextBefore, keyboardIdBefore != KeyboardLayout.id {
+            imeSuppressedKeyUpKeyCodes.insert(event.keyCode)
 #if DEBUG
             let syncPreeditStart = ProcessInfo.processInfo.systemUptime
 #endif

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7175,6 +7175,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let result = super.becomeFirstResponder()
         var shouldApplySurfaceFocus = false
         if result {
+            imeSuppressedKeyUpKeyCodes.removeAll()
             if let terminalSurface,
                AppDelegate.shared?.allowsTerminalKeyboardFocus(
                    workspaceId: terminalSurface.tabId,

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -8,6 +8,7 @@ import ObjectiveC.runtime
 @testable import cmux
 #endif
 
+@MainActor
 var cjkIMEInterpretKeyEventsHook: ((GhosttyNSView, [NSEvent]) -> Bool)?
 private var ghosttyPasteActionSwizzled = false
 private var ghosttyPasteActionHook: ((GhosttyNSView, Any?) -> Void)?
@@ -1121,6 +1122,10 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
 
         view.setMarkedText("한", selectedRange: NSRange(location: 0, length: 1), replacementRange: NSRange(location: NSNotFound, length: 0))
 
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+
         // Simulate Korean input source so shouldSendCommittedIMEConfirmKey fires
         KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Korean.2SetKorean"
         installCJKIMEInterpretKeyEventsSwizzle()
@@ -1130,8 +1135,9 @@ final class KoreanIMEReturnCommitRegressionTests: XCTestCase {
             return true
         }
         defer {
-            KeyboardLayout.debugInputSourceIdOverride = nil
-            cjkIMEInterpretKeyEventsHook = nil
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
         }
 
         var sawReturnPress = false
@@ -1178,6 +1184,9 @@ final class KoreanIMEMarkedTextLeakRegressionTests: XCTestCase {
             workingDirectory: nil
         )
         let hostedView = surface.hostedView
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
@@ -1187,8 +1196,9 @@ final class KoreanIMEMarkedTextLeakRegressionTests: XCTestCase {
         )
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
-            KeyboardLayout.debugInputSourceIdOverride = nil
-            cjkIMEInterpretKeyEventsHook = nil
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
             window.orderOut(nil)
         }
 

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -77,6 +77,54 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         ))
     }
 
+    private struct NoMarkedIMEKeyProbe {
+        let name: String
+        let text: String
+        let keyCode: UInt16
+    }
+
+    private var noMarkedNavigationKeyProbes: [NoMarkedIMEKeyProbe] {
+        [
+            NoMarkedIMEKeyProbe(name: "Left", text: "\u{F702}", keyCode: UInt16(kVK_LeftArrow)),
+            NoMarkedIMEKeyProbe(name: "Right", text: "\u{F703}", keyCode: UInt16(kVK_RightArrow)),
+            NoMarkedIMEKeyProbe(name: "Up", text: "\u{F700}", keyCode: UInt16(kVK_UpArrow)),
+            NoMarkedIMEKeyProbe(name: "Down", text: "\u{F701}", keyCode: UInt16(kVK_DownArrow)),
+            NoMarkedIMEKeyProbe(name: "Home", text: "\u{F729}", keyCode: UInt16(kVK_Home)),
+            NoMarkedIMEKeyProbe(name: "End", text: "\u{F72B}", keyCode: UInt16(kVK_End)),
+            NoMarkedIMEKeyProbe(name: "PageUp", text: "\u{F72C}", keyCode: UInt16(kVK_PageUp)),
+            NoMarkedIMEKeyProbe(name: "PageDown", text: "\u{F72D}", keyCode: UInt16(kVK_PageDown)),
+            NoMarkedIMEKeyProbe(name: "Space", text: " ", keyCode: UInt16(kVK_Space)),
+        ]
+    }
+
+    private func assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
+        _ inputSourceId: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let view = GhosttyNSView(frame: .zero)
+
+        for probe in noMarkedNavigationKeyProbes {
+            let event = try keyEvent(text: probe.text, keyCode: probe.keyCode, windowNumber: 0)
+
+            XCTAssertFalse(
+                view.shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
+                    markedTextBefore: "",
+                    markedSelectionBefore: NSRange(location: NSNotFound, length: 0),
+                    markedTextAfter: "",
+                    markedSelectionAfter: NSRange(location: NSNotFound, length: 0),
+                    accumulatedText: [],
+                    event: event,
+                    textInputHandledEvent: true,
+                    inputSourceId: inputSourceId
+                ),
+                "\(inputSourceId) should forward \(probe.name) to Ghostty when no composition is active",
+                file: file,
+                line: line
+            )
+        }
+    }
+
     func testSelectedRangeReturnsEmptyRangeWithoutSelectionOrMarkedText() {
         let view = GhosttyNSView(frame: .zero)
         let range = view.selectedRange()
@@ -695,6 +743,30 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testKoreanInputSourceDoesNotSwallowArrowKeysWithoutComposition() throws {
+        try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
+            "com.apple.inputmethod.Korean.2SetKorean"
+        )
+    }
+
+    func testJapaneseInputSourceDoesNotSwallowArrowKeysWithoutComposition() throws {
+        try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
+            "com.apple.inputmethod.Kotoeri.Japanese"
+        )
+    }
+
+    func testSimplifiedChinesePinyinDoesNotSwallowArrowKeysWithoutComposition() throws {
+        try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
+            "com.apple.inputmethod.SCIM.ITABC"
+        )
+    }
+
+    func testCangjieDoesNotSwallowArrowKeysWithoutComposition() throws {
+        try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
+            "com.apple.inputmethod.TCIM.Cangjie"
+        )
+    }
+
     func testUnmarkTextPreservesSuppressedKeyUpStateWithoutMarkedText() {
         let view = GhosttyNSView(frame: .zero)
         view.setIMETransientStateForTesting(
@@ -710,7 +782,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         XCTAssertFalse(view.zhuyinCandidateOpenRequestedForTesting)
     }
 
-    func testSuppressesInputMethodHandledKeyWithoutMarkedText() throws {
+    func testZhuyinPreCompositionStillUsesNoMarkedTextSuppression() throws {
         let view = GhosttyNSView(frame: .zero)
         let event = try keyEvent(
             text: "\u{F701}",

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -396,6 +396,50 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
+    func testDoesNotRouteNonInputMethodDeadKeyMarkedTextThroughKeyDown() throws {
+        let view = GhosttyNSView(frame: .zero)
+        view.setMarkedText(
+            "`",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: 0
+        )
+
+        XCTAssertFalse(
+            view.shouldRouteTextInputKeyEquivalentToKeyDown(
+                event,
+                inputSourceId: "com.apple.keylayout.USInternational"
+            ),
+            "Dead-key marked text should keep normal AppKit key-equivalent dispatch"
+        )
+    }
+
+    func testRoutesInputMethodMarkedTextCommandThroughKeyDown() throws {
+        let view = GhosttyNSView(frame: .zero)
+        view.setMarkedText(
+            "ㄓㄨ",
+            selectedRange: NSRange(location: 2, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        let event = try keyEvent(
+            text: "\u{F701}",
+            keyCode: UInt16(kVK_DownArrow),
+            windowNumber: 0
+        )
+
+        XCTAssertTrue(
+            view.shouldRouteTextInputKeyEquivalentToKeyDown(
+                event,
+                inputSourceId: "com.apple.inputmethod.TCIM.Zhuyin"
+            ),
+            "Input-method marked text should still route command keys through keyDown"
+        )
+    }
+
     func testSuppressesInputMethodCommandWhenMarkedTextIsUnchanged() throws {
         let view = GhosttyNSView(frame: .zero)
         let event = try keyEvent(

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -220,10 +220,12 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }
@@ -312,10 +314,12 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -597,4 +597,75 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             "The eventual keyUp must reach Ghostty after a forwarded keyDown clears stale suppression"
         )
     }
+
+    func testLayoutChangeIMEHandledKeyDownSuppressesMatchingKeyUp() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        let keyCode = UInt16(kVK_ANSI_5)
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        GhosttyNSView.debugTextInputEventHandler = { candidateView, _ in
+            guard candidateView === surfaceView else { return false }
+            KeyboardLayout.debugInputSourceIdOverride = "com.apple.keylayout.US"
+            return true
+        }
+
+        var forwardedPressCount = 0
+        var forwardedReleaseCount = 0
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.keycode == UInt32(keyCode) else { return }
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressCount += 1
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseCount += 1
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "5",
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "5",
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+        }
+
+        XCTAssertEqual(forwardedPressCount, 0)
+        XCTAssertTrue(
+            surfaceView.imeSuppressedKeyUpKeyCodesForTesting.contains(keyCode),
+            "Layout-change IME handling consumes keyDown and must suppress the matching keyUp"
+        )
+
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertEqual(
+            forwardedReleaseCount,
+            0,
+            "IME-consumed layout-change keyDown must not leave Ghostty with an unmatched release"
+        )
+        XCTAssertFalse(surfaceView.imeSuppressedKeyUpKeyCodesForTesting.contains(keyCode))
+    }
 }

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -413,25 +413,25 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
-    func testKoreanInputSourceDoesNotSwallowArrowKeysWithoutComposition() throws {
+    func testKoreanInputSourceDoesNotSwallowNavigationAndSpaceKeysWithoutComposition() throws {
         try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
             "com.apple.inputmethod.Korean.2SetKorean"
         )
     }
 
-    func testJapaneseInputSourceDoesNotSwallowArrowKeysWithoutComposition() throws {
+    func testJapaneseInputSourceDoesNotSwallowNavigationAndSpaceKeysWithoutComposition() throws {
         try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
             "com.apple.inputmethod.Kotoeri.Japanese"
         )
     }
 
-    func testSimplifiedChinesePinyinDoesNotSwallowArrowKeysWithoutComposition() throws {
+    func testSimplifiedChinesePinyinDoesNotSwallowNavigationAndSpaceKeysWithoutComposition() throws {
         try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
             "com.apple.inputmethod.SCIM.ITABC"
         )
     }
 
-    func testCangjieDoesNotSwallowArrowKeysWithoutComposition() throws {
+    func testCangjieDoesNotSwallowNavigationAndSpaceKeysWithoutComposition() throws {
         try assertInputSourceDoesNotSwallowNoMarkedIMECommandKeys(
             "com.apple.inputmethod.TCIM.Cangjie"
         )

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -459,7 +459,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
         )
     }
 
-    func testAllowsDeferredNumpadFallbackWithoutMarkedText() throws {
+    func testZhuyinNumpadInputForwardsWithoutMarkedText() throws {
         let view = GhosttyNSView(frame: .zero)
         let event = try keyEvent(
             text: "1",
@@ -477,7 +477,7 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
                 accumulatedText: [],
                 event: event,
                 textInputHandledEvent: true,
-                inputSourceId: "com.apple.inputmethod.TCIM.Pinyin"
+                inputSourceId: "com.apple.inputmethod.TCIM.Zhuyin"
             )
         )
     }

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import Carbon.HIToolbox
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV

--- a/cmuxTests/CJKIMEMarkedSelectionTests.swift
+++ b/cmuxTests/CJKIMEMarkedSelectionTests.swift
@@ -486,4 +486,71 @@ final class CJKIMEMarkedSelectionTests: XCTestCase {
             )
         )
     }
+
+    func testForwardedKeyDownClearsStaleIMESuppressedKeyUpEntry() throws {
+        let hostedTerminal = try makeHostedTerminalWindow()
+        let terminalSurface = hostedTerminal.surface
+        let window = hostedTerminal.window
+        let surfaceView = hostedTerminal.surfaceView
+        let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
+        defer {
+            GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
+            KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
+            window.orderOut(nil)
+            withExtendedLifetime(terminalSurface) {}
+        }
+
+        let keyCode = UInt16(kVK_DownArrow)
+        surfaceView.setIMETransientStateForTesting(suppressedKeyUpKeyCodes: [keyCode])
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.TCIM.Zhuyin"
+        GhosttyNSView.debugTextInputEventHandler = { _, _ in false }
+
+        var forwardedPressCount = 0
+        var forwardedReleaseCount = 0
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyEventObserver?(keyEvent)
+            guard keyEvent.keycode == UInt32(keyCode) else { return }
+            if keyEvent.action == GHOSTTY_ACTION_PRESS {
+                forwardedPressCount += 1
+            } else if keyEvent.action == GHOSTTY_ACTION_RELEASE {
+                forwardedReleaseCount += 1
+            }
+        }
+
+        let keyDown = try keyEvent(
+            text: "\u{F701}",
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+        let keyUp = try keyEvent(
+            type: .keyUp,
+            text: "\u{F701}",
+            keyCode: keyCode,
+            windowNumber: window.windowNumber
+        )
+
+        window.makeFirstResponder(surfaceView)
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyDown(with: keyDown)
+        }
+
+        XCTAssertEqual(forwardedPressCount, 1)
+        XCTAssertFalse(
+            surfaceView.imeSuppressedKeyUpKeyCodesForTesting.contains(keyCode),
+            "Forwarded keyDown must clear stale IME keyUp suppression for the same key"
+        )
+
+        withExtendedLifetime(terminalSurface) {
+            surfaceView.keyUp(with: keyUp)
+        }
+
+        XCTAssertEqual(
+            forwardedReleaseCount,
+            1,
+            "The eventual keyUp must reach Ghostty after a forwarded keyDown clears stale suppression"
+        )
+    }
 }

--- a/cmuxTests/TraditionalChineseIMENumpadRegressionTests.swift
+++ b/cmuxTests/TraditionalChineseIMENumpadRegressionTests.swift
@@ -252,10 +252,12 @@ final class TraditionalChineseIMENumpadRegressionTests: XCTestCase {
         let previousKeyEventObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
         let previousInputSourceOverride = KeyboardLayout.debugInputSourceIdOverride
         let previousInterpretHook = cjkIMEInterpretKeyEventsHook
+        let previousTextInputEventHandler = GhosttyNSView.debugTextInputEventHandler
         defer {
             GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyEventObserver
             KeyboardLayout.debugInputSourceIdOverride = previousInputSourceOverride
             cjkIMEInterpretKeyEventsHook = previousInterpretHook
+            GhosttyNSView.debugTextInputEventHandler = previousTextInputEventHandler
             window.orderOut(nil)
             withExtendedLifetime(terminalSurface) {}
         }


### PR DESCRIPTION
## Summary
- Narrows no-marked-text IME suppression to Bopomofo/Zhuyin candidate keys instead of every input method
- Routes relevant terminal key-equivalent events through the text-input path so AppKit can consume the intended candidate commands
- Adds regression coverage that Korean, Japanese, Pinyin, and Cangjie do not swallow navigation/space keys when no composition is active

Fixes #3762

## Testing
- git diff --check
- git diff --cached --check
- Local tests not run per repository/user instructions; CI is the verification gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches macOS keyboard/IME event routing in `AppDelegate` and `GhosttyTerminalView`, which can regress shortcuts or key press/release pairing across input sources.
> 
> **Overview**
> **Refines IME key suppression/routing for CJK input.** No-marked-text suppression is narrowed to Zhuyin/Bopomofo candidate/navigation keys, while marked-text command keys are only retained inside the text-input path for true input-method sources (not dead-key layouts).
> 
> **Improves event dispatch correctness.** Window-level key equivalents can now be re-routed into `GhosttyNSView.keyDown` when they belong to IME text input, and `GhosttyTerminalView` tracks IME-consumed keyDowns to suppress the matching `keyUp` so Ghostty doesn’t receive unmatched releases.
> 
> **Strengthens test coverage and hooks.** Replaces fragile `interpretKeyEvents` swizzling with a debug text-input handler hook and adds regression tests covering Zhuyin pre/post-composition, layout-change consumption, and ensuring other IMEs (Korean/Japanese/Pinyin/Cangjie) don’t swallow navigation/space without composition.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcc9a37e07c7ed581005102ae6cd6cfb93e15ca7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS IME handling and key-equivalent routing to prevent lost/duplicated navigation, space, Return, and key-up events; ensured key-up delivery stays in sync after IME interactions.

* **Tests**
  * Expanded CJK coverage (Zhuyin, Korean, Japanese, Cangjie, SCIM) for pre/post-composition, no-marked-text, and command-key behaviors.

* **Chores**
  * Added deterministic debug/test hooks and preserved/restored debug state to make IME-event tests reliable.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3867)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->