### PR TITLE
Avoid blocking zsh prompts on tmux publish

### DIFF
--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -230,6 +230,8 @@ typeset -g _CMUX_TTY_REPORTED=0
 typeset -g _CMUX_GHOSTTY_SEMANTIC_PATCHED=0
 typeset -g _CMUX_WINCH_GUARD_INSTALLED=0
 typeset -g _CMUX_TMUX_PUSH_SIGNATURE=""
+typeset -g _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
+typeset -g _CMUX_TMUX_PUSH_JOB_PID=""
 typeset -g _CMUX_TMUX_PULL_SIGNATURE=""
 typeset -g _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT=${_CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT:-0}
 typeset -ga _CMUX_TMUX_SYNC_KEYS=(
@@ -277,27 +279,73 @@ _cmux_tmux_shell_env_signature() {
     print -r -- "${(j:\x1f:)parts}"
 }
 
+_cmux_tmux_publish_cmux_environment_apply() {
+    local key value
+    for key in "${_CMUX_TMUX_SYNC_KEYS[@]}"; do
+        value="${(P)key}"
+        [[ -n "$value" ]] || continue
+        tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 1
+    done
+
+    for key in "${_CMUX_TMUX_SURFACE_SCOPED_KEYS[@]}"; do
+        tmux set-environment -gu "$key" >/dev/null 2>&1 || return 1
+    done
+}
+
+_cmux_tmux_publish_job_is_running() {
+    [[ -n "$_CMUX_TMUX_PUSH_JOB_PID" ]] || return 1
+    kill -0 "$_CMUX_TMUX_PUSH_JOB_PID" 2>/dev/null
+}
+
+_cmux_tmux_finish_completed_publish_job() {
+    [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || return 0
+    _cmux_tmux_publish_job_is_running && return 0
+
+    _CMUX_TMUX_PUSH_SIGNATURE="$_CMUX_TMUX_PUSH_PENDING_SIGNATURE"
+    _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
+    _CMUX_TMUX_PUSH_JOB_PID=""
+}
+
+_cmux_tmux_cancel_publish_job() {
+    if _cmux_tmux_publish_job_is_running; then
+        kill "$_CMUX_TMUX_PUSH_JOB_PID" >/dev/null 2>&1 || true
+    fi
+    _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
+    _CMUX_TMUX_PUSH_JOB_PID=""
+}
+
 _cmux_tmux_publish_cmux_environment() {
+    local mode="${1:-async}"
     [[ -z "$TMUX" ]] || return 0
     command -v tmux >/dev/null 2>&1 || return 0
 
     local signature
     signature="$(_cmux_tmux_shell_env_signature)"
     [[ -n "$signature" ]] || return 0
+
+    _cmux_tmux_finish_completed_publish_job
+
+    if [[ "$mode" == "sync" ]]; then
+        if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" && "$signature" != "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]]; then
+            return 0
+        fi
+        _cmux_tmux_cancel_publish_job
+        _cmux_tmux_publish_cmux_environment_apply || return 0
+        _CMUX_TMUX_PUSH_SIGNATURE="$signature"
+        return 0
+    fi
+
     [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" ]] && return 0
+    if [[ "$signature" == "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] && _cmux_tmux_publish_job_is_running; then
+        return 0
+    fi
 
-    local key value
-    for key in "${_CMUX_TMUX_SYNC_KEYS[@]}"; do
-        value="${(P)key}"
-        [[ -n "$value" ]] || continue
-        tmux set-environment -g "$key" "$value" >/dev/null 2>&1 || return 0
-    done
-
-    for key in "${_CMUX_TMUX_SURFACE_SCOPED_KEYS[@]}"; do
-        tmux set-environment -gu "$key" >/dev/null 2>&1 || return 0
-    done
-
-    _CMUX_TMUX_PUSH_SIGNATURE="$signature"
+    _cmux_tmux_cancel_publish_job
+    _CMUX_TMUX_PUSH_PENDING_SIGNATURE="$signature"
+    {
+        _cmux_tmux_publish_cmux_environment_apply
+    } >/dev/null 2>&1 &!
+    _CMUX_TMUX_PUSH_JOB_PID=$!
 }
 
 _cmux_tmux_refresh_cmux_environment() {
@@ -347,10 +395,11 @@ _cmux_tmux_refresh_cmux_environment() {
 }
 
 _cmux_tmux_sync_cmux_environment() {
+    local mode="${1:-async}"
     if [[ -n "$TMUX" ]]; then
         _cmux_tmux_refresh_cmux_environment
     else
-        _cmux_tmux_publish_cmux_environment
+        _cmux_tmux_publish_cmux_environment "$mode"
     fi
 }
 
@@ -1097,13 +1146,56 @@ _cmux_command_starts_nested_shell() {
     return 1
 }
 
+_cmux_command_starts_tmux() {
+    local cmd="$1"
+    local -a words
+    words=("${(z)cmd}")
+
+    local index=1
+    local word base
+    while (( index <= ${#words} )); do
+        word="${words[index]}"
+
+        case "$word" in
+            *=*)
+                index=$(( index + 1 ))
+                continue ;;
+            exec|command|builtin|noglob|time)
+                index=$(( index + 1 ))
+                continue ;;
+            env)
+                index=$(( index + 1 ))
+                while (( index <= ${#words} )); do
+                    word="${words[index]}"
+                    case "$word" in
+                        -*|*=*)
+                            index=$(( index + 1 ))
+                            continue ;;
+                    esac
+                    break
+                done
+                continue ;;
+        esac
+
+        base="${word:t}"
+        [[ "$base" == "tmux" ]] && return 0
+        return 1
+    done
+
+    return 1
+}
+
 _cmux_preexec() {
     _cmux_normalize_claude_config_dir
     if (( ! _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT )); then
         _cmux_restore_terminal_identity_after_startup
     fi
-    _cmux_tmux_sync_cmux_environment
     local cmd="${1## }"
+    if _cmux_command_starts_tmux "$cmd"; then
+        _cmux_tmux_sync_cmux_environment sync
+    else
+        _cmux_tmux_sync_cmux_environment async
+    fi
 
     if [[ -z "$_CMUX_TTY_NAME" ]]; then
         local t

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -232,7 +232,11 @@ typeset -g _CMUX_WINCH_GUARD_INSTALLED=0
 typeset -g _CMUX_TMUX_PUSH_SIGNATURE=""
 typeset -g _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
 typeset -g _CMUX_TMUX_PUSH_JOB_PID=""
+typeset -g _CMUX_TMUX_PUSH_SUCCESS_MARKER=""
 typeset -g _CMUX_TMUX_PULL_SIGNATURE=""
+typeset -g _CMUX_RESOLVED_COMMAND_BASE=""
+typeset -g _CMUX_RESOLVED_COMMAND_INDEX=0
+typeset -ga _CMUX_RESOLVED_COMMAND_WORDS=()
 typeset -g _CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT=${_CMUX_DELAY_TERM_RESTORE_UNTIL_FIRST_PROMPT:-0}
 typeset -ga _CMUX_TMUX_SYNC_KEYS=(
     CMUX_BUNDLED_CLI_PATH
@@ -301,17 +305,24 @@ _cmux_tmux_finish_completed_publish_job() {
     [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || return 0
     _cmux_tmux_publish_job_is_running && return 0
 
-    _CMUX_TMUX_PUSH_SIGNATURE="$_CMUX_TMUX_PUSH_PENDING_SIGNATURE"
+    if [[ -n "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" && -f "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" ]]; then
+        _CMUX_TMUX_PUSH_SIGNATURE="$_CMUX_TMUX_PUSH_PENDING_SIGNATURE"
+    fi
+    [[ -n "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" ]] && /bin/rm -f -- "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" >/dev/null 2>&1 || true
     _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
     _CMUX_TMUX_PUSH_JOB_PID=""
+    _CMUX_TMUX_PUSH_SUCCESS_MARKER=""
 }
 
 _cmux_tmux_cancel_publish_job() {
     if _cmux_tmux_publish_job_is_running; then
         kill "$_CMUX_TMUX_PUSH_JOB_PID" >/dev/null 2>&1 || true
     fi
+    [[ -n "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" ]] && /bin/rm -f -- "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" >/dev/null 2>&1 || true
+    _CMUX_TMUX_PUSH_SIGNATURE=""
     _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
     _CMUX_TMUX_PUSH_JOB_PID=""
+    _CMUX_TMUX_PUSH_SUCCESS_MARKER=""
 }
 
 _cmux_tmux_publish_cmux_environment() {
@@ -327,6 +338,9 @@ _cmux_tmux_publish_cmux_environment() {
 
     if [[ "$mode" == "sync" ]]; then
         if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" && "$signature" != "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]]; then
+            if [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || _cmux_tmux_publish_job_is_running; then
+                _cmux_tmux_cancel_publish_job
+            fi
             return 0
         fi
         _cmux_tmux_cancel_publish_job
@@ -335,15 +349,27 @@ _cmux_tmux_publish_cmux_environment() {
         return 0
     fi
 
-    [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" ]] && return 0
+    if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" ]]; then
+        if [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || _cmux_tmux_publish_job_is_running; then
+            _cmux_tmux_cancel_publish_job
+        fi
+        return 0
+    fi
     if [[ "$signature" == "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] && _cmux_tmux_publish_job_is_running; then
         return 0
     fi
 
     _cmux_tmux_cancel_publish_job
     _CMUX_TMUX_PUSH_PENDING_SIGNATURE="$signature"
+    _CMUX_TMUX_PUSH_SUCCESS_MARKER="${TMPDIR:-/tmp}/cmux-tmux-publish-${$}-${RANDOM}-${RANDOM}.ok"
+    /bin/rm -f -- "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" >/dev/null 2>&1 || true
+    local success_marker="$_CMUX_TMUX_PUSH_SUCCESS_MARKER"
     {
-        _cmux_tmux_publish_cmux_environment_apply
+        if _cmux_tmux_publish_cmux_environment_apply; then
+            : >| "$success_marker"
+        else
+            /bin/rm -f -- "$success_marker" >/dev/null 2>&1 || true
+        fi
     } >/dev/null 2>&1 &!
     _CMUX_TMUX_PUSH_JOB_PID=$!
 }
@@ -622,16 +648,17 @@ _cmux_report_git_branch_for_path() {
     fi
 }
 
-_cmux_record_pr_command_hint() {
+_cmux_resolve_leading_command() {
     local cmd="$1"
-    _CMUX_LAST_PR_ACTION=""
-    _CMUX_LAST_PR_TARGET=""
-
     local -a words
     words=("${(z)cmd}")
 
+    _CMUX_RESOLVED_COMMAND_BASE=""
+    _CMUX_RESOLVED_COMMAND_INDEX=0
+    _CMUX_RESOLVED_COMMAND_WORDS=("${words[@]}")
+
     local index=1
-    local word base
+    local word
     while (( index <= ${#words} )); do
         word="${words[index]}"
 
@@ -656,11 +683,78 @@ _cmux_record_pr_command_hint() {
                 continue ;;
         esac
 
-        base="${word:t}"
-        [[ "$base" == "gh" ]] || return 0
-        index=$(( index + 1 ))
-        break
+        _CMUX_RESOLVED_COMMAND_BASE="${word:t}"
+        _CMUX_RESOLVED_COMMAND_INDEX="$index"
+        return 0
     done
+
+    return 1
+}
+
+_cmux_command_segment_matches_kind() {
+    local kind="$1"
+    local segment="$2"
+    _cmux_resolve_leading_command "$segment" || return 1
+
+    local base="$_CMUX_RESOLVED_COMMAND_BASE"
+    case "$kind" in
+        tmux)
+            [[ "$base" == "tmux" ]] && return 0 ;;
+        nested)
+            case "$base" in
+                bash|zsh|sh|fish|nu|nix-shell)
+                    return 0 ;;
+                nix)
+                    local next_index=$(( _CMUX_RESOLVED_COMMAND_INDEX + 1 ))
+                    local next_word="${_CMUX_RESOLVED_COMMAND_WORDS[next_index]}"
+                    case "$next_word" in
+                        develop|shell)
+                            return 0 ;;
+                    esac ;;
+            esac ;;
+    esac
+
+    return 1
+}
+
+_cmux_command_any_segment_matches_kind() {
+    local kind="$1"
+    local cmd="$2"
+    local -a words segment
+    words=("${(z)cmd}")
+    segment=()
+
+    local word
+    for word in "${words[@]}"; do
+        case "$word" in
+            '&&'|'||'|';'|'|'|'|&'|'&')
+                if (( ${#segment} )); then
+                    _cmux_command_segment_matches_kind "$kind" "${(j: :)segment}" && return 0
+                    segment=()
+                fi
+                continue ;;
+        esac
+        segment+=("$word")
+    done
+
+    if (( ${#segment} )); then
+        _cmux_command_segment_matches_kind "$kind" "${(j: :)segment}" && return 0
+    fi
+    return 1
+}
+
+_cmux_record_pr_command_hint() {
+    local cmd="$1"
+    _CMUX_LAST_PR_ACTION=""
+    _CMUX_LAST_PR_TARGET=""
+
+    _cmux_resolve_leading_command "$cmd" || return 0
+    [[ "$_CMUX_RESOLVED_COMMAND_BASE" == "gh" ]] || return 0
+
+    local -a words
+    words=("${_CMUX_RESOLVED_COMMAND_WORDS[@]}")
+    local index=$(( _CMUX_RESOLVED_COMMAND_INDEX + 1 ))
+    local word
 
     (( index + 1 <= ${#words} )) || return 0
     [[ "${words[index]}" == "pr" ]] || return 0
@@ -1097,92 +1191,11 @@ _cmux_start_git_head_watch() {
 }
 
 _cmux_command_starts_nested_shell() {
-    local cmd="$1"
-    local -a words
-    words=("${(z)cmd}")
-
-    local index=1
-    local word base
-    while (( index <= ${#words} )); do
-        word="${words[index]}"
-
-        case "$word" in
-            *=*)
-                index=$(( index + 1 ))
-                continue ;;
-            exec|command|builtin|noglob|time)
-                index=$(( index + 1 ))
-                continue ;;
-            env)
-                index=$(( index + 1 ))
-                while (( index <= ${#words} )); do
-                    word="${words[index]}"
-                    case "$word" in
-                        -*|*=*)
-                            index=$(( index + 1 ))
-                            continue ;;
-                    esac
-                    break
-                done
-                continue ;;
-        esac
-
-        base="${word:t}"
-        case "$base" in
-            bash|zsh|sh|fish|nu|nix-shell)
-                return 0 ;;
-            nix)
-                local next_index=$(( index + 1 ))
-                local next_word="${words[next_index]}"
-                case "$next_word" in
-                    develop|shell)
-                        return 0 ;;
-                esac ;;
-        esac
-
-        return 1
-    done
-
-    return 1
+    _cmux_command_any_segment_matches_kind nested "$1"
 }
 
 _cmux_command_starts_tmux() {
-    local cmd="$1"
-    local -a words
-    words=("${(z)cmd}")
-
-    local index=1
-    local word base
-    while (( index <= ${#words} )); do
-        word="${words[index]}"
-
-        case "$word" in
-            *=*)
-                index=$(( index + 1 ))
-                continue ;;
-            exec|command|builtin|noglob|time)
-                index=$(( index + 1 ))
-                continue ;;
-            env)
-                index=$(( index + 1 ))
-                while (( index <= ${#words} )); do
-                    word="${words[index]}"
-                    case "$word" in
-                        -*|*=*)
-                            index=$(( index + 1 ))
-                            continue ;;
-                    esac
-                    break
-                done
-                continue ;;
-        esac
-
-        base="${word:t}"
-        [[ "$base" == "tmux" ]] && return 0
-        return 1
-    done
-
-    return 1
+    _cmux_command_any_segment_matches_kind tmux "$1"
 }
 
 _cmux_preexec() {

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -319,7 +319,6 @@ _cmux_tmux_cancel_publish_job() {
         kill "$_CMUX_TMUX_PUSH_JOB_PID" >/dev/null 2>&1 || true
     fi
     [[ -n "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" ]] && /bin/rm -f -- "$_CMUX_TMUX_PUSH_SUCCESS_MARKER" >/dev/null 2>&1 || true
-    _CMUX_TMUX_PUSH_SIGNATURE=""
     _CMUX_TMUX_PUSH_PENDING_SIGNATURE=""
     _CMUX_TMUX_PUSH_JOB_PID=""
     _CMUX_TMUX_PUSH_SUCCESS_MARKER=""
@@ -337,10 +336,7 @@ _cmux_tmux_publish_cmux_environment() {
     _cmux_tmux_finish_completed_publish_job
 
     if [[ "$mode" == "sync" ]]; then
-        if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" && "$signature" != "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]]; then
-            if [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || _cmux_tmux_publish_job_is_running; then
-                _cmux_tmux_cancel_publish_job
-            fi
+        if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" && -z "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] && ! _cmux_tmux_publish_job_is_running; then
             return 0
         fi
         _cmux_tmux_cancel_publish_job
@@ -350,10 +346,10 @@ _cmux_tmux_publish_cmux_environment() {
     fi
 
     if [[ "$signature" == "$_CMUX_TMUX_PUSH_SIGNATURE" ]]; then
-        if [[ -n "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] || _cmux_tmux_publish_job_is_running; then
-            _cmux_tmux_cancel_publish_job
+        if [[ -z "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] && ! _cmux_tmux_publish_job_is_running; then
+            return 0
         fi
-        return 0
+        _cmux_tmux_cancel_publish_job
     fi
     if [[ "$signature" == "$_CMUX_TMUX_PUSH_PENDING_SIGNATURE" ]] && _cmux_tmux_publish_job_is_running; then
         return 0

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3235,6 +3235,41 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
 
         XCTAssertEqual(output, "READY", output)
+
+        let deadline = Date().addingTimeInterval(1)
+        var log = ""
+        while Date() < deadline {
+            log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+            if log.contains("set-environment") {
+                break
+            }
+            RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
+        }
+        XCTAssertTrue(log.contains("set-environment"), log)
+    }
+
+    func testShellIntegrationDetectsTmuxInCompoundPreexecCommand() throws {
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            _cmux_command_starts_tmux 'git status && tmux attach' && print -r -- compound-tmux=yes || print -r -- compound-tmux=no
+            _cmux_command_starts_tmux 'env FOO=bar command tmux new' && print -r -- wrapped-tmux=yes || print -r -- wrapped-tmux=no
+            _cmux_command_starts_nested_shell 'echo ok || nix develop' && print -r -- compound-nested=yes || print -r -- compound-nested=no
+            _cmux_command_starts_tmux 'echo tmux' && print -r -- echo-tmux=yes || print -r -- echo-tmux=no
+            """
+        )
+
+        XCTAssertEqual(
+            output,
+            [
+                "compound-tmux=yes",
+                "wrapped-tmux=yes",
+                "compound-nested=yes",
+                "echo-tmux=no",
+            ].joined(separator: "\n"),
+            output
+        )
     }
 
     func testShellIntegrationPublishesOnlyWorkspaceScopedCmuxEnvironmentToTmuxServerAutomatically() throws {

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3273,6 +3273,57 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
     }
 
+    func testShellIntegrationSyncTmuxPublishReappliesWhenAsyncPublishIsInFlight() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-tmux-sync-reapply-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            _CMUX_TMUX_PUSH_SIGNATURE="$(_cmux_tmux_shell_env_signature)"
+            _CMUX_TMUX_PUSH_PENDING_SIGNATURE=stale-signature
+            /bin/sleep 5 >/dev/null 2>&1 &!
+            _CMUX_TMUX_PUSH_JOB_PID=$!
+            _cmux_tmux_publish_cmux_environment sync
+            print -r -- READY
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current.sock",
+                "CMUX_TAG": "feat-tmux-notification-attention-state",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertEqual(output, "READY", output)
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        XCTAssertTrue(log.contains("set-environment -g CMUX_TAG feat-tmux-notification-attention-state"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_SOCKET_PATH /tmp/cmux-current.sock"), log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_WORKSPACE_ID 11111111-1111-1111-1111-111111111111"), log)
+    }
+
     func testShellIntegrationPublishesOnlyWorkspaceScopedCmuxEnvironmentToTmuxServerAutomatically() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3236,7 +3236,7 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
 
         XCTAssertEqual(output, "READY", output)
 
-        let deadline = Date().addingTimeInterval(1)
+        let deadline = Date().addingTimeInterval(5)
         var log = ""
         while Date() < deadline {
             log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
@@ -3245,6 +3245,7 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
             }
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.02))
         }
+        try? fileManager.removeItem(at: blockPath)
         XCTAssertTrue(log.contains("set-environment"), log)
     }
 

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3249,6 +3249,106 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         XCTAssertTrue(log.contains("set-environment"), log)
     }
 
+    func testShellIntegrationDoesNotFailWhenTmuxIsNotInstalled() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-no-tmux-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            command -v tmux >/dev/null && print -r -- HAS_TMUX || print -r -- NO_TMUX
+            _cmux_tmux_publish_cmux_environment async
+            print -r -- READY
+            """,
+            extraEnvironment: [
+                "PATH": binDir.path,
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current.sock",
+                "CMUX_TAG": "feat-tmux-notification-attention-state",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertEqual(
+            output,
+            [
+                "NO_TMUX",
+                "READY",
+            ].joined(separator: "\n"),
+            output
+        )
+    }
+
+    func testShellIntegrationRetriesAsyncTmuxEnvironmentPublishAfterFailure() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-tmux-async-retry-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        let failPath = root.appendingPathComponent("tmux-fail", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try Data().write(to: failPath)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            if [ -e "\(failPath.path)" ] && [ "$1" = "set-environment" ]; then
+              exit 1
+            fi
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: """
+            _cmux_precmd
+            while _cmux_tmux_publish_job_is_running; do
+              /bin/sleep 0.02
+            done
+            /bin/rm -f "\(failPath.path)"
+            _cmux_precmd
+            while _cmux_tmux_publish_job_is_running; do
+              /bin/sleep 0.02
+            done
+            print -r -- READY
+            """,
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current.sock",
+                "CMUX_TAG": "feat-tmux-notification-attention-state",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertEqual(output, "READY", output)
+
+        let log = (try? String(contentsOf: logPath, encoding: .utf8)) ?? ""
+        let setEnvironmentCount = log
+            .split(separator: "\n")
+            .filter { $0.contains("set-environment") }
+            .count
+        XCTAssertGreaterThanOrEqual(setEnvironmentCount, 2, log)
+        XCTAssertTrue(log.contains("set-environment -g CMUX_TAG feat-tmux-notification-attention-state"), log)
+    }
+
     func testShellIntegrationDetectsTmuxInCompoundPreexecCommand() throws {
         let output = try runInteractiveZsh(
             cmuxLoadGhosttyIntegration: false,

--- a/cmuxTests/GhosttyConfigTests.swift
+++ b/cmuxTests/GhosttyConfigTests.swift
@@ -3190,6 +3190,53 @@ final class ZshShellIntegrationHandoffTests: XCTestCase {
         )
     }
 
+    func testShellIntegrationDoesNotBlockPromptOnTmuxEnvironmentPublish() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-zsh-tmux-async-publish-\(UUID().uuidString)")
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let logPath = root.appendingPathComponent("tmux.log", isDirectory: false)
+        let blockPath = root.appendingPathComponent("tmux-block", isDirectory: false)
+
+        try fileManager.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try Data().write(to: blockPath)
+        defer { try? fileManager.removeItem(at: blockPath) }
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeExecutableScript(
+            at: binDir.appendingPathComponent("tmux", isDirectory: false),
+            contents: """
+            #!/bin/sh
+            if [ "$1" = "show-environment" ] && [ "$2" = "-g" ]; then
+              exit 0
+            fi
+            printf '%s\\n' "$*" >> "\(logPath.path)"
+            if [ "$1" = "set-environment" ]; then
+              while [ -e "\(blockPath.path)" ]; do
+                /bin/sleep 0.05
+              done
+            fi
+            exit 0
+            """
+        )
+
+        let output = try runInteractiveZsh(
+            cmuxLoadGhosttyIntegration: false,
+            cmuxLoadShellIntegration: true,
+            command: "_cmux_precmd; print -r -- READY",
+            extraEnvironment: [
+                "PATH": "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": "/tmp/cmux-current.sock",
+                "CMUX_TAG": "feat-tmux-notification-attention-state",
+                "CMUX_WORKSPACE_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_TAB_ID": "11111111-1111-1111-1111-111111111111",
+                "CMUX_PANEL_ID": "22222222-2222-2222-2222-222222222222",
+            ]
+        )
+
+        XCTAssertEqual(output, "READY", output)
+    }
+
     func testShellIntegrationPublishesOnlyWorkspaceScopedCmuxEnvironmentToTmuxServerAutomatically() throws {
         let fileManager = FileManager.default
         let root = fileManager.temporaryDirectory

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentAutoResumePending: false,
+            restorableAgentResumeState: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
Summary
- Benchmarked cmux, Ghostty, and iTerm shell startup paths.
- Made cmux zsh prompt tmux environment publishing asynchronous outside tmux.
- Kept _cmux_preexec tmux synchronous so new tmux servers still inherit cmux workspace env.
- Added a regression test for prompt progress while tmux set-environment is blocked.

Benchmark method
- Timed from spawn request to an interactive login zsh marker script running.
- cmux used the tagged shspawn app and workspace.create with focus true.
- Ghostty used the app binary with -e for reliable per-process cleanup. The LaunchServices open -n path produced 3 valid samples at 1.40s average, then delayed orphan benchmark instances, so I did not use it for the 10-sample average.
- iTerm used /Applications/iTerm.app/Contents/MacOS/iTerm2 --command.

Averages
- cmux warmed focused workspace: count 10, avg 1.145s, median 1.135s, min 0.606s, max 1.678s.
- Ghostty direct command window: count 10, avg 1.201s, median 1.222s, min 0.890s, max 1.517s.
- iTerm command window: count 10, avg 1.781s, median 1.687s, min 1.341s, max 2.209s.

Diagnosis
- cmux surface creation itself was already in Ghostty's range. The user-visible stall risk was first-prompt shell integration doing synchronous tmux set-environment work when tmux exists in PATH.
- tmux set-environment is conditional on cmux shell integration, being outside tmux, tmux existing in PATH, and the workspace-scoped CMUX env signature changing. With this change, prompt-time publishing is async; starting tmux remains synchronous.
- No-tmux behavior is safe: verified with PATH=/usr/bin:/bin:/usr/sbin:/sbin, _cmux_precmd and _cmux_preexec returned READY with empty stderr.

Verification
- zsh -n Resources/shell-integration/cmux-zsh-integration.zsh
- git diff --check
- Direct zsh harness: _cmux_precmd returned READY while a stubbed tmux set-environment was blocked, 680.7 ms.
- Direct zsh harness: _cmux_preexec tmux still published CMUX_TAG and cleared CMUX_SURFACE_ID synchronously.
- Direct zsh harness: no tmux in PATH returned NO_TMUX and READY, status 0, empty stderr.
- ./scripts/reload.sh --tag shspawn

Known local test blocker
- Targeted xcodebuild tests did not reach execution because cmuxTests currently fails to compile in cmuxTests/WorkspaceUnitTests.swift:2443 due an unrelated DetachedSurfaceTransfer argument rename.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches zsh shell-integration around tmux environment propagation and adds background job state/cleanup, which can affect prompt/preexec timing and tmux inheritance behavior if edge cases are missed.
> 
> **Overview**
> Avoids first-prompt stalls by making tmux `set-environment` publishing **asynchronous by default** when outside tmux, while keeping a **synchronous path** for commands that start `tmux` so newly created tmux servers still inherit the latest CMUX workspace environment.
> 
> This introduces publish job tracking (PID + success marker), cancellation/retry behavior, and more robust command parsing to detect `tmux`/nested-shell invocations even in compound commands. Adds regression tests covering non-blocking prompt behavior, missing `tmux`, retry-after-failure, compound command detection, and sync reapply while an async publish is in flight; also updates a workspace test initializer parameter rename (`restorableAgentResumeState`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cef8c82fa793282dd635244e2bf47a2b0973750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shell integration publishes environment changes asynchronously by default for snappier prompts.
  * Automatic synchronous mode when launching tmux so nested sessions see updated environment immediately.
  * Improved command classification to decide async vs sync publishing more reliably.

* **Bug Fixes**
  * Prevents environment publishing from blocking the interactive prompt.

* **Tests**
  * Added a test ensuring prompt execution isn’t blocked by background tmux environment publishes.

* **Chores**
  * Minor test helper adjustment in workspace tests.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4073)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->