### PR TITLE
Fix CircleCI macos-unit-tests: update test helper for restorableAgentResumeState rename

### DIFF
--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentAutoResumePending: false,
+            restorableAgentResumeState: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
PR #3921 renamed the field in production code but missed cmuxTests/WorkspaceUnitTests.swift; CircleCI job 10551 on main commit 4202d42e fails to compile; this PR is a one-line label and type rename in the test helper.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 5e56ca0ae7988b8c68cc689b57cce250997a05d1. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates WorkspaceUnitTests to use the renamed field `restorableAgentResumeState`, fixing the macOS unit test compile error and unblocking CircleCI.

- **Bug Fixes**
  - Replace `restorableAgentAutoResumePending: false` with `restorableAgentResumeState: nil` in WorkspaceUnitTests to match the production API rename and type change.

<sup>Written for commit 5e56ca0ae7988b8c68cc689b57cce250997a05d1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test helper for workspace initialization to reflect current detached surface state handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4068)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->