### PR TITLE
Fix dead pane garbled input (#3998)

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -387,6 +387,7 @@
 		F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */; };
 		D3571002A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */; };
 		1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */; };
+		D3998000D3998000D3998000 /* TerminalDeadPaneInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3998001D3998001D3998001 /* TerminalDeadPaneInputTests.swift */; };
 		D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */; };
 		F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */; };
 		C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */; };
@@ -881,6 +882,7 @@
 		F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEInputTests.swift; sourceTree = "<group>"; };
 		D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKIMEMarkedSelectionTests.swift; sourceTree = "<group>"; };
 		1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyCommandShiftForwardingTests.swift; sourceTree = "<group>"; };
+		D3998001D3998001D3998001 /* TerminalDeadPaneInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalDeadPaneInputTests.swift; sourceTree = "<group>"; };
 		D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TraditionalChineseIMENumpadRegressionTests.swift; sourceTree = "<group>"; };
 		F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyConfigTests.swift; sourceTree = "<group>"; };
 		C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalStartupEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -1369,6 +1371,7 @@
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
 				1718C0DE1718C0DE17180001 /* GhosttyCommandShiftForwardingTests.swift */,
+				D3998001D3998001D3998001 /* TerminalDeadPaneInputTests.swift */,
 				D3284002A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift */,
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
 				A11EB0000000000000000001 /* GhosttyConfigPathResolverTests.swift */,
@@ -2048,6 +2051,7 @@
 				F3000000A1B2C3D4E5F60718 /* CJKIMEInputTests.swift in Sources */,
 				D3571002A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift in Sources */,
 				1718C0DE1718C0DE17180002 /* GhosttyCommandShiftForwardingTests.swift in Sources */,
