### PR TITLE
Fix stale SSH ControlPath cleanup before pane launch

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4806,6 +4806,7 @@ struct CMUXCLI {
             sshOptions.sshOptions,
             remoteRelayPort: sshOptions.remoteRelayPort
         )
+        let controlPathPreflightShellFunction = sshControlPathPreflightShellFunction(options: sshOptions)
         let initialSSHCommand = buildSSHCommandText(sshOptions)
         // For VM workspaces (Freestyle), skip the interactive bootstrap script: the russh
         // gateway forwards shell-request PTYs but stalls on exec-channel I/O, and the bootstrap
@@ -4859,25 +4860,29 @@ struct CMUXCLI {
                 remoteBootstrapScript: remoteTerminalBootstrapScript,
                 shellFeatures: shellFeaturesValue,
                 remoteRelayPort: sshOptions.remoteRelayPort,
-                localCommandScript: combinedLocalCommandScript
+                localCommandScript: combinedLocalCommandScript,
+                controlPathPreflightShellFunction: controlPathPreflightShellFunction
             )
             remoteTerminalSSHStartupCommand = buildReusableBootstrapSSHStartupCommand(
                 options: sshOptions,
                 remoteBootstrapScript: remoteTerminalBootstrapScript,
                 shellFeatures: shellFeaturesValue,
                 remoteRelayPort: sshOptions.remoteRelayPort,
-                localCommandScript: combinedLocalCommandScript
+                localCommandScript: combinedLocalCommandScript,
+                controlPathPreflightShellFunction: controlPathPreflightShellFunction
             )
         } else {
             initialSSHStartupCommand = try buildSSHStartupCommand(
                 sshCommand: startupInitialSSHCommand,
                 shellFeatures: "",
-                remoteRelayPort: sshOptions.remoteRelayPort
+                remoteRelayPort: sshOptions.remoteRelayPort,
+                controlPathPreflightShellFunction: controlPathPreflightShellFunction
             )
             remoteTerminalSSHStartupCommand = buildReusableSSHStartupCommand(
                 sshCommand: startupRemoteTerminalSSHCommand,
                 shellFeatures: shellFeaturesValue,
-                remoteRelayPort: sshOptions.remoteRelayPort
+                remoteRelayPort: sshOptions.remoteRelayPort,
+                controlPathPreflightShellFunction: controlPathPreflightShellFunction
             )
         }
         let reusableTerminalStartupCommand: String
