### PR TITLE
Fix #3863: pass Claude subcommands through the cmux wrapper

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -261,13 +261,70 @@ encode_launch_argv() {
     } | base64 | tr -d '\n'
 }
 
-# Pass through subcommands that don't support session/hook flags.
-case "${1:-}" in
-    mcp|config|api-key|rc|remote-control)
-        clear_inherited_claude_auth_selection_env
-        exec "$REAL_CLAUDE" "$@"
-        ;;
-esac
+claude_option_consumes_value() {
+    case "$1" in
+        --add-dir|--agent|--agents|--allowedTools|--allowed-tools|\
+        --append-system-prompt|--betas|--debug-file|--disallowedTools|\
+        --disallowed-tools|--effort|--fallback-model|--file|\
+        --input-format|--json-schema|--max-budget-usd|--mcp-config|\
+        --model|-n|--name|--output-format|--permission-mode|--plugin-dir|\
+        --plugin-url|--remote-control-session-name-prefix|--setting-sources|\
+        --settings|--system-prompt|--tools)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+claude_interactive_entry_flag() {
+    case "$1" in
+        --print|--print=*|-p|--resume|--resume=*|-r|--continue|-c|\
+        --session-id|--session-id=*|--remote-control|--remote-control=*|\
+        --from-pr|--from-pr=*|--worktree|--worktree=*)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+should_inject_claude_hooks() {
+    (( $# == 0 )) && return 0
+
+    local arg
+    local skip_next=false
+    for arg in "$@"; do
+        if [[ "$skip_next" == true ]]; then
+            skip_next=false
+            continue
+        fi
+        case "$arg" in
+            --)
+                return 0
+                ;;
+            -*)
+                if claude_interactive_entry_flag "$arg"; then
+                    return 0
+                fi
+                if [[ "$arg" != *=* ]] && claude_option_consumes_value "$arg"; then
+                    skip_next=true
+                fi
+                continue
+                ;;
+            *)
+                return 1
+                ;;
+        esac
+    done
+
+    return 0
+}
+
+# Only inject hooks for Claude session entrypoints. Other command-like
+# invocations pass through so new Claude subcommands do not need cmux changes.
+if ! should_inject_claude_hooks "$@"; then
+    clear_inherited_claude_auth_selection_env
+    exec "$REAL_CLAUDE" "$@"
+fi
 
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
 # independent sessions even when the parent shell was launched from Claude Code.

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -280,7 +280,7 @@ claude_interactive_entry_flag() {
     case "$1" in
         --print|--print=*|-p|--resume|--resume=*|-r|--continue|-c|\
         --session-id|--session-id=*|--remote-control|--remote-control=*|\
-        --from-pr|--from-pr=*|--worktree|--worktree=*)
+        --from-pr|--from-pr=*|--worktree|--worktree=*|-w|-w=*)
             return 0
             ;;
     esac

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -267,7 +267,7 @@ claude_option_consumes_value() {
         --append-system-prompt|--betas|--debug-file|--disallowedTools|\
         --disallowed-tools|--effort|--fallback-model|--file|\
         --input-format|--json-schema|--max-budget-usd|--mcp-config|\
-        --model|-n|--name|--output-format|--permission-mode|--plugin-dir|\
+        --model|-m|-n|--name|--output-format|--permission-mode|--plugin-dir|\
         --plugin-url|--remote-control-session-name-prefix|--setting-sources|\
         --settings|--system-prompt|--tools)
             return 0

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -326,7 +326,7 @@ exit 0
 def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: list[str]) -> None:
     code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, hook_cmux_bin, _ = run_wrapper(
         socket_state="live",
-        argv=["hello"],
+        argv=["--print", "hello"],
     )
     expect(code == 0, f"live socket: wrapper exited {code}: {stderr}", failures)
     expect("--settings" in real_argv, f"live socket: missing --settings in args: {real_argv}", failures)
@@ -337,7 +337,7 @@ def test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures: 
             f"live socket: wrapper should not unlock bypass permissions via {flag}: {real_argv}",
             failures,
         )
