### PR TITLE
Handle bridged Codex plan updates in Feed

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17977,6 +17977,73 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         return nil
     }
 
+    private func codexPlanFeedToolInput(
+        rawEvent: String,
+        toolName: String,
+        rawObject: [String: Any]
+    ) -> [String: Any]? {
+        let eventTokens = [
+            rawEvent,
+            firstString(in: rawObject, keys: ["method", "type", "event", "hook_event_name"]) ?? "",
+            toolName,
+        ].map { $0.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() }
+
+        let looksLikeCodexPlanUpdate = eventTokens.contains { token in
+            switch token {
+            case "turn/plan/updated", "turnplanupdated", "planupdate", "plan_update", "update_plan":
+                return true
+            default:
+                return false
+            }
+        }
+        guard looksLikeCodexPlanUpdate else { return nil }
+
+        let candidate = (rawObject["params"] as? [String: Any])
+            ?? feedToolInputDictionary(rawObject["tool_input"])
+            ?? rawObject
+        guard let rawPlan = candidate["plan"] as? [Any] else { return nil }
+
+        let todos: [[String: Any]] = rawPlan.enumerated().compactMap { index, raw in
+            let step: String?
+            let status: Any?
+            if let text = raw as? String {
+                step = text
+                status = nil
+            } else if let dict = raw as? [String: Any] {
+                step = firstString(in: dict, keys: ["step", "content", "text", "title"])
+                status = dict["status"] ?? dict["state"]
+            } else {
+                step = nil
+                status = nil
+            }
+            guard let step else { return nil }
+            return [
+                "id": "plan-\(index)",
+                "content": step,
+                "status": codexPlanTodoStatus(from: status),
+            ]
+        }
+        guard !todos.isEmpty else { return nil }
+
+        var toolInput: [String: Any] = ["todos": todos]
+        if let explanation = firstString(in: candidate, keys: ["explanation"]) {
+            toolInput["explanation"] = explanation
+        }
+        return toolInput
+    }
+
+    private func codexPlanTodoStatus(from raw: Any?) -> String {
+        guard let string = raw as? String else { return "pending" }
+        switch string.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "completed", "complete", "done":
+            return "completed"
+        case "inprogress", "in_progress", "active", "running":
+            return "in_progress"
+        default:
+            return "pending"
+        }
+    }
+
     private func enrichUserPromptSubmitFeedEvent(
         _ event: inout [String: Any],
         hookEventName: String,
@@ -18170,6 +18237,13 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             summary = firstString(in: dict, keys: ["description", "command"])
         } else if ["write", "edit", "multiedit", "read"].contains(lower) {
             summary = firstString(in: dict, keys: ["file_path", "path"])
+        } else if lower == "update_plan" {
+            summary = firstString(in: dict, keys: ["explanation"])
+            if summary == nil,
+               let todos = dict["todos"] as? [[String: Any]],
+               let first = todos.first {
+                summary = firstString(in: first, keys: ["content", "step", "text", "title"])
+            }
         } else if lower == "askuserquestion" {
             if let questions = dict["questions"] as? [[String: Any]],
                let first = questions.first {
@@ -19688,12 +19762,26 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         // Derive the hook event name, mapped to our wire format. Claude
         // uses `hook_event_name`; Codex uses `event` or `hook_event_name`.
-        let rawEvent = (stdinObj["hook_event_name"] as? String)
+        var rawEvent = (stdinObj["hook_event_name"] as? String)
             ?? (stdinObj["event"] as? String)
             ?? optionValue(commandArgs, name: "--event")
             ?? ""
-        let toolName = (stdinObj["tool_name"] as? String) ?? ""
+        var toolName = (stdinObj["tool_name"] as? String) ?? ""
         let sessionId = (stdinObj["session_id"] as? String) ?? UUID().uuidString
+        let codexPlanToolInput: [String: Any]?
+        if source == "codex" {
+            codexPlanToolInput = codexPlanFeedToolInput(
+                rawEvent: rawEvent,
+                toolName: toolName,
+                rawObject: stdinObj
+            )
+        } else {
+            codexPlanToolInput = nil
+        }
+        if codexPlanToolInput != nil {
+            rawEvent = "TodoWrite"
+            toolName = "update_plan"
+        }
 
         // Decide whether this event is Feed-actionable. Non-actionable
         // events are forwarded as telemetry (non-blocking) and exit `{}`
@@ -19742,7 +19830,9 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         if let cwd = stdinObj["cwd"] as? String { eventDict["cwd"] = cwd }
         if !toolName.isEmpty { eventDict["tool_name"] = toolName }
         let promptText = hookEventName == "UserPromptSubmit" ? feedPromptText(from: stdinObj) : nil
-        if let toolInput = stdinObj["tool_input"] {
+        if let codexPlanToolInput {
+            eventDict["tool_input"] = codexPlanToolInput
+        } else if let toolInput = stdinObj["tool_input"] {
             eventDict["tool_input"] = toolInput
         }
         if let context = feedContextForEvent(
@@ -19857,6 +19947,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 return ("Stop", false)
             case "Notification":
                 return ("Notification", false)
+            case "TodoWrite":
+                return ("TodoWrite", false)
             default:
                 return ("PreToolUse", false)
             }

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -404,6 +404,87 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
         )
     }
 
+    func testCodexFeedHookNormalizesPlanUpdatedFramesToTodos() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex-plan-feed")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+
+            XCTAssertEqual(method, "feed.push")
+            let params = payload["params"] as? [String: Any] ?? [:]
+            XCTAssertEqual((params["wait_timeout_seconds"] as? NSNumber)?.doubleValue, 0.0)
+            let event = params["event"] as? [String: Any] ?? [:]
+            XCTAssertEqual(event["hook_event_name"] as? String, "TodoWrite")
+            XCTAssertEqual(event["_source"] as? String, "codex")
+            XCTAssertEqual(event["tool_name"] as? String, "update_plan")
+            XCTAssertEqual(event["workspace_id"] as? String, workspaceId)
+
+            let toolInput = event["tool_input"] as? [String: Any] ?? [:]
+            XCTAssertEqual(toolInput["explanation"] as? String, "Plan changed")
+            let todos = toolInput["todos"] as? [[String: Any]] ?? []
+            XCTAssertEqual(todos.count, 3)
+            XCTAssertEqual(todos[0]["content"] as? String, "Research Codex hooks")
+            XCTAssertEqual(todos[0]["status"] as? String, "completed")
+            XCTAssertEqual(todos[1]["content"] as? String, "Patch cmux Feed")
+            XCTAssertEqual(todos[1]["status"] as? String, "in_progress")
+            XCTAssertEqual(todos[2]["content"] as? String, "Open PR")
+            XCTAssertEqual(todos[2]["status"] as? String, "pending")
+
+            return self.v2Response(id: id, ok: true, result: ["status": "acknowledged"])
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "feed", "--source", "codex", "--event", "turn/plan/updated"],
+            environment: environment,
+            standardInput: #"""
+            {
+              "session_id": "codex-plan-session",
+              "cwd": "/tmp/codex-plan",
+              "method": "turn/plan/updated",
+              "params": {
+                "threadId": "thread-1",
+                "turnId": "turn-1",
+                "explanation": "Plan changed",
+                "plan": [
+                  {"step": "Research Codex hooks", "status": "completed"},
+                  {"step": "Patch cmux Feed", "status": "inProgress"},
+                  {"step": "Open PR", "status": "pending"}
+                ]
+              }
+            }
+            """#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+        XCTAssertTrue(result.stderr.isEmpty, result.stderr)
+        XCTAssertEqual(state.commands.count, 1)
+    }
+
     func testBrowserImportDefaultsNonInteractiveInCodingAgent() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("browser-import-agent")

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -18,7 +18,7 @@ Supported agent names are `codex`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, 
 | Agent | Binary checked | Installed file | Session restore | Feed bridge |
 | --- | --- | --- | --- | --- |
 | Claude Code | `claude` through wrapper | wrapper-injected settings | `claude --resume <id>` | PermissionRequest |
-| Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest |
+| Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest, bridged plan updates |
 | OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
 | Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | none |
 | Amp | `amp` | `~/.config/amp/plugins/cmux-session.ts` | `amp threads continue <id>` | none |

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -75,7 +75,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | Agent        | Config                                    | Feed trigger             |
 |--------------|-------------------------------------------|--------------------------|
 | Claude Code  | wrapper-injected                          | PermissionRequest        |
-| Codex        | `~/.codex/hooks.json`                     | PermissionRequest        |
+| Codex        | `~/.codex/hooks.json`                     | PermissionRequest, bridged plan updates |
 | OpenCode     | `~/.config/opencode/plugins/cmux-feed.js` | plugin event bus         |
 | Cursor CLI   | `~/.cursor/hooks.json`                    | beforeShellExecution     |
 | Gemini       | `~/.gemini/settings.json`                 | PreToolUse               |
@@ -124,7 +124,7 @@ For Claude Code, the cmux wrapper launches Claude with `--allow-dangerously-skip
 
 For Claude Code, AskUserQuestion is answered by allowing the PermissionRequest with an updated tool input containing the selected answers. Other agents use their native question reply shape where available.
 
-Codex's `request_user_input` and `update_plan` currently surface through its app-server request/notification path, not through command hooks. A stock `codex` TUI running in a cmux terminal keeps those frames inside Codex's in-process app-server client, so its plan-mode questions still fall back to Codex's own TUI. cmux can route Codex permission approvals through `PermissionRequest`; showing Codex plan questions in Feed would require launching Codex against a shared standalone app server and adding a Codex app-server Feed adapter, or upstream Codex hook coverage for those frames.
+Codex's command hook list currently includes lifecycle, tool, compact, prompt, permission, and stop events, but no dedicated plan event. Codex `update_plan` emits app-server `turn/plan/updated` notifications and `request_user_input` emits app-server requests. When a Codex app-server bridge forwards `turn/plan/updated` or `update_plan` payloads into `cmux hooks feed --source codex`, cmux normalizes them into Feed todo/progress telemetry. A stock `codex` TUI running in a cmux terminal still keeps plan-mode questions inside Codex's in-process app-server client, so those questions fall back to Codex's own TUI unless Codex adds command-hook coverage or cmux launches Codex against a shared app server adapter.
 
 ## Timeout behavior
 
@@ -156,7 +156,7 @@ Double-click a Feed row and cmux focuses the cmux workspace + surface where the 
 
 **Feed shows nothing even though the agent is running.** Check that the hook got installed: `cat ~/.codex/hooks.json` (or similar) should contain a `cmux hooks feed --source codex` entry. Re-run `cmux hooks setup`.
 
-**Codex plan-mode question stays in the terminal.** Codex `request_user_input` is not a hook event in the stock TUI path. Feed only sees Codex permission hooks today.
+**Codex plan-mode question stays in the terminal.** Codex `request_user_input` is not a command hook event in the stock TUI path. Feed sees Codex permission hooks and any app-server plan-update frames that a bridge forwards into `cmux hooks feed`.
 
 **Agent hangs on a permission request.** Feed never blocks the agent longer than 120 seconds; if you see a longer hang, the hook failed to reach the socket. Verify `$CMUX_SOCKET_PATH` matches the running app (default is `~/.config/cmux/cmux.sock`).
 


### PR DESCRIPTION
## Summary
- researched current OpenAI Codex hooks at https://github.com/openai/codex/tree/2630a6ca35/codex-rs and confirmed command hooks do not include a dedicated plan event
- normalize bridged Codex app-server `turn/plan/updated` / `update_plan` payloads into Feed `TodoWrite` telemetry
- document the Codex plan-mode limitation and the bridge path

## Testing
- `./scripts/reload.sh --tag codplan`
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-codplan-unit build-for-testing`\n\n## Related\n- https://github.com/openai/codex

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds heuristic parsing/rewriting of Codex hook payloads to synthesize `TodoWrite`/`update_plan` events, which could misclassify or drop unexpected Codex frames and affect Feed telemetry rendering.
> 
> **Overview**
> **Codex plan updates can now show up in Feed as todo/progress activity.** The `cmux hooks feed --source codex` bridge detects bridged Codex app-server plan-update payloads (e.g. `turn/plan/updated` / `update_plan`), normalizes them into a synthetic `TodoWrite` event with an `update_plan`-shaped `tool_input` containing `todos` (+ optional `explanation`), and forwards that through `feed.push` as non-blocking telemetry.
> 
> Feed context summarization is updated to better describe `update_plan` events (prefer `explanation`, otherwise the first todo), a new integration test asserts the normalization behavior, and docs are updated to note Codex now supports *bridged plan updates* in Feed and to clarify remaining plan-question limitations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e09b86ff5db6137e33a6c7abf694306babae4ff9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Codex app‑server plan updates into Feed so `turn/plan/updated` and `update_plan` frames show up as `TodoWrite` with progress.

- **New Features**
  - When `--source codex`, detect plan update frames and emit Feed `TodoWrite` with `tool_name` `update_plan`.
  - Parse `plan` arrays into `todos` (string or object items). Map statuses to `completed`, `in_progress`, or `pending`. Include `explanation` when available.
  - Improve event summary for `update_plan` using `explanation` or the first todo’s content.
  - Add integration test that validates the normalization end‑to‑end.
  - Update docs to note no Codex command‑hook plan event and document the bridged path via `cmux hooks feed --source codex`.

<sup>Written for commit e09b86ff5db6137e33a6c7abf694306babae4ff9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Codex plan updates through the feed bridge system, automatically converting plan steps into normalized to-do items with status tracking.

* **Tests**
  * Added integration test validating Codex plan update frame normalization.

* **Documentation**
  * Updated documentation to reflect Codex bridged plan updates support.
  * Clarified Codex plan-mode decision semantics in feed behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4058)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->