### PR TITLE
Fix main window close lifecycle memory leaks

### DIFF
--- a/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
+++ b/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
@@ -59,7 +59,11 @@ extension AppDelegate {
     }
 
     private func liveRecoverableMainWindow(windowId: UUID, cachedWindow: NSWindow?) -> NSWindow? {
-        cachedWindow ?? windowForMainWindowId(windowId)
+        guard let window = cachedWindow ?? windowForMainWindowId(windowId),
+              window.isVisible || window.isMiniaturized else {
+            return nil
+        }
+        return window
     }
 
     private func sortedRecoverableMainWindowRoutes() -> [RecoverableMainWindowRoute] {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -4846,8 +4846,32 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func closeMainWindow(windowId: UUID) -> Bool {
         guard let window = windowForMainWindowId(windowId) else { return false }
-        window.performClose(nil)
-        return true
+        return closeMainTerminalWindow(window, expectedWindowId: windowId)
+    }
+
+    @discardableResult
+    private func closeMainTerminalWindow(
+        _ window: NSWindow,
+        expectedWindowId: UUID? = nil
+    ) -> Bool {
+        let windowId = expectedWindowId
+            ?? contextForMainTerminalWindow(window, reindex: false)?.windowId
+            ?? mainWindowId(from: window)
+        guard let windowId else { return false }
+
+        WebViewInspectorTeardown.closeAllInspectors(in: window)
+        window.close()
+        forgetRecoverableMainWindowRoute(windowId: windowId)
+
+        let didClose = !mainWindowContexts.values.contains { $0.windowId == windowId }
+#if DEBUG
+        if !didClose {
+            cmuxDebugLog(
+                "mainWindow.close.incomplete windowId=\(String(windowId.uuidString.prefix(8))) window={\(debugWindowToken(window))}"
+            )
+        }
+#endif
+        return didClose
     }
 
     private func confirmCloseMainWindow(_ window: NSWindow) -> Bool {
@@ -4885,9 +4909,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             window.performClose(nil)
             return true
         }
-        guard confirmCloseMainWindow(window) else { return true }
-        window.performClose(nil)
-        return true
+        guard confirmCloseMainWindow(window) else { return false }
+        return closeMainTerminalWindow(window)
     }
 
     private func orderedMainWindowSummaries(referenceWindowId: UUID?) -> [MainWindowSummary] {
@@ -13455,6 +13478,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Keep geometry available as a fallback for the next window placement.
         persistWindowGeometry(from: window)
 
+        let closingContext = contextForMainTerminalWindow(window, reindex: false)
+        closingContext?.tabManager.teardownForWindowClose()
+
         guard let removed = unregisterMainWindowContext(for: window) else { return }
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
@@ -13513,9 +13539,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func closeMainWindowContainingTabId(_ tabId: UUID) {
         guard let context = contextContainingTabId(tabId) else { return }
-        let expectedIdentifier = "cmux.main.\(context.windowId.uuidString)"
-        let window: NSWindow? = context.window ?? NSApp.windows.first(where: { $0.identifier?.rawValue == expectedIdentifier })
-        window?.performClose(nil)
+        _ = closeMainWindow(windowId: context.windowId)
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -546,6 +546,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let keyboardFocusCoordinator: MainWindowFocusController
         var cmuxConfigStore: CmuxConfigStore?
         weak var window: NSWindow?
+        private var windowCloseObserver: NSObjectProtocol?
+        private weak var windowCloseObserverWindow: NSWindow?
 
         init(
             windowId: UUID,
@@ -569,6 +571,24 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 tabManager: tabManager,
                 fileExplorerState: fileExplorerState
             )
+        }
+
+        func isObservingClose(for window: NSWindow) -> Bool {
+            windowCloseObserver != nil && windowCloseObserverWindow === window
+        }
+
+        func setWindowCloseObserver(_ observer: NSObjectProtocol, for window: NSWindow) {
+            removeWindowCloseObserver()
+            windowCloseObserver = observer
+            windowCloseObserverWindow = window
+        }
+
+        func removeWindowCloseObserver() {
+            if let windowCloseObserver {
+                NotificationCenter.default.removeObserver(windowCloseObserver)
+            }
+            windowCloseObserver = nil
+            windowCloseObserverWindow = nil
         }
     }
 
