### PR TITLE
Add NSRemindersUsageDescription to Info.plist

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -51,6 +51,8 @@
 	<string>A program running within cmux would like to use Bluetooth to discover passkeys and security keys.</string>
 	<key>NSAppleEventsUsageDescription</key>
 	<string>A program running within cmux would like to use AppleScript.</string>
+	<key>NSRemindersUsageDescription</key>
+	<string>A program running within cmux would like to access your reminders.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>


### PR DESCRIPTION
## What

Adds `NSRemindersUsageDescription` to `Resources/Info.plist`, matching the pattern of the other usage description keys already present (microphone, camera, Bluetooth, Apple Events).

## Why

Terminal apps inside cmux often spawn CLIs that talk to EventKit (Reminders). Without this key, macOS won't surface the TCC prompt — the request silently fails with "access denied" and the user has no way to grant permission from System Settings (the app doesn't appear in the list and `+` won't accept apps without the declared usage string).

This brings Reminders in line with how the other personal-data permissions are already declared, so child processes can prompt and the user can grant access normally.

## Diff

```xml
<key>NSRemindersUsageDescription</key>
<string>A program running within cmux would like to access your reminders.</string>
```

Inserted next to the existing `NSAppleEventsUsageDescription` entry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `NSRemindersUsageDescription` to `Resources/Info.plist` so macOS shows the Reminders permission prompt for EventKit calls from cmux child processes. This prevents silent “access denied” failures and lets users grant access in System Settings.

<sup>Written for commit 1c393385b0a8899e42880364a378a2124e941f6f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added Reminders access permission declaration to support integration with the user's Reminders app.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4003)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->