### PR TITLE
Fix cmux ssh bootstrap for non-POSIX shells

### DIFF
--- a/CLI/CMUXCLI+SSHCommandSupport.swift
+++ b/CLI/CMUXCLI+SSHCommandSupport.swift
@@ -9,11 +9,29 @@ extension CMUXCLI {
     }
 
     internal func openSSHRemoteCommandValue(shellScript: String) -> String {
-        openSSHCommandOptionValue(posixShellCommand(shellScript))
+        openSSHCommandOptionValue(remoteLoginShellSafePOSIXCommand(shellScript))
     }
 
     internal func posixShellCommand(_ shellScript: String) -> String {
         "/bin/sh -c " + shellQuote(shellScript)
+    }
+
+    internal func remoteLoginShellSafePOSIXCommand(_ shellScript: String) -> String {
+        let encodedScript = Data(shellScript.utf8).base64EncodedString()
+        let wrapper = [
+            "cmux_b64=\(encodedScript)",
+            "cmux_tmp=$(mktemp \"${TMPDIR:-/tmp}/cmux-remote-command.XXXXXX\") || exit 1",
+            "cmux_cleanup() { rm -f -- \"$cmux_tmp\" 2>/dev/null || true; }",
+            "trap \"cmux_cleanup\" EXIT HUP INT TERM",
+            "(printf %s \"$cmux_b64\" | base64 -d 2>/dev/null || printf %s \"$cmux_b64\" | base64 -D 2>/dev/null) > \"$cmux_tmp\" || exit 1",
+            "chmod 700 \"$cmux_tmp\" >/dev/null 2>&1 || true",
+            "/bin/sh \"$cmux_tmp\"",
+            "cmux_status=$?",
+            "trap - EXIT HUP INT TERM",
+            "cmux_cleanup",
+            "exit $cmux_status",
+        ].joined(separator: "; ")
+        return posixShellCommand(wrapper)
     }
 
     internal func openSSHCommandOptionValue(_ command: String) -> String {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5490,7 +5490,7 @@ struct CMUXCLI {
                 remoteRelayPort: options.remoteRelayPort
             )
         )
