### PR TITLE
Preserve Claude env auth selectors in cmux wrapper

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -98,6 +98,19 @@ should_preserve_claude_auth_selection_key() {
     return 1
 }
 
+should_clear_claude_auth_selection_key() {
+    local key="$1"
+
+    should_preserve_claude_auth_selection_key "$key" && return 1
+    [[ ${!key+x} ]] || return 1
+
+    if [[ "$PRESERVE_CLAUDE_AUTH_SELECTION_ENV" == true && -n "${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}" ]]; then
+        return 0
+    fi
+
+    [[ -z "${!key}" ]]
+}
+
 normalize_claude_config_dir() {
     [[ -n "${CLAUDE_CONFIG_DIR:-}" ]] || return 0
     [[ -n "${HOME:-}" ]] || return 0
@@ -124,8 +137,7 @@ clear_inherited_claude_auth_selection_env() {
     if [[ "${IN_CMUX:-0}" == "1" ]]; then
         local key
         for key in "${CLAUDE_AUTH_SELECTION_ENV_KEYS[@]}"; do
-            should_preserve_claude_auth_selection_key "$key" && continue
-            unset "$key"
+            should_clear_claude_auth_selection_key "$key" && unset "$key"
         done
     fi
     # Safe outside cmux: this only rewrites an existing subrouter path when the account alias exists.

--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -104,7 +104,8 @@ should_clear_claude_auth_selection_key() {
     should_preserve_claude_auth_selection_key "$key" && return 1
     [[ ${!key+x} ]] || return 1
 
-    if [[ "$PRESERVE_CLAUDE_AUTH_SELECTION_ENV" == true && -n "${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}" ]]; then
+    # Resume-with-allowlist mode clears non-allowlisted keys regardless of value.
+    if [[ -n "${CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS:-}" ]]; then
         return 0
     fi
 

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -13,6 +13,12 @@ cmux hooks uninstall <agent>
 
 Supported agent names are `codex`, `opencode`, `pi`, `cursor`, `gemini`, `rovodev` (or `rovo`), `copilot`, `codebuddy`, `factory`, and `qoder`. `cmux hooks setup` skips agents whose binary is not on `PATH` and prints a summary.
 
+The Claude wrapper preserves non-empty environment-driven Claude auth selectors such as `ANTHROPIC_API_KEY`,
+`ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_USE_BEDROCK`, and `CLAUDE_CODE_USE_VERTEX`.
+cmux may clear empty masked values that it inserted during terminal startup to avoid leaking stale parent-session auth
+into a new shell. Resume commands use `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV=1` with
+`CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS` internally when they need to preserve a captured auth selector value.
+
 ## Integrations
 
 | Agent | Binary checked | Installed file | Session restore | Feed bridge |

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -416,14 +416,14 @@ def test_plain_claude_launch_argv_has_no_empty_argument(failures: list[str]) -> 
     expect(argv[0].endswith("/real-bin/claude"), f"plain claude: expected real claude executable, got {argv}", failures)
 
 
-def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures: list[str]) -> None:
+def test_live_socket_preserves_env_driven_claude_auth_for_fresh_launch(failures: list[str]) -> None:
     inherited = {
         "CLAUDE_CONFIG_DIR": "/tmp/claude-config",
-        "ANTHROPIC_API_KEY": "stale-api-key",
+        "ANTHROPIC_API_KEY": "api-key",
         "ANTHROPIC_AUTH_TOKEN": "third-party-auth-token",
         "ANTHROPIC_BASE_URL": "https://api.example.test",
-        "ANTHROPIC_MODEL": "stale-model",
-        "ANTHROPIC_SMALL_FAST_MODEL": "stale-small-model",
+        "ANTHROPIC_MODEL": "model",
+        "ANTHROPIC_SMALL_FAST_MODEL": "small-model",
         "CLAUDE_CODE_USE_BEDROCK": "1",
         "CLAUDE_CODE_USE_VERTEX": "1",
     }
@@ -435,15 +435,30 @@ def test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures
     expect(auth_env.get("CLAUDE_CONFIG_DIR") == "/tmp/claude-config", f"fresh auth env: expected CLAUDE_CONFIG_DIR preserved, got {auth_env.get('CLAUDE_CONFIG_DIR')!r}", failures)
     expect(auth_env.get("ANTHROPIC_AUTH_TOKEN") == "third-party-auth-token", f"fresh auth env: expected ANTHROPIC_AUTH_TOKEN preserved, got {auth_env.get('ANTHROPIC_AUTH_TOKEN')!r}", failures)
     expect(auth_env.get("ANTHROPIC_BASE_URL") == "https://api.example.test", f"fresh auth env: expected ANTHROPIC_BASE_URL preserved, got {auth_env.get('ANTHROPIC_BASE_URL')!r}", failures)
-    for key in [
-        "ANTHROPIC_API_KEY",
-        "ANTHROPIC_MODEL",
-        "ANTHROPIC_SMALL_FAST_MODEL",
-        "CLAUDE_CODE_USE_BEDROCK",
-        "CLAUDE_CODE_USE_VERTEX",
-    ]:
-        expect(auth_env.get(key) == "__UNSET__", f"fresh auth env: expected {key} unset, got {auth_env.get(key)!r}", failures)
+    expect(auth_env.get("ANTHROPIC_API_KEY") == "api-key", f"fresh auth env: expected ANTHROPIC_API_KEY preserved, got {auth_env.get('ANTHROPIC_API_KEY')!r}", failures)
+    expect(auth_env.get("ANTHROPIC_MODEL") == "model", f"fresh auth env: expected ANTHROPIC_MODEL preserved, got {auth_env.get('ANTHROPIC_MODEL')!r}", failures)
+    expect(auth_env.get("ANTHROPIC_SMALL_FAST_MODEL") == "small-model", f"fresh auth env: expected ANTHROPIC_SMALL_FAST_MODEL preserved, got {auth_env.get('ANTHROPIC_SMALL_FAST_MODEL')!r}", failures)
+    expect(auth_env.get("CLAUDE_CODE_USE_BEDROCK") == "1", f"fresh auth env: expected CLAUDE_CODE_USE_BEDROCK preserved, got {auth_env.get('CLAUDE_CODE_USE_BEDROCK')!r}", failures)
+    expect(auth_env.get("CLAUDE_CODE_USE_VERTEX") == "1", f"fresh auth env: expected CLAUDE_CODE_USE_VERTEX preserved, got {auth_env.get('CLAUDE_CODE_USE_VERTEX')!r}", failures)
     expect("--session-id" in real_argv, f"fresh auth env: expected session injection, got {real_argv}", failures)
+
+
+def test_live_socket_clears_empty_masked_claude_auth_selection_env(failures: list[str]) -> None:
+    inherited = {
+        "ANTHROPIC_API_KEY": "",
+        "ANTHROPIC_MODEL": "",
+        "ANTHROPIC_SMALL_FAST_MODEL": "",
+        "CLAUDE_CODE_USE_BEDROCK": "",
+        "CLAUDE_CODE_USE_VERTEX": "",
+    }
+    code, auth_env, real_argv, stderr = run_wrapper_auth_env(
+        argv=["hello"],
+        inherited_env=inherited,
+    )
+    expect(code == 0, f"masked auth env: wrapper exited {code}: {stderr}", failures)
+    for key in inherited:
+        expect(auth_env.get(key) == "__UNSET__", f"masked auth env: expected empty {key} unset, got {auth_env.get(key)!r}", failures)
+    expect("--session-id" in real_argv, f"masked auth env: expected session injection, got {real_argv}", failures)
 
 
 def test_live_socket_normalizes_subrouter_claude_config_dir(failures: list[str]) -> None:
@@ -658,7 +673,8 @@ def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
-    test_live_socket_preserves_third_party_claude_auth_for_fresh_launch(failures)
+    test_live_socket_preserves_env_driven_claude_auth_for_fresh_launch(failures)
+    test_live_socket_clears_empty_masked_claude_auth_selection_env(failures)
     test_live_socket_normalizes_subrouter_claude_config_dir(failures)
     test_live_socket_preserves_claude_auth_for_resume_launch(failures)
     test_live_socket_preserves_only_listed_claude_auth_keys(failures)

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -537,7 +537,7 @@ def test_live_socket_clears_empty_masked_claude_auth_selection_env(failures: lis
         "CLAUDE_CODE_USE_VERTEX": "",
     }
     code, auth_env, real_argv, stderr = run_wrapper_auth_env(
-        argv=["hello"],
+        argv=["--print", "hello"],
         inherited_env=inherited,
     )
     expect(code == 0, f"masked auth env: wrapper exited {code}: {stderr}", failures)


### PR DESCRIPTION
Closes #3641.

## Summary
- Preserve non-empty environment-driven Claude auth selector variables in the cmux Claude wrapper.
- Continue clearing empty masked auth selector values that cmux may inject during terminal startup.
- Document the wrapper behavior and add regression coverage for Vertex/Bedrock/API-key env auth.

## Verification
- Reproduced main wrapper unsetting CLAUDE_CODE_USE_VERTEX with a fake Claude target.
- Verified the fixed wrapper preserves CLAUDE_CODE_USE_VERTEX with the same repro command.
- Local test suites were not run per repository policy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts environment-variable scrubbing for Claude auth selectors, which can affect which credentials/models are used when launching Claude inside cmux. While scoped and covered by tests, it touches auth-related env handling so regressions could impact session isolation or leaked/stale selectors.
> 
> **Overview**
> **Claude launches in cmux now keep valid env-based auth selectors.** The `claude` wrapper stops unconditionally unsetting `ANTHROPIC_API_KEY`/model and Vertex/Bedrock selector vars, and instead only clears them when they are *present-but-empty* (masked) or when resume-mode allowlisting explicitly requires clearing non-allowlisted keys.
> 
> Adds documentation describing this preservation/clearing behavior and expands regression tests to verify non-empty selector values are preserved on fresh launches while empty masked values are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84425f6561257356f996017b9d5cdb18e2081a68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves non-empty env-driven Claude auth selectors in the `cmux` Claude wrapper so fresh launches keep valid API key/model/Vertex/Bedrock settings. Empty masked values are cleared; resume mode still unsets keys not on the allowlist.

- **Bug Fixes**
  - Keep non-empty selectors (`ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`, `ANTHROPIC_SMALL_FAST_MODEL`, `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_USE_VERTEX`) unless running with `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS`, which clears non-allowlisted keys, or the value is empty.
  - Honor `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV` and `CMUX_PRESERVE_CLAUDE_AUTH_SELECTION_ENV_KEYS`; docs updated and tests added for preserving non-empty values and clearing empty masked ones.

<sup>Written for commit 84425f6561257356f996017b9d5cdb18e2081a68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

