### PR TITLE
Add sortable cmux top output

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -756,6 +756,11 @@ private enum TopSortKey: Equatable {
     case proc
 }
 
+private enum TopTextFormat: Equatable {
+    case tree
+    case tsv
+}
+
 enum SocketPasswordResolver {
     private static let service = "com.cmuxterm.app.socket-control"
     private static let account = "local-socket-password"
@@ -9741,17 +9746,21 @@ struct CMUXCLI {
               --workspace <id|ref|index>   Show only one workspace
               --processes                  Include process trees under surfaces, webviews, and tags
               --sort <cpu|rss|proc>         Sort sibling rows by CPU, memory, or process count
+              --flat                        Print independent rows for shell sorting
+              --format <tree|tsv>           Text output format (tsv implies --flat)
               --json                        Structured JSON output
 
             Output:
               CPU comes from macOS process accounting and can exceed 100% across cores.
               RSS is summed across the unique process IDs attributed to each tree node.
               Browser webviews are attributed through their WebKit content process PID.
+              TSV columns are: cpu_percent, rss_bytes, process_count, kind, ref, parent_ref, title.
 
             Example:
               cmux top
               cmux top --all
               cmux top --sort cpu
+              cmux top --format tsv | sort -t $'\\t' -nrk1,1
               cmux top --workspace workspace:2 --processes
               cmux --json top --all
             """
@@ -11033,6 +11042,9 @@ struct CMUXCLI {
         let jsonOutput: Bool
         let showProcesses: Bool
         let sortKey: TopSortKey?
+        let textFormat: TopTextFormat
+        let requestedFlatOutput: Bool
+        let requestedFormat: Bool
     }
 
     private struct TreePath {
@@ -11100,16 +11112,29 @@ struct CMUXCLI {
         if structuredOutput, options.sortKey != nil {
             throw CLIError(message: "top: --sort is only supported for text output; use --json to sort structured data externally")
         }
+        if structuredOutput, options.requestedFlatOutput || options.requestedFormat {
+            throw CLIError(message: "top: --flat and --format are only supported for text output")
+        }
         let payload = try buildTopPayload(options: options, client: client)
         if structuredOutput {
             print(jsonString(formatIDs(payload, mode: idFormat)))
         } else {
-            print(renderTopText(
-                payload: payload,
-                idFormat: idFormat,
-                showProcesses: options.showProcesses,
-                sortKey: options.sortKey
-            ))
+            switch options.textFormat {
+            case .tree:
+                print(renderTopText(
+                    payload: payload,
+                    idFormat: idFormat,
+                    showProcesses: options.showProcesses,
+                    sortKey: options.sortKey
+                ))
+            case .tsv:
+                print(renderTopFlatTSV(
+                    payload: payload,
+                    idFormat: idFormat,
+                    showProcesses: options.showProcesses,
+                    sortKey: options.sortKey
+                ))
+            }
         }
     }
 
@@ -11122,12 +11147,17 @@ struct CMUXCLI {
         if rem1.contains("--sort") {
             throw CLIError(message: "top requires --sort <cpu|rss|proc>")
         }
+        let (formatOpt, rem2) = parseOption(rem1, name: "--format")
+        if rem2.contains("--format") {
+            throw CLIError(message: "top requires --format <tree|tsv>")
+        }
 
         var includeAll = false
         var jsonOutput = false
         var showProcesses = false
+        var flatOutput = false
         var remaining: [String] = []
-        for arg in rem1 {
+        for arg in rem2 {
             if arg == "--all" {
                 includeAll = true
                 continue
@@ -11140,14 +11170,22 @@ struct CMUXCLI {
                 showProcesses = true
                 continue
             }
+            if arg == "--flat" {
+                flatOutput = true
+                continue
+            }
             remaining.append(arg)
         }
 
         if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-            throw CLIError(message: "top: unknown flag '\(unknown)'. Known flags: --all --workspace <id|ref|index> --processes --sort <cpu|rss|proc> --json")
+            throw CLIError(message: "top: unknown flag '\(unknown)'. Known flags: --all --workspace <id|ref|index> --processes --sort <cpu|rss|proc> --flat --format <tree|tsv> --json")
         }
         if let extra = remaining.first {
             throw CLIError(message: "top: unexpected argument '\(extra)'")
+        }
+        let format = try parseTopTextFormat(formatOpt)
+        if flatOutput, format == .tree {
+            throw CLIError(message: "top: --flat requires --format tsv or no --format")
         }
 
         return TopCommandOptions(
@@ -11155,7 +11193,10 @@ struct CMUXCLI {
             workspaceHandle: workspaceOpt,
             jsonOutput: jsonOutput,
             showProcesses: showProcesses,
-            sortKey: try parseTopSortKey(sortOpt)
+            sortKey: try parseTopSortKey(sortOpt),
+            textFormat: format ?? (flatOutput ? .tsv : .tree),
+            requestedFlatOutput: flatOutput,
+            requestedFormat: formatOpt != nil
         )
     }
 
@@ -11171,6 +11212,19 @@ struct CMUXCLI {
             return .proc
         default:
             throw CLIError(message: "top: invalid --sort value '\(raw)'. Use cpu, rss, or proc")
+        }
+    }
+
+    private func parseTopTextFormat(_ raw: String?) throws -> TopTextFormat? {
+        guard let raw else { return nil }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "tree":
+            return .tree
+        case "tsv", "tab", "tabs":
+            return .tsv
+        default:
+            throw CLIError(message: "top: invalid --format value '\(raw)'. Use tree or tsv")
         }
     }
 
@@ -11807,6 +11861,260 @@ struct CMUXCLI {
         case .proc:
             return Double(topInt(resources["process_count"]) ?? 0)
         }
+    }
+
+    private struct TopFlatRow {
+        let resources: [String: Any]
+        let kind: String
+        let ref: String
+        let parentRef: String
+        let title: String
+        let ordinal: Int
+
+        var node: [String: Any] {
+            ["resources": resources]
+        }
+    }
+
+    private func renderTopFlatTSV(
+        payload: [String: Any],
+        idFormat: CLIIDFormat,
+        showProcesses: Bool,
+        sortKey: TopSortKey? = nil
+    ) -> String {
+        let windows = payload["windows"] as? [[String: Any]] ?? []
+        guard !windows.isEmpty else { return "" }
+
+        var rows: [TopFlatRow] = []
+        var ordinal = 0
+        if let totals = payload["totals"] as? [String: Any] {
+            appendTopFlatRow(
+                resources: totals,
+                kind: "total",
+                ref: "total",
+                parentRef: "",
+                title: "",
+                ordinal: &ordinal,
+                to: &rows
+            )
+        }
+
+        for window in windows {
+            let windowRef = topFlatHandle(window, fallback: "window", idFormat: idFormat)
+            appendTopFlatNode(
+                window,
+                kind: "window",
+                ref: windowRef,
+                parentRef: "total",
+                title: "",
+                ordinal: &ordinal,
+                to: &rows
+            )
+
+            let workspaces = window["workspaces"] as? [[String: Any]] ?? []
+            for workspace in workspaces {
+                let workspaceRef = topFlatHandle(workspace, fallback: "workspace", idFormat: idFormat)
+                appendTopFlatNode(
+                    workspace,
+                    kind: "workspace",
+                    ref: workspaceRef,
+                    parentRef: windowRef,
+                    title: workspace["title"] as? String ?? "",
+                    ordinal: &ordinal,
+                    to: &rows
+                )
+
+                for tag in workspace["tags"] as? [[String: Any]] ?? [] {
+                    let tagRef = topFlatHandle(tag, fallback: topLabelText(tag["key"] as? String), idFormat: idFormat)
+                    appendTopFlatNode(
+                        tag,
+                        kind: "tag",
+                        ref: tagRef,
+                        parentRef: workspaceRef,
+                        title: tag["value"] as? String ?? "",
+                        ordinal: &ordinal,
+                        to: &rows
+                    )
+                    if showProcesses {
+                        appendTopFlatProcesses(
+                            tag["processes"] as? [[String: Any]] ?? [],
+                            parentRef: tagRef,
+                            ordinal: &ordinal,
+                            to: &rows
+                        )
+                    }
+                }
+
+                for pane in workspace["panes"] as? [[String: Any]] ?? [] {
+                    let paneRef = topFlatHandle(pane, fallback: "pane", idFormat: idFormat)
+                    appendTopFlatNode(
+                        pane,
+                        kind: "pane",
+                        ref: paneRef,
+                        parentRef: workspaceRef,
+                        title: "",
+                        ordinal: &ordinal,
+                        to: &rows
+                    )
+
+                    for surface in pane["surfaces"] as? [[String: Any]] ?? [] {
+                        let surfaceRef = topFlatHandle(surface, fallback: "surface", idFormat: idFormat)
+                        appendTopFlatNode(
+                            surface,
+                            kind: "surface",
+                            ref: surfaceRef,
+                            parentRef: paneRef,
+                            title: surface["title"] as? String ?? "",
+                            ordinal: &ordinal,
+                            to: &rows
+                        )
+
+                        for webview in surface["webviews"] as? [[String: Any]] ?? [] {
+                            let fallback = topInt(webview["pid"]).map { "pid:\($0)" } ?? "webview"
+                            let webviewRef = topFlatHandle(webview, fallback: fallback, idFormat: idFormat)
+                            appendTopFlatNode(
+                                webview,
+                                kind: "webview",
+                                ref: webviewRef,
+                                parentRef: surfaceRef,
+                                title: webview["title"] as? String ?? "",
+                                ordinal: &ordinal,
+                                to: &rows
+                            )
+                            if showProcesses {
+                                appendTopFlatProcesses(
+                                    webview["processes"] as? [[String: Any]] ?? [],
+                                    parentRef: webviewRef,
+                                    ordinal: &ordinal,
+                                    to: &rows
+                                )
+                            }
+                        }
+
+                        if showProcesses {
+                            appendTopFlatProcesses(
+                                surface["processes"] as? [[String: Any]] ?? [],
+                                parentRef: surfaceRef,
+                                ordinal: &ordinal,
+                                to: &rows
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        let outputRows: [TopFlatRow]
+        if let sortKey {
+            outputRows = rows.sorted { lhs, rhs in
+                let lhsValue = topSortValue(lhs.node, sortKey: sortKey)
+                let rhsValue = topSortValue(rhs.node, sortKey: sortKey)
+                guard lhsValue != rhsValue else { return lhs.ordinal < rhs.ordinal }
+                return lhsValue > rhsValue
+            }
+        } else {
+            outputRows = rows
+        }
+
+        return outputRows.map(topFlatTSVLine).joined(separator: "\n")
+    }
+
+    private func appendTopFlatNode(
+        _ node: [String: Any],
+        kind: String,
+        ref: String,
+        parentRef: String,
+        title: String,
+        ordinal: inout Int,
+        to rows: inout [TopFlatRow]
+    ) {
+        appendTopFlatRow(
+            resources: node["resources"] as? [String: Any] ?? [:],
+            kind: kind,
+            ref: ref,
+            parentRef: parentRef,
+            title: title,
+            ordinal: &ordinal,
+            to: &rows
+        )
+    }
+
+    private func appendTopFlatProcesses(
+        _ processes: [[String: Any]],
+        parentRef: String,
+        ordinal: inout Int,
+        to rows: inout [TopFlatRow]
+    ) {
+        for process in processes {
+            let processRef = topInt(process["pid"]).map(String.init)
+                ?? topFlatHandle(process, fallback: "process", idFormat: .refs)
+            appendTopFlatNode(
+                process,
+                kind: "process",
+                ref: processRef,
+                parentRef: parentRef,
+                title: process["name"] as? String ?? "",
+                ordinal: &ordinal,
+                to: &rows
+            )
+            appendTopFlatProcesses(
+                process["children"] as? [[String: Any]] ?? [],
+                parentRef: processRef,
+                ordinal: &ordinal,
+                to: &rows
+            )
+        }
+    }
+
+    private func appendTopFlatRow(
+        resources: [String: Any],
+        kind: String,
+        ref: String,
+        parentRef: String,
+        title: String,
+        ordinal: inout Int,
+        to rows: inout [TopFlatRow]
+    ) {
+        rows.append(TopFlatRow(
+            resources: resources,
+            kind: kind,
+            ref: ref,
+            parentRef: parentRef,
+            title: title,
+            ordinal: ordinal
+        ))
+        ordinal += 1
+    }
+
+    private func topFlatHandle(_ node: [String: Any], fallback: String, idFormat: CLIIDFormat) -> String {
+        let handle = topLabelText(textHandle(node, idFormat: idFormat))
+        if handle != "?" {
+            return handle
+        }
+        let sanitizedFallback = topLabelText(fallback)
+        return sanitizedFallback.isEmpty ? "unknown" : sanitizedFallback
+    }
+
+    private func topFlatTSVLine(_ row: TopFlatRow) -> String {
+        [
+            topFlatCPU(row.resources),
+            String(topInt64(row.resources["resident_bytes"])),
+            String(topInt(row.resources["process_count"]) ?? 0),
+            topTSVField(row.kind),
+            topTSVField(row.ref),
+            topTSVField(row.parentRef),
+            topTSVField(row.title),
+        ].joined(separator: "\t")
+    }
+
+    private func topFlatCPU(_ resources: [String: Any]) -> String {
+        let value = topDouble(resources["cpu_percent"])
+        guard value.isFinite else { return "0.0" }
+        return String(format: "%.1f", value)
+    }
+
+    private func topTSVField(_ raw: String) -> String {
+        topLabelText(raw)
     }
 
     private func appendTopProcessLines(
@@ -21809,7 +22117,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           list-panes [--workspace <id|ref>]
           list-pane-surfaces [--workspace <id|ref>] [--pane <id|ref>]
           tree [--all] [--workspace <id|ref|index>]
-          top [--all] [--workspace <id|ref|index>] [--processes] [--sort <cpu|rss|proc>]
+          top [--all] [--workspace <id|ref|index>] [--processes] [--sort <cpu|rss|proc>] [--flat] [--format <tree|tsv>]
           focus-pane --pane <id|ref> [--workspace <id|ref>]
           new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>] [--focus <true|false>]
           new-surface [--type <terminal|browser>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>] [--focus <true|false>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -750,6 +750,12 @@ enum CLIIDFormat: String {
     }
 }
 
+private enum TopSortKey: Equatable {
+    case cpu
+    case rss
+    case proc
+}
+
 enum SocketPasswordResolver {
     private static let service = "com.cmuxterm.app.socket-control"
     private static let account = "local-socket-password"
@@ -9734,6 +9740,7 @@ struct CMUXCLI {
               --all                         Include all windows (default: current window only)
               --workspace <id|ref|index>   Show only one workspace
               --processes                  Include process trees under surfaces, webviews, and tags
+              --sort <cpu|rss|proc>         Sort sibling rows by CPU, memory, or process count
               --json                        Structured JSON output
 
             Output:
@@ -9744,6 +9751,7 @@ struct CMUXCLI {
             Example:
               cmux top
               cmux top --all
+              cmux top --sort cpu
               cmux top --workspace workspace:2 --processes
               cmux --json top --all
             """
@@ -11024,6 +11032,7 @@ struct CMUXCLI {
         let workspaceHandle: String?
         let jsonOutput: Bool
         let showProcesses: Bool
+        let sortKey: TopSortKey?
     }
 
     private struct TreePath {
@@ -11088,11 +11097,19 @@ struct CMUXCLI {
     ) throws {
         let options = try parseTopCommandOptions(commandArgs)
         let structuredOutput = jsonOutput || options.jsonOutput
+        if structuredOutput, options.sortKey != nil {
+            throw CLIError(message: "top: --sort is only supported for text output; use --json to sort structured data externally")
+        }
         let payload = try buildTopPayload(options: options, client: client)
         if structuredOutput {
             print(jsonString(formatIDs(payload, mode: idFormat)))
         } else {
-            print(renderTopText(payload: payload, idFormat: idFormat, showProcesses: options.showProcesses))
+            print(renderTopText(
+                payload: payload,
+                idFormat: idFormat,
+                showProcesses: options.showProcesses,
+                sortKey: options.sortKey
+            ))
         }
     }
 
@@ -11101,12 +11118,16 @@ struct CMUXCLI {
         if rem0.contains("--workspace") {
             throw CLIError(message: "top requires --workspace <id|ref|index>")
         }
+        let (sortOpt, rem1) = parseOption(rem0, name: "--sort")
+        if rem1.contains("--sort") {
+            throw CLIError(message: "top requires --sort <cpu|rss|proc>")
+        }
 
         var includeAll = false
         var jsonOutput = false
         var showProcesses = false
         var remaining: [String] = []
-        for arg in rem0 {
+        for arg in rem1 {
             if arg == "--all" {
                 includeAll = true
                 continue
@@ -11123,7 +11144,7 @@ struct CMUXCLI {
         }
 
         if let unknown = remaining.first(where: { $0.hasPrefix("--") }) {
-            throw CLIError(message: "top: unknown flag '\(unknown)'. Known flags: --all --workspace <id|ref|index> --processes --json")
+            throw CLIError(message: "top: unknown flag '\(unknown)'. Known flags: --all --workspace <id|ref|index> --processes --sort <cpu|rss|proc> --json")
         }
         if let extra = remaining.first {
             throw CLIError(message: "top: unexpected argument '\(extra)'")
@@ -11133,8 +11154,24 @@ struct CMUXCLI {
             includeAllWindows: includeAll,
             workspaceHandle: workspaceOpt,
             jsonOutput: jsonOutput,
-            showProcesses: showProcesses
+            showProcesses: showProcesses,
+            sortKey: try parseTopSortKey(sortOpt)
         )
+    }
+
+    private func parseTopSortKey(_ raw: String?) throws -> TopSortKey? {
+        guard let raw else { return nil }
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch normalized {
+        case "cpu", "cpu%":
+            return .cpu
+        case "rss", "mem", "memory", "ram":
+            return .rss
+        case "proc", "process", "processes", "count":
+            return .proc
+        default:
+            throw CLIError(message: "top: invalid --sort value '\(raw)'. Use cpu, rss, or proc")
+        }
     }
 
     private func buildTopPayload(
@@ -11639,7 +11676,8 @@ struct CMUXCLI {
     private func renderTopText(
         payload: [String: Any],
         idFormat: CLIIDFormat,
-        showProcesses: Bool
+        showProcesses: Bool,
+        sortKey: TopSortKey? = nil
     ) -> String {
         let windows = payload["windows"] as? [[String: Any]] ?? []
         guard !windows.isEmpty else { return "No windows" }
@@ -11649,10 +11687,10 @@ struct CMUXCLI {
             lines.append("\(topResourceColumns(resources: totals))total")
         }
 
-        for window in windows {
+        for window in topSortedItems(windows, sortKey: sortKey, node: { $0 }) {
             lines.append("\(topResourceColumns(node: window))\(topWindowLabel(window, idFormat: idFormat))")
 
-            let workspaces = window["workspaces"] as? [[String: Any]] ?? []
+            let workspaces = topSortedItems(window["workspaces"] as? [[String: Any]] ?? [], sortKey: sortKey, node: { $0 })
             for (workspaceIndex, workspace) in workspaces.enumerated() {
                 let workspaceIsLast = workspaceIndex == workspaces.count - 1
                 let workspaceBranch = workspaceIsLast ? "└── " : "├── "
@@ -11661,57 +11699,69 @@ struct CMUXCLI {
 
                 let tags = workspace["tags"] as? [[String: Any]] ?? []
                 let panes = workspace["panes"] as? [[String: Any]] ?? []
-                let workspaceChildCount = tags.count + panes.count
-                var workspaceChildIndex = 0
+                let workspaceChildren = topSortedItems(
+                    tags.map { TopWorkspaceChild.tag($0) } + panes.map { TopWorkspaceChild.pane($0) },
+                    sortKey: sortKey,
+                    node: { $0.node }
+                )
 
-                for tag in tags {
-                    let tagIsLast = workspaceChildIndex == workspaceChildCount - 1
-                    workspaceChildIndex += 1
-                    let tagBranch = tagIsLast ? "└── " : "├── "
-                    let tagIndent = tagIsLast ? "    " : "│   "
-                    lines.append("\(topResourceColumns(node: tag))\(workspaceIndent)\(tagBranch)\(topTagLabel(tag))")
-                    if showProcesses {
-                        appendTopProcessLines(
-                            tag["processes"] as? [[String: Any]] ?? [],
-                            to: &lines,
-                            indent: workspaceIndent + tagIndent
-                        )
-                    }
-                }
+                for (workspaceChildIndex, workspaceChild) in workspaceChildren.enumerated() {
+                    let childIsLast = workspaceChildIndex == workspaceChildren.count - 1
+                    switch workspaceChild {
+                    case .tag(let tag):
+                        let tagIsLast = childIsLast
+                        let tagBranch = tagIsLast ? "└── " : "├── "
+                        let tagIndent = tagIsLast ? "    " : "│   "
+                        lines.append("\(topResourceColumns(node: tag))\(workspaceIndent)\(tagBranch)\(topTagLabel(tag))")
+                        if showProcesses {
+                            appendTopProcessLines(
+                                tag["processes"] as? [[String: Any]] ?? [],
+                                to: &lines,
+                                indent: workspaceIndent + tagIndent,
+                                sortKey: sortKey
+                            )
+                        }
+                    case .pane(let pane):
+                        let paneIsLast = childIsLast
+                        let paneBranch = paneIsLast ? "└── " : "├── "
+                        let paneIndent = paneIsLast ? "    " : "│   "
+                        lines.append("\(topResourceColumns(node: pane))\(workspaceIndent)\(paneBranch)\(topPaneLabel(pane, idFormat: idFormat))")
 
-                for pane in panes {
-                    let paneIsLast = workspaceChildIndex == workspaceChildCount - 1
-                    workspaceChildIndex += 1
-                    let paneBranch = paneIsLast ? "└── " : "├── "
-                    let paneIndent = paneIsLast ? "    " : "│   "
-                    lines.append("\(topResourceColumns(node: pane))\(workspaceIndent)\(paneBranch)\(topPaneLabel(pane, idFormat: idFormat))")
+                        let surfaces = topSortedItems(pane["surfaces"] as? [[String: Any]] ?? [], sortKey: sortKey, node: { $0 })
+                        for (surfaceIndex, surface) in surfaces.enumerated() {
+                            let surfaceIsLast = surfaceIndex == surfaces.count - 1
+                            let surfaceBranch = surfaceIsLast ? "└── " : "├── "
+                            let surfaceIndent = surfaceIsLast ? "    " : "│   "
+                            lines.append("\(topResourceColumns(node: surface))\(workspaceIndent)\(paneIndent)\(surfaceBranch)\(topSurfaceLabel(surface, idFormat: idFormat))")
 
-                    let surfaces = pane["surfaces"] as? [[String: Any]] ?? []
-                    for (surfaceIndex, surface) in surfaces.enumerated() {
-                        let surfaceIsLast = surfaceIndex == surfaces.count - 1
-                        let surfaceBranch = surfaceIsLast ? "└── " : "├── "
-                        let surfaceIndent = surfaceIsLast ? "    " : "│   "
-                        lines.append("\(topResourceColumns(node: surface))\(workspaceIndent)\(paneIndent)\(surfaceBranch)\(topSurfaceLabel(surface, idFormat: idFormat))")
-
-                        let webviews = surface["webviews"] as? [[String: Any]] ?? []
-                        let surfaceProcesses = surface["processes"] as? [[String: Any]] ?? []
-                        let hasSurfaceProcesses = showProcesses && !surfaceProcesses.isEmpty
-                        if !webviews.isEmpty {
-                            for (webviewIndex, webview) in webviews.enumerated() {
-                                let webviewIsLast = webviewIndex == webviews.count - 1 && !hasSurfaceProcesses
-                                let webviewBranch = webviewIsLast ? "└── " : "├── "
-                                let webviewIndent = webviewIsLast ? "    " : "│   "
-                                lines.append("\(topResourceColumns(node: webview))\(workspaceIndent)\(paneIndent)\(surfaceIndent)\(webviewBranch)\(topWebViewLabel(webview))")
-                                if showProcesses {
-                                    appendTopProcessLines(
-                                        webview["processes"] as? [[String: Any]] ?? [],
-                                        to: &lines,
-                                        indent: workspaceIndent + paneIndent + surfaceIndent + webviewIndent
-                                    )
+                            let webviews = topSortedItems(surface["webviews"] as? [[String: Any]] ?? [], sortKey: sortKey, node: { $0 })
+                            let surfaceProcesses = surface["processes"] as? [[String: Any]] ?? []
+                            let hasSurfaceProcesses = showProcesses && !surfaceProcesses.isEmpty
+                            if !webviews.isEmpty {
+                                for (webviewIndex, webview) in webviews.enumerated() {
+                                    let webviewIsLast = webviewIndex == webviews.count - 1 && !hasSurfaceProcesses
+                                    let webviewBranch = webviewIsLast ? "└── " : "├── "
+                                    let webviewIndent = webviewIsLast ? "    " : "│   "
+                                    lines.append("\(topResourceColumns(node: webview))\(workspaceIndent)\(paneIndent)\(surfaceIndent)\(webviewBranch)\(topWebViewLabel(webview))")
+                                    if showProcesses {
+                                        appendTopProcessLines(
+                                            webview["processes"] as? [[String: Any]] ?? [],
+                                            to: &lines,
+                                            indent: workspaceIndent + paneIndent + surfaceIndent + webviewIndent,
+                                            sortKey: sortKey
+                                        )
+                                    }
                                 }
                             }
+                            if showProcesses {
+                                appendTopProcessLines(
+                                    surfaceProcesses,
+                                    to: &lines,
+                                    indent: workspaceIndent + paneIndent + surfaceIndent,
+                                    sortKey: sortKey
+                                )
+                            }
                         }
-                        if showProcesses { appendTopProcessLines(surfaceProcesses, to: &lines, indent: workspaceIndent + paneIndent + surfaceIndent) }
                     }
                 }
             }
@@ -11720,20 +11770,62 @@ struct CMUXCLI {
         return lines.joined(separator: "\n")
     }
 
+    private enum TopWorkspaceChild {
+        case tag([String: Any])
+        case pane([String: Any])
+
+        var node: [String: Any] {
+            switch self {
+            case .tag(let node), .pane(let node):
+                return node
+            }
+        }
+    }
+
+    private func topSortedItems<T>(
+        _ items: [T],
+        sortKey: TopSortKey?,
+        node: (T) -> [String: Any]
+    ) -> [T] {
+        guard let sortKey else { return items }
+        return items.enumerated().sorted { lhs, rhs in
+            let lhsValue = topSortValue(node(lhs.element), sortKey: sortKey)
+            let rhsValue = topSortValue(node(rhs.element), sortKey: sortKey)
+            guard lhsValue != rhsValue else { return lhs.offset < rhs.offset }
+            return lhsValue > rhsValue
+        }.map(\.element)
+    }
+
+    private func topSortValue(_ node: [String: Any], sortKey: TopSortKey) -> Double {
+        let resources = node["resources"] as? [String: Any] ?? [:]
+        switch sortKey {
+        case .cpu:
+            let value = topDouble(resources["cpu_percent"])
+            return value.isFinite ? value : 0
+        case .rss:
+            return Double(topInt64(resources["resident_bytes"]))
+        case .proc:
+            return Double(topInt(resources["process_count"]) ?? 0)
+        }
+    }
+
     private func appendTopProcessLines(
         _ processes: [[String: Any]],
         to lines: inout [String],
-        indent: String
+        indent: String,
+        sortKey: TopSortKey?
     ) {
-        for (index, process) in processes.enumerated() {
-            let isLast = index == processes.count - 1
+        let sortedProcesses = topSortedItems(processes, sortKey: sortKey, node: { $0 })
+        for (index, process) in sortedProcesses.enumerated() {
+            let isLast = index == sortedProcesses.count - 1
             let branch = isLast ? "└── " : "├── "
             let childIndent = isLast ? "    " : "│   "
             lines.append("\(topResourceColumns(node: process))\(indent)\(branch)\(topProcessLabel(process))")
             appendTopProcessLines(
                 process["children"] as? [[String: Any]] ?? [],
                 to: &lines,
-                indent: indent + childIndent
+                indent: indent + childIndent,
+                sortKey: sortKey
             )
         }
     }
@@ -21717,7 +21809,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
           list-panes [--workspace <id|ref>]
           list-pane-surfaces [--workspace <id|ref>] [--pane <id|ref>]
           tree [--all] [--workspace <id|ref|index>]
-          top [--all] [--workspace <id|ref|index>] [--processes]
+          top [--all] [--workspace <id|ref|index>] [--processes] [--sort <cpu|rss|proc>]
           focus-pane --pane <id|ref> [--workspace <id|ref>]
           new-pane [--type <terminal|browser>] [--direction <left|right|up|down>] [--workspace <id|ref>] [--url <url>] [--focus <true|false>]
           new-surface [--type <terminal|browser>] [--pane <id|ref>] [--workspace <id|ref>] [--url <url>] [--focus <true|false>]

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -196,6 +196,112 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertTrue(lines[4].contains("tag codex"), result.stdout)
     }
 
+    func testTopCommandOutputsFlatTSVForShellSorting() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("top-tsv")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let payload: [String: Any] = [
+            "totals": topResources(cpu: 12, rss: 12_000, processCount: 4),
+            "windows": [
+                topNode(ref: "window:1", cpu: 2, rss: 2_000, processCount: 2, extra: [
+                    "workspaces": [
+                        topNode(ref: "workspace:1", cpu: 10, rss: 10_000, processCount: 3, extra: [
+                            "title": "High\tCPU\nWorkspace",
+                        ]),
+                    ],
+                ]),
+            ],
+        ]
+        let serverHandled = startTopMockServer(listenerFD: listenerFD, payload: payload)
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["top", "--flat", "--format", "tsv"]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(outputLines(result.stdout), [
+            "12.0\t12000\t4\ttotal\ttotal\t\t",
+            "2.0\t2000\t2\twindow\twindow:1\ttotal\t",
+            "10.0\t10000\t3\tworkspace\tworkspace:1\twindow:1\tHigh CPU Workspace",
+        ])
+    }
+
+    func testTopCommandFormatTSVImpliesFlatOutput() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("top-fmt")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let payload: [String: Any] = [
+            "windows": [
+                topNode(ref: "window:1", cpu: 2, rss: 2_000, processCount: 2),
+            ],
+        ]
+        let serverHandled = startTopMockServer(listenerFD: listenerFD, payload: payload)
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["top", "--format", "tsv"]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(outputLines(result.stdout), [
+            "2.0\t2000\t2\twindow\twindow:1\ttotal\t",
+        ])
+    }
+
+    func testTopCommandSortsFlatTSVGloballyByMemory() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("top-tsv-sort")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let payload: [String: Any] = [
+            "windows": [
+                topNode(ref: "window:1", cpu: 2, rss: 2_000, processCount: 2, extra: [
+                    "workspaces": [
+                        topNode(ref: "workspace:low", cpu: 1, rss: 1_000, processCount: 1),
+                        topNode(ref: "workspace:high", cpu: 3, rss: 10_000, processCount: 3),
+                    ],
+                ]),
+            ],
+        ]
+        let serverHandled = startTopMockServer(listenerFD: listenerFD, payload: payload)
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["top", "--format", "tsv", "--sort", "rss"]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(outputLines(result.stdout), [
+            "3.0\t10000\t3\tworkspace\tworkspace:high\twindow:1\t",
+            "2.0\t2000\t2\twindow\twindow:1\ttotal\t",
+            "1.0\t1000\t1\tworkspace\tworkspace:low\twindow:1\t",
+        ])
+    }
+
     private func runCLI(cliPath: String, socketPath: String, arguments: [String]) -> ProcessRunResult {
         var environment = ProcessInfo.processInfo.environment
         environment["CMUX_SOCKET_PATH"] = socketPath

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -120,6 +120,82 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertEqual(state.commands.compactMap { Self.v2Payload(from: $0)?["method"] as? String }, ["file.open", "workspace.create"])
     }
 
+    func testTopCommandSortsWorkspacesByCPUDescending() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("top-cpu")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let payload: [String: Any] = [
+            "windows": [
+                topNode(ref: "window:1", cpu: 2, rss: 2_000, processCount: 2, extra: [
+                    "workspaces": [
+                        topNode(ref: "workspace:low", cpu: 1, rss: 1_000, processCount: 1),
+                        topNode(ref: "workspace:high", cpu: 10, rss: 10_000, processCount: 3),
+                    ],
+                ]),
+            ],
+        ]
+        let serverHandled = startTopMockServer(listenerFD: listenerFD, payload: payload)
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["top", "--sort", "cpu"]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let lines = outputLines(result.stdout)
+        XCTAssertTrue(lines[2].contains("workspace workspace:high"), result.stdout)
+        XCTAssertTrue(lines[3].contains("workspace workspace:low"), result.stdout)
+    }
+
+    func testTopCommandSortsMixedWorkspaceChildrenByMemoryAlias() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("top-mem")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let payload: [String: Any] = [
+            "windows": [
+                topNode(ref: "window:1", cpu: 2, rss: 2_000, processCount: 2, extra: [
+                    "workspaces": [
+                        topNode(ref: "workspace:1", cpu: 2, rss: 2_000, processCount: 2, extra: [
+                            "tags": [
+                                topTag(key: "codex", cpu: 1, rss: 10_000, processCount: 1),
+                            ],
+                            "panes": [
+                                topNode(ref: "pane:1", cpu: 2, rss: 50_000, processCount: 2),
+                            ],
+                        ]),
+                    ],
+                ]),
+            ],
+        ]
+        let serverHandled = startTopMockServer(listenerFD: listenerFD, payload: payload)
+
+        let result = runCLI(
+            cliPath: cliPath,
+            socketPath: socketPath,
+            arguments: ["top", "--sort", "mem"]
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let lines = outputLines(result.stdout)
+        XCTAssertTrue(lines[3].contains("pane pane:1"), result.stdout)
+        XCTAssertTrue(lines[4].contains("tag codex"), result.stdout)
+    }
+
     private func runCLI(cliPath: String, socketPath: String, arguments: [String]) -> ProcessRunResult {
         var environment = ProcessInfo.processInfo.environment
         environment["CMUX_SOCKET_PATH"] = socketPath
@@ -273,6 +349,54 @@ final class CMUXOpenCommandTests: XCTestCase {
             }
         }
         return handled
+    }
+
+    private func startTopMockServer(listenerFD: Int32, payload: [String: Any]) -> XCTestExpectation {
+        startMockServer(listenerFD: listenerFD, state: MockSocketServerState()) { line in
+            guard let request = Self.v2Payload(from: line),
+                  let id = request["id"] as? String,
+                  request["method"] as? String == "system.top" else {
+                return Self.v2Response(id: "unknown", ok: false, error: ["code": "unexpected"])
+            }
+            return Self.v2Response(id: id, ok: true, result: payload)
+        }
+    }
+
+    private func topNode(
+        ref: String,
+        cpu: Double,
+        rss: Int,
+        processCount: Int,
+        extra: [String: Any] = [:]
+    ) -> [String: Any] {
+        var result = extra
+        result["ref"] = ref
+        result["resources"] = topResources(cpu: cpu, rss: rss, processCount: processCount)
+        return result
+    }
+
+    private func topTag(
+        key: String,
+        cpu: Double,
+        rss: Int,
+        processCount: Int
+    ) -> [String: Any] {
+        [
+            "key": key,
+            "resources": topResources(cpu: cpu, rss: rss, processCount: processCount),
+        ]
+    }
+
+    private func topResources(cpu: Double, rss: Int, processCount: Int) -> [String: Any] {
+        [
+            "cpu_percent": cpu,
+            "resident_bytes": rss,
+            "process_count": processCount,
+        ]
+    }
+
+    private func outputLines(_ output: String) -> [String] {
+        output.split(separator: "\n").map(String.init)
     }
 
     private static func v2Payload(from line: String) -> [String: Any]? {

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentAutoResumePending: false,
+            restorableAgentResumeState: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
## Summary
- Add `cmux top --sort <cpu|rss|proc>` for tree text output.
- Add `cmux top --format tsv` and `--flat` for headerless TSV rows that are easy to pipe to shell sort.
- Keep JSON structured output unchanged and reject text-only formatting and sorting flags with `--json`.

## TSV Columns
`cpu_percent`, `rss_bytes`, `process_count`, `kind`, `ref`, `parent_ref`, `title`.

Example:
`cmux top --format tsv | sort -t $'\t' -nrk1,1`

## Testing
- `./scripts/reload.sh --tag topsort` passed.
- `/tmp/cmux-cli top --format tsv | sort -t $'\t' -nrk1,1` produced sorted live TSV.
- `/tmp/cmux-cli top --flat --format tsv --sort rss` produced built-in sorted live TSV.
- `/tmp/cmux-cli --json top --format tsv` returns the expected text-output-only error.
- XcodeBuildMCP `cmux-unit` targeted tests passed for `CMUXOpenCommandTests` top sorting and TSV coverage.

## Issues
- Related plain-text task: improve `cmux top` sortability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended `cmux top` command with sorting capabilities (by CPU, RSS, or process count)
  * Added text output formatting options (tree and TSV formats)
  * Added flat output mode for simplified display
  * Improved validation for incompatible flag combinations

* **Tests**
  * Added comprehensive test coverage for top command sorting and formatting functionality
  * Added test coverage for TSV output and flat format combinations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4071)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->