-    expect(real_argv[-1] == "hello", f"live socket: expected original arg to pass through, got {real_argv}", failures)
+    expect(real_argv[-2:] == ["--print", "hello"], f"live socket: expected original print args to pass through, got {real_argv}", failures)
     expect(any(" ping" in line for line in cmux_log), f"live socket: expected cmux ping, got {cmux_log}", failures)
     expect(
         any("timeout=0.75" in line for line in cmux_log),
@@ -416,15 +416,62 @@ def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> 
     expect(argv[0].endswith("/real-bin/claude"), f"plain claude: expected real claude executable, got {argv}", failures)
 
 
-def test_agents_subcommand_bypasses_hook_injection(failures: list[str]) -> None:
+def test_plain_claude_injects_hook_flags(failures: list[str]) -> None:
     code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
         socket_state="live",
-        argv=["agents"],
+        argv=[],
     )
-    expect(code == 0, f"agents passthrough: wrapper exited {code}: {stderr}", failures)
-    expect(real_argv == ["agents"], f"agents passthrough: expected raw argv, got {real_argv}", failures)
-    expect("--settings" not in real_argv, f"agents passthrough: expected no --settings injection, got {real_argv}", failures)
-    expect("--session-id" not in real_argv, f"agents passthrough: expected no --session-id injection, got {real_argv}", failures)
+    expect(code == 0, f"plain claude injection: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"plain claude injection: expected --settings injection, got {real_argv}", failures)
+    expect("--session-id" in real_argv, f"plain claude injection: expected --session-id injection, got {real_argv}", failures)
+
+
+def test_print_invocation_injects_hook_flags(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["--print", "hi"],
+    )
+    expect(code == 0, f"print injection: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"print injection: expected --settings injection, got {real_argv}", failures)
+    expect("--session-id" in real_argv, f"print injection: expected --session-id injection, got {real_argv}", failures)
+    expect(real_argv[-2:] == ["--print", "hi"], f"print injection: expected print args preserved, got {real_argv}", failures)
+
+
+def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> None:
+    subcommands = [
+        "mcp",
+        "config",
+        "api-key",
+        "rc",
+        "remote-control",
+        "agents",
+        "doctor",
+        "update",
+        "upgrade",
+        "auth",
+        "project",
+        "setup-token",
+        "install",
+        "daemon",
+    ]
+    for subcommand in subcommands:
+        code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=[subcommand],
+        )
+        expect(code == 0, f"{subcommand} passthrough: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == [subcommand], f"{subcommand} passthrough: expected raw argv, got {real_argv}", failures)
+        expect("--settings" not in real_argv, f"{subcommand} passthrough: expected no --settings injection, got {real_argv}", failures)
+        expect("--session-id" not in real_argv, f"{subcommand} passthrough: expected no --session-id injection, got {real_argv}", failures)
+
+    code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["--model", "sonnet", "agents"],
+    )
+    expect(code == 0, f"agents after global option passthrough: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["--model", "sonnet", "agents"], f"agents after global option passthrough: expected raw argv, got {real_argv}", failures)
+    expect("--settings" not in real_argv, f"agents after global option passthrough: expected no --settings injection, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"agents after global option passthrough: expected no --session-id injection, got {real_argv}", failures)
 
 
 def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures: list[str]) -> None:
@@ -439,7 +486,7 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
         "CLAUDE_CODE_USE_VERTEX": "1",
     }
     code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["hello"],
+        argv=["--print", "hello"],
         inherited_env=inherited,
     )
     expect(code == 0, f"fresh auth env: wrapper exited {code}: {stderr}", failures)
