### PR TITLE
Fix new-workspace caller window routing

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2802,11 +2802,13 @@ struct CMUXCLI {
             let (nameOpt, rem2) = parseOption(rem1, name: "--name")
             let (descriptionOpt, rem3) = parseOption(rem2, name: "--description")
             let (layoutOpt, rem4) = parseOption(rem3, name: "--layout")
-            let (focusOpt, remaining) = parseOption(rem4, name: "--focus")
+            let (windowOpt, rem5) = parseOption(rem4, name: "--window")
+            let (focusOpt, remaining) = parseOption(rem5, name: "--focus")
             if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>, --layout <json>, --focus <true|false>")
+                throw CLIError(message: "new-workspace: unknown flag '\(unknown)'. Known flags: --name <title>, --description <text>, --command <text>, --cwd <path>, --layout <json>, --window <id|ref|index>, --focus <true|false>")
             }
             var params: [String: Any] = [:]
+            try applyWindowOrCallerContext(to: &params, client: client, windowRaw: windowOpt ?? windowId)
             if let cwdOpt {
                 let resolved = resolvePath(cwdOpt)
                 params["cwd"] = resolved
@@ -9306,9 +9308,9 @@ struct CMUXCLI {
             """
         case "new-workspace":
             return """
-            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--focus <true|false>]
+            Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
 
-            Create a new workspace in the current window.
+            Create a new workspace in the caller's window.
 
             Flags:
               --name <title>       Set a custom name for the new workspace
@@ -9318,6 +9320,8 @@ struct CMUXCLI {
               --layout <json>      Create workspace with a predefined split layout (inline JSON).
                                    Uses the same schema as cmux.json layout definitions.
                                    When provided, --command is ignored (layout surfaces define their own commands).
+              --window <id|ref|index>
+                                   Target window (default: caller's window from $CMUX_WORKSPACE_ID/$CMUX_SURFACE_ID)
               --focus <true|false> Focus the new workspace (default: false)
 
             Example:
@@ -10381,6 +10385,23 @@ struct CMUXCLI {
         // When --window is explicitly targeted, don't fall back to env workspace from a different window
         if windowOverride != nil { return nil }
         return ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
+    }
+
+    private func applyWindowOrCallerContext(to params: inout [String: Any], client: SocketClient, windowRaw: String?) throws {
+        if let windowHandle = try normalizeWindowHandle(windowRaw, client: client) {
+            params["window_id"] = windowHandle
+            return
+        }
+
+        let env = ProcessInfo.processInfo.environment
+        let workspaceHandle = try normalizeWorkspaceHandle(env["CMUX_WORKSPACE_ID"], client: client)
+        if let workspaceHandle {
+            params["workspace_id"] = workspaceHandle
+        }
+        let surfaceHandle = try normalizeSurfaceHandle(env["CMUX_SURFACE_ID"], client: client, workspaceHandle: workspaceHandle)
+        if let surfaceHandle {
+            params["surface_id"] = surfaceHandle
+        }
     }
 
     private func forwardSidebarMetadataCommand(
@@ -20951,7 +20972,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           workspace-action --action <name> [--workspace <id|ref|index>] [--title <text>] [--color <name|#hex>] [--description <text>]
           move-tab-to-new-workspace [--tab <id|ref|index>] [--surface <id|ref|index>] [--workspace <id|ref|index>] [--title <text>] [--focus <true|false>]
           list-workspaces
-          new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--focus <true|false>]
+          new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--layout <json>] [--window <id|ref|index>] [--focus <true|false>]
           ssh <destination> [--name <title>] [--port <n>] [--identity <path>] [--ssh-option <opt>] [--no-focus] [-- <remote-command-args>]
           remote-daemon-status [--os <darwin|linux>] [--arch <arm64|amd64>]
           new-split <left|right|up|down> [--workspace <id|ref>] [--surface <id|ref>] [--panel <id|ref>] [--focus <true|false>]

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -18,6 +18,7 @@ PANE_ID = "22222222-2222-4222-8222-222222222222"
 SURFACE_ID = "33333333-3333-4333-8333-333333333333"
 NEW_PANE_ID = "44444444-4444-4444-8444-444444444444"
 NEW_SURFACE_ID = "55555555-5555-4555-8555-555555555555"
+WINDOW_ID = "window:7"
 
 
 class FakeCmuxState:
@@ -190,6 +191,29 @@ def main() -> int:
                     "focus": False,
                 },
             )
+
+            run_cli(
+                cli,
+                socket_path,
+                ["new-workspace", "--window", WINDOW_ID, "--name", "explicit-window"],
+                env_overrides={
+                    "CMUX_WORKSPACE_ID": WORKSPACE_ID,
+                    "CMUX_SURFACE_ID": SURFACE_ID,
+                },
+            )
+            assert_last_call(
+                state,
+                "workspace.create",
+                {
+                    "title": "explicit-window",
+                    "window_id": WINDOW_ID,
+                    "focus": False,
+                },
+            )
+            explicit_params = state.calls[-1][1]
+            for caller_key in ["workspace_id", "surface_id"]:
+                if caller_key in explicit_params:
+                    raise AssertionError(f"explicit --window should not include {caller_key}: {explicit_params!r}")
 
             run_cli(
                 cli,

--- a/tests/test_cli_layout_focus_contract.py
+++ b/tests/test_cli_layout_focus_contract.py
@@ -98,10 +98,17 @@ class ThreadedUnixServer(socketserver.ThreadingMixIn, socketserver.UnixStreamSer
     state: FakeCmuxState
 
 
-def run_cli(cli: str, socket_path: str, args: list[str]) -> str:
+def run_cli(
+    cli: str,
+    socket_path: str,
+    args: list[str],
+    env_overrides: dict[str, str] | None = None,
+) -> str:
     env = dict(os.environ)
     for key in ["CMUX_WORKSPACE_ID", "CMUX_SURFACE_ID", "CMUX_TAB_ID"]:
         env.pop(key, None)
+    if env_overrides:
+        env.update(env_overrides)
     proc = subprocess.run(
         [cli, "--socket", socket_path, *args],
         capture_output=True,
@@ -163,6 +170,26 @@ def main() -> int:
         try:
             run_cli(cli, socket_path, ["new-workspace", "--name", "agent"])
             assert_last_call(state, "workspace.create", {"title": "agent", "focus": False})
+
+            run_cli(
+                cli,
+                socket_path,
+                ["new-workspace", "--name", "caller-target"],
+                env_overrides={
+                    "CMUX_WORKSPACE_ID": WORKSPACE_ID,
+                    "CMUX_SURFACE_ID": SURFACE_ID,
+                },
+            )
+            assert_last_call(
+                state,
+                "workspace.create",
+                {
+                    "title": "caller-target",
+                    "workspace_id": WORKSPACE_ID,
+                    "surface_id": SURFACE_ID,
+                    "focus": False,
+                },
+            )
 
             run_cli(
                 cli,


### PR DESCRIPTION
Fixes #4039

## Summary
- route `cmux new-workspace` through an explicit `--window` target or the caller's `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` context
- document `new-workspace --window` and keep explicit window targeting from inheriting caller env
- add CLI socket-contract coverage for caller-targeted `workspace.create` params

## Local verification
- Reproduced manually against the live app: caller env was in window 5 while the focused/scriptable window was window 0; `cmux new-workspace --name issue4039-repro-codex --focus false` increased window 0 from 51 to 52 and left window 5 at 26. Removed the temporary workspace afterward.
- `git diff --check -- CLI/cmux.swift tests/test_cli_layout_focus_contract.py`
- Did not run local tests per repository/user instruction.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the targeting logic for `cmux new-workspace`, which can alter where workspaces get created when run from scripts or with environment context. Risk is limited to CLI behavior and is covered by updated socket-contract tests.
> 
> **Overview**
> `cmux new-workspace` now supports `--window <id|ref|index>` and sends `workspace.create` with either an explicit `window_id` or, by default, the caller’s `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` context (instead of assuming the current window).
> 
> Adds `applyWindowOrCallerContext` to avoid inheriting caller env when `--window` is explicitly provided, updates help/unknown-flag messaging, and extends the CLI socket contract test to cover both caller-context and explicit-window requests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfb4704858969fa5e2e575d6525deb9587baac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes routing for `cmux new-workspace` so new workspaces go to the caller’s window/context by default, with an explicit `--window` override. Prevents creating workspaces in the focused/scriptable window unintentionally and updates CLI help and tests.

- **Bug Fixes**
  - Added `--window <id|ref|index>` to target a specific window.
  - Default routing uses caller context from `CMUX_WORKSPACE_ID`/`CMUX_SURFACE_ID` when `--window` is not provided.
  - Explicit `--window` no longer inherits caller `workspace_id`/`surface_id`.
  - Updated CLI usage text and added socket-contract tests for `workspace.create` parameters.

<sup>Written for commit bdfb4704858969fa5e2e575d6525deb9587baac2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

