### PR TITLE
Update Codex hooks feature flag

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -39,7 +39,7 @@ extension CMUXCLI {
         }
 
         enum PostInstallAction {
-            case codexConfigToml // write codex_hooks = true to config.toml on install, remove on uninstall
+            case codexConfigToml // write hooks = true to config.toml on install, remove on uninstall
         }
 
         /// Resolves the config directory, respecting env override if set.

--- a/CLI/CMUXCLI+CodexConfigToml.swift
+++ b/CLI/CMUXCLI+CodexConfigToml.swift
@@ -8,10 +8,16 @@ extension CMUXCLI {
         var lines = tomlLines(from: existingContent)
         removeCmuxCodexHooksFeatureBlock(from: &lines)
         lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
 
         let insertedLines = [
             cmuxCodexHooksFeatureBegin,
             "hooks = true",
+            cmuxCodexHooksFeatureEnd,
+        ]
+        let insertedDottedLines = [
+            cmuxCodexHooksFeatureBegin,
+            "features.hooks = true",
             cmuxCodexHooksFeatureEnd,
         ]
 
@@ -25,6 +31,10 @@ extension CMUXCLI {
             } else {
                 lines.insert(contentsOf: insertedLines, at: featuresStart + 1)
             }
+        } else if let dottedHooksIndex = lines.firstIndex(where: { tomlLineDefinesDottedFeaturesKey("hooks", line: $0) }) {
+            lines[dottedHooksIndex] = "features.hooks = true"
+        } else if let firstDottedFeaturesIndex = lines.firstIndex(where: { tomlLineDefinesAnyDottedFeaturesKey($0) }) {
+            lines.insert(contentsOf: insertedDottedLines, at: firstDottedFeaturesIndex)
         } else {
             if !lines.isEmpty, lines.last?.isEmpty == false {
                 lines.append("")
@@ -40,6 +50,7 @@ extension CMUXCLI {
         var lines = tomlLines(from: existingContent)
         removeCmuxCodexHooksFeatureBlock(from: &lines)
         lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
         removeEmptyFeaturesTable(from: &lines)
         return tomlContent(from: lines)
     }
@@ -62,6 +73,21 @@ extension CMUXCLI {
         let escapedKey = NSRegularExpression.escapedPattern(for: key)
         return line.range(
             of: #"^\s*"# + escapedKey + #"\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineDefinesDottedFeaturesKey(_ key: String, line: String) -> Bool {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        return line.range(
+            of: #"^\s*features\s*\.\s*"# + escapedKey + #"\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineDefinesAnyDottedFeaturesKey(_ line: String) -> Bool {
+        line.range(
+            of: #"^\s*features\s*\.\s*[^=\s]+\s*="#,
             options: .regularExpression
         ) != nil
     }

--- a/CLI/CMUXCLI+CodexConfigToml.swift
+++ b/CLI/CMUXCLI+CodexConfigToml.swift
@@ -3,6 +3,7 @@ import Foundation
 extension CMUXCLI {
     private static let cmuxCodexHooksFeatureBegin = "# cmux hooks codex feature begin"
     private static let cmuxCodexHooksFeatureEnd = "# cmux hooks codex feature end"
+    private static let cmuxCodexHooksFeaturePreviousLinePrefix = "# cmux hooks codex feature previous line: "
 
     static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
         var lines = tomlLines(from: existingContent)
@@ -27,12 +28,24 @@ extension CMUXCLI {
                let hooksIndex = (featuresStart + 1..<featuresEnd)
                 .first(where: { tomlLineDefinesKey("hooks", line: lines[$0]) })
             {
-                lines[hooksIndex] = "hooks = true"
+                if !tomlLineDefinesTrueKey("hooks", line: lines[hooksIndex]) {
+                    let previousLine = lines[hooksIndex]
+                    lines.replaceSubrange(
+                        hooksIndex...hooksIndex,
+                        with: codexHooksFeatureLines(settingLine: "hooks = true", previousLine: previousLine)
+                    )
+                }
             } else {
                 lines.insert(contentsOf: insertedLines, at: featuresStart + 1)
             }
         } else if let dottedHooksIndex = lines.firstIndex(where: { tomlLineDefinesDottedFeaturesKey("hooks", line: $0) }) {
-            lines[dottedHooksIndex] = "features.hooks = true"
+            if !tomlLineDefinesDottedFeaturesTrueKey("hooks", line: lines[dottedHooksIndex]) {
+                let previousLine = lines[dottedHooksIndex]
+                lines.replaceSubrange(
+                    dottedHooksIndex...dottedHooksIndex,
+                    with: codexHooksFeatureLines(settingLine: "features.hooks = true", previousLine: previousLine)
+                )
+            }
         } else if let firstDottedFeaturesIndex = lines.firstIndex(where: { tomlLineDefinesAnyDottedFeaturesKey($0) }) {
             lines.insert(contentsOf: insertedDottedLines, at: firstDottedFeaturesIndex)
         } else {
@@ -44,6 +57,16 @@ extension CMUXCLI {
         }
 
         return tomlContent(from: lines)
+    }
+
+    private static func codexHooksFeatureLines(settingLine: String, previousLine: String? = nil) -> [String] {
+        var lines = [cmuxCodexHooksFeatureBegin]
+        if let previousLine {
+            lines.append(cmuxCodexHooksFeaturePreviousLinePrefix + previousLine)
+        }
+        lines.append(settingLine)
+        lines.append(cmuxCodexHooksFeatureEnd)
+        return lines
     }
 
     static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
@@ -77,10 +100,26 @@ extension CMUXCLI {
         ) != nil
     }
 
+    private static func tomlLineDefinesTrueKey(_ key: String, line: String) -> Bool {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        return line.range(
+            of: #"^\s*"# + escapedKey + #"\s*=\s*true\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
     private static func tomlLineDefinesDottedFeaturesKey(_ key: String, line: String) -> Bool {
         let escapedKey = NSRegularExpression.escapedPattern(for: key)
         return line.range(
             of: #"^\s*features\s*\.\s*"# + escapedKey + #"\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineDefinesDottedFeaturesTrueKey(_ key: String, line: String) -> Bool {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        return line.range(
+            of: #"^\s*features\s*\.\s*"# + escapedKey + #"\s*=\s*true\s*(#.*)?$"#,
             options: .regularExpression
         ) != nil
     }
@@ -129,7 +168,12 @@ extension CMUXCLI {
             if let endIndex = lines[index...].firstIndex(where: {
                 $0.trimmingCharacters(in: .whitespaces) == cmuxCodexHooksFeatureEnd
             }) {
-                lines.removeSubrange(index...endIndex)
+                let previousLines = lines[index...endIndex].compactMap { line -> String? in
+                    line.hasPrefix(cmuxCodexHooksFeaturePreviousLinePrefix)
+                        ? String(line.dropFirst(cmuxCodexHooksFeaturePreviousLinePrefix.count))
+                        : nil
+                }
+                lines.replaceSubrange(index...endIndex, with: previousLines)
             } else {
                 lines.remove(at: index)
             }

--- a/CLI/CMUXCLI+CodexConfigToml.swift
+++ b/CLI/CMUXCLI+CodexConfigToml.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+extension CMUXCLI {
+    private static let cmuxCodexHooksFeatureBegin = "# cmux hooks codex feature begin"
+    private static let cmuxCodexHooksFeatureEnd = "# cmux hooks codex feature end"
+
+    static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
+        var lines = tomlLines(from: existingContent)
+        removeCmuxCodexHooksFeatureBlock(from: &lines)
+        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+
+        let insertedLines = [
+            cmuxCodexHooksFeatureBegin,
+            "hooks = true",
+            cmuxCodexHooksFeatureEnd,
+        ]
+
+        if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
+            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
+            if featuresStart + 1 < featuresEnd,
+               let hooksIndex = (featuresStart + 1..<featuresEnd)
+                .first(where: { tomlLineDefinesKey("hooks", line: lines[$0]) })
+            {
+                lines[hooksIndex] = "hooks = true"
+            } else {
+                lines.insert(contentsOf: insertedLines, at: featuresStart + 1)
+            }
+        } else {
+            if !lines.isEmpty, lines.last?.isEmpty == false {
+                lines.append("")
+            }
+            lines.append("[features]")
+            lines.append(contentsOf: insertedLines)
+        }
+
+        return tomlContent(from: lines)
+    }
+
+    static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
+        var lines = tomlLines(from: existingContent)
+        removeCmuxCodexHooksFeatureBlock(from: &lines)
+        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+        removeEmptyFeaturesTable(from: &lines)
+        return tomlContent(from: lines)
+    }
+
+    private static func tomlLines(from content: String) -> [String] {
+        guard !content.isEmpty else { return [] }
+        var lines = content.components(separatedBy: "\n")
+        if content.hasSuffix("\n"), lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func tomlContent(from lines: [String]) -> String {
+        guard !lines.isEmpty else { return "" }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func tomlLineDefinesKey(_ key: String, line: String) -> Bool {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        return line.range(
+            of: #"^\s*"# + escapedKey + #"\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineIsTable(_ name: String, line: String) -> Bool {
+        let escapedName = NSRegularExpression.escapedPattern(for: name)
+        return line.range(
+            of: #"^\s*\[\s*"# + escapedName + #"\s*\]\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
+        line.range(
+            of: #"^\s*\[+[^]]+\]+\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlTableEndIndex(in lines: [String], after tableStart: Int) -> Int {
+        var index = tableStart + 1
+        while index < lines.count {
+            if tomlLineIsAnyTableHeader(lines[index]) {
+                return index
+            }
+            index += 1
+        }
+        return lines.count
+    }
+
+    private static func removeCmuxCodexHooksFeatureBlock(from lines: inout [String]) {
+        var index = 0
+        while index < lines.count {
+            guard lines[index].trimmingCharacters(in: .whitespaces) == cmuxCodexHooksFeatureBegin else {
+                index += 1
+                continue
+            }
+
+            if let endIndex = lines[index...].firstIndex(where: {
+                $0.trimmingCharacters(in: .whitespaces) == cmuxCodexHooksFeatureEnd
+            }) {
+                lines.removeSubrange(index...endIndex)
+            } else {
+                lines.remove(at: index)
+            }
+        }
+    }
+
+    private static func removeEmptyFeaturesTable(from lines: inout [String]) {
+        guard let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) else {
+            return
+        }
+        let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
+        let bodyRange = featuresStart + 1..<featuresEnd
+        let hasContent = bodyRange.contains { index in
+            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
+            return !trimmed.isEmpty && !trimmed.hasPrefix("#")
+        }
+        if !hasContent {
+            lines.removeSubrange(featuresStart..<featuresEnd)
+        }
+    }
+}

--- a/CLI/CMUXCLI+CodexConfigToml.swift
+++ b/CLI/CMUXCLI+CodexConfigToml.swift
@@ -1,9 +1,15 @@
 import Foundation
 
 extension CMUXCLI {
-    private static let cmuxCodexHooksFeatureBegin = "# cmux hooks codex feature begin"
-    private static let cmuxCodexHooksFeatureEnd = "# cmux hooks codex feature end"
-    private static let cmuxCodexHooksFeaturePreviousLinePrefix = "# cmux hooks codex feature previous line: "
+    private static let cmuxCodexHooksFeatureBegin =
+        "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df begin"
+    private static let cmuxCodexHooksFeatureEnd =
+        "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df end"
+    private static let cmuxCodexHooksFeaturePreviousLinePrefix =
+        "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df previous line: "
+    private static let legacyCmuxCodexHooksFeatureBegin = "# cmux hooks codex feature begin"
+    private static let legacyCmuxCodexHooksFeatureEnd = "# cmux hooks codex feature end"
+    private static let legacyCmuxCodexHooksFeaturePreviousLinePrefix = "# cmux hooks codex feature previous line: "
 
     static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
         var lines = tomlLines(from: existingContent)
@@ -140,8 +146,12 @@ extension CMUXCLI {
     }
 
     private static func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
-        line.range(
-            of: #"^\s*\[+[^]]+\]+\s*(#.*)?$"#,
+        let tomlKey = "(?:[A-Za-z0-9_-]+|\"[^\"\\n]*\"|'[^'\\n]*')"
+        let tomlKeyPath = tomlKey + "(?:\\s*\\.\\s*" + tomlKey + ")*"
+        let pattern = "^\\s*(?:\\[\\s*" + tomlKeyPath + "\\s*\\]|\\[\\[\\s*" + tomlKeyPath
+            + "\\s*\\]\\])\\s*(#.*)?$"
+        return line.range(
+            of: pattern,
             options: .regularExpression
         ) != nil
     }
@@ -160,24 +170,40 @@ extension CMUXCLI {
     private static func removeCmuxCodexHooksFeatureBlock(from lines: inout [String]) {
         var index = 0
         while index < lines.count {
-            guard lines[index].trimmingCharacters(in: .whitespaces) == cmuxCodexHooksFeatureBegin else {
+            guard tomlLineIsCodexHooksFeatureBegin(lines[index]) else {
                 index += 1
                 continue
             }
 
             if let endIndex = lines[index...].firstIndex(where: {
-                $0.trimmingCharacters(in: .whitespaces) == cmuxCodexHooksFeatureEnd
+                tomlLineIsCodexHooksFeatureEnd($0)
             }) {
                 let previousLines = lines[index...endIndex].compactMap { line -> String? in
-                    line.hasPrefix(cmuxCodexHooksFeaturePreviousLinePrefix)
-                        ? String(line.dropFirst(cmuxCodexHooksFeaturePreviousLinePrefix.count))
-                        : nil
+                    tomlCodexHooksFeaturePreviousLine(from: line)
                 }
                 lines.replaceSubrange(index...endIndex, with: previousLines)
             } else {
                 lines.remove(at: index)
             }
         }
+    }
+
+    private static func tomlLineIsCodexHooksFeatureBegin(_ line: String) -> Bool {
+        line == cmuxCodexHooksFeatureBegin || line == legacyCmuxCodexHooksFeatureBegin
+    }
+
+    private static func tomlLineIsCodexHooksFeatureEnd(_ line: String) -> Bool {
+        line == cmuxCodexHooksFeatureEnd || line == legacyCmuxCodexHooksFeatureEnd
+    }
+
+    private static func tomlCodexHooksFeaturePreviousLine(from line: String) -> String? {
+        if line.hasPrefix(cmuxCodexHooksFeaturePreviousLinePrefix) {
+            return String(line.dropFirst(cmuxCodexHooksFeaturePreviousLinePrefix.count))
+        }
+        if line.hasPrefix(legacyCmuxCodexHooksFeaturePreviousLinePrefix) {
+            return String(line.dropFirst(legacyCmuxCodexHooksFeaturePreviousLinePrefix.count))
+        }
+        return nil
     }
 
     private static func removeEmptyFeaturesTable(from lines: inout [String]) {

--- a/CLI/CMUXCLI+CodexConfigToml.swift
+++ b/CLI/CMUXCLI+CodexConfigToml.swift
@@ -183,7 +183,18 @@ extension CMUXCLI {
                 }
                 lines.replaceSubrange(index...endIndex, with: previousLines)
             } else {
-                lines.remove(at: index)
+                var blockEnd = index + 1
+                var previousLines: [String] = []
+                if blockEnd < lines.count,
+                   let previousLine = tomlCodexHooksFeaturePreviousLine(from: lines[blockEnd])
+                {
+                    previousLines.append(previousLine)
+                    blockEnd += 1
+                }
+                if blockEnd < lines.count, tomlLineIsCodexHooksFeatureSetting(lines[blockEnd]) {
+                    blockEnd += 1
+                }
+                lines.replaceSubrange(index..<blockEnd, with: previousLines)
             }
         }
     }
@@ -204,6 +215,11 @@ extension CMUXCLI {
             return String(line.dropFirst(legacyCmuxCodexHooksFeaturePreviousLinePrefix.count))
         }
         return nil
+    }
+
+    private static func tomlLineIsCodexHooksFeatureSetting(_ line: String) -> Bool {
+        tomlLineDefinesTrueKey("hooks", line: line)
+            || tomlLineDefinesDottedFeaturesTrueKey("hooks", line: line)
     }
 
     private static func removeEmptyFeaturesTable(from lines: inout [String]) {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17077,22 +17077,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 let existingContent: String = fm.fileExists(atPath: configPath)
                     ? ((try? String(contentsOfFile: configPath, encoding: .utf8)) ?? "")
                     : ""
-                let newContent: String
-                if existingContent.contains("codex_hooks") {
-                    // Replace existing value (might be false) with true
-                    newContent = existingContent.replacingOccurrences(
-                        of: "codex_hooks\\s*=\\s*\\w+",
-                        with: "codex_hooks = true",
-                        options: .regularExpression
-                    )
-                } else if existingContent.contains("[features]") {
-                    newContent = existingContent.replacingOccurrences(
-                        of: "[features]",
-                        with: "[features]\ncodex_hooks = true"
-                    )
-                } else {
-                    newContent = existingContent + "\n[features]\ncodex_hooks = true\n"
-                }
+                let newContent = Self.codexConfigTomlInstallingHooksFeature(in: existingContent)
                 if newContent != existingContent {
                     if !skipConfirm {
                         Self.printInstallPreview(
@@ -17108,7 +17093,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                         }
                     }
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    print("Enabled codex_hooks in \(configPath)")
+                    print("Enabled hooks in \(configPath)")
                 }
             }
         }
@@ -17189,20 +17174,105 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             case .codexConfigToml:
                 let configPath = "\(configDir)/config.toml"
                 guard fm.fileExists(atPath: configPath),
-                      let content = try? String(contentsOfFile: configPath, encoding: .utf8),
-                      content.contains("codex_hooks") else { return }
-                // Remove the codex_hooks line
-                let newContent = content.replacingOccurrences(
-                    of: "\\n?codex_hooks\\s*=\\s*\\w+",
-                    with: "",
-                    options: .regularExpression
-                )
+                      let content = try? String(contentsOfFile: configPath, encoding: .utf8) else { return }
+                let newContent = Self.codexConfigTomlUninstallingHooksFeature(from: content)
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    print("Removed codex_hooks from \(configPath)")
+                    print("Removed hooks from \(configPath)")
                 }
             }
         }
+    }
+
+    private static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
+        var lines = tomlLines(from: existingContent)
+        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+
+        if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
+            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
+            if featuresStart + 1 < featuresEnd,
+               let hooksIndex = (featuresStart + 1..<featuresEnd)
+                .first(where: { tomlLineDefinesKey("hooks", line: lines[$0]) })
+            {
+                lines[hooksIndex] = "hooks = true"
+            } else {
+                lines.insert("hooks = true", at: featuresStart + 1)
+            }
+        } else {
+            if !lines.isEmpty, lines.last?.isEmpty == false {
+                lines.append("")
+            }
+            lines.append("[features]")
+            lines.append("hooks = true")
+        }
+
+        return tomlContent(from: lines)
+    }
+
+    private static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
+        var lines = tomlLines(from: existingContent)
+        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
+
+        if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
+            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
+            if featuresStart + 1 < featuresEnd {
+                for index in (featuresStart + 1..<featuresEnd).reversed()
+                    where tomlLineDefinesKey("hooks", line: lines[index])
+                {
+                    lines.remove(at: index)
+                }
+            }
+        }
+
+        return tomlContent(from: lines)
+    }
+
+    private static func tomlLines(from content: String) -> [String] {
+        guard !content.isEmpty else { return [] }
+        var lines = content.components(separatedBy: "\n")
+        if content.hasSuffix("\n"), lines.last == "" {
+            lines.removeLast()
+        }
+        return lines
+    }
+
+    private static func tomlContent(from lines: [String]) -> String {
+        guard !lines.isEmpty else { return "" }
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func tomlLineDefinesKey(_ key: String, line: String) -> Bool {
+        let escapedKey = NSRegularExpression.escapedPattern(for: key)
+        return line.range(
+            of: #"^\s*"# + escapedKey + #"\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineIsTable(_ name: String, line: String) -> Bool {
+        let escapedName = NSRegularExpression.escapedPattern(for: name)
+        return line.range(
+            of: #"^\s*\[\s*"# + escapedName + #"\s*\]\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
+        line.range(
+            of: #"^\s*\[+[^]]+\]+\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlTableEndIndex(in lines: [String], after tableStart: Int) -> Int {
+        var index = tableStart + 1
+        while index < lines.count {
+            if tomlLineIsAnyTableHeader(lines[index]) {
+                return index
+            }
+            index += 1
+        }
+        return lines.count
     }
 
     // MARK: Generic hook handler

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17178,101 +17178,10 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 let newContent = Self.codexConfigTomlUninstallingHooksFeature(from: content)
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    print("Removed hooks from \(configPath)")
+                    print("Updated hooks in \(configPath)")
                 }
             }
         }
-    }
-
-    private static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
-        var lines = tomlLines(from: existingContent)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-
-        if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
-            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
-            if featuresStart + 1 < featuresEnd,
-               let hooksIndex = (featuresStart + 1..<featuresEnd)
-                .first(where: { tomlLineDefinesKey("hooks", line: lines[$0]) })
-            {
-                lines[hooksIndex] = "hooks = true"
-            } else {
-                lines.insert("hooks = true", at: featuresStart + 1)
-            }
-        } else {
-            if !lines.isEmpty, lines.last?.isEmpty == false {
-                lines.append("")
-            }
-            lines.append("[features]")
-            lines.append("hooks = true")
-        }
-
-        return tomlContent(from: lines)
-    }
-
-    private static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
-        var lines = tomlLines(from: existingContent)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-
-        if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
-            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
-            if featuresStart + 1 < featuresEnd {
-                for index in (featuresStart + 1..<featuresEnd).reversed()
-                    where tomlLineDefinesKey("hooks", line: lines[index])
-                {
-                    lines.remove(at: index)
-                }
-            }
-        }
-
-        return tomlContent(from: lines)
-    }
-
-    private static func tomlLines(from content: String) -> [String] {
-        guard !content.isEmpty else { return [] }
-        var lines = content.components(separatedBy: "\n")
-        if content.hasSuffix("\n"), lines.last == "" {
-            lines.removeLast()
-        }
-        return lines
-    }
-
-    private static func tomlContent(from lines: [String]) -> String {
-        guard !lines.isEmpty else { return "" }
-        return lines.joined(separator: "\n") + "\n"
-    }
-
-    private static func tomlLineDefinesKey(_ key: String, line: String) -> Bool {
-        let escapedKey = NSRegularExpression.escapedPattern(for: key)
-        return line.range(
-            of: #"^\s*"# + escapedKey + #"\s*="#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineIsTable(_ name: String, line: String) -> Bool {
-        let escapedName = NSRegularExpression.escapedPattern(for: name)
-        return line.range(
-            of: #"^\s*\[\s*"# + escapedName + #"\s*\]\s*(#.*)?$"#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
-        line.range(
-            of: #"^\s*\[+[^]]+\]+\s*(#.*)?$"#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlTableEndIndex(in lines: [String], after tableStart: Int) -> Int {
-        var index = tableStart + 1
-        while index < lines.count {
-            if tomlLineIsAnyTableHeader(lines[index]) {
-                return index
-            }
-            index += 1
-        }
-        return lines.count
     }
 
     // MARK: Generic hook handler

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17074,9 +17074,12 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             switch action {
             case .codexConfigToml:
                 let configPath = "\(configDir)/config.toml"
-                let existingContent: String = fm.fileExists(atPath: configPath)
-                    ? ((try? String(contentsOfFile: configPath, encoding: .utf8)) ?? "")
-                    : ""
+                let existingContent: String
+                if fm.fileExists(atPath: configPath) {
+                    existingContent = try String(contentsOfFile: configPath, encoding: .utf8)
+                } else {
+                    existingContent = ""
+                }
                 let newContent = Self.codexConfigTomlInstallingHooksFeature(in: existingContent)
                 if newContent != existingContent {
                     if !skipConfirm {
@@ -17173,8 +17176,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             switch action {
             case .codexConfigToml:
                 let configPath = "\(configDir)/config.toml"
-                guard fm.fileExists(atPath: configPath),
-                      let content = try? String(contentsOfFile: configPath, encoding: .utf8) else { return }
+                guard fm.fileExists(atPath: configPath) else { return }
+                let content = try String(contentsOfFile: configPath, encoding: .utf8)
                 let newContent = Self.codexConfigTomlUninstallingHooksFeature(from: content)
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -333,6 +333,7 @@
 		B9000052A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */; };
 		B9000061A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000060A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift */; };
 		B9000063A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000062A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift */; };
+		B9000066A1B2C3D4E5F60719 /* CMUXCLI+CodexConfigToml.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000067A1B2C3D4E5F60719 /* CMUXCLI+CodexConfigToml.swift */; };
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		B900002EA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900002CA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift */; };
 		B900002FA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */; };
@@ -821,6 +822,7 @@
 		B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+InstallPreview.swift"; sourceTree = "<group>"; };
 		B9000060A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+HermesAgentHooks.swift"; sourceTree = "<group>"; };
 		B9000062A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+AgentHookDefinitions.swift"; sourceTree = "<group>"; };
+		B9000067A1B2C3D4E5F60719 /* CMUXCLI+CodexConfigToml.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CodexConfigToml.swift"; sourceTree = "<group>"; };
 		B9000004A1B2C3D4E5F60719 /* cmux */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = cmux; sourceTree = BUILT_PRODUCTS_DIR; };
 		B900002CA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Themes.swift"; sourceTree = "<group>"; };
 		B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+ThemeSupport.swift"; sourceTree = "<group>"; };