+				D3998000D3998000D3998000 /* TerminalDeadPaneInputTests.swift in Sources */,
 				D3284001A1B2C3D4E5F60718 /* TraditionalChineseIMENumpadRegressionTests.swift in Sources */,
 				F4000000A1B2C3D4E5F60718 /* GhosttyConfigTests.swift in Sources */,
 				A11EB0000000000000000000 /* GhosttyConfigPathResolverTests.swift in Sources */,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3724,6 +3724,7 @@ class GhosttyApp {
         let callbackContext = Self.callbackContext(from: ghostty_surface_userdata(target.target.surface))
         let callbackTabId = callbackContext?.tabId
         let callbackSurfaceId = callbackContext?.surfaceId
+        let callbackTerminalSurface = callbackContext?.terminalSurface
 
         if action.tag == GHOSTTY_ACTION_SHOW_CHILD_EXITED {
             // The child (shell) exited. Ghostty will fall back to printing
@@ -3735,9 +3736,6 @@ class GhosttyApp {
                 "surface.action.showChildExited tab=\(callbackTabId?.uuidString.prefix(5) ?? "nil") " +
                 "surface=\(callbackSurfaceId?.uuidString.prefix(5) ?? "nil")"
             )
-            Task { @MainActor in
-                GhosttyApp.debugShowChildExitedActionObserver?(callbackTabId, callbackSurfaceId)
-            }
 #endif
 #if DEBUG
             cmuxWriteChildExitProbe(
@@ -3750,7 +3748,11 @@ class GhosttyApp {
 #endif
             // Keep host-close async to avoid re-entrant close/deinit while Ghostty is still
             // dispatching this action callback.
-            DispatchQueue.main.async {
+            Task { @MainActor in
+                callbackTerminalSurface?.markChildProcessExited(reason: "ghostty.childExited")
+#if DEBUG
+                GhosttyApp.debugShowChildExitedActionObserver?(callbackTabId, callbackSurfaceId)
+#endif
                 guard let app = AppDelegate.shared else { return }
                 if let callbackTabId,
                    let callbackSurfaceId,
@@ -4412,6 +4414,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    private enum InputLifecycleState: String {
+        case accepting
+        case childExited
+        case closed
+    }
+
     private(set) var surface: ghostty_surface_t?
     private weak var attachedView: GhosttyNSView?
 
@@ -4467,6 +4475,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     private var pendingSocketInputQueue: [PendingSocketInput] = []
     private var pendingSocketInputBytes: Int = 0
     private let maxPendingSocketInputBytes = 1_048_576
+    private var inputLifecycleState: InputLifecycleState = .accepting
     private var backgroundSurfaceStartQueued = false
     private var surfaceCallbackContext: Unmanaged<GhosttySurfaceCallbackContext>?
     /// The desired focus state for the Ghostty C surface. May be set before the
@@ -4840,13 +4849,67 @@ final class TerminalSurface: Identifiable, ObservableObject {
         }
     }
 
+    var canAcceptInput: Bool {
+        inputLifecycleState == .accepting && portalLifecycleState == .live
+    }
+
+    func markChildProcessExited(reason: String) {
+        guard inputLifecycleState == .accepting else { return }
+        inputLifecycleState = .childExited
+        clearPendingSocketInput(reason: reason)
+#if DEBUG
+        cmuxDebugLog(
+            "surface.input.child_exited surface=\(id.uuidString.prefix(5)) " +
+            "workspace=\(tabId.uuidString.prefix(5)) reason=\(reason)"
+        )
+#endif
+    }
+
+    private func markInputClosed(reason: String) {
+        guard inputLifecycleState != .closed else { return }
+        inputLifecycleState = .closed
+        clearPendingSocketInput(reason: reason)
+#if DEBUG
+        cmuxDebugLog(
+            "surface.input.closed surface=\(id.uuidString.prefix(5)) " +
+            "workspace=\(tabId.uuidString.prefix(5)) reason=\(reason)"
+        )
+#endif
+    }
+
+    private func clearPendingSocketInput(reason: String) {
+        guard !pendingSocketInputQueue.isEmpty || pendingSocketInputBytes != 0 else { return }
+        let droppedItems = pendingSocketInputQueue.count
+        let droppedBytes = pendingSocketInputBytes
+        pendingSocketInputQueue.removeAll(keepingCapacity: false)
+        pendingSocketInputBytes = 0
+#if DEBUG
+        cmuxDebugLog(
+            "surface.socket_input.drop_pending surface=\(id.uuidString.prefix(8)) " +
+            "reason=\(reason) items=\(droppedItems) bytes=\(droppedBytes)"
+        )
+#endif
+    }
+
+    private func logDroppedInput(reason: String, bytes: Int? = nil) {
+#if DEBUG
+        let byteText = bytes.map { " bytes=\($0)" } ?? ""
+        cmuxDebugLog(
+            "surface.input.drop surface=\(id.uuidString.prefix(5)) " +
+            "workspace=\(tabId.uuidString.prefix(5)) state=\(inputLifecycleState.rawValue) " +
+            "portal=\(portalLifecycleState.rawValue) reason=\(reason)\(byteText)"
+        )
+#endif
+    }
+
     private func allowsRuntimeSurfaceCreation() -> Bool {
-        portalLifecycleState == .live
+        canAcceptInput
     }
 
     func beginPortalCloseLifecycle(reason: String) {
         guard portalLifecycleState != .closed else { return }
         guard portalLifecycleState != .closing else { return }
+        markInputClosed(reason: reason)
         recordTeardownRequest(reason: reason)
         portalLifecycleState = .closing
         portalLifecycleGeneration &+= 1
@@ -4861,6 +4924,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     private func markPortalLifecycleClosed(reason: String) {
         guard portalLifecycleState != .closed else { return }
+        markInputClosed(reason: reason)
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
 #if DEBUG
@@ -5579,6 +5643,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func sendText(_ text: String) {
         guard let data = text.data(using: .utf8), !data.isEmpty else { return }
+        guard canAcceptInput else {
+            logDroppedInput(reason: "sendText.deadConsumer", bytes: data.count)
+            return
+        }
         guard let surface = surface else {
             enqueuePendingSocketInput(.text(data))
             requestBackgroundSurfaceStartIfNeeded()
@@ -5590,6 +5658,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
     @discardableResult
     func sendNamedKey(_ keyName: String) -> Bool {
         guard let event = pendingKeyEvent(for: keyName) else { return false }
+        guard canAcceptInput else {
+            logDroppedInput(reason: "sendNamedKey.deadConsumer", bytes: max(event.label.utf8.count, 1))
+            return true
+        }
         if let surface = surface {
             sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
         } else {
@@ -5603,6 +5675,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// events so the shell processes them, while regular text is sent via the
     /// normal key-text path.  Mirrors `TerminalController.sendSocketText`.
     func sendInput(_ text: String) {
+        guard canAcceptInput else {
+            logDroppedInput(reason: "sendInput.deadConsumer", bytes: text.utf8.count)
+            return
+        }
         guard let surface = surface else { return }
         var bufferedText = ""
         var previousWasCR = false
@@ -5872,7 +5948,12 @@ final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     private func flushPendingSocketInputIfNeeded() {
-        guard let surface = surface, !pendingSocketInputQueue.isEmpty else { return }
+        guard !pendingSocketInputQueue.isEmpty else { return }
+        guard canAcceptInput else {
+            clearPendingSocketInput(reason: "flushPending.deadConsumer")
+            return
+        }
+        guard let surface = surface else { return }
         let queued = pendingSocketInputQueue
         let queuedBytes = pendingSocketInputBytes
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
@@ -6773,6 +6854,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @discardableResult
     private func ensureSurfaceReadyForInput() -> ghostty_surface_t? {
+        if let terminalSurface, !terminalSurface.canAcceptInput {
+#if DEBUG
+            cmuxDebugLog(
+                "surface.input.view_drop surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                "reason=ensureSurfaceReadyForInput"
+            )
+#endif
+            return nil
+        }
         if let surface = surface {
             return surface
         }
@@ -6780,10 +6870,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         terminalSurface?.attachToView(self)
         updateSurfaceSize(size: bounds.size)
         applySurfaceColorScheme(force: true)
+        if let terminalSurface, !terminalSurface.canAcceptInput {
+            return nil
+        }
         return surface
     }
 
     private func requestInputRecoveryAfterSurfaceMiss(reason: String) {
+        guard terminalSurface?.canAcceptInput != false else { return }
         terminalSurface?.requestBackgroundSurfaceStartIfNeeded()
 #if DEBUG
         cmuxDebugLog(
@@ -7545,6 +7639,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let ensureSurfaceStart = ProcessInfo.processInfo.systemUptime
 #endif
         guard let surface = ensureSurfaceReadyForInput() else {
+            if terminalSurface?.canAcceptInput == false { return }
             requestInputRecoveryAfterSurfaceMiss(reason: "keyDown.missingSurface")
 #if DEBUG
             ensureSurfaceMs = (ProcessInfo.processInfo.systemUptime - ensureSurfaceStart) * 1000.0
@@ -8013,6 +8108,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         guard let surface = ensureSurfaceReadyForInput() else {
+            if terminalSurface?.canAcceptInput == false { return }
             super.keyUp(with: event)
             return
         }
@@ -8042,7 +8138,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func flagsChanged(with event: NSEvent) {
-        guard let surface = surface else {
+        guard terminalSurface?.canAcceptInput != false, let surface = surface else {
             super.flagsChanged(with: event)
             return
         }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -1655,6 +1655,9 @@ class GhosttyApp {
     }
 
     static let shared = GhosttyApp()
+#if DEBUG
+    @MainActor static var debugShowChildExitedActionObserver: ((UUID?, UUID?) -> Void)?
+#endif
     private static let releaseBundleIdentifier = "com.cmuxterm.app"
     private static let fallbackAppearanceConfig = GhosttyConfig()
     private static let backgroundLogTimestampFormatter: ISO8601DateFormatter = {
@@ -3732,6 +3735,9 @@ class GhosttyApp {
                 "surface.action.showChildExited tab=\(callbackTabId?.uuidString.prefix(5) ?? "nil") " +
                 "surface=\(callbackSurfaceId?.uuidString.prefix(5) ?? "nil")"
             )
+            Task { @MainActor in
+                GhosttyApp.debugShowChildExitedActionObserver?(callbackTabId, callbackSurfaceId)
+            }
 #endif
 #if DEBUG
             cmuxWriteChildExitProbe(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3746,13 +3746,16 @@ class GhosttyApp {
                 increments: ["probeShowChildExitedCount": 1]
             )
 #endif
-            // Keep host-close async to avoid re-entrant close/deinit while Ghostty is still
-            // dispatching this action callback.
-            Task { @MainActor in
+            performOnMain {
+                // Stop every host-owned input path before Ghostty returns to normal event
+                // processing. The panel close remains async below to avoid re-entrant teardown
+                // while Ghostty is still dispatching this action callback.
                 callbackTerminalSurface?.markChildProcessExited(reason: "ghostty.childExited")
 #if DEBUG
                 GhosttyApp.debugShowChildExitedActionObserver?(callbackTabId, callbackSurfaceId)
 #endif
+            }
+            Task { @MainActor in
                 guard let app = AppDelegate.shared else { return }
                 if let callbackTabId,
                    let callbackSurfaceId,
@@ -4902,6 +4905,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
 #endif
     }
 
+    func acceptInputOrLogDrop(reason: String, bytes: Int? = nil) -> Bool {
+        guard canAcceptInput else {
+            logDroppedInput(reason: reason, bytes: bytes)
+            return false
+        }
+        return true
+    }
+
     private func allowsRuntimeSurfaceCreation() -> Bool {
         canAcceptInput
     }
@@ -5643,10 +5654,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
 
     func sendText(_ text: String) {
         guard let data = text.data(using: .utf8), !data.isEmpty else { return }
-        guard canAcceptInput else {
-            logDroppedInput(reason: "sendText.deadConsumer", bytes: data.count)
-            return
-        }
+        guard acceptInputOrLogDrop(reason: "sendText.deadConsumer", bytes: data.count) else { return }
         guard let surface = surface else {
             enqueuePendingSocketInput(.text(data))
             requestBackgroundSurfaceStartIfNeeded()
@@ -5658,10 +5666,10 @@ final class TerminalSurface: Identifiable, ObservableObject {
     @discardableResult
     func sendNamedKey(_ keyName: String) -> Bool {
         guard let event = pendingKeyEvent(for: keyName) else { return false }
-        guard canAcceptInput else {
-            logDroppedInput(reason: "sendNamedKey.deadConsumer", bytes: max(event.label.utf8.count, 1))
-            return true
-        }
+        guard acceptInputOrLogDrop(
+            reason: "sendNamedKey.deadConsumer",
+            bytes: max(event.label.utf8.count, 1)
+        ) else { return true }
         if let surface = surface {
             sendKeyEvent(surface: surface, keycode: event.keycode, mods: event.mods)
         } else {
@@ -5675,10 +5683,7 @@ final class TerminalSurface: Identifiable, ObservableObject {
     /// events so the shell processes them, while regular text is sent via the
     /// normal key-text path.  Mirrors `TerminalController.sendSocketText`.
     func sendInput(_ text: String) {
-        guard canAcceptInput else {
-            logDroppedInput(reason: "sendInput.deadConsumer", bytes: text.utf8.count)
-            return
-        }
+        guard acceptInputOrLogDrop(reason: "sendInput.deadConsumer", bytes: text.utf8.count) else { return }
         guard let surface = surface else { return }
         var bufferedText = ""
         var previousWasCR = false
@@ -6854,13 +6859,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     @discardableResult
     private func ensureSurfaceReadyForInput() -> ghostty_surface_t? {
-        if let terminalSurface, !terminalSurface.canAcceptInput {
-#if DEBUG
-            cmuxDebugLog(
-                "surface.input.view_drop surface=\(terminalSurface.id.uuidString.prefix(5)) " +
-                "reason=ensureSurfaceReadyForInput"
-            )
-#endif
+        if let terminalSurface,
+           !terminalSurface.acceptInputOrLogDrop(reason: "ensureSurfaceReadyForInput") {
             return nil
         }
         if let surface = surface {
@@ -12917,6 +12917,10 @@ extension GhosttyNSView: NSTextInputClient {
     /// execution, etc.). Programmatic callers can preserve literal ESC bytes so
     /// automation payloads remain byte-for-byte stable.
     fileprivate func sendTextToSurface(_ chars: String, preserveLiteralEscape: Bool) {
+        if let terminalSurface,
+           !terminalSurface.acceptInputOrLogDrop(reason: "sendTextToSurface.deadConsumer", bytes: chars.utf8.count) {
+            return
+        }
         guard let surface = surface else { return }
 #if DEBUG
         let typingTimingStart = CmuxTypingTiming.start()
@@ -13193,6 +13197,7 @@ extension GhosttyNSView: NSTextInputClient {
             )
         }
 #endif
+        guard terminalSurface?.canAcceptInput != false else { return }
         guard let surface = surface else { return }
 
         if markedText.length > 0 {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -6782,6 +6782,18 @@ class TerminalController {
                 result = .err(code: "invalid_params", message: "Surface is not a terminal", data: ["surface_id": surfaceId.uuidString])
                 return
             }
+            guard terminalPanel.surface.canAcceptInput else {
+                result = .ok([
+                    "workspace_id": ws.id.uuidString,
+                    "workspace_ref": v2Ref(kind: .workspace, uuid: ws.id),
+                    "surface_id": surfaceId.uuidString,
+                    "surface_ref": v2Ref(kind: .surface, uuid: surfaceId),
+                    "window_id": v2OrNull(v2ResolveWindowId(tabManager: tabManager)?.uuidString),
+                    "window_ref": v2Ref(kind: .window, uuid: v2ResolveWindowId(tabManager: tabManager)),
+                    "dropped": true
+                ])
+                return
+            }
             #if DEBUG
             let sendStart = ProcessInfo.processInfo.systemUptime
             #endif
@@ -6842,7 +6854,7 @@ class TerminalController {
                 result = .err(code: "invalid_params", message: "Surface is not a terminal", data: ["surface_id": surfaceId.uuidString])
                 return
             }
-            let surfaceWasReady = terminalPanel.surface.surface != nil
+            let surfaceWasReady = terminalPanel.surface.canAcceptInput && terminalPanel.surface.surface != nil
             guard terminalPanel.surface.sendNamedKey(key) else {
                 result = .err(code: "invalid_params", message: "Unknown key", data: ["key": key])
                 return
@@ -14995,6 +15007,7 @@ class TerminalController {
     }
 
     private func waitForTerminalSurface(_ terminalPanel: TerminalPanel, waitUpTo timeout: TimeInterval = 0.6) -> ghostty_surface_t? {
+        guard terminalPanel.surface.canAcceptInput else { return nil }
         if let surface = terminalPanel.surface.surface { return surface }
 
         let terminalSurface = terminalPanel.surface
@@ -15025,17 +15038,18 @@ class TerminalController {
                 queue: .main
             ) { _ in
                 Task { @MainActor in
-                    if terminalSurface.surface != nil {
+                    if terminalSurface.canAcceptInput, terminalSurface.surface != nil {
                         finishOnce()
                     }
                 }
             }
 
-            if terminalSurface.surface != nil {
+            if terminalSurface.canAcceptInput, terminalSurface.surface != nil {
                 finishOnce()
             }
         }
 
+        guard terminalPanel.surface.canAcceptInput else { return nil }
         return terminalPanel.surface.surface
     }
 
@@ -15314,6 +15328,7 @@ class TerminalController {
             // payload does not hold the control-socket response open in CI.
             TerminalMutationBus.shared.enqueueMainActorMutation { [weak self] in
                 guard let self else { return }
+                guard terminalPanel.surface.canAcceptInput else { return }
                 if let surface = terminalPanel.surface.surface {
                     self.sendSocketText(unescaped, surface: surface)
                 } else {

--- a/cmuxTests/TerminalDeadPaneInputTests.swift
+++ b/cmuxTests/TerminalDeadPaneInputTests.swift
@@ -40,6 +40,25 @@ final class TerminalDeadPaneInputTests: XCTestCase {
         let sentinel = "cmuxdeadpaneinput3998"
         XCTAssertFalse(try readSurfaceText(from: hostedTerminal.surface).contains(sentinel))
 
+        var postExitGhosttyKeyEvents = 0
+        let previousKeyObserver = GhosttyNSView.debugGhosttySurfaceKeyEventObserver
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            previousKeyObserver?(keyEvent)
+            postExitGhosttyKeyEvents += 1
+        }
+        defer { GhosttyNSView.debugGhosttySurfaceKeyEventObserver = previousKeyObserver }
+
+        let directInsertSentinel = "cmuxdirectdeadpane3998"
+        hostedTerminal.surfaceView.insertText(
+            directInsertSentinel,
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
+        XCTAssertEqual(
+            postExitGhosttyKeyEvents,
+            0,
+            "Direct committed text after child exit should not reach Ghostty input"
+        )
+
         for scalar in sentinel.unicodeScalars {
             XCTAssertTrue(
                 hostedTerminal.hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
@@ -51,9 +70,18 @@ final class TerminalDeadPaneInputTests: XCTestCase {
         }
 
         let afterInput = try readSurfaceText(from: hostedTerminal.surface)
+        XCTAssertEqual(
+            postExitGhosttyKeyEvents,
+            0,
+            "Synthetic key events after child exit should not reach Ghostty input"
+        )
         XCTAssertFalse(
             afterInput.contains(sentinel),
             "Terminal input after child exit should be dropped before Ghostty can render it into the cell grid"
+        )
+        XCTAssertFalse(
+            afterInput.contains(directInsertSentinel),
+            "Direct committed text after child exit should be dropped before Ghostty can render it into the cell grid"
         )
 #else
         throw XCTSkip("Debug-only regression test")

--- a/cmuxTests/TerminalDeadPaneInputTests.swift
+++ b/cmuxTests/TerminalDeadPaneInputTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+import AppKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+final class TerminalDeadPaneInputTests: XCTestCase {
+    private struct HostedTerminal {
+        let surface: TerminalSurface
+        let hostedView: GhosttySurfaceScrollView
+        let surfaceView: GhosttyNSView
+        let window: NSWindow
+    }
+
+    func testKeyDownAfterChildExitDoesNotRenderTypedBytes() throws {
+#if DEBUG
+        let hostedTerminal = try makeHostedTerminal(initialInput: "exec cat\r")
+        defer {
+            hostedTerminal.surface.teardownSurface()
+            hostedTerminal.window.orderOut(nil)
+        }
+
+        let childExited = expectation(description: "child exited")
+        let previousObserver = GhosttyApp.debugShowChildExitedActionObserver
+        GhosttyApp.debugShowChildExitedActionObserver = { tabId, surfaceId in
+            previousObserver?(tabId, surfaceId)
+            guard surfaceId == hostedTerminal.surface.id else { return }
+            childExited.fulfill()
+        }
+        defer { GhosttyApp.debugShowChildExitedActionObserver = previousObserver }
+
+        XCTAssertTrue(hostedTerminal.window.makeFirstResponder(hostedTerminal.surfaceView))
+        XCTAssertTrue(hostedTerminal.hostedView.sendSyntheticCtrlDForUITest())
+        wait(for: [childExited], timeout: 2.0)
+
+        let sentinel = "cmuxdeadpaneinput3998"
+        XCTAssertFalse(try readSurfaceText(from: hostedTerminal.surface).contains(sentinel))
+
+        for scalar in sentinel.unicodeScalars {
+            XCTAssertTrue(
+                hostedTerminal.hostedView.debugSendSyntheticKeyPressAndReleaseForUITest(
+                    characters: String(scalar),
+                    charactersIgnoringModifiers: String(scalar),
+                    keyCode: 0
+                )
+            )
+        }
+
+        let afterInput = try readSurfaceText(from: hostedTerminal.surface)
+        XCTAssertFalse(
+            afterInput.contains(sentinel),
+            "Terminal input after child exit should be dropped before Ghostty can render it into the cell grid"
+        )
+#else
+        throw XCTSkip("Debug-only regression test")
+#endif
+    }
+
+#if DEBUG
+    private func makeHostedTerminal(initialInput: String) throws -> HostedTerminal {
+        _ = NSApplication.shared
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil,
+            initialInput: initialInput
+        )
+        let hostedView = surface.hostedView
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let contentView = try XCTUnwrap(window.contentView)
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        return HostedTerminal(
+            surface: surface,
+            hostedView: hostedView,
+            surfaceView: try XCTUnwrap(findGhosttyNSView(in: hostedView)),
+            window: window
+        )
+    }
+
+    private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
+        if let ghosttyView = view as? GhosttyNSView {
+            return ghosttyView
+        }
+        for subview in view.subviews {
+            if let found = findGhosttyNSView(in: subview) {
+                return found
+            }
+        }
+        return nil
+    }
+
+    private func readSurfaceText(from terminalSurface: TerminalSurface) throws -> String {
+        let surface = try XCTUnwrap(terminalSurface.surface)
+        let topLeft = ghostty_point_s(
+            tag: GHOSTTY_POINT_SCREEN,
+            coord: GHOSTTY_POINT_COORD_TOP_LEFT,
+            x: 0,
+            y: 0
+        )
+        let bottomRight = ghostty_point_s(
+            tag: GHOSTTY_POINT_SCREEN,
+            coord: GHOSTTY_POINT_COORD_BOTTOM_RIGHT,
+            x: 0,
+            y: 0
+        )
+        let selection = ghostty_selection_s(
+            top_left: topLeft,
+            bottom_right: bottomRight,
+            rectangle: false
+        )
+
+        var text = ghostty_text_s()
+        guard ghostty_surface_read_text(surface, selection, &text) else {
+            return ""
+        }
+        defer { ghostty_surface_free_text(surface, &text) }
+
+        guard let ptr = text.text, text.text_len > 0 else {
+            return ""
+        }
+        return String(decoding: Data(bytes: ptr, count: Int(text.text_len)), as: UTF8.self)
+    }
+#endif
+}


### PR DESCRIPTION
## Summary
- add a behavioral regression test for typing after Ghostty reports child exit
- track terminal input lifecycle on TerminalSurface and drop UI/socket input once the child process has exited
- gate socket surface resolution so direct key/text injection cannot write into a dead terminal grid

Closes #3998

## Verification
- Reproduced locally before the fix: in a pane, ran `(exec </dev/null >/dev/null 2>&1; sleep 9999)`, then typed `c12348h3t4r;`; observed the bytes render directly into the grid without a prompt. Expected input to be dropped or the pane to show a clean dead state.
- The single regression test was queued behind the shared xcodebuild lock, but did not acquire the lock before the fix sequence proceeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal input dispatch paths (UI key events and control-socket injection) and pane close lifecycle, so regressions could block legitimate input or interfere with pane teardown, but the change is guarded and covered by a new regression test.
> 
> **Overview**
> Prevents typed or socket-injected bytes from being rendered into a terminal pane after Ghostty reports the child process has exited (fix for dead-pane garbled input).
> 
> This introduces an input lifecycle on `TerminalSurface` (`accepting` → `childExited`/`closed`) that clears pending queued socket input and gates all input entry points (`sendText`, `sendNamedKey`, `sendInput`, IME commits/preedit, `keyDown`/`keyUp`/`flagsChanged`, and pending flush) so dead panes immediately drop input instead of forwarding it to Ghostty.
> 
> Control-socket APIs in `TerminalController` now refuse to resolve/send to dead surfaces (returning a `"dropped": true` response for `v2SurfaceSendText`), and a new `TerminalDeadPaneInputTests` regression test is added and wired into the Xcode project.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6a7c5d576c50b420239cc6cbf4260a06812708d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop accepting all input (UI keys, IME/committed text, and control-socket) after a pane’s child process exits so bytes never render into a dead grid. Adds a regression test, drops queued socket input, and returns dropped responses when dead (closes #3998).

- **Bug Fixes**
  - Track input lifecycle on `TerminalSurface` (`accepting` → `childExited` → `closed`); clear pending socket input and block new input and flushes post-exit.
  - Gate all paths: `GhosttyNSView`/`NSTextInputClient` (keyDown/up, flags, insertText/markedText) and `TerminalController` check `canAcceptInput`, avoid waiting/creating surfaces, and return `"dropped": true` on socket APIs.
  - Add debug child-exit observer and `TerminalDeadPaneInputTests` to verify committed text and synthetic keys don’t reach Ghostty after exit.

<sup>Written for commit b6a7c5d576c50b420239cc6cbf4260a06812708d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