-        let remoteBootstrapInstallCommand = posixShellCommand(
+        let remoteBootstrapInstallCommand = remoteLoginShellSafePOSIXCommand(
             remoteBootstrapInstallShell(remoteRelayPort: options.remoteRelayPort)
         )
         var lines: [String] = [
@@ -5745,12 +5745,19 @@ struct CMUXCLI {
         outerLines += [
             "    exec \"$CMUX_LOGIN_SHELL\" --rcfile \"$cmux_shell_dir/.bashrc\" -i",
             "    ;;",
-            "  *)",
+            "  csh|tcsh)",
         ]
         outerLines.append(contentsOf: commonShellExportLines)
         outerLines.append(contentsOf: relayWarmupLines)
         outerLines += [
             "exec \"$CMUX_LOGIN_SHELL\" -i",
+            ";;",
+            "  *)",
+        ]
+        outerLines.append(contentsOf: commonShellExportLines)
+        outerLines.append(contentsOf: relayWarmupLines)
+        outerLines += [
+            "exec \"$CMUX_LOGIN_SHELL\"",
             ";;",
             "esac",
         ]

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -469,6 +469,167 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertTrue(result.stderr.contains("[cmux] press Enter to close this pane."), result.stderr)
     }
 
+    func testSSHRemoteBootstrapFallbackShellDoesNotAssumeDashI() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-fallback-shell-\(UUID().uuidString)", isDirectory: true)
+        let remoteHome = root.appendingPathComponent("remote-home", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let fakeLoginShell = root.appendingPathComponent("cmux-fallback-shell")
+        let sshLog = root.appendingPathComponent("ssh.log")
+        let fallbackShellArgs = root.appendingPathComponent("fallback-shell-args.txt")
+
+        try fileManager.createDirectory(at: remoteHome, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "exit 0",
+        ])
+        try writeShellFile(at: fakeLoginShell, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" > \"${CMUX_TEST_FALLBACK_SHELL_ARGS}\"",
+            "for arg in \"$@\"; do",
+            "  if [ \"$arg\" = '-i' ]; then",
+            "    printf 'unsupported -i\\n' >&2",
+            "    exit 64",
+            "  fi",
+            "done",
+            "exit 0",
+        ])
+        try writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" >> \"${CMUX_TEST_SSH_LOG}\"",
+            "remote_command=",
+            "last_arg=",
+            "previous_arg=",
+            "for arg in \"$@\"; do",
+            "  if [ \"$previous_arg\" = '-o' ]; then",
+            "    case \"$arg\" in",
+            "      RemoteCommand=*) remote_command=\"${arg#RemoteCommand=}\" ;;",
+            "    esac",
+            "  fi",
+            "  previous_arg=\"$arg\"",
+            "  last_arg=\"$arg\"",
+            "done",
+            "if [ -z \"$remote_command\" ]; then remote_command=\"$last_arg\"; fi",
+            "remote_command=$(printf '%s' \"$remote_command\" | sed 's/%%/%/g')",
+            "HOME=\"${CMUX_TEST_REMOTE_HOME}\" SHELL=\"${CMUX_TEST_REMOTE_LOGIN_SHELL}\" /bin/sh -c \"$remote_command\"",
+        ])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLI.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeLoginShell.path)
+
+        let startupCommand = try generatedSSHStartupCommand()
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_SSH_LOG"] = sshLog.path
+        environment["CMUX_TEST_REMOTE_HOME"] = remoteHome.path
+        environment["CMUX_TEST_REMOTE_LOGIN_SHELL"] = fakeLoginShell.path
+        environment["CMUX_TEST_FALLBACK_SHELL_ARGS"] = fallbackShellArgs.path
+        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let recordedArgs = (try? String(contentsOf: fallbackShellArgs, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(recordedArgs, "")
+        XCTAssertGreaterThanOrEqual(
+            (try? String(contentsOf: sshLog, encoding: .utf8).split(separator: "\n").count) ?? 0,
+            2
+        )
+    }
+
+    func testSSHRemoteBootstrapKeepsDashIForCShellFallback() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-cshell-\(UUID().uuidString)", isDirectory: true)
+        let remoteHome = root.appendingPathComponent("remote-home", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let fakeLoginShell = root.appendingPathComponent("tcsh")
+        let cShellArgs = root.appendingPathComponent("cshell-args.txt")
+
+        try fileManager.createDirectory(at: remoteHome, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "exit 0",
+        ])
+        try writeShellFile(at: fakeLoginShell, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" > \"${CMUX_TEST_CSHELL_ARGS}\"",
+            "saw_interactive=0",
+            "for arg in \"$@\"; do",
+            "  if [ \"$arg\" = '-i' ]; then saw_interactive=1; fi",
+            "done",
+            "if [ \"$saw_interactive\" != 1 ]; then",
+            "  printf 'missing -i\\n' >&2",
+            "  exit 65",
+            "fi",
+            "exit 0",
+        ])
+        try writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "remote_command=",
+            "last_arg=",
+            "previous_arg=",
+            "for arg in \"$@\"; do",
+            "  if [ \"$previous_arg\" = '-o' ]; then",
+            "    case \"$arg\" in",
+            "      RemoteCommand=*) remote_command=\"${arg#RemoteCommand=}\" ;;",
+            "    esac",
+            "  fi",
+            "  previous_arg=\"$arg\"",
+            "  last_arg=\"$arg\"",
+            "done",
+            "if [ -z \"$remote_command\" ]; then remote_command=\"$last_arg\"; fi",
+            "remote_command=$(printf '%s' \"$remote_command\" | sed 's/%%/%/g')",
+            "HOME=\"${CMUX_TEST_REMOTE_HOME}\" SHELL=\"${CMUX_TEST_REMOTE_LOGIN_SHELL}\" /bin/csh -c \"$remote_command\"",
+        ])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLI.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeLoginShell.path)
+
+        let startupCommand = try generatedSSHStartupCommand()
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_REMOTE_HOME"] = remoteHome.path
+        environment["CMUX_TEST_REMOTE_LOGIN_SHELL"] = fakeLoginShell.path
+        environment["CMUX_TEST_CSHELL_ARGS"] = cShellArgs.path
+        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let recordedArgs = (try? String(contentsOf: cShellArgs, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        XCTAssertEqual(recordedArgs, "-i")
+    }
+
     private func generatedSSHStartupCommand(
         sshOptions: [String] = [
             "ControlMaster no",

--- a/cmuxTests/WorkspaceSSHFishShellTests.swift
+++ b/cmuxTests/WorkspaceSSHFishShellTests.swift
@@ -252,9 +252,30 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
             "Expected the staged bootstrap installer to be passed as one SSH remote command, saw \(firstInvocation)"
         )
         XCTAssertTrue(remoteCommandArgs[0].contains("/bin/sh -c"), "Expected a POSIX shell wrapper in \(remoteCommandArgs)")
-        XCTAssertTrue(remoteCommandArgs[0].contains("set -eu"), "Expected installer command body in \(remoteCommandArgs)")
         XCTAssertFalse(remoteCommandArgs.contains("sh"))
         XCTAssertFalse(remoteCommandArgs.contains("-c"))
+        let remoteInstallerFishCommandCheck = runProcess(
+            executablePath: fishExecutable,
+            arguments: ["-n", "-c", remoteCommandArgs[0]],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertEqual(
+            remoteInstallerFishCommandCheck.status,
+            0,
+            "Expected staged installer wrapper to parse cleanly when the remote login shell is fish, stderr: \(remoteInstallerFishCommandCheck.stderr)"
+        )
+        let remoteInstallerCShellCommandCheck = runProcess(
+            executablePath: "/bin/csh",
+            arguments: ["-n", "-c", remoteCommandArgs[0]],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertEqual(
+            remoteInstallerCShellCommandCheck.status,
+            0,
+            "Expected staged installer wrapper to parse cleanly when the remote login shell is csh, stderr: \(remoteInstallerCShellCommandCheck.stderr)"
+        )
         let secondInvocationData = try XCTUnwrap(logLines.dropFirst().first?.data(using: .utf8))
         let secondInvocation = try XCTUnwrap(
             JSONSerialization.jsonObject(with: secondInvocationData, options: []) as? [String]
@@ -271,10 +292,6 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
             secondRemoteCommand.contains("/bin/sh -c"),
             "Expected the interactive remote command to force a POSIX shell so fish login shells can execute it, saw \(secondInvocation)"
         )
-        XCTAssertTrue(
-            secondRemoteCommand.contains("cmux_bootstrap_tty=") || secondRemoteCommand.contains("cmux_bootstrap_tty\\\""),
-            "Expected staged remote bootstrap command body in \(secondRemoteCommand)"
-        )
         let remoteFishCommandCheck = runProcess(
             executablePath: fishExecutable,
             arguments: ["-n", "-c", secondRemoteCommand],
@@ -285,6 +302,17 @@ final class WorkspaceSSHFishShellTests: XCTestCase {
             remoteFishCommandCheck.status,
             0,
             "Expected staged remote command wrapper to parse cleanly when the remote login shell is fish, stderr: \(remoteFishCommandCheck.stderr)"
+        )
+        let remoteCShellCommandCheck = runProcess(
+            executablePath: "/bin/csh",
+            arguments: ["-n", "-c", secondRemoteCommand],
+            environment: ProcessInfo.processInfo.environment,
+            timeout: 5
+        )
+        XCTAssertEqual(
+            remoteCShellCommandCheck.status,
+            0,
+            "Expected staged remote command wrapper to parse cleanly when the remote login shell is csh, stderr: \(remoteCShellCommandCheck.stderr)"
         )
 
         XCTAssertEqual(foregroundAuthState.commands.count, 1)

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentAutoResumePending: false,
+            restorableAgentResumeState: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
Fixes cmux ssh startup for login shells that either do not support POSIX RemoteCommand parsing or do not accept -i.\n\nWhat changed:\n- Encode remote bootstrap scripts before passing them through OpenSSH RemoteCommand or remote command args, so csh/tcsh/fish only parse a simple /bin/sh wrapper.\n- Keep -i for csh/tcsh interactive startup.\n- Stop passing -i to unknown fallback shells.\n- Add regression coverage for fallback shells and csh-style RemoteCommand parsing.\n\nVerification:\n- ./scripts/reload.sh --tag sshsh\n- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sshsh-unit-tests -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHRemoteBootstrapFallbackShellDoesNotAssumeDashI -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHRemoteBootstrapKeepsDashIForCShellFallback\n- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS' -derivedDataPath /tmp/cmux-sshsh-unit-tests -only-testing:cmuxTests/WorkspaceSSHFishShellTests/testSSHBootstrapStartupCommandPassesRemoteInstallScriptAsSingleSSHCommand (skipped locally because fish is not installed)\n- Cloud Mac shell matrix: zsh, bash, sh, csh, tcsh, fish, and custom fallback shell.\n\nCloud evidence:\n- Cloud run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25780414507\n- Before transcript/video local artifacts: /tmp/cmux-ssh-shells-artifacts/before-fallback-read-screen.txt and /tmp/cmux-ssh-shells-artifacts/before-fallback-read-screen.mp4\n- After transcript/video local artifacts: /tmp/cmux-ssh-shells-artifacts/after-matrix-read-screen.txt and /tmp/cmux-ssh-shells-artifacts/after-matrix-read-screen.mp4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how remote SSH `RemoteCommand`/install scripts are constructed and executed, which can break remote session startup across environments. Added targeted tests reduce regression risk but this is still a cross-shell/SSH integration surface.
> 
> **Overview**
> Fixes `cmux ssh` startup when the *remote login shell* is not POSIX-friendly (e.g. `fish`, `csh`, `tcsh`). Remote bootstrap/installer commands are now base64-encoded and executed via a temporary `/bin/sh` script (`remoteLoginShellSafePOSIXCommand`) so the login shell only sees a simple wrapper.
> 
> Updates interactive remote shell startup to keep `-i` for `csh`/`tcsh`, and to avoid forcing `-i` for unknown fallback shells. Adds regression tests to validate wrapper parsing under `fish`/`csh` and correct `-i` behavior, and updates a workspace unit test fixture to use `restorableAgentResumeState`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit afdf648dff15c4ffd7629b8e2efcbe4c33482f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SSH bootstrap on non-POSIX login shells by sending a base64-encoded installer/command through a `/bin/sh` wrapper and adjusting `-i` handling. SSH startup now works reliably with csh/tcsh/fish and unknown fallback shells.

- **Bug Fixes**
  - Encode remote bootstrap scripts as base64 and run via a `/bin/sh -c` wrapper so csh/tcsh/fish only parse a simple command.
  - Keep `-i` only for `csh`/`tcsh`; stop passing `-i` to unknown fallback shells to avoid startup errors.
  - Use the new `remoteLoginShellSafePOSIXCommand` for both installer and interactive `RemoteCommand` values (with `%` escaping preserved for `OpenSSH`).
  - Added regression tests for fallback shells and fish/csh `RemoteCommand` parsing.

<sup>Written for commit afdf648dff15c4ffd7629b8e2efcbe4c33482f68. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security mechanisms for remote shell script execution on SSH connections.
  * Improved shell compatibility for csh and tcsh environments in remote bootstrap initialization.

* **Tests**
  * Added integration tests validating remote SSH shell fallback behavior and cross-shell environment compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4072)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->