### PR TITLE
Fix #373: accept remote CLI trailing JSON flag

### DIFF
--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -262,8 +262,11 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 		params[key] = value
 	}
 
+	cleanedArgs, commandJSONOutput := extractJSONOutputFlag(args, spec.flagKeys)
+	jsonOutput = jsonOutput || commandJSONOutput
+
 	if !spec.noParams {
-		parsed, err := parseFlags(args, spec.flagKeys)
+		parsed, err := parseFlags(cleanedArgs, spec.flagKeys)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "cmux: %v\n", err)
 			return 2
@@ -286,6 +289,9 @@ func execV2(socketPath string, spec *commandSpec, args []string, jsonOutput bool
 
 		applyWorkspaceEnvFallback(params)
 		applySurfaceEnvFallback(params)
+	} else if len(cleanedArgs) > 0 {
+		fmt.Fprintf(os.Stderr, "cmux: unexpected argument %q\n", cleanedArgs[0])
+		return 2
 	}
 
 	resp, err := socketRoundTripV2(socketPath, spec.v2Method, params, refreshAddr)
@@ -343,7 +349,9 @@ func runBrowserRelay(socketPath string, args []string, jsonOutput bool, refreshA
 	}
 
 	params := make(map[string]any)
-	parsed, err := parseFlags(subArgs, spec.flagKeys)
+	cleanedArgs, commandJSONOutput := extractJSONOutputFlag(subArgs, spec.flagKeys)
+	jsonOutput = jsonOutput || commandJSONOutput
+	parsed, err := parseFlags(cleanedArgs, spec.flagKeys)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "cmux browser: %v\n", err)
 		return 2
@@ -400,6 +408,36 @@ func runBrowserRelay(socketPath string, args []string, jsonOutput bool, refreshA
 		fmt.Println(defaultRelayOutput(resp))
 	}
 	return 0
+}
+
+func extractJSONOutputFlag(args []string, valueFlags []string) ([]string, bool) {
+	valueFlagSet := make(map[string]bool, len(valueFlags))
+	for _, flag := range valueFlags {
+		valueFlagSet[flag] = true
+	}
+
+	cleaned := make([]string, 0, len(args))
+	jsonOutput := false
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if arg == "--" {
+			cleaned = append(cleaned, args[i:]...)
+			break
+		}
+		if arg == "--json" {
+			jsonOutput = true
+			continue
+		}
+		cleaned = append(cleaned, arg)
+		if strings.HasPrefix(arg, "--") {
+			key := strings.TrimPrefix(arg, "--")
+			if valueFlagSet[key] && i+1 < len(args) {
+				i++
+				cleaned = append(cleaned, args[i])
+			}
+		}
+	}
+	return cleaned, jsonOutput
 }
 
 func browserSubcommandHint() string {

--- a/daemon/remote/cmd/cmuxd-remote/cli.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli.go
@@ -431,7 +431,7 @@ func extractJSONOutputFlag(args []string, valueFlags []string) ([]string, bool) 
 		cleaned = append(cleaned, arg)
 		if strings.HasPrefix(arg, "--") {
 			key := strings.TrimPrefix(arg, "--")
-			if valueFlagSet[key] && i+1 < len(args) {
+			if valueFlagSet[key] && i+1 < len(args) && args[i+1] != "--json" {
 				i++
 				cleaned = append(cleaned, args[i])
 			}

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -534,6 +534,26 @@ func TestCLIListWorkspacesV2(t *testing.T) {
 	}
 }
 
+func TestCLIListWorkspacesAcceptsTrailingJSONFlag(t *testing.T) {
+	sockPath := startMockV2TCPSocketWithResult(t, map[string]any{
+		"workspaces": []any{
+			map[string]any{"id": "ws-1"},
+		},
+	})
+
+	output := captureStdout(t, func() {
+		code := runCLI([]string{"--socket", sockPath, "list-workspaces", "--json"})
+		if code != 0 {
+			t.Fatalf("list-workspaces should return 0, got %d", code)
+		}
+	})
+
+	want := "{\"workspaces\":[{\"id\":\"ws-1\"}]}\n"
+	if output != want {
+		t.Fatalf("trailing --json output mismatch:\ngot  %q\nwant %q", output, want)
+	}
+}
+
 func TestCLIListWorkspacesV2DefaultOutputShowsResult(t *testing.T) {
 	sockPath := startMockV2TCPSocketWithResult(t, map[string]any{"method": "workspace.list", "params": map[string]any{}})
 	output := captureStdout(t, func() {

--- a/daemon/remote/cmd/cmuxd-remote/cli_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/cli_test.go
@@ -43,6 +43,33 @@ func captureStdout(t *testing.T, fn func()) string {
 	return string(output)
 }
 
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	original := os.Stderr
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stderr: %v", err)
+	}
+	os.Stderr = writer
+	defer func() {
+		os.Stderr = original
+	}()
+
+	fn()
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stderr writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	if err := reader.Close(); err != nil {
+		t.Fatalf("close stderr reader: %v", err)
+	}
+	return string(output)
+}
+
 func makeShortUnixSocketPath(t *testing.T) string {
 	t.Helper()
 	dir, err := os.MkdirTemp("/tmp", "cmuxd-")
@@ -554,6 +581,21 @@ func TestCLIListWorkspacesAcceptsTrailingJSONFlag(t *testing.T) {
 	}
 }
 
+func TestCLINoParamsCommandRejectsUnexpectedArgs(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+
+	stderr := captureStderr(t, func() {
+		code := runCLI([]string{"--socket", sockPath, "list-workspaces", "extra"})
+		if code != 2 {
+			t.Fatalf("list-workspaces extra arg should return 2, got %d", code)
+		}
+	})
+
+	if !strings.Contains(stderr, `unexpected argument "extra"`) {
+		t.Fatalf("expected unexpected argument error, got %q", stderr)
+	}
+}
+
 func TestCLIListWorkspacesV2DefaultOutputShowsResult(t *testing.T) {
 	sockPath := startMockV2TCPSocketWithResult(t, map[string]any{"method": "workspace.list", "params": map[string]any{}})
 	output := captureStdout(t, func() {
@@ -577,6 +619,21 @@ func TestCLINotifyDefaultOutputPrintsOKForEmptyResult(t *testing.T) {
 	})
 	if strings.TrimSpace(output) != "OK" {
 		t.Fatalf("expected empty-result command to print OK, got %q", output)
+	}
+}
+
+func TestCLINotifyTrailingJSONDoesNotSatisfyMissingBodyValue(t *testing.T) {
+	sockPath := startMockV2Socket(t)
+
+	stderr := captureStderr(t, func() {
+		code := runCLI([]string{"--socket", sockPath, "notify", "--body", "--json"})
+		if code != 2 {
+			t.Fatalf("notify missing body value should return 2, got %d", code)
+		}
+	})
+
+	if !strings.Contains(stderr, "flag --body requires a value") {
+		t.Fatalf("expected missing body value error, got %q", stderr)
 	}
 }
 
@@ -687,6 +744,35 @@ func TestCLIBrowserSubcommand(t *testing.T) {
 	code := runCLI([]string{"--socket", sockPath, "--json", "browser", "open", "--url", "https://example.com"})
 	if code != 0 {
 		t.Fatalf("browser open should return 0, got %d", code)
+	}
+}
+
+func TestCLIBrowserOpenAcceptsTrailingJSONFlag(t *testing.T) {
+	sockPath, requests := startMockV2SocketWithRequestCapture(t)
+
+	output := captureStdout(t, func() {
+		code := runCLI([]string{"--socket", sockPath, "browser", "open", "--url", "https://example.com", "--json"})
+		if code != 0 {
+			t.Fatalf("browser open should return 0, got %d", code)
+		}
+	})
+
+	want := "{\"method\":\"browser.open_split\",\"params\":{\"url\":\"https://example.com\"}}\n"
+	if output != want {
+		t.Fatalf("browser trailing --json output mismatch:\ngot  %q\nwant %q", output, want)
+	}
+
+	select {
+	case req := <-requests:
+		if got := req["method"]; got != "browser.open_split" {
+			t.Fatalf("expected browser.open_split, got %v", got)
+		}
+		params, _ := req["params"].(map[string]any)
+		if got := params["url"]; got != "https://example.com" {
+			t.Fatalf("expected url to be forwarded, got %v", got)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for browser open request")
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a regression test for `cmux list-workspaces --json` through the Go remote CLI relay
- accept command-level `--json` after remote V2 and browser relay commands without swallowing flag values

## Testing
- Not run locally per repository policy; CI will run the regression suite.

Closes #373

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk, localized CLI argument parsing change with added regression tests; main behavior change is more strict rejection of unexpected args for no-params v2 commands.
> 
> **Overview**
> Fixes remote CLI parsing so command-level `--json` can appear *after* v2 and `cmux browser` subcommands (e.g. `cmux list-workspaces --json`) and still enables raw JSON output.
> 
> Adds `extractJSONOutputFlag` to strip `--json` without swallowing required flag values, and makes no-params v2 commands error on extra args. Updates tests to cover trailing `--json`, unexpected-arg rejection, and the `notify --body --json` missing-value regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e215408f61ea22d785605000f9a0cf6b07a5aa2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Accept trailing `--json` in the remote CLI so commands like `cmux list-workspaces --json` work over V2 and `browser` relays. Fixes flag parsing to preserve value flags, reject unexpected args, and cover edge cases from #373.

- **Bug Fixes**
  - Strip/apply command-level `--json` and merge with global JSON mode for both V2 and `browser` paths.
  - Parse flags from cleaned args so value flags keep their values; `--json` never satisfies a missing value; error on extra args for no-arg commands. Added tests for `list-workspaces`, `browser open`, and missing `--body` value.

<sup>Written for commit 4e215408f61ea22d785605000f9a0cf6b07a5aa2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

