### PR TITLE
Add Pi agent icon

### DIFF
--- a/Assets.xcassets/AgentIcons/Pi.imageset/Contents.json
+++ b/Assets.xcassets/AgentIcons/Pi.imageset/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "filename" : "Pi.svg",
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  },
+  "properties" : {
+    "preserves-vector-representation" : true
+  }
+}

--- a/Assets.xcassets/AgentIcons/Pi.imageset/Pi.svg
+++ b/Assets.xcassets/AgentIcons/Pi.imageset/Pi.svg
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 800">
+  <rect width="800" height="800" rx="120" fill="#09090b"/>
+  <path fill="#fff" fill-rule="evenodd" d="
+    M165.29 165.29
+    H517.36
+    V400
+    H400
+    V517.36
+    H282.65
+    V634.72
+    H165.29
+    Z
+    M282.65 282.65
+    V400
+    H400
+    V282.65
+    Z
+  "/>
+  <path fill="#fff" d="M517.36 400 H634.72 V634.72 H517.36 Z"/>
+</svg>

--- a/Sources/VaultAgentRegistry.swift
+++ b/Sources/VaultAgentRegistry.swift
@@ -113,6 +113,7 @@ struct CmuxVaultAgentRegistration: Codable, Hashable, Sendable {
         CmuxVaultAgentRegistration(
             id: "pi",
             name: "Pi",
+            iconAssetName: "AgentIcons/Pi",
             detect: CmuxVaultAgentDetectRule(processName: "pi", argvContains: ["pi"]),
             sessionIdSource: .piSessionFile,
             resumeCommand: "{{executable}} --session {{sessionId}}",

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -40,6 +40,13 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         )
     }
 
+    func testBuiltInPiRegistrationUsesBrandedIconAsset() {
+        let agent = RegisteredSessionAgent(registration: CmuxVaultAgentRegistration.builtInPi)
+
+        XCTAssertEqual(agent.iconAssetName, "AgentIcons/Pi")
+        XCTAssertEqual(SessionAgent.registered(agent).assetName, "AgentIcons/Pi")
+    }
+
     func testRegisteredAgentTemplateFailsClosedWhenPlaceholderIsUnavailable() {
         let registration = CmuxVaultAgentRegistration(
             id: "acme-agent",


### PR DESCRIPTION
## Summary
- Add a vector Pi badge asset under AgentIcons/Pi from https://pi.dev/press-kit#brand-assets.
- Wire the built-in Pi Vault registration to use AgentIcons/Pi so Pi session rows use the branded avatar.
- Cover the registration-to-session-agent presentation path.

## Testing
- python3 -m json.tool Assets.xcassets/AgentIcons/Pi.imageset/Contents.json >/dev/null
- xmllint --noout Assets.xcassets/AgentIcons/Pi.imageset/Pi.svg
- ./scripts/reload.sh --tag pilogo

## Issues
- Related: https://pi.dev/press-kit#brand-assets

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new asset and wires it into the built-in Pi registration with a small test to guard the presentation path.
> 
> **Overview**
> Adds a new vector asset `AgentIcons/Pi` (SVG + asset catalog metadata) for the Pi agent.
> 
> Updates `CmuxVaultAgentRegistration.builtInPi` to set `iconAssetName: "AgentIcons/Pi"`, and adds a unit test asserting the built-in Pi registration flows through to `RegisteredSessionAgent`/`SessionAgent` with the branded asset name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 109d3b20c94c345a7d2ba19ab22419a8070f2a66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a branded Pi agent icon and wires it into the built-in Pi Vault registration so Pi session rows show the Pi avatar. Includes a test covering the registration-to-session-agent path.

- **New Features**
  - Added `AgentIcons/Pi` SVG from the Pi brand kit (vector preserved).
  - Updated built-in Pi registration to use `AgentIcons/Pi`; test verifies sessions use the branded icon.

<sup>Written for commit 109d3b20c94c345a7d2ba19ab22419a8070f2a66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a branded icon asset for the Pi agent with vector graphics support.

* **Tests**
  * Added test coverage to verify the Pi agent uses the branded icon asset correctly.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4057)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->