### PR TITLE
fix: Claude Code TUI falls back to non-interactive mode in cmux (no PTY allocated) (#4001)

### DIFF
--- a/Resources/bin/claude
+++ b/Resources/bin/claude
@@ -174,6 +174,28 @@ clear_inherited_claude_auth_selection_env() {
     normalize_claude_config_dir
 }
 
+# Inside cmux build variants that route child-process IO without a controlling
+# terminal (e.g. "manual-io-minimal"), Ink-based TUIs such as Claude Code drop
+# into non-interactive output because stdin is not a real PTY. Allocate one via
+# BSD `script` before exec'ing claude so interactive TUIs render correctly.
+# Set CMUX_CLAUDE_FORCE_PTY=0 to opt out.
+# Ref: https://github.com/manaflow-ai/cmux/issues/4001
+exec_real_claude() {
+    if [[ "${IN_CMUX:-0}" == "1" ]] \
+        && [[ "${CMUX_CLAUDE_FORCE_PTY:-1}" != "0" ]] \
+        && [[ ! -t 0 ]] \
+        && [[ -x /usr/bin/script ]]; then
+        # BSD `script` calls tcgetattr on stdin and aborts when it cannot read
+        # attrs (some socket types). Probe with /usr/bin/true so a hostile
+        # stdin can never regress claude into "failed to start" — fall back to
+        # direct exec instead, preserving today's behavior.
+        if /usr/bin/script -q /dev/null /usr/bin/true >/dev/null 2>&1; then
+            exec /usr/bin/script -q /dev/null "$@"
+        fi
+    fi
+    exec "$@"
+}
+
 # Pass through if not in a cmux terminal, hooks are disabled, or the cmux
 # socket is unavailable (stale env / app not running).
 IN_CMUX=0
@@ -189,7 +211,7 @@ if [[ "$IN_CMUX" == "0" || "$CMUX_CLAUDE_HOOKS_DISABLED" == "1" ]] || ! cmux_soc
     fi
     clear_inherited_claude_auth_selection_env
     REAL_CLAUDE="$(find_real_claude)" || { echo "Error: claude not found in PATH" >&2; exit 127; }
-    exec "$REAL_CLAUDE" "$@"
+    exec_real_claude "$REAL_CLAUDE" "$@"
 fi
 
 # Find real claude.
@@ -365,7 +387,7 @@ should_inject_claude_hooks() {
 # invocations pass through so new Claude subcommands do not need cmux changes.
 if ! should_inject_claude_hooks "$@"; then
     clear_inherited_claude_auth_selection_env
-    exec "$REAL_CLAUDE" "$@"
+    exec_real_claude "$REAL_CLAUDE" "$@"
 fi
 
 # Unset CLAUDECODE to avoid "nested session" detection — cmux terminals are
@@ -421,8 +443,8 @@ fi
 HOOKS_JSON='{"preferredNotifChannel":"notifications_disabled","hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-start","timeout":10}]}],"Stop":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude stop","timeout":10}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":10,"async":true}]}],"SessionEnd":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude session-end","timeout":1}]}],"Notification":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude notification","timeout":10}]}],"UserPromptSubmit":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude prompt-submit","timeout":10}]}],"PreToolUse":[{"matcher":"CronCreate","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude cron-create-guard","timeout":5}]},{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks claude pre-tool-use","timeout":5,"async":true}]}],"PermissionRequest":[{"matcher":"","hooks":[{"type":"command","command":"\"${CMUX_CLAUDE_HOOK_CMUX_BIN:-cmux}\" hooks feed --source claude","timeout":125}]}]}}'
 
 if [[ "$SKIP_SESSION_ID" == true ]]; then
-    exec "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
+    exec_real_claude "$REAL_CLAUDE" --settings "$HOOKS_JSON" "$@"
 else
     SESSION_ID="$(uuidgen | tr '[:upper:]' '[:lower:]')"
-    exec "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
+    exec_real_claude "$REAL_CLAUDE" --session-id "$SESSION_ID" --settings "$HOOKS_JSON" "$@"
 fi

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1083,7 +1083,13 @@ def test_inside_cmux_without_tty_allocates_pty_for_real_claude(failures: list[st
     must allocate one so the spawned claude sees a TTY on stdin.
     """
     if not os.access("/usr/bin/script", os.X_OK):
-        return  # BSD `script` is required for the workaround.
+        # BSD `script` is required for the workaround; surface an explicit
+        # SKIP so CI logs distinguish skipped-on-Linux from passed-on-macOS.
+        print(
+            "SKIP: test_inside_cmux_without_tty_allocates_pty_for_real_claude "
+            "(requires BSD /usr/bin/script)"
+        )
+        return
 
     cases: list[tuple[str, list[str]]] = [
         ("interactive entry", []),

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -985,6 +985,120 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
     expect(hook_cmux_bin == "__UNSET__", f"stale socket: expected hook cmux unset, got {hook_cmux_bin!r}", failures)
 
 
+def run_wrapper_pty_probe(
+    *,
+    argv: list[str],
+    socket_state: str = "live",
+) -> tuple[int, str, str]:
+    """
+    Drive the wrapper with stdin=/dev/null (non-TTY) and capture whether the
+    fake real claude saw a TTY on its own stdin. Mirrors run_wrapper's faked
+    PATH layout but trims the parts that aren't relevant to the PTY check.
+    """
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-pty-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper-bin"
+        real_dir = tmp / "real-bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        real_dir.mkdir(parents=True, exist_ok=True)
+
+        wrapper = wrapper_dir / "claude"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        tty_log = tmp / "real-tty-state.log"
+        cmux_log = tmp / "cmux.log"
+        socket_path = str(tmp / "cmux.sock")
+
+        make_executable(
+            real_dir / "claude",
+            """#!/usr/bin/env bash
+set -euo pipefail
+if [ -t 0 ]; then
+  printf 'tty\\n' > "$FAKE_REAL_TTY_LOG"
+else
+  printf 'not_a_tty\\n' > "$FAKE_REAL_TTY_LOG"
+fi
+""",
+        )
+
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$FAKE_CMUX_LOG"
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  if [[ "${FAKE_CMUX_PING_OK:-0}" == "1" ]]; then
+    exit 0
+  fi
+  exit 1
+fi
+exit 0
+""",
+        )
+
+        test_socket: socket.socket | None = None
+        if socket_state in {"live", "stale"}:
+            test_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            test_socket.bind(socket_path)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+        env["CMUX_SURFACE_ID"] = "surface:test"
+        env["CMUX_SOCKET_PATH"] = socket_path
+        env["FAKE_REAL_TTY_LOG"] = str(tty_log)
+        env["FAKE_CMUX_LOG"] = str(cmux_log)
+        env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
+        env.pop("NODE_OPTIONS", None)
+        env.pop("CMUX_CLAUDE_FORCE_PTY", None)
+
+        try:
+            proc = subprocess.run(
+                ["claude", *argv],
+                cwd=tmp,
+                env=env,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+        finally:
+            if test_socket is not None:
+                test_socket.close()
+
+        tty_state = tty_log.read_text(encoding="utf-8").strip() if tty_log.exists() else "<missing>"
+        return proc.returncode, tty_state, proc.stderr.strip()
+
+
+def test_inside_cmux_without_tty_allocates_pty_for_real_claude(failures: list[str]) -> None:
+    """
+    Regression for https://github.com/manaflow-ai/cmux/issues/4001.
+
+    cmux build variants that wire child-process IO without a controlling
+    terminal cause Ink-based TUIs (e.g. `claude`, `claude agents`) to drop
+    into non-interactive mode because stdin is not a real PTY. The wrapper
+    must allocate one so the spawned claude sees a TTY on stdin.
+    """
+    if not os.access("/usr/bin/script", os.X_OK):
+        return  # BSD `script` is required for the workaround.
+
+    cases: list[tuple[str, list[str]]] = [
+        ("interactive entry", []),
+        ("agents subcommand", ["agents"]),
+    ]
+    for label, argv in cases:
+        code, tty_state, stderr = run_wrapper_pty_probe(argv=argv)
+        expect(code == 0, f"pty alloc ({label}): wrapper exited {code}: {stderr}", failures)
+        expect(
+            tty_state == "tty",
+            f"pty alloc ({label}): expected real claude stdin to be a tty, got {tty_state!r}",
+            failures,
+        )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
@@ -1010,6 +1124,7 @@ def main() -> int:
     test_missing_socket_skips_hook_injection(failures)
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
+    test_inside_cmux_without_tty_allocates_pty_for_real_claude(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -989,11 +989,16 @@ def run_wrapper_pty_probe(
     *,
     argv: list[str],
     socket_state: str = "live",
+    force_pty: str | None = None,
 ) -> tuple[int, str, str]:
     """
     Drive the wrapper with stdin=/dev/null (non-TTY) and capture whether the
     fake real claude saw a TTY on its own stdin. Mirrors run_wrapper's faked
     PATH layout but trims the parts that aren't relevant to the PTY check.
+
+    When ``force_pty`` is ``None`` the env var is cleared so the wrapper's
+    default path is exercised; pass an explicit value (e.g. ``"0"``) to drive
+    the documented opt-out.
     """
     with tempfile.TemporaryDirectory(prefix="cmux-claude-wrapper-pty-") as td:
         tmp = Path(td)
@@ -1053,7 +1058,10 @@ exit 0
         env["FAKE_CMUX_LOG"] = str(cmux_log)
         env["FAKE_CMUX_PING_OK"] = "1" if socket_state == "live" else "0"
         env.pop("NODE_OPTIONS", None)
-        env.pop("CMUX_CLAUDE_FORCE_PTY", None)
+        if force_pty is None:
+            env.pop("CMUX_CLAUDE_FORCE_PTY", None)
+        else:
+            env["CMUX_CLAUDE_FORCE_PTY"] = force_pty
 
         try:
             proc = subprocess.run(
@@ -1105,6 +1113,26 @@ def test_inside_cmux_without_tty_allocates_pty_for_real_claude(failures: list[st
         )
 
 
+def test_force_pty_opt_out_skips_pty_allocation(failures: list[str]) -> None:
+    """
+    The wrapper documents ``CMUX_CLAUDE_FORCE_PTY=0`` as the escape hatch for
+    callers that need the real claude to see the wrapper's original (non-TTY)
+    stdin — e.g. piping data into ``claude --print``. Verify the opt-out
+    actually disables the PTY allocation instead of being a documented no-op.
+    """
+    code, tty_state, stderr = run_wrapper_pty_probe(argv=[], force_pty="0")
+    expect(
+        code == 0,
+        f"force-pty opt-out: wrapper exited {code}: {stderr}",
+        failures,
+    )
+    expect(
+        tty_state == "not_a_tty",
+        f"force-pty opt-out: expected real claude stdin to remain non-tty, got {tty_state!r}",
+        failures,
+    )
+
+
 def main() -> int:
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
@@ -1131,6 +1159,7 @@ def main() -> int:
     test_disabled_integration_skips_hook_injection(failures)
     test_stale_socket_skips_hook_injection(failures)
     test_inside_cmux_without_tty_allocates_pty_for_real_claude(failures)
+    test_force_pty_opt_out_skips_pty_allocation(failures)
 
     if failures:
         print("FAIL: claude wrapper regression checks failed")


### PR DESCRIPTION
# # Summary
- Wrap `exec "$REAL_CLAUDE"` calls in `Resources/bin/claude` with `/usr/bin/script -q /dev/null` via a new `exec_real_claude` helper, so the Ink-based TUI sees a PTY on stdin.
- Without this, cmux build variants that route child IO without a controlling terminal made Claude Code fall back to non-interactive mode. ## Testing
- Updated `tests/test_claude_wrapper_hooks.py` to cover the new exec path.
- Verified the helper probes `/usr/bin/script` first so a broken stdin can't regress claude into a "failed to start" state. ## Review Trigger (Copy/Paste as PR comment) ```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
``` ## Checklist
- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved Fixes #4001

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Claude Code’s TUI interactive under `cmux` by allocating a PTY when stdin isn’t a terminal. Adds a safe `/usr/bin/script` exec path with probing to prevent non-interactive fallback (fixes #4001).

- **Bug Fixes**
  - Added `exec_real_claude` in `Resources/bin/claude` and used it for all real `claude` execs (pass-through, hooks, session-id) to wrap with `/usr/bin/script -q /dev/null` when `IN_CMUX=1`, stdin is not a TTY, and `CMUX_CLAUDE_FORCE_PTY` != `0` (covers `claude` and `claude agents`).
  - Probes `/usr/bin/script` with `/usr/bin/true` and falls back to direct exec if unavailable or unsafe to avoid start failures.
  - Extended tests with a PTY allocation harness that asserts the real `claude` sees a TTY for both entry and `agents`, and verifies `CMUX_CLAUDE_FORCE_PTY=0` disables PTY allocation; skips when `/usr/bin/script` is missing.

<sup>Written for commit 61e8d0d58ed535aa48d07762c64071c4a46836c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Ensures claude is launched with a proper terminal (PTY) across environments and build variants, improving interactive behavior, hook handling, and session handling; adds an opt-out for PTY allocation.

* **Tests**
  * Adds regression tests verifying PTY allocation, successful terminal detection for real claude, and opt-out behavior across launch modes and CMUX socket states.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4002)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->