@@ -3699,6 +3719,29 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         NotificationCenter.default.post(name: .mainWindowContextsDidChange, object: self)
     }
 
+    private func installMainWindowCloseObserver(for context: MainWindowContext, window: NSWindow) {
+        guard !context.isObservingClose(for: window) else { return }
+        let observer = NotificationCenter.default.addObserver(
+            forName: NSWindow.willCloseNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] note in
+            guard let self, let closing = note.object as? NSWindow else { return }
+            self.unregisterMainWindow(closing)
+        }
+        context.setWindowCloseObserver(observer, for: window)
+    }
+
+    private func teardownClosedMainWindowViewTree(_ window: NSWindow) {
+        _ = window.makeFirstResponder(nil)
+        while !window.titlebarAccessoryViewControllers.isEmpty {
+            window.removeTitlebarAccessoryViewController(at: 0)
+        }
+        window.toolbar = nil
+        window.contentViewController = nil
+        window.contentView = nil
+    }
+
     /// Register a terminal window with the AppDelegate so menu commands and socket control
     /// can target whichever window is currently active.
     func registerMainWindow(
@@ -3730,6 +3773,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             if let cmuxConfigStore {
                 existing.cmuxConfigStore = cmuxConfigStore
             }
+            installMainWindowCloseObserver(for: existing, window: window)
         } else if let existing = mainWindowContexts.values.first(where: { $0.windowId == windowId }) {
             if let existingWindow = existing.window,
                existingWindow !== window,
@@ -3765,9 +3809,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 existing.cmuxConfigStore = cmuxConfigStore
             }
             reindexMainWindowContextIfNeeded(existing, for: window)
