### PR TITLE
Fix shared WebView task manager attribution

### DIFF
--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -21,6 +21,15 @@ nonisolated struct CmuxTopResourceSummary: Sendable {
             "missing_pids": missingPIDs
         ]
     }
+
+    func attributedPayload(sharedAcross occurrenceCount: Int) -> [String: Any] {
+        guard occurrenceCount > 1 else { return payload() }
+        var attributed = self
+        attributed.cpuPercent /= Double(occurrenceCount)
+        attributed.residentBytes = attributed.residentBytes / Int64(occurrenceCount)
+        attributed.virtualBytes = attributed.virtualBytes / Int64(occurrenceCount)
+        return attributed.payload()
+    }
 }
 
 nonisolated struct CmuxTopProcessInfo: Sendable {

--- a/Sources/TerminalControllerTopSupport.swift
+++ b/Sources/TerminalControllerTopSupport.swift
@@ -216,11 +216,13 @@ extension TerminalController {
 
         let rootPIDs: Set<Int> = [pid]
         let pids = processSnapshot.expandedPIDs(rootPIDs: rootPIDs)
-        webview["shared_process_count"] = browserPIDOccurrences[pid] ?? 1
+        let sharedProcessCount = max(1, browserPIDOccurrences[pid] ?? 1)
+        let resources = processSnapshot.summary(for: pids, rootPIDs: rootPIDs)
+        webview["shared_process_count"] = sharedProcessCount
         webview["root_pids"] = rootPIDs.sorted()
         webview["top_level_pids"] = processSnapshot.topLevelPIDs(for: pids).sorted()
         webview["foreground_pgids"] = processSnapshot.foregroundProcessGroupIDs(for: pids).sorted()
-        webview["resources"] = processSnapshot.summaryPayload(for: pids, rootPIDs: rootPIDs)
+        webview["resources"] = resources.attributedPayload(sharedAcross: sharedProcessCount)
         webview["processes"] = includeProcesses ? processSnapshot.processTreePayload(for: pids, rootPIDs: rootPIDs) : []
         return pids
     }

--- a/cmuxTests/CmuxTopSnapshotScopeTests.swift
+++ b/cmuxTests/CmuxTopSnapshotScopeTests.swift
@@ -124,6 +124,61 @@ final class CmuxTopSnapshotScopeTests: XCTestCase {
         XCTAssertTrue(([fixture.parentPID] + fixture.childPIDs).allSatisfy { totalPIDs.contains($0) })
     }
 
+    @MainActor
+    func testSharedWebViewResourceRowsAreAttributedAcrossOccurrences() throws {
+        let fixture = try SpawnedProcessTree.start()
+        defer { fixture.terminate() }
+
+        let snapshot = CmuxTopProcessSnapshot.capture(includeProcessDetails: false)
+        var windows: [[String: Any]] = [[
+            "kind": "window",
+            "id": UUID().uuidString,
+            "index": 0,
+            "key": true,
+            "visible": true,
+            "app_process_pids": [],
+            "workspaces": [[
+                "kind": "workspace",
+                "id": UUID().uuidString,
+                "index": 0,
+                "title": "shared webview fixture",
+                "selected": true,
+                "pinned": false,
+                "tags": [],
+                "panes": [[
+                    "kind": "pane",
+                    "id": UUID().uuidString,
+                    "index": 0,
+                    "surfaces": [
+                        sharedWebViewSurface(pid: fixture.parentPID),
+                        sharedWebViewSurface(pid: fixture.parentPID)
+                    ]
+                ] as [String: Any]]
+            ] as [String: Any]]
+        ]]
+
+        let browserPIDOccurrences = TerminalController.shared.v2TopBrowserPIDOccurrences(in: windows)
+        XCTAssertEqual(browserPIDOccurrences[fixture.parentPID], 2)
+
+        _ = TerminalController.shared.v2AnnotateTopWindows(
+            &windows,
+            processSnapshot: snapshot,
+            browserPIDOccurrences: browserPIDOccurrences,
+            includeProcesses: false
+        )
+
+        let windowResources = try XCTUnwrap(windows[0]["resources"] as? [String: Any])
+        let windowResidentBytes = int64(windowResources["resident_bytes"])
+        let webViewResidentBytes = try annotatedWebViewResources(in: windows)
+            .map { int64($0["resident_bytes"]) }
+
+        XCTAssertGreaterThan(windowResidentBytes, 0)
+        XCTAssertEqual(webViewResidentBytes.count, 2)
+        for residentBytes in webViewResidentBytes {
+            XCTAssertLessThanOrEqual(abs(residentBytes * 2 - windowResidentBytes), 1)
+        }
+    }
+
     func testApplicationProcessAttachesToKeyWindow() {
         var windows: [[String: Any]] = [
             ["kind": "window", "id": "first", "key": false],
@@ -383,6 +438,35 @@ while allocations:
             throw XCTSkip("ps failed with status \(process.terminationStatus)")
         }
         return String(data: data, encoding: .utf8) ?? ""
+    }
+
+    private func sharedWebViewSurface(pid: Int) -> [String: Any] {
+        let surfaceID = UUID().uuidString
+        return [
+            "kind": "surface",
+            "id": surfaceID,
+            "index": 0,
+            "type": "browser",
+            "title": "Browser",
+            "webviews": [[
+                "kind": "webview",
+                "id": "\(surfaceID):webview",
+                "index": 0,
+                "title": "Shared WebView",
+                "pid": pid
+            ] as [String: Any]]
+        ]
+    }
+
+    private func annotatedWebViewResources(in windows: [[String: Any]]) throws -> [[String: Any]] {
+        let workspaces = try XCTUnwrap(windows[0]["workspaces"] as? [[String: Any]])
+        let panes = try XCTUnwrap(workspaces[0]["panes"] as? [[String: Any]])
+        let surfaces = try XCTUnwrap(panes[0]["surfaces"] as? [[String: Any]])
+        return try surfaces.map { surface in
+            let webviews = try XCTUnwrap(surface["webviews"] as? [[String: Any]])
+            let webview = try XCTUnwrap(webviews.first)
+            return try XCTUnwrap(webview["resources"] as? [String: Any])
+        }
     }
 
     private func int64(_ raw: Any?) -> Int64 {

--- a/cmuxTests/TaskManagerResourcesTests.swift
+++ b/cmuxTests/TaskManagerResourcesTests.swift
@@ -8,12 +8,7 @@ import XCTest
 
 final class TaskManagerResourcesTests: XCTestCase {
     func testAttributedPayloadProratesSharedResourceMeasurements() {
-        var summary = CmuxTopResourceSummary()
-        summary.cpuPercent = 42
-        summary.residentBytes = 1001
-        summary.virtualBytes = 2001
-        summary.processCount = 1
-        summary.pids = [101]
+        let summary = resourceSummary()
 
         let payload = summary.attributedPayload(sharedAcross: 2)
 
@@ -22,6 +17,25 @@ final class TaskManagerResourcesTests: XCTestCase {
         XCTAssertEqual(int64(payload["virtual_bytes"]), 1000)
         XCTAssertEqual(int(payload["process_count"]), 1)
         XCTAssertEqual(intArray(payload["pids"]), [101])
+        XCTAssertEqual(intArray(payload["missing_pids"]), [202])
+    }
+
+    func testAttributedPayloadReturnsUnmodifiedPayloadForSingleOccurrence() {
+        let payload = resourceSummary().attributedPayload(sharedAcross: 1)
+
+        assertUnmodifiedAttributedPayload(payload)
+    }
+
+    func testAttributedPayloadReturnsUnmodifiedPayloadForZeroOccurrences() {
+        let payload = resourceSummary().attributedPayload(sharedAcross: 0)
+
+        assertUnmodifiedAttributedPayload(payload)
+    }
+
+    func testAttributedPayloadReturnsUnmodifiedPayloadForNegativeOccurrences() {
+        let payload = resourceSummary().attributedPayload(sharedAcross: -1)
+
+        assertUnmodifiedAttributedPayload(payload)
     }
 
     func testParsesTypedIntPIDArrayFromSummaryPayload() {
@@ -48,6 +62,30 @@ final class TaskManagerResourcesTests: XCTestCase {
         let resources = CmuxTaskManagerResources(payload)
 
         XCTAssertEqual(resources.processIds, [101, 202])
+    }
+
+    private func resourceSummary() -> CmuxTopResourceSummary {
+        var summary = CmuxTopResourceSummary()
+        summary.cpuPercent = 42
+        summary.residentBytes = 1001
+        summary.virtualBytes = 2001
+        summary.processCount = 1
+        summary.pids = [101]
+        summary.missingPIDs = [202]
+        return summary
+    }
+
+    private func assertUnmodifiedAttributedPayload(
+        _ payload: [String: Any],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(double(payload["cpu_percent"]), 42, file: file, line: line)
+        XCTAssertEqual(int64(payload["resident_bytes"]), 1001, file: file, line: line)
+        XCTAssertEqual(int64(payload["virtual_bytes"]), 2001, file: file, line: line)
+        XCTAssertEqual(int(payload["process_count"]), 1, file: file, line: line)
+        XCTAssertEqual(intArray(payload["pids"]), [101], file: file, line: line)
+        XCTAssertEqual(intArray(payload["missing_pids"]), [202], file: file, line: line)
     }
 
     private func double(_ raw: Any?) -> Double {

--- a/cmuxTests/TaskManagerResourcesTests.swift
+++ b/cmuxTests/TaskManagerResourcesTests.swift
@@ -7,6 +7,23 @@ import XCTest
 #endif
 
 final class TaskManagerResourcesTests: XCTestCase {
+    func testAttributedPayloadProratesSharedResourceMeasurements() {
+        var summary = CmuxTopResourceSummary()
+        summary.cpuPercent = 42
+        summary.residentBytes = 1001
+        summary.virtualBytes = 2001
+        summary.processCount = 1
+        summary.pids = [101]
+
+        let payload = summary.attributedPayload(sharedAcross: 2)
+
+        XCTAssertEqual(double(payload["cpu_percent"]), 21)
+        XCTAssertEqual(int64(payload["resident_bytes"]), 500)
+        XCTAssertEqual(int64(payload["virtual_bytes"]), 1000)
+        XCTAssertEqual(int(payload["process_count"]), 1)
+        XCTAssertEqual(intArray(payload["pids"]), [101])
+    }
+
     func testParsesTypedIntPIDArrayFromSummaryPayload() {
         let payload: [String: Any] = [
             "cpu_percent": 3.5,
@@ -31,5 +48,35 @@ final class TaskManagerResourcesTests: XCTestCase {
         let resources = CmuxTaskManagerResources(payload)
 
         XCTAssertEqual(resources.processIds, [101, 202])
+    }
+
+    private func double(_ raw: Any?) -> Double {
+        if let value = raw as? Double { return value }
+        if let value = raw as? NSNumber { return value.doubleValue }
+        return 0
+    }
+
+    private func int64(_ raw: Any?) -> Int64 {
+        if let value = raw as? Int64 { return value }
+        if let value = raw as? Int { return Int64(value) }
+        if let value = raw as? NSNumber { return value.int64Value }
+        return 0
+    }
+
+    private func int(_ raw: Any?) -> Int {
+        if let value = raw as? Int { return value }
+        if let value = raw as? NSNumber { return value.intValue }
+        return 0
+    }
+
+    private func intArray(_ raw: Any?) -> [Int] {
+        if let values = raw as? [Int] { return values }
+        guard let values = raw as? [Any] else { return [] }
+        return values.compactMap { raw in
+            if let value = raw as? Int { return value }
+            if let value = raw as? NSNumber { return value.intValue }
+            if let value = raw as? String { return Int(value) }
+            return nil
+        }
     }
 }


### PR DESCRIPTION
Fixes task manager resource attribution for WebView rows that share the same WebContent PID. Each shared WebView row now shows its attributed share of CPU, resident memory, and virtual memory while keeping the PID list intact for process actions.

Verification:
- Local tagged reload: `./scripts/reload.sh --tag wvperc`
- Cloud Mac run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25772279288
- Cloud Mac targeted unit tests: `TaskManagerResourcesTests/testAttributedPayloadProratesSharedResourceMeasurements`, `CmuxTopSnapshotScopeTests/testSharedWebViewResourceRowsAreAttributedAcrossOccurrences`
- Cloud Mac tagged reload: `./scripts/reload.sh --tag wvpc1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts task manager resource attribution for WebView rows sharing a PID; risk is moderate because it changes how CPU/memory numbers are computed and displayed but is scoped and covered by new unit tests.
> 
> **Overview**
> Fixes task manager resource attribution when multiple WebView rows share the same WebContent PID by prorating CPU, resident memory, and virtual memory per occurrence while keeping the underlying PID lists intact for actions.
> 
> Adds `CmuxTopResourceSummary.attributedPayload(sharedAcross:)` and updates `v2AnnotateTopWebView` to use it (and to clamp `shared_process_count` to at least 1). Adds targeted unit tests validating both the prorating logic and end-to-end window/WebView annotation behavior for shared PIDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e58b18b2e806712613f939653286b391ede6182. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix resource attribution in the task manager for shared WebView rows. Each WebView now shows its proportional CPU, resident, and virtual memory when multiple rows share the same WebContent PID, while keeping PID lists usable for process actions; edge cases (<=1 occurrence) return unmodified totals.

- **Bug Fixes**
  - Prorate CPU, resident, and virtual memory across shared WebView rows via `attributedPayload(sharedAcross:)` (no-op for counts <= 1).
  - Use prorated resources when annotating WebView rows in `TerminalController`.
  - Add tests for prorating math, end-to-end shared-WebView annotation, edge cases (0/negative), and a regression verifying per-WebView attribution against window totals.

<sup>Written for commit 1e58b18b2e806712613f939653286b391ede6182. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced shared resource reporting: CPU percentage, resident memory, and virtual memory are now accurately distributed across multiple process occurrences, providing precise resource metrics for shared processes and webviews.

* **Tests**
  * Added comprehensive test coverage for shared resource attribution calculations and multi-occurrence resource distribution scenarios.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4047)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->