### PR TITLE
Fix #2791: preserve window position across sleep/wake with multiple monitors

### DIFF
--- a/Sources/App/SessionSnapshotDebugBenchmark.swift
+++ b/Sources/App/SessionSnapshotDebugBenchmark.swift
@@ -7,8 +7,7 @@ enum SessionSnapshotDebugBenchmark {
         includeScrollback: Bool,
         persist: Bool,
         buildSnapshot: (Bool) -> AppSessionSnapshot?,
-        persistedGeometryData: (AppSessionSnapshot?) -> Data?,
-        persistSnapshot: (AppSessionSnapshot?, Data?) -> Void
+        persistSnapshot: (AppSessionSnapshot?) -> Void
     ) -> [String: Any] {
         let buildStart = ProcessInfo.processInfo.systemUptime
         let snapshot = buildSnapshot(includeScrollback)
@@ -16,9 +15,8 @@ enum SessionSnapshotDebugBenchmark {
 
         var persistMs: Double?
         if persist {
-            let geometryData = persistedGeometryData(snapshot)
             let persistStart = ProcessInfo.processInfo.systemUptime
-            persistSnapshot(snapshot, geometryData)
+            persistSnapshot(snapshot)
             persistMs = elapsedMs(since: persistStart)
         }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3265,7 +3265,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             persistSessionSnapshot(
                 nil,
                 removeWhenEmpty: removeWhenEmpty,
-                persistedGeometryData: nil,
                 synchronously: writeSynchronously
             )
             return false
@@ -3277,7 +3276,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         persistSessionSnapshot(
             snapshot,
             removeWhenEmpty: false,
-            persistedGeometryData: nil,
             synchronously: writeSynchronously
         )
         return true
@@ -3294,12 +3292,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             buildSnapshot: { [self] includeScrollback in
                 buildSessionSnapshot(includeScrollback: includeScrollback)
             },
-            persistedGeometryData: { _ in nil },
-            persistSnapshot: { [self] snapshot, persistedGeometryData in
+            persistSnapshot: { [self] snapshot in
                 persistSessionSnapshot(
                     snapshot,
                     removeWhenEmpty: false,
-                    persistedGeometryData: persistedGeometryData,
                     synchronously: true
                 )
             }
@@ -3501,19 +3497,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private func persistSessionSnapshot(
         _ snapshot: AppSessionSnapshot?,
         removeWhenEmpty: Bool,
-        persistedGeometryData: Data?,
         synchronously: Bool
     ) {
-        guard snapshot != nil || removeWhenEmpty || persistedGeometryData != nil else { return }
+        guard snapshot != nil || removeWhenEmpty else { return }
 
         let writeBlock = {
             Self.removeLegacyPersistedWindowGeometry()
-            if let persistedGeometryData {
-                UserDefaults.standard.set(
-                    persistedGeometryData,
-                    forKey: Self.persistedWindowGeometryDefaultsKey
-                )
-            }
             if let snapshot {
                 _ = SessionPersistenceStore.save(snapshot)
             } else if removeWhenEmpty {
@@ -6775,10 +6764,41 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func mainWindowFrameAutosaveName(windowId: UUID, wantsPrimarySlot: Bool) -> NSWindow.FrameAutosaveName {
         if wantsPrimarySlot,
-           !NSApp.windows.contains(where: { $0.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName }) {
+           !hasLivePrimaryMainWindowFrameAutosaveOwner() {
             return Self.primaryMainWindowFrameAutosaveName
         }
         return "\(Self.mainWindowFrameAutosaveNamePrefix).\(windowId.uuidString)"
+    }
+
+    private func hasLivePrimaryMainWindowFrameAutosaveOwner(excluding excludedWindow: NSWindow? = nil) -> Bool {
+        NSApp.windows.contains { window in
+            if let excludedWindow, window === excludedWindow {
+                return false
+            }
+            return window.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName
+        }
+    }
+
+    private func promotePrimaryMainWindowFrameAutosaveNameIfNeeded(excluding excludedWindow: NSWindow? = nil) {
+        guard !hasLivePrimaryMainWindowFrameAutosaveOwner(excluding: excludedWindow) else { return }
+        guard let survivor = sortedMainWindowContextsForSessionSnapshot()
+            .compactMap({ resolvedWindow(for: $0) })
+            .first(where: { window in
+                guard let excludedWindow else { return true }
+                return window !== excludedWindow
+            }) else {
+            return
+        }
+
+        let previousAutosaveName = survivor.frameAutosaveName
+        guard previousAutosaveName != Self.primaryMainWindowFrameAutosaveName else { return }
+        _ = survivor.setFrameAutosaveName(Self.primaryMainWindowFrameAutosaveName)
+        survivor.saveFrame(usingName: Self.primaryMainWindowFrameAutosaveName)
+
+        if !previousAutosaveName.isEmpty,
+           previousAutosaveName.hasPrefix("\(Self.mainWindowFrameAutosaveNamePrefix).") {
+            NSWindow.removeFrame(usingName: previousAutosaveName)
+        }
     }
 
     private func removeEphemeralMainWindowFrameAutosaveNameIfNeeded(_ window: NSWindow) {
@@ -6890,7 +6910,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         let frameAutosaveName = mainWindowFrameAutosaveName(
             windowId: windowId,
-            wantsPrimarySlot: restoredFrame == nil && sourceWindow == nil && mainWindowContexts.isEmpty
+            wantsPrimarySlot: !hasLivePrimaryMainWindowFrameAutosaveOwner()
         )
 
         let window = CmuxMainWindow(
@@ -13412,6 +13432,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         removeEphemeralMainWindowFrameAutosaveNameIfNeeded(window)
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
+        promotePrimaryMainWindowFrameAutosaveNameIfNeeded(excluding: window)
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
         commandPalettePendingOpenByWindowId.removeValue(forKey: removed.windowId)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6792,7 +6792,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let previousAutosaveName = survivor.frameAutosaveName
         guard previousAutosaveName != Self.primaryMainWindowFrameAutosaveName else { return }
+        let survivorFrame = survivor.frame
+        // Registering an autosave name can reload its saved frame; seed it with the survivor first.
+        survivor.saveFrame(usingName: Self.primaryMainWindowFrameAutosaveName)
         guard survivor.setFrameAutosaveName(Self.primaryMainWindowFrameAutosaveName) else { return }
+        if survivor.frame != survivorFrame {
+            survivor.setFrame(survivorFrame, display: false)
+        }
         survivor.saveFrame(usingName: Self.primaryMainWindowFrameAutosaveName)
 
         if !previousAutosaveName.isEmpty,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -664,9 +664,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         primaryMainWindowFrameAutosaveName
     }
     nonisolated static var debugPersistedWindowGeometryDefaultsKey: String { persistedWindowGeometryDefaultsKey }
+    nonisolated static func debugRemoveLegacyPersistedWindowGeometry(
+        defaults: UserDefaults = .standard
+    ) {
+        removeLegacyPersistedWindowGeometry(defaults: defaults)
+    }
 #endif
     private nonisolated static let legacyPersistedWindowGeometryDefaultsKeys = [
-        "cmux.session.lastWindowGeometry.v1"
+        "cmux.session.lastWindowGeometry.v1",
+        persistedWindowGeometryDefaultsKey,
     ]
 
     weak var tabManager: TabManager?
@@ -6782,6 +6788,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
               autosaveName.hasPrefix("\(Self.mainWindowFrameAutosaveNamePrefix).") else {
             return
         }
+        _ = window.setFrameAutosaveName("")
         NSWindow.removeFrame(usingName: autosaveName)
     }
 

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6762,9 +6762,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
-    private func mainWindowFrameAutosaveName(windowId: UUID, wantsPrimarySlot: Bool) -> NSWindow.FrameAutosaveName {
-        if wantsPrimarySlot,
-           !hasLivePrimaryMainWindowFrameAutosaveOwner() {
+    private func mainWindowFrameAutosaveName(windowId: UUID) -> NSWindow.FrameAutosaveName {
+        if !hasLivePrimaryMainWindowFrameAutosaveOwner() {
             return Self.primaryMainWindowFrameAutosaveName
         }
         return "\(Self.mainWindowFrameAutosaveNamePrefix).\(windowId.uuidString)"
@@ -6914,10 +6913,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         } else {
             initialRect = CmuxMainWindow.defaultContentRect(styleMask: styleMask)
         }
-        let frameAutosaveName = mainWindowFrameAutosaveName(
-            windowId: windowId,
-            wantsPrimarySlot: !hasLivePrimaryMainWindowFrameAutosaveOwner()
-        )
+        let frameAutosaveName = mainWindowFrameAutosaveName(windowId: windowId)
 
         let window = CmuxMainWindow(
             contentRect: initialRect,

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -654,9 +654,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let display: SessionDisplaySnapshot?
     }
 
+    private nonisolated static let primaryMainWindowFrameAutosaveName: NSWindow.FrameAutosaveName =
+        "cmux.mainWindow.primary"
+    private nonisolated static let mainWindowFrameAutosaveNamePrefix = "cmux.mainWindow"
     nonisolated static let persistedWindowGeometrySchemaVersion = 2
     private nonisolated static let persistedWindowGeometryDefaultsKey = "cmux.session.lastWindowGeometry.v2"
 #if DEBUG
+    nonisolated static var debugPrimaryMainWindowFrameAutosaveName: NSWindow.FrameAutosaveName {
+        primaryMainWindowFrameAutosaveName
+    }
     nonisolated static var debugPersistedWindowGeometryDefaultsKey: String { persistedWindowGeometryDefaultsKey }
 #endif
     private nonisolated static let legacyPersistedWindowGeometryDefaultsKeys = [
@@ -2513,43 +2519,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         startupSessionSnapshot = SessionPersistenceStore.load()
     }
 
-    private func persistedWindowGeometry(defaults: UserDefaults = .standard) -> PersistedWindowGeometry? {
-        Self.removeLegacyPersistedWindowGeometry(defaults: defaults)
-        guard let data = defaults.data(forKey: Self.persistedWindowGeometryDefaultsKey) else {
-            return nil
-        }
-        guard let payload = Self.decodedPersistedWindowGeometryData(data) else {
-            defaults.removeObject(forKey: Self.persistedWindowGeometryDefaultsKey)
-            return nil
-        }
-        return payload
-    }
-
-    private func persistWindowGeometry(
-        frame: SessionRectSnapshot?,
-        display: SessionDisplaySnapshot?,
-        defaults: UserDefaults = .standard
-    ) {
-        Self.removeLegacyPersistedWindowGeometry(defaults: defaults)
-        guard let data = Self.encodedPersistedWindowGeometryData(frame: frame, display: display) else {
-            return
-        }
-        defaults.set(data, forKey: Self.persistedWindowGeometryDefaultsKey)
-    }
-
-    private nonisolated static func encodedPersistedWindowGeometryData(
-        frame: SessionRectSnapshot?,
-        display: SessionDisplaySnapshot?
-    ) -> Data? {
-        guard let frame else { return nil }
-        let payload = PersistedWindowGeometry(
-            version: persistedWindowGeometrySchemaVersion,
-            frame: frame,
-            display: display
-        )
-        return try? JSONEncoder().encode(payload)
-    }
-
     nonisolated static func decodedPersistedWindowGeometryData(_ data: Data) -> PersistedWindowGeometry? {
         guard let payload = try? JSONDecoder().decode(PersistedWindowGeometry.self, from: data),
               payload.version == persistedWindowGeometrySchemaVersion else {
@@ -2562,14 +2531,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         defaults: UserDefaults = .standard
     ) {
         legacyPersistedWindowGeometryDefaultsKeys.forEach { defaults.removeObject(forKey: $0) }
-    }
-
-    private func persistWindowGeometry(from window: NSWindow?) {
-        guard let window else { return }
-        persistWindowGeometry(
-            frame: SessionRectSnapshot(window.frame),
-            display: displaySnapshot(for: window)
-        )
     }
 
     private func currentDisplayGeometries() -> (available: [SessionDisplayGeometry], fallback: SessionDisplayGeometry?) {
@@ -2588,17 +2549,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             )
         }
         return (available, fallback)
-    }
-
-    private func resolvedPersistedWindowGeometryFrame() -> NSRect? {
-        let displays = currentDisplayGeometries()
-        let fallbackGeometry = persistedWindowGeometry()
-        return Self.resolvedWindowFrame(
-            from: fallbackGeometry?.frame,
-            display: fallbackGeometry?.display,
-            availableDisplays: displays.available,
-            fallbackDisplay: displays.fallback
-        )
     }
 
     private func attemptStartupSessionRestoreIfNeeded(primaryWindow: NSWindow) {
@@ -2623,18 +2573,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 to: primaryContext,
                 window: primaryWindow
             )
-        } else {
-            let displays = currentDisplayGeometries()
-            let fallbackGeometry = persistedWindowGeometry()
-            if let restoredFrame = Self.resolvedStartupPrimaryWindowFrame(
-                primarySnapshot: nil,
-                fallbackFrame: fallbackGeometry?.frame,
-                fallbackDisplaySnapshot: fallbackGeometry?.display,
-                availableDisplays: displays.available,
-                fallbackDisplay: displays.fallback
-            ) {
-                primaryWindow.setFrame(restoredFrame, display: true)
-            }
         }
 
         if let startupSnapshot {
@@ -3327,20 +3265,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        let persistedGeometryData = snapshot.windows.first.flatMap { primaryWindow in
-            Self.encodedPersistedWindowGeometryData(
-                frame: primaryWindow.frame,
-                display: primaryWindow.display
-            )
-        }
-
 #if DEBUG
         debugLogSessionSaveSnapshot(snapshot, includeScrollback: includeScrollback)
 #endif
         persistSessionSnapshot(
             snapshot,
             removeWhenEmpty: false,
-            persistedGeometryData: persistedGeometryData,
+            persistedGeometryData: nil,
             synchronously: writeSynchronously
         )
         return true
@@ -3357,14 +3288,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             buildSnapshot: { [self] includeScrollback in
                 buildSessionSnapshot(includeScrollback: includeScrollback)
             },
-            persistedGeometryData: { snapshot in
-                snapshot?.windows.first.flatMap { primaryWindow in
-                    Self.encodedPersistedWindowGeometryData(
-                        frame: primaryWindow.frame,
-                        display: primaryWindow.display
-                    )
-                }
-            },
+            persistedGeometryData: { _ in nil },
             persistSnapshot: { [self] snapshot, persistedGeometryData in
                 persistSessionSnapshot(
                     snapshot,
@@ -6843,6 +6767,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
     }
 
+    private func mainWindowFrameAutosaveName(windowId: UUID, wantsPrimarySlot: Bool) -> NSWindow.FrameAutosaveName {
+        if wantsPrimarySlot,
+           !NSApp.windows.contains(where: { $0.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName }) {
+            return Self.primaryMainWindowFrameAutosaveName
+        }
+        return "\(Self.mainWindowFrameAutosaveNamePrefix).\(windowId.uuidString)"
+    }
+
     @discardableResult
     func createMainWindow(
         initialWorkspaceTitle: String? = nil,
@@ -6929,19 +6861,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let shouldTemporarilyDisallowFullScreenTiling =
             sessionWindowSnapshot == nil && sourceWindowIsNativeFullScreen
         let restoredFrame = resolvedWindowFrame(from: sessionWindowSnapshot)
-        let persistedGeometryFrame = (restoredFrame == nil && sourceWindow == nil)
-            ? resolvedPersistedWindowGeometryFrame()
-            : nil
         let initialRect: NSRect
         if restoredFrame == nil, let existingFrame {
             // Convert frame rect to content rect so the new window matches the
             // source window's actual size (frame includes titlebar insets).
             initialRect = NSWindow.contentRect(forFrameRect: existingFrame, styleMask: styleMask)
-        } else if let explicitInitialFrame = restoredFrame ?? persistedGeometryFrame {
+        } else if let explicitInitialFrame = restoredFrame {
             initialRect = NSWindow.contentRect(forFrameRect: explicitInitialFrame, styleMask: styleMask)
         } else {
             initialRect = CmuxMainWindow.defaultContentRect(styleMask: styleMask)
         }
+        let frameAutosaveName = mainWindowFrameAutosaveName(
+            windowId: windowId,
+            wantsPrimarySlot: restoredFrame == nil && sourceWindow == nil && mainWindowContexts.isEmpty
+        )
 
         let window = CmuxMainWindow(
             contentRect: initialRect,
@@ -6969,9 +6902,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // a movable/resizable window. Empty titlebar drags are routed through
         // WindowDragHandleView instead of background dragging.
         window.isMovable = true
-        let explicitInitialFrame = restoredFrame ?? persistedGeometryFrame
+        let appKitSavedFrameApplied = window.setFrameAutosaveName(frameAutosaveName)
+            && restoredFrame == nil
+            && sourceWindow == nil
+            && window.setFrameUsingName(frameAutosaveName, force: true)
+        let explicitInitialFrame = restoredFrame
         if let explicitInitialFrame {
             window.setFrame(explicitInitialFrame, display: false)
+        } else if appKitSavedFrameApplied {
+            lastCascadePoint = NSPoint(x: window.frame.minX, y: window.frame.maxY)
         } else if let sourceWindow {
             positionNewMainWindow(window, relativeTo: sourceWindow)
         } else {
@@ -7034,7 +6973,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             window.setFrame(explicitInitialFrame, display: true)
 #if DEBUG
             cmuxDebugLog(
-                "mainWindow.initialFrameApplied source=\(restoredFrame == nil ? "persistedGeometry" : "sessionSnapshot") window=\(windowId.uuidString.prefix(8)) " +
+                "mainWindow.initialFrameApplied source=sessionSnapshot window=\(windowId.uuidString.prefix(8)) " +
                     "applied={\(debugNSRectDescription(window.frame))}"
             )
 #endif
@@ -13451,9 +13390,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // window's position, matching upstream Ghostty behavior.
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
-
-        // Keep geometry available as a fallback for the next window placement.
-        persistWindowGeometry(from: window)
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13429,12 +13429,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
 
-        if window.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName {
-            _ = window.setFrameAutosaveName("")
-        }
+        let shouldReleasePrimaryFrameAutosaveName =
+            window.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName
         removeEphemeralMainWindowFrameAutosaveNameIfNeeded(window)
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
+        if shouldReleasePrimaryFrameAutosaveName {
+            _ = window.setFrameAutosaveName("")
+        }
         promotePrimaryMainWindowFrameAutosaveNameIfNeeded(excluding: window)
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6792,7 +6792,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         let previousAutosaveName = survivor.frameAutosaveName
         guard previousAutosaveName != Self.primaryMainWindowFrameAutosaveName else { return }
-        _ = survivor.setFrameAutosaveName(Self.primaryMainWindowFrameAutosaveName)
+        guard survivor.setFrameAutosaveName(Self.primaryMainWindowFrameAutosaveName) else { return }
         survivor.saveFrame(usingName: Self.primaryMainWindowFrameAutosaveName)
 
         if !previousAutosaveName.isEmpty,
@@ -13429,6 +13429,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
 
+        if window.frameAutosaveName == Self.primaryMainWindowFrameAutosaveName {
+            _ = window.setFrameAutosaveName("")
+        }
         removeEphemeralMainWindowFrameAutosaveNameIfNeeded(window)
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -6775,6 +6775,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         return "\(Self.mainWindowFrameAutosaveNamePrefix).\(windowId.uuidString)"
     }
 
+    private func removeEphemeralMainWindowFrameAutosaveNameIfNeeded(_ window: NSWindow) {
+        let autosaveName = window.frameAutosaveName
+        guard !autosaveName.isEmpty,
+              autosaveName != Self.primaryMainWindowFrameAutosaveName,
+              autosaveName.hasPrefix("\(Self.mainWindowFrameAutosaveNamePrefix).") else {
+            return
+        }
+        NSWindow.removeFrame(usingName: autosaveName)
+    }
+
     @discardableResult
     func createMainWindow(
         initialWorkspaceTitle: String? = nil,
@@ -6902,7 +6912,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // a movable/resizable window. Empty titlebar drags are routed through
         // WindowDragHandleView instead of background dragging.
         window.isMovable = true
-        let appKitSavedFrameApplied = window.setFrameAutosaveName(frameAutosaveName)
+        let didRegisterFrameAutosaveName = window.setFrameAutosaveName(frameAutosaveName)
+        let appKitSavedFrameApplied = didRegisterFrameAutosaveName
             && restoredFrame == nil
             && sourceWindow == nil
             && window.setFrameUsingName(frameAutosaveName, force: true)
@@ -13390,6 +13401,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // window's position, matching upstream Ghostty behavior.
         let frame = window.frame
         lastCascadePoint = NSPoint(x: frame.minX, y: frame.maxY)
+
+        removeEphemeralMainWindowFrameAutosaveNameIfNeeded(window)
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -406,6 +406,21 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
             defaults.object(forKey: primaryFrameAutosaveKey),
             "Promotion should immediately persist the survivor's frame under the stable primary autosave key."
         )
+        let probeWindow = NSWindow(
+            contentRect: CGRect(x: 0, y: 0, width: 10, height: 10),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { probeWindow.close() }
+        XCTAssertTrue(
+            probeWindow.setFrameUsingName(primaryFrameAutosaveName, force: true),
+            "Promotion should leave the survivor's restorable frame in the stable primary autosave slot."
+        )
+        XCTAssertEqual(probeWindow.frame.minX, survivorFrameBeforePromotion.minX, accuracy: 1)
+        XCTAssertEqual(probeWindow.frame.minY, survivorFrameBeforePromotion.minY, accuracy: 1)
+        XCTAssertEqual(probeWindow.frame.width, survivorFrameBeforePromotion.width, accuracy: 1)
+        XCTAssertEqual(probeWindow.frame.height, survivorFrameBeforePromotion.height, accuracy: 1)
         XCTAssertEqual(secondWindow.frame.minX, survivorFrameBeforePromotion.minX, accuracy: 1)
         XCTAssertEqual(secondWindow.frame.minY, survivorFrameBeforePromotion.minY, accuracy: 1)
         XCTAssertEqual(secondWindow.frame.width, survivorFrameBeforePromotion.width, accuracy: 1)

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -129,7 +129,7 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(manager.tabs.count, initialCount + 1, "Bare Space chord should dispatch on the second stroke")
     }
 
-    func testCreateMainWindowUsesPersistedGeometryWhenNoSourceWindow() throws {
+    func testCreateMainWindowIgnoresLegacyPersistedGeometryWhenNoSourceWindow() throws {
         let previousShared = AppDelegate.shared
         let appDelegate = AppDelegate()
         defer { AppDelegate.shared = previousShared }
@@ -137,11 +137,20 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         let defaults = UserDefaults.standard
         let persistedGeometryKey = AppDelegate.debugPersistedWindowGeometryDefaultsKey
         let previousPersistedGeometry = defaults.object(forKey: persistedGeometryKey)
+        let primaryFrameAutosaveName = AppDelegate.debugPrimaryMainWindowFrameAutosaveName
+        let primaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(primaryFrameAutosaveName)
+        let previousPrimaryFrameAutosave = defaults.object(forKey: primaryFrameAutosaveKey)
+        NSWindow.removeFrame(usingName: primaryFrameAutosaveName)
         var windowId: UUID?
         defer {
             if let windowId {
                 closeWindow(withId: windowId)
             }
+            restoreDefaultsValue(
+                previousPrimaryFrameAutosave,
+                forKey: primaryFrameAutosaveKey,
+                defaults: defaults
+            )
             restoreDefaultsValue(
                 previousPersistedGeometry,
                 forKey: persistedGeometryKey,
@@ -153,15 +162,15 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         let visibleFrame = screen.visibleFrame
         let savedWidth = max(
             CGFloat(SessionPersistencePolicy.minimumWindowWidth),
-            min(1_100, visibleFrame.width - 40)
+            min(720, visibleFrame.width - 80)
         )
         let savedHeight = max(
             CGFloat(SessionPersistencePolicy.minimumWindowHeight),
-            min(760, visibleFrame.height - 40)
+            min(520, visibleFrame.height - 80)
         )
         let savedFrame = CGRect(
-            x: visibleFrame.midX - savedWidth / 2,
-            y: visibleFrame.midY - savedHeight / 2,
+            x: visibleFrame.minX + 37,
+            y: visibleFrame.minY + 43,
             width: savedWidth,
             height: savedHeight
         )
@@ -180,22 +189,39 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         windowId = createdWindowId
 
         let window = try XCTUnwrap(window(withId: createdWindowId))
-        XCTAssertEqual(window.frame.minX, savedFrame.minX, accuracy: 1)
-        XCTAssertEqual(window.frame.minY, savedFrame.minY, accuracy: 1)
-        XCTAssertEqual(window.frame.width, savedFrame.width, accuracy: 1)
-        XCTAssertEqual(window.frame.height, savedFrame.height, accuracy: 1)
+        XCTAssertFalse(window.frameAutosaveName.isEmpty)
+        XCTAssertGreaterThan(
+            abs(window.frame.minX - savedFrame.minX),
+            1,
+            "Legacy cmux lastWindowGeometry must not compete with AppKit frame autosave."
+        )
+        XCTAssertGreaterThan(
+            abs(window.frame.minY - savedFrame.minY),
+            1,
+            "Legacy cmux lastWindowGeometry must not compete with AppKit frame autosave."
+        )
     }
 
     func testCreateMainWindowRegistersAppKitFrameAutosaveNames() throws {
         let previousShared = AppDelegate.shared
         let appDelegate = AppDelegate()
         defer { AppDelegate.shared = previousShared }
+        let defaults = UserDefaults.standard
+        let primaryFrameAutosaveName = AppDelegate.debugPrimaryMainWindowFrameAutosaveName
+        let primaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(primaryFrameAutosaveName)
+        let previousPrimaryFrameAutosave = defaults.object(forKey: primaryFrameAutosaveKey)
+        NSWindow.removeFrame(usingName: primaryFrameAutosaveName)
 
         let firstWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
         let secondWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
         defer {
             closeWindow(withId: secondWindowId)
             closeWindow(withId: firstWindowId)
+            restoreDefaultsValue(
+                previousPrimaryFrameAutosave,
+                forKey: primaryFrameAutosaveKey,
+                defaults: defaults
+            )
         }
 
         let firstWindow = try XCTUnwrap(window(withId: firstWindowId))
@@ -270,5 +296,9 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         } else {
             defaults.removeObject(forKey: key)
         }
+    }
+
+    private func appKitFrameAutosaveDefaultsKey(_ name: NSWindow.FrameAutosaveName) -> String {
+        "NSWindow Frame \(name)"
     }
 }

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -211,12 +211,16 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         let primaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(primaryFrameAutosaveName)
         let previousPrimaryFrameAutosave = defaults.object(forKey: primaryFrameAutosaveKey)
         NSWindow.removeFrame(usingName: primaryFrameAutosaveName)
+        var secondaryFrameAutosaveName: NSWindow.FrameAutosaveName?
 
         let firstWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
         let secondWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
         defer {
             closeWindow(withId: secondWindowId)
             closeWindow(withId: firstWindowId)
+            if let secondaryFrameAutosaveName {
+                NSWindow.removeFrame(usingName: secondaryFrameAutosaveName)
+            }
             restoreDefaultsValue(
                 previousPrimaryFrameAutosave,
                 forKey: primaryFrameAutosaveKey,
@@ -226,6 +230,7 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
 
         let firstWindow = try XCTUnwrap(window(withId: firstWindowId))
         let secondWindow = try XCTUnwrap(window(withId: secondWindowId))
+        secondaryFrameAutosaveName = secondWindow.frameAutosaveName
 
         XCTAssertFalse(
             firstWindow.frameAutosaveName.isEmpty,

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -186,6 +186,36 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         XCTAssertEqual(window.frame.height, savedFrame.height, accuracy: 1)
     }
 
+    func testCreateMainWindowRegistersAppKitFrameAutosaveNames() throws {
+        let previousShared = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer { AppDelegate.shared = previousShared }
+
+        let firstWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        let secondWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        defer {
+            closeWindow(withId: secondWindowId)
+            closeWindow(withId: firstWindowId)
+        }
+
+        let firstWindow = try XCTUnwrap(window(withId: firstWindowId))
+        let secondWindow = try XCTUnwrap(window(withId: secondWindowId))
+
+        XCTAssertFalse(
+            firstWindow.frameAutosaveName.isEmpty,
+            "Main windows must opt in to AppKit frame autosave so macOS owns screen topology restoration."
+        )
+        XCTAssertFalse(
+            secondWindow.frameAutosaveName.isEmpty,
+            "Additional main windows also need autosave names so monitor wake restores do not fall back to cmux-only geometry."
+        )
+        XCTAssertNotEqual(
+            firstWindow.frameAutosaveName,
+            secondWindow.frameAutosaveName,
+            "Each live main window needs a distinct AppKit frame autosave name."
+        )
+    }
+
     private func makeKeyDownEvent(
         key: String,
         keyCode: UInt16,

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -361,8 +361,34 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
 
         XCTAssertEqual(firstWindow.frameAutosaveName, primaryFrameAutosaveName)
         XCTAssertNotEqual(secondWindow.frameAutosaveName, primaryFrameAutosaveName)
+        let screen = try XCTUnwrap(NSScreen.main ?? NSScreen.screens.first)
+        let visibleFrame = screen.visibleFrame
+        let savedWidth = max(
+            CGFloat(SessionPersistencePolicy.minimumWindowWidth),
+            min(520, visibleFrame.width - 120)
+        )
+        let savedHeight = max(
+            CGFloat(SessionPersistencePolicy.minimumWindowHeight),
+            min(360, visibleFrame.height - 120)
+        )
+        let firstFrame = CGRect(
+            x: visibleFrame.minX + 24,
+            y: visibleFrame.minY + 32,
+            width: savedWidth,
+            height: savedHeight
+        )
+        let secondFrame = CGRect(
+            x: min(visibleFrame.minX + 144, visibleFrame.maxX - savedWidth - 24),
+            y: min(visibleFrame.minY + 152, visibleFrame.maxY - savedHeight - 32),
+            width: savedWidth,
+            height: savedHeight
+        )
+        firstWindow.setFrame(firstFrame, display: false)
+        firstWindow.saveFrame(usingName: primaryFrameAutosaveName)
+        secondWindow.setFrame(secondFrame, display: false)
         NSWindow.removeFrame(usingName: secondWindow.frameAutosaveName)
         secondWindow.saveFrame(usingName: secondWindow.frameAutosaveName)
+        let survivorFrameBeforePromotion = secondWindow.frame
         XCTAssertNotNil(defaults.object(forKey: secondaryFrameAutosaveKey))
 
         closeWindow(withId: firstWindowId)
@@ -380,6 +406,10 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
             defaults.object(forKey: primaryFrameAutosaveKey),
             "Promotion should immediately persist the survivor's frame under the stable primary autosave key."
         )
+        XCTAssertEqual(secondWindow.frame.minX, survivorFrameBeforePromotion.minX, accuracy: 1)
+        XCTAssertEqual(secondWindow.frame.minY, survivorFrameBeforePromotion.minY, accuracy: 1)
+        XCTAssertEqual(secondWindow.frame.width, survivorFrameBeforePromotion.width, accuracy: 1)
+        XCTAssertEqual(secondWindow.frame.height, survivorFrameBeforePromotion.height, accuracy: 1)
     }
 
     private func makeKeyDownEvent(

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -242,6 +242,55 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         )
     }
 
+    func testClosingSecondaryMainWindowRemovesEphemeralFrameAutosaveName() throws {
+        let previousShared = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer { AppDelegate.shared = previousShared }
+        let defaults = UserDefaults.standard
+        let primaryFrameAutosaveName = AppDelegate.debugPrimaryMainWindowFrameAutosaveName
+        let primaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(primaryFrameAutosaveName)
+        let previousPrimaryFrameAutosave = defaults.object(forKey: primaryFrameAutosaveKey)
+        NSWindow.removeFrame(usingName: primaryFrameAutosaveName)
+
+        let firstWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        let secondWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        defer {
+            closeWindow(withId: secondWindowId)
+            closeWindow(withId: firstWindowId)
+            restoreDefaultsValue(
+                previousPrimaryFrameAutosave,
+                forKey: primaryFrameAutosaveKey,
+                defaults: defaults
+            )
+        }
+
+        let secondWindow = try XCTUnwrap(window(withId: secondWindowId))
+        let secondaryFrameAutosaveName = secondWindow.frameAutosaveName
+        let secondaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(secondaryFrameAutosaveName)
+        let previousSecondaryFrameAutosave = defaults.object(forKey: secondaryFrameAutosaveKey)
+        defer {
+            restoreDefaultsValue(
+                previousSecondaryFrameAutosave,
+                forKey: secondaryFrameAutosaveKey,
+                defaults: defaults
+            )
+        }
+
+        XCTAssertFalse(secondaryFrameAutosaveName.isEmpty)
+        XCTAssertNotEqual(secondaryFrameAutosaveName, primaryFrameAutosaveName)
+
+        NSWindow.removeFrame(usingName: secondaryFrameAutosaveName)
+        secondWindow.saveFrame(usingName: secondaryFrameAutosaveName)
+        XCTAssertNotNil(defaults.object(forKey: secondaryFrameAutosaveKey))
+
+        closeWindow(withId: secondWindowId)
+
+        XCTAssertNil(
+            defaults.object(forKey: secondaryFrameAutosaveKey),
+            "UUID-scoped autosave names are per-window and must be removed when the window closes."
+        )
+    }
+
     private func makeKeyDownEvent(
         key: String,
         keyCode: UInt16,

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -202,6 +202,28 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         )
     }
 
+    func testLegacyPersistedGeometryCleanupRemovesCurrentV2Key() throws {
+        let defaults = UserDefaults.standard
+        let persistedGeometryKey = AppDelegate.debugPersistedWindowGeometryDefaultsKey
+        let previousPersistedGeometry = defaults.object(forKey: persistedGeometryKey)
+        defer {
+            restoreDefaultsValue(
+                previousPersistedGeometry,
+                forKey: persistedGeometryKey,
+                defaults: defaults
+            )
+        }
+
+        defaults.set(Data([1, 2, 3]), forKey: persistedGeometryKey)
+
+        AppDelegate.debugRemoveLegacyPersistedWindowGeometry(defaults: defaults)
+
+        XCTAssertNil(
+            defaults.object(forKey: persistedGeometryKey),
+            "The removed cmux-owned frame geometry key must be cleared so AppKit frame autosave is the only persisted frame source."
+        )
+    }
+
     func testCreateMainWindowRegistersAppKitFrameAutosaveNames() throws {
         let previousShared = AppDelegate.shared
         let appDelegate = AppDelegate()
@@ -290,6 +312,10 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
 
         closeWindow(withId: secondWindowId)
 
+        XCTAssertTrue(
+            secondWindow.frameAutosaveName.isEmpty,
+            "Ephemeral autosave names must be cleared before removing their saved frame."
+        )
         XCTAssertNil(
             defaults.object(forKey: secondaryFrameAutosaveKey),
             "UUID-scoped autosave names are per-window and must be removed when the window closes."

--- a/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateBareSpaceShortcutRoutingTests.swift
@@ -322,6 +322,66 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         )
     }
 
+    func testClosingPrimaryMainWindowPromotesSurvivingWindowAutosaveName() throws {
+        let previousShared = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        defer { AppDelegate.shared = previousShared }
+        let defaults = UserDefaults.standard
+        let primaryFrameAutosaveName = AppDelegate.debugPrimaryMainWindowFrameAutosaveName
+        let primaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(primaryFrameAutosaveName)
+        let previousPrimaryFrameAutosave = defaults.object(forKey: primaryFrameAutosaveKey)
+        NSWindow.removeFrame(usingName: primaryFrameAutosaveName)
+
+        let firstWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        let secondWindowId = appDelegate.createMainWindow(shouldActivate: false, sourceWindow: nil)
+        var secondaryFrameAutosaveName: NSWindow.FrameAutosaveName?
+        var previousSecondaryFrameAutosave: Any?
+        defer {
+            closeWindow(withId: secondWindowId)
+            closeWindow(withId: firstWindowId)
+            if let secondaryFrameAutosaveName {
+                restoreDefaultsValue(
+                    previousSecondaryFrameAutosave,
+                    forKey: appKitFrameAutosaveDefaultsKey(secondaryFrameAutosaveName),
+                    defaults: defaults
+                )
+            }
+            restoreDefaultsValue(
+                previousPrimaryFrameAutosave,
+                forKey: primaryFrameAutosaveKey,
+                defaults: defaults
+            )
+        }
+
+        let firstWindow = try XCTUnwrap(window(withId: firstWindowId))
+        let secondWindow = try XCTUnwrap(window(withId: secondWindowId))
+        secondaryFrameAutosaveName = secondWindow.frameAutosaveName
+        let secondaryFrameAutosaveKey = appKitFrameAutosaveDefaultsKey(secondWindow.frameAutosaveName)
+        previousSecondaryFrameAutosave = defaults.object(forKey: secondaryFrameAutosaveKey)
+
+        XCTAssertEqual(firstWindow.frameAutosaveName, primaryFrameAutosaveName)
+        XCTAssertNotEqual(secondWindow.frameAutosaveName, primaryFrameAutosaveName)
+        NSWindow.removeFrame(usingName: secondWindow.frameAutosaveName)
+        secondWindow.saveFrame(usingName: secondWindow.frameAutosaveName)
+        XCTAssertNotNil(defaults.object(forKey: secondaryFrameAutosaveKey))
+
+        closeWindow(withId: firstWindowId)
+
+        XCTAssertEqual(
+            secondWindow.frameAutosaveName,
+            primaryFrameAutosaveName,
+            "A surviving main window must take over the stable AppKit autosave slot when the primary closes."
+        )
+        XCTAssertNil(
+            defaults.object(forKey: secondaryFrameAutosaveKey),
+            "Promoting a survivor to the primary slot must also retire its UUID-scoped saved frame."
+        )
+        XCTAssertNotNil(
+            defaults.object(forKey: primaryFrameAutosaveKey),
+            "Promotion should immediately persist the survivor's frame under the stable primary autosave key."
+        )
+    }
+
     private func makeKeyDownEvent(
         key: String,
         keyCode: UInt16,
@@ -378,6 +438,8 @@ final class AppDelegateBareSpaceShortcutRoutingTests: XCTestCase {
         }
     }
 
+    /// Mirrors AppKit's internal frame-autosave UserDefaults key convention.
+    /// Keep this localized to tests because AppKit does not document the format.
     private func appKitFrameAutosaveDefaultsKey(_ name: NSWindow.FrameAutosaveName) -> String {
         "NSWindow Frame \(name)"
     }


### PR DESCRIPTION
Fixes #2791

## Summary
- Enroll cmux main windows in AppKit frame autosave so macOS owns screen-topology frame restoration.
- Stop using the cmux lastWindowGeometry fallback as a competing main-window frame source.
- Add a regression test that real main windows register non-colliding AppKit autosave names.

## Verification
- git diff --check
- Local tests/build not run per repo policy and user instruction; CI is the verification gate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes main-window placement and persistence by switching from cmux-owned geometry to AppKit frame autosave, which could affect window restore/positioning across multi-window scenarios. Includes new autosave-name promotion/cleanup logic that needs validation across edge cases (multiple windows, close ordering, sleep/wake).
> 
> **Overview**
> Main window geometry persistence is switched to **AppKit frame autosave**: new windows now register a stable primary autosave name (`cmux.mainWindow.primary`) and UUID-scoped names for additional windows, and AppKit-saved frames are applied when not restoring from a session snapshot or source window.
> 
> The PR removes the `lastWindowGeometry` fallback path (including snapshot persistence/debug plumbing) and expands legacy cleanup to delete both v1 and v2 geometry keys, making AppKit the single frame source.
> 
> On window close, ephemeral autosave entries are removed and, if the primary window closes, a surviving window is promoted into the stable autosave slot without changing its on-screen frame. Tests are expanded to cover autosave name registration, legacy-key cleanup/ignoring, ephemeral cleanup, and primary-slot promotion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc7d2473bd2b7eb2b55605bb521b5de61e6a96f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2791: Preserves main‑window position across sleep/wake and monitor changes by using AppKit frame autosave with a stable primary slot and frame‑neutral promotion on close. Removes cmux‑owned geometry so AppKit is the single source of truth.

- **Bug Fixes**
  - Main windows register AppKit frame autosave on creation (`cmux.mainWindow.primary` for the first live window; UUID‑scoped for others); AppKit‑saved frames apply when not restoring from a snapshot or source window.
  - On close, unregisters the window; if it held the primary name, clears it, promotes a survivor into `cmux.mainWindow.primary`, seeds the primary slot with the survivor’s frame, restores that frame if AppKit reloads, then retires the survivor’s old UUID key only after promotion succeeds.
  - Secondary windows clear their autosave name before removing the saved frame so UUID‑scoped keys don’t persist.
  - Removed all `lastWindowGeometry` read/write paths (including snapshot plumbing) and expanded legacy cleanup to delete both v1 and v2 keys.
  - Tests cover autosave registration, ignoring legacy geometry, legacy‑key cleanup, secondary cleanup, primary promotion with safe handoff, and proving the primary autosave payload matches the survivor frame.

<sup>Written for commit fbc7d2473bd2b7eb2b55605bb521b5de61e6a96f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Modernized window sizing/restoration and AppKit autosave-name handling for main windows
  * Simplified session snapshot persistence and removed legacy geometry payloads
  * Updated window teardown to clear ephemeral autosave names and promote primary autosave as needed

* **Tests**
  * Added coverage for legacy-geometry cleanup, autosave-name registration/promotion, and teardown behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3882)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->