### PR TITLE
Report search-related terminal close freezes

### DIFF
--- a/docs/search-shutdown-freeze-report.md
+++ b/docs/search-shutdown-freeze-report.md
@@ -1,0 +1,62 @@
+# Search-active terminal close freeze report
+
+## Summary
+
+I have been hitting frequent cmux freezes where the macOS app becomes unresponsive and shows the spinner. The clearest sampled occurrence happened while terminal search/find state was active or recently active and a terminal surface was being torn down.
+
+This document records the observed failure and links a possible fix. The proposed fix is entirely AI-suggested and should be reviewed as a hypothesis-backed patch, not as a fully human-audited Ghostty threading change.
+
+## Observed hang
+
+A local sample of the hung cmux process showed the app/main thread blocked in Ghostty teardown:
+
+```text
+Main Thread
+  ghostty_surface_free
+  Surface.deinit
+  pthread_join
+```
+
+The join location corresponds to Ghostty's per-surface search thread shutdown, before renderer and IO thread joins.
+
+## Suspected deadlock
+
+The suspected sequence is:
+
+1. cmux closes or frees a terminal surface on the app/main thread.
+2. Ghostty `Surface.deinit` asks the per-surface search thread to stop and then synchronously joins it.
+3. While exiting, the search thread emits final search UI callbacks such as clearing selected match, viewport highlights, and match counts.
+4. Those callbacks can enqueue messages into renderer/app mailboxes.
+5. If a mailbox is full and the callback waits indefinitely, the search thread waits for queue progress while the app/main thread is already waiting for the search thread to exit.
+
+That produces a full app freeze.
+
+## Proposed fix
+
+A proposed Ghostty-side patch is open here:
+
+- https://github.com/manaflow-ai/ghostty/pull/55
+
+The patch changes search-thread callback delivery so it no longer waits forever on renderer/app mailbox pushes:
+
+- normal search callback delivery gets a short bounded wait to preserve ordering in ordinary cases;
+- once surface teardown has started, search callback delivery becomes instant/best-effort;
+- arena-backed renderer messages deinitialize their arena if they cannot be enqueued.
+
+Search UI notifications are stale/recoverable state. During teardown the surface is already closing, so dropping a final search reset is preferable to deadlocking the application.
+
+## Local validation performed
+
+The AI-suggested patch was built locally with:
+
+```bash
+zig fmt --check ghostty/src/Surface.zig
+zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
+./scripts/reload.sh --tag fix-search-shutdown-hang
+```
+
+The tagged cmux debug build completed successfully.
+
+## Caveat
+
+The freeze is real and has been happening often locally, but the proposed fix and root-cause analysis are AI-assisted. Please treat the linked Ghostty PR as a concrete candidate fix that needs careful review by someone familiar with Ghostty's search, mailbox, and surface teardown threading model.


### PR DESCRIPTION
## Summary

This PR documents a freeze I have been hitting frequently in the local cmux macOS app. The common pattern is that terminal search/find state is active or recently active, then a terminal surface is closed or torn down, and the app becomes unresponsive with the spinner.

I am opening this primarily as a problem report plus a concrete possible fix path. The diagnosis and proposed fix are entirely AI-suggested, so they should be treated as a candidate explanation/patch that needs careful review rather than a fully human-audited conclusion.

## What was observed

A sampled hung cmux process showed the main thread blocked in Ghostty surface teardown:

- `ghostty_surface_free`
- `Surface.deinit`
- `pthread_join`

The join point appears to be the per-surface Ghostty search thread shutdown.

## Suspected cause

The suspected deadlock is:

1. cmux closes/frees a terminal surface on the app/main thread.
2. Ghostty asks the search thread to stop and synchronously joins it.
3. The search thread emits final search UI callbacks while exiting.
4. Those callbacks can wait forever while pushing renderer/app mailbox messages.
5. If the app/main thread is already waiting in the join and the mailbox is full, both sides can wait forever.

## Possible fix

I opened the AI-suggested Ghostty-side patch here:

- https://github.com/manaflow-ai/ghostty/pull/55

The proposed patch makes search-thread callback delivery bounded/best-effort during teardown, so stale search UI reset messages cannot block surface destruction forever.

## Local validation

The linked Ghostty patch was built locally into GhosttyKit and a tagged cmux debug build completed successfully:

```bash
zig fmt --check ghostty/src/Surface.zig
zig build -Demit-xcframework=true -Demit-macos-app=false -Dxcframework-target=universal -Doptimize=ReleaseFast
./scripts/reload.sh --tag fix-search-shutdown-hang
```

## Caveat

The freeze is real and it has been happening a lot for me locally. The root-cause analysis and fix are AI-assisted. Please review the Ghostty PR carefully, especially around search-thread callbacks, mailbox backpressure, and surface teardown ordering.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a report on a freeze when closing a terminal surface while search is active or recently active. It captures a suspected join deadlock in `Ghostty` surface teardown, links to a proposed upstream patch, and notes local build validation.

<sup>Written for commit d4b0126b85d3a041d8ce443fceba4363356308e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation describing a known macOS terminal freeze issue occurring during shutdown with active search functionality. Includes stack trace evidence, suspected deadlock analysis, reference to proposed solution, and comprehensive validation steps for local testing.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/3999)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->