### PR TITLE
Add --bracketed flag to paste-buffer for bracketed paste support

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7676,7 +7676,7 @@ struct CMUXCLI {
             """
         case "paste-buffer":
             return """
-            Usage: cmux paste-buffer [--name <name>] [--workspace <id|ref>] [--surface <id|ref>]
+            Usage: cmux paste-buffer [--name <name>] [--workspace <id|ref>] [--surface <id|ref>] [--bracketed]
 
             Paste a named tmux-compat buffer into a surface.
 
@@ -7684,6 +7684,7 @@ struct CMUXCLI {
               --name <name>         Buffer name (default: default)
               --workspace <id|ref>  Workspace context (default: $CMUX_WORKSPACE_ID)
               --surface <id|ref>    Surface context (default: focused surface)
+              --bracketed           Send via paste input path (bracketed paste; safe for vim-mode editors)
             """
         case "list-buffers":
             return """
@@ -14430,7 +14431,7 @@ struct CMUXCLI {
           bind-key | unbind-key | copy-mode
           set-buffer [--name <name>] <text>
           list-buffers
-          paste-buffer [--name <name>] [--workspace <id|ref>] [--surface <id|ref>]
+          paste-buffer [--name <name>] [--workspace <id|ref>] [--surface <id|ref>] [--bracketed]
           respawn-pane [--workspace <id|ref>] [--surface <id|ref>] [--command <cmd>]
           display-message [-p|--print] <text>
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -12348,7 +12348,9 @@ struct CMUXCLI {
             guard let buffer = store.buffers[name] else {
                 throw CLIError(message: "Buffer not found: \(name)")
             }
+            let bracketed = commandArgs.contains("--bracketed")
             var params: [String: Any] = ["text": buffer]
+            if bracketed { params["paste"] = true }
             let wsId = try normalizeWorkspaceHandle(workspaceArg, client: client, allowCurrent: true)
             if let wsId { params["workspace_id"] = wsId }
             let sfId = try normalizeSurfaceHandle(surfaceArg, client: client, workspaceHandle: wsId, allowFocused: true)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5675,8 +5675,12 @@ class TerminalController {
             #if DEBUG
             let sendStart = ProcessInfo.processInfo.systemUptime
             #endif
+            let usePastePath = (params["paste"] as? Bool) == true
             let queued: Bool
-            if let surface = terminalPanel.surface.surface {
+            if usePastePath {
+                terminalPanel.sendText(text)
+                queued = false
+            } else if let surface = terminalPanel.surface.surface {
                 sendSocketText(text, surface: surface)
                 // Ensure we present a new frame after injecting input so snapshot-based tests (and
                 // socket-driven agents) can observe the updated terminal without requiring a focus

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5679,7 +5679,12 @@ class TerminalController {
             let queued: Bool
             if usePastePath {
                 terminalPanel.sendText(text)
-                queued = false
+                queued = terminalPanel.surface.surface == nil
+                if !queued {
+                    // Match the non-paste path so snapshot tests and socket-driven
+                    // agents see the freshly-pasted text without needing focus.
+                    terminalPanel.surface.forceRefresh(reason: "terminalController.v2SurfaceSendText.paste")
+                }
             } else if let surface = terminalPanel.surface.surface {
                 sendSocketText(text, surface: surface)
                 // Ensure we present a new frame after injecting input so snapshot-based tests (and


### PR DESCRIPTION
Addresses #2396 — same `ghostty_surface_key` vs paste-path mismatch, but for `paste-buffer` instead of `send`. Symptom here: vim-mode editors eat the first character (e.g. Claude Code with `editorMode: "vim"`: "Alright" → "lright").

## Summary

- Adds `--bracketed` flag to `paste-buffer` that routes text through the paste input path ([`ghostty_surface_text` / `textCallback`](https://github.com/manaflow-ai/cmux/blob/main/ghostty/src/Surface.zig#L3292)) instead of the key event path (`ghostty_surface_key`).
- Applications with vim-mode keybindings (e.g., Claude Code with `editorMode: "vim"`) currently interpret the first character of `paste-buffer` text as a command. For example, pasting "Alright" → `A` enters append-after mode → user sees "lright".
- With `--bracketed`, text is delivered as a paste event, matching Cmd+V behavior. No character is consumed.
- Without the flag, behavior is unchanged.

The V2 API `surface.send_text` accepts a `"paste": true` parameter to select the paste input path.

## Testing

- Tested in cmux DEV with Claude Code in vim mode (`editorMode: "vim"`)
- Without `--bracketed`: first character eaten by vim
- With `--bracketed`: full text preserved
- Multi-line paste: all lines arrive as one block in the prompt, not executed separately
- Tested in both vim normal mode and insert mode — both work correctly
- Default `paste-buffer` (no flag): unchanged behavior verified
- `send`: unchanged behavior verified

## Demo Video

N/A — CLI-only flag, no visual change.

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `--bracketed` flag to `paste-buffer` to send text via the paste input path for bracketed paste. Matches Cmd+V and stops vim‑mode from eating the first character; updates help text, forces a post‑paste refresh for tests/agents, and reports the queued state correctly; default behavior is unchanged.

<sup>Written for commit 9a261aabf09edf6e253f9cee00944314729e558a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--bracketed` flag to the paste-buffer command, enabling bracketed paste mode for terminal input.

* **Bug Fixes / Reliability**
  * Improved paste handling so pasted text is queued or applied with a forced terminal refresh to keep displayed output consistent.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3872)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
