### PR TITLE
Keep manual unread sticky until terminal interaction

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1330,6 +1330,8 @@ struct ContentView: View {
         let contentView = window.contentView
 
         let unreadRects: [CGRect]
+        let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
+        let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
         if let layoutSnapshot, let contentView {
             unreadRects = layoutSnapshot.panes.compactMap { pane in
                 guard let selectedTabId = pane.selectedTabId,
@@ -1344,7 +1346,9 @@ struct ContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panelId
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId)
+                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId),
+                    isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                    isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId
                 )
                 guard shouldShowUnread else { return nil }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7563,7 +7563,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 #if DEBUG
             let dismissNotificationStart = ProcessInfo.processInfo.systemUptime
 #endif
-            AppDelegate.shared?.tabManager?.dismissNotificationOnDirectInteraction(
+            AppDelegate.shared?.tabManager?.dismissNotificationOnTerminalInteraction(
                 tabId: terminalSurface.tabId,
                 surfaceId: terminalSurface.id
             )
@@ -8367,7 +8367,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         requestPointerFocusRecovery()
         window?.makeFirstResponder(self)
         if let terminalSurface {
-            AppDelegate.shared?.tabManager?.dismissNotificationOnDirectInteraction(
+            AppDelegate.shared?.tabManager?.dismissNotificationOnTerminalInteraction(
                 tabId: terminalSurface.tabId,
                 surfaceId: terminalSurface.id
             )

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5109,16 +5109,34 @@ class TabManager: ObservableObject {
             guard AppFocusState.isAppActive() else { return false }
         }
         guard let notificationStore = AppDelegate.shared?.notificationStore else { return false }
+        let workspace = tabs.first(where: { $0.id == tabId })
+        let hasManualPanelUnread = surfaceId.map { workspace?.manualUnreadPanelIds.contains($0) ?? false } ?? false
+        let hasManualWorkspaceUnread = notificationStore.hasManualUnread(forTabId: tabId)
+        let canDismissManualUnread = context == .directInteraction && (hasManualPanelUnread || hasManualWorkspaceUnread)
         let hasUnreadNotification = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         let hasFocusedIndicator = notificationStore.hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: surfaceId)
-        guard hasUnreadNotification || hasFocusedIndicator else { return false }
+        guard hasUnreadNotification || hasFocusedIndicator || canDismissManualUnread else { return false }
         if hasUnreadNotification {
             notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
         }
+        var didDismissManualUnread = false
+        if context == .directInteraction {
+            if let panelId = surfaceId, hasManualPanelUnread {
+                workspace?.clearManualUnread(panelId: panelId)
+                didDismissManualUnread = true
+            }
+            if hasManualWorkspaceUnread {
+                didDismissManualUnread = notificationStore.clearManualUnread(forTabId: tabId) || didDismissManualUnread
+            }
+        }
         notificationStore.clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         if let panelId = surfaceId,
-           let tab = tabs.first(where: { $0.id == tabId }) {
-            tab.triggerNotificationDismissFlash(panelId: panelId)
+           let workspace {
+            if hasUnreadNotification || hasFocusedIndicator {
+                workspace.triggerNotificationDismissFlash(panelId: panelId)
+            } else if didDismissManualUnread {
+                workspace.triggerManualUnreadDismissFlash(panelId: panelId)
+            }
         }
         return true
     }

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5073,6 +5073,7 @@ class TabManager: ObservableObject {
     private enum NotificationDismissalContext {
         case activeFocus
         case directInteraction
+        case terminalInteraction
     }
 
     private func dismissFocusedPanelNotificationIfActive(tabId: UUID) {
@@ -5099,6 +5100,11 @@ class TabManager: ObservableObject {
     }
 
     @discardableResult
+    func dismissNotificationOnTerminalInteraction(tabId: UUID, surfaceId: UUID?) -> Bool {
+        dismissNotification(tabId: tabId, surfaceId: surfaceId, context: .terminalInteraction)
+    }
+
+    @discardableResult
     private func dismissNotification(
         tabId: UUID,
         surfaceId: UUID?,
@@ -5112,7 +5118,7 @@ class TabManager: ObservableObject {
         let workspace = tabs.first(where: { $0.id == tabId })
         let hasManualPanelUnread = surfaceId.map { workspace?.manualUnreadPanelIds.contains($0) ?? false } ?? false
         let hasManualWorkspaceUnread = notificationStore.hasManualUnread(forTabId: tabId)
-        let canDismissManualUnread = context == .directInteraction && (hasManualPanelUnread || hasManualWorkspaceUnread)
+        let canDismissManualUnread = context == .terminalInteraction && (hasManualPanelUnread || hasManualWorkspaceUnread)
         let hasUnreadNotification = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         let hasFocusedIndicator = notificationStore.hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: surfaceId)
         guard hasUnreadNotification || hasFocusedIndicator || canDismissManualUnread else { return false }
@@ -5120,7 +5126,7 @@ class TabManager: ObservableObject {
             notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
         }
         var didDismissManualUnread = false
-        if context == .directInteraction {
+        if context == .terminalInteraction {
             if let panelId = surfaceId, hasManualPanelUnread {
                 workspace?.clearManualUnread(panelId: panelId)
                 didDismissManualUnread = true

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -896,7 +896,8 @@ final class TerminalNotificationStore: ObservableObject {
         refreshAuthorizationStatus()
     }
 
-    private func setWorkspaceManualUnread(_ isUnread: Bool, forTabId tabId: UUID) {
+    @discardableResult
+    private func setWorkspaceManualUnread(_ isUnread: Bool, forTabId tabId: UUID) -> Bool {
         var nextIds = manualUnreadWorkspaceIds
         let didChange: Bool
         if isUnread {
@@ -904,13 +905,23 @@ final class TerminalNotificationStore: ObservableObject {
         } else {
             didChange = nextIds.remove(tabId) != nil
         }
-        guard didChange else { return }
+        guard didChange else { return false }
         manualUnreadWorkspaceIds = nextIds
+        return true
     }
 
     private func clearWorkspaceManualUnread() {
         guard !manualUnreadWorkspaceIds.isEmpty else { return }
         manualUnreadWorkspaceIds = []
+    }
+
+    func hasManualUnread(forTabId tabId: UUID) -> Bool {
+        manualUnreadWorkspaceIds.contains(tabId)
+    }
+
+    @discardableResult
+    func clearManualUnread(forTabId tabId: UUID) -> Bool {
+        setWorkspaceManualUnread(false, forTabId: tabId)
     }
 
     // Per-workspace badges treat manualUnreadWorkspaceIds as "has unread
@@ -1350,7 +1361,6 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
-        setWorkspaceManualUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1359,20 +1369,7 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     func markUnread(forTabId tabId: UUID) {
-        var updated = notifications
-        var didChange = false
-        for index in updated.indices {
-            if updated[index].tabId == tabId, updated[index].isRead {
-                updated[index].isRead = false
-                didChange = true
-            }
-        }
-        if didChange {
-            setWorkspaceManualUnread(false, forTabId: tabId)
-            notifications = updated
-        } else if !workspaceIsUnread(forTabId: tabId) {
-            setWorkspaceManualUnread(true, forTabId: tabId)
-        }
+        setWorkspaceManualUnread(true, forTabId: tabId)
     }
 
     @discardableResult

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7202,17 +7202,27 @@ final class Workspace: Identifiable, ObservableObject {
     }
 
     func representativePanelIdForWorkspaceManualUnread() -> UUID? {
-        if let focusedPanelId {
+        if let focusedPanelId, panels[focusedPanelId] != nil {
             return focusedPanelId
         }
 
-        for paneId in bonsplitController.allPaneIds {
-            guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
-                  let panelId = panelIdFromSurfaceId(tabId) else { continue }
+        let selectedPanelsByPaneId = Dictionary(
+            uniqueKeysWithValues: bonsplitController.allPaneIds.compactMap { paneId -> (String, UUID)? in
+                guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
+                      let panelId = panelIdFromSurfaceId(tabId),
+                      panels[panelId] != nil else {
+                    return nil
+                }
+                return (paneId.id.uuidString, panelId)
+            }
+        )
+
+        for paneId in SidebarBranchOrdering.orderedPaneIds(tree: bonsplitController.treeSnapshot()) {
+            guard let panelId = selectedPanelsByPaneId[paneId] else { continue }
             return panelId
         }
 
-        return panels.keys.first
+        return sidebarOrderedPanelIds().first
     }
 
     func effectiveSelectedPanelId(inPane paneId: PaneID) -> UUID? {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7221,8 +7221,6 @@ final class Workspace: Identifiable, ObservableObject {
     @Published private(set) var tmuxWorkspaceFlashReason: WorkspaceAttentionFlashReason?
     @Published private(set) var tmuxWorkspaceFlashToken: UInt64 = 0
     var manualUnreadMarkedAt: [UUID: Date] = [:]
-    nonisolated private static let manualUnreadFocusGraceInterval: TimeInterval = 0.2
-    nonisolated private static let manualUnreadClearDelayAfterFocusFlash: TimeInterval = 0.2
     @Published var statusEntries: [String: SidebarStatusEntry] = [:]
     @Published var metadataBlocks: [String: SidebarMetadataBlock] = [:]
     @Published private(set) var latestConversationMessage: String?
@@ -8465,24 +8463,6 @@ final class Workspace: Identifiable, ObservableObject {
         manualUnreadMarkedAt.removeValue(forKey: panelId)
         guard didRemoveUnread else { return }
         syncUnreadBadgeStateForPanel(panelId)
-    }
-
-    static func shouldClearManualUnread(
-        previousFocusedPanelId: UUID?,
-        nextFocusedPanelId: UUID,
-        isManuallyUnread: Bool,
-        markedAt: Date?,
-        now: Date = Date(),
-        sameTabGraceInterval: TimeInterval = manualUnreadFocusGraceInterval
-    ) -> Bool {
-        guard isManuallyUnread else { return false }
-
-        if let previousFocusedPanelId, previousFocusedPanelId != nextFocusedPanelId {
-            return true
-        }
-
-        guard let markedAt else { return true }
-        return now.timeIntervalSince(markedAt) >= sameTabGraceInterval
     }
 
     static func shouldShowUnreadIndicator(hasUnreadNotification: Bool, isManuallyUnread: Bool) -> Bool {
@@ -11889,6 +11869,11 @@ final class Workspace: Identifiable, ObservableObject {
         requestAttentionFlash(panelId: panelId, reason: .notificationDismiss)
     }
 
+    func triggerManualUnreadDismissFlash(panelId: UUID) {
+        guard terminalPanel(for: panelId) != nil else { return }
+        requestAttentionFlash(panelId: panelId, reason: .manualUnreadDismiss)
+    }
+
     func triggerDebugFlash(panelId: UUID) {
         guard panels[panelId] != nil else { return }
         focusPanel(panelId)
@@ -13352,24 +13337,6 @@ extension Workspace: BonsplitDelegate {
         }
         if let terminalPanel = panel as? TerminalPanel {
             rememberTerminalConfigInheritanceSource(terminalPanel)
-        }
-        let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
-        let markedAt = manualUnreadMarkedAt[panelId]
-        if Self.shouldClearManualUnread(
-            previousFocusedPanelId: previousFocusedPanelId,
-            nextFocusedPanelId: panelId,
-            isManuallyUnread: isManuallyUnread,
-            markedAt: markedAt
-        ) {
-            triggerFocusFlash(panelId: panelId)
-            let clearDelay = Self.manualUnreadClearDelayAfterFocusFlash
-            if clearDelay <= 0 {
-                clearManualUnread(panelId: panelId)
-            } else {
-                DispatchQueue.main.asyncAfter(deadline: .now() + clearDelay) { [weak self] in
-                    self?.clearManualUnread(panelId: panelId)
-                }
-            }
         }
 
         // Converge AppKit first responder with bonsplit's selected tab in the focused pane.

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7201,6 +7201,20 @@ final class Workspace: Identifiable, ObservableObject {
         return panel
     }
 
+    func representativePanelIdForWorkspaceManualUnread() -> UUID? {
+        if let focusedPanelId {
+            return focusedPanelId
+        }
+
+        for paneId in bonsplitController.allPaneIds {
+            guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id,
+                  let panelId = panelIdFromSurfaceId(tabId) else { continue }
+            return panelId
+        }
+
+        return panels.keys.first
+    }
+
     func effectiveSelectedPanelId(inPane paneId: PaneID) -> UUID? {
         bonsplitController.selectedTab(inPane: paneId).flatMap { panelIdFromSurfaceId($0.id) }
     }
@@ -8302,9 +8316,12 @@ final class Workspace: Identifiable, ObservableObject {
 
     private func syncUnreadBadgeStateForPanel(_ panelId: UUID) {
         guard let tabId = surfaceIdFromPanelId(panelId) else { return }
+        let notificationStore = AppDelegate.shared?.notificationStore
         let shouldShowUnread = Self.shouldShowUnreadIndicator(
             hasUnreadNotification: hasUnreadNotification(panelId: panelId),
-            isManuallyUnread: manualUnreadPanelIds.contains(panelId)
+            isManuallyUnread: manualUnreadPanelIds.contains(panelId),
+            isWorkspaceManuallyUnread: notificationStore?.hasManualUnread(forTabId: id) ?? false,
+            isWorkspaceManualUnreadRepresentative: representativePanelIdForWorkspaceManualUnread() == panelId
         )
         if let existing = bonsplitController.tab(tabId), existing.showsNotificationBadge == shouldShowUnread {
             return
@@ -8465,8 +8482,15 @@ final class Workspace: Identifiable, ObservableObject {
         syncUnreadBadgeStateForPanel(panelId)
     }
 
-    static func shouldShowUnreadIndicator(hasUnreadNotification: Bool, isManuallyUnread: Bool) -> Bool {
-        hasUnreadNotification || isManuallyUnread
+    static func shouldShowUnreadIndicator(
+        hasUnreadNotification: Bool,
+        isManuallyUnread: Bool,
+        isWorkspaceManuallyUnread: Bool = false,
+        isWorkspaceManualUnreadRepresentative: Bool = false
+    ) -> Bool {
+        hasUnreadNotification ||
+            isManuallyUnread ||
+            (isWorkspaceManuallyUnread && isWorkspaceManualUnreadRepresentative)
     }
 
     // MARK: - Title Management

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8329,6 +8329,12 @@ final class Workspace: Identifiable, ObservableObject {
         bonsplitController.updateTab(tabId, showsNotificationBadge: shouldShowUnread)
     }
 
+    private func syncUnreadBadgeStateForAllPanels() {
+        for panelId in panels.keys {
+            syncUnreadBadgeStateForPanel(panelId)
+        }
+    }
+
     private func normalizePinnedTabs(in paneId: PaneID) {
         guard !isNormalizingPinnedTabOrder else { return }
         isNormalizingPinnedTabOrder = true
@@ -13344,7 +13350,11 @@ extension Workspace: BonsplitDelegate {
         let panelId = effectiveFocusedPanelId
 
         syncPinnedStateForTab(selectedTabId, panelId: selectedPanelId)
-        syncUnreadBadgeStateForPanel(selectedPanelId)
+        if previousFocusedPanelId != panelId {
+            syncUnreadBadgeStateForAllPanels()
+        } else {
+            syncUnreadBadgeStateForPanel(selectedPanelId)
+        }
 
         // Unfocus all other panels
         for (id, p) in panels where id != effectiveFocusedPanelId {

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -195,6 +195,8 @@ struct WorkspaceContentView: View {
         let isSplit = workspace.bonsplitController.allPaneIds.count > 1 ||
             workspace.panels.count > 1
         let usesWorkspacePaneOverlay = TmuxOverlayExperimentSettings.target().usesWorkspacePaneOverlay
+        let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
+        let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
 
         // Inactive workspaces are kept alive in a ZStack (for state preservation) but their
         // AppKit-backed views can still intercept drags. Disable drop acceptance for them.
@@ -229,7 +231,9 @@ struct WorkspaceContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panel.id
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id)
+                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id),
+                    isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                    isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
                 )
                 PanelContentView(
                     panel: panel,
@@ -296,6 +300,9 @@ struct WorkspaceContentView: View {
         .onChange(of: workspace.manualUnreadPanelIds) { _, _ in
             syncBonsplitNotificationBadges()
         }
+        .onChange(of: isWorkspaceManuallyUnread) { _, _ in
+            syncBonsplitNotificationBadges()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
             refreshGhosttyAppearanceConfig(reason: "ghosttyConfigDidReload")
         }
@@ -328,6 +335,8 @@ struct WorkspaceContentView: View {
 
     private func syncBonsplitNotificationBadges() {
         let manualUnread = workspace.manualUnreadPanelIds
+        let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
+        let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
 
         for paneId in workspace.bonsplitController.allPaneIds {
             for tab in workspace.bonsplitController.tabs(inPane: paneId) {
@@ -335,8 +344,15 @@ struct WorkspaceContentView: View {
                 let expectedKind = panelId.flatMap { workspace.panelKind(panelId: $0) }
                 let expectedPinned = panelId.map { workspace.isPanelPinned($0) } ?? false
                 let shouldShow = panelId.map {
-                    notificationStore.hasVisibleNotificationIndicator(forTabId: workspace.id, surfaceId: $0) ||
-                        manualUnread.contains($0)
+                    Workspace.shouldShowUnreadIndicator(
+                        hasUnreadNotification: notificationStore.hasVisibleNotificationIndicator(
+                            forTabId: workspace.id,
+                            surfaceId: $0
+                        ),
+                        isManuallyUnread: manualUnread.contains($0),
+                        isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                        isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == $0
+                    )
                 } ?? false
                 let kindUpdate: String?? = expectedKind.map { .some($0) }
 
@@ -419,6 +435,8 @@ struct WorkspaceContentView: View {
         trimMode: TmuxWorkspacePaneOverlayTrimMode
     ) -> [CGRect] {
         guard let layoutSnapshot else { return [] }
+        let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
+        let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
 
         return layoutSnapshot.panes.compactMap { pane in
             guard let selectedTabId = pane.selectedTabId,
@@ -432,7 +450,9 @@ struct WorkspaceContentView: View {
                     forTabId: workspace.id,
                     surfaceId: panelId
                 ),
-                isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId)
+                isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId),
+                isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
+                isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId
             )
             guard shouldShowUnread else { return nil }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -303,6 +303,9 @@ struct WorkspaceContentView: View {
         .onChange(of: isWorkspaceManuallyUnread) { _, _ in
             syncBonsplitNotificationBadges()
         }
+        .onChange(of: workspaceManualUnreadPanelId) { _, _ in
+            syncBonsplitNotificationBadges()
+        }
         .onReceive(NotificationCenter.default.publisher(for: .ghosttyConfigDidReload)) { _ in
             refreshGhosttyAppearanceConfig(reason: "ghosttyConfigDidReload")
         }

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -96,8 +96,38 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         store.markUnread(forTabId: workspace.id)
 
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
-        XCTAssertTrue(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
+    }
+
+    func testManualWorkspaceUnreadSurvivesNonTerminalDirectInteraction() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertFalse(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
     }
 
     func testMarkLatestNotificationAsOldestUnreadDefersCurrentNotificationBehindUnreadQueue() {
@@ -231,8 +261,38 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         workspace.markPanelUnread(panelId)
 
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
-        XCTAssertTrue(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
         XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
+    }
+
+    func testManualPanelUnreadSurvivesNonTerminalDirectInteraction() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.markPanelUnread(panelId)
+
+        XCTAssertFalse(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
     }
 
     func testManualPanelUnreadSurvivesFocusNavigation() {
@@ -246,12 +306,6 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         workspace.focusPanel(initialPanelId)
         workspace.markPanelUnread(splitPanel.id)
         workspace.focusPanel(splitPanel.id)
-
-        let focusSettle = expectation(description: "focus settled")
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
-            focusSettle.fulfill()
-        }
-        wait(for: [focusSettle], timeout: 1.0)
 
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(splitPanel.id))
     }
@@ -318,6 +372,40 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         workspace.focusPanel(splitPanel.id)
 
         XCTAssertEqual(workspace.representativePanelIdForWorkspaceManualUnread(), splitPanel.id)
+    }
+
+    func testWorkspaceManualUnreadBadgeMovesWhenFocusChanges() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        guard let initialPanelId = workspace.focusedPanelId,
+              let splitPanel = workspace.newTerminalSplit(from: initialPanelId, orientation: .horizontal, focus: false),
+              let initialTabId = workspace.surfaceIdFromPanelId(initialPanelId),
+              let splitTabId = workspace.surfaceIdFromPanelId(splitPanel.id) else {
+            XCTFail("Expected workspace with a split panel")
+            return
+        }
+
+        store.markUnread(forTabId: workspace.id)
+        workspace.focusPanel(initialPanelId)
+
+        XCTAssertTrue(workspace.bonsplitController.tab(initialTabId)?.showsNotificationBadge ?? false)
+        XCTAssertFalse(workspace.bonsplitController.tab(splitTabId)?.showsNotificationBadge ?? true)
+
+        workspace.focusPanel(splitPanel.id)
+
+        XCTAssertFalse(workspace.bonsplitController.tab(initialTabId)?.showsNotificationBadge ?? true)
+        XCTAssertTrue(workspace.bonsplitController.tab(splitTabId)?.showsNotificationBadge ?? false)
     }
 }
 

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -32,6 +32,12 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         store.markRead(forTabId: workspaceId, surfaceId: UUID())
 
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 1)
+        XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
+        XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
+
+        store.markRead(forTabId: workspaceId)
+
         XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
         XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
         XCTAssertFalse(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
@@ -47,6 +53,51 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0)
         XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspaceId]))
         XCTAssertFalse(store.canMarkWorkspaceRead(forTabIds: [workspaceId]))
+    }
+
+    func testSurfaceMarkReadDoesNotClearManualWorkspaceUnread() {
+        let store = TerminalNotificationStore.shared
+        let workspaceId = UUID()
+
+        store.replaceNotificationsForTesting([])
+        store.markUnread(forTabId: workspaceId)
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 1)
+
+        store.markRead(forTabId: workspaceId, surfaceId: UUID())
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 1)
+    }
+
+    func testManualWorkspaceUnreadClearsOnDirectTerminalInteraction() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
+        XCTAssertTrue(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
     }
 
     func testMarkLatestNotificationAsOldestUnreadDefersCurrentNotificationBehindUnreadQueue() {
@@ -153,76 +204,56 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(store.notifications.last?.isRead ?? true)
     }
 
-    func testShouldClearManualUnreadWhenFocusMovesToDifferentPanel() {
-        let previousFocusedPanelId = UUID()
-        let nextFocusedPanelId = UUID()
+    func testManualPanelUnreadClearsOnDirectTerminalInteraction() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
 
-        XCTAssertTrue(
-            Workspace.shouldClearManualUnread(
-                previousFocusedPanelId: previousFocusedPanelId,
-                nextFocusedPanelId: nextFocusedPanelId,
-                isManuallyUnread: true,
-                markedAt: Date()
-            )
-        )
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.markPanelUnread(panelId)
+
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertTrue(manager.dismissNotificationOnDirectInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
     }
 
-    func testShouldNotClearManualUnreadWhenFocusStaysOnSamePanelWithinGrace() {
-        let panelId = UUID()
-        let now = Date()
+    func testManualPanelUnreadSurvivesFocusNavigation() {
+        let workspace = Workspace()
+        guard let initialPanelId = workspace.focusedPanelId,
+              let splitPanel = workspace.newTerminalSplit(from: initialPanelId, orientation: .horizontal, focus: false) else {
+            XCTFail("Expected workspace with a split panel")
+            return
+        }
 
-        XCTAssertFalse(
-            Workspace.shouldClearManualUnread(
-                previousFocusedPanelId: panelId,
-                nextFocusedPanelId: panelId,
-                isManuallyUnread: true,
-                markedAt: now.addingTimeInterval(-0.05),
-                now: now,
-                sameTabGraceInterval: 0.2
-            )
-        )
-    }
+        workspace.focusPanel(initialPanelId)
+        workspace.markPanelUnread(splitPanel.id)
+        workspace.focusPanel(splitPanel.id)
 
-    func testShouldClearManualUnreadWhenFocusStaysOnSamePanelAfterGrace() {
-        let panelId = UUID()
-        let now = Date()
+        let focusSettle = expectation(description: "focus settled")
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            focusSettle.fulfill()
+        }
+        wait(for: [focusSettle], timeout: 1.0)
 
-        XCTAssertTrue(
-            Workspace.shouldClearManualUnread(
-                previousFocusedPanelId: panelId,
-                nextFocusedPanelId: panelId,
-                isManuallyUnread: true,
-                markedAt: now.addingTimeInterval(-0.25),
-                now: now,
-                sameTabGraceInterval: 0.2
-            )
-        )
-    }
-
-    func testShouldNotClearManualUnreadWhenNotManuallyUnread() {
-        XCTAssertFalse(
-            Workspace.shouldClearManualUnread(
-                previousFocusedPanelId: UUID(),
-                nextFocusedPanelId: UUID(),
-                isManuallyUnread: false,
-                markedAt: Date()
-            )
-        )
-    }
-
-    func testShouldNotClearManualUnreadWhenNoPreviousFocusAndWithinGrace() {
-        let now = Date()
-
-        XCTAssertFalse(
-            Workspace.shouldClearManualUnread(
-                previousFocusedPanelId: nil,
-                nextFocusedPanelId: UUID(),
-                isManuallyUnread: true,
-                markedAt: now.addingTimeInterval(-0.05),
-                now: now,
-                sameTabGraceInterval: 0.2
-            )
-        )
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(splitPanel.id))
     }
 
     func testShouldShowUnreadIndicatorWhenNotificationIsUnread() {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -274,6 +274,28 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         )
     }
 
+    func testShouldShowUnreadIndicatorWhenWorkspaceManualUnreadTargetsRepresentativePanel() {
+        XCTAssertTrue(
+            Workspace.shouldShowUnreadIndicator(
+                hasUnreadNotification: false,
+                isManuallyUnread: false,
+                isWorkspaceManuallyUnread: true,
+                isWorkspaceManualUnreadRepresentative: true
+            )
+        )
+    }
+
+    func testShouldHideWorkspaceManualUnreadIndicatorOnNonRepresentativePanel() {
+        XCTAssertFalse(
+            Workspace.shouldShowUnreadIndicator(
+                hasUnreadNotification: false,
+                isManuallyUnread: false,
+                isWorkspaceManuallyUnread: true,
+                isWorkspaceManualUnreadRepresentative: false
+            )
+        )
+    }
+
     func testShouldHideUnreadIndicatorWhenNeitherNotificationNorManualUnreadExists() {
         XCTAssertFalse(
             Workspace.shouldShowUnreadIndicator(
@@ -281,6 +303,21 @@ final class WorkspaceManualUnreadTests: XCTestCase {
                 isManuallyUnread: false
             )
         )
+    }
+
+    func testWorkspaceManualUnreadRepresentativeTracksFocusedPanel() {
+        let workspace = Workspace()
+        guard let initialPanelId = workspace.focusedPanelId,
+              let splitPanel = workspace.newTerminalSplit(from: initialPanelId, orientation: .horizontal, focus: false) else {
+            XCTFail("Expected workspace with a split panel")
+            return
+        }
+
+        XCTAssertEqual(workspace.representativePanelIdForWorkspaceManualUnread(), initialPanelId)
+
+        workspace.focusPanel(splitPanel.id)
+
+        XCTAssertEqual(workspace.representativePanelIdForWorkspaceManualUnread(), splitPanel.id)
     }
 }
 


### PR DESCRIPTION
Summary
- Keeps manually marked workspace/tab unread state separate from notification unread state.
- Navigation, focus, and surface mark-read no longer clear manual unread.
- Direct terminal interaction clears manual workspace and panel unread state.

Regression
- b1bc63b7a adds sticky manual unread coverage before the fix.
- Red failure before the fix: focus navigation and surface mark-read cleared manual unread, while direct terminal interaction did not clear manual-only unread state.

Verification
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-manunread-red -only-testing:cmuxTests/WorkspaceManualUnreadTests test
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-manunread-red -only-testing:cmuxTests/TerminalNotificationStaleFocusDismissalTests -only-testing:cmuxTests/TabManagerFocusedNotificationIndicatorTests/testDismissNotificationOnDirectInteractionClearsFocusedNotificationIndicator -only-testing:cmuxTests/TabManagerFocusedNotificationIndicatorTests/testDismissNotificationOnDirectInteractionTriggersDismissFlashForFocusedIndicatorOnly test
- ./scripts/reload.sh --tag unread

Cloud proof
- Before lane: https://github.com/manaflow-ai/cmux-loader/actions/runs/25801014204
- CUA setup reached app state capture, but fullscreen recording smoke ended with a recorder dimension mismatch, so no accepted before/after video is attached.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes unread/notification dismissal behavior and badge rendering across workspaces/panels, which can impact user-visible state and focus-driven UI updates. Risk is moderate due to nuanced interaction paths (focus, clicks, tmux overlays) but is covered by expanded unit tests.
> 
> **Overview**
> Manual unread state is now treated as *sticky* until the user directly interacts with a terminal, rather than being cleared by focus/navigation or `markRead` calls.
> 
> This introduces a distinct terminal-interaction dismissal path (`dismissNotificationOnTerminalInteraction`) that can clear manual panel/workspace unread and trigger a dedicated flash, while non-terminal direct interactions no longer clear manual-only unread.
> 
> Unread indicators/badges are updated to support **workspace-level manual unread** by showing the ring on a single *representative* panel (computed via `representativePanelIdForWorkspaceManualUnread`) and keeping badges in sync when focus changes (including tmux pane overlays and Bonsplit tabs). Unit tests are expanded to cover the new stickiness, dismissal rules, representative-panel selection, and badge movement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 919fc29c2c7cabae6acea095c55a530457bea58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps manual unread sticky until you interact with the terminal. Shows a workspace-level manual unread ring on one representative panel, keeps badges in sync on focus, and stabilizes representative fallback.

- **Bug Fixes**
  - Terminal interaction only clears manual panel/workspace unread and shows a manual-unread dismiss flash; non-terminal direct interaction does not clear it.
  - Badge logic: recompute across all panels on focus so the representative ring follows focus; add stable fallback for the representative panel (focus > per-pane selection by sidebar order > first panel).
  - APIs: added `dismissNotificationOnTerminalInteraction(...)`, `hasManualUnread(...)`/`clearManualUnread(...)`, and expanded `shouldShowUnreadIndicator(...)` to include workspace manual unread with representative gating.
  - `markRead(forTabId:surfaceId:)` no longer clears workspace manual unread.
  - Updated `ContentView`/`WorkspaceContentView` to pass workspace-manual-unread and representative flags and resync badges on changes.
  - Added tests for terminal-only dismissal, sticky behavior across focus/navigation, representative selection, and badge movement on focus.

<sup>Written for commit 919fc29c2c7cabae6acea095c55a530457bea58e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace-level manual-unread state with a single representative panel and consistent indicator display

* **Bug Fixes**
  * Manual unread now dismisses on terminal interactions and clears correctly for panel/workspace cases
  * Unread badges reflect both panel- and workspace-level manual unread status, shown only on the representative panel and updated on focus changes

* **Tests**
  * Added coverage for workspace/panel manual-unread behaviors and indicator visibility across interactions and focus changes

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4104)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->