### PR TITLE
Fix #3827: write cmuxterm Ghostty config so theme switch reaches terminal surfaces

### DIFF
--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -56,6 +56,15 @@ enum AppearanceSettings {
                 },
                 systemAppearance: {
                     AppearanceSettings.systemNSAppearance()
+                },
+                writeManagedGhosttyConfig: { _, _, source in
+                    do {
+                        try ConfigSourceEnvironment.live().writeManagedAppearanceConfigIfNeeded()
+                    } catch {
+#if DEBUG
+                        cmuxDebugLog("appearance.managedGhosttyConfig.writeFailed source=\(source) error=\(error)")
+#endif
+                    }
                 }
             )
         }
@@ -182,6 +191,7 @@ enum AppearanceSettings {
             duringLaunch: duringLaunch,
             environment: environment
         )
+        environment.writeManagedGhosttyConfig(normalized, appearance, source)
         environment.setApplicationAppearance(appearance)
         if synchronizeTerminalTheme {
             environment.synchronizeTerminalThemeWithAppearance(appearance, source)

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -32,6 +32,19 @@ enum AppearanceSettings {
         let setApplicationAppearance: (NSAppearance?) -> Void
         let synchronizeTerminalThemeWithAppearance: (NSAppearance?, String) -> Void
         let systemAppearance: () -> NSAppearance?
+        let writeManagedGhosttyConfig: (AppearanceMode, NSAppearance?, String) -> Void
+
+        init(
+            setApplicationAppearance: @escaping (NSAppearance?) -> Void,
+            synchronizeTerminalThemeWithAppearance: @escaping (NSAppearance?, String) -> Void,
+            systemAppearance: @escaping () -> NSAppearance?,
+            writeManagedGhosttyConfig: @escaping (AppearanceMode, NSAppearance?, String) -> Void = { _, _, _ in }
+        ) {
+            self.setApplicationAppearance = setApplicationAppearance
+            self.synchronizeTerminalThemeWithAppearance = synchronizeTerminalThemeWithAppearance
+            self.systemAppearance = systemAppearance
+            self.writeManagedGhosttyConfig = writeManagedGhosttyConfig
+        }
 
         static var live: LiveApplyEnvironment {
             LiveApplyEnvironment(

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -1,5 +1,8 @@
 import AppKit
+import OSLog
 import SwiftUI
+
+private let appearanceSettingsLogger = Logger(subsystem: "com.cmuxterm.app", category: "appearance")
 
 enum AppearanceMode: String, CaseIterable, Identifiable {
     case system
@@ -61,6 +64,9 @@ enum AppearanceSettings {
                     do {
                         try ConfigSourceEnvironment.live().writeManagedAppearanceConfigIfNeeded()
                     } catch {
+                        appearanceSettingsLogger.error(
+                            "Failed to write managed Ghostty theme config source=\(source, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
+                        )
 #if DEBUG
                         cmuxDebugLog("appearance.managedGhosttyConfig.writeFailed source=\(source) error=\(error)")
 #endif

--- a/Sources/AppearanceSettings.swift
+++ b/Sources/AppearanceSettings.swift
@@ -63,7 +63,7 @@ enum AppearanceSettings {
                 writeManagedGhosttyConfig: { _, _, source in
                     do {
                         try ConfigSourceEnvironment.live().writeManagedAppearanceConfigIfNeeded()
-                    } catch {
+                    } catch let error {
                         appearanceSettingsLogger.error(
                             "Failed to write managed Ghostty theme config source=\(source, privacy: .public) error=\(error.localizedDescription, privacy: .private)"
                         )

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -68,14 +68,22 @@ struct ConfigSourceEnvironment {
 
     func materializeCmuxConfigFileIfNeeded() throws -> URL {
         let url = cmuxConfigURL
-        guard !fileManager.fileExists(atPath: url.path) else { return url }
-        try writeCmuxConfigContents("", to: url)
+        // Preserve the selected editable URL even if a legacy config appears during existence checks.
+        _ = fileManager.fileExists(atPath: url.path)
+        try writeManagedAppearanceConfigIfNeeded(to: url)
         return url
     }
 
     func writeCmuxConfigContents(_ contents: String) throws {
         let url = cmuxConfigURL
         try writeCmuxConfigContents(contents, to: url)
+    }
+
+    @discardableResult
+    func writeManagedAppearanceConfigIfNeeded() throws -> URL {
+        let url = cmuxConfigURL
+        try writeManagedAppearanceConfigIfNeeded(to: url)
+        return url
     }
 
     private func writeCmuxConfigContents(_ contents: String, to url: URL) throws {
@@ -86,6 +94,21 @@ struct ConfigSourceEnvironment {
             attributes: nil
         )
         try contents.write(to: writeURL, atomically: true, encoding: .utf8)
+    }
+
+    private func writeManagedAppearanceConfigIfNeeded(to url: URL) throws {
+        let writeURL = configWriteURL(for: url)
+        let existingContents = (try? String(contentsOf: writeURL, encoding: .utf8)) ?? ""
+        let hasManagedBlock = CmuxManagedGhosttyThemeConfig.containsManagedBlock(in: existingContents)
+        if !hasManagedBlock,
+           !GhosttyApp.shouldApplyManagedDefaultAppearance(configPaths: [writeURL.path]) {
+            return
+        }
+        let updatedContents = CmuxManagedGhosttyThemeConfig.contentsByInstallingManagedBlock(
+            in: existingContents
+        )
+        guard updatedContents != existingContents else { return }
+        try writeCmuxConfigContents(updatedContents, to: url)
     }
 
     func abbreviatedPath(for url: URL) -> String {
@@ -149,6 +172,52 @@ struct ConfigSourceEnvironment {
             destinationURL = url.deletingLastPathComponent().appendingPathComponent(destination)
         }
         return destinationURL.standardizedFileURL.resolvingSymlinksInPath()
+    }
+}
+
+enum CmuxManagedGhosttyThemeConfig {
+    private static let beginMarker = "# cmux-managed-theme: begin"
+    private static let endMarker = "# cmux-managed-theme: end"
+    static let themeDirective = "theme = light:Apple System Colors Light,dark:Apple System Colors"
+
+    static var managedBlock: String {
+        """
+        \(beginMarker)
+        # Managed by cmux Settings > Theme. Keep this block unless you want to own terminal theme config manually.
+        \(themeDirective)
+        \(endMarker)
+        """
+    }
+
+    static func containsManagedBlock(in contents: String) -> Bool {
+        contents.contains(beginMarker) || contents.contains(endMarker)
+    }
+
+    static func contentsByInstallingManagedBlock(in contents: String) -> String {
+        if let range = managedBlockRange(in: contents) {
+            return contents.replacingCharacters(in: range, with: managedBlock)
+        }
+
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            return managedBlock + "\n"
+        }
+
+        let separator = contents.hasPrefix("\n") ? "\n" : "\n\n"
+        return managedBlock + separator + contents
+    }
+
+    private static func managedBlockRange(in contents: String) -> Range<String.Index>? {
+        guard let begin = contents.range(of: beginMarker),
+              let end = contents.range(of: endMarker, range: begin.upperBound..<contents.endIndex) else {
+            return nil
+        }
+
+        var upperBound = end.upperBound
+        if upperBound < contents.endIndex, contents[upperBound] == "\n" {
+            upperBound = contents.index(after: upperBound)
+        }
+        return begin.lowerBound..<upperBound
     }
 }
 

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -68,8 +68,6 @@ struct ConfigSourceEnvironment {
 
     func materializeCmuxConfigFileIfNeeded() throws -> URL {
         let url = cmuxConfigURL
-        // Preserve the selected editable URL even if a legacy config appears during existence checks.
-        _ = fileManager.fileExists(atPath: url.path)
         try writeManagedAppearanceConfigIfNeeded(to: url)
         return url
     }
@@ -99,8 +97,8 @@ struct ConfigSourceEnvironment {
     private func writeManagedAppearanceConfigIfNeeded(to url: URL) throws {
         let writeURL = configWriteURL(for: url)
         let existingContents = (try? String(contentsOf: writeURL, encoding: .utf8)) ?? ""
-        let hasManagedBlock = CmuxManagedGhosttyThemeConfig.containsManagedBlock(in: existingContents)
-        if !hasManagedBlock,
+        let hasManagedState = CmuxManagedGhosttyThemeConfig.containsManagedState(in: existingContents)
+        if !hasManagedState,
            !GhosttyApp.shouldApplyManagedDefaultAppearance(configPaths: [writeURL.path]) {
             return
         }
@@ -178,33 +176,44 @@ struct ConfigSourceEnvironment {
 enum CmuxManagedGhosttyThemeConfig {
     private static let beginMarker = "# cmux-managed-theme: begin"
     private static let endMarker = "# cmux-managed-theme: end"
+    private static let managedComment =
+        "# Managed by cmux Settings > Theme. Keep this block unless you want to own terminal theme config manually."
     static let themeDirective = "theme = light:Apple System Colors Light,dark:Apple System Colors"
 
     static var managedBlock: String {
         """
         \(beginMarker)
-        # Managed by cmux Settings > Theme. Keep this block unless you want to own terminal theme config manually.
+        \(managedComment)
         \(themeDirective)
         \(endMarker)
         """
     }
 
+    static func containsManagedState(in contents: String) -> Bool {
+        containsManagedBlock(in: contents)
+            || contents.contains(beginMarker)
+            || contents.contains(endMarker)
+    }
+
     static func containsManagedBlock(in contents: String) -> Bool {
-        contents.contains(beginMarker) || contents.contains(endMarker)
+        managedBlockRange(in: contents) != nil
     }
 
     static func contentsByInstallingManagedBlock(in contents: String) -> String {
         if let range = managedBlockRange(in: contents) {
-            return contents.replacingCharacters(in: range, with: managedBlock)
+            let prefix = contentsByRemovingOrphanedManagedState(from: String(contents[..<range.lowerBound]))
+            let suffix = contentsByRemovingOrphanedManagedState(from: String(contents[range.upperBound...]))
+            return contentsByJoiningManagedBlock(prefix: prefix, suffix: suffix)
         }
 
-        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        let sanitizedContents = contentsByRemovingOrphanedManagedState(from: contents)
+        let trimmed = sanitizedContents.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
             return managedBlock + "\n"
         }
 
-        let separator = contents.hasPrefix("\n") ? "\n" : "\n\n"
-        return managedBlock + separator + contents
+        let separator = sanitizedContents.hasPrefix("\n") ? "\n" : "\n\n"
+        return managedBlock + separator + sanitizedContents
     }
 
     private static func managedBlockRange(in contents: String) -> Range<String.Index>? {
@@ -218,6 +227,35 @@ enum CmuxManagedGhosttyThemeConfig {
             upperBound = contents.index(after: upperBound)
         }
         return begin.lowerBound..<upperBound
+    }
+
+    private static func contentsByJoiningManagedBlock(prefix: String, suffix: String) -> String {
+        var contents = prefix
+        if !contents.isEmpty, !contents.hasSuffix("\n") {
+            contents += "\n"
+        }
+        contents += managedBlock
+        if !suffix.isEmpty, !suffix.hasPrefix("\n") {
+            contents += "\n"
+        }
+        contents += suffix
+        return contents
+    }
+
+    private static func contentsByRemovingOrphanedManagedState(from contents: String) -> String {
+        guard contents.contains(beginMarker) || contents.contains(endMarker) else {
+            return contents
+        }
+
+        let lines = contents.split(separator: "\n", omittingEmptySubsequences: false)
+        let sanitizedLines = lines.filter { line in
+            let value = String(line)
+            return value != beginMarker
+                && value != endMarker
+                && value != managedComment
+                && value != themeDirective
+        }
+        return sanitizedLines.joined(separator: "\n")
     }
 }
 

--- a/Sources/Settings/ConfigSource.swift
+++ b/Sources/Settings/ConfigSource.swift
@@ -96,7 +96,12 @@ struct ConfigSourceEnvironment {
 
     private func writeManagedAppearanceConfigIfNeeded(to url: URL) throws {
         let writeURL = configWriteURL(for: url)
-        let existingContents = (try? String(contentsOf: writeURL, encoding: .utf8)) ?? ""
+        let existingContents: String
+        if fileManager.fileExists(atPath: writeURL.path) {
+            existingContents = try String(contentsOf: writeURL, encoding: .utf8)
+        } else {
+            existingContents = ""
+        }
         let hasManagedState = CmuxManagedGhosttyThemeConfig.containsManagedState(in: existingContents)
         if !hasManagedState,
            !GhosttyApp.shouldApplyManagedDefaultAppearance(configPaths: [writeURL.path]) {

--- a/cmuxTests/AppearanceSettingsTests.swift
+++ b/cmuxTests/AppearanceSettingsTests.swift
@@ -182,6 +182,136 @@ final class AppearanceSettingsTests: XCTestCase {
         XCTAssertEqual(synchronizedSource, "settings.themePicker")
     }
 
+    func testSelectingAppearanceWritesManagedGhosttyConfigBeforeTerminalRefresh() throws {
+        let fakeSurface = try XCTUnwrap(UnsafeMutableRawPointer(bitPattern: 0x3827))
+
+        try withTemporaryHomeDirectory { homeDirectory in
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: "com.cmuxterm.app"
+            )
+            let suiteName = "AppearanceSettingsTests.ManagedGhosttyConfig.\(UUID().uuidString)"
+            guard let defaults = UserDefaults(suiteName: suiteName) else {
+                XCTFail("Failed to create isolated UserDefaults suite")
+                return
+            }
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+
+            for mode in [AppearanceMode.light, .dark, .system] {
+                try? FileManager.default.removeItem(at: environment.cmuxConfigURL)
+                var events: [String] = []
+                let liveEnvironment = AppearanceSettings.LiveApplyEnvironment(
+                    setApplicationAppearance: { appearance in
+                        events.append("app:\(Self.appearanceLabel(appearance))")
+                    },
+                    synchronizeTerminalThemeWithAppearance: { _, source in
+                        events.append("sync:\(source)")
+                        GhosttySurfaceConfigurationRefresh.applyAfterAppConfigReload(
+                            to: fakeSurface,
+                            source: source,
+                            reloadSurfaceConfiguration: { surface, soft, source in
+                                XCTAssertEqual(surface, fakeSurface)
+                                XCTAssertTrue(soft)
+                                events.append("surface-reload:\(source)")
+                            },
+                            refreshHostBackground: {
+                                events.append("host-background")
+                            },
+                            forceRefresh: { reason in
+                                events.append("force-refresh:\(reason)")
+                            }
+                        )
+                    },
+                    systemAppearance: {
+                        NSAppearance(named: .aqua)
+                    },
+                    writeManagedGhosttyConfig: { selectedMode, _, source in
+                        XCTAssertEqual(selectedMode, mode)
+                        events.append("write:\(source)")
+                        try? environment.writeCmuxConfigContents(Self.managedGhosttyThemeFixture)
+                    }
+                )
+
+                let selected = AppearanceSettings.selectMode(
+                    mode,
+                    defaults: defaults,
+                    source: "settings.themePicker",
+                    environment: liveEnvironment
+                )
+
+                XCTAssertEqual(selected, mode)
+                let contents = try String(contentsOf: environment.cmuxConfigURL, encoding: .utf8)
+                XCTAssertFalse(contents.isEmpty)
+                XCTAssertTrue(contents.contains(Self.expectedManagedThemeDirective), contents)
+                XCTAssertEqual(events.first, "write:settings.themePicker")
+                XCTAssertTrue(events.contains("surface-reload:settings.themePicker"))
+                XCTAssertTrue(
+                    events.contains("force-refresh:\(GhosttySurfaceConfigurationRefresh.forceRefreshReason)")
+                )
+            }
+        }
+    }
+
+    func testSystemAppearanceLaunchWritesManagedGhosttyConfigForLightAndDarkSystemAppearances() throws {
+        try withTemporaryHomeDirectory { homeDirectory in
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: "com.cmuxterm.app"
+            )
+            let suiteName = "AppearanceSettingsTests.SystemManagedGhosttyConfig.\(UUID().uuidString)"
+            guard let defaults = UserDefaults(suiteName: suiteName) else {
+                XCTFail("Failed to create isolated UserDefaults suite")
+                return
+            }
+            defer { defaults.removePersistentDomain(forName: suiteName) }
+
+            let cases: [(label: String, systemAppearance: NSAppearance.Name?, expectedApplied: NSAppearance.Name)] = [
+                ("light-system", nil, .aqua),
+                ("dark-system", .darkAqua, .darkAqua),
+            ]
+
+            for testCase in cases {
+                try? FileManager.default.removeItem(at: environment.cmuxConfigURL)
+                var events: [String] = []
+                let liveEnvironment = AppearanceSettings.LiveApplyEnvironment(
+                    setApplicationAppearance: { appearance in
+                        events.append("app:\(Self.appearanceLabel(appearance))")
+                    },
+                    synchronizeTerminalThemeWithAppearance: { appearance, source in
+                        events.append("sync:\(Self.appearanceLabel(appearance)):\(source)")
+                    },
+                    systemAppearance: {
+                        if let systemAppearance = testCase.systemAppearance {
+                            return NSAppearance(named: systemAppearance)
+                        }
+                        return NSAppearance(named: .aqua)
+                    },
+                    writeManagedGhosttyConfig: { selectedMode, _, source in
+                        XCTAssertEqual(selectedMode, .system)
+                        events.append("write:\(source)")
+                        try? environment.writeCmuxConfigContents(Self.managedGhosttyThemeFixture)
+                    }
+                )
+
+                let applied = AppearanceSettings.applyStoredMode(
+                    rawValue: AppearanceMode.system.rawValue,
+                    defaults: defaults,
+                    source: testCase.label,
+                    duringLaunch: true,
+                    environment: liveEnvironment
+                )
+
+                XCTAssertEqual(applied, .system)
+                let contents = try String(contentsOf: environment.cmuxConfigURL, encoding: .utf8)
+                XCTAssertFalse(contents.isEmpty)
+                XCTAssertTrue(contents.contains(Self.expectedManagedThemeDirective), contents)
+                XCTAssertEqual(events.first, "write:\(testCase.label)")
+                XCTAssertTrue(events.contains("app:\(testCase.expectedApplied.rawValue)"))
+                XCTAssertTrue(events.contains("sync:\(testCase.expectedApplied.rawValue):\(testCase.label)"))
+            }
+        }
+    }
+
     func testSelectingSystemModeClearsRuntimeAppearanceOverrideForSystemFollow() {
         let suiteName = "AppearanceSettingsTests.SelectSystem.\(UUID().uuidString)"
         guard let defaults = UserDefaults(suiteName: suiteName) else {
@@ -254,5 +384,28 @@ final class AppearanceSettingsTests: XCTestCase {
         } else {
             defaults.removeObject(forKey: key)
         }
+    }
+
+    private func withTemporaryHomeDirectory(_ body: (URL) throws -> Void) throws {
+        let fileManager = FileManager.default
+        let directory = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-appearance-home-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: directory) }
+        try body(directory)
+    }
+
+    private static let expectedManagedThemeDirective =
+        "theme = light:Apple System Colors Light,dark:Apple System Colors"
+
+    private static let managedGhosttyThemeFixture = """
+    # cmux-managed-theme: begin
+    \(expectedManagedThemeDirective)
+    # cmux-managed-theme: end
+
+    """
+
+    private static func appearanceLabel(_ appearance: NSAppearance?) -> String {
+        appearance?.bestMatch(from: [.darkAqua, .aqua])?.rawValue ?? "nil"
     }
 }

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -148,41 +148,26 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
         }
     }
 
-    func testMaterializeWritesSelectedEditableConfigWhenLegacyConfigAppearsDuringCheck() throws {
+    func testMaterializeLeavesExistingLegacyAppearanceConfigUntouched() throws {
         try withTemporaryHomeDirectory { homeDirectory in
-            let fileManager = RaceCreatingFileManager()
             let appSupportDirectory = homeDirectory
                 .appendingPathComponent("Library", isDirectory: true)
                 .appendingPathComponent("Application Support", isDirectory: true)
             let bundleDirectory = appSupportDirectory
                 .appendingPathComponent("com.cmuxterm.app.debug.issue-3518", isDirectory: true)
-            let configGhosttyURL = bundleDirectory.appendingPathComponent("config.ghostty", isDirectory: false)
             let legacyConfigURL = bundleDirectory.appendingPathComponent("config", isDirectory: false)
-
-            fileManager.onFirstMissingPlainExistenceCheck = { path in
-                guard path == configGhosttyURL.path else { return }
-                try FileManager.default.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
-                try "background = #000000\n".write(to: legacyConfigURL, atomically: true, encoding: .utf8)
-            }
+            try FileManager.default.createDirectory(at: bundleDirectory, withIntermediateDirectories: true)
+            try "background = #000000\n".write(to: legacyConfigURL, atomically: true, encoding: .utf8)
 
             let environment = ConfigSourceEnvironment(
                 homeDirectoryURL: homeDirectory,
-                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-3518",
-                fileManager: fileManager
+                currentBundleIdentifier: "com.cmuxterm.app.debug.issue-3518"
             )
 
             let materializedURL = try environment.materializeCmuxConfigFileIfNeeded()
 
-            XCTAssertEqual(materializedURL, configGhosttyURL)
-            XCTAssertTrue(FileManager.default.fileExists(atPath: configGhosttyURL.path))
-            let contents = try String(contentsOf: configGhosttyURL, encoding: .utf8)
-            XCTAssertFalse(contents.isEmpty)
-            XCTAssertTrue(
-                contents.contains("theme = light:Apple System Colors Light,dark:Apple System Colors"),
-                contents
-            )
+            XCTAssertEqual(materializedURL, legacyConfigURL)
             XCTAssertEqual(try String(contentsOf: legacyConfigURL, encoding: .utf8), "background = #000000\n")
-            XCTAssertNil(fileManager.creationError)
         }
     }
 
@@ -204,6 +189,59 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
                 contents
             )
             XCTAssertTrue(contents.contains("# cmux-managed-theme: end"), contents)
+        }
+    }
+
+    func testWriteManagedAppearanceConfigRepairsOrphanedManagedThemeMarkers() throws {
+        let orphanedConfigs = [
+            """
+            # cmux-managed-theme: begin
+            # Managed by cmux Settings > Theme. Keep this block unless you want to own terminal theme config manually.
+            theme = light:Apple System Colors Light,dark:Apple System Colors
+            font-size = 13
+            """,
+            """
+            theme = light:Apple System Colors Light,dark:Apple System Colors
+            # cmux-managed-theme: end
+            font-size = 13
+            """,
+            """
+            # cmux-managed-theme: begin
+            # Managed by cmux Settings > Theme. Keep this block unless you want to own terminal theme config manually.
+            theme = light:Apple System Colors Light,dark:Apple System Colors
+            # cmux-managed-theme: end
+            # cmux-managed-theme: end
+            font-size = 13
+            """,
+        ]
+
+        for orphanedConfig in orphanedConfigs {
+            try withTemporaryHomeDirectory { homeDirectory in
+                let environment = ConfigSourceEnvironment(
+                    homeDirectoryURL: homeDirectory,
+                    currentBundleIdentifier: "com.cmuxterm.app"
+                )
+                let configURL = environment.cmuxConfigURL
+                try FileManager.default.createDirectory(
+                    at: configURL.deletingLastPathComponent(),
+                    withIntermediateDirectories: true
+                )
+                try (orphanedConfig + "\n").write(to: configURL, atomically: true, encoding: .utf8)
+
+                try environment.writeManagedAppearanceConfigIfNeeded()
+
+                let contents = try String(contentsOf: configURL, encoding: .utf8)
+                XCTAssertEqual(contents.components(separatedBy: "# cmux-managed-theme: begin").count - 1, 1, contents)
+                XCTAssertEqual(contents.components(separatedBy: "# cmux-managed-theme: end").count - 1, 1, contents)
+                XCTAssertEqual(
+                    contents.components(
+                        separatedBy: "theme = light:Apple System Colors Light,dark:Apple System Colors"
+                    ).count - 1,
+                    1,
+                    contents
+                )
+                XCTAssertTrue(contents.contains("font-size = 13"), contents)
+            }
         }
     }
 
@@ -476,23 +514,4 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
         return configURL
     }
 
-    private final class RaceCreatingFileManager: FileManager {
-        var onFirstMissingPlainExistenceCheck: ((String) throws -> Void)?
-        var creationError: Error?
-        private var hasRunPlainExistenceHook = false
-
-        override func fileExists(atPath path: String) -> Bool {
-            let exists = super.fileExists(atPath: path)
-            guard !exists, !hasRunPlainExistenceHook else {
-                return exists
-            }
-            hasRunPlainExistenceHook = true
-            do {
-                try onFirstMissingPlainExistenceCheck?(path)
-            } catch {
-                creationError = error
-            }
-            return exists
-        }
-    }
 }

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -175,9 +175,35 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
 
             XCTAssertEqual(materializedURL, configGhosttyURL)
             XCTAssertTrue(FileManager.default.fileExists(atPath: configGhosttyURL.path))
-            XCTAssertEqual(try String(contentsOf: configGhosttyURL, encoding: .utf8), "")
+            let contents = try String(contentsOf: configGhosttyURL, encoding: .utf8)
+            XCTAssertFalse(contents.isEmpty)
+            XCTAssertTrue(
+                contents.contains("theme = light:Apple System Colors Light,dark:Apple System Colors"),
+                contents
+            )
             XCTAssertEqual(try String(contentsOf: legacyConfigURL, encoding: .utf8), "background = #000000\n")
             XCTAssertNil(fileManager.creationError)
+        }
+    }
+
+    func testMaterializeWritesManagedThemeConfigForCleanCmuxConfigDirectory() throws {
+        try withTemporaryHomeDirectory { homeDirectory in
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: "com.cmuxterm.app"
+            )
+
+            let materializedURL = try environment.materializeCmuxConfigFileIfNeeded()
+            let contents = try String(contentsOf: materializedURL, encoding: .utf8)
+
+            XCTAssertEqual(materializedURL.lastPathComponent, "config.ghostty")
+            XCTAssertFalse(contents.isEmpty)
+            XCTAssertTrue(contents.contains("# cmux-managed-theme: begin"), contents)
+            XCTAssertTrue(
+                contents.contains("theme = light:Apple System Colors Light,dark:Apple System Colors"),
+                contents
+            )
+            XCTAssertTrue(contents.contains("# cmux-managed-theme: end"), contents)
         }
     }
 

--- a/cmuxTests/GhosttyConfigPathResolverTests.swift
+++ b/cmuxTests/GhosttyConfigPathResolverTests.swift
@@ -245,6 +245,25 @@ final class GhosttyConfigPathResolverTests: XCTestCase {
         }
     }
 
+    func testWriteManagedAppearanceConfigThrowsWithoutOverwritingUnreadableExistingConfig() throws {
+        try withTemporaryHomeDirectory { homeDirectory in
+            let environment = ConfigSourceEnvironment(
+                homeDirectoryURL: homeDirectory,
+                currentBundleIdentifier: "com.cmuxterm.app"
+            )
+            let configURL = environment.cmuxConfigURL
+            try FileManager.default.createDirectory(
+                at: configURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let invalidUTF8 = Data([0xff, 0xfe, 0xfd])
+            try invalidUTF8.write(to: configURL)
+
+            XCTAssertThrowsError(try environment.writeManagedAppearanceConfigIfNeeded())
+            XCTAssertEqual(try Data(contentsOf: configURL), invalidUTF8)
+        }
+    }
+
     func testSyncedConfigPreviewIncludesSymlinkedStandaloneGhosttyConfig() throws {
         try withTemporaryHomeDirectory { homeDirectory in
             let fileManager = FileManager.default


### PR DESCRIPTION
Fixes #3827.\n\nThis PR makes the app appearance path materialize the cmux app-support Ghostty config instead of leaving config.ghostty missing or empty. The first commit adds regression coverage for clean config materialization, Light/Dark/System selection, system Light/Dark launch resolution, and surface refresh ordering; the second commit writes the managed light/dark Ghostty theme block before Ghostty reloads terminal surfaces.\n\nLocal tests/builds were not run per repository and task instructions; CI is expected to validate the regression and fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk: changes when/where the app writes the cmux-managed `config.ghostty` theme block and can modify user config files (with marker repair), though behavior is guarded and covered by new tests.
> 
> **Overview**
> Ensures theme changes actually reach Ghostty terminal surfaces by **materializing/updating the cmux app-support Ghostty config** with a managed light/dark `theme` block when needed.
> 
> Appearance application now calls a new `writeManagedGhosttyConfig` hook *before* setting AppKit appearance and triggering Ghostty theme sync, and logs failures via `OSLog`.
> 
> Adds robust managed-block install/repair logic (handles orphaned markers, preserves other config content, avoids writing when unmanaged) and expands regression tests for clean installs, legacy config preservation, launch/system appearance cases, write-before-reload ordering, and unreadable-config safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4798553f3635f2bba6e9fc8ee79ad769b55f8312. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Writes the cmux‑managed Ghostty theme block to app‑support `config.ghostty` before terminal reloads and hardens the writer to avoid overwriting unreadable user configs, repair malformed blocks, and log failures. Fixes #3827.

- **Bug Fixes**
  - Materializes `config.ghostty` with a managed theme block on clean installs; preserves user/legacy configs.
  - Invokes `writeManagedGhosttyConfig` before AppKit appearance and Ghostty reload to ensure correct ordering.
  - Repairs orphaned managed markers to a single valid block, fails closed on unreadable existing files, and logs errors via OSLog.
  - Tests cover materialization, Light/Dark/System and launch flows, write‑before‑reload ordering, marker repair, and unreadable‑config protection.

<sup>Written for commit 4798553f3635f2bba6e9fc8ee79ad769b55f8312. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Appearance settings now automatically synchronize with Ghostty terminal configuration when applied.

* **Tests**
  * Added test coverage for appearance mode selection and managed theme configuration handling.
  * Enhanced configuration materialization tests to verify managed theme content generation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3878)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->