### PR TITLE
Fix #3856: honor focusPaneOnFirstClick for minimal-mode chrome and workspace sidebar

### DIFF
--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -27,6 +27,46 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
     }
 }
 
+class FirstMouseGatedHostingView<Content: View>: NSHostingView<Content> {
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: NSView.noIntrinsicMetric, height: NSView.noIntrinsicMetric)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        if shouldCaptureInactiveFirstMouse(at: point) {
+            return self
+        }
+        return super.hitTest(point)
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        PaneFirstClickFocusSettings.isEnabled()
+    }
+
+    func shouldCaptureInactiveFirstMouse(at point: NSPoint) -> Bool {
+        let localPoint = superview.map { convert(point, from: $0) } ?? point
+        return window?.isKeyWindow != true &&
+            !PaneFirstClickFocusSettings.isEnabled() &&
+            bounds.contains(localPoint)
+    }
+}
+
+final class FirstMouseGatedPassThroughHostingView<Content: View>: FirstMouseGatedHostingView<Content> {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        shouldCaptureInactiveFirstMouse(at: point) ? self : nil
+    }
+}
+
+struct FirstMouseGatedHostingOverlay: NSViewRepresentable {
+    func makeNSView(context: Context) -> FirstMouseGatedPassThroughHostingView<AnyView> {
+        FirstMouseGatedPassThroughHostingView(rootView: AnyView(EmptyView()))
+    }
+
+    func updateNSView(_ nsView: FirstMouseGatedPassThroughHostingView<AnyView>, context: Context) {
+        nsView.rootView = AnyView(EmptyView())
+    }
+}
+
 @MainActor
 final class CmuxMainWindow: NSWindow {
     private var isSoftHiddenForVisibilityController = false

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9170,6 +9170,11 @@ struct VerticalTabsSidebar: View {
             SidebarFooter(updateViewModel: updateViewModel, fileExplorerState: fileExplorerState, onSendFeedback: onSendFeedback)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
+        .overlay {
+            FirstMouseGatedHostingOverlay()
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .accessibilityHidden(true)
+        }
         .accessibilityIdentifier("Sidebar")
         .ignoresSafeArea()
         .overlay(alignment: .trailing) {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1049,7 +1049,7 @@ final class FilePreviewPDFChromeHostView: NSView {
 
 final class FilePreviewPDFChromeHostingView: NSHostingView<AnyView> {
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        true
+        PaneFirstClickFocusSettings.isEnabled()
     }
 }
 

--- a/Sources/Update/MinimalModeSidebarControls.swift
+++ b/Sources/Update/MinimalModeSidebarControls.swift
@@ -143,7 +143,7 @@ final class MinimalModeSidebarControlActionView: NSView {
     }
 
     override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        true
+        PaneFirstClickFocusSettings.isEnabled()
     }
 
     override func hitTest(_ point: NSPoint) -> NSView? {

--- a/cmuxTests/InactivePaneFirstClickFocusTests.swift
+++ b/cmuxTests/InactivePaneFirstClickFocusTests.swift
@@ -1,5 +1,6 @@
 import XCTest
 import AppKit
+import SwiftUI
 import WebKit
 
 #if canImport(cmux_DEV)
@@ -68,5 +69,302 @@ final class InactivePaneFirstClickFocusTests: XCTestCase {
         let view = MarkdownPanelPointerObserverView(frame: .zero)
 
         XCTAssertFalse(view.acceptsFirstMouse(for: nil))
+    }
+
+    func testMinimalModeSidebarControlsAcceptFirstMouseWhenSettingEnabled() {
+        UserDefaults.standard.set(true, forKey: settingsKey)
+
+        let view = MinimalModeSidebarControlActionView(frame: NSRect(x: 0, y: 0, width: 120, height: 32))
+
+        XCTAssertTrue(view.acceptsFirstMouse(for: nil))
+    }
+
+    func testMinimalModeSidebarControlsRejectFirstMouseWhenSettingDisabled() {
+        UserDefaults.standard.set(false, forKey: settingsKey)
+
+        let view = MinimalModeSidebarControlActionView(frame: NSRect(x: 0, y: 0, width: 120, height: 32))
+
+        XCTAssertFalse(view.acceptsFirstMouse(for: nil))
+    }
+
+    func testPDFChromeHostingViewAcceptsFirstMouseWhenSettingEnabled() {
+        UserDefaults.standard.set(true, forKey: settingsKey)
+
+        let view = FilePreviewPDFChromeHostingView(rootView: AnyView(EmptyView()))
+
+        XCTAssertTrue(view.acceptsFirstMouse(for: nil))
+    }
+
+    func testPDFChromeHostingViewRejectsFirstMouseWhenSettingDisabled() {
+        UserDefaults.standard.set(false, forKey: settingsKey)
+
+        let view = FilePreviewPDFChromeHostingView(rootView: AnyView(EmptyView()))
+
+        XCTAssertFalse(view.acceptsFirstMouse(for: nil))
+    }
+
+    private struct SidebarFirstClickHarness {
+        let tabManager: TabManager
+        let initialWorkspace: Workspace
+        let targetWorkspace: Workspace
+        let window: NSWindow
+        let keyWindow: NSWindow
+        let host: NSView
+
+        @MainActor
+        func close() {
+            window.orderOut(nil)
+            keyWindow.orderOut(nil)
+        }
+    }
+
+    private enum SidebarFirstClickHarnessError: Error, CustomStringConvertible {
+        case missingAccessibilityElement(String)
+        case missingAccessibilityFrame(String)
+
+        var description: String {
+            switch self {
+            case .missingAccessibilityElement(let identifier):
+                return "Missing sidebar accessibility element \(identifier)"
+            case .missingAccessibilityFrame(let identifier):
+                return "Missing sidebar accessibility frame \(identifier)"
+            }
+        }
+    }
+
+    private typealias AccessibilityNode = NSAccessibilityElementProtocol & NSAccessibilityProtocol
+
+    private struct InactiveFirstClickResult {
+        let acceptedFirstMouse: Bool
+        let hitViewClassName: String
+    }
+
+    private func makeSidebarFirstClickHarness() throws -> SidebarFirstClickHarness {
+        let tabManager = TabManager(autoWelcomeIfNeeded: false)
+        let initialWorkspace = try XCTUnwrap(tabManager.selectedWorkspace)
+        let targetWorkspace = tabManager.addWorkspace(
+            title: "Second Workspace",
+            select: false,
+            eagerLoadTerminal: false,
+            autoWelcomeIfNeeded: false
+        )
+        var selection = SidebarSelection.tabs
+        var selectedTabIds: Set<UUID> = [initialWorkspace.id]
+        var lastSidebarSelectionIndex: Int? = 0
+        let sidebar = VerticalTabsSidebar(
+            updateViewModel: UpdateViewModel(),
+            fileExplorerState: FileExplorerState(),
+            onSendFeedback: {},
+            onToggleSidebar: {},
+            onNewTab: {},
+            selection: Binding(
+                get: { selection },
+                set: { selection = $0 }
+            ),
+            selectedTabIds: Binding(
+                get: { selectedTabIds },
+                set: { selectedTabIds = $0 }
+            ),
+            lastSidebarSelectionIndex: Binding(
+                get: { lastSidebarSelectionIndex },
+                set: { lastSidebarSelectionIndex = $0 }
+            )
+        )
+        .environmentObject(tabManager)
+        .environmentObject(TerminalNotificationStore.shared)
+        let host = NSHostingView(rootView: sidebar)
+        let frame = NSRect(x: 0, y: 0, width: 240, height: 360)
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        let keyWindow = NSWindow(
+            contentRect: NSRect(x: 260, y: 0, width: 120, height: 120),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = host
+        host.frame = frame
+        window.orderFront(nil)
+        keyWindow.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        host.layoutSubtreeIfNeeded()
+
+        XCTAssertFalse(window.isKeyWindow)
+
+        return SidebarFirstClickHarness(
+            tabManager: tabManager,
+            initialWorkspace: initialWorkspace,
+            targetWorkspace: targetWorkspace,
+            window: window,
+            keyWindow: keyWindow,
+            host: host
+        )
+    }
+
+    private func findAccessibilityElement(
+        identifier: String,
+        in root: Any,
+        visited: inout Set<ObjectIdentifier>
+    ) -> AccessibilityNode? {
+        guard let element = root as? AccessibilityNode,
+              let object = root as? NSObject else {
+            return nil
+        }
+        let objectIdentifier = ObjectIdentifier(object)
+        guard visited.insert(objectIdentifier).inserted else { return nil }
+
+        if let elementIdentifier = element.accessibilityIdentifier?(), elementIdentifier == identifier {
+            return element
+        }
+
+        let children = object.accessibilityAttributeValue(.children) as? [Any] ?? []
+        for child in children {
+            if let match = findAccessibilityElement(identifier: identifier, in: child, visited: &visited) {
+                return match
+            }
+        }
+
+        let visibleChildren = object.accessibilityAttributeValue(.visibleChildren) as? [Any] ?? []
+        for child in visibleChildren {
+            if let match = findAccessibilityElement(identifier: identifier, in: child, visited: &visited) {
+                return match
+            }
+        }
+
+        return nil
+    }
+
+    private func targetRowPoint(in harness: SidebarFirstClickHarness) throws -> NSPoint {
+        let identifier = "sidebarWorkspace.\(harness.targetWorkspace.id.uuidString)"
+        var visited = Set<ObjectIdentifier>()
+        guard let targetElement = findAccessibilityElement(
+            identifier: identifier,
+            in: harness.host,
+            visited: &visited
+        ) else {
+            throw SidebarFirstClickHarnessError.missingAccessibilityElement(identifier)
+        }
+        let targetFrame = targetElement.accessibilityFrame()
+        guard !targetFrame.isEmpty else {
+            throw SidebarFirstClickHarnessError.missingAccessibilityFrame(identifier)
+        }
+
+        let screenCenter = NSPoint(x: targetFrame.midX, y: targetFrame.midY)
+        let windowPoint = harness.window.convertPoint(fromScreen: screenCenter)
+        XCTAssertTrue(
+            harness.host.bounds.contains(windowPoint),
+            "Expected \(identifier) center \(windowPoint) to be inside the sidebar host."
+        )
+        return windowPoint
+    }
+
+    private func mouseEvent(
+        _ type: NSEvent.EventType,
+        at point: NSPoint,
+        in window: NSWindow,
+        eventNumber: Int,
+        pressure: Float
+    ) throws -> NSEvent {
+        try XCTUnwrap(NSEvent.mouseEvent(
+            with: type,
+            location: point,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: eventNumber,
+            clickCount: 1,
+            pressure: pressure
+        ))
+    }
+
+    private func sendClick(at point: NSPoint, in window: NSWindow) throws {
+        NSApp.sendEvent(try mouseEvent(.leftMouseDown, at: point, in: window, eventNumber: 1, pressure: 1))
+        NSApp.sendEvent(try mouseEvent(.leftMouseUp, at: point, in: window, eventNumber: 2, pressure: 0))
+        RunLoop.current.run(until: Date(timeIntervalSinceNow: 0.05))
+    }
+
+    private func dispatchInactiveFirstClick(in harness: SidebarFirstClickHarness) throws -> InactiveFirstClickResult {
+        let targetRowPoint = try targetRowPoint(in: harness)
+        let downEvent = try XCTUnwrap(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: targetRowPoint,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: harness.window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+        let hitView = try XCTUnwrap(harness.host.hitTest(targetRowPoint))
+        let acceptedFirstMouse = hitView.acceptsFirstMouse(for: downEvent)
+
+        try sendClick(at: targetRowPoint, in: harness.window)
+        return InactiveFirstClickResult(
+            acceptedFirstMouse: acceptedFirstMouse,
+            hitViewClassName: String(describing: type(of: hitView))
+        )
+    }
+
+    func testWorkspaceSidebarClickSwitchesWorkspaceWhenWindowIsActive() throws {
+        UserDefaults.standard.set(true, forKey: settingsKey)
+
+        let harness = try makeSidebarFirstClickHarness()
+        defer { harness.close() }
+
+        harness.window.makeKeyAndOrderFront(nil)
+        harness.window.displayIfNeeded()
+        harness.host.layoutSubtreeIfNeeded()
+
+        XCTAssertTrue(harness.window.isKeyWindow)
+        try sendClick(at: try targetRowPoint(in: harness), in: harness.window)
+        XCTAssertEqual(harness.tabManager.selectedTabId, harness.targetWorkspace.id)
+    }
+
+    func testWorkspaceSidebarInactiveFirstClickSwitchesWorkspaceWhenSettingEnabled() throws {
+        UserDefaults.standard.set(true, forKey: settingsKey)
+
+        let harness = try makeSidebarFirstClickHarness()
+        defer { harness.close() }
+
+        let result = try dispatchInactiveFirstClick(in: harness)
+
+        XCTAssertTrue(
+            result.acceptedFirstMouse,
+            "Inactive first click on workspace \(harness.targetWorkspace.id) should pass through when the setting is enabled."
+        )
+        XCTAssertTrue(harness.window.isKeyWindow)
+        XCTAssertFalse(
+            result.hitViewClassName.contains("FirstMouseGated"),
+            "Enabled inactive sidebar click should not be captured by the production first-mouse gate, got \(result.hitViewClassName)."
+        )
+        XCTAssertEqual(harness.tabManager.selectedTabId, harness.targetWorkspace.id)
+        XCTAssertNotEqual(harness.tabManager.selectedTabId, harness.initialWorkspace.id)
+    }
+
+    func testWorkspaceSidebarInactiveFirstClickDoesNotSwitchWorkspaceWhenSettingDisabled() throws {
+        UserDefaults.standard.set(false, forKey: settingsKey)
+
+        let harness = try makeSidebarFirstClickHarness()
+        defer { harness.close() }
+
+        let result = try dispatchInactiveFirstClick(in: harness)
+
+        XCTAssertFalse(
+            result.acceptedFirstMouse,
+            "Inactive first click on workspace \(harness.targetWorkspace.id) should activate the window only."
+        )
+        XCTAssertTrue(harness.window.isKeyWindow)
+        XCTAssertTrue(
+            result.hitViewClassName.contains("FirstMouseGated"),
+            "Expected inactive sidebar click to be captured by the production first-mouse gate, got \(result.hitViewClassName)."
+        )
+        XCTAssertEqual(harness.tabManager.selectedTabId, harness.initialWorkspace.id)
+        XCTAssertNotEqual(harness.tabManager.selectedTabId, harness.targetWorkspace.id)
     }
 }

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1733,6 +1733,17 @@ private final class FilePreviewPDFChromeNotificationFlag: @unchecked Sendable {
 @MainActor
 final class FilePreviewPDFChromeTests: XCTestCase {
     func testChromeHostsAcceptFirstMouse() {
+        let settingsKey = "paneFirstClickFocus.enabled"
+        let previousValue = UserDefaults.standard.object(forKey: settingsKey)
+        defer {
+            if let previousValue {
+                UserDefaults.standard.set(previousValue, forKey: settingsKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: settingsKey)
+            }
+        }
+        UserDefaults.standard.set(true, forKey: settingsKey)
+
         let host = FilePreviewPDFChromeHostingView(rootView: AnyView(EmptyView()))
 
         XCTAssertTrue(host.acceptsFirstMouse(for: nil))


### PR DESCRIPTION
Fixes #3856.

This PR keeps PaneFirstClickFocusSettings as the single source of truth for inactive first-click behavior. It adds failing regression coverage first, then gates the minimal-mode sidebar controls, PDF chrome hosting view, and SwiftUI workspace sidebar first-mouse boundary so inactive first clicks only activate cmux when app.focusPaneOnFirstClick is false.

Local tests/build were not run per repo and task instructions; CI is the verification path before the required tagged reload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS first-mouse hit-testing/acceptance for several UI surfaces, which can subtly affect click/focus behavior across the app. Adds broad UI-event-driven test coverage, reducing risk but still sensitive to edge cases in AppKit/SwiftUI integration.
> 
> **Overview**
> Ensures inactive-window first clicks consistently respect `PaneFirstClickFocusSettings` (aka `focusPaneOnFirstClick`) across minimal-mode titlebar controls, PDF preview chrome, and the SwiftUI workspace sidebar.
> 
> Adds a SwiftUI/AppKit boundary “first-mouse gate” overlay (`FirstMouseGatedHostingOverlay`) on the sidebar to capture the initial click when the window is inactive and the setting is disabled, preventing accidental workspace switches.
> 
> Updates/expands regression tests to cover these behaviors, including an integration-style sidebar harness that locates rows via accessibility IDs and dispatches real mouse events; also adjusts existing PDF chrome tests to set the setting explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cf33d88eed1315a51fdf8525e721e555b903702. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #3856 by honoring the inactive first‑click policy across the workspace sidebar, minimal‑mode controls, and PDF preview chrome. When `PaneFirstClickFocusSettings` is off, the first click on an inactive window only activates the app and does not switch panes or workspaces.

- **Bug Fixes**
  - Added `FirstMouseGatedHostingView`, `FirstMouseGatedPassThroughHostingView`, and `FirstMouseGatedHostingOverlay`; overlay (accessibility‑hidden) is applied to `VerticalTabsSidebar` to capture inactive first clicks at the SwiftUI↔AppKit boundary.
  - Gated `acceptsFirstMouse` in `MinimalModeSidebarControlActionView` and `FilePreviewPDFChromeHostingView` with `PaneFirstClickFocusSettings.isEnabled()`.
  - Expanded tests with a runtime sidebar harness using accessibility IDs and real mouse events; verifies active‑window clicks switch workspaces, inactive first clicks are intercepted by a `FirstMouseGated*` view when the setting is off, and updated PDF chrome tests to respect the setting.

<sup>Written for commit 9cf33d88eed1315a51fdf8525e721e555b903702. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * First-click handling updated so inactive-window clicks respect the user focus setting across sidebars, previews, and minimal controls.

* **Bug Fixes**
  * Prevents unintended activation/selection when clicking inactive panes by gating first-mouse behavior.

* **Tests**
  * Added end-to-end and unit tests covering first-click behavior for active/inactive window scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3881)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->