@@ -524,7 +571,7 @@ def test_live_socket_enforces_heap_cap_for_space_separated_flag(failures: list[s
     restored = "--max-old-space-size=2048 --trace-warnings"
     code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
         socket_state="live",
-        argv=["hello"],
+        argv=["--print", "hello"],
         node_options=existing,
     )
     expect(code == 0, f"space-separated heap flag: wrapper exited {code}: {stderr}", failures)
@@ -550,7 +597,7 @@ def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[
         bad_tmpdir.write_text("occupied", encoding="utf-8")
         code, real_argv, cmux_log, stderr, claudecode, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
-            argv=["hello"],
+            argv=["--print", "hello"],
             tmpdir=str(bad_tmpdir),
         )
     expect(code == 0, f"tmpdir failure: wrapper exited {code}: {stderr}", failures)
@@ -565,9 +612,9 @@ def test_live_socket_tmpdir_failure_skips_node_options_injection(failures: list[
 
 def test_live_socket_preserves_explicit_bypass_availability_flag(failures: list[str]) -> None:
     cases = [
-        ("allow/plain", ["--allow-dangerously-skip-permissions", "hello"], True, "--allow-dangerously-skip-permissions"),
+        ("allow/print", ["--allow-dangerously-skip-permissions", "--print", "hello"], True, "--allow-dangerously-skip-permissions"),
         ("allow/resume", ["--allow-dangerously-skip-permissions", "--resume", "some-session-id"], False, "--allow-dangerously-skip-permissions"),
-        ("short/plain", ["--dangerously-skip-permissions", "hello"], True, "--dangerously-skip-permissions"),
+        ("short/print", ["--dangerously-skip-permissions", "--print", "hello"], True, "--dangerously-skip-permissions"),
         ("short/resume", ["--dangerously-skip-permissions", "--resume", "some-session-id"], False, "--dangerously-skip-permissions"),
     ]
     for label, argv, expects_session_id, expected_flag in cases:
@@ -592,7 +639,7 @@ def test_live_socket_stale_mktemp_literal_does_not_warn(failures: list[str]) -> 
         (guard_dir / "restore-node-options.XXXXXX.cjs").write_text("stale", encoding="utf-8")
         code, _, _, stderr, _, node_options, runtime_node_options, child_node_options, _, _ = run_wrapper(
             socket_state="live",
-            argv=["hello"],
+            argv=["--print", "hello"],
             tmpdir=str(tmpdir),
         )
     expect(code == 0, f"stale mktemp literal: wrapper exited {code}: {stderr}", failures)
@@ -669,7 +716,9 @@ def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
-    test_agents_subcommand_bypasses_hook_injection(failures)
+    test_plain_claude_injects_hook_flags(failures)
+    test_print_invocation_injects_hook_flags(failures)
+    test_command_like_invocations_bypass_hook_injection(failures)
     test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -448,6 +448,22 @@ def test_short_worktree_invocation_injects_hook_flags(failures: list[str]) -> No
     expect(real_argv[-2:] == ["-w", "feature-worktree"], f"short worktree injection: expected worktree args preserved, got {real_argv}", failures)
 
 
+def test_value_options_before_print_do_not_hide_interactive_entry(failures: list[str]) -> None:
+    cases = [
+        ("short model", ["-m", "claude-opus-4", "--print", "hello"]),
+        ("agents json", ["--agents", '{"reviewer":{}}', "--print", "hello"]),
+    ]
+    for label, argv in cases:
+        code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=argv,
+        )
+        expect(code == 0, f"{label} value-option injection: wrapper exited {code}: {stderr}", failures)
+        expect("--settings" in real_argv, f"{label} value-option injection: expected --settings injection, got {real_argv}", failures)
+        expect("--session-id" in real_argv, f"{label} value-option injection: expected --session-id injection, got {real_argv}", failures)
+        expect(real_argv[-len(argv):] == argv, f"{label} value-option injection: expected original args preserved, got {real_argv}", failures)
+
+
 def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> None:
     subcommands = [
         "mcp",
@@ -730,6 +746,7 @@ def main() -> int:
     test_plain_claude_injects_hook_flags(failures)
     test_print_invocation_injects_hook_flags(failures)
     test_short_worktree_invocation_injects_hook_flags(failures)
+    test_value_options_before_print_do_not_hide_interactive_entry(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -416,6 +416,17 @@ def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> 
     expect(argv[0].endswith("/real-bin/claude"), f"plain claude: expected real claude executable, got {argv}", failures)
 
 
+def test_agents_subcommand_bypasses_hook_injection(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["agents"],
+    )
+    expect(code == 0, f"agents passthrough: wrapper exited {code}: {stderr}", failures)
+    expect(real_argv == ["agents"], f"agents passthrough: expected raw argv, got {real_argv}", failures)
+    expect("--settings" not in real_argv, f"agents passthrough: expected no --settings injection, got {real_argv}", failures)
+    expect("--session-id" not in real_argv, f"agents passthrough: expected no --session-id injection, got {real_argv}", failures)
+
+
 def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures: list[str]) -> None:
     inherited = {
         "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
@@ -658,6 +669,7 @@ def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
+    test_agents_subcommand_bypasses_hook_injection(failures)
     test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -437,6 +437,17 @@ def test_print_invocation_injects_hook_flags(failures: list[str]) -> None:
     expect(real_argv[-2:] == ["--print", "hi"], f"print injection: expected print args preserved, got {real_argv}", failures)
 
 
+def test_short_worktree_invocation_injects_hook_flags(failures: list[str]) -> None:
+    code, real_argv, _, stderr, _, _, _, _, _, _ = run_wrapper(
+        socket_state="live",
+        argv=["-w", "feature-worktree"],
+    )
+    expect(code == 0, f"short worktree injection: wrapper exited {code}: {stderr}", failures)
+    expect("--settings" in real_argv, f"short worktree injection: expected --settings injection, got {real_argv}", failures)
+    expect("--session-id" in real_argv, f"short worktree injection: expected --session-id injection, got {real_argv}", failures)
+    expect(real_argv[-2:] == ["-w", "feature-worktree"], f"short worktree injection: expected worktree args preserved, got {real_argv}", failures)
+
+
 def test_command_like_invocations_bypass_hook_injection(failures: list[str]) -> None:
     subcommands = [
         "mcp",
@@ -718,6 +729,7 @@ def main() -> int:
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_plain_claude_injects_hook_flags(failures)
     test_print_invocation_injects_hook_flags(failures)
+    test_short_worktree_invocation_injects_hook_flags(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)


### PR DESCRIPTION
## Summary
- fixes #3863 by changing the Claude wrapper from a fragile pass-through subcommand allowlist to an inverted injection policy
- keeps hook/session injection for Claude session entrypoints: no-arg launches, --print/-p, --resume/-r, --continue/-c, and existing session-like flags
- passes command-like invocations such as agents, doctor, update, upgrade, auth, project, setup-token, install, and daemon to the real Claude binary without --session-id or --settings

## Option decision
I chose Option B. Option A would extend the hardcoded allowlist and fix the current agents breakage, but the same bug would recur whenever Claude adds or renames a flag-incompatible subcommand. Option B makes pass-through the default for command-like invocations, so unknown future subcommands do not need cmux changes before they behave like they do outside cmux.

I verified current claude --help lists the key current commands including agents, auth, doctor, install, mcp, project, setup-token, and update|upgrade. Because this PR uses Option B, daemon and any future command-like entrypoint are covered without needing to be present in today's help output.

## Tests
- Added the first commit as a failing regression test for claude agents receiving injected flags.
- Expanded wrapper harness coverage for raw subcommand pass-through, no-arg injection, and --print injection.
- Local syntax checks only: bash -n Resources/bin/claude, python3 -m py_compile tests/test_claude_wrapper_hooks.py, git diff --check. Per repo policy, behavioral tests run in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes argument-parsing and hook/session injection behavior for all `claude` invocations under cmux, which could accidentally skip hooks or inject flags into unsupported command modes. Risk is mitigated by expanded regression tests covering interactive entry flags and subcommand passthrough cases.
> 
> **Overview**
> Updates the `Resources/bin/claude` cmux wrapper from a brittle subcommand allowlist to an **inverted policy**: inject `--settings`/`--session-id` only when the argv looks like a Claude session entrypoint (no args or interactive flags like `--print`, `--resume`, `--continue`, `--worktree`/`-w`, etc.), and otherwise exec the real `claude` binary unchanged.
> 
> Adds wrapper argument scanning to recognize flags that *consume values* so options like `-m <model>` don’t hide an interactive entry flag later in argv. Expands `tests/test_claude_wrapper_hooks.py` to cover injection for plain/print/worktree launches and to assert raw passthrough for command-like invocations (including when preceded by global options).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit adae99743e5babb10b72ba092a74701d50f2e43c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3863 by updating the `claude` cmux wrapper to inject session hooks only for interactive launches and pass command-like subcommands straight to the real `claude` binary. Also treats `--worktree`/`-w` as session entrypoints and preserves injection when value-taking options appear before `--print`.

- **Bug Fixes**
  - Default pass-through for subcommands like `agents`, `doctor`, `update`, `upgrade`, `auth`, `project`, `setup-token`, `install`, `daemon`, `mcp`, `config`, `api-key`, `rc`, `remote-control` (no `--session-id` or `--settings`), including when preceded by global options.
  - Keep injection for session entrypoints: no-arg launches, `--print`/`-p`, `--resume`/`-r`, `--continue`/`-c`, `--worktree`/`-w`, and other session-like flags.
  - Detect value-taking options before interactive flags (`-m` as `--model`, `--agents <json>`) so these values don’t hide later `--print` and injection still occurs.
  - Added regression tests for pass-through and injection behavior, including `-w` and value-option-before-`--print` cases.

<sup>Written for commit adae99743e5babb10b72ba092a74701d50f2e43c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

