### PR TITLE
Fix garbled Chinese paste text

### DIFF
--- a/Packages/CMUXPasteboardFidelity/Sources/CMUXPasteboardFidelity/PasteboardTextFidelity.swift
+++ b/Packages/CMUXPasteboardFidelity/Sources/CMUXPasteboardFidelity/PasteboardTextFidelity.swift
@@ -23,7 +23,7 @@ public enum PasteboardTextFidelity {
 
     public static func shouldInspectRichTextForPlainTextLoss(_ plainText: String) -> Bool {
         let metrics = textFidelityMetrics(plainText)
-        return metrics.questionMarks > 0 || metrics.replacementCharacters > 0
+        return metrics.replacementCharacters > 0 || metrics.questionMarks >= 2
     }
 
     public static func shouldPreferRichText(

--- a/Packages/CMUXPasteboardFidelity/Sources/CMUXPasteboardFidelity/PasteboardTextFidelity.swift
+++ b/Packages/CMUXPasteboardFidelity/Sources/CMUXPasteboardFidelity/PasteboardTextFidelity.swift
@@ -21,6 +21,28 @@ public enum PasteboardTextFidelity {
             (richTextHasLossySubstitution && richTextSubstitutionIsRelevant)
     }
 
+    public static func shouldInspectRichTextForPlainTextLoss(_ plainText: String) -> Bool {
+        let metrics = textFidelityMetrics(plainText)
+        return metrics.questionMarks > 0 || metrics.replacementCharacters > 0
+    }
+
+    public static func shouldPreferRichText(
+        _ richText: String,
+        overPlainText plainText: String
+    ) -> Bool {
+        guard plainText != richText else { return false }
+
+        let plainMetrics = textFidelityMetrics(plainText)
+        let richMetrics = textFidelityMetrics(richText)
+
+        let plainTextHasLossySubstitution =
+            plainMetrics.replacementCharacters > richMetrics.replacementCharacters ||
+            plainMetrics.questionMarks > richMetrics.questionMarks
+
+        return plainTextHasLossySubstitution &&
+            richMetrics.nonASCII > plainMetrics.nonASCII
+    }
+
     public static func htmlHasNoVisibleText(_ html: String) -> Bool {
         var visibleCandidate = html.replacingOccurrences(
             of: "<!--[\\s\\S]*?-->",

--- a/Packages/CMUXPasteboardFidelity/Tests/CMUXPasteboardFidelityTests/PasteboardTextFidelityTests.swift
+++ b/Packages/CMUXPasteboardFidelity/Tests/CMUXPasteboardFidelityTests/PasteboardTextFidelityTests.swift
@@ -60,6 +60,7 @@ final class PasteboardTextFidelityTests: XCTestCase {
         XCTAssertTrue(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("??~"))
         XCTAssertTrue(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("\u{FFFD}~"))
         XCTAssertFalse(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("您好~"))
+        XCTAssertFalse(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("Is this right?"))
     }
 
     func testPrefersRichTextWhenPlainTextReplacesNonASCIIWithQuestionMarks() {

--- a/Packages/CMUXPasteboardFidelity/Tests/CMUXPasteboardFidelityTests/PasteboardTextFidelityTests.swift
+++ b/Packages/CMUXPasteboardFidelity/Tests/CMUXPasteboardFidelityTests/PasteboardTextFidelityTests.swift
@@ -56,6 +56,30 @@ final class PasteboardTextFidelityTests: XCTestCase {
         )
     }
 
+    func testInspectsRichTextWhenPlainTextHasLossyMarkers() {
+        XCTAssertTrue(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("??~"))
+        XCTAssertTrue(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("\u{FFFD}~"))
+        XCTAssertFalse(PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss("您好~"))
+    }
+
+    func testPrefersRichTextWhenPlainTextReplacesNonASCIIWithQuestionMarks() {
+        XCTAssertTrue(
+            PasteboardTextFidelity.shouldPreferRichText(
+                "您好~",
+                overPlainText: "??~"
+            )
+        )
+    }
+
+    func testDoesNotPreferRichTextWhenQuestionMarkIsPreservedContent() {
+        XCTAssertFalse(
+            PasteboardTextFidelity.shouldPreferRichText(
+                "what? 您好",
+                overPlainText: "what?"
+            )
+        )
+    }
+
     func testHTMLWithOnlyHiddenBlocksHasNoVisibleText() {
         let html = """
         <!-- comment -->

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -357,6 +357,14 @@ enum GhosttyPasteboardHelper {
             return richText
         }
 
+        if let plainText,
+           PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss(plainText),
+           types.contains(where: isRichTextType),
+           let richText = richTextContents(from: pasteboard),
+           PasteboardTextFidelity.shouldPreferRichText(richText, overPlainText: plainText) {
+            return richText
+        }
+
         // Match upstream Ghostty's fast plain-text path for normal text paste.
         // Large clipboard payloads often also advertise HTML/RTF variants, and
         // eagerly rendering those rich-text flavors makes Cmd-V much slower than
@@ -477,6 +485,10 @@ enum GhosttyPasteboardHelper {
               let utType = UTType(type.rawValue) else { return false }
 
         return utType.conforms(to: .plainText)
+    }
+
+    private static func isRichTextType(_ type: NSPasteboard.PasteboardType) -> Bool {
+        type == .html || type == .rtf || type == .rtfd
     }
 
     private static func attributedString(

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -83,6 +83,25 @@ final class GhosttyPasteboardHelperTests: XCTestCase {
         )
     }
 
+    /// Regression test for https://github.com/manaflow-ai/cmux/issues/3910.
+    /// Some editors expose a lossy plain-text flavor where CJK scalars are
+    /// replaced with literal "?" characters, while the HTML flavor preserves the
+    /// original text. The terminal paste path should recover the faithful text.
+    func testPrefersFaithfulRichTextWhenPlainTextReplacesChineseWithQuestionMarks() {
+        let pasteboard = NSPasteboard(name: .init("cmux-test-lossy-chinese-plain-\(UUID().uuidString)"))
+        pasteboard.clearContents()
+
+        let chineseText = "您好~"
+        pasteboard.declareTypes([.string, .html], owner: nil)
+        pasteboard.setString("??~", forType: .string)
+        pasteboard.setString("<p>\(chineseText)</p>", forType: .html)
+
+        XCTAssertEqual(
+            cmuxPasteboardStringContentsForTesting(pasteboard),
+            chineseText
+        )
+    }
+
     /// Fallback-loop coverage: when *only* a legacy / unknown plain-text
     /// type is present and no UTF-8 variant exists, the helper should still
     /// return whatever string the pasteboard does expose (best-effort).


### PR DESCRIPTION
Closes #3910.

## Summary
- Add a regression test for pasteboards where plain text replaces Chinese scalars with literal question marks while rich text preserves the original text.
- Recover faithful rich-text content only when the plain-text flavor shows lossy substitution markers, preserving the fast path for normal plain-text pastes.

## Testing
- Not run locally per repo policy; CI will run the regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts terminal paste selection logic to sometimes decode HTML/RTF instead of the fast plain-text path, which could affect paste performance or change which clipboard flavor is used in edge cases.
> 
> **Overview**
> Fixes garbled CJK pastes when some apps put a lossy plain-text flavor (literal `?`/U+FFFD) alongside faithful HTML/RTF.
> 
> Adds `PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss` and `shouldPreferRichText` to detect lossy plain text and only then re-check rich-text flavors; `GhosttyTerminalView` now conditionally prefers rich text in that scenario while keeping the normal fast plain-text path.
> 
> Extends unit and integration regression tests to cover lossy-marker detection and the specific Chinese `??~` vs HTML case (issue #3910).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 164bd3d2efde98ad617943e4e1521becdf3279f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes garbled Chinese (CJK) paste from apps that replace characters with “?” by preferring faithful HTML/RTF only when plain text looks lossy. Keeps the fast plain‑text path for normal pastes and single “?” content.

- **Bug Fixes**
  - In `GhosttyTerminalView`, only consider rich text when plain text has U+FFFD or 2+ “?” and rich text preserves non‑ASCII; otherwise keep the plain‑text fast path.
  - Add `PasteboardTextFidelity.shouldInspectRichTextForPlainTextLoss` and `shouldPreferRichText` to detect lossy substitution and choose the better source.
  - Extend tests in `CMUXPasteboardFidelityTests` and `cmuxTests` for CJK replacement scenarios and single‑question‑mark cases.

<sup>Written for commit 164bd3d2efde98ad617943e4e1521becdf3279f5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

