### PR TITLE
Revert Codex hook approval merge for dogfood

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -245,60 +245,6 @@ extension CMUXCLI {
         return agentDefs.first { $0.name == normalized || $0.aliases.contains(normalized) }
     }
 
-    static func hookCommandString(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
-        "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux hooks \(def.name) \(event.cmuxSubcommand) || echo '{}'"
-    }
-
-    static func feedHookCommandString(for def: AgentHookDef, agentEvent: String) -> String {
-        "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux hooks feed --source \(def.name) --event \(agentEvent) || echo '{}'"
-    }
-
-    static func isCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef, includeLegacy: Bool = true) -> Bool {
-        if def.events.contains(where: { hookCommandString(for: def, event: $0) == command })
-            || def.feedHookEvents.contains(where: { feedHookCommandString(for: def, agentEvent: $0) == command })
-        {
-            return true
-        }
-        return includeLegacy && isLegacyCmuxOwnedHookCommand(command, for: def)
-    }
-
-    private static func isLegacyCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef) -> Bool {
-        guard def.name == "codex",
-              let tokens = legacyCmuxCommandTokens(from: command, for: def),
-              !tokens.isEmpty,
-              URL(fileURLWithPath: String(tokens[0])).lastPathComponent == "cmux"
-        else {
-            return false
-        }
-
-        if tokens.count >= 2, tokens[1] == "codex-hook" {
-            return true
-        }
-        if tokens.count >= 4, tokens[1] == "feed-hook", tokens[2] == "--source", tokens[3] == def.name {
-            return true
-        }
-        if tokens.count >= 5, tokens[1] == "hooks", tokens[2] == "feed", tokens[3] == "--source", tokens[4] == def.name {
-            return true
-        }
-        return false
-    }
-
-    private static func legacyCmuxCommandTokens(from command: String, for def: AgentHookDef) -> [Substring]? {
-        let guardedPrefix = "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && "
-        let fallbackSuffix = " || echo '{}'"
-        var body = command
-        if body.hasPrefix(guardedPrefix) {
-            body.removeFirst(guardedPrefix.count)
-        }
-        if body.hasSuffix(fallbackSuffix) {
-            body.removeLast(fallbackSuffix.count)
-        }
-        guard !body.contains(";"), !body.contains("|"), !body.contains("&"), !body.contains("`") else {
-            return nil
-        }
-        return body.split(whereSeparator: { $0 == " " || $0 == "\t" })
-    }
-
     static func hookMarkers(for def: AgentHookDef) -> [String] {
         var markers = [def.hookMarker]
         if def.name == "codex" {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17164,7 +17164,7 @@ struct CMUXCLI {
 
     // MARK: Generic hook install/uninstall
     func hookCommand(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
-        Self.hookCommandString(for: def, event: event)
+        "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux hooks \(def.name) \(event.cmuxSubcommand) || echo '{}'"
     }
 
     /// Shell command the agent runs for a Feed bridge event. 120s timeout
@@ -17172,7 +17172,7 @@ struct CMUXCLI {
     /// nested hook config (see `buildHooksDict`); the shell command
     /// itself just dispatches.
     func feedHookCommand(for def: AgentHookDef, agentEvent: String) -> String {
-        Self.feedHookCommandString(for: def, agentEvent: agentEvent)
+        "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux hooks feed --source \(def.name) --event \(agentEvent) || echo '{}'"
     }
 
     private func buildHooksDict(for def: AgentHookDef) -> [String: Any] {
@@ -17866,45 +17866,32 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         // Remove existing cmux-owned entries (both the per-agent hook
         // dispatcher and the Feed bridge). Non-cmux entries are
-        // always preserved, even when the user mixed them into the
+        // always preserved — even when the user mixed them into the
         // same group as a cmux hook, we only prune our own entries
         // within that group so the user's stays put.
         let isCmuxOwnedCommand: (String) -> Bool = { cmd in
-            Self.isCmuxOwnedHookCommand(cmd, for: def)
+            Self.hookMarkers(for: def).contains { cmd.contains($0) }
+                || Self.feedHookMarkers(for: def).contains { cmd.contains($0) }
         }
-        var cmuxInsertionIndexes: [String: Int] = [:]
         for (event, value) in hooks {
             switch def.format {
             case .flat:
-                guard let entries = value as? [[String: Any]] else { continue }
-                var rewrittenEntries: [[String: Any]] = []
-                for entry in entries {
-                    if isCmuxOwnedCommand(entry["command"] as? String ?? "") {
-                        if cmuxInsertionIndexes[event] == nil {
-                            cmuxInsertionIndexes[event] = rewrittenEntries.count
-                        }
-                        continue
-                    }
-                    rewrittenEntries.append(entry)
-                }
-                hooks[event] = rewrittenEntries.isEmpty ? nil : rewrittenEntries
+                guard var entries = value as? [[String: Any]] else { continue }
+                entries.removeAll { isCmuxOwnedCommand($0["command"] as? String ?? "") }
+                hooks[event] = entries.isEmpty ? nil : entries
             case .nested:
                 guard let groups = value as? [[String: Any]] else { continue }
                 var rewrittenGroups: [[String: Any]] = []
                 for var group in groups {
                     guard var hookList = group["hooks"] as? [[String: Any]] else {
-                        // Unknown shape: preserve verbatim so we don't
+                        // Unknown shape — preserve verbatim so we don't
                         // accidentally mutate user custom data.
                         rewrittenGroups.append(group)
                         continue
                     }
-                    if hookList.contains(where: { isCmuxOwnedCommand($0["command"] as? String ?? "") }),
-                       cmuxInsertionIndexes[event] == nil {
-                        cmuxInsertionIndexes[event] = rewrittenGroups.count
-                    }
                     hookList.removeAll { isCmuxOwnedCommand($0["command"] as? String ?? "") }
                     if hookList.isEmpty {
-                        // Fully cmux-owned group, drop it entirely.
+                        // Fully cmux-owned group → drop it entirely.
                         continue
                     }
                     group["hooks"] = hookList
@@ -17921,23 +17908,11 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             switch def.format {
             case .flat:
                 var entries = hooks[event] as? [[String: Any]] ?? []
-                if let newEntries = value as? [[String: Any]] {
-                    if let insertionIndex = cmuxInsertionIndexes[event] {
-                        entries.insert(contentsOf: newEntries, at: min(insertionIndex, entries.count))
-                    } else {
-                        entries.append(contentsOf: newEntries)
-                    }
-                }
+                if let newEntries = value as? [[String: Any]] { entries.append(contentsOf: newEntries) }
                 hooks[event] = entries
             case .nested:
                 var groups = hooks[event] as? [[String: Any]] ?? []
-                if let newGroups = value as? [[String: Any]] {
-                    if let insertionIndex = cmuxInsertionIndexes[event] {
-                        groups.insert(contentsOf: newGroups, at: min(insertionIndex, groups.count))
-                    } else {
-                        groups.append(contentsOf: newGroups)
-                    }
-                }
+                if let newGroups = value as? [[String: Any]] { groups.append(contentsOf: newGroups) }
                 hooks[event] = groups
             case .rovoDevYAML, .hermesAgentYAML:
                 break
@@ -17946,11 +17921,6 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
 
         existing["hooks"] = hooks
         if case .flat = def.format { existing["version"] = 1 }
-        let codexHookTrustEntries = Self.codexHookTrustEntries(
-            hooks: hooks,
-            hooksFilePath: filePath,
-            def: def
-        )
 
         let newData = try JSONSerialization.data(withJSONObject: existing, options: [.prettyPrinted, .sortedKeys])
         let newString = String(data: newData, encoding: .utf8) ?? "{}"
@@ -17999,11 +17969,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                 } else {
                     existingContent = ""
                 }
-                let featureContent = Self.codexConfigTomlInstallingHooksFeature(in: existingContent)
-                let newContent = Self.codexConfigTomlInstallingHookTrust(
-                    in: featureContent,
-                    entries: codexHookTrustEntries
-                )
+                let newContent = Self.codexConfigTomlInstallingHooksFeature(in: existingContent)
                 if newContent != existingContent {
                     if !skipConfirm {
                         Self.printInstallPreview(
@@ -18019,11 +17985,7 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                         }
                     }
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    if def.name == "codex", !codexHookTrustEntries.isEmpty {
-                        print("Enabled hooks and approved cmux hooks in \(configPath)")
-                    } else {
-                        print("Enabled hooks in \(configPath)")
-                    }
+                    print("Enabled codex_hooks in \(configPath)")
                 }
             }
         }
@@ -18065,7 +18027,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         var removed = 0
 
         let isCmuxOwnedCommand: (String) -> Bool = { cmd in
-            Self.isCmuxOwnedHookCommand(cmd, for: def)
+            Self.hookMarkers(for: def).contains { cmd.contains($0) }
+                || Self.feedHookMarkers(for: def).contains { cmd.contains($0) }
         }
         for (event, value) in hooks {
             switch def.format {
@@ -18106,13 +18069,8 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
             switch action {
             case .codexConfigToml:
                 let configPath = "\(configDir)/config.toml"
-                guard fm.fileExists(atPath: configPath) else { return }
-                let content: String
-                do {
-                    content = try String(contentsOfFile: configPath, encoding: .utf8)
-                } catch {
-                    throw CLIError(message: "\(configPath) exists but could not be read. Fix permissions or remove it before uninstalling \(def.displayName) hooks.")
-                }
+                guard fm.fileExists(atPath: configPath),
+                      let content = try? String(contentsOfFile: configPath, encoding: .utf8) else { return }
                 let newContent = Self.codexConfigTomlUninstallingHooksFeature(from: content)
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
@@ -18132,296 +18090,130 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
     private static let legacyCmuxCodexHooksFeatureEnd = "# cmux hooks codex feature end"
     private static let legacyCmuxCodexHooksFeaturePreviousLinePrefix =
         "# cmux hooks codex feature previous line: "
-    private static let cmuxCodexHookTrustBegin =
-        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin"
-    private static let cmuxCodexHookTrustEnd =
-        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end"
 
-    struct CodexHookTrustEntry: Equatable {
-        let key: String
-        let trustedHash: String
-    }
-
-    private enum CodexHookTrustBlockRemovalResult {
-        case notFound
-        case removed
-        case malformed
-    }
-
-    static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
+    private static func codexConfigTomlInstallingHooksFeature(in existingContent: String) -> String {
         var lines = tomlLines(from: existingContent)
-        removeCmuxCodexHooksFeatureBlock(from: &lines)
-        removeCmuxCodexHookTrustBlock(from: &lines)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
-
-        let insertedLines = [
-            cmuxCodexHooksFeatureBegin,
-            "hooks = true",
-            cmuxCodexHooksFeatureEnd,
-        ]
-        let insertedDottedLines = [
-            cmuxCodexHooksFeatureBegin,
-            "features.hooks = true",
-            cmuxCodexHooksFeatureEnd,
-        ]
+        removeLegacyCodexHooksFeatureBlock(from: &lines)
+        var currentTable: String?
+        for index in lines.indices {
+            let line = lines[index]
+            if let tableName = tomlTableName(in: line) {
+                currentTable = tableName
+                continue
+            }
+            if (currentTable == nil || currentTable == "features"),
+               tomlLineDefinesCodexHooksKey(line) {
+                lines[index] = "codex_hooks = true"
+                return tomlContent(from: lines)
+            }
+            if currentTable == nil, tomlLineDefinesDottedCodexHooksKey(line) {
+                lines[index] = "features.codex_hooks = true"
+                return tomlContent(from: lines)
+            }
+        }
 
         if let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) {
-            let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
-            if featuresStart + 1 < featuresEnd,
-               let hooksIndex = (featuresStart + 1..<featuresEnd)
-                .first(where: { tomlLineDefinesKey("hooks", line: lines[$0]) })
-            {
-                if !tomlLineDefinesTrueKey("hooks", line: lines[hooksIndex]) {
-                    let previousLine = lines[hooksIndex]
-                    lines.replaceSubrange(
-                        hooksIndex...hooksIndex,
-                        with: codexHooksFeatureLines(settingLine: "hooks = true", previousLine: previousLine)
-                    )
-                }
-            } else {
-                lines.insert(contentsOf: insertedLines, at: featuresStart + 1)
-            }
-        } else if let dottedHooksIndex = lines.firstIndex(where: { tomlLineDefinesDottedFeaturesKey("hooks", line: $0) }) {
-            if !tomlLineDefinesDottedFeaturesTrueKey("hooks", line: lines[dottedHooksIndex]) {
-                let previousLine = lines[dottedHooksIndex]
-                lines.replaceSubrange(
-                    dottedHooksIndex...dottedHooksIndex,
-                    with: codexHooksFeatureLines(settingLine: "features.hooks = true", previousLine: previousLine)
-                )
-            }
-        } else if let firstDottedFeaturesIndex = lines.firstIndex(where: { tomlLineDefinesAnyDottedFeaturesKey($0) }) {
-            lines.insert(contentsOf: insertedDottedLines, at: firstDottedFeaturesIndex)
+            lines.insert("codex_hooks = true", at: featuresStart + 1)
         } else {
             if !lines.isEmpty, lines.last?.isEmpty == false {
                 lines.append("")
             }
             lines.append("[features]")
-            lines.append(contentsOf: insertedLines)
+            lines.append("codex_hooks = true")
         }
-
         return tomlContent(from: lines)
     }
 
-    private static func codexHooksFeatureLines(settingLine: String, previousLine: String? = nil) -> [String] {
-        var lines = [cmuxCodexHooksFeatureBegin]
-        if let previousLine {
-            lines.append(cmuxCodexHooksFeaturePreviousLinePrefix + previousLine)
-        }
-        lines.append(settingLine)
-        lines.append(cmuxCodexHooksFeatureEnd)
-        return lines
-    }
-
-    static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
+    private static func codexConfigTomlUninstallingHooksFeature(from existingContent: String) -> String {
         var lines = tomlLines(from: existingContent)
-        removeCmuxCodexHooksFeatureBlock(from: &lines)
-        removeCmuxCodexHookTrustBlock(from: &lines)
-        lines.removeAll { tomlLineDefinesKey("codex_hooks", line: $0) }
-        lines.removeAll { tomlLineDefinesDottedFeaturesKey("codex_hooks", line: $0) }
-        removeEmptyFeaturesTable(from: &lines)
-        return tomlContent(from: lines)
-    }
-
-    static func codexConfigTomlInstallingHookTrust(
-        in existingContent: String,
-        entries: [CodexHookTrustEntry]
-    ) -> String {
-        var lines = tomlLines(from: existingContent)
-        let removalResult = removeCmuxCodexHookTrustBlock(from: &lines)
-        guard removalResult != .malformed else {
-            return tomlContent(from: lines)
-        }
-        guard !entries.isEmpty else {
-            return tomlContent(from: lines)
-        }
-
-        if !lines.isEmpty, lines.last?.isEmpty == false {
-            lines.append("")
-        }
-        lines.append(cmuxCodexHookTrustBegin)
-        for entry in entries {
-            lines.append("[hooks.state.\"\(tomlBasicStringContent(entry.key))\"]")
-            lines.append("trusted_hash = \"\(tomlBasicStringContent(entry.trustedHash))\"")
-        }
-        lines.append(cmuxCodexHookTrustEnd)
-        return tomlContent(from: lines)
-    }
-
-    static func codexHookTrustEntries(
-        hooks: [String: Any],
-        hooksFilePath: String,
-        def: AgentHookDef
-    ) -> [CodexHookTrustEntry] {
-        guard def.name == "codex" else { return [] }
-        let isOwnedCommand: (String) -> Bool = { command in
-            isCmuxOwnedHookCommand(command, for: def, includeLegacy: false)
-        }
-        var entries: [CodexHookTrustEntry] = []
-        let keySource = codexNormalizedHookSourcePath(hooksFilePath)
-
-        for eventName in codexHookEventNames {
-            guard let groups = hooks[eventName] as? [[String: Any]],
-                  let eventLabel = codexHookEventLabel(eventName) else {
+        removeLegacyCodexHooksFeatureBlock(from: &lines)
+        var filteredLines: [String] = []
+        var currentTable: String?
+        for line in lines {
+            if let tableName = tomlTableName(in: line) {
+                currentTable = tableName
+                filteredLines.append(line)
                 continue
             }
-            for (groupIndex, group) in groups.enumerated() {
-                guard let hookList = group["hooks"] as? [[String: Any]] else { continue }
-                let matcher = codexHookEventUsesMatcher(eventName) ? group["matcher"] as? String : nil
-                for (handlerIndex, hook) in hookList.enumerated() {
-                    guard let command = hook["command"] as? String,
-                          isOwnedCommand(command) else {
-                        continue
-                    }
-                    let timeoutSec = max(intValue(hook["timeout"]) ?? 600, 1)
-                    let statusMessage = hook["statusMessage"] as? String
-                    let key = "\(keySource):\(eventLabel):\(groupIndex):\(handlerIndex)"
-                    let trustedHash = codexCommandHookHash(
-                        eventLabel: eventLabel,
-                        matcher: matcher,
-                        command: command,
-                        timeoutSec: timeoutSec,
-                        statusMessage: statusMessage
-                    )
-                    entries.append(CodexHookTrustEntry(key: key, trustedHash: trustedHash))
-                }
+            if (currentTable == nil || currentTable == "features"),
+               tomlLineDefinesCodexHooksKey(line) {
+                continue
+            }
+            if currentTable == nil, tomlLineDefinesDottedCodexHooksKey(line) {
+                continue
+            }
+            filteredLines.append(line)
+        }
+        removeEmptyFeaturesTable(from: &filteredLines)
+        return tomlContent(from: filteredLines)
+    }
+
+    private static func removeEmptyFeaturesTable(from lines: inout [String]) {
+        var index = 0
+        while index < lines.count {
+            guard tomlLineIsTable("features", line: lines[index]) else {
+                index += 1
+                continue
+            }
+
+            let bodyStart = index + 1
+            var bodyEnd = bodyStart
+            while bodyEnd < lines.count, tomlTableName(in: lines[bodyEnd]) == nil {
+                bodyEnd += 1
+            }
+
+            let bodyIsEmpty = lines[bodyStart..<bodyEnd].allSatisfy { line in
+                line.trimmingCharacters(in: .whitespaces).isEmpty
+            }
+            guard bodyIsEmpty else {
+                index = bodyEnd
+                continue
+            }
+
+            lines.removeSubrange(index..<bodyEnd)
+            if index == lines.count, index > 0,
+               lines[index - 1].trimmingCharacters(in: .whitespaces).isEmpty
+            {
+                lines.remove(at: index - 1)
+            } else if index > 0, index < lines.count,
+                      lines[index - 1].trimmingCharacters(in: .whitespaces).isEmpty,
+                      lines[index].trimmingCharacters(in: .whitespaces).isEmpty
+            {
+                lines.remove(at: index)
             }
         }
-
-        return entries
     }
 
-    private static func codexNormalizedHookSourcePath(_ path: String) -> String {
-        let url = URL(fileURLWithPath: path).standardizedFileURL
-        if let resolved = realPath(url.path) {
-            return resolved
-        }
-        let parent = url.deletingLastPathComponent()
-        if let resolvedParent = realPath(parent.path) {
-            return URL(fileURLWithPath: resolvedParent, isDirectory: true)
-                .appendingPathComponent(url.lastPathComponent)
-                .path
-        }
-        return url.path
-    }
+    private static func removeLegacyCodexHooksFeatureBlock(from lines: inout [String]) {
+        var index = 0
+        while index < lines.count {
+            guard tomlLineIsLegacyCodexHooksFeatureBegin(lines[index]) else {
+                index += 1
+                continue
+            }
 
-    private static func realPath(_ path: String) -> String? {
-        var buffer = [CChar](repeating: 0, count: Int(PATH_MAX))
-        guard realpath(path, &buffer) != nil else { return nil }
-        return String(cString: buffer)
-    }
-
-    private static let codexHookEventNames = [
-        "PreToolUse",
-        "PermissionRequest",
-        "PostToolUse",
-        "PreCompact",
-        "PostCompact",
-        "SessionStart",
-        "UserPromptSubmit",
-        "Stop",
-    ]
-
-    private static func codexHookEventLabel(_ eventName: String) -> String? {
-        switch eventName {
-        case "PreToolUse": return "pre_tool_use"
-        case "PermissionRequest": return "permission_request"
-        case "PostToolUse": return "post_tool_use"
-        case "PreCompact": return "pre_compact"
-        case "PostCompact": return "post_compact"
-        case "SessionStart": return "session_start"
-        case "UserPromptSubmit": return "user_prompt_submit"
-        case "Stop": return "stop"
-        default: return nil
-        }
-    }
-
-    private static func codexHookEventUsesMatcher(_ eventName: String) -> Bool {
-        switch eventName {
-        case "PreToolUse", "PermissionRequest", "PostToolUse", "PreCompact", "PostCompact", "SessionStart":
-            return true
-        default:
-            return false
-        }
-    }
-
-    private static func codexCommandHookHash(
-        eventLabel: String,
-        matcher: String?,
-        command: String,
-        timeoutSec: Int,
-        statusMessage: String?
-    ) -> String {
-        let normalizedTimeoutSec = max(timeoutSec, 1)
-        var handler: [String: Any] = [
-            "async": false,
-            "command": command,
-            "timeout": normalizedTimeoutSec,
-            "type": "command",
-        ]
-        if let statusMessage {
-            handler["statusMessage"] = statusMessage
-        }
-        var identity: [String: Any] = [
-            "event_name": eventLabel,
-            "hooks": [handler],
-        ]
-        if let matcher {
-            identity["matcher"] = matcher
-        }
-
-        let data = (try? JSONSerialization.data(
-            withJSONObject: identity,
-            options: [.sortedKeys, .withoutEscapingSlashes]
-        )) ?? Data()
-        let digest = SHA256.hash(data: data)
-            .map { String(format: "%02x", $0) }
-            .joined()
-        return "sha256:\(digest)"
-    }
-
-    private static func intValue(_ value: Any?) -> Int? {
-        if let intValue = value as? Int {
-            return intValue
-        }
-        if let number = value as? NSNumber {
-            return number.intValue
-        }
-        return nil
-    }
-
-    private static func tomlBasicStringContent(_ value: String) -> String {
-        var escaped = ""
-        escaped.reserveCapacity(value.count)
-
-        for scalar in value.unicodeScalars {
-            switch scalar.value {
-            case 0x08:
-                escaped += "\\b"
-            case 0x09:
-                escaped += "\\t"
-            case 0x0A:
-                escaped += "\\n"
-            case 0x0C:
-                escaped += "\\f"
-            case 0x0D:
-                escaped += "\\r"
-            case 0x22:
-                escaped += "\\\""
-            case 0x5C:
-                escaped += "\\\\"
-            case 0x00...0x1F, 0x7F...0x9F:
-                if scalar.value <= 0xFFFF {
-                    escaped += String(format: "\\u%04X", scalar.value)
-                } else {
-                    escaped += String(format: "\\U%08X", scalar.value)
+            if let endIndex = lines[index...].firstIndex(where: {
+                tomlLineIsLegacyCodexHooksFeatureEnd($0)
+            }) {
+                let restoredLines = lines[index...endIndex].compactMap { line -> String? in
+                    tomlLegacyCodexHooksFeaturePreviousLine(from: line)
                 }
-            default:
-                escaped.unicodeScalars.append(scalar)
+                lines.replaceSubrange(index...endIndex, with: restoredLines)
+            } else {
+                var blockEnd = index + 1
+                var restoredLines: [String] = []
+                if blockEnd < lines.count,
+                   let previousLine = tomlLegacyCodexHooksFeaturePreviousLine(from: lines[blockEnd])
+                {
+                    restoredLines.append(previousLine)
+                    blockEnd += 1
+                }
+                if blockEnd < lines.count, tomlLineIsLegacyCodexHooksFeatureSetting(lines[blockEnd]) {
+                    blockEnd += 1
+                }
+                lines.replaceSubrange(index..<blockEnd, with: restoredLines)
             }
         }
-
-        return escaped
     }
 
     private static func tomlLines(from content: String) -> [String] {
@@ -18438,41 +18230,47 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    private static func tomlLineDefinesKey(_ key: String, line: String) -> Bool {
-        let escapedKey = NSRegularExpression.escapedPattern(for: key)
-        return line.range(
-            of: #"^\s*"# + escapedKey + #"\s*="#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineDefinesTrueKey(_ key: String, line: String) -> Bool {
-        let escapedKey = NSRegularExpression.escapedPattern(for: key)
-        return line.range(
-            of: #"^\s*"# + escapedKey + #"\s*=\s*true\s*(#.*)?$"#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineDefinesDottedFeaturesKey(_ key: String, line: String) -> Bool {
-        let escapedKey = NSRegularExpression.escapedPattern(for: key)
-        return line.range(
-            of: #"^\s*features\s*\.\s*"# + escapedKey + #"\s*="#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineDefinesDottedFeaturesTrueKey(_ key: String, line: String) -> Bool {
-        let escapedKey = NSRegularExpression.escapedPattern(for: key)
-        return line.range(
-            of: #"^\s*features\s*\.\s*"# + escapedKey + #"\s*=\s*true\s*(#.*)?$"#,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlLineDefinesAnyDottedFeaturesKey(_ line: String) -> Bool {
+    private static func tomlLineDefinesCodexHooksKey(_ line: String) -> Bool {
         line.range(
-            of: #"^\s*features\s*\.\s*[^=\s]+\s*="#,
+            of: #"^\s*codex_hooks\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineDefinesDottedCodexHooksKey(_ line: String) -> Bool {
+        line.range(
+            of: #"^\s*features\s*\.\s*codex_hooks\s*="#,
+            options: .regularExpression
+        ) != nil
+    }
+
+    private static func tomlLineIsLegacyCodexHooksFeatureBegin(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed == cmuxCodexHooksFeatureBegin || trimmed == legacyCmuxCodexHooksFeatureBegin
+    }
+
+    private static func tomlLineIsLegacyCodexHooksFeatureEnd(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        return trimmed == cmuxCodexHooksFeatureEnd || trimmed == legacyCmuxCodexHooksFeatureEnd
+    }
+
+    private static func tomlLegacyCodexHooksFeaturePreviousLine(from line: String) -> String? {
+        let trimmed = line.trimmingCharacters(in: .whitespaces)
+        if trimmed.hasPrefix(cmuxCodexHooksFeaturePreviousLinePrefix) {
+            return String(trimmed.dropFirst(cmuxCodexHooksFeaturePreviousLinePrefix.count))
+        }
+        if trimmed.hasPrefix(legacyCmuxCodexHooksFeaturePreviousLinePrefix) {
+            return String(trimmed.dropFirst(legacyCmuxCodexHooksFeaturePreviousLinePrefix.count))
+        }
+        return nil
+    }
+
+    private static func tomlLineIsLegacyCodexHooksFeatureSetting(_ line: String) -> Bool {
+        line.range(
+            of: #"^\s*hooks\s*=\s*true\s*(#.*)?$"#,
+            options: .regularExpression
+        ) != nil || line.range(
+            of: #"^\s*features\s*\.\s*hooks\s*=\s*true\s*(#.*)?$"#,
             options: .regularExpression
         ) != nil
     }
@@ -18485,129 +18283,18 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
         ) != nil
     }
 
-    private static func tomlLineIsAnyTableHeader(_ line: String) -> Bool {
-        let tomlKey = "(?:[A-Za-z0-9_-]+|\"[^\"\\n]*\"|'[^'\\n]*')"
-        let tomlKeyPath = tomlKey + "(?:\\s*\\.\\s*" + tomlKey + ")*"
-        let pattern = "^\\s*(?:\\[\\s*" + tomlKeyPath + "\\s*\\]|\\[\\[\\s*" + tomlKeyPath
-            + "\\s*\\]\\])\\s*(#.*)?$"
-        return line.range(
-            of: pattern,
-            options: .regularExpression
-        ) != nil
-    }
-
-    private static func tomlTableEndIndex(in lines: [String], after tableStart: Int) -> Int {
-        var index = tableStart + 1
-        while index < lines.count {
-            if tomlLineIsAnyTableHeader(lines[index]) {
-                return index
-            }
-            index += 1
+    private static func tomlTableName(in line: String) -> String? {
+        let pattern = #"^\s*\[\s*([A-Za-z0-9_.-]+)\s*\]\s*(#.*)?$"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(
+                  in: line,
+                  range: NSRange(line.startIndex..., in: line)
+              ),
+              match.numberOfRanges > 1,
+              let range = Range(match.range(at: 1), in: line) else {
+            return nil
         }
-        return lines.count
-    }
-
-    private static func removeCmuxCodexHooksFeatureBlock(from lines: inout [String]) {
-        var index = 0
-        while index < lines.count {
-            guard tomlLineIsCodexHooksFeatureBegin(lines[index]) else {
-                index += 1
-                continue
-            }
-
-            if let endIndex = lines[index...].firstIndex(where: {
-                tomlLineIsCodexHooksFeatureEnd($0)
-            }) {
-                let previousLines = lines[index...endIndex].compactMap { line -> String? in
-                    tomlCodexHooksFeaturePreviousLine(from: line)
-                }
-                lines.replaceSubrange(index...endIndex, with: previousLines)
-            } else {
-                var blockEnd = index + 1
-                var previousLines: [String] = []
-                if blockEnd < lines.count,
-                   let previousLine = tomlCodexHooksFeaturePreviousLine(from: lines[blockEnd])
-                {
-                    previousLines.append(previousLine)
-                    blockEnd += 1
-                }
-                if blockEnd < lines.count, tomlLineIsCodexHooksFeatureSetting(lines[blockEnd]) {
-                    blockEnd += 1
-                }
-                lines.replaceSubrange(index..<blockEnd, with: previousLines)
-            }
-        }
-    }
-
-    @discardableResult
-    private static func removeCmuxCodexHookTrustBlock(from lines: inout [String]) -> CodexHookTrustBlockRemovalResult {
-        var ranges: [ClosedRange<Int>] = []
-        var index = 0
-        while index < lines.count {
-            guard lines[index] == cmuxCodexHookTrustBegin else {
-                index += 1
-                continue
-            }
-
-            guard let endIndex = lines[index...].firstIndex(of: cmuxCodexHookTrustEnd) else {
-                return .malformed
-            }
-            ranges.append(index...endIndex)
-            index = endIndex + 1
-        }
-
-        for range in ranges.reversed() {
-            lines.removeSubrange(range)
-        }
-        return ranges.isEmpty ? .notFound : .removed
-    }
-
-    private static func tomlLineIsCodexHooksFeatureBegin(_ line: String) -> Bool {
-        line == cmuxCodexHooksFeatureBegin || line == legacyCmuxCodexHooksFeatureBegin
-    }
-
-    private static func tomlLineIsCodexHooksFeatureEnd(_ line: String) -> Bool {
-        line == cmuxCodexHooksFeatureEnd || line == legacyCmuxCodexHooksFeatureEnd
-    }
-
-    private static func tomlCodexHooksFeaturePreviousLine(from line: String) -> String? {
-        if line.hasPrefix(cmuxCodexHooksFeaturePreviousLinePrefix) {
-            return String(line.dropFirst(cmuxCodexHooksFeaturePreviousLinePrefix.count))
-        }
-        if line.hasPrefix(legacyCmuxCodexHooksFeaturePreviousLinePrefix) {
-            return String(line.dropFirst(legacyCmuxCodexHooksFeaturePreviousLinePrefix.count))
-        }
-        return nil
-    }
-
-    private static func tomlLineIsCodexHooksFeatureSetting(_ line: String) -> Bool {
-        tomlLineDefinesTrueKey("hooks", line: line)
-            || tomlLineDefinesDottedFeaturesTrueKey("hooks", line: line)
-    }
-
-    private static func removeEmptyFeaturesTable(from lines: inout [String]) {
-        guard let featuresStart = lines.firstIndex(where: { tomlLineIsTable("features", line: $0) }) else {
-            return
-        }
-        let featuresEnd = tomlTableEndIndex(in: lines, after: featuresStart)
-        let bodyRange = featuresStart + 1..<featuresEnd
-        let hasContent = bodyRange.contains { index in
-            let trimmed = lines[index].trimmingCharacters(in: .whitespaces)
-            return !trimmed.isEmpty && !trimmed.hasPrefix("#")
-        }
-        if !hasContent {
-            lines.removeSubrange(featuresStart..<featuresEnd)
-            if featuresStart == lines.count, featuresStart > 0,
-               lines[featuresStart - 1].trimmingCharacters(in: .whitespaces).isEmpty
-            {
-                lines.remove(at: featuresStart - 1)
-            } else if featuresStart > 0, featuresStart < lines.count,
-                      lines[featuresStart - 1].trimmingCharacters(in: .whitespaces).isEmpty,
-                      lines[featuresStart].trimmingCharacters(in: .whitespaces).isEmpty
-            {
-                lines.remove(at: featuresStart)
-            }
-        }
+        return String(line[range])
     }
 
     // MARK: Generic hook handler

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentResumeState: nil,
+            restorableAgentAutoResumePending: false,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,

--- a/tests/test_codex_feed_hooks.py
+++ b/tests/test_codex_feed_hooks.py
@@ -6,7 +6,6 @@ Regression tests for Codex Feed hook wiring and decision output.
 from __future__ import annotations
 
 import json
-import hashlib
 import os
 import shutil
 import socket
@@ -17,38 +16,6 @@ import time
 from pathlib import Path
 
 from claude_teams_test_utils import resolve_cmux_cli
-
-
-CODEX_HOOK_EVENT_LABELS = {
-    "PreToolUse": "pre_tool_use",
-    "PermissionRequest": "permission_request",
-    "PostToolUse": "post_tool_use",
-    "PreCompact": "pre_compact",
-    "PostCompact": "post_compact",
-    "SessionStart": "session_start",
-    "UserPromptSubmit": "user_prompt_submit",
-    "Stop": "stop",
-}
-
-CODEX_HOOK_EVENTS_WITH_MATCHERS = {
-    "PreToolUse",
-    "PermissionRequest",
-    "PostToolUse",
-    "PreCompact",
-    "PostCompact",
-    "SessionStart",
-}
-
-CMUX_CODEX_HOOK_SUBCOMMANDS = (
-    "session-start",
-    "prompt-submit",
-    "stop",
-)
-
-CMUX_CODEX_FEED_EVENTS = (
-    "PreToolUse",
-    "PermissionRequest",
-)
 
 
 class FakeCmuxSocket:
@@ -525,156 +492,6 @@ def assert_codex_allow_has_no_persistent_fields(stdout: dict) -> None:
         raise AssertionError(f"Codex permission output included unsupported fields {present}: {stdout!r}")
 
 
-def codex_command_hook_hash(
-    *,
-    event_label: str,
-    matcher: str | None,
-    command: str,
-    timeout: int,
-    status_message: str | None,
-) -> str:
-    handler: dict = {
-        "async": False,
-        "command": command,
-        "timeout": max(timeout, 1),
-        "type": "command",
-    }
-    if status_message is not None:
-        handler["statusMessage"] = status_message
-    identity: dict = {
-        "event_name": event_label,
-        "hooks": [handler],
-    }
-    if matcher is not None:
-        identity["matcher"] = matcher
-    canonical = json.dumps(identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")).encode()
-    return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
-
-
-def cmux_codex_hook_command(subcommand: str) -> str:
-    return (
-        '[ -n "$CMUX_SURFACE_ID" ] && [ "$CMUX_CODEX_HOOKS_DISABLED" != "1" ] '
-        f"&& command -v cmux >/dev/null 2>&1 && cmux hooks codex {subcommand} || echo '{{}}'"
-    )
-
-
-def cmux_codex_feed_command(agent_event: str) -> str:
-    return (
-        '[ -n "$CMUX_SURFACE_ID" ] && [ "$CMUX_CODEX_HOOKS_DISABLED" != "1" ] '
-        f"&& command -v cmux >/dev/null 2>&1 && cmux hooks feed --source codex --event {agent_event} "
-        "|| echo '{}'"
-    )
-
-
-def is_cmux_codex_hook_command(command: str) -> bool:
-    hook_commands = {cmux_codex_hook_command(subcommand) for subcommand in CMUX_CODEX_HOOK_SUBCOMMANDS}
-    feed_commands = {cmux_codex_feed_command(agent_event) for agent_event in CMUX_CODEX_FEED_EVENTS}
-    return command in hook_commands or command in feed_commands
-
-
-def toml_basic_string_unescape(value: str) -> str:
-    escaped = {
-        "b": "\b",
-        "t": "\t",
-        "n": "\n",
-        "f": "\f",
-        "r": "\r",
-        '"': '"',
-        "\\": "\\",
-    }
-    result: list[str] = []
-    index = 0
-    while index < len(value):
-        char = value[index]
-        if char != "\\":
-            result.append(char)
-            index += 1
-            continue
-
-        index += 1
-        if index >= len(value):
-            raise AssertionError(f"trailing TOML escape in {value!r}")
-        escape = value[index]
-        if escape in escaped:
-            result.append(escaped[escape])
-            index += 1
-        elif escape in {"u", "U"}:
-            width = 4 if escape == "u" else 8
-            start = index + 1
-            end = start + width
-            hex_value = value[start:end]
-            if len(hex_value) != width:
-                raise AssertionError(f"short TOML unicode escape in {value!r}")
-            result.append(chr(int(hex_value, 16)))
-            index = end
-        else:
-            raise AssertionError(f"unsupported TOML escape \\{escape} in {value!r}")
-    return "".join(result)
-
-
-def codex_hook_trust_state(config_toml: str) -> dict[str, dict[str, str]]:
-    state: dict[str, dict[str, str]] = {}
-    current_key: str | None = None
-    prefix = '[hooks.state."'
-    suffix = '"]'
-
-    for line in config_toml.splitlines():
-        stripped = line.strip()
-        if stripped.startswith(prefix) and stripped.endswith(suffix):
-            current_key = toml_basic_string_unescape(stripped[len(prefix) : -len(suffix)])
-            state[current_key] = {}
-            continue
-        if stripped.startswith("["):
-            current_key = None
-            continue
-        if current_key is None:
-            continue
-        key, separator, raw_value = stripped.partition("=")
-        if separator != "=" or key.strip() != "trusted_hash":
-            continue
-        value = raw_value.strip()
-        if not value.startswith('"') or not value.endswith('"'):
-            raise AssertionError(f"trusted_hash is not a TOML basic string: {line!r}")
-        state[current_key]["trusted_hash"] = toml_basic_string_unescape(value[1:-1])
-
-    return state
-
-
-def expected_cmux_codex_hook_trust(hooks: dict, hooks_path: Path) -> dict[str, str]:
-    expected: dict[str, str] = {}
-    hooks_path = hooks_path.resolve()
-    for event_name, groups in hooks.get("hooks", {}).items():
-        event_label = CODEX_HOOK_EVENT_LABELS.get(event_name)
-        if event_label is None:
-            continue
-        for group_index, group in enumerate(groups):
-            matcher = group.get("matcher") if event_name in CODEX_HOOK_EVENTS_WITH_MATCHERS else None
-            for handler_index, hook in enumerate(group.get("hooks", [])):
-                command = hook.get("command", "")
-                if not is_cmux_codex_hook_command(command):
-                    continue
-                key = f"{hooks_path}:{event_label}:{group_index}:{handler_index}"
-                expected[key] = codex_command_hook_hash(
-                    event_label=event_label,
-                    matcher=matcher,
-                    command=command,
-                    timeout=int(hook.get("timeout", 600)),
-                    status_message=hook.get("statusMessage"),
-                )
-    return expected
-
-
-def codex_hook_commands(hooks: dict) -> list[str]:
-    commands: list[str] = []
-    for groups in hooks.get("hooks", {}).values():
-        for group in groups:
-            for hook in group.get("hooks", []):
-                command = hook.get("command")
-                if isinstance(command, str):
-                    commands.append(command)
-    return commands
-
-
 def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -> None:
     codex_home = root / "codex-home"
     codex_home.mkdir()
@@ -707,254 +524,12 @@ def test_install_adds_codex_permission_request_hook(cli_path: str, root: Path) -
             raise AssertionError(f"wrong {event_name} timeout: {groups[-1]!r}")
 
     config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "hooks = true" not in config_toml:
-        raise AssertionError(f"hooks feature was not enabled: {config_toml!r}")
-    if "codex_hooks" in config_toml:
-        raise AssertionError(f"deprecated codex_hooks feature was written: {config_toml!r}")
-    state = codex_hook_trust_state(config_toml)
-    expected_trust = expected_cmux_codex_hook_trust(hooks, codex_home / "hooks.json")
-    if not expected_trust:
-        raise AssertionError(f"expected cmux Codex trust entries, got {expected_trust!r}")
-    for key, trusted_hash in expected_trust.items():
-        if state.get(key, {}).get("trusted_hash") != trusted_hash:
-            raise AssertionError(
-                f"missing trusted hash for {key}: expected {trusted_hash!r}, got state {state!r}"
-            )
-
-
-def test_install_escapes_codex_hook_trust_state_keys(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home\twith\ncontrols"
-    codex_home.mkdir()
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    state = codex_hook_trust_state(config_toml)
-    expected_trust = expected_cmux_codex_hook_trust(hooks, codex_home / "hooks.json")
-    if not expected_trust:
-        raise AssertionError(f"expected cmux Codex trust entries, got {expected_trust!r}")
-    for key, trusted_hash in expected_trust.items():
-        if state.get(key, {}).get("trusted_hash") != trusted_hash:
-            raise AssertionError(
-                f"missing escaped-key trusted hash for {key}: expected {trusted_hash!r}, got state {state!r}"
-            )
-
-
-def test_install_preserves_codex_hook_position_with_third_party_hooks(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-third-party"
-    codex_home.mkdir()
-    cmux_pre_tool = (
-        '[ -n "$CMUX_SURFACE_ID" ] && [ "$CMUX_CODEX_HOOKS_DISABLED" != "1" ] '
-        "&& command -v cmux >/dev/null 2>&1 && cmux hooks feed --source codex --event PreToolUse || echo '{}'"
-    )
-    orca_hook = (
-        "if [ -x '/Users/lawrence/Library/Application Support/orca/agent-hooks/codex-hook.sh' ]; "
-        "then /bin/sh '/Users/lawrence/Library/Application Support/orca/agent-hooks/codex-hook.sh'; fi"
-    )
-    (codex_home / "hooks.json").write_text(
-        json.dumps(
-            {
-                "hooks": {
-                    "PreToolUse": [
-                        {"hooks": [{"type": "command", "command": cmux_pre_tool, "timeout": 120000}]},
-                        {"hooks": [{"type": "command", "command": orca_hook}]},
-                    ]
-                }
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
-    groups = hooks["hooks"]["PreToolUse"]
-    first_command = groups[0]["hooks"][0]["command"]
-    second_command = groups[1]["hooks"][0]["command"]
-    if "cmux hooks feed --source codex --event PreToolUse" not in first_command:
-        raise AssertionError(f"cmux hook did not keep its existing position: {groups!r}")
-    if second_command != orca_hook:
-        raise AssertionError(f"third-party hook was not preserved after cmux hook: {groups!r}")
-
-
-def test_install_replaces_legacy_codex_hook_commands(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-legacy-hooks"
-    codex_home.mkdir()
-    (codex_home / "hooks.json").write_text(
-        json.dumps(
-            {
-                "hooks": {
-                    "Stop": [
-                        {"hooks": [{"type": "command", "command": "cmux codex-hook stop"}]},
-                    ],
-                    "PreToolUse": [
-                        {
-                            "hooks": [
-                                {
-                                    "type": "command",
-                                    "command": "cmux feed-hook --source codex --event PreToolUse",
-                                }
-                            ]
-                        },
-                    ],
-                }
-            },
-            indent=2,
-        ),
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    hooks = json.loads((codex_home / "hooks.json").read_text(encoding="utf-8"))
-    commands = codex_hook_commands(hooks)
-    if any("cmux codex-hook" in command or "cmux feed-hook --source" in command for command in commands):
-        raise AssertionError(f"legacy cmux hook commands were not removed: {commands!r}")
-    if cmux_codex_hook_command("stop") not in commands:
-        raise AssertionError(f"current Stop hook was not installed: {commands!r}")
-    if cmux_codex_feed_command("PreToolUse") not in commands:
-        raise AssertionError(f"current PreToolUse feed hook was not installed: {commands!r}")
-
-
-def test_install_migrates_legacy_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-legacy"
-    codex_home.mkdir()
-    # Real configs can contain both names after users tried the old and new flags.
-    (codex_home / "config.toml").write_text(
-        "[features]\napps = true\ncodex_hooks = false\nhooks = false\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "codex_hooks" in config_toml:
-        raise AssertionError(f"deprecated codex_hooks feature was preserved: {config_toml!r}")
-    if "hooks = true" not in config_toml:
-        raise AssertionError(f"hooks feature was not enabled: {config_toml!r}")
-    if "apps = true" not in config_toml:
-        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
-
-
-def test_install_migrates_dotted_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-dotted-legacy"
-    codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        "features.apps = true\nfeatures.codex_hooks = false\nfeatures.hooks = false\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "features.codex_hooks" in config_toml or "[features]" in config_toml:
-        raise AssertionError(f"dotted legacy config was rewritten incorrectly: {config_toml!r}")
-    if "features.hooks = true" not in config_toml:
-        raise AssertionError(f"dotted hooks feature was not enabled: {config_toml!r}")
-    if "features.apps = true" not in config_toml:
-        raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
-
-
-def test_uninstall_preserves_existing_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-uninstall-existing"
-    codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        "[features]\napps = true\nhooks = true\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    for action in ["install", "uninstall"]:
-        result = subprocess.run(
-            [cli_path, "hooks", "codex", action, "--yes"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=20,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-            )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "hooks = true" not in config_toml:
-        raise AssertionError(f"pre-existing hooks feature was removed: {config_toml!r}")
-    if "apps = true" not in config_toml:
-        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
+    if "codex_hooks = true" not in config_toml:
+        raise AssertionError(f"codex_hooks feature was not enabled: {config_toml!r}")
 
 
 def test_install_codex_hooks_only_edits_real_features_table(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-real-features"
+    codex_home = root / "codex-home"
     codex_home.mkdir()
     config_path = codex_home / "config.toml"
     config_path.write_text(
@@ -987,10 +562,8 @@ def test_install_codex_hooks_only_edits_real_features_table(cli_path: str, root:
         )
 
     config_toml = config_path.read_text(encoding="utf-8")
-    if config_toml.count("hooks = true") != 1:
-        raise AssertionError(f"hooks should be inserted exactly once: {config_toml!r}")
-    if "codex_hooks" in config_toml:
-        raise AssertionError(f"deprecated codex_hooks feature was written: {config_toml!r}")
+    if config_toml.count("codex_hooks = true") != 1:
+        raise AssertionError(f"codex_hooks should be inserted exactly once: {config_toml!r}")
     if "# See [features] in the documentation." not in config_toml:
         raise AssertionError(f"comment with [features] was corrupted: {config_toml!r}")
     if 'note = "literal [features] mention"' not in config_toml:
@@ -998,10 +571,8 @@ def test_install_codex_hooks_only_edits_real_features_table(cli_path: str, root:
 
     lines = config_toml.splitlines()
     features_index = lines.index("[features]")
-    if lines[features_index + 1] != "# cmux-codex-hooks-feature-78f1e4ba-66df-4d35-93c1-67fdf1cbb7df begin":
-        raise AssertionError(f"cmux marker should be inserted into [features]: {config_toml!r}")
-    if lines[features_index + 2] != "hooks = true":
-        raise AssertionError(f"hooks should be inserted into [features]: {config_toml!r}")
+    if lines[features_index + 1] != "codex_hooks = true":
+        raise AssertionError(f"codex_hooks should be inserted into [features]: {config_toml!r}")
 
 
 def test_uninstall_codex_hooks_removes_empty_features_table_from_install(cli_path: str, root: Path) -> None:
@@ -1027,10 +598,8 @@ def test_uninstall_codex_hooks_removes_empty_features_table_from_install(cli_pat
         )
 
     installed_config = config_path.read_text(encoding="utf-8")
-    if "[features]" not in installed_config or "hooks = true" not in installed_config:
-        raise AssertionError(f"install should add the hooks feature table: {installed_config!r}")
-    if "codex_hooks" in installed_config:
-        raise AssertionError(f"install should not add deprecated codex_hooks: {installed_config!r}")
+    if "[features]" not in installed_config or "codex_hooks = true" not in installed_config:
+        raise AssertionError(f"install should add the codex_hooks feature table: {installed_config!r}")
 
     result = subprocess.run(
         [cli_path, "hooks", "codex", "uninstall", "--yes"],
@@ -1048,210 +617,6 @@ def test_uninstall_codex_hooks_removes_empty_features_table_from_install(cli_pat
     config_toml = config_path.read_text(encoding="utf-8")
     if config_toml != original_config:
         raise AssertionError(f"uninstall should remove the empty [features] table: {config_toml!r}")
-
-def test_uninstall_restores_disabled_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-uninstall-disabled"
-    codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        "[features]\napps = true\nhooks = false\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    for action in ["install", "uninstall"]:
-        result = subprocess.run(
-            [cli_path, "hooks", "codex", action, "--yes"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=20,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-            )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "hooks = false" not in config_toml:
-        raise AssertionError(f"pre-existing disabled hooks feature was not restored: {config_toml!r}")
-    if "hooks = true" in config_toml:
-        raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
-    if "apps = true" not in config_toml:
-        raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
-
-
-def test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-uninstall-dotted-disabled"
-    codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        "features.apps = true\nfeatures.hooks = false\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    for action in ["install", "uninstall"]:
-        result = subprocess.run(
-            [cli_path, "hooks", "codex", action, "--yes"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=20,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-            )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "features.hooks = false" not in config_toml:
-        raise AssertionError(f"pre-existing disabled dotted hooks feature was not restored: {config_toml!r}")
-    if "features.hooks = true" in config_toml:
-        raise AssertionError(f"cmux-owned dotted hooks feature was not removed: {config_toml!r}")
-    if "features.apps = true" not in config_toml:
-        raise AssertionError(f"existing dotted feature setting was not preserved: {config_toml!r}")
-
-
-def test_install_scans_features_past_bracketed_array(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-bracketed-array"
-    codex_home.mkdir()
-    (codex_home / "config.toml").write_text(
-        "[features]\napps = [\n  [1, 2],\n]\nhooks = false\n",
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    for action in ["install", "uninstall"]:
-        result = subprocess.run(
-            [cli_path, "hooks", "codex", action, "--yes"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=20,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-            )
-        config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-        if action == "install" and config_toml.count("hooks = true") != 1:
-            raise AssertionError(f"install wrote duplicate hooks settings: {config_toml!r}")
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "hooks = false" not in config_toml or "hooks = true" in config_toml:
-        raise AssertionError(f"uninstall did not restore hooks after bracketed array: {config_toml!r}")
-    if "[1, 2]" not in config_toml:
-        raise AssertionError(f"bracketed array content was not preserved: {config_toml!r}")
-
-
-def test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-uninstall-owned"
-    codex_home.mkdir()
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    for action in ["install", "uninstall"]:
-        result = subprocess.run(
-            [cli_path, "hooks", "codex", action, "--yes"],
-            capture_output=True,
-            text=True,
-            check=False,
-            env=env,
-            timeout=20,
-        )
-        if result.returncode != 0:
-            raise AssertionError(
-                f"hooks codex {action} failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-            )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if "hooks = true" in config_toml or "codex_hooks" in config_toml:
-        raise AssertionError(f"cmux-owned hooks feature was not removed: {config_toml!r}")
-    if "hooks.state" in config_toml or "trusted_hash" in config_toml:
-        raise AssertionError(f"cmux-owned hook trust was not removed: {config_toml!r}")
-    if "[features]" in config_toml:
-        raise AssertionError(f"empty features table was preserved: {config_toml!r}")
-
-
-def test_uninstall_preserves_unowned_hook_trust_when_cmux_marker_is_unclosed(
-    cli_path: str, root: Path
-) -> None:
-    codex_home = root / "codex-home-unclosed-trust"
-    codex_home.mkdir()
-    (codex_home / "hooks.json").write_text('{"hooks": {}}\n', encoding="utf-8")
-    (codex_home / "config.toml").write_text(
-        "[features]\n"
-        "hooks = true\n"
-        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
-        "[hooks.state.\"/tmp/cmux/hooks.json:pre_tool_use:0:0\"]\n"
-        'trusted_hash = "sha256:cmux"\n'
-        "[hooks.state.\"/tmp/third-party/hooks.json:pre_tool_use:0:0\"]\n"
-        'trusted_hash = "sha256:third-party"\n',
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "uninstall", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex uninstall failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if 'trusted_hash = "sha256:third-party"' not in config_toml:
-        raise AssertionError(f"unowned hook trust was removed: {config_toml!r}")
-
-
-def test_install_does_not_append_hook_trust_when_cmux_marker_is_unclosed(
-    cli_path: str, root: Path
-) -> None:
-    codex_home = root / "codex-home-unclosed-trust-install"
-    codex_home.mkdir()
-    stale_key = f"{(codex_home / 'hooks.json').resolve()}:pre_tool_use:0:0"
-    (codex_home / "config.toml").write_text(
-        "[features]\n"
-        "hooks = true\n"
-        "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin\n"
-        f'[hooks.state."{stale_key}"]\n'
-        'trusted_hash = "sha256:stale"\n',
-        encoding="utf-8",
-    )
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"hooks codex install failed exit={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-
-    config_toml = (codex_home / "config.toml").read_text(encoding="utf-8")
-    if config_toml.count("# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 begin") != 1:
-        raise AssertionError(f"install appended a second cmux hook trust marker: {config_toml!r}")
-    if "# cmux-codex-hook-trust-f5cc24da-7a09-4b20-a756-89e7786f6738 end" in config_toml:
-        raise AssertionError(f"install appended a new hook trust block after malformed marker: {config_toml!r}")
-    if config_toml.count("[hooks.state.") != 1:
-        raise AssertionError(f"install appended duplicate hook trust tables: {config_toml!r}")
 
 
 def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root: Path) -> None:
@@ -1308,69 +673,8 @@ def test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path: str, root:
         raise AssertionError(f"existing feature setting was not preserved: {config_toml!r}")
 
 
-def test_install_surfaces_invalid_codex_config_encoding(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-invalid-install-config"
-    codex_home.mkdir()
-    config_path = codex_home / "config.toml"
-    invalid_bytes = b"\xff"
-    config_path.write_bytes(invalid_bytes)
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode == 0:
-        raise AssertionError("hooks codex install unexpectedly succeeded with invalid config encoding")
-    if config_path.read_bytes() != invalid_bytes:
-        raise AssertionError("hooks codex install overwrote unreadable config content")
-
-
-def test_uninstall_surfaces_invalid_codex_config_encoding(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-invalid-uninstall-config"
-    codex_home.mkdir()
-    env = os.environ.copy()
-    env["CODEX_HOME"] = str(codex_home)
-
-    install_result = subprocess.run(
-        [cli_path, "hooks", "codex", "install", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if install_result.returncode != 0:
-        raise AssertionError(
-            "initial hooks codex install failed "
-            f"exit={install_result.returncode}\nstdout={install_result.stdout}\nstderr={install_result.stderr}"
-        )
-
-    config_path = codex_home / "config.toml"
-    invalid_bytes = b"\xff"
-    config_path.write_bytes(invalid_bytes)
-
-    result = subprocess.run(
-        [cli_path, "hooks", "codex", "uninstall", "--yes"],
-        capture_output=True,
-        text=True,
-        check=False,
-        env=env,
-        timeout=20,
-    )
-    if result.returncode == 0:
-        raise AssertionError("hooks codex uninstall unexpectedly succeeded with invalid config encoding")
-    if config_path.read_bytes() != invalid_bytes:
-        raise AssertionError("hooks codex uninstall overwrote unreadable config content")
-
-
 def test_install_codex_hooks_preserves_config_when_toml_read_fails(cli_path: str, root: Path) -> None:
-    codex_home = root / "codex-home-toml-read-fails"
+    codex_home = root / "codex-home"
     codex_home.mkdir()
     config_path = codex_home / "config.toml"
     original_bytes = b'model = "safe"\ninvalid_utf8 = "\xff"\n'
@@ -1494,23 +798,9 @@ def main() -> int:
             test_codex_monitor_exits_when_workspace_has_no_surfaces(cli_path, root)
             test_codex_monitor_survives_transient_owner_rpc_timeout(cli_path, root)
             test_install_adds_codex_permission_request_hook(cli_path, root)
-            test_install_escapes_codex_hook_trust_state_keys(cli_path, root)
-            test_install_preserves_codex_hook_position_with_third_party_hooks(cli_path, root)
-            test_install_replaces_legacy_codex_hook_commands(cli_path, root)
-            test_install_migrates_legacy_codex_hooks_feature(cli_path, root)
-            test_install_migrates_dotted_codex_hooks_feature(cli_path, root)
-            test_uninstall_preserves_existing_codex_hooks_feature(cli_path, root)
             test_install_codex_hooks_only_edits_real_features_table(cli_path, root)
             test_uninstall_codex_hooks_removes_empty_features_table_from_install(cli_path, root)
-            test_uninstall_restores_disabled_codex_hooks_feature(cli_path, root)
-            test_uninstall_restores_disabled_dotted_codex_hooks_feature(cli_path, root)
-            test_install_scans_features_past_bracketed_array(cli_path, root)
-            test_uninstall_removes_cmux_owned_codex_hooks_feature(cli_path, root)
-            test_uninstall_preserves_unowned_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
-            test_install_does_not_append_hook_trust_when_cmux_marker_is_unclosed(cli_path, root)
             test_uninstall_codex_hooks_removes_legacy_managed_block(cli_path, root)
-            test_install_surfaces_invalid_codex_config_encoding(cli_path, root)
-            test_uninstall_surfaces_invalid_codex_config_encoding(cli_path, root)
             test_install_codex_hooks_preserves_config_when_toml_read_fails(cli_path, root)
             test_permission_reply_uses_codex_permission_request_schema(cli_path, root)
             test_codex_persistent_permission_modes_degrade_to_once(cli_path, root)


### PR DESCRIPTION
Reverts https://github.com/manaflow-ai/cmux/pull/4035 so the Codex hook approval change can be dogfooded before relanding.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies Codex hook install/uninstall behavior and TOML config rewriting, which can affect users’ hook configs and migration paths. Risk is limited to hook management, but regressions could break existing Codex hook setups or leave stale entries behind.
> 
> **Overview**
> Reverts the Codex hook approval/trust changes: the CLI no longer computes/writes Codex hook trust hashes into `config.toml`, and install messaging is simplified to only enabling `codex_hooks`.
> 
> Hook install/uninstall now identifies cmux-owned entries via substring **markers** (including legacy `cmux codex-hook` / `cmux feed-hook`) rather than exact command matching, and no longer tries to preserve prior insertion positions when re-installing.
> 
> Codex `config.toml` editing is rewritten to directly set/remove `codex_hooks` (including dotted form) and to strip legacy managed blocks; Python regression tests are trimmed/updated accordingly, and a workspace unit test is updated for a renamed auto-resume field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dee2d2fcdbfe8b46294d4b49726f87e600018cf4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts Codex hook auto-approval so we can dogfood the flow before relanding. Removes writing trusted hashes to Codex `config.toml` and restores the previous `codex_hooks` feature behavior.

- **Refactors**
  - Remove hook trust/approval generation and migration; stop writing `hooks.state.*.trusted_hash` to `config.toml`.
  - Restore marker-based detection for `cmux`-owned hooks; simplify install/uninstall without insertion indices.
  - `cmux hooks codex install` now enables `[features]` with `codex_hooks = true` (no migration to `features.hooks`).
  - `cmux hooks codex uninstall` removes the empty `[features]` table when applicable.
  - Update tests to drop trust/approval cases and assert `codex_hooks` behavior only.
  - Minor test rename: `restorableAgentResumeState` → `restorableAgentAutoResumePending`.

<sup>Written for commit dee2d2fcdbfe8b46294d4b49726f87e600018cf4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for Codex configuration files—now gracefully handles unreadable files instead of throwing errors.

* **Refactor**
  * Simplified Codex hooks installation and detection mechanisms for improved reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4074)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->