### PR TITLE
Restore terminal file drop path insertion

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11207,6 +11207,7 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     func paneDropTargetForDrop(at localPoint: NSPoint) -> TerminalPaneDropTargetView? {
+        guard paneDropTargetView.dropContext != nil else { return nil }
         guard bounds.contains(localPoint) else { return nil }
         let pointInTarget = paneDropTargetView.convert(localPoint, from: self)
         guard paneDropTargetView.bounds.contains(pointInTarget) else { return nil }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -2195,6 +2195,33 @@ final class WindowTerminalHostViewTests: XCTestCase {
         return hostedView
     }
 
+    func testTerminalPaneDropTargetLookupRequiresActiveDropContext() {
+        let frame = NSRect(x: 0, y: 0, width: 240, height: 160)
+        let hostedView = makeHostedTerminalView(frame: frame)
+        hostedView.layoutSubtreeIfNeeded()
+        hostedView.layout()
+        let dropPoint = NSPoint(x: frame.midX, y: frame.midY)
+
+        hostedView.setPaneDropContext(TerminalPaneDropContext(
+            workspaceId: UUID(),
+            panelId: UUID(),
+            paneId: PaneID(id: UUID())
+        ))
+        XCTAssertNotNil(
+            hostedView.paneDropTargetForDrop(at: dropPoint),
+            "Active terminal pane drop targets should remain discoverable for pane drop routing"
+        )
+
+        hostedView.setPaneDropContext(nil)
+
+        let target = hostedView.paneDropTargetForDrop(at: dropPoint)
+
+        XCTAssertNil(
+            target,
+            "Inactive terminal pane drop targets must not shadow terminal file-path drop insertion"
+        )
+    }
+
     private func assertHitFallsInsideHostedTerminal(
         _ hitView: NSView?,
         hostedView: GhosttySurfaceScrollView,


### PR DESCRIPTION
Closes #3729.

## Summary
- keep terminal pane drop target lookup inactive when the pane has no drop context
- add a regression test for inactive terminal drop targets shadowing file path insertion

## Verification
- Not run locally per repository/user instruction; CI is the verification path for this branch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small guard condition changes drop-target hit-testing behavior and is covered by a focused regression test, with minimal impact outside drag-and-drop routing.
> 
> **Overview**
> Ensures `GhosttySurfaceScrollView.paneDropTargetForDrop(at:)` only returns a pane drop target when a `dropContext` is active, so an inactive pane no longer intercepts/"shadows" file-path drops intended for terminal insertion.
> 
> Adds a regression test (`testTerminalPaneDropTargetLookupRequiresActiveDropContext`) validating drop target discovery works when context is set and returns `nil` once the context is cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13460744820eae16d500108eb045a1ec09e65176. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores terminal file drop path insertion by ignoring pane drop targets when the pane has no drop context. Adds a regression test to enforce this and closes #3729.

- **Bug Fixes**
  - Require an active `dropContext` in `GhosttySurfaceScrollView.paneDropTargetForDrop` before advertising a pane drop target.
  - Add `testTerminalPaneDropTargetLookupRequiresActiveDropContext` to ensure inactive pane targets don’t shadow file-path insertion.

<sup>Written for commit 13460744820eae16d500108eb045a1ec09e65176. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

