### PR TITLE
Avoid rendering hidden sibling tabs

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2759,7 +2759,7 @@ struct ContentView: View {
         })
 
         // Prime background workspaces off-screen. Rendering them just to run a task
-        // mounts every keepAllAlive tab view and can materialize hidden terminals.
+        // can mount AppKit-backed panel views and materialize hidden terminals.
         view = AnyView(view.task(id: backgroundWorkspacePrimeCoordinator.taskKey(for: tabManager)) {
             await backgroundWorkspacePrimeCoordinator.primePendingBackgroundWorkspaces(tabManager: tabManager)
         })

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7599,8 +7599,10 @@ final class Workspace: Identifiable, ObservableObject {
             : FileManager.default.homeDirectoryForCurrentUser.path
         self.surfaceTabBarDirectory = initialDirectory
 
-        // Configure bonsplit with keepAllAlive to preserve terminal state
-        // and keep split entry instantaneous.
+        // Render only the selected tab in each split pane. Terminal/browser
+        // process state lives on the panel objects, while keeping every
+        // sibling tab's SwiftUI/AppKit content mounted lets hidden terminals
+        // keep driving layout and display work.
         // Use the cached Ghostty config so new workspaces inherit tab-strip sizing
         // without paying repeated parse costs on the workspace-creation hot path.
         let initialSurfaceTabBarFontSize = GhosttyConfig.load().surfaceTabBarFontSize
@@ -7616,7 +7618,7 @@ final class Workspace: Identifiable, ObservableObject {
             allowTabReordering: true,
             allowCrossPaneTabMove: true,
             autoCloseEmptyPanes: true,
-            contentViewLifecycle: .keepAllAlive,
+            contentViewLifecycle: .recreateOnSwitch,
             newTabPosition: .current,
             appearance: appearance
         )
@@ -8658,17 +8660,13 @@ final class Workspace: Identifiable, ObservableObject {
             didMutate = true
         }
 
-        // Update bonsplit tab title only when this panel's title changed.
+        // Update bonsplit tab title only when this panel's title changed and
+        // the panel is currently rendered. Some TUIs animate the terminal title
+        // at frame-rate; pushing those hidden sibling-tab title changes through
+        // Bonsplit invalidates the visible tab bar and forces AppKit layout.
         if didMutate,
-           let tabId = surfaceIdFromPanelId(panelId),
-           let panel = panels[panelId] {
-            let baseTitle = panelTitles[panelId] ?? panel.displayTitle
-            let resolvedTitle = resolvedPanelTitle(panelId: panelId, fallback: baseTitle)
-            bonsplitController.updateTab(
-                tabId,
-                title: resolvedTitle,
-                hasCustomTitle: panelCustomTitles[panelId] != nil
-            )
+           renderedVisiblePanelIdsForCurrentLayout().contains(panelId) {
+            publishBonsplitTabTitle(panelId: panelId)
         }
 
         // If this is the only panel and no custom title, update workspace title
@@ -8683,6 +8681,18 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         return didMutate
+    }
+
+    private func publishBonsplitTabTitle(panelId: UUID) {
+        guard let tabId = surfaceIdFromPanelId(panelId),
+              let panel = panels[panelId] else { return }
+        let baseTitle = panelTitles[panelId] ?? panel.displayTitle
+        let resolvedTitle = resolvedPanelTitle(panelId: panelId, fallback: baseTitle)
+        bonsplitController.updateTab(
+            tabId,
+            title: resolvedTitle,
+            hasCustomTitle: panelCustomTitles[panelId] != nil
+        )
     }
 
     func pruneSurfaceMetadata(validSurfaceIds: Set<UUID>) {
@@ -12900,6 +12910,7 @@ extension Workspace: BonsplitDelegate {
         let panelId = effectiveFocusedPanelId
 
         syncPinnedStateForTab(selectedTabId, panelId: selectedPanelId)
+        publishBonsplitTabTitle(panelId: selectedPanelId)
         syncUnreadBadgeStateForPanel(selectedPanelId)
 
         // Unfocus all other panels
@@ -12908,11 +12919,11 @@ extension Workspace: BonsplitDelegate {
         }
 
         // Explicitly hide browser portals for deselected tabs in this pane.
-        // Bonsplit's keepAllAlive mode hides non-selected tabs via SwiftUI .opacity(0),
-        // but portal-hosted WKWebViews render at the window level in AppKit and are not
-        // affected by SwiftUI opacity. Without an explicit hide, the deselected browser's
-        // portal layer can remain visible above the newly selected tab.
+        // Portal-hosted WKWebViews render at the window level in AppKit, so tab
+        // deselection needs an explicit portal hide in addition to SwiftUI
+        // content lifecycle changes.
         hideBrowserPortalsForDeselectedTabs(inPane: focusedPane, selectedTabId: selectedTabId)
+        reconcileTerminalPortalVisibilityForCurrentRenderedLayout()
 
         if let focusWindow = activationWindow(for: panel) {
             yieldForeignOwnedFocusIfNeeded(


### PR DESCRIPTION
## Summary

This changes hidden sibling tab handling in two places:

- Render only the selected tab for each visible split pane instead of keeping every sibling tab mounted in a hidden `ZStack`.
- Keep terminal title changes for hidden sibling tabs internal until the tab becomes selected, so TUIs that animate the terminal title do not invalidate the visible tab bar at frame-rate.

The previous `.keepAllAlive` path in Bonsplit keeps sibling tab views mounted and hides inactive tabs with opacity. That means a hidden sibling terminal tab can continue to drive SwiftUI/AppKit layout and display work even when it is not visible. In the reported Codex case, the terminal title also animated with the spinner, which kept updating the still-visible sibling tab label and cascading into AppKit constraint/layout work.

Visible split panes are still handled normally because each pane renders its own selected tab. Terminal portal visibility is reconciled after tab selection changes so deselected sibling tabs are marked hidden/inactive instead of relying on SwiftUI opacity.

## Context

I checked for existing reports and found related work, but not this exact sibling-tab case:

- Related but distinct from #3018 / #3022, which focus on background workspace priming and memory/thread growth.
- Possibly adjacent to #2408, which tracks generic idle CPU usage.
- This PR specifically targets hidden sibling tabs inside the selected sidebar workspace, where switching to another top tab leaves the old tab mounted or lets high-frequency tab-title changes churn the visible tab bar.

Local samples from the reported case showed cmux around 85% CPU while a hidden sibling tab contained Codex activity. The hot samples were dominated by the main thread in SwiftUI/AppKit layout/display (`CA::Transaction::commit`, `NSDisplayCycleFlush`, `NSHostingView.minSize`, `ViewGraph.sizeThatFits`), not by Ghostty renderer threads.

## Testing

- `git diff --check`
- Earlier version of this branch built with `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag hidden-sibling-tabs --launch` after cleaning a generated `ghostty/zig-pkg` directory from a failed Zig 0.16 Ghostty build attempt.

I did not rebuild after the latest hidden-title update because local profiling was stopped to avoid loading the machine; this remains draft pending another local validation pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Render only the active tab per split pane and unmount hidden sibling tabs to stop off-screen terminals from driving layout/display work. Also hide browser and terminal portals on tab switch to prevent bleed-through.

- **Bug Fixes**
  - Switched `contentViewLifecycle` from `.keepAllAlive` to `.recreateOnSwitch` so inactive tabs are not mounted.
  - On tab change, explicitly hide deselected browser portals and call `reconcileTerminalPortalVisibilityForCurrentRenderedLayout()` to keep AppKit-backed views from rendering off-screen.

<sup>Written for commit 1144e882c93bb260914ccd5f4f4ea0b2f2dbf783. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