@@ -5171,7 +5176,8 @@ struct CMUXCLI {
         remoteBootstrapScript: String,
         shellFeatures: String,
         remoteRelayPort: Int,
-        localCommandScript: String? = nil
+        localCommandScript: String? = nil,
+        controlPathPreflightShellFunction: String? = nil
     ) throws -> String {
         let commandSnippet = buildSSHBootstrapCommandSnippet(
             options: options,
@@ -5182,7 +5188,8 @@ struct CMUXCLI {
             sshCommand: commandSnippet,
             shellFeatures: shellFeatures,
             remoteRelayPort: remoteRelayPort,
-            isShellSnippet: true
+            isShellSnippet: true,
+            controlPathPreflightShellFunction: controlPathPreflightShellFunction
         )
     }
 
@@ -5191,7 +5198,8 @@ struct CMUXCLI {
         remoteBootstrapScript: String,
         shellFeatures: String,
         remoteRelayPort: Int,
-        localCommandScript: String? = nil
+        localCommandScript: String? = nil,
+        controlPathPreflightShellFunction: String? = nil
     ) -> String {
         let commandSnippet = buildSSHBootstrapCommandSnippet(
             options: options,
@@ -5202,7 +5210,8 @@ struct CMUXCLI {
             sshCommand: commandSnippet,
             shellFeatures: shellFeatures,
             remoteRelayPort: remoteRelayPort,
-            isShellSnippet: true
+            isShellSnippet: true,
+            controlPathPreflightShellFunction: controlPathPreflightShellFunction
         )
     }
 
@@ -5325,6 +5334,39 @@ struct CMUXCLI {
             merged.append("StrictHostKeyChecking=accept-new")
         }
         return merged
+    }
+
+    private func sshControlPathPreflightShellFunction(options: SSHCommandOptions) -> String? {
+        let effectiveOptions = effectiveSSHOptions(
+            options.sshOptions,
+            remoteRelayPort: options.remoteRelayPort
+        )
+        let controlMaster = sshOptionValue(named: "ControlMaster", in: effectiveOptions)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? "auto"
+        guard !["no", "false", "off"].contains(controlMaster),
+              let controlPath = sshOptionValue(named: "ControlPath", in: effectiveOptions)?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              !controlPath.isEmpty,
+              controlPath.lowercased() != "none" else {
+            return nil
+        }
+
+        let sshPrefix = baseSSHArguments(options).map(shellQuote).joined(separator: " ")
+        let destination = shellQuote(options.destination)
+        return [
+            "cmux_ssh_preflight_control_path() {",
+            #"  cmux_ssh_control_path="$(command \#(sshPrefix) -G \#(destination) 2>/dev/null | awk 'tolower($1) == "controlpath" { $1 = ""; sub(/^[[:space:]]+/, ""); print; exit }')" "#,
+            "  case \"${cmux_ssh_control_path:-}\" in",
+            "    /tmp/cmux-ssh-*|\"$HOME\"/.cmux/control/*)",
+            "      if ! command \(sshPrefix) -S \"$cmux_ssh_control_path\" -O check \(destination) >/dev/null 2>&1; then",
+            "        rm -f -- \"$cmux_ssh_control_path\" 2>/dev/null || true",
+            "      fi",
+            "      ;;",
+            "  esac",
+            "  unset cmux_ssh_control_path",
+            "}",
+        ].joined(separator: "\n")
     }
 
     func buildInteractiveRemoteShellScript(
@@ -5720,13 +5762,15 @@ struct CMUXCLI {
         sshCommand: String,
         shellFeatures: String,
         remoteRelayPort: Int,
-        isShellSnippet: Bool = false
+        isShellSnippet: Bool = false,
+        controlPathPreflightShellFunction: String? = nil
     ) throws -> String {
         let script = buildSSHStartupScriptBody(
             sshCommand: sshCommand,
             shellFeatures: shellFeatures,
             remoteRelayPort: remoteRelayPort,
-            isShellSnippet: isShellSnippet
+            isShellSnippet: isShellSnippet,
+            controlPathPreflightShellFunction: controlPathPreflightShellFunction
         )
         return try writeSSHStartupScript(script, remoteRelayPort: remoteRelayPort)
     }
@@ -5735,13 +5779,15 @@ struct CMUXCLI {
         sshCommand: String,
         shellFeatures: String,
         remoteRelayPort: Int,
-        isShellSnippet: Bool = false
+        isShellSnippet: Bool = false,
+        controlPathPreflightShellFunction: String? = nil
     ) -> String {
         let script = buildSSHStartupScriptBody(
             sshCommand: sshCommand,
             shellFeatures: shellFeatures,
             remoteRelayPort: remoteRelayPort,
-            isShellSnippet: isShellSnippet
+            isShellSnippet: isShellSnippet,
+            controlPathPreflightShellFunction: controlPathPreflightShellFunction
         )
         return reusableShellStartupCommand(
             scriptBody: script,
@@ -5753,16 +5799,22 @@ struct CMUXCLI {
         sshCommand: String,
         shellFeatures: String,
         remoteRelayPort: Int,
-        isShellSnippet: Bool
+        isShellSnippet: Bool,
+        controlPathPreflightShellFunction: String?
     ) -> String {
         let trimmedFeatures = shellFeatures.trimmingCharacters(in: .whitespacesAndNewlines)
         let shellFeaturesBootstrap: String = trimmedFeatures.isEmpty
             ? ""
             : "export GHOSTTY_SHELL_FEATURES=\(shellQuote(trimmedFeatures))"
         let lifecycleCleanup = buildSSHSessionEndShellCommand(remoteRelayPort: remoteRelayPort)
+        let trimmedControlPathPreflight = controlPathPreflightShellFunction?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
         var scriptLines: [String] = []
         if !shellFeaturesBootstrap.isEmpty {
             scriptLines.append(shellFeaturesBootstrap)
+        }
+        if let trimmedControlPathPreflight, !trimmedControlPathPreflight.isEmpty {
+            scriptLines.append(trimmedControlPathPreflight)
         }
         scriptLines += [
             "rm -f -- \"$0\" 2>/dev/null || true",
@@ -5785,6 +5837,9 @@ struct CMUXCLI {
             "trap 'cmux_ssh_signal_exit 143' TERM",
             "while :; do",
         ]
+        if trimmedControlPathPreflight?.isEmpty == false {
+            scriptLines.append("  cmux_ssh_preflight_control_path")
+        }
         if isShellSnippet {
             scriptLines += [
                 "  (",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5341,10 +5341,10 @@ struct CMUXCLI {
             options.sshOptions,
             remoteRelayPort: options.remoteRelayPort
         )
-        let controlMaster = sshOptionValue(named: "ControlMaster", in: effectiveOptions)?
+        guard let controlMaster = sshOptionValue(named: "ControlMaster", in: effectiveOptions)?
             .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased() ?? "auto"
-        guard !["no", "false", "off"].contains(controlMaster),
+            .lowercased(),
+              !["no", "false", "off"].contains(controlMaster),
               let controlPath = sshOptionValue(named: "ControlPath", in: effectiveOptions)?
                 .trimmingCharacters(in: .whitespacesAndNewlines),
               !controlPath.isEmpty,
@@ -5837,7 +5837,7 @@ struct CMUXCLI {
             "trap 'cmux_ssh_signal_exit 143' TERM",
             "while :; do",
         ]
-        if trimmedControlPathPreflight?.isEmpty == false {
+        if let trimmedControlPathPreflight, !trimmedControlPathPreflight.isEmpty {
             scriptLines.append("  cmux_ssh_preflight_control_path")
         }
         if isShellSnippet {

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -124,6 +124,87 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(sessionEndCalls.count, 1, recordedCalls)
     }
 
+    func testSSHStartupRemovesStaleCmuxControlSocketBeforeLaunchingPaneSSH() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-stale-control-\(UUID().uuidString)", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let logFile = root.appendingPathComponent("ssh.log")
+        let staleControlPath = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cmux-ssh-\(getuid())-\(UUID().uuidString.prefix(8)).sock")
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: root)
+            unlink(staleControlPath.path)
+        }
+
+        let staleSocketFD = try bindUnixSocket(at: staleControlPath.path)
+        Darwin.close(staleSocketFD)
+        XCTAssertTrue(fileManager.fileExists(atPath: staleControlPath.path))
+
+        try writeShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" >> \"${CMUX_TEST_SESSION_END_LOG}\"",
+        ])
+        try writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" >> \"${CMUX_TEST_SSH_LOG}\"",
+            "for arg in \"$@\"; do",
+            "  if [ \"$arg\" = '-G' ]; then",
+            "    printf 'controlpath %s\\n' \"${CMUX_TEST_CONTROL_PATH}\"",
+            "    exit 0",
+            "  fi",
+            "done",
+            "previous_arg=",
+            "for arg in \"$@\"; do",
+            "  if [ \"$previous_arg\" = '-O' ] && [ \"$arg\" = 'check' ]; then",
+            "    exit 255",
+            "  fi",
+            "  previous_arg=\"$arg\"",
+            "done",
+            "if [ -e \"${CMUX_TEST_CONTROL_PATH}\" ]; then",
+            "  printf 'ControlSocket %s already exists, disabling multiplexing\\n' \"${CMUX_TEST_CONTROL_PATH}\" >&2",
+            "  exit 99",
+            "fi",
+            "exit 0",
+        ])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLI.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+
+        let startupCommand = try generatedSSHStartupCommand(sshOptions: [
+            "ControlMaster auto",
+            "ControlPersist 600",
+            "ControlPath \(staleControlPath.path)",
+        ])
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_CONTROL_PATH"] = staleControlPath.path
+        environment["CMUX_TEST_SESSION_END_LOG"] = root.appendingPathComponent("ssh-session-end.log").path
+        environment["CMUX_TEST_SSH_LOG"] = logFile.path
+        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertFalse(fileManager.fileExists(atPath: staleControlPath.path))
+
+        let sshLog = (try? String(contentsOf: logFile, encoding: .utf8)) ?? ""
+        XCTAssertTrue(sshLog.contains("-G"), sshLog)
+        XCTAssertTrue(sshLog.contains("-O check"), sshLog)
+    }
+
     func testSSHStartupStopsAtConfiguredReconnectLimit() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory
@@ -388,7 +469,12 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertTrue(result.stderr.contains("[cmux] press Enter to close this pane."), result.stderr)
     }
 
-    private func generatedSSHStartupCommand() throws -> String {
+    private func generatedSSHStartupCommand(
+        sshOptions: [String] = [
+            "ControlMaster no",
+            "ControlPath /tmp/cmux-ssh-%C",
+        ]
+    ) throws -> String {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("ssh-pane-close")
         let listenerFD = try bindUnixSocket(at: socketPath)
@@ -449,16 +535,19 @@ extension CLINotifyProcessIntegrationRegressionTests {
         environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
         environment["CMUX_CLAUDE_HOOK_SENTRY_DISABLED"] = "1"
 
+        var arguments = [
+            "ssh",
+            "--no-focus",
+            "--port", "2222",
+        ]
+        for option in sshOptions {
+            arguments += ["--ssh-option", option]
+        }
+        arguments.append("cmux-macmini")
+
         let result = runProcess(
             executablePath: cliPath,
-            arguments: [
-                "ssh",
-                "--no-focus",
-                "--port", "2222",
-                "--ssh-option", "ControlMaster no",
-                "--ssh-option", "ControlPath /tmp/cmux-ssh-%C",
-                "cmux-macmini",
-            ],
+            arguments: arguments,
             environment: environment,
             timeout: 5
         )

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -131,7 +131,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let fakeCLI = root.appendingPathComponent("cmux")
         let fakeSSH = root.appendingPathComponent("ssh")
         let logFile = root.appendingPathComponent("ssh.log")
-        let staleControlPath = URL(fileURLWithPath: NSTemporaryDirectory())
+        let staleControlPath = URL(fileURLWithPath: "/tmp", isDirectory: true)
             .appendingPathComponent("cmux-ssh-\(getuid())-\(UUID().uuidString.prefix(8)).sock")
 
         try fileManager.createDirectory(at: root, withIntermediateDirectories: true)


### PR DESCRIPTION
## Summary
- Add a regression for generated pane startup scripts encountering a stale cmux SSH control socket.
- Preflight cmux-owned OpenSSH ControlPath values before launching pane SSH, removing stale paths only after `ssh -O check` fails.

## Local Repro
1. Started a disposable localhost `sshd` on a high port with temp host/client keys.
2. Created a Unix socket path, closed the listener without unlinking it, leaving a stale socket file.
3. Ran OpenSSH with `ControlMaster=yes` and `ControlPath=<stale socket>` against the disposable SSH server.

Observed: OpenSSH printed `ControlSocket <path> already exists, disabling multiplexing` and continued without multiplexing.
Expected: cmux should remove stale cmux-owned ControlPath files before pane SSH launches so OpenSSH can create or attach to a master cleanly.

Note: On this machine, the same disposable-server probe with `ControlMaster=auto` did not emit the warning, so the committed regression covers cmux behavior by executing the generated pane startup wrapper with a fake `ssh` and a real stale Unix socket.

## Verification
- `git diff --check`
- Local unit/UI tests not run per repo instruction; CI owns test execution.
- Dev app build/launch intentionally deferred until CI is fully green per issue instructions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches generated SSH startup scripts and can delete `ControlPath` socket files; while gated to cmux-owned path patterns and only after `ssh -O check` fails, mistakes could disrupt SSH multiplexing behavior.
> 
> **Overview**
> Adds a **ControlPath preflight** to generated SSH pane/VM startup scripts to prevent OpenSSH from disabling multiplexing when a stale cmux-owned control socket exists.
> 
> When `ControlMaster` is enabled, the startup wrapper now resolves the effective `ControlPath` via `ssh -G`, runs `ssh -O check`, and removes the socket only if the check fails and the path matches cmux-owned locations (`/tmp/cmux-ssh-*` or `$HOME/.cmux/control/*`). A new regression test (`testSSHStartupRemovesStaleCmuxControlSocketBeforeLaunchingPaneSSH`) validates the preflight unlinks a real stale socket and that `-G`/`-O check` are invoked; the helper for generating startup commands was updated to accept custom SSH options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e330620b87a7963a6c09eec3afd73f5f68ce77f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale cmux-owned SSH `ControlPath` sockets that blocked pane startup and disabled multiplexing. Adds a preflight in generated startup scripts to clean stale sockets before launching `ssh`, restoring multiplexing and meeting Linear 3723.

- **Bug Fixes**
  - Injects a shell preflight into all generated SSH startup scripts (bootstrap and reusable) and runs it before each `ssh` spawn: resolves the effective `ControlPath` via `ssh -G`, checks the master with `ssh -O check`, and removes the path only when the check fails and it’s under `/tmp/cmux-ssh-*` or `$HOME/.cmux/control/*`. Only runs when `ControlMaster` is enabled and `ControlPath` is set (and not `none`); tightened quoting and option parsing per review.
  - Regression test uses a fake `ssh` and a real stale socket; exercises the generated startup command and verifies the `-G`/`-O check` calls and unlink happen before the first SSH child, and that the script exits cleanly.

<sup>Written for commit e330620b87a7963a6c09eec3afd73f5f68ce77f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

Closes #3723