+            installMainWindowCloseObserver(for: existing, window: window)
         } else {
             tabManager.window = window
-            mainWindowContexts[key] = MainWindowContext(
+            let context = MainWindowContext(
                 windowId: windowId,
                 tabManager: tabManager,
                 sidebarState: sidebarState,
@@ -3776,14 +3821,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 cmuxConfigStore: cmuxConfigStore,
                 window: window
             )
-            NotificationCenter.default.addObserver(
-                forName: NSWindow.willCloseNotification,
-                object: window,
-                queue: .main
-            ) { [weak self] note in
-                guard let self, let closing = note.object as? NSWindow else { return }
-                self.unregisterMainWindow(closing)
-            }
+            mainWindowContexts[key] = context
+            installMainWindowCloseObserver(for: context, window: window)
         }
         commandPaletteVisibilityByWindowId[windowId] = false
         commandPaletteSelectionByWindowId[windowId] = 0
@@ -5106,6 +5145,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         for key in removedKeys {
             mainWindowContexts.removeValue(forKey: key)
         }
+        removed.removeWindowCloseObserver()
         rememberRecoverableMainWindowRoute(windowId: removed.windowId, tabManager: removed.tabManager, window: removed.window)
         notifyMainWindowContextsDidChange()
         return removed
@@ -5118,6 +5158,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         for key in contextKeys {
             mainWindowContexts.removeValue(forKey: key)
         }
+        context.removeWindowCloseObserver()
         rememberRecoverableMainWindowRoute(windowId: context.windowId, tabManager: context.tabManager, window: context.window)
         notifyMainWindowContextsDidChange()
 
@@ -13482,6 +13523,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         closingContext?.tabManager.teardownForWindowClose()
 
         guard let removed = unregisterMainWindowContext(for: window) else { return }
+        teardownClosedMainWindowViewTree(window)
         publishCmuxWindowLifecycle(name: "window.closed", windowId: removed.windowId, origin: "appkit_close")
         commandPaletteVisibilityByWindowId.removeValue(forKey: removed.windowId)
         commandPalettePendingOpenByWindowId.removeValue(forKey: removed.windowId)

--- a/Sources/AppleScriptSupport.swift
+++ b/Sources/AppleScriptSupport.swift
@@ -336,13 +336,12 @@ final class ScriptWindow: NSObject {
     func handleCloseWindow(_ command: NSScriptCommand) -> Any? {
         guard NSApp.validateScript(command: command) else { return nil }
 
-        guard let window = state?.window else {
+        guard AppDelegate.shared?.closeMainWindow(windowId: windowId) == true else {
             command.scriptErrorNumber = errAEEventFailed
             command.scriptErrorString = AppleScriptStrings.windowUnavailable
             return nil
         }
 
-        window.performClose(nil)
         return nil
     }
 
@@ -474,13 +473,12 @@ final class ScriptTab: NSObject {
             return nil
         }
 
-        guard let window = state.window else {
+        guard AppDelegate.shared?.closeMainWindow(windowId: windowId) == true else {
             command.scriptErrorNumber = errAEEventFailed
             command.scriptErrorString = AppleScriptStrings.windowUnavailable
             return nil
         }
 
-        window.performClose(nil)
         return nil
     }
 
@@ -625,13 +623,12 @@ final class ScriptTerminal: NSObject {
                 return nil
             }
 
-            guard let window = state.window else {
+            guard AppDelegate.shared?.closeMainWindow(windowId: state.windowId) == true else {
                 command.scriptErrorNumber = errAEEventFailed
                 command.scriptErrorString = AppleScriptStrings.windowUnavailable
                 return nil
             }
 
-            window.performClose(nil)
             return nil
         }
 

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4162,6 +4162,28 @@ class TabManager: ObservableObject {
         publishCmuxWorkspaceClosed(workspace)
     }
 
+    func teardownForWindowClose() {
+        guard !tabs.isEmpty else { return }
+        sentryBreadcrumb("window.close", data: ["workspaceCount": tabs.count])
+
+        let closingWorkspaces = tabs
+        sidebarSelectedWorkspaceIds.removeAll()
+
+        for workspace in closingWorkspaces {
+            clearWorkspaceGitProbes(workspaceId: workspace.id)
+            clearWorkspacePullRequestTracking(workspaceId: workspace.id)
+            AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: workspace.id)
+            workspace.teardownAllPanels()
+            workspace.teardownRemoteConnection()
+            unwireClosedBrowserTracking(for: workspace)
+            workspace.owningTabManager = nil
+            publishCmuxWorkspaceClosed(workspace)
+        }
+
+        tabs.removeAll(keepingCapacity: false)
+        selectedTabId = nil
+    }
+
     /// Detach a workspace from this window without closing its panels.
     /// Used by the socket API for cross-window moves.
     @discardableResult
@@ -4553,10 +4575,10 @@ class TabManager: ObservableObject {
         }
         if tabs.count <= 1 {
             // Last workspace in this window: match Close Workspace shortcut behavior.
-            if let window {
-                window.performClose(nil)
+            if let app = AppDelegate.shared {
+                app.closeMainWindowContainingTabId(workspace.id)
             } else {
-                AppDelegate.shared?.closeMainWindowContainingTabId(workspace.id)
+                window?.close()
             }
         } else {
             closeWorkspace(workspace)

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -243,6 +243,42 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         XCTAssertNil(app.tabManagerFor(windowId: windowId))
     }
 
+    func testCloseMainWindowReleasesRegisteredWindowContent() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+        weak var releasedContentView: NSView?
+
+        autoreleasepool {
+            let windowId = UUID()
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+                styleMask: [.titled, .closable, .resizable],
+                backing: .buffered,
+                defer: false
+            )
+            window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+            window.isReleasedWhenClosed = false
+            let contentView = NSView(frame: window.contentLayoutRect)
+            window.contentView = contentView
+            releasedContentView = contentView
+
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            app.registerMainWindow(
+                window,
+                windowId: windowId,
+                tabManager: manager,
+                sidebarState: SidebarState(),
+                sidebarSelectionState: SidebarSelectionState(),
+                fileExplorerState: FileExplorerState()
+            )
+
+            XCTAssertTrue(app.closeMainWindow(windowId: windowId))
+            XCTAssertNil(app.tabManagerFor(windowId: windowId))
+        }
+
+        XCTAssertNil(releasedContentView)
+    }
+
     func testSynchronizeActiveMainWindowContextPrefersProvidedWindowOverStaleActiveManager() {
         _ = NSApplication.shared
         let app = AppDelegate()

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -213,6 +213,36 @@ final class AppDelegateWindowContextRoutingTests: XCTestCase {
         return window
     }
 
+    func testCloseMainWindowTearsDownContextWhenStandardCloseControlIsUnavailable() {
+        _ = NSApplication.shared
+        let app = AppDelegate()
+
+        let windowId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 500, height: 320),
+            styleMask: [.titled, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.main.\(windowId.uuidString)")
+
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        app.registerMainWindow(
+            window,
+            windowId: windowId,
+            tabManager: manager,
+            sidebarState: SidebarState(),
+            sidebarSelectionState: SidebarSelectionState(),
+            fileExplorerState: FileExplorerState()
+        )
+        window.makeKeyAndOrderFront(nil)
+
+        XCTAssertTrue(app.listMainWindowSummaries().contains { $0.windowId == windowId })
+        XCTAssertTrue(app.closeMainWindow(windowId: windowId))
+        XCTAssertFalse(app.listMainWindowSummaries().contains { $0.windowId == windowId })
+        XCTAssertNil(app.tabManagerFor(windowId: windowId))
+    }
+
     func testSynchronizeActiveMainWindowContextPrefersProvidedWindowOverStaleActiveManager() {
         _ = NSApplication.shared
         let app = AppDelegate()


### PR DESCRIPTION
## Summary
- route main-window close requests through one teardown path
- tear down workspaces, panels, surfaces, and child processes on window close
- retain and remove per-window close observers, then detach closed window view trees

## Repro evidence
Latest main on `cmux-macmini`, commit `0576fb93`, tag `nwin185456`:
- baseline: 1 window, 1 workspace, 1 pane, 1 surface, app RSS 180.8 MB, descendants 16.1 MB
- after six `window.create` and `window.close` cycles: 7 windows, 7 workspaces, 7 panes, 7 surfaces, app RSS 271.4 MB, descendants 112.2 MB

Current main on `cmux-macmini`, commit `a20248b0e`, tag `nmainkid`:
- created four windows and started one controlled 512 MB terminal child in each
- after all four `window.close` calls: 5 windows, 5 workspaces, 5 surfaces, app RSS 237.5 MB, descendants 14 processes and 2.16 GB
- all four controlled terminal children stayed alive after close, totaling 2.08 GB
- cleanup killed the tagged repro process tree after measurement

Broader stress on latest main, tag `nfeat181631`:
- exercised window, workspace, pane, surface, browser, and debug APIs
- highwater: app RSS 1.86 GB, app footprint 5.6 GB dirty, descendants 6.3 GB, WebKit 1.87 GB

Fixed branch on `cmux-macmini`, commit `705968d9e`, tag `nobs705`:
- after 30 `window.create` and `window.close` cycles: tree returned to 1 window, 1 workspace, 1 pane, 1 surface
- descendants returned to 2 processes and 16.2 MB after every close
- app RSS was 171.5 MB baseline and 219.9 MB final, with `vmmap` physical footprint 180.7 MB and peak 203.1 MB
- heap showed only one `MainWindowHostingView`, the live window, after 30 cycles

## Tests
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-winclose-content-test '-only-testing:cmuxTests/AppDelegateWindowContextRoutingTests/testCloseMainWindowReleasesRegisteredWindowContent' '-only-testing:cmuxTests/AppDelegateWindowContextRoutingTests/testCloseMainWindowTearsDownContextWhenStandardCloseControlIsUnavailable' test`
- `./scripts/reload.sh --tag winleak`
