### PR TITLE
Fix terminal file drops inserting paths

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11207,6 +11207,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func paneDropTargetForDrop(at localPoint: NSPoint) -> TerminalPaneDropTargetView? {
+        guard paneDropTargetView.dropContext != nil else { return nil }
         guard bounds.contains(localPoint) else { return nil }
         let pointInTarget = paneDropTargetView.convert(localPoint, from: self)
         guard paneDropTargetView.bounds.contains(pointInTarget) else { return nil }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2195,6 +2195,33 @@ final class WindowTerminalHostViewTests: XCTestCase {
         return hostedView
     }
 
+    func testTerminalPaneDropTargetLookupRequiresActiveDropContext() {
+        let frame = NSRect(x: 0, y: 0, width: 240, height: 160)
+        let hostedView = makeHostedTerminalView(frame: frame)
+        hostedView.layoutSubtreeIfNeeded()
+        hostedView.layout()
+        let dropPoint = NSPoint(x: frame.midX, y: frame.midY)
+
+        hostedView.setPaneDropContext(TerminalPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        XCTAssertNotNil(
+            hostedView.paneDropTargetForDrop(at: dropPoint),
+            "Active terminal pane drop targets should remain discoverable for pane drop routing"
+        )
+
+        hostedView.setPaneDropContext(nil)
+
+        let target = hostedView.paneDropTargetForDrop(at: dropPoint)
+
+        XCTAssertNil(
+            target,
+            "Inactive terminal pane drop targets must not shadow terminal file-path drop insertion"
+        )
+    }
+
     private func assertHitFallsInsideHostedTerminal(
         _ hitView: NSView?,
         hostedView: GhosttySurfaceScrollView,


### PR DESCRIPTION
## Summary
- Restore terminal file drops to the file-path insertion path by refusing inactive terminal pane drop targets.
- Add a regression test for the portal lookup invariant that let viewer-oriented pane routing shadow terminal text insertion, with both active-context and cleared-context assertions.

## Local repro
1. On current `main`, construct a `GhosttySurfaceScrollView` and install an active `TerminalPaneDropContext`.
2. Query `paneDropTargetForDrop(at:)` at the center of the hosted terminal; active pane routing is available.
3. Clear the pane drop context with `setPaneDropContext(nil)`, mirroring a stale/inactive terminal portal lookup during a Finder file drop.
4. Observed on the failing regression commit: lookup still returns a `TerminalPaneDropTargetView`, even though that target cannot handle the drop because its context is nil. This can route the file drop toward the built-in preview path instead of terminal text insertion.
5. Expected: lookup returns nil after context is cleared, allowing terminal file-path insertion to receive the drop.

## Commits
- `47b730493` adds the failing regression test only.
- `6d13e2b09` applies the fix.

## Testing
- Not run locally by request; direct `xcodebuild`/local test execution is intentionally avoided before CI.
- CI/CD is being driven with `$iterate-pr` until fully green.

Closes #3729

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard condition changes drop-target discovery only when `dropContext` is nil, plus a focused regression test to lock the behavior in.
> 
> **Overview**
> Fixes Finder file drops being misrouted by making `paneDropTargetForDrop(at:)` return `nil` unless `paneDropTargetView.dropContext` is set, so inactive pane-drop targets no longer shadow file-path insertion.
> 
> Adds a regression test ensuring drop-target lookup succeeds with an active context and returns `nil` after `setPaneDropContext(nil)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d13e2b09db309ce8a42f79b83917cfda98b73b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented inactive/no-drop contexts from participating in drop hit-testing so they no longer interfere with file-path drop insertion.

* **Tests**
  * Added a test ensuring drop target lookup returns no target when the drop context is inactive, guarding against accidental drop handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3900)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3900)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->