### PR TITLE
Fix workspace unit test after Codex hook revert

### DIFF
--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2456,7 +2456,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             customTitle: nil,
             manuallyUnread: false,
             restorableAgent: nil,
-            restorableAgentAutoResumePending: false,
+            restorableAgentResumeState: nil,
             agentRuntime: nil,
             isRemoteTerminal: false,
             remoteRelayPort: nil,


### PR DESCRIPTION
Restores the `Workspace.DetachedSurfaceTransfer` initializer argument update that was accidentally reverted by https://github.com/manaflow-ai/cmux/pull/4074. This keeps the hook approval feature reverted while fixing the existing unit test compile break.\n\nVerification:\n- Targeted `cmux-unit` test for `WorkspaceCreationWorkingDirectoryInheritanceTests/testDisabledInheritanceLeavesDetachedWorkspaceFallbackCwdUnsetWhenTransferHasNoDirectory` passed locally with isolated derived data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only change adjusting a single initializer argument with no production logic changes.
> 
> **Overview**
> Updates `cmuxTests/WorkspaceUnitTests.swift` to use the newer `Workspace.DetachedSurfaceTransfer` initializer argument (`restorableAgentResumeState`) instead of the reverted `restorableAgentAutoResumePending`, restoring unit test compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 762b96d5cadf436dba6f4863af230c9ab4981fd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing workspace unit test by updating the `Workspace.DetachedSurfaceTransfer` initializer to use `restorableAgentResumeState: nil` instead of the removed `restorableAgentAutoResumePending` flag. Keeps the hook approval feature reverted while restoring test compile and behavior.

<sup>Written for commit 762b96d5cadf436dba6f4863af230c9ab4981fd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure for workspace transfer validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4076)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->