### PR TITLE
Fix terminal TUI background seam

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -2098,8 +2098,9 @@ class GhosttyApp {
                 return
             }
 
+            let fallbackShouldUseHostLayerBackground = usesHostLayerBackground(for: fallbackConfig)
             loadInlineGhosttyConfig(
-                "macos-background-from-layer = true",
+                "macos-background-from-layer = \(fallbackShouldUseHostLayerBackground)",
                 into: fallbackConfig,
                 prefix: "cmux-renderer-bg",
                 logLabel: "renderer background (fallback)"
@@ -2112,7 +2113,7 @@ class GhosttyApp {
             )
             loadCmuxOwnedGhosttyKeybindOverrides(fallbackConfig)
             let fallbackRenderingModeChanged = setUsesHostLayerBackground(
-                true,
+                fallbackShouldUseHostLayerBackground,
                 source: "initialize.fallbackConfig"
             )
             ghostty_config_finalize(fallbackConfig)
@@ -2248,15 +2249,17 @@ class GhosttyApp {
         }
         #endif
         loadCJKFontFallbackIfNeeded(config)
+        let shouldUseHostLayerBackground = usesHostLayerBackground(for: config)
         let renderingModeChanged = setUsesHostLayerBackground(
-            true,
+            shouldUseHostLayerBackground,
             source: "loadDefaultConfigFilesWithLegacyFallback"
         )
-        // Let cmux own the window-level backdrop once, while Ghostty keeps
-        // rendering text, cell backgrounds, and background images. This avoids
-        // separate translucent fills for terminal and chrome surfaces.
+        // Let Ghostty paint solid opaque terminal backgrounds so default cells
+        // and explicit ANSI background cells share one renderer/compositor path.
+        // Host-layer ownership remains required for translucent and blurred
+        // terminal backgrounds.
         loadInlineGhosttyConfig(
-            "macos-background-from-layer = true",
+            "macos-background-from-layer = \(shouldUseHostLayerBackground)",
             into: config,
             prefix: "cmux-renderer-bg",
             logLabel: "renderer background"
@@ -3214,10 +3217,7 @@ class GhosttyApp {
         let resolvedCursorText = ghosttyColorValue(from: config, key: "cursor-text", fallback: baseline.cursorTextColor)
         let resolvedSelectionBackground = ghosttyColorValue(from: config, key: "selection-background", fallback: baseline.selectionBackground)
         let resolvedSelectionForeground = ghosttyColorValue(from: config, key: "selection-foreground", fallback: baseline.selectionForeground)
-        var opacity = baseline.backgroundOpacity
-        let opacityKey = "background-opacity"
-        _ = ghostty_config_get(config, &opacity, opacityKey, UInt(opacityKey.lengthOfBytes(using: .utf8)))
-        opacity = min(1.0, max(0.0, opacity))
+        let opacity = defaultBackgroundOpacityValue(from: config)
         let backgroundBlur = defaultBackgroundBlurValue(from: config)
         applyDefaultBackground(
             color: resolvedColor,
@@ -3231,6 +3231,20 @@ class GhosttyApp {
             source: source,
             scope: scope,
             forceNotify: forceNotify
+        )
+    }
+
+    private func defaultBackgroundOpacityValue(from config: ghostty_config_t) -> Double {
+        var opacity = Self.fallbackAppearanceConfig.backgroundOpacity
+        let key = "background-opacity"
+        _ = ghostty_config_get(config, &opacity, key, UInt(key.lengthOfBytes(using: .utf8)))
+        return Double(WindowAppearanceSnapshot.clampedOpacity(opacity))
+    }
+
+    private func usesHostLayerBackground(for config: ghostty_config_t) -> Bool {
+        WindowAppearanceSnapshot.usesHostLayerBackground(
+            backgroundOpacity: defaultBackgroundOpacityValue(from: config),
+            backgroundBlur: defaultBackgroundBlurValue(from: config)
         )
     }
 

--- a/Sources/Windowing/WindowAppearanceSnapshot.swift
+++ b/Sources/Windowing/WindowAppearanceSnapshot.swift
@@ -285,6 +285,28 @@ struct WindowAppearanceSnapshot {
         usesHostLayerBackground ? .windowHostBackdrop : .ghosttyRendererOwnedBackgroundImage
     }
 
+    static func usesHostLayerBackground(
+        backgroundOpacity: Double,
+        backgroundBlur: GhosttyBackgroundBlur
+    ) -> Bool {
+        if backgroundBlur != .disabled {
+            return true
+        }
+        return clampedOpacity(backgroundOpacity) < 0.999
+    }
+
+    static func terminalRenderingMode(
+        backgroundOpacity: Double,
+        backgroundBlur: GhosttyBackgroundBlur
+    ) -> GhosttyTerminalBackdropRenderingMode {
+        terminalRenderingMode(
+            usesHostLayerBackground: usesHostLayerBackground(
+                backgroundOpacity: backgroundOpacity,
+                backgroundBlur: backgroundBlur
+            )
+        )
+    }
+
     var compositedTerminalBackgroundColor: NSColor {
         terminalBackgroundColor.withAlphaComponent(terminalBackgroundOpacity)
     }

--- a/Sources/Windowing/WindowAppearanceSnapshot.swift
+++ b/Sources/Windowing/WindowAppearanceSnapshot.swift
@@ -213,6 +213,11 @@ struct WindowGlassSettingsSnapshot {
 }
 
 struct WindowAppearanceSnapshot {
+    /// Treat opacity values within floating-point round-trip tolerance of 1.0
+    /// as opaque so user-configured `1.0` does not accidentally trigger host
+    /// ownership after Double/CGFloat conversions.
+    private static let opaqueBackgroundOwnershipThreshold: CGFloat = 0.999
+
     let terminalBackgroundColor: NSColor
     let terminalBackgroundOpacity: CGFloat
     let terminalBackgroundBlur: GhosttyBackgroundBlur
@@ -292,7 +297,7 @@ struct WindowAppearanceSnapshot {
         if backgroundBlur != .disabled {
             return true
         }
-        return clampedOpacity(backgroundOpacity) < 0.999
+        return clampedOpacity(backgroundOpacity) < opaqueBackgroundOwnershipThreshold
     }
 
     static func terminalRenderingMode(

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -126,6 +126,38 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertEqual(renderingMode, .ghosttyRendererOwnedBackgroundImage)
     }
 
+    func testTranslucentTerminalBackgroundStaysHostLayerOwned() {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: false,
+            backgroundOpacity: 0.9,
+            backgroundBlur: .disabled
+        )
+        let policy = snapshot.policy(for: .windowRoot)
+
+        XCTAssertNotNil(policy.hostLayerBackgroundColor)
+        guard case let .ghosttyTerminalBackdrop(_, _, renderingMode) = policy else {
+            XCTFail("expected terminal backdrop policy")
+            return
+        }
+        XCTAssertEqual(renderingMode, .windowHostBackdrop)
+    }
+
+    func testBlurredTerminalBackgroundStaysHostLayerOwned() {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: false,
+            backgroundOpacity: 1.0,
+            backgroundBlur: .radius(20)
+        )
+        let policy = snapshot.policy(for: .windowRoot)
+
+        XCTAssertNotNil(policy.hostLayerBackgroundColor)
+        guard case let .ghosttyTerminalBackdrop(_, _, renderingMode) = policy else {
+            XCTFail("expected terminal backdrop policy")
+            return
+        }
+        XCTAssertEqual(renderingMode, .windowHostBackdrop)
+    }
+
     func testDebugBackgroundGlassUsesWindowGlassPhase() {
         let snapshot = makeSnapshot(
             unifySurfaceBackdrops: false,

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -153,7 +153,10 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
             terminalBackgroundColor: NSColor(hex: "#272822") ?? .black,
             terminalBackgroundOpacity: backgroundOpacity,
             terminalBackgroundBlur: backgroundBlur,
-            terminalRenderingMode: .windowHostBackdrop,
+            terminalRenderingMode: WindowAppearanceSnapshot.terminalRenderingMode(
+                backgroundOpacity: Double(backgroundOpacity),
+                backgroundBlur: backgroundBlur
+            ),
             unifySurfaceBackdrops: unifySurfaceBackdrops,
             sidebarSettings: SidebarBackdropSettingsSnapshot(
                 materialRawValue: SidebarMaterialOption.sidebar.rawValue,

--- a/cmuxTests/WindowAppearanceSnapshotTests.swift
+++ b/cmuxTests/WindowAppearanceSnapshotTests.swift
@@ -110,6 +110,22 @@ final class WindowAppearanceSnapshotTests: XCTestCase {
         XCTAssertEqual(plan.windowBackgroundColor.hexString(includeAlpha: true), "#272822FF")
     }
 
+    func testOpaqueUnblurredTerminalBackgroundIsRendererOwned() {
+        let snapshot = makeSnapshot(
+            unifySurfaceBackdrops: false,
+            backgroundOpacity: 1.0,
+            backgroundBlur: .disabled
+        )
+        let policy = snapshot.policy(for: .windowRoot)
+
+        XCTAssertNil(policy.hostLayerBackgroundColor)
+        guard case let .ghosttyTerminalBackdrop(_, _, renderingMode) = policy else {
+            XCTFail("expected terminal backdrop policy")
+            return
+        }
+        XCTAssertEqual(renderingMode, .ghosttyRendererOwnedBackgroundImage)
+    }
+
     func testDebugBackgroundGlassUsesWindowGlassPhase() {
         let snapshot = makeSnapshot(
             unifySurfaceBackdrops: false,


### PR DESCRIPTION
## Summary
- Keep solid opaque, unblurred terminal backgrounds renderer-owned instead of forcing `macos-background-from-layer` for every terminal.
- Preserve host-layer ownership for translucent or blurred terminal backgrounds where the macOS compositor is required.
- Add a regression assertion that opaque terminal backdrops do not expose a host-layer background color.

## Repro
1. Built and launched tagged DEV with `./scripts/reload.sh --tag issue-3655-terminal-bg-tui-seam --launch`.
2. Opened a cmux workspace pane and ran `claude`.
3. Compared against standalone Ghostty with empty/fresh local Ghostty config, running the same Claude Code binary: `/Applications/cmux.app/Contents/Resources/bin/claude`.
4. Captured local evidence at `/tmp/cmux-claude-window.png` and `/tmp/ghostty-claude-typed.png`.

Observed: Claude Code's input/statusline chrome in cmux rendered over a visibly different backdrop than surrounding terminal scrollback. The same TUI in standalone Ghostty blended with the surrounding terminal background.

Expected: solid opaque terminal backgrounds should be composited through the same renderer path as explicit ANSI cell backgrounds so Claude Code chrome blends into the scrollback.

## Commit Structure
- `e60b06251` adds the failing regression test only.
- `caa37c5dc` applies the renderer-owned background fix.

Fixes #3655

## Verification
- `git diff --check`

Not run locally: XCTest/build execution per repository policy; CI will run on the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes terminal backdrop ownership logic and config injection based on opacity/blur, which can affect rendering/compositing across macOS window surfaces. Regression risk is mostly visual (seams, transparency/blur behavior) rather than security or data correctness.
> 
> **Overview**
> Fixes terminal background seams by **no longer forcing** `macos-background-from-layer = true` for all terminals; instead, `GhosttyTerminalView` derives `usesHostLayerBackground` from `background-opacity` and `background-blur` (including fallback config) and injects the matching `macos-background-from-layer` value.
> 
> `WindowAppearanceSnapshot` adds a shared `usesHostLayerBackground(backgroundOpacity:backgroundBlur:)` helper (with an opacity threshold to avoid float round-trip issues) and new tests assert that **opaque, unblurred** terminals are renderer-owned while **translucent or blurred** terminals remain host-layer owned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75b2ece3a4fd0c8765b501e5e1e1dfea653969bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a visible seam in TUIs by keeping solid, opaque terminal backgrounds renderer-owned. We now only use the macOS host layer for blurred or translucent terminals, clarified the opacity threshold to avoid float rounding issues, and synced with `main`.

- **Bug Fixes**
  - Derive `usesHostLayerBackground` from `background-opacity` and `background-blur` (including fallback config); stop forcing `macos-background-from-layer = true`.
  - Treat opacity ≥ 0.999 as opaque to prevent rounding from flipping ownership; centralize logic in `WindowAppearanceSnapshot` (`usesHostLayerBackground`, `terminalRenderingMode`).
  - Expand tests: assert opaque, unblurred terminals use a renderer-owned background (no host-layer color), and that translucent or blurred terminals remain host-layer owned.

<sup>Written for commit 75b2ece3a4fd0c8765b501e5e1e1dfea653969bb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background rendering reliability by preventing floating-point precision issues from affecting background layer decisions.
  * Enhanced handling of background opacity and blur settings for more consistent visual behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3903)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->