@@ -1344,6 +1346,7 @@
 						B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */,
 						B9000060A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift */,
 						B9000062A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift */,
+						B9000067A1B2C3D4E5F60719 /* CMUXCLI+CodexConfigToml.swift */,
 						B9000031A1B2C3D4E5F60719 /* CMUXCLI+DocsSettings.swift */,
 				B900002DA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift */,
 				B900002CA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift */,
@@ -1978,6 +1981,7 @@
 					B9000052A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift in Sources */,
 					B9000061A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift in Sources */,
 					B9000063A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift in Sources */,
+					B9000066A1B2C3D4E5F60719 /* CMUXCLI+CodexConfigToml.swift in Sources */,
 					B9000035A1B2C3D4E5F60719 /* CMUXCLI+DocsSettings.swift in Sources */,
 				B900002FA1B2C3D4E5F60719 /* CMUXCLI+ThemeSupport.swift in Sources */,
 				B900002EA1B2C3D4E5F60719 /* CMUXCLI+Themes.swift in Sources */,

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -533,6 +533,7 @@ def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -
 def test_install_migrates_legacy_codex_hooks_feature(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-legacy"
     codex_home.mkdir()
+    # Real configs can contain both names after users tried the old and new flags.
     (codex_home / "config.toml").write_text(
         "[features]\napps = true\ncodex_hooks = false\nhooks = false\n",
         encoding="utf-8",
@@ -652,7 +653,7 @@ def test_uninstall_restores_disabled_codex_hooks_feature(cli_path: str, root: Pa
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
     if "hooks = false" not in config_toml:
         raise AssertionError(f"pre-existing disabled hooks feature was not restored: {config_toml!r}")
-    if "hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
+    if "hooks = true" in config_toml:
         raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
     if "apps = true" not in config_toml:
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
@@ -685,7 +686,7 @@ def test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path: str, r
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
     if "features.hooks = false" not in config_toml:
         raise AssertionError(f"pre-existing disabled dotted hooks feature was not restored: {config_toml!r}")
-    if "features.hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
+    if "features.hooks = true" in config_toml:
         raise AssertionError(f"cmux-owned dotted hooks feature was not removed: {config_toml!r}")
     if "features.apps = true" not in config_toml:
         raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
@@ -783,7 +784,7 @@ def test_uninstall_recovers_orphaned_codex_hooks_marker(cli_path: str, root: Pat
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
     if "hooks = false" not in config_toml:
         raise AssertionError(f"previous hooks setting was not restored: {config_toml!r}")
-    if "hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
+    if "hooks = true" in config_toml:
         raise AssertionError(f"orphaned cmux marker was not removed: {config_toml!r}")
     if "apps = true" not in config_toml:
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -562,6 +562,64 @@ def test_install_migrates_legacy_codex_hooks_feature(cli_path: str, root: Path) 
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
 
 
+def test_uninstall_preserves_existing_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-uninstall-existing"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "[features]\napps = true\nhooks = true\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    for action in ["install", "uninstall"]:
+        result = subprocess.run(
+            [cli_path, "hooks", "codex", action, "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "hooks = true" not in config_toml:
+        raise AssertionError(f"pre-existing hooks feature was removed: {config_toml!r}")
+    if "apps = true" not in config_toml:
+        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
+
+
+def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-uninstall-owned"
+    codex_home.mkdir()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    for action in ["install", "uninstall"]:
+        result = subprocess.run(
+            [cli_path, "hooks", "codex", action, "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "hooks = true" in config_toml or "codex_hooks" in config_toml:
+        raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
+    if "[features]" in config_toml:
+        raise AssertionError(f"empty features table was preserved: {config_toml!r}")
+
+
 def test_permission_reply_uses_codex_permission_request_schema(cli_path: str, root: Path) -> None:
     socket_path = root / "cmux.sock"
     payload = {
@@ -659,6 +717,9 @@ def main() -> int:
             test_codex_monitor_exits_when_workspace_has_no_surfaces(cli_path, root)
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)
+            test_install_migrates_legacy_codex_hooks_feature(cli_path, root)
+            test_uninstall_preserves_existing_codex_hooks_feature(cli_path, root)
+            test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
             test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)
             test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -752,6 +752,43 @@ def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: P
         raise AssertionError(f"empty features table was preserved: {config_toml!r}")
 
 
+def test_uninstall_recovers_orphaned_codex_hooks_marker(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-orphaned-marker"
+    codex_home.mkdir()
+    (codex_home / "hooks.json").write_text('{"hooks": {}}\n', encoding="utf-8")
+    (codex_home / "config.toml").write_text(
+        "[features]\n"
+        "apps = true\n"
+        "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df begin\n"
+        "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df previous line: hooks = false\n"
+        "hooks = true\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex uninstall failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "hooks = false" not in config_toml:
+        raise AssertionError(f"previous hooks setting was not restored: {config_toml!r}")
+    if "hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
+        raise AssertionError(f"orphaned cmux marker was not removed: {config_toml!r}")
+    if "apps = true" not in config_toml:
+        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
+
+
 def test_install_surfaces_invalid_codex_config_encoding(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-invalid-install-config"
     codex_home.mkdir()
@@ -917,6 +954,7 @@ def main() -> int:
             test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path, root)
             test_install_scans_features_past_bracketed_array(cli_path, root)
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
+            test_uninstall_recovers_orphaned_codex_hooks_marker(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -625,6 +625,72 @@ def test_uninstall_preserves_existing_codex_hooks_feature(cli_path: str, root: P
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
 
 
+def test_uninstall_restores_disabled_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-uninstall-disabled"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "[features]\napps = true\nhooks = false\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    for action in ["install", "uninstall"]:
+        result = subprocess.run(
+            [cli_path, "hooks", "codex", action, "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "hooks = false" not in config_toml:
+        raise AssertionError(f"pre-existing disabled hooks feature was not restored: {config_toml!r}")
+    if "hooks = true" in config_toml or "cmux hooks codex feature" in config_toml:
+        raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
+    if "apps = true" not in config_toml:
+        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
+
+
+def test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-uninstall-dotted-disabled"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "features.apps = true\nfeatures.hooks = false\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    for action in ["install", "uninstall"]:
+        result = subprocess.run(
+            [cli_path, "hooks", "codex", action, "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "features.hooks = false" not in config_toml:
+        raise AssertionError(f"pre-existing disabled dotted hooks feature was not restored: {config_toml!r}")
+    if "features.hooks = true" in config_toml or "cmux hooks codex feature" in config_toml:
+        raise AssertionError(f"cmux-owned dotted hooks feature was not removed: {config_toml!r}")
+    if "features.apps = true" not in config_toml:
+        raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
+
+
 def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-uninstall-owned"
     codex_home.mkdir()
@@ -752,6 +818,8 @@ def main() -> int:
             test_install_migrates_legacy_codex_hooks_feature(cli_path, root)
             test_install_migrates_dotted_codex_hooks_feature(cli_path, root)
             test_uninstall_preserves_existing_codex_hooks_feature(cli_path, root)
+            test_uninstall_restores_disabled_codex_hooks_feature(cli_path, root)
+            test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path, root)
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
             test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -718,6 +718,67 @@ def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: P
         raise AssertionError(f"empty features table was preserved: {config_toml!r}")
 
 
+def test_install_surfaces_invalid_codex_config_encoding(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-invalid-install-config"
+    codex_home.mkdir()
+    config_path = codex_home / "config.toml"
+    invalid_bytes = b"\xff"
+    config_path.write_bytes(invalid_bytes)
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode == 0:
+        raise AssertionError("hooks codex install unexpectedly succeeded with invalid config encoding")
+    if config_path.read_bytes() != invalid_bytes:
+        raise AssertionError("hooks codex install overwrote unreadable config content")
+
+
+def test_uninstall_surfaces_invalid_codex_config_encoding(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-invalid-uninstall-config"
+    codex_home.mkdir()
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    install_result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if install_result.returncode != 0:
+        raise AssertionError(
+            "initial hooks codex install failed "
+            f"exit={install_result.returncode}\nstdout={install_result.stdout}\nstderr={install_result.stderr}"
+        )
+
+    config_path = codex_home / "config.toml"
+    invalid_bytes = b"\xff"
+    config_path.write_bytes(invalid_bytes)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "uninstall", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode == 0:
+        raise AssertionError("hooks codex uninstall unexpectedly succeeded with invalid config encoding")
+    if config_path.read_bytes() != invalid_bytes:
+        raise AssertionError("hooks codex uninstall overwrote unreadable config content")
+
+
 def test_permission_reply_uses_codex_permission_request_schema(cli_path: str, root: Path) -> None:
     socket_path = root / "cmux.sock"
     payload = {
@@ -821,6 +882,8 @@ def main() -> int:
             test_uninstall_restores_disabled_codex_hooks_feature(cli_path, root)
             test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path, root)
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
+            test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
+            test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
             test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)
             test_codex_pre_tool_use_is_telemetry_not_actionable(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -562,6 +562,38 @@ def test_install_migrates_legacy_codex_hooks_feature(cli_path: str, root: Path) 
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
 
 
+def test_install_migrates_dotted_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-dotted-legacy"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "features.apps = true\nfeatures.codex_hooks = false\nfeatures.hooks = false\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "features.codex_hooks" in config_toml or "[features]" in config_toml:
+        raise AssertionError(f"dotted legacy config was rewritten incorrectly: {config_toml!r}")
+    if "features.hooks = true" not in config_toml:
+        raise AssertionError(f"dotted hooks feature was not enabled: {config_toml!r}")
+    if "features.apps = true" not in config_toml:
+        raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
+
+
 def test_uninstall_preserves_existing_codex_hooks_feature(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home-uninstall-existing"
     codex_home.mkdir()
@@ -718,6 +750,7 @@ def main() -> int:
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)
             test_install_migrates_legacy_codex_hooks_feature(cli_path, root)
+            test_install_migrates_dotted_codex_hooks_feature(cli_path, root)
             test_uninstall_preserves_existing_codex_hooks_feature(cli_path, root)
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -524,8 +524,42 @@ def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -
             raise AssertionError(f"wrong {event_name} timeout: {groups[-1]!r}")
 
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "codex_hooks = true" not in config_toml:
-        raise AssertionError(f"codex_hooks feature was not enabled: {config_toml!r}")
+    if "hooks = true" not in config_toml:
+        raise AssertionError(f"hooks feature was not enabled: {config_toml!r}")
+    if "codex_hooks" in config_toml:
+        raise AssertionError(f"deprecated codex_hooks feature was written: {config_toml!r}")
+
+
+def test_install_migrates_legacy_codex_hooks_feature(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-legacy"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "[features]\napps = true\ncodex_hooks = false\nhooks = false\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    result = subprocess.run(
+        [cli_path, "hooks", "codex", "install", "--yes"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "codex_hooks" in config_toml:
+        raise AssertionError(f"deprecated codex_hooks feature was preserved: {config_toml!r}")
+    if "hooks = true" not in config_toml:
+        raise AssertionError(f"hooks feature was not enabled: {config_toml!r}")
+    if "apps = true" not in config_toml:
+        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
 
 
 def test_permission_reply_uses_codex_permission_request_schema(cli_path: str, root: Path) -> None:

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -652,7 +652,7 @@ def test_uninstall_restores_disabled_codex_hooks_feature(cli_path: str, root: Pa
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
     if "hooks = false" not in config_toml:
         raise AssertionError(f"pre-existing disabled hooks feature was not restored: {config_toml!r}")
-    if "hooks = true" in config_toml or "cmux hooks codex feature" in config_toml:
+    if "hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
         raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
     if "apps = true" not in config_toml:
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
@@ -685,10 +685,44 @@ def test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path: str, r
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
     if "features.hooks = false" not in config_toml:
         raise AssertionError(f"pre-existing disabled dotted hooks feature was not restored: {config_toml!r}")
-    if "features.hooks = true" in config_toml or "cmux hooks codex feature" in config_toml:
+    if "features.hooks = true" in config_toml or "cmux-codex-hooks-feature" in config_toml:
         raise AssertionError(f"cmux-owned dotted hooks feature was not removed: {config_toml!r}")
     if "features.apps = true" not in config_toml:
         raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
+
+
+def test_install_scans_features_past_bracketed_array(cli_path: str, root: Path) -> None:
+    codex_home = root / "codex-home-bracketed-array"
+    codex_home.mkdir()
+    (codex_home / "config.toml").write_text(
+        "[features]\napps = [\n  [1, 2],\n]\nhooks = false\n",
+        encoding="utf-8",
+    )
+    env = os.environ.copy()
+    env["CODEX_HOME"] = str(codex_home)
+
+    for action in ["install", "uninstall"]:
+        result = subprocess.run(
+            [cli_path, "hooks", "codex", action, "--yes"],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=20,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+        if action == "install" and config_toml.count("hooks = true") != 1:
+            raise AssertionError(f"install wrote duplicate hooks settings: {config_toml!r}")
+
+    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
+    if "hooks = false" not in config_toml or "hooks = true" in config_toml:
+        raise AssertionError(f"uninstall did not restore hooks after bracketed array: {config_toml!r}")
+    if "[1, 2]" not in config_toml:
+        raise AssertionError(f"bracketed array content was not preserved: {config_toml!r}")
 
 
 def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: Path) -> None:
@@ -881,6 +915,7 @@ def main() -> int:
             test_uninstall_preserves_existing_codex_hooks_feature(cli_path, root)
             test_uninstall_restores_disabled_codex_hooks_feature(cli_path, root)
             test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path, root)
+            test_install_scans_features_past_bracketed_array(cli_path, root)
             test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
             test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)


### PR DESCRIPTION
Summary:
- Write [features].hooks = true for Codex hook setup instead of deprecated codex_hooks.
- Migrate legacy codex_hooks entries while preserving other feature settings.
- Update Codex hook install regression coverage.

Verification:
- ./scripts/setup.sh
- xcodebuild -downloadComponent MetalToolchain
- ./scripts/reload.sh --tag codhooks
- Temp CODEX_HOME install and legacy migration smoke check with the built codhooks CLI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes how the CLI edits users’ `config.toml` during Codex hook install/uninstall, including migration/rollback logic that could affect existing feature settings if parsing misses edge cases.
> 
> **Overview**
> Codex hook install/uninstall now enables **`hooks = true`** (or `features.hooks = true`) in `config.toml` instead of the deprecated **`codex_hooks`**, and removes any legacy `codex_hooks` entries during install.
> 
> This replaces the previous regex-based edits with a new TOML-line rewrite helper (`CMUXCLI+CodexConfigToml.swift`) that inserts a cmux-owned marker block (recording the prior `hooks` line for restoration), supports both `[features]` and dotted `features.*` styles, cleans up empty `[features]` tables, and handles orphaned/legacy markers.
> 
> `cmux hooks codex` tests are expanded to cover legacy migrations, dotted configs, restoring pre-existing `hooks` states on uninstall, bracketed-array/table scanning, orphan-marker recovery, and failing safely when `config.toml` has invalid UTF-8.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24446cd6cfbac407ba1b00f1466de77e85558ed9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Codex hook setup to enable `hooks` instead of deprecated `codex_hooks`, with TOML-aware edits that handle `[features]`, dotted `features.*`, and bracketed arrays. Adds UUID cmux-owned markers and recovers orphaned markers; install/uninstall preserve prior `hooks`, keep other flags, and fail safely on unreadable configs.

- **Migration**
  - Install removes all `codex_hooks` (including `features.codex_hooks`) and enables `hooks` under `[features]` or as `features.hooks`, inserting a cmux-owned block with UUID markers that records the prior `hooks` line for undo.
  - Uninstall deletes only the cmux block (including legacy and orphaned markers), restores the recorded `hooks` value (true/false), removes an empty `[features]`, and preserves other flags; no write on invalid config encodings.

<sup>Written for commit 24446cd6cfbac407ba1b00f1466de77e85558ed9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Use TOML-aware updates for enabling/disabling hooks, remove deprecated codex_hooks entries, preserve other feature flags, and avoid leaving empty [features] sections.
  * Update install/uninstall console messages to reference the new hooks setting.

* **New Features**
  * Robust TOML-based configuration migration and uninstall handling for the hooks feature.

* **Tests**
  * Added regression tests covering install/uninstall, legacy and dotted-key migrations, and state restoration.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3884)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->