### PR TITLE
Fix flaky Claude notifications

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -14707,7 +14707,6 @@ struct CMUXCLI {
                     "clear_agent_pid claude_code --tab=\(workspaceId)\(socketPanelOption(consumedSession.surfaceId)) --clear-status",
                     client: client
                 )
-                _ = try? sendV1Command("clear_notifications --tab=\(workspaceId)", client: client)
             }
             print("OK")
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -20,6 +20,44 @@ private func ghostty_surface_clear_selection_compat(_ surface: ghostty_surface_t
 @_silgen_name("ghostty_surface_select_cursor_cell")
 private func ghostty_surface_select_cursor_cell_compat(_ surface: ghostty_surface_t) -> Bool
 
+enum TerminalDesktopNotificationBridge {
+    static func resolvedTitle(actionTitle: String, fallbackTabTitle: String) -> String {
+        actionTitle.isEmpty ? fallbackTabTitle : actionTitle
+    }
+
+    static func shouldSuppressNotification(
+        workspaceAgentPIDs: [String: pid_t],
+        latestNotification: TerminalNotification?,
+        title: String,
+        body: String,
+        now: Date = Date.now
+    ) -> Bool {
+        guard workspaceAgentPIDs["claude_code"] != nil else { return false }
+        guard matchesClaudeAttentionDuplicate(title: title, body: body) else { return false }
+        guard let latestNotification else { return false }
+        guard normalizedText(latestNotification.title).contains("claude") else {
+            return false
+        }
+        let age = now.timeIntervalSince(latestNotification.createdAt)
+        return age >= 0 && age <= 120
+    }
+
+    private static func matchesClaudeAttentionDuplicate(title: String, body: String) -> Bool {
+        let normalized = normalizedText("\(title) \(body)")
+        guard normalized.contains("claude") else { return false }
+        return normalized.contains("needs your attention") ||
+            normalized.contains("needs your input") ||
+            normalized.contains("waiting for your input")
+    }
+
+    private static func normalizedText(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+    }
+}
+
 enum GhosttyStartupAppearancePreviewProfile: String, CaseIterable, Identifiable {
     case realUserConfig
     case freshInstall
@@ -3670,18 +3708,29 @@ class GhosttyApp {
                           let tabId = tabManager.selectedTabId else {
                         return false
                     }
-                    // Suppress OSC notifications for workspaces with active Claude hook sessions.
-                    // The hook system manages notifications with proper lifecycle tracking;
-                    // raw OSC notifications would duplicate or outlive the structured hooks.
+                    // Suppress only delayed generic Claude OSC banners that duplicate a
+                    // recent hook notification; preserve OSC as a fallback when hooks did
+                    // not actually deliver.
                     let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? tabManager
+                    let surfaceId = tabManager.focusedSurfaceId(for: tabId)
                     if ClaudeCodeIntegrationSettings.hooksEnabled(), let workspace = owningManager.tabs.first(where: { $0.id == tabId }),
-                       workspace.agentPIDs["claude_code"] != nil {
+                       TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                           workspaceAgentPIDs: workspace.agentPIDs,
+                           latestNotification: TerminalNotificationStore.shared.latestNotification(
+                               forTabId: tabId,
+                               surfaceId: surfaceId
+                           ),
+                           title: actionTitle,
+                           body: actionBody
+                       ) {
                         return true
                     }
                     let tabTitle = owningManager.titleForTab(tabId) ?? "Terminal"
-                    let command = actionTitle.isEmpty ? tabTitle : actionTitle
+                    let command = TerminalDesktopNotificationBridge.resolvedTitle(
+                        actionTitle: actionTitle,
+                        fallbackTabTitle: tabTitle
+                    )
                     let body = actionBody
-                    let surfaceId = tabManager.focusedSurfaceId(for: tabId)
                     TerminalNotificationStore.shared.addNotification(
                         tabId: tabId,
                         surfaceId: surfaceId,
@@ -3936,14 +3985,27 @@ class GhosttyApp {
             let actionBody = action.action.desktop_notification.body
                 .flatMap { String(cString: $0) } ?? ""
             performOnMain {
-                // Suppress OSC notifications for workspaces with active Claude hook sessions.
+                // Suppress only delayed generic Claude OSC banners that duplicate a
+                // recent hook notification; preserve OSC as a fallback when hooks did
+                // not actually deliver.
                 let owningManager = AppDelegate.shared?.tabManagerFor(tabId: tabId) ?? AppDelegate.shared?.tabManager
                 if ClaudeCodeIntegrationSettings.hooksEnabled(), let workspace = owningManager?.tabs.first(where: { $0.id == tabId }),
-                   workspace.agentPIDs["claude_code"] != nil {
+                   TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                       workspaceAgentPIDs: workspace.agentPIDs,
+                       latestNotification: TerminalNotificationStore.shared.latestNotification(
+                           forTabId: tabId,
+                           surfaceId: surfaceId
+                       ),
+                       title: actionTitle,
+                       body: actionBody
+                   ) {
                     return
                 }
                 let tabTitle = owningManager?.titleForTab(tabId) ?? "Terminal"
-                let command = actionTitle.isEmpty ? tabTitle : actionTitle
+                let command = TerminalDesktopNotificationBridge.resolvedTitle(
+                    actionTitle: actionTitle,
+                    fallbackTabTitle: tabTitle
+                )
                 let body = actionBody
                 TerminalNotificationStore.shared.addNotification(
                     tabId: tabId,

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -928,6 +928,10 @@ final class TerminalNotificationStore: ObservableObject {
         indexes.latestByTabId[tabId]
     }
 
+    func latestNotification(forTabId tabId: UUID, surfaceId: UUID?) -> TerminalNotification? {
+        notifications.first { $0.tabId == tabId && $0.surfaceId == surfaceId }
+    }
+
     func clearLatestNotification(forTabId tabId: UUID) {
         guard let latestNotification = indexes.latestByTabId[tabId] else { return }
         remove(id: latestNotification.id)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -13,6 +13,90 @@ import UserNotifications
 @testable import cmux
 #endif
 
+final class TerminalDesktopNotificationBridgeTests: XCTestCase {
+    func testClaudeAttentionOSCFallsThroughWhenHookHasNotDeliveredNotification() {
+        XCTAssertFalse(
+            TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                workspaceAgentPIDs: ["claude_code": 123],
+                latestNotification: nil,
+                title: "Claude Code",
+                body: "Claude needs your attention"
+            )
+        )
+    }
+
+    func testClaudeAttentionOSCSuppressedAfterRecentHookNotification() {
+        let tabId = UUID()
+        let surfaceId = UUID()
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: tabId,
+            surfaceId: surfaceId,
+            title: "Claude Code",
+            subtitle: "Completed",
+            body: "Done",
+            createdAt: Date(timeIntervalSince1970: 100),
+            isRead: false
+        )
+
+        XCTAssertTrue(
+            TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                workspaceAgentPIDs: ["claude_code": 123],
+                latestNotification: notification,
+                title: "Claude Code",
+                body: "Claude is waiting for your input",
+                now: Date(timeIntervalSince1970: 130)
+            )
+        )
+    }
+
+    func testActiveClaudePIDDoesNotSuppressNonClaudeOSCNotification() {
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: UUID(),
+            title: "Claude Code",
+            subtitle: "Completed",
+            body: "Done",
+            createdAt: Date(timeIntervalSince1970: 100),
+            isRead: false
+        )
+
+        XCTAssertFalse(
+            TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                workspaceAgentPIDs: ["claude_code": 123],
+                latestNotification: notification,
+                title: "Build",
+                body: "Tests finished",
+                now: Date(timeIntervalSince1970: 130)
+            )
+        )
+    }
+
+    func testOldClaudeNotificationDoesNotSuppressFreshOSCFallback() {
+        let notification = TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: UUID(),
+            title: "Claude Code",
+            subtitle: "Completed",
+            body: "Old",
+            createdAt: Date(timeIntervalSince1970: 100),
+            isRead: false
+        )
+
+        XCTAssertFalse(
+            TerminalDesktopNotificationBridge.shouldSuppressNotification(
+                workspaceAgentPIDs: ["claude_code": 123],
+                latestNotification: notification,
+                title: "Claude Code",
+                body: "Claude needs your attention",
+                now: Date(timeIntervalSince1970: 300)
+            )
+        )
+    }
+}
+
 @MainActor
 final class GhosttyPasteboardHelperTests: XCTestCase {
     private func make1x1PNG(color: NSColor) throws -> Data {

--- a/tests/test_claude_hook_stop_last_assistant.py
+++ b/tests/test_claude_hook_stop_last_assistant.py
@@ -203,6 +203,22 @@ def main() -> int:
             print(f"commands={server.commands!r}")
             return 1
 
+        start_proc = subprocess.run(
+            [cli_path, "--socket", server.socket_path, "claude-hook", "session-start"],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=8,
+            check=False,
+        )
+        if start_proc.returncode != 0:
+            print("FAIL: claude-hook session-start failed")
+            print(f"stdout={start_proc.stdout!r}")
+            print(f"stderr={start_proc.stderr!r}")
+            print(f"commands={server.commands!r}")
+            return 1
+
         proc = subprocess.run(
             [cli_path, "--socket", server.socket_path, "claude-hook", "stop"],
             input=json.dumps(payload),
@@ -235,7 +251,31 @@ def main() -> int:
             print(f"commands={server.commands!r}")
             return 1
 
-    print("PASS: Claude cron guard denies durable jobs and Stop notification uses final assistant text")
+        command_count_after_stop = len(server.commands)
+        end_proc = subprocess.run(
+            [cli_path, "--socket", server.socket_path, "claude-hook", "session-end"],
+            input=json.dumps(payload),
+            text=True,
+            capture_output=True,
+            env=env,
+            timeout=8,
+            check=False,
+        )
+        if end_proc.returncode != 0:
+            print("FAIL: claude-hook session-end failed")
+            print(f"stdout={end_proc.stdout!r}")
+            print(f"stderr={end_proc.stderr!r}")
+            print(f"commands={server.commands!r}")
+            return 1
+
+        session_end_commands = server.commands[command_count_after_stop:]
+        if any(line.startswith("clear_notifications ") for line in session_end_commands):
+            print("FAIL: session-end should not clear the stop completion notification")
+            print(f"session_end_commands={session_end_commands!r}")
+            print(f"commands={server.commands!r}")
+            return 1
+
+    print("PASS: Claude cron guard denies durable jobs and Stop notification survives session-end cleanup")
     return 0
 
 


### PR DESCRIPTION
Fixes #2322

## Summary
- keep Claude SessionEnd cleanup from clearing freshly queued completion notifications
- narrow Claude OSC suppression so it only suppresses delayed duplicate Claude attention banners after a recent hook notification
- preserve OSC fallback when hooks have not delivered and keep non-Claude OSC notifications flowing

## Testing
- Not run locally per repo policy; CI will run the regression suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches notification suppression/cleanup paths for Claude hook sessions, which can affect whether users see (or miss) important desktop alerts. Logic is time/heuristic-based (recent-notification window, text matching), so regressions are possible across edge cases/tabs/surfaces.
> 
> **Overview**
> Prevents `claude-hook session-end` cleanup from clearing notifications when the session was already consumed by `stop`, so freshly queued completion alerts survive.
> 
> Refines Ghostty OSC desktop-notification suppression: only suppresses *generic Claude “needs your attention/input”* banners when a `claude_code` agent is active **and** a recent hook notification (per tab+surface) was delivered within ~2 minutes, while keeping non-Claude OSC notifications and OSC fallback when hooks didn’t deliver.
> 
> Adds `TerminalDesktopNotificationBridge` plus a `TerminalNotificationStore.latestNotification(forTabId:surfaceId:)` helper and new unit/regression tests covering the dedupe and session-end behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ad7bececbbd88638174dd15f1fe56e9f01c459a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #2322 by stabilizing Claude notifications: keep stop-completion banners at session end, and only suppress delayed duplicate OSC attention banners when a recent hook notification exists. OSC remains a fallback when hooks don’t deliver; non-Claude OSC is unaffected.

- **Bug Fixes**
  - Limit OSC suppression to generic Claude attention banners within 2 minutes when `claude_code` is active and a recent tab/surface notification exists.
  - Add `TerminalDesktopNotificationBridge` and `TerminalNotificationStore.latestNotification(tabId:surfaceId:)`; use consistent title fallback when the action title is empty.
  - Remove `clear_notifications` from `claude-hook session-end` to preserve the stop-completion banner.

<sup>Written for commit 5ad7bececbbd88638174dd15f1fe56e9f01c459a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

