### PR TITLE
Fix titlebar icon ownership and chrome alignment

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2302,7 +2302,6 @@ struct ContentView: View {
                 if let directory = focusedDirectory {
                     DetachedFolderDragIcon(directory: directory)
                         .frame(width: 16, height: 16)
-                        .padding(.leading, -6)
                 }
 
                 Text(titlebarText)

--- a/Sources/DetachedFolderDragIcon.swift
+++ b/Sources/DetachedFolderDragIcon.swift
@@ -4,166 +4,13 @@ import SwiftUI
 struct DetachedFolderDragIcon: NSViewRepresentable {
     let directory: String
 
-    func makeNSView(context: Context) -> DetachedFolderDragIconHostView {
-        DetachedFolderDragIconHostView(directory: directory)
+    func makeNSView(context: Context) -> DraggableFolderNSView {
+        DraggableFolderNSView(directory: directory)
     }
 
-    func updateNSView(_ nsView: DetachedFolderDragIconHostView, context: Context) {
+    func updateNSView(_ nsView: DraggableFolderNSView, context: Context) {
         nsView.directory = directory
-        nsView.syncDetachedIcon()
-    }
-}
-
-@MainActor
-final class DetachedFolderDragIconHostView: NSView {
-    var directory: String
-    private var childWindow: NSPanel?
-    private var iconView: DraggableFolderNSView?
-    private var observers: [NSObjectProtocol] = []
-    private weak var observedParentWindow: NSWindow?
-
-    init(directory: String) {
-        self.directory = directory
-        super.init(frame: NSRect(origin: .zero, size: NSSize(width: 16, height: 16)))
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
-    deinit {
-        MainActor.assumeIsolated {
-            tearDownDetachedIcon()
-        }
-    }
-
-    override var intrinsicContentSize: NSSize {
-        NSSize(width: 16, height: 16)
-    }
-
-    override var mouseDownCanMoveWindow: Bool { false }
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        syncDetachedIcon()
-    }
-
-    override func viewDidMoveToSuperview() {
-        super.viewDidMoveToSuperview()
-        syncDetachedIcon()
-    }
-
-    override func layout() {
-        super.layout()
-        syncDetachedIconFrame()
-    }
-
-    func syncDetachedIcon() {
-        guard let parentWindow = window else {
-            tearDownDetachedIcon()
-            return
-        }
-
-        let child = childWindow ?? makeDetachedIconWindow(parentWindow: parentWindow)
-        if child.parent !== parentWindow {
-            child.parent?.removeChildWindow(child)
-            parentWindow.addChildWindow(child, ordered: .above)
-            installParentWindowObservers(parentWindow)
-        }
-
-        if iconView?.directory != directory {
-            iconView?.directory = directory
-            iconView?.updateIcon()
-        }
-
-        child.orderFront(nil)
-        syncDetachedIconFrame()
-    }
-
-    private func makeDetachedIconWindow(parentWindow: NSWindow) -> NSPanel {
-        let iconView = DraggableFolderNSView(directory: directory)
-        iconView.frame = NSRect(origin: .zero, size: NSSize(width: 16, height: 16))
-
-        let panel = NSPanel(
-            contentRect: iconView.frame,
-            styleMask: [.borderless, .nonactivatingPanel],
-            backing: .buffered,
-            defer: false
-        )
-        panel.contentView = iconView
-        panel.backgroundColor = .clear
-        panel.isOpaque = false
-        panel.hasShadow = false
-        panel.hidesOnDeactivate = false
-        panel.ignoresMouseEvents = false
-        panel.isMovable = false
-        panel.isMovableByWindowBackground = false
-        panel.collectionBehavior = [.fullScreenAuxiliary]
-        panel.identifier = NSUserInterfaceItemIdentifier("cmux.folderDragIcon")
-        parentWindow.addChildWindow(panel, ordered: .above)
-        self.childWindow = panel
-        self.iconView = iconView
-        installParentWindowObservers(parentWindow)
-        return panel
-    }
-
-    private func installParentWindowObservers(_ parentWindow: NSWindow) {
-        guard observedParentWindow !== parentWindow || observers.isEmpty else { return }
-        removeParentWindowObservers()
-
-        // The child panel frame is derived from this host view in the parent
-        // window. AppKit does not call layout() when only the parent window
-        // moves, resizes, or changes miniaturized state, so observe those
-        // window events and recompute the panel's screen-space frame.
-        let center = NotificationCenter.default
-        let names: [Notification.Name] = [
-            NSWindow.didMoveNotification,
-            NSWindow.didResizeNotification,
-            NSWindow.didMiniaturizeNotification,
-            NSWindow.didDeminiaturizeNotification,
-        ]
-        observers = names.map { name in
-            center.addObserver(forName: name, object: parentWindow, queue: .main) { [weak self] _ in
-                MainActor.assumeIsolated {
-                    self?.syncDetachedIconFrame()
-                }
-            }
-        }
-        observedParentWindow = parentWindow
-    }
-
-    private func syncDetachedIconFrame() {
-        guard let parentWindow = window,
-              let childWindow else { return }
-        let localRect = bounds.isEmpty
-            ? NSRect(origin: .zero, size: NSSize(width: 16, height: 16))
-            : bounds
-        let rectInWindow = convert(localRect, to: nil)
-        let rectOnScreen = parentWindow.convertToScreen(rectInWindow)
-        if childWindow.frame.origin != rectOnScreen.origin || childWindow.frame.size != rectOnScreen.size {
-            childWindow.setFrame(rectOnScreen, display: true)
-        }
-    }
-
-    private func removeParentWindowObservers() {
-        for observer in observers {
-            NotificationCenter.default.removeObserver(observer)
-        }
-        observers.removeAll()
-        observedParentWindow = nil
-    }
-
-    private func tearDownDetachedIcon() {
-        // Observer lifetime is tied to the derived child panel: once this host
-        // leaves its parent window or deinitializes, remove both so no stale
-        // panel keeps tracking an old parent window.
-        removeParentWindowObservers()
-        if let childWindow {
-            childWindow.parent?.removeChildWindow(childWindow)
-            childWindow.orderOut(nil)
-        }
-        childWindow = nil
-        iconView = nil
+        nsView.updateIcon()
     }
 }
 
@@ -186,6 +33,7 @@ final class DraggableFolderNSView: NSView, NSDraggingSource {
     init(directory: String) {
         self.directory = directory
         super.init(frame: .zero)
+        identifier = NSUserInterfaceItemIdentifier("cmux.folderDragIcon")
         setupImageView()
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1469,6 +1469,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         )
         let yOffset = max(0, (containerHeight - contentSize.height) / 2.0)
             + CGFloat(MinimalModeTitlebarDebugSettings.defaultLeftControlsTopInset - debugSnapshot.leftControlsTopInset)
+            + CGFloat(MinimalModeTitlebarDebugSettings.titlebarControlsUpwardOffset)
         let nextLayoutSnapshot = TitlebarControlsLayoutSnapshot(
             contentSize: contentSize,
             containerHeight: containerHeight,

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -7,11 +7,14 @@ final class WindowDecorationsController {
     private var lastMinimalModeTitlebarClick: MinimalModeTitlebarClickRecord?
     private var lastKnownPresentationMode = WorkspacePresentationModeSettings.mode()
     private var lastKnownTitlebarDebugSnapshot = MinimalModeTitlebarDebugSettings.snapshot()
+    private let trafficLightFrameStates = NSMapTable<NSButton, TrafficLightFrameState>(
+        keyOptions: .weakMemory,
+        valueOptions: .strongMemory
+    )
     private let minimalModeSidebarTitlebarClickTargets = NSMapTable<NSWindow, MinimalModeSidebarControlActionView>(
         keyOptions: .weakMemory,
         valueOptions: .strongMemory
     )
-    private static var trafficLightDebugFrameStateKey: UInt8 = 0
 
     deinit {
         let center = NotificationCenter.default
@@ -45,7 +48,7 @@ final class WindowDecorationsController {
         let shouldHideButtons = shouldHideTrafficLights(for: window)
         hideStandardButtons(on: window, hidden: shouldHideButtons)
         if isMainWorkspaceWindow(window) {
-            applyTrafficLightDebugOffsets(to: window)
+            applyTrafficLightOffsets(to: window)
         }
         applyMinimalModeSidebarTitlebarClickTarget(to: window)
     }
@@ -366,6 +369,37 @@ final class WindowDecorationsController {
         window.standardWindowButton(.zoomButton)?.isHidden = hidden
     }
 
+    private func applyTrafficLightOffsets(to window: NSWindow) {
+        let snapshot = MinimalModeTitlebarDebugSettings.snapshot()
+        let offset = NSPoint(
+            x: CGFloat(snapshot.trafficLightsXOffset),
+            y: CGFloat(snapshot.trafficLightsYOffset)
+        )
+        for buttonType in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
+            guard let button = window.standardWindowButton(buttonType) else { continue }
+            let state = trafficLightFrameState(for: button)
+            let baseOrigin = state.currentFrameMatchesApplied(button.frame)
+                ? state.baseOrigin
+                : button.frame.origin
+            let nextOrigin = NSPoint(x: baseOrigin.x + offset.x, y: baseOrigin.y + offset.y)
+            if abs(button.frame.origin.x - nextOrigin.x) > 0.25
+                || abs(button.frame.origin.y - nextOrigin.y) > 0.25 {
+                button.setFrameOrigin(nextOrigin)
+            }
+            state.baseOrigin = baseOrigin
+            state.appliedFrame = button.frame
+        }
+    }
+
+    private func trafficLightFrameState(for button: NSButton) -> TrafficLightFrameState {
+        if let state = trafficLightFrameStates.object(forKey: button) {
+            return state
+        }
+        let state = TrafficLightFrameState(baseOrigin: button.frame.origin, appliedFrame: button.frame)
+        trafficLightFrameStates.setObject(state, forKey: button)
+        return state
+    }
+
     private func applyMinimalModeSidebarTitlebarClickTarget(to window: NSWindow) {
         let shouldInstall = isMainWorkspaceWindow(window)
             && WorkspacePresentationModeSettings.isMinimal()
@@ -442,39 +476,6 @@ final class WindowDecorationsController {
         minimalModeSidebarTitlebarClickTargets.removeObject(forKey: window)
     }
 
-    private func applyTrafficLightDebugOffsets(to window: NSWindow) {
-        let snapshot = MinimalModeTitlebarDebugSettings.snapshot()
-        let offset = NSPoint(
-            x: CGFloat(snapshot.trafficLightsXOffset),
-            y: CGFloat(snapshot.trafficLightsYOffset)
-        )
-        for buttonType in [NSWindow.ButtonType.closeButton, .miniaturizeButton, .zoomButton] {
-            guard let button = window.standardWindowButton(buttonType) else { continue }
-            let state = trafficLightFrameState(for: button)
-            let baseOrigin: NSPoint
-            if state.currentFrameMatchesApplied(button.frame) {
-                baseOrigin = state.baseOrigin
-            } else {
-                baseOrigin = button.frame.origin
-            }
-            let nextOrigin = NSPoint(x: baseOrigin.x + offset.x, y: baseOrigin.y + offset.y)
-            if abs(button.frame.origin.x - nextOrigin.x) > 0.25 || abs(button.frame.origin.y - nextOrigin.y) > 0.25 {
-                button.setFrameOrigin(nextOrigin)
-            }
-            state.baseOrigin = baseOrigin
-            state.appliedFrame = NSRect(origin: nextOrigin, size: button.frame.size)
-        }
-    }
-
-    private func trafficLightFrameState(for button: NSButton) -> TrafficLightDebugFrameState {
-        if let state = objc_getAssociatedObject(button, &Self.trafficLightDebugFrameStateKey) as? TrafficLightDebugFrameState {
-            return state
-        }
-        let state = TrafficLightDebugFrameState(baseOrigin: button.frame.origin, appliedFrame: button.frame)
-        objc_setAssociatedObject(button, &Self.trafficLightDebugFrameStateKey, state, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return state
-    }
-
     private func shouldHideTrafficLights(for window: NSWindow) -> Bool {
         if window.isSheet {
             return true
@@ -489,7 +490,7 @@ final class WindowDecorationsController {
     }
 }
 
-private final class TrafficLightDebugFrameState {
+private final class TrafficLightFrameState {
     var baseOrigin: NSPoint
     var appliedFrame: NSRect
 

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -476,7 +476,7 @@ enum MinimalModeTitlebarDebugSettings {
     static let defaultLeftControlsLeadingInset = 72.0
     static let defaultLeftControlsTopInset = -4.0
     static let defaultTrafficLightsXOffset = 0.0
-    static let defaultTrafficLightsYOffset = 2.0
+    static let defaultTrafficLightsYOffset = 3.0
     static let titlebarControlsUpwardOffset = 2.0
     static let defaultTrafficLightTabBarInset = 80.0
     static let defaultTrafficLightTitlebarLeadingInset = 78.0

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -474,9 +474,10 @@ func isMinimalModeTitlebarControlHit(window: NSWindow, locationInWindow: NSPoint
 
 enum MinimalModeTitlebarDebugSettings {
     static let defaultLeftControlsLeadingInset = 72.0
-    static let defaultLeftControlsTopInset = -2.0
+    static let defaultLeftControlsTopInset = -4.0
     static let defaultTrafficLightsXOffset = 0.0
-    static let defaultTrafficLightsYOffset = 1.7
+    static let defaultTrafficLightsYOffset = 2.0
+    static let titlebarControlsUpwardOffset = 2.0
     static let defaultTrafficLightTabBarInset = 80.0
     static let defaultTrafficLightTitlebarLeadingInset = 78.0
 


### PR DESCRIPTION
## Summary
- keep the folder drag icon inline in the SwiftUI titlebar instead of a detached child panel
- move traffic lights and sidebar/titlebar controls up slightly with stable, non-accumulating offsets
- keep traffic-light offset state in the decorations controller instead of associated objects on AppKit private buttons

## Verification
- ./scripts/reload.sh --tag tfix
- attempted cmux-unit focused test; hosted AppKit test runner crashed before assertions, so no unit test was kept for this UI placement change

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches AppKit titlebar chrome positioning and traffic-light button frame adjustments, which can regress window controls across macOS versions. Scope is localized to UI/layout with no data/auth changes.
> 
> **Overview**
> Keeps the focused-directory folder drag icon *inline* in the SwiftUI titlebar by removing the detached child `NSPanel` hosting approach and rendering `DraggableFolderNSView` directly.
> 
> Adjusts minimal-mode titlebar chrome alignment by nudging left controls and traffic lights upward, and makes traffic-light offsets non-accumulating by tracking per-button base/applied frames inside `WindowDecorationsController` via an `NSMapTable` (replacing associated-object storage on the buttons).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f79dac5cfecb20cb1a5049da11bdec07cef88f01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->