### PR TITLE
Fix cmux frontmost state without keyboard focus

### DIFF
--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -153,15 +153,17 @@ final class MainWindowVisibilityController {
             dependencies.unhideApplication()
             trace("focus.unhide.end", reason: reason, windows: [window])
         }
+        let effectiveActivation = activationRequiringKeyTransfer(activation, makeKey: makeKey)
+
         if activationTiming == .beforeWindowOrdering {
-            activate(activation)
+            activate(effectiveActivation)
         }
         let shouldActivateBeforeWindowOrdering = activationTiming == .afterWindowOrdering &&
             deminiaturize &&
             dependencies.windowOperations.isMiniaturized(window)
         if shouldActivateBeforeWindowOrdering {
             trace("focus.activate.beforeMiniaturize.begin", reason: reason, windows: [window])
-            activate(activation)
+            activate(effectiveActivation)
             trace("focus.activate.beforeMiniaturize.end", reason: reason, windows: [window])
         }
         if deminiaturize, dependencies.windowOperations.isMiniaturized(window) {
@@ -181,7 +183,7 @@ final class MainWindowVisibilityController {
         }
         if activationTiming == .afterWindowOrdering && !shouldActivateBeforeWindowOrdering {
             trace("focus.activate.begin", reason: reason, windows: [window])
-            activate(activation)
+            activate(effectiveActivation)
             trace("focus.activate.end", reason: reason, windows: [window])
         }
         log("focus", reason: reason, windows: [window])
@@ -383,8 +385,9 @@ final class MainWindowVisibilityController {
         for window in windows {
             dependencies.windowOperations.softShow(window)
         }
+        let effectiveActivation = activationRequiringKeyTransfer(activation, makeKey: makeKey)
         trace("reveal.activate.begin", reason: reason, windows: windows)
-        activate(activation)
+        activate(effectiveActivation)
         trace("reveal.activate.end", reason: reason, windows: windows)
 
         let focusWindow = resolvedPreferredFocusWindow(preferredWindow: preferredWindow, in: windows)
@@ -457,6 +460,10 @@ final class MainWindowVisibilityController {
         case .runningApplication(let options):
             dependencies.activateRunningApplication(options)
         }
+    }
+
+    private func activationRequiringKeyTransfer(_ activation: Activation, makeKey: Bool) -> Activation {
+        makeKey ? activation : .none
     }
 
     private func uniqueWindows(_ windows: [NSWindow]) -> [NSWindow] {

--- a/Sources/App/MainWindowVisibilityController.swift
+++ b/Sources/App/MainWindowVisibilityController.swift
@@ -371,7 +371,9 @@ final class MainWindowVisibilityController {
         activation: Activation = .runningApplication([.activateAllWindows]),
         makeKey: Bool = true
     ) -> NSWindow? {
-        let windows = uniqueWindows(windows)
+        let windows = uniqueWindows(windows).filter { window in
+            makeKey || !dependencies.windowOperations.isMiniaturized(window)
+        }
         guard !windows.isEmpty else {
             log("reveal.empty", reason: reason, windows: [])
             return nil

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5156,19 +5156,6 @@ class TabManager: ObservableObject {
             userInfo: [GhosttyNotificationKey.tabId: tabId]
         )
 
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
-            NSApp.activate(ignoringOtherApps: true)
-            NSApp.unhide(nil)
-            if let app = AppDelegate.shared,
-               let windowId = app.windowId(for: self),
-               let window = app.mainWindow(for: windowId) {
-                window.makeKeyAndOrderFront(nil)
-            } else if let window = NSApp.keyWindow ?? NSApp.windows.first {
-                window.makeKeyAndOrderFront(nil)
-            }
-        }
-
         if let surfaceId {
             if !suppressFlash {
                 focusSurface(tabId: tabId, surfaceId: surfaceId)

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1952,7 +1952,12 @@ class TabManager: ObservableObject {
         if panel.searchState == nil {
             panel.searchState = TerminalSurface.SearchState()
         }
-        NSLog("Find: searchSelection workspace=%@ panel=%@", panel.workspaceId.uuidString, panel.id.uuidString)
+#if DEBUG
+        cmuxDebugLog(
+            "find.searchSelection workspace=\(panel.workspaceId.uuidString.prefix(5)) " +
+            "panel=\(panel.id.uuidString.prefix(5))"
+        )
+#endif
         NotificationCenter.default.post(name: .ghosttySearchFocus, object: panel.surface)
         _ = panel.performBindingAction("search_selection")
     }

--- a/Sources/TaskManagerWindowController.swift
+++ b/Sources/TaskManagerWindowController.swift
@@ -123,7 +123,11 @@ final class CmuxTaskManagerModel: ObservableObject {
 
     func viewWorkspace(for row: CmuxTaskManagerRow) {
         guard let workspaceId = row.workspaceId,
-              let manager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) else { return }
+              let appDelegate = AppDelegate.shared,
+              let manager = appDelegate.tabManagerFor(tabId: workspaceId) else { return }
+        if let windowId = appDelegate.windowId(for: manager) {
+            _ = appDelegate.focusMainWindow(windowId: windowId)
+        }
         manager.focusTab(workspaceId, surfaceId: row.surfaceId, suppressFlash: true)
         flashSelection(workspaceId: workspaceId, surfaceId: row.surfaceId)
     }
@@ -131,7 +135,11 @@ final class CmuxTaskManagerModel: ObservableObject {
     func viewTerminal(for row: CmuxTaskManagerRow) {
         guard let workspaceId = row.workspaceId,
               let terminalSurfaceId = row.terminalSurfaceId,
-              let manager = AppDelegate.shared?.tabManagerFor(tabId: workspaceId) else { return }
+              let appDelegate = AppDelegate.shared,
+              let manager = appDelegate.tabManagerFor(tabId: workspaceId) else { return }
+        if let windowId = appDelegate.windowId(for: manager) {
+            _ = appDelegate.focusMainWindow(windowId: windowId)
+        }
         manager.focusTab(workspaceId, surfaceId: terminalSurfaceId, suppressFlash: true)
         flashSelection(workspaceId: workspaceId, surfaceId: terminalSurfaceId)
     }

--- a/cmuxTests/MainWindowVisibilityControllerTests.swift
+++ b/cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -257,6 +257,45 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         XCTAssertFalse(madeKeyWindows.contains { $0 === dismissedWindow })
     }
 
+    func testPassiveRevealWithoutKeyTransferDoesNotActivateApplication() {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        let visibleIds: Set<ObjectIdentifier> = [ObjectIdentifier(window)]
+        var activationCount = 0
+        var orderedRegardlessWindows: [NSWindow] = []
+        var madeKeyWindows: [NSWindow] = []
+
+        let controller = MainWindowVisibilityController(
+            dependencies: .init(
+                isActivationSuppressed: { false },
+                setActiveMainWindow: { _ in },
+                isApplicationHidden: { false },
+                activateRunningApplication: { _ in activationCount += 1 },
+                windowOperations: makeWindowOperations(
+                    isVisible: { visibleIds.contains(ObjectIdentifier($0)) },
+                    isMiniaturized: { _ in false },
+                    makeKey: { madeKeyWindows.append($0) },
+                    orderFrontRegardless: { orderedRegardlessWindows.append($0) }
+                )
+            )
+        )
+
+        _ = controller.showApplicationWindows(
+            windows: [window],
+            reason: .applicationReopen,
+            makeKey: false
+        )
+
+        XCTAssertEqual(
+            activationCount,
+            0,
+            "Ordering a visible cmux window without transferring key focus must not make cmux the Launch Services frontmost app."
+        )
+        XCTAssertTrue(orderedRegardlessWindows.contains { $0 === window })
+        XCTAssertTrue(madeKeyWindows.isEmpty)
+    }
+
     func testHiddenAppRestoreFallsBackToSoftDismissedTargets() {
         let window = makeWindow()
         defer { window.orderOut(nil) }

--- a/cmuxTests/MainWindowVisibilityControllerTests.swift
+++ b/cmuxTests/MainWindowVisibilityControllerTests.swift
@@ -296,6 +296,51 @@ final class MainWindowVisibilityControllerTests: XCTestCase {
         XCTAssertTrue(madeKeyWindows.isEmpty)
     }
 
+    func testPassiveRevealWithoutKeyTransferDoesNotDeminiaturizeWindow() {
+        let window = makeWindow()
+        defer { window.orderOut(nil) }
+
+        var miniaturizedIds: Set<ObjectIdentifier> = [ObjectIdentifier(window)]
+        var activationCount = 0
+        var deminiaturizedWindows: [NSWindow] = []
+        var orderedRegardlessWindows: [NSWindow] = []
+        var madeKeyWindows: [NSWindow] = []
+
+        let controller = MainWindowVisibilityController(
+            dependencies: .init(
+                isActivationSuppressed: { false },
+                setActiveMainWindow: { _ in },
+                isApplicationHidden: { false },
+                activateRunningApplication: { _ in activationCount += 1 },
+                windowOperations: makeWindowOperations(
+                    isVisible: { _ in false },
+                    isMiniaturized: { miniaturizedIds.contains(ObjectIdentifier($0)) },
+                    deminiaturize: { window in
+                        miniaturizedIds.remove(ObjectIdentifier(window))
+                        deminiaturizedWindows.append(window)
+                    },
+                    makeKey: { madeKeyWindows.append($0) },
+                    orderFrontRegardless: { orderedRegardlessWindows.append($0) }
+                )
+            )
+        )
+
+        let revealedWindow = controller.showApplicationWindows(
+            windows: [window],
+            reason: .applicationReopen,
+            makeKey: false
+        )
+
+        XCTAssertNil(
+            revealedWindow,
+            "A passive reveal must not unminiaturize a background cmux window because AppKit can mark the app frontmost."
+        )
+        XCTAssertEqual(activationCount, 0)
+        XCTAssertTrue(deminiaturizedWindows.isEmpty)
+        XCTAssertTrue(orderedRegardlessWindows.isEmpty)
+        XCTAssertTrue(madeKeyWindows.isEmpty)
+    }
+
     func testHiddenAppRestoreFallsBackToSoftDismissedTargets() {
         let window = makeWindow()
         defer { window.orderOut(nil) }


### PR DESCRIPTION
## Summary
- reproduce issue #3347 locally: desktop/app-control layer reported Spotify frontmost while Launch Services and NSWorkspace still reported `/Applications/cmux.app` (`com.cmuxterm.app`) as frontmost
- add a regression test proving passive window reveal must not activate cmux when it does not transfer key focus
- keep app activation in explicit main-window focus entrypoints and remove model-layer activation from `TabManager.focusTab`

## Repro Evidence
1. Existing running app: `/Applications/cmux.app`, bundle `com.cmuxterm.app`, pid `38162`.
2. Activated Spotify.
3. App-control layer reported `Spotify — com.spotify.client [frontmost]`.
4. `lsappinfo info -app cmux` still showed `(in front)`.
5. `NSWorkspace.shared.frontmostApplication` still returned `com.cmuxterm.app`.

Expected: after Spotify owns focus, cmux should not be Launch Services frontmost and NSWorkspace should not report `com.cmuxterm.app`.

## Test Plan
- `git diff --check`
- Local XCTest/build not run per repo policy; CI will validate.

Closes #3347

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes macOS window reveal/focus behavior and app activation timing, which can subtly affect focus/ordering across multiple windows. Risk is mitigated by new regression tests covering passive reveal and miniaturized-window handling.
> 
> **Overview**
> Prevents cmux from becoming Launch Services/NSWorkspace frontmost when *revealing* windows without transferring keyboard focus (`makeKey: false`). `MainWindowVisibilityController` now gates `activate(...)` behind key transfer and skips miniaturized windows during passive reveals.
> 
> Removes model-layer AppKit activation/unhide/window-raising from `TabManager.focusTab`, and instead has Task Manager navigation explicitly focus the owning main window before switching tabs.
> 
> Adds regression tests ensuring passive reveals do not activate the app and do not deminiaturize/background-order miniaturized windows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8eab914b64886b0cc350b249a516028ba386af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents cmux from becoming frontmost when revealing windows or focusing tabs without transferring key focus. Activation only happens when the same request makes a window key; passive reveals also skip miniaturized windows, fixing #3347.

- **Bug Fixes**
  - Gate activation behind key transfer in `MainWindowVisibilityController` for both focus and reveal; passive reveal (`makeKey: false`) skips miniaturized windows.
  - Remove AppKit activation from `TabManager.focusTab`; keep activation in explicit main-window focus paths; guard find-selection debug logging behind `#if DEBUG` to reduce noise.
  - Task Manager rows call `AppDelegate.focusMainWindow` before selecting a workspace/terminal to retain bring-to-front behavior.
  - Add tests: passive reveal does not activate the app, and miniaturized windows are not unminiaturized or activated.

<sup>Written for commit 9a8eab914b64886b0cc350b249a516028ba386af. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved window reveal/focus behavior so windows can be brought forward without forcing app activation or stealing key focus; minimized windows are no longer implicitly unminimized during passive reveals.
  * Ensure the main window is focused when available before switching to a tab to make tab focus more reliable.

* **Tests**
  * Added tests for passive reveal scenarios to verify non-activating reveals and handling of miniaturized windows.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3907)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->