### PR TITLE
Add tagged debug CLI helper

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,21 @@ App path:
 
 Never use `/tmp/cmux-<tag>/...` app links in chat output.
 
+For CLI or socket dogfood against a tagged Debug app, use the tag-bound helper and set `CMUX_TAG`.
+Do not use `/tmp/cmux-cli` for tagged dogfood, since that symlink points at the most recently
+reloaded build and can target the user's main app socket.
+
+```bash
+CMUX_TAG=<tag> scripts/cmux-debug-cli.sh list-workspaces
+CMUX_TAG=<tag> scripts/cmux-debug-cli.sh send --workspace workspace:1 --surface surface:1 "echo ok"
+```
+
+The helper refuses to run without `CMUX_TAG`, targets `/tmp/cmux-debug-<tag>.sock`, and uses the
+matching tagged CLI from `~/Library/Developer/Xcode/DerivedData/cmux-<tag>/...`. It also scrubs
+ambient cmux terminal context (`CMUX_SOCKET`, `CMUX_SOCKET_PASSWORD`, workspace/surface/tab/panel
+IDs, cmuxd socket, and debug log), then sets `CMUX_SOCKET_PATH`, `CMUX_BUNDLE_ID`, and
+`CMUX_BUNDLED_CLI_PATH` for the selected tag.
+
 After making code changes, always use `reload.sh --tag` to build. **Never run bare `xcodebuild` or `open` an untagged `cmux DEV.app`.** Untagged builds share the default debug socket and bundle ID with other agents, causing conflicts and stealing focus.
 
 ```bash

--- a/scripts/cmux-debug-cli.sh
+++ b/scripts/cmux-debug-cli.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${CMUX_TAG:-}" ]]; then
+  cat >&2 <<'EOF'
+CMUX_TAG is required.
+
+Usage:
+  CMUX_TAG=<tag> scripts/cmux-debug-cli.sh <cmux-command> [args...]
+
+Example:
+  CMUX_TAG=codext scripts/cmux-debug-cli.sh list-workspaces
+EOF
+  exit 2
+fi
+
+if [[ ! "$CMUX_TAG" =~ ^[A-Za-z0-9._-]+$ ]]; then
+  echo "Invalid CMUX_TAG: $CMUX_TAG" >&2
+  exit 2
+fi
+
+if [[ $# -eq 0 ]]; then
+  echo "Usage: CMUX_TAG=$CMUX_TAG scripts/cmux-debug-cli.sh <cmux-command> [args...]" >&2
+  exit 2
+fi
+
+sanitize_bundle() {
+  local raw="$1"
+  local cleaned
+  cleaned="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/./g; s/^\.+//; s/\.+$//; s/\.+/./g')"
+  if [[ -z "$cleaned" ]]; then
+    cleaned="agent"
+  fi
+  printf '%s\n' "$cleaned"
+}
+
+sanitize_path() {
+  local raw="$1"
+  local cleaned
+  cleaned="$(printf '%s' "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  if [[ -z "$cleaned" ]]; then
+    cleaned="agent"
+  fi
+  printf '%s\n' "$cleaned"
+}
+
+tag_slug="$(sanitize_path "$CMUX_TAG")"
+tag_bundle_id="$(sanitize_bundle "$CMUX_TAG")"
+
+socket_path="/tmp/cmux-debug-${tag_slug}.sock"
+if [[ ! -S "$socket_path" ]]; then
+  cat >&2 <<EOF
+Tagged cmux socket not found:
+  $socket_path
+
+Launch the tagged app first:
+  ./scripts/reload.sh --tag $CMUX_TAG --launch
+EOF
+  exit 1
+fi
+
+cli_path="${HOME}/Library/Developer/Xcode/DerivedData/cmux-${tag_slug}/Build/Products/Debug/cmux DEV ${tag_slug}.app/Contents/Resources/bin/cmux"
+if [[ ! -x "$cli_path" ]]; then
+  cat >&2 <<EOF
+Tagged cmux CLI not found:
+  $cli_path
+
+Build the tagged app first:
+  ./scripts/reload.sh --tag $CMUX_TAG
+EOF
+  exit 1
+fi
+
+unset CMUX_SOCKET
+unset CMUX_SOCKET_PASSWORD
+unset CMUX_WORKSPACE_ID
+unset CMUX_SURFACE_ID
+unset CMUX_TAB_ID
+unset CMUX_PANEL_ID
+unset CMUXD_UNIX_PATH
+unset CMUX_DEBUG_LOG
+export CMUX_SOCKET_PATH="$socket_path"
+export CMUX_TAG="$tag_slug"
+export CMUX_BUNDLE_ID="com.cmuxterm.app.debug.${tag_bundle_id}"
+export CMUX_BUNDLED_CLI_PATH="$cli_path"
+exec "$cli_path" "$@"

--- a/tests/test_cmux_debug_cli_helper.sh
+++ b/tests/test_cmux_debug_cli_helper.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Regression test: the tag-bound debug CLI helper scrubs ambient cmux env and
+# routes commands through the tagged socket and tagged bundled CLI.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TAG="Debug_Helper.Test"
+TAG_SLUG="debug-helper-test"
+TAG_BUNDLE_ID="debug.helper.test"
+SOCKET_PATH="/tmp/cmux-debug-${TAG_SLUG}.sock"
+TMP_DIR="$(mktemp -d)"
+SERVER_PID=""
+
+cleanup() {
+  if [[ -n "$SERVER_PID" ]]; then
+    kill "$SERVER_PID" >/dev/null 2>&1 || true
+  fi
+  rm -rf "$TMP_DIR"
+  rm -f "$SOCKET_PATH"
+}
+trap cleanup EXIT
+
+FAKE_HOME="$TMP_DIR/home"
+FAKE_CLI_DIR="$FAKE_HOME/Library/Developer/Xcode/DerivedData/cmux-${TAG_SLUG}/Build/Products/Debug/cmux DEV ${TAG_SLUG}.app/Contents/Resources/bin"
+FAKE_CLI="$FAKE_CLI_DIR/cmux"
+mkdir -p "$FAKE_CLI_DIR"
+cat > "$FAKE_CLI" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "env" ]]; then
+  env | sort
+  exit 0
+fi
+printf 'fake cmux argv:'
+printf ' %q' "$@"
+printf '\n'
+EOF
+chmod +x "$FAKE_CLI"
+
+rm -f "$SOCKET_PATH"
+python3 - "$SOCKET_PATH" <<'PY' >/dev/null 2>&1 &
+import os
+import socket
+import sys
+import time
+
+path = sys.argv[1]
+try:
+    os.unlink(path)
+except FileNotFoundError:
+    pass
+
+sock = socket.socket(socket.AF_UNIX)
+sock.bind(path)
+sock.listen(1)
+time.sleep(60)
+PY
+SERVER_PID="$!"
+
+for _ in {1..100}; do
+  if [[ -S "$SOCKET_PATH" ]]; then
+    break
+  fi
+  sleep 0.05
+done
+
+if [[ ! -S "$SOCKET_PATH" ]]; then
+  echo "FAIL: test socket was not created at $SOCKET_PATH"
+  exit 1
+fi
+
+OUTPUT="$(
+  HOME="$FAKE_HOME" \
+  CMUX_TAG="$TAG" \
+  CMUX_SOCKET="/tmp/main-cmux-legacy.sock" \
+  CMUX_SOCKET_PATH="/tmp/main-cmux.sock" \
+  CMUX_SOCKET_PASSWORD="main-secret" \
+  CMUX_BUNDLE_ID="com.cmuxterm.app" \
+  CMUX_BUNDLED_CLI_PATH="/Applications/cmux.app/Contents/Resources/bin/cmux" \
+  CMUX_WORKSPACE_ID="main-workspace" \
+  CMUX_TAB_ID="main-tab" \
+  CMUX_SURFACE_ID="main-surface" \
+  CMUX_PANEL_ID="main-panel" \
+  CMUXD_UNIX_PATH="/tmp/main-cmuxd.sock" \
+  CMUX_DEBUG_LOG="/tmp/main-cmux.log" \
+  "$ROOT_DIR/scripts/cmux-debug-cli.sh" env
+)"
+
+require_line() {
+  local expected="$1"
+  if ! grep -Fxq "$expected" <<<"$OUTPUT"; then
+    echo "FAIL: expected env line not found: $expected"
+    echo "$OUTPUT"
+    exit 1
+  fi
+}
+
+reject_prefix() {
+  local prefix="$1"
+  if grep -Eq "^${prefix}=" <<<"$OUTPUT"; then
+    echo "FAIL: unexpected env line with prefix: $prefix"
+    echo "$OUTPUT"
+    exit 1
+  fi
+}
+
+require_line "CMUX_SOCKET_PATH=$SOCKET_PATH"
+require_line "CMUX_TAG=$TAG_SLUG"
+require_line "CMUX_BUNDLE_ID=com.cmuxterm.app.debug.${TAG_BUNDLE_ID}"
+require_line "CMUX_BUNDLED_CLI_PATH=$FAKE_CLI"
+
+reject_prefix "CMUX_SOCKET"
+reject_prefix "CMUX_SOCKET_PASSWORD"
+reject_prefix "CMUX_WORKSPACE_ID"
+reject_prefix "CMUX_TAB_ID"
+reject_prefix "CMUX_SURFACE_ID"
+reject_prefix "CMUX_PANEL_ID"
+reject_prefix "CMUXD_UNIX_PATH"
+reject_prefix "CMUX_DEBUG_LOG"
+
+echo "PASS: cmux-debug-cli.sh routes through the tagged CLI/socket and scrubs ambient cmux env"


### PR DESCRIPTION
## Summary
- Add scripts/cmux-debug-cli.sh for tag-bound debug CLI calls.
- Document the helper in AGENTS.md via CLAUDE.md.
- Add a shell regression test proving ambient main-app cmux env is scrubbed.

## Testing
- bash -n scripts/cmux-debug-cli.sh && bash -n tests/test_cmux_debug_cli_helper.sh && tests/test_cmux_debug_cli_helper.sh
- manual env probe through scripts/cmux-debug-cli.sh
- CMUX_TAG=codext scripts/cmux-debug-cli.sh list-windows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a standalone bash helper + regression test and updates developer docs, without touching app/runtime codepaths.
> 
> **Overview**
> Adds `scripts/cmux-debug-cli.sh`, a tag-bound wrapper for running `cmux` CLI commands against a *specific* tagged Debug build by deriving `/tmp/cmux-debug-<tag>.sock` and the matching bundled CLI from DerivedData, while scrubbing ambient `CMUX_*` context that could accidentally hit the main app.
> 
> Updates `CLAUDE.md` to document using the helper (instead of `/tmp/cmux-cli`) for tagged dogfooding, and adds `tests/test_cmux_debug_cli_helper.sh` to assert the env-scrub + socket/CLI routing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f15cf60299ae5b563fa124cff42074f03316e83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a tag-bound debug CLI helper to run cmux commands against a specific tagged Debug app/socket. This prevents accidental calls to the main app and makes tagged dogfooding safe.

- **New Features**
  - Added `scripts/cmux-debug-cli.sh`; requires `CMUX_TAG`, targets `/tmp/cmux-debug-<tag>.sock`, and uses the matching bundled CLI in `~/Library/Developer/Xcode/DerivedData/cmux-<tag>/...`.
  - Scrubs ambient cmux env (`CMUX_SOCKET`, `CMUX_SOCKET_PASSWORD`, `CMUX_*_ID`, `CMUXD_UNIX_PATH`, `CMUX_DEBUG_LOG`) and sets `CMUX_SOCKET_PATH`, `CMUX_TAG`, `CMUX_BUNDLE_ID` (`com.cmuxterm.app.debug.<tag>`), and `CMUX_BUNDLED_CLI_PATH`.
  - Documented usage in `CLAUDE.md` with examples; added regression test `tests/test_cmux_debug_cli_helper.sh` to verify scrubbing and routing to the tagged CLI/socket.

<sup>Written for commit 5f15cf60299ae5b563fa124cff42074f03316e83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

