### PR TITLE
Fix #3803: clear sidebar freeze after color/reorder so workspace row keeps updating

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12514,7 +12514,10 @@ private struct TabItemView: View, Equatable {
         .contentShape(Rectangle())
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay {
-            SidebarWorkspaceRowHoverTracker(rowInteractionState: $rowInteractionState)
+            SidebarWorkspaceRowHoverTracker(
+                rowInteractionState: $rowInteractionState,
+                onMenuTrackingEnded: flushWorkspaceContextMenuFreezeIfLive
+            )
         }
         .overlay {
             MiddleClickCapture {
@@ -12634,8 +12637,7 @@ private struct TabItemView: View, Equatable {
                 }
                 .onDisappear {
                     rowInteractionState.contextMenuDidDisappear()
-                    frozenPresentation = nil
-                    flushDeferredWorkspaceObservationInvalidation()
+                    flushWorkspaceContextMenuFreezeIfLive()
                 }
         }
     }
@@ -12646,7 +12648,7 @@ private struct TabItemView: View, Equatable {
             current: workspaceSnapshotStorage,
             next: nextSnapshot,
             force: force,
-            contextMenuVisible: rowInteractionState.contextMenuVisible
+            freezesSidebarWorkspaceDetails: rowInteractionState.freezesSidebarWorkspaceDetails
         )
 
         if workspaceSnapshotStorage != decision.workspaceSnapshotStorage {
@@ -12667,6 +12669,12 @@ private struct TabItemView: View, Equatable {
             workspaceSnapshotStorage = pendingSnapshot
         }
         contextMenuState.pendingWorkspaceSnapshot = nil
+    }
+
+    private func flushWorkspaceContextMenuFreezeIfLive() {
+        guard !rowInteractionState.freezesSidebarWorkspaceDetails else { return }
+        frozenPresentation = nil
+        flushDeferredWorkspaceObservationInvalidation()
     }
 
     private func contextMenuLabel(multi: String, single: String, isMulti: Bool) -> String {

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverTracker.swift
@@ -3,9 +3,13 @@ import SwiftUI
 
 struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
     @Binding var rowInteractionState: SidebarWorkspaceRowInteractionState
+    var onMenuTrackingEnded: () -> Void = {}
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(rowInteractionState: $rowInteractionState)
+        Coordinator(
+            rowInteractionState: $rowInteractionState,
+            onMenuTrackingEnded: onMenuTrackingEnded
+        )
     }
 
     func makeNSView(context: Context) -> SidebarWorkspaceRowHoverTrackingView {
@@ -22,13 +26,19 @@ struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
 
     func updateNSView(_ nsView: SidebarWorkspaceRowHoverTrackingView, context: Context) {
         context.coordinator.rowInteractionState = $rowInteractionState
+        context.coordinator.onMenuTrackingEnded = onMenuTrackingEnded
     }
 
     final class Coordinator {
         var rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>
+        var onMenuTrackingEnded: () -> Void
 
-        init(rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>) {
+        init(
+            rowInteractionState: Binding<SidebarWorkspaceRowInteractionState>,
+            onMenuTrackingEnded: @escaping () -> Void = {}
+        ) {
             self.rowInteractionState = rowInteractionState
+            self.onMenuTrackingEnded = onMenuTrackingEnded
         }
 
         func pointerHoverChanged(_ hovering: Bool) {
@@ -40,6 +50,7 @@ struct SidebarWorkspaceRowHoverTracker: NSViewRepresentable {
                 rowInteractionState.wrappedValue.contextMenuTrackingDidBegin()
             } else {
                 rowInteractionState.wrappedValue.contextMenuTrackingDidEnd()
+                onMenuTrackingEnded()
             }
         }
     }

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -54,9 +54,9 @@ struct SidebarWorkspaceSnapshotRefreshPolicy {
         current: SidebarWorkspaceSnapshotBuilder.Snapshot?,
         next: SidebarWorkspaceSnapshotBuilder.Snapshot,
         force: Bool,
-        contextMenuVisible: Bool
+        freezesSidebarWorkspaceDetails: Bool
     ) -> Decision {
-        guard contextMenuVisible else {
+        guard freezesSidebarWorkspaceDetails else {
             return Decision(
                 workspaceSnapshotStorage: force || current != next ? next : current,
                 pendingWorkspaceSnapshot: nil,
@@ -77,10 +77,24 @@ struct SidebarWorkspaceSnapshotRefreshPolicy {
 }
 
 struct SidebarWorkspaceRowInteractionState: Equatable {
+    // AppKit menu tracking is the authoritative freeze lifetime for row pointer
+    // context menus. SwiftUI appearance is only a fallback for menu surfaces that
+    // do not emit AppKit tracking; it must not end an active AppKit-tracking
+    // freeze early.
+    private enum ContextMenuDetailsFreezePhase: Equatable {
+        case live
+        case swiftUIFallback
+        case appKitTracking
+    }
+
     private(set) var isPointerHovering = false
-    private(set) var contextMenuVisible = false
+    private var contextMenuDetailsFreezePhase: ContextMenuDetailsFreezePhase = .live
     private var contextMenuTrackingSuppressesCloseButton = false
     private var deferredPointerHoveringWhileContextMenuTracking: Bool?
+
+    var freezesSidebarWorkspaceDetails: Bool {
+        contextMenuDetailsFreezePhase != .live
+    }
 
     mutating func setPointerHovering(_ hovering: Bool) {
         if contextMenuTrackingSuppressesCloseButton {
@@ -93,25 +107,27 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
     }
 
     mutating func contextMenuDidAppear() {
-        contextMenuVisible = true
+        beginSwiftUIFallbackContextMenuFreeze()
         contextMenuTrackingSuppressesCloseButton = true
         deferredPointerHoveringWhileContextMenuTracking = nil
         isPointerHovering = false
     }
 
     mutating func contextMenuDidDisappear() {
-        contextMenuVisible = false
+        endSwiftUIFallbackContextMenuFreeze()
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }
 
     mutating func contextMenuTrackingDidBegin() {
+        beginAppKitTrackingContextMenuFreeze()
         contextMenuTrackingSuppressesCloseButton = true
         deferredPointerHoveringWhileContextMenuTracking = nil
         isPointerHovering = false
     }
 
     mutating func contextMenuTrackingDidEnd() {
+        endAppKitTrackingContextMenuFreeze()
         contextMenuTrackingSuppressesCloseButton = false
         applyDeferredPointerHovering()
     }
@@ -124,6 +140,24 @@ struct SidebarWorkspaceRowInteractionState: Equatable {
             && !contextMenuTrackingSuppressesCloseButton
             && canCloseWorkspace
             && !shortcutHintModeActive
+    }
+
+    private mutating func beginSwiftUIFallbackContextMenuFreeze() {
+        guard contextMenuDetailsFreezePhase == .live else { return }
+        contextMenuDetailsFreezePhase = .swiftUIFallback
+    }
+
+    private mutating func endSwiftUIFallbackContextMenuFreeze() {
+        guard contextMenuDetailsFreezePhase == .swiftUIFallback else { return }
+        contextMenuDetailsFreezePhase = .live
+    }
+
+    private mutating func beginAppKitTrackingContextMenuFreeze() {
+        contextMenuDetailsFreezePhase = .appKitTracking
+    }
+
+    private mutating func endAppKitTrackingContextMenuFreeze() {
+        contextMenuDetailsFreezePhase = .live
     }
 
     private mutating func applyDeferredPointerHovering() {

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -31,7 +31,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             current: current,
             next: next,
             force: false,
-            contextMenuVisible: true
+            freezesSidebarWorkspaceDetails: true
         )
 
         var expectedDisplayed = current
@@ -63,7 +63,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             current: current,
             next: next,
             force: false,
-            contextMenuVisible: true
+            freezesSidebarWorkspaceDetails: true
         )
 
         XCTAssertEqual(decision.workspaceSnapshotStorage, next)
@@ -79,7 +79,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             current: current,
             next: next,
             force: false,
-            contextMenuVisible: false
+            freezesSidebarWorkspaceDetails: false
         )
 
         XCTAssertEqual(decision.workspaceSnapshotStorage, next)
@@ -105,12 +105,13 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             compactBranchDirectoryRow: "feature/live - ~/repo"
         )
 
+        interactionState.contextMenuTrackingDidBegin()
         interactionState.contextMenuDidAppear()
         let colorDecision = SidebarWorkspaceSnapshotRefreshPolicy.decision(
             current: initial,
             next: colorAssigned,
             force: false,
-            contextMenuVisible: interactionState.contextMenuVisible
+            freezesSidebarWorkspaceDetails: interactionState.freezesSidebarWorkspaceDetails
         )
         XCTAssertEqual(colorDecision.workspaceSnapshotStorage?.customColorHex, "#C0392B")
 
@@ -119,7 +120,7 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             current: colorDecision.workspaceSnapshotStorage,
             next: branchChanged,
             force: false,
-            contextMenuVisible: interactionState.contextMenuVisible
+            freezesSidebarWorkspaceDetails: interactionState.freezesSidebarWorkspaceDetails
         )
 
         XCTAssertEqual(
@@ -168,9 +169,25 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
 }
 
 final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
+    func testMenuTrackingEndEndsSidebarDetailsFreezeEvenIfSwiftUIDisappearIsStale() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuTrackingDidBegin()
+        state.contextMenuDidAppear()
+        XCTAssertTrue(state.freezesSidebarWorkspaceDetails)
+
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertFalse(
+            state.freezesSidebarWorkspaceDetails,
+            "AppKit menu tracking end is the authoritative lifetime boundary for deferred sidebar detail snapshots."
+        )
+    }
+
     func testHoverRevealIsIndependentFromStaleContextMenuVisibility() {
         var state = SidebarWorkspaceRowInteractionState()
 
+        state.contextMenuTrackingDidBegin()
         state.contextMenuDidAppear()
         state.contextMenuTrackingDidEnd()
         state.setPointerHovering(true)
@@ -192,6 +209,23 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
             ),
             "The stale SwiftUI menu flag must not make the close affordance visible when the pointer is no longer hovering."
         )
+    }
+
+    func testSwiftUIDisappearDoesNotEndAppKitTrackingFreezeBeforeTrackingEnds() {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        state.contextMenuTrackingDidBegin()
+        state.contextMenuDidAppear()
+        state.contextMenuDidDisappear()
+
+        XCTAssertTrue(
+            state.freezesSidebarWorkspaceDetails,
+            "SwiftUI disappearance is only a fallback cleanup path; AppKit tracking remains the authoritative lifetime while it is active."
+        )
+
+        state.contextMenuTrackingDidEnd()
+
+        XCTAssertFalse(state.freezesSidebarWorkspaceDetails)
     }
 
     func testContextMenuTrackingBeginHidesExistingCloseButtonBeforeSwiftUIMenuAppears() {
@@ -219,6 +253,7 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
     func testHoverDuringContextMenuTrackingStaysHiddenUntilTrackingEnds() {
         var state = SidebarWorkspaceRowInteractionState()
 
+        state.contextMenuTrackingDidBegin()
         state.contextMenuDidAppear()
         state.setPointerHovering(true)
 
@@ -247,8 +282,10 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
             get: { state },
             set: { state = $0 }
         )
+        var menuTrackingEndCount = 0
         let coordinator = SidebarWorkspaceRowHoverTracker.Coordinator(
-            rowInteractionState: binding
+            rowInteractionState: binding,
+            onMenuTrackingEnded: { menuTrackingEndCount += 1 }
         )
 
         coordinator.menuTrackingChanged(true)
@@ -263,6 +300,7 @@ final class SidebarWorkspaceRowInteractionStateTests: XCTestCase {
             ),
             "A pointer exit observed during menu tracking must overwrite any earlier deferred hover enter before the menu dismisses."
         )
+        XCTAssertEqual(menuTrackingEndCount, 1)
     }
 
     func testMenuTrackingSuppressionOnlyAppliesToPointerMenusInsideRow() {

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -87,6 +87,51 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         XCTAssertFalse(decision.hasDeferredWorkspaceObservationInvalidation)
     }
 
+    func testMenuTrackingEndRestoresLiveDetailsAfterColorAction() {
+        var interactionState = SidebarWorkspaceRowInteractionState()
+        let initial = Self.snapshot(
+            customColorHex: nil,
+            compactGitBranchSummaryText: "main",
+            compactBranchDirectoryRow: "main - ~/repo"
+        )
+        let colorAssigned = Self.snapshot(
+            customColorHex: "#C0392B",
+            compactGitBranchSummaryText: "main",
+            compactBranchDirectoryRow: "main - ~/repo"
+        )
+        let branchChanged = Self.snapshot(
+            customColorHex: "#C0392B",
+            compactGitBranchSummaryText: "feature/live",
+            compactBranchDirectoryRow: "feature/live - ~/repo"
+        )
+
+        interactionState.contextMenuDidAppear()
+        let colorDecision = SidebarWorkspaceSnapshotRefreshPolicy.decision(
+            current: initial,
+            next: colorAssigned,
+            force: false,
+            contextMenuVisible: interactionState.contextMenuVisible
+        )
+        XCTAssertEqual(colorDecision.workspaceSnapshotStorage?.customColorHex, "#C0392B")
+
+        interactionState.contextMenuTrackingDidEnd()
+        let branchDecision = SidebarWorkspaceSnapshotRefreshPolicy.decision(
+            current: colorDecision.workspaceSnapshotStorage,
+            next: branchChanged,
+            force: false,
+            contextMenuVisible: interactionState.contextMenuVisible
+        )
+
+        XCTAssertEqual(
+            branchDecision.workspaceSnapshotStorage?.compactGitBranchSummaryText,
+            "feature/live",
+            "Once AppKit menu tracking ends after assigning a workspace color, live sidebar details such as git branch must update even if SwiftUI does not deliver context-menu disappearance."
+        )
+        XCTAssertEqual(branchDecision.workspaceSnapshotStorage?.compactBranchDirectoryRow, "feature/live - ~/repo")
+        XCTAssertNil(branchDecision.pendingWorkspaceSnapshot)
+        XCTAssertFalse(branchDecision.hasDeferredWorkspaceObservationInvalidation)
+    }
+
     private static func snapshot(
         title: String = "workspace",
         customDescription: String? = nil,
@@ -94,6 +139,8 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
         customColorHex: String? = nil,
         remoteConnectionStatusText: String = "Disconnected",
         latestSubmittedMessage: String? = nil,
+        compactGitBranchSummaryText: String? = nil,
+        compactBranchDirectoryRow: String? = nil,
         listeningPorts: [Int] = []
     ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
@@ -110,8 +157,8 @@ final class SidebarWorkspaceSnapshotRefreshPolicyTests: XCTestCase {
             metadataBlocks: [],
             latestLog: nil,
             progress: nil,
-            compactGitBranchSummaryText: nil,
-            compactBranchDirectoryRow: nil,
+            compactGitBranchSummaryText: compactGitBranchSummaryText,
+            compactBranchDirectoryRow: compactBranchDirectoryRow,
             branchDirectoryLines: [],
             branchLinesContainBranch: false,
             pullRequestRows: [],


### PR DESCRIPTION
Fixes #3803.

## Summary
- Adds a regression test proving sidebar details resume after a workspace color context-menu action.
- Ends the sidebar detail freeze from the AppKit menu-tracking lifetime, so stale SwiftUI context-menu disappearance cannot keep pwd/git/sidebar details frozen.

## Verification
- git diff --check
- Local tests/build intentionally not run per task instruction; CI will verify.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change that adjusts how sidebar row snapshots are frozen/unfrozen around context menus; main risk is subtle regressions in hover/menu lifecycle handling.
> 
> **Overview**
> Fixes a sidebar regression where workspace row details (e.g., branch/pwd telemetry) could remain frozen after context-menu actions (like color/reorder) when SwiftUI doesn’t reliably emit `onDisappear`.
> 
> This introduces an explicit freeze state (`freezesSidebarWorkspaceDetails`) in `SidebarWorkspaceRowInteractionState`, updates `SidebarWorkspaceSnapshotRefreshPolicy` to gate deferral on that freeze, and wires `SidebarWorkspaceRowHoverTracker` to notify when AppKit menu tracking ends so `ContentView` can flush any pending snapshot/unfreeze promptly. Adds focused regression tests covering menu-tracking end behavior and ensuring SwiftUI lifecycle events can’t prematurely or permanently control the freeze.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdcb16a340bf900b174b61baac3c0e175fb2e873. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3803 by ending the sidebar details freeze when AppKit menu tracking ends, so git/cwd info keeps updating after color or reorder actions even if SwiftUI never fires disappear.

- **Bug Fixes**
  - Replaced the old visibility flag with an explicit freeze phase and `freezesSidebarWorkspaceDetails` in `SidebarWorkspaceRowInteractionState`.
  - `SidebarWorkspaceSnapshotRefreshPolicy.decision(...)` now gates on `freezesSidebarWorkspaceDetails` (was `contextMenuVisible`).
  - Added `flushWorkspaceContextMenuFreezeIfLive()` in `TabItemView`; called on SwiftUI disappear and via `SidebarWorkspaceRowHoverTracker` `onMenuTrackingEnded`.
  - `SidebarWorkspaceRowHoverTracker` now accepts `onMenuTrackingEnded` and invokes it when AppKit menu tracking ends.
  - Added tests asserting details resume after a color action, AppKit tracking end is authoritative over SwiftUI disappear, and hover/close-button behavior remains correct.

<sup>Written for commit cdcb16a340bf900b174b61baac3c0e175fb2e873. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar workspace details now properly refresh when unfrozen after context menu interactions.
  * Improved responsiveness ensuring cached snapshots update correctly when the sidebar details freeze state changes.
  * Context menu lifecycle events no longer prevent timely sidebar detail updates.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3874)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->