### PR TITLE
Add markdown typography settings

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */; };
 		D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */; };
+		D0B10024A1B2C3D4E5F60001 /* ViewZoomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */; };
 		D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */; };
 		D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000002 /* SidebarDropPlanner.swift */; };
 		D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */; };
@@ -685,6 +686,7 @@
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropTargetView.swift; sourceTree = "<group>"; };
 		D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTextEditor.swift; sourceTree = "<group>"; };
+		D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ViewZoomControls.swift; sourceTree = "<group>"; };
 		A5001016 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1307,6 +1309,7 @@
 				A50014F4 /* MarkdownWebRenderer.swift */,
 				A50014F6 /* MarkdownTypographySettings.swift */,
 				A50014F1 /* MarkdownViewerAssets.swift */,
+				D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */,
 				A5001423 /* FilePreviewPanel.swift */,
 				D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */,
 				A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */,
@@ -1989,6 +1992,7 @@
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
 				A5001422 /* FilePreviewPanel.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
+				D0B10024A1B2C3D4E5F60001 /* ViewZoomControls.swift in Sources */,
 				A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */,
 				A5001445A5001445A5001445 /* FilePreviewWorkspaceOpenSupport.swift in Sources */,
 				A5001447A5001447A5001447 /* FilePreviewMagnifyingPDFView.swift in Sources */,

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -269,6 +269,7 @@
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		A50014F3 /* MarkdownViewerAssets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F1 /* MarkdownViewerAssets.swift */; };
 		A50014F5 /* MarkdownWebRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F4 /* MarkdownWebRenderer.swift */; };
+		A50014F7 /* MarkdownTypographySettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F6 /* MarkdownTypographySettings.swift */; };
 		A5001422 /* FilePreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001423 /* FilePreviewPanel.swift */; };
 		A5001441A5001441A5001441 /* FileOpenSocketSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */; };
 		A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */; };
@@ -792,6 +793,7 @@
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		A50014F1 /* MarkdownViewerAssets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownViewerAssets.swift; sourceTree = "<group>"; };
 		A50014F4 /* MarkdownWebRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownWebRenderer.swift; sourceTree = "<group>"; };
+		A50014F6 /* MarkdownTypographySettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographySettings.swift; sourceTree = "<group>"; };
 		A5001423 /* FilePreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewPanel.swift; sourceTree = "<group>"; };
 		A5001440A5001440A5001440 /* FileOpenSocketSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileOpenSocketSupport.swift; sourceTree = "<group>"; };
 		A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewModeSupport.swift; sourceTree = "<group>"; };
@@ -1303,6 +1305,7 @@
 				A50014F0 /* MarkdownPanelFileLinkResolver.swift */,
 				A5001419 /* MarkdownPanelView.swift */,
 				A50014F4 /* MarkdownWebRenderer.swift */,
+				A50014F6 /* MarkdownTypographySettings.swift */,
 				A50014F1 /* MarkdownViewerAssets.swift */,
 				A5001423 /* FilePreviewPanel.swift */,
 				D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */,
@@ -1982,6 +1985,7 @@
 				A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,
 				A50014F5 /* MarkdownWebRenderer.swift in Sources */,
+				A50014F7 /* MarkdownTypographySettings.swift in Sources */,
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
 				A5001422 /* FilePreviewPanel.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2,6 +2,8 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "filePreview.pdf.zoomControls": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Zoom Controls" } }, "ja": { "stringUnit": { "state": "translated", "value": "ズームコントロール" } } } },
+    "view.zoom.controls": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "View Zoom" } }, "ja": { "stringUnit": { "state": "translated", "value": "表示ズーム" } } } },
     "cli.error.dismissNotificationSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "dismiss-notification requires exactly one of --id or --all-read" } }, "ja": { "stringUnit": { "state": "translated", "value": "dismiss-notification には --id または --all-read のどちらか一方だけを指定してください" } } } },
     "cli.error.markNotificationReadSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "mark-notification-read requires exactly one selector: --id, --workspace, or --all" } }, "ja": { "stringUnit": { "state": "translated", "value": "mark-notification-read には --id、--workspace、--all のいずれか一つだけを指定してください" } } } },
     "cli.error.markNotificationReadSurfaceRequiresWorkspace": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "--surface requires --workspace" } }, "ja": { "stringUnit": { "state": "translated", "value": "--surface には --workspace が必要です" } } } },

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -178,7 +178,7 @@ body {
 .cmux-frontmatter pre code.hljs {
   padding: 10px 12px;
   background: transparent;
-  font-size: var(--cmux-markdown-code-block-font-size, 12.5px);
+  font-size: 12.5px;
   line-height: 1.45;
 }
 .cmux-render-error {

--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -29,22 +29,36 @@ body {
 }
 .markdown-body {
   background: transparent;
-  /* GitHub uses 16px on github.com for body text; keep that exact
-     metric so headings, line-height, and spacing match. */
-  font-size: 15px;
+  font-family: var(--cmux-markdown-font-family, -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji");
+  /* cmux defaults to 15px for panel density, while cmux.json can
+     override the body and heading metrics below. */
+  font-size: var(--cmux-markdown-font-size, 15px);
   /* The package sets max-width via wrapper class on github.com; we
      let it span the panel and just cap it to a comfortable reading
      width on very wide splits. */
   max-width: 980px;
   margin: 0 auto;
 }
+.markdown-body h1 { font-size: var(--cmux-markdown-h1-font-size, 2em); }
+.markdown-body h2 { font-size: var(--cmux-markdown-h2-font-size, 1.5em); }
+.markdown-body h3 { font-size: var(--cmux-markdown-h3-font-size, 1.25em); }
+.markdown-body h4 { font-size: var(--cmux-markdown-h4-font-size, 1em); }
+.markdown-body h5 { font-size: var(--cmux-markdown-h5-font-size, .875em); }
+.markdown-body h6 { font-size: var(--cmux-markdown-h6-font-size, .85em); }
 /* Fenced code blocks: github-markdown-css already styles `pre`; we
    add highlight.js's hljs class so the syntax theme applies. */
 .markdown-body pre code.hljs {
   padding: 16px;
   background: transparent;
-  font-size: 13.5px;
+  font-family: var(--cmux-markdown-code-block-font-family, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace);
+  font-size: var(--cmux-markdown-code-block-font-size, 13.5px);
   line-height: 1.5;
+}
+.markdown-body pre,
+.markdown-body pre code,
+.cmux-frontmatter pre,
+.cmux-frontmatter pre code.hljs {
+  font-family: var(--cmux-markdown-code-block-font-family, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace);
 }
 .markdown-body pre {
   padding: 0; /* hljs class already pads */
@@ -164,7 +178,7 @@ body {
 .cmux-frontmatter pre code.hljs {
   padding: 10px 12px;
   background: transparent;
-  font-size: 12.5px;
+  font-size: var(--cmux-markdown-code-block-font-size, 12.5px);
   line-height: 1.45;
 }
 .cmux-render-error {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11989,16 +11989,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if matchConfiguredShortcut(event: event, action: .browserZoomIn) {
-            return shortcutEventBrowserPanel(event)?.zoomIn() ?? false
-        }
-
-        if matchConfiguredShortcut(event: event, action: .browserZoomOut) {
-            return shortcutEventBrowserPanel(event)?.zoomOut() ?? false
-        }
-
-        if matchConfiguredShortcut(event: event, action: .browserZoomReset) {
-            return shortcutEventBrowserPanel(event)?.resetZoom() ?? false
+        if let viewZoomCommand = configuredViewZoomShortcutCommand(for: event) {
+            if shouldLetFocusedTerminalHandleViewZoomShortcut(event) {
+                return false
+            }
+            let didHandle = shortcutEventTabManager(event)?.performViewZoomCommand(viewZoomCommand) ?? false
+            return didHandle
         }
 
         if matchConfiguredShortcut(event: event, action: .findInDirectory) {
@@ -12092,6 +12088,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         return true
+    }
+
+    private func configuredViewZoomShortcutCommand(for event: NSEvent) -> ViewZoomCommand? {
+        if matchConfiguredShortcut(event: event, action: .browserZoomIn) {
+            return .zoomIn
+        }
+        if matchConfiguredShortcut(event: event, action: .browserZoomOut) {
+            return .zoomOut
+        }
+        if matchConfiguredShortcut(event: event, action: .browserZoomReset) {
+            return .reset
+        }
+        return ViewZoomControl.command(for: event)
+    }
+
+    private func shouldLetFocusedTerminalHandleViewZoomShortcut(_ event: NSEvent) -> Bool {
+        let targetWindow = resolvedShortcutEventWindow(event) ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+        guard let firstResponder = targetWindow?.firstResponder,
+              cmuxOwningGhosttyView(for: firstResponder) != nil else {
+            return false
+        }
+        return browserZoomShortcutAction(
+            flags: event.modifierFlags,
+            chars: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode,
+            literalChars: event.characters
+        ) != nil
+    }
+
+    private func shortcutEventTabManager(_ event: NSEvent) -> TabManager? {
+        preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
     }
 
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1462,6 +1462,7 @@ struct ContentView: View {
         static let panelName = "panel.name"
         static let panelIsBrowser = "panel.isBrowser"
         static let panelIsTerminal = "panel.isTerminal"
+        static let panelSupportsViewZoom = "panel.supportsViewZoom"
         static let panelHasPane = "panel.hasPane"
         static let panelHasCustomName = "panel.hasCustomName"
         static let panelShouldPin = "panel.shouldPin"
@@ -6046,10 +6047,15 @@ struct ContentView: View {
             let workspace = panelContext.workspace
             let panelId = panelContext.panelId
             let panelIsTerminal = panelContext.panel.panelType == .terminal
+            let panelSupportsViewZoom =
+                panelContext.panel is BrowserPanel ||
+                panelContext.panel is MarkdownPanel ||
+                ((panelContext.panel as? FilePreviewPanel)?.previewMode == .text)
             snapshot.setBool(CommandPaletteContextKeys.hasFocusedPanel, true)
             snapshot.setString(CommandPaletteContextKeys.panelName, panelDisplayName(workspace: workspace, panelId: panelId, fallback: panelContext.panel.displayTitle))
             snapshot.setBool(CommandPaletteContextKeys.panelIsBrowser, panelContext.panel.panelType == .browser)
             snapshot.setBool(CommandPaletteContextKeys.panelIsTerminal, panelIsTerminal)
+            snapshot.setBool(CommandPaletteContextKeys.panelSupportsViewZoom, panelSupportsViewZoom)
             snapshot.setBool(CommandPaletteContextKeys.panelHasPane, workspace.paneId(forPanelId: panelId) != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelHasCustomName, workspace.panelCustomTitles[panelId] != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelShouldPin, !workspace.isPanelPinned(panelId))
@@ -6755,27 +6761,27 @@ struct ContentView: View {
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomIn",
                 title: constant(String(localized: "command.browserZoomIn.title", defaultValue: "Zoom In")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "in"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "in", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomOut",
                 title: constant(String(localized: "command.browserZoomOut.title", defaultValue: "Zoom Out")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "out"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "out", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomReset",
                 title: constant(String(localized: "command.browserZoomReset.title", defaultValue: "Actual Size")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "reset", "actual size"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "reset", "actual size", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(
@@ -7438,17 +7444,17 @@ struct ContentView: View {
             }
         }
         registry.register(commandId: "palette.browserZoomIn") {
-            if !tabManager.zoomInFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.zoomIn) {
                 NSSound.beep()
             }
         }
         registry.register(commandId: "palette.browserZoomOut") {
-            if !tabManager.zoomOutFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.zoomOut) {
                 NSSound.beep()
             }
         }
         registry.register(commandId: "palette.browserZoomReset") {
-            if !tabManager.resetZoomFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.reset) {
                 NSSound.beep()
             }
         }

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -53,8 +53,7 @@ extension KeyboardShortcutSettings.Action {
             return .rightSidebarFocus
         case .renameTab, .renameWorkspace:
             return .nonBrowserPanel
-        case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
-             .browserZoomIn, .browserZoomOut, .browserZoomReset:
+        case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole:
             return .browserPanel
         default:
             return .application

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -160,6 +160,22 @@ extension CmuxSettingsFileStore {
                 ],
             ],
             [
+                "markdown": [
+                    "fontFamily": MarkdownTypographySettings.defaultFontFamily,
+                    "fontSize": MarkdownTypographySettings.defaultFontSize,
+                    "headingSizes": [
+                        "h1": MarkdownTypographySettings.defaultHeadingSizes.h1,
+                        "h2": MarkdownTypographySettings.defaultHeadingSizes.h2,
+                        "h3": MarkdownTypographySettings.defaultHeadingSizes.h3,
+                        "h4": MarkdownTypographySettings.defaultHeadingSizes.h4,
+                        "h5": MarkdownTypographySettings.defaultHeadingSizes.h5,
+                        "h6": MarkdownTypographySettings.defaultHeadingSizes.h6,
+                    ],
+                    "codeBlockFontFamily": MarkdownTypographySettings.defaultCodeBlockFontFamily,
+                    "codeBlockFontSize": MarkdownTypographySettings.defaultCodeBlockFontSize,
+                ],
+            ],
+            [
                 "shortcuts": [
                     "bindings": shortcutsBindings,
                 ],

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -329,6 +329,9 @@ final class CmuxSettingsFileStore {
         if let browserSection = root["browser"] as? [String: Any] {
             parseBrowserSection(browserSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
+        if let markdownSection = root["markdown"] as? [String: Any] {
+            parseMarkdownSection(markdownSection, sourcePath: sourcePath, snapshot: &snapshot)
+        }
         if let shortcutsSection = root["shortcuts"] {
             parseShortcutsSection(shortcutsSection, sourcePath: sourcePath, snapshot: &snapshot)
         }
@@ -778,6 +781,120 @@ final class CmuxSettingsFileStore {
         if let raw = jsonString(section["reactGrabVersion"]) {
             snapshot.managedUserDefaults[ReactGrabSettings.versionKey] = .string(raw)
         }
+    }
+
+    private func parseMarkdownSection(
+        _ section: [String: Any],
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        if let raw = jsonString(section["fontFamily"]) {
+            if let normalized = MarkdownTypographySettings.normalizedFontFamily(raw) {
+                snapshot.managedUserDefaults[MarkdownTypographySettings.fontFamilyKey] = .string(normalized)
+            } else {
+                logInvalid("markdown.fontFamily", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("fontFamily") {
+            logInvalid("markdown.fontFamily", sourcePath: sourcePath)
+        }
+
+        parseMarkdownSize(
+            section["fontSize"],
+            path: "markdown.fontSize",
+            defaultsKey: MarkdownTypographySettings.fontSizeKey,
+            range: MarkdownTypographySettings.fontSizeRange,
+            sourcePath: sourcePath,
+            snapshot: &snapshot
+        )
+
+        if let headingSizes = section["headingSizes"] as? [String: Any] {
+            parseMarkdownSize(
+                headingSizes["h1"],
+                path: "markdown.headingSizes.h1",
+                defaultsKey: MarkdownTypographySettings.headingH1SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+            parseMarkdownSize(
+                headingSizes["h2"],
+                path: "markdown.headingSizes.h2",
+                defaultsKey: MarkdownTypographySettings.headingH2SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+            parseMarkdownSize(
+                headingSizes["h3"],
+                path: "markdown.headingSizes.h3",
+                defaultsKey: MarkdownTypographySettings.headingH3SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+            parseMarkdownSize(
+                headingSizes["h4"],
+                path: "markdown.headingSizes.h4",
+                defaultsKey: MarkdownTypographySettings.headingH4SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+            parseMarkdownSize(
+                headingSizes["h5"],
+                path: "markdown.headingSizes.h5",
+                defaultsKey: MarkdownTypographySettings.headingH5SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+            parseMarkdownSize(
+                headingSizes["h6"],
+                path: "markdown.headingSizes.h6",
+                defaultsKey: MarkdownTypographySettings.headingH6SizeKey,
+                range: MarkdownTypographySettings.headingSizeRange,
+                sourcePath: sourcePath,
+                snapshot: &snapshot
+            )
+        } else if section.keys.contains("headingSizes") {
+            logInvalid("markdown.headingSizes", sourcePath: sourcePath)
+        }
+
+        if let raw = jsonString(section["codeBlockFontFamily"]) {
+            if let normalized = MarkdownTypographySettings.normalizedFontFamily(raw) {
+                snapshot.managedUserDefaults[MarkdownTypographySettings.codeBlockFontFamilyKey] = .string(normalized)
+            } else {
+                logInvalid("markdown.codeBlockFontFamily", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("codeBlockFontFamily") {
+            logInvalid("markdown.codeBlockFontFamily", sourcePath: sourcePath)
+        }
+
+        parseMarkdownSize(
+            section["codeBlockFontSize"],
+            path: "markdown.codeBlockFontSize",
+            defaultsKey: MarkdownTypographySettings.codeBlockFontSizeKey,
+            range: MarkdownTypographySettings.codeBlockFontSizeRange,
+            sourcePath: sourcePath,
+            snapshot: &snapshot
+        )
+    }
+
+    private func parseMarkdownSize(
+        _ rawValue: Any?,
+        path: String,
+        defaultsKey: String,
+        range: ClosedRange<Double>,
+        sourcePath: String,
+        snapshot: inout ResolvedSettingsSnapshot
+    ) {
+        guard rawValue != nil else { return }
+        guard let raw = jsonDouble(rawValue),
+              let normalized = MarkdownTypographySettings.normalizedSize(raw, range: range) else {
+            logInvalid(path, sourcePath: sourcePath)
+            return
+        }
+        snapshot.managedUserDefaults[defaultsKey] = .double(normalized)
     }
 
     private func parseShortcutsSection(

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1867,7 +1867,7 @@ final class BrowserPortalAnchorView: NSView {
 }
 
 @MainActor
-final class BrowserPanel: Panel, ObservableObject {
+final class BrowserPanel: Panel, ObservableObject, ViewZoomControlling {
     /// Shared process pool for cookie sharing across all browser panels
     private static let sharedProcessPool = WKProcessPool()
 
@@ -5123,6 +5123,27 @@ extension BrowserPanel {
     func setPageZoomFactor(_ pageZoom: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, pageZoom))
         return applyPageZoom(clamped)
+    }
+
+    var viewZoomFactor: CGFloat {
+        currentPageZoomFactor()
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        setPageZoomFactor(ViewZoomControl.normalized(factor))
+    }
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        switch command {
+        case .zoomIn:
+            return zoomIn()
+        case .zoomOut:
+            return zoomOut()
+        case .reset:
+            return resetZoom()
+        }
     }
 
     /// Take a snapshot of the web view

--- a/Sources/Panels/FilePreviewMagnifyingPDFView.swift
+++ b/Sources/Panels/FilePreviewMagnifyingPDFView.swift
@@ -9,6 +9,7 @@ final class FilePreviewMagnifyingPDFView: PDFView {
     var onRotate: ((NSEvent) -> Void)?
     var onSwipe: ((NSEvent) -> Void)?
     var onFocusChanged: ((Bool) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -31,6 +32,14 @@ final class FilePreviewMagnifyingPDFView: PDFView {
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         super.mouseDown(with: event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 
     override func magnify(with event: NSEvent) {
@@ -73,4 +82,5 @@ final class FilePreviewMagnifyingPDFView: PDFView {
             super.swipe(with: event)
         }
     }
+
 }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -830,7 +830,7 @@ enum FilePreviewTextSaver {
 }
 
 @MainActor
-final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPanel {
+final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPanel, ViewZoomControlling {
     let id: UUID
     let panelType: PanelType = .filePreview
     let filePath: String
@@ -843,6 +843,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     @Published private(set) var isSaving = false
     @Published private(set) var focusFlashToken = 0
     @Published private(set) var previewMode: FilePreviewMode
+    @Published private(set) var viewZoomFactor: CGFloat = ViewZoomControl.defaultFactor
 
     private var originalTextContent = ""
     private var textEncoding: String.Encoding = .utf8
@@ -926,6 +927,21 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     func noteFilePreviewFocusIntent(_ intent: FilePreviewPanelFocusIntent) {
         focusCoordinator.notePreferredIntent(intent)
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        guard previewMode == .text else { return false }
+        let normalized = ViewZoomControl.normalized(factor)
+        guard abs(viewZoomFactor - normalized) > 0.0001 else { return false }
+        viewZoomFactor = normalized
+        return true
+    }
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        guard previewMode == .text else { return false }
+        return setViewZoomFactor(ViewZoomControl.applying(command, to: viewZoomFactor))
     }
 
     func currentFilePreviewFocusIntent(in window: NSWindow?) -> FilePreviewPanelFocusIntent? {
@@ -1179,6 +1195,14 @@ struct FilePreviewPanelView: View {
                     label: String(localized: "filePreview.save", defaultValue: "Save"),
                     isDisabled: !panel.isDirty || panel.isSaving,
                     action: { panel.saveTextContent() }
+                )
+
+                PanelHeaderViewZoomButton(
+                    zoomFactor: Binding(
+                        get: { panel.viewZoomFactor },
+                        set: { panel.setViewZoomFactor($0) }
+                    ),
+                    isDisabled: panel.isFileUnavailable || panel.previewMode != .text
                 )
             }
 
@@ -1981,6 +2005,7 @@ final class FilePreviewPDFThumbnailSidebarView: NSView, NSCollectionViewDataSour
 
 private final class FilePreviewPDFOutlineView: NSOutlineView {
     var onFocusChanged: ((Bool) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
 
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
@@ -2004,6 +2029,14 @@ private final class FilePreviewPDFOutlineView: NSOutlineView {
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         super.mouseDown(with: event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 }
 
@@ -2311,6 +2344,9 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
         pdfView.onSmartMagnify = { [weak self] in
             self?.togglePDFSmartZoom()
         }
+        pdfView.onViewZoomCommand = { [weak self] command in
+            self?.performPDFViewZoomCommand(command)
+        }
         pdfView.onRotate = { [weak self] event in
             self?.rotatePDF(with: event)
         }
@@ -2379,6 +2415,9 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
         outlineView.delegate = self
         outlineView.onFocusChanged = { [weak self] isActive in
             self?.setActivePDFRegion(isActive ? .pdfOutline : nil)
+        }
+        outlineView.onViewZoomCommand = { [weak self] command in
+            self?.performPDFViewZoomCommand(command)
         }
         outlineView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -2533,6 +2572,17 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
     @objc private func actualSize() {
         pdfView.autoScales = false
         setPDFScaleFactor(1.0, preservingVisibleCenter: true)
+    }
+
+    private func performPDFViewZoomCommand(_ command: ViewZoomCommand) {
+        switch command {
+        case .zoomIn:
+            zoomIn()
+        case .zoomOut:
+            zoomOut()
+        case .reset:
+            actualSize()
+        }
     }
 
     @objc private func rotateLeft() {
@@ -3448,6 +3498,9 @@ private final class FilePreviewImageContainerView: NSView {
         scrollView.onSmartMagnify = { [weak self] event in
             self?.toggleImageSmartZoom(with: event)
         }
+        scrollView.onViewZoomCommand = { [weak self] command in
+            self?.performImageViewZoomCommand(command)
+        }
         scrollView.onRotate = { [weak self] event in
             self?.rotateImage(with: event)
         }
@@ -3497,6 +3550,17 @@ private final class FilePreviewImageContainerView: NSView {
     @objc private func actualSize() {
         isFitMode = false
         setImageScale(1.0, preservingVisibleCenter: true)
+    }
+
+    private func performImageViewZoomCommand(_ command: ViewZoomCommand) {
+        switch command {
+        case .zoomIn:
+            zoomIn()
+        case .zoomOut:
+            zoomOut()
+        case .reset:
+            actualSize()
+        }
     }
 
     @objc private func rotateLeft() {
@@ -3696,6 +3760,7 @@ private final class FilePreviewImageScrollView: NSScrollView {
     var onMagnify: ((NSEvent) -> Void)?
     var onScrollZoom: ((NSEvent) -> Void)?
     var onSmartMagnify: ((NSEvent) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
     var onRotate: ((NSEvent) -> Void)?
     private var panStartClipPoint: CGPoint?
     private var panStartDocumentOrigin: CGPoint?
@@ -3709,6 +3774,14 @@ private final class FilePreviewImageScrollView: NSScrollView {
         } else {
             super.magnify(with: event)
         }
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -3801,6 +3874,7 @@ private final class FilePreviewImageScrollView: NSScrollView {
             hasPushedPanCursor = false
         }
     }
+
 }
 
 private final class FilePreviewImageDocumentView: NSView {

--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -4,10 +4,15 @@ import SwiftUI
 @MainActor
 protocol FilePreviewTextEditingPanel: AnyObject {
     var textContent: String { get }
+    var viewZoomFactor: CGFloat { get }
 
     func attachTextView(_ textView: NSTextView)
     func retryPendingFocus()
     func updateTextContent(_ nextContent: String)
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool
     @discardableResult
     func saveTextContent() -> Task<Void, Never>?
 }
@@ -41,7 +46,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         textView.importsGraphics = false
         textView.usesFindPanel = true
         textView.usesFontPanel = false
-        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
         textView.drawsBackground = false
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
@@ -69,6 +74,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         guard let textView = scrollView.documentView as? SavingTextView else { return }
         textView.panel = panel
         textView.applyFilePreviewTextEditorInsets()
+        textView.applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
         panel.attachTextView(textView)
         guard textView.string != panel.textContent else { return }
         context.coordinator.isApplyingPanelUpdate = true
@@ -135,12 +141,8 @@ extension NSTextView {
 }
 
 final class SavingTextView: NSTextView {
-    private static let defaultPreviewFontSize: CGFloat = 13
-    private static let minimumPreviewFontSize: CGFloat = 8
-    private static let maximumPreviewFontSize: CGFloat = 36
-
     weak var panel: (any FilePreviewTextEditingPanel)?
-    private var previewFontSize: CGFloat = 13
+    private var previewFontSize: CGFloat = ViewZoomControl.textEditorDefaultFontSize
     private var pendingSaveShortcutChordPrefix: ShortcutStroke?
 
     deinit {}
@@ -155,6 +157,13 @@ final class SavingTextView: NSTextView {
         guard event.type == .keyDown else {
             return super.performKeyEquivalent(with: event)
         }
+        if let zoomCommand = ViewZoomControl.command(for: event) {
+            guard let panel else { return false }
+            panel.performViewZoomCommand(zoomCommand)
+            applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
+            return true
+        }
+
         guard let shouldSave = saveShortcutMatch(for: event) else {
             return super.performKeyEquivalent(with: event)
         }
@@ -179,11 +188,20 @@ final class SavingTextView: NSTextView {
     }
 
     override func smartMagnify(with event: NSEvent) {
-        if previewFontSize == Self.defaultPreviewFontSize {
+        if previewFontSize == ViewZoomControl.textEditorDefaultFontSize {
             setPreviewFontSize(18)
         } else {
-            setPreviewFontSize(Self.defaultPreviewFontSize)
+            setPreviewFontSize(ViewZoomControl.textEditorDefaultFontSize)
         }
+    }
+
+    func applyPreviewFontSize(_ nextFontSize: CGFloat) {
+        let clamped = Self.clampedFontSize(nextFontSize)
+        guard abs(previewFontSize - clamped) > 0.001 || font?.pointSize != clamped else { return }
+        previewFontSize = clamped
+        let nextFont = NSFont.monospacedSystemFont(ofSize: clamped, weight: .regular)
+        font = nextFont
+        typingAttributes[.font] = nextFont
     }
 
     private func adjustPreviewFontSize(by factor: CGFloat) {
@@ -191,12 +209,14 @@ final class SavingTextView: NSTextView {
     }
 
     private func setPreviewFontSize(_ nextFontSize: CGFloat) {
-        let clamped = min(max(nextFontSize, Self.minimumPreviewFontSize), Self.maximumPreviewFontSize)
-        guard clamped.isFinite else { return }
-        previewFontSize = clamped
-        let nextFont = NSFont.monospacedSystemFont(ofSize: clamped, weight: .regular)
-        font = nextFont
-        typingAttributes[.font] = nextFont
+        let clamped = Self.clampedFontSize(nextFontSize)
+        panel?.setViewZoomFactor(ViewZoomControl.textEditorZoomFactor(forFontSize: clamped))
+        applyPreviewFontSize(clamped)
+    }
+
+    private static func clampedFontSize(_ fontSize: CGFloat) -> CGFloat {
+        guard fontSize.isFinite else { return ViewZoomControl.textEditorDefaultFontSize }
+        return ViewZoomControl.textEditorFontSize(for: ViewZoomControl.textEditorZoomFactor(forFontSize: fontSize))
     }
 
     private func saveShortcutMatch(for event: NSEvent) -> Bool? {

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -12,7 +12,7 @@ enum MarkdownPanelDisplayMode: String, CaseIterable, Identifiable {
 /// A panel that renders a markdown file with live file-watching.
 /// When the file changes on disk, the content is automatically reloaded.
 @MainActor
-final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel {
+final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel, ViewZoomControlling {
     let id: UUID
     let panelType: PanelType = .markdown
 
@@ -48,6 +48,9 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     /// Token incremented to trigger focus flash animation.
     @Published private(set) var focusFlashToken: Int = 0
+
+    /// Per-panel view zoom used by both rendered preview and TextEdit mode.
+    @Published private(set) var viewZoomFactor: CGFloat = ViewZoomControl.defaultFactor
 
     // MARK: - File watching
 
@@ -108,6 +111,14 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         if mode == .text {
             focus()
         }
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        let normalized = ViewZoomControl.normalized(factor)
+        guard abs(viewZoomFactor - normalized) > 0.0001 else { return false }
+        viewZoomFactor = normalized
+        return true
     }
 
     func attachTextView(_ textView: NSTextView) {

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -31,12 +31,12 @@ struct MarkdownPanelView: View {
     @State private var renderer = MarkdownWebRendererHandle()
     @AppStorage(MarkdownTypographySettings.fontFamilyKey) private var markdownFontFamily = MarkdownTypographySettings.defaultFontFamily
     @AppStorage(MarkdownTypographySettings.fontSizeKey) private var markdownFontSize = MarkdownTypographySettings.defaultFontSize
-    @AppStorage(MarkdownTypographySettings.headingH1SizeKey) private var markdownHeadingH1Size = MarkdownTypographySettings.defaultHeadingSizes.h1
-    @AppStorage(MarkdownTypographySettings.headingH2SizeKey) private var markdownHeadingH2Size = MarkdownTypographySettings.defaultHeadingSizes.h2
-    @AppStorage(MarkdownTypographySettings.headingH3SizeKey) private var markdownHeadingH3Size = MarkdownTypographySettings.defaultHeadingSizes.h3
-    @AppStorage(MarkdownTypographySettings.headingH4SizeKey) private var markdownHeadingH4Size = MarkdownTypographySettings.defaultHeadingSizes.h4
-    @AppStorage(MarkdownTypographySettings.headingH5SizeKey) private var markdownHeadingH5Size = MarkdownTypographySettings.defaultHeadingSizes.h5
-    @AppStorage(MarkdownTypographySettings.headingH6SizeKey) private var markdownHeadingH6Size = MarkdownTypographySettings.defaultHeadingSizes.h6
+    @AppStorage(MarkdownTypographySettings.headingH1SizeKey) private var markdownHeadingH1Size = MarkdownTypographySettings.unsetHeadingSize
+    @AppStorage(MarkdownTypographySettings.headingH2SizeKey) private var markdownHeadingH2Size = MarkdownTypographySettings.unsetHeadingSize
+    @AppStorage(MarkdownTypographySettings.headingH3SizeKey) private var markdownHeadingH3Size = MarkdownTypographySettings.unsetHeadingSize
+    @AppStorage(MarkdownTypographySettings.headingH4SizeKey) private var markdownHeadingH4Size = MarkdownTypographySettings.unsetHeadingSize
+    @AppStorage(MarkdownTypographySettings.headingH5SizeKey) private var markdownHeadingH5Size = MarkdownTypographySettings.unsetHeadingSize
+    @AppStorage(MarkdownTypographySettings.headingH6SizeKey) private var markdownHeadingH6Size = MarkdownTypographySettings.unsetHeadingSize
     @AppStorage(MarkdownTypographySettings.codeBlockFontFamilyKey) private var markdownCodeBlockFontFamily = MarkdownTypographySettings.defaultCodeBlockFontFamily
     @AppStorage(MarkdownTypographySettings.codeBlockFontSizeKey) private var markdownCodeBlockFontSize = MarkdownTypographySettings.defaultCodeBlockFontSize
 
@@ -209,17 +209,55 @@ struct MarkdownPanelView: View {
     }
 
     private var markdownTypography: MarkdownWebTypography {
-        _ = markdownFontFamily
-        _ = markdownFontSize
-        _ = markdownHeadingH1Size
-        _ = markdownHeadingH2Size
-        _ = markdownHeadingH3Size
-        _ = markdownHeadingH4Size
-        _ = markdownHeadingH5Size
-        _ = markdownHeadingH6Size
-        _ = markdownCodeBlockFontFamily
-        _ = markdownCodeBlockFontSize
-        return MarkdownTypographySettings.resolved()
+        let bodyFontSize = MarkdownTypographySettings.normalizedSize(
+            markdownFontSize,
+            range: MarkdownTypographySettings.fontSizeRange
+        ) ?? MarkdownTypographySettings.defaultFontSize
+        let derivedHeadingSizes = MarkdownTypographySettings.defaultHeadingSizes(forFontSize: bodyFontSize)
+        return MarkdownWebTypography(
+            fontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownFontFamily)
+                ?? MarkdownTypographySettings.defaultFontFamily,
+            fontSize: bodyFontSize,
+            headingSizes: MarkdownWebTypography.HeadingSizes(
+                h1: markdownHeadingSize(
+                    markdownHeadingH1Size,
+                    fallback: derivedHeadingSizes.h1
+                ),
+                h2: markdownHeadingSize(
+                    markdownHeadingH2Size,
+                    fallback: derivedHeadingSizes.h2
+                ),
+                h3: markdownHeadingSize(
+                    markdownHeadingH3Size,
+                    fallback: derivedHeadingSizes.h3
+                ),
+                h4: markdownHeadingSize(
+                    markdownHeadingH4Size,
+                    fallback: derivedHeadingSizes.h4
+                ),
+                h5: markdownHeadingSize(
+                    markdownHeadingH5Size,
+                    fallback: derivedHeadingSizes.h5
+                ),
+                h6: markdownHeadingSize(
+                    markdownHeadingH6Size,
+                    fallback: derivedHeadingSizes.h6
+                )
+            ),
+            codeBlockFontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownCodeBlockFontFamily)
+                ?? MarkdownTypographySettings.defaultCodeBlockFontFamily,
+            codeBlockFontSize: MarkdownTypographySettings.normalizedSize(
+                markdownCodeBlockFontSize,
+                range: MarkdownTypographySettings.codeBlockFontSizeRange
+            ) ?? MarkdownTypographySettings.defaultCodeBlockFontSize
+        )
+    }
+
+    private func markdownHeadingSize(_ raw: Double, fallback: Double) -> Double {
+        return MarkdownTypographySettings.normalizedSize(
+            raw,
+            range: MarkdownTypographySettings.headingSizeRange
+        ) ?? fallback
     }
 
     // MARK: - Copy actions

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -98,6 +98,7 @@ struct MarkdownPanelView: View {
                     backgroundColor: themeBackgroundColor,
                     typography: markdownTypography
                 ),
+                zoomFactor: panel.viewZoomFactor,
                 panelId: panel.id,
                 workspaceId: panel.workspaceId,
                 filePath: panel.filePath,
@@ -143,6 +144,13 @@ struct MarkdownPanelView: View {
                 )
             }
             markdownModeButton
+            PanelHeaderViewZoomButton(
+                zoomFactor: Binding(
+                    get: { panel.viewZoomFactor },
+                    set: { panel.setViewZoomFactor($0) }
+                ),
+                isDisabled: panel.isFileUnavailable
+            )
             MarkdownPanelToolbar(
                 confirmation: copyConfirmation?.label,
                 onCopyMarkdown: { copyAsMarkdown() },

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -29,6 +29,16 @@ struct MarkdownPanelView: View {
     @State private var copyConfirmation: CopyConfirmation? = nil
     @State private var copyConfirmationGeneration: Int = 0
     @State private var renderer = MarkdownWebRendererHandle()
+    @AppStorage(MarkdownTypographySettings.fontFamilyKey) private var markdownFontFamily = MarkdownTypographySettings.defaultFontFamily
+    @AppStorage(MarkdownTypographySettings.fontSizeKey) private var markdownFontSize = MarkdownTypographySettings.defaultFontSize
+    @AppStorage(MarkdownTypographySettings.headingH1SizeKey) private var markdownHeadingH1Size = MarkdownTypographySettings.defaultHeadingSizes.h1
+    @AppStorage(MarkdownTypographySettings.headingH2SizeKey) private var markdownHeadingH2Size = MarkdownTypographySettings.defaultHeadingSizes.h2
+    @AppStorage(MarkdownTypographySettings.headingH3SizeKey) private var markdownHeadingH3Size = MarkdownTypographySettings.defaultHeadingSizes.h3
+    @AppStorage(MarkdownTypographySettings.headingH4SizeKey) private var markdownHeadingH4Size = MarkdownTypographySettings.defaultHeadingSizes.h4
+    @AppStorage(MarkdownTypographySettings.headingH5SizeKey) private var markdownHeadingH5Size = MarkdownTypographySettings.defaultHeadingSizes.h5
+    @AppStorage(MarkdownTypographySettings.headingH6SizeKey) private var markdownHeadingH6Size = MarkdownTypographySettings.defaultHeadingSizes.h6
+    @AppStorage(MarkdownTypographySettings.codeBlockFontFamilyKey) private var markdownCodeBlockFontFamily = MarkdownTypographySettings.defaultCodeBlockFontFamily
+    @AppStorage(MarkdownTypographySettings.codeBlockFontSizeKey) private var markdownCodeBlockFontSize = MarkdownTypographySettings.defaultCodeBlockFontSize
 
     private enum CopyConfirmation: Equatable {
         case markdown
@@ -84,7 +94,10 @@ struct MarkdownPanelView: View {
         ZStack {
             MarkdownWebRenderer(
                 markdown: panel.content,
-                theme: MarkdownWebTheme.resolve(backgroundColor: themeBackgroundColor),
+                theme: MarkdownWebTheme.resolve(
+                    backgroundColor: themeBackgroundColor,
+                    typography: markdownTypography
+                ),
                 panelId: panel.id,
                 workspaceId: panel.workspaceId,
                 filePath: panel.filePath,
@@ -193,6 +206,37 @@ struct MarkdownPanelView: View {
 
     private var themeColorScheme: ColorScheme {
         themeBackgroundColor.isLightColor ? .light : .dark
+    }
+
+    private var markdownTypography: MarkdownWebTypography {
+        MarkdownWebTypography(
+            fontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownFontFamily)
+                ?? MarkdownTypographySettings.defaultFontFamily,
+            fontSize: MarkdownTypographySettings.normalizedSize(
+                markdownFontSize,
+                range: MarkdownTypographySettings.fontSizeRange
+            ) ?? MarkdownTypographySettings.defaultFontSize,
+            headingSizes: MarkdownWebTypography.HeadingSizes(
+                h1: MarkdownTypographySettings.normalizedSize(markdownHeadingH1Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h1,
+                h2: MarkdownTypographySettings.normalizedSize(markdownHeadingH2Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h2,
+                h3: MarkdownTypographySettings.normalizedSize(markdownHeadingH3Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h3,
+                h4: MarkdownTypographySettings.normalizedSize(markdownHeadingH4Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h4,
+                h5: MarkdownTypographySettings.normalizedSize(markdownHeadingH5Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h5,
+                h6: MarkdownTypographySettings.normalizedSize(markdownHeadingH6Size, range: MarkdownTypographySettings.headingSizeRange)
+                    ?? MarkdownTypographySettings.defaultHeadingSizes.h6
+            ),
+            codeBlockFontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownCodeBlockFontFamily)
+                ?? MarkdownTypographySettings.defaultCodeBlockFontFamily,
+            codeBlockFontSize: MarkdownTypographySettings.normalizedSize(
+                markdownCodeBlockFontSize,
+                range: MarkdownTypographySettings.codeBlockFontSizeRange
+            ) ?? MarkdownTypographySettings.defaultCodeBlockFontSize
+        )
     }
 
     // MARK: - Copy actions

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -209,34 +209,17 @@ struct MarkdownPanelView: View {
     }
 
     private var markdownTypography: MarkdownWebTypography {
-        MarkdownWebTypography(
-            fontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownFontFamily)
-                ?? MarkdownTypographySettings.defaultFontFamily,
-            fontSize: MarkdownTypographySettings.normalizedSize(
-                markdownFontSize,
-                range: MarkdownTypographySettings.fontSizeRange
-            ) ?? MarkdownTypographySettings.defaultFontSize,
-            headingSizes: MarkdownWebTypography.HeadingSizes(
-                h1: MarkdownTypographySettings.normalizedSize(markdownHeadingH1Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h1,
-                h2: MarkdownTypographySettings.normalizedSize(markdownHeadingH2Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h2,
-                h3: MarkdownTypographySettings.normalizedSize(markdownHeadingH3Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h3,
-                h4: MarkdownTypographySettings.normalizedSize(markdownHeadingH4Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h4,
-                h5: MarkdownTypographySettings.normalizedSize(markdownHeadingH5Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h5,
-                h6: MarkdownTypographySettings.normalizedSize(markdownHeadingH6Size, range: MarkdownTypographySettings.headingSizeRange)
-                    ?? MarkdownTypographySettings.defaultHeadingSizes.h6
-            ),
-            codeBlockFontFamily: MarkdownTypographySettings.normalizedFontFamily(markdownCodeBlockFontFamily)
-                ?? MarkdownTypographySettings.defaultCodeBlockFontFamily,
-            codeBlockFontSize: MarkdownTypographySettings.normalizedSize(
-                markdownCodeBlockFontSize,
-                range: MarkdownTypographySettings.codeBlockFontSizeRange
-            ) ?? MarkdownTypographySettings.defaultCodeBlockFontSize
-        )
+        _ = markdownFontFamily
+        _ = markdownFontSize
+        _ = markdownHeadingH1Size
+        _ = markdownHeadingH2Size
+        _ = markdownHeadingH3Size
+        _ = markdownHeadingH4Size
+        _ = markdownHeadingH5Size
+        _ = markdownHeadingH6Size
+        _ = markdownCodeBlockFontFamily
+        _ = markdownCodeBlockFontSize
+        return MarkdownTypographySettings.resolved()
     }
 
     // MARK: - Copy actions

--- a/Sources/Panels/MarkdownTypographySettings.swift
+++ b/Sources/Panels/MarkdownTypographySettings.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+struct MarkdownWebTypography: Equatable {
+    struct HeadingSizes: Equatable {
+        let h1: Double
+        let h2: Double
+        let h3: Double
+        let h4: Double
+        let h5: Double
+        let h6: Double
+    }
+
+    let fontFamily: String
+    let fontSize: Double
+    let headingSizes: HeadingSizes
+    let codeBlockFontFamily: String
+    let codeBlockFontSize: Double
+
+    static let `default` = MarkdownWebTypography(
+        fontFamily: MarkdownTypographySettings.defaultFontFamily,
+        fontSize: MarkdownTypographySettings.defaultFontSize,
+        headingSizes: HeadingSizes(
+            h1: MarkdownTypographySettings.defaultHeadingSizes.h1,
+            h2: MarkdownTypographySettings.defaultHeadingSizes.h2,
+            h3: MarkdownTypographySettings.defaultHeadingSizes.h3,
+            h4: MarkdownTypographySettings.defaultHeadingSizes.h4,
+            h5: MarkdownTypographySettings.defaultHeadingSizes.h5,
+            h6: MarkdownTypographySettings.defaultHeadingSizes.h6
+        ),
+        codeBlockFontFamily: MarkdownTypographySettings.defaultCodeBlockFontFamily,
+        codeBlockFontSize: MarkdownTypographySettings.defaultCodeBlockFontSize
+    )
+
+    var cssVariables: [String: String] {
+        [
+            "--cmux-markdown-font-family": fontFamily,
+            "--cmux-markdown-font-size": Self.cssPixels(fontSize),
+            "--cmux-markdown-h1-font-size": Self.cssPixels(headingSizes.h1),
+            "--cmux-markdown-h2-font-size": Self.cssPixels(headingSizes.h2),
+            "--cmux-markdown-h3-font-size": Self.cssPixels(headingSizes.h3),
+            "--cmux-markdown-h4-font-size": Self.cssPixels(headingSizes.h4),
+            "--cmux-markdown-h5-font-size": Self.cssPixels(headingSizes.h5),
+            "--cmux-markdown-h6-font-size": Self.cssPixels(headingSizes.h6),
+            "--cmux-markdown-code-block-font-family": codeBlockFontFamily,
+            "--cmux-markdown-code-block-font-size": Self.cssPixels(codeBlockFontSize),
+        ]
+    }
+
+    private static func cssPixels(_ value: Double) -> String {
+        let rounded = (value * 100).rounded() / 100
+        if rounded.rounded() == rounded {
+            return "\(Int(rounded))px"
+        }
+        return "\(rounded)px"
+    }
+}
+
+enum MarkdownTypographySettings {
+    struct HeadingSizes: Equatable {
+        let h1: Double
+        let h2: Double
+        let h3: Double
+        let h4: Double
+        let h5: Double
+        let h6: Double
+    }
+
+    static let fontFamilyKey = "markdown.typography.fontFamily"
+    static let fontSizeKey = "markdown.typography.fontSize"
+    static let headingH1SizeKey = "markdown.typography.headingSizes.h1"
+    static let headingH2SizeKey = "markdown.typography.headingSizes.h2"
+    static let headingH3SizeKey = "markdown.typography.headingSizes.h3"
+    static let headingH4SizeKey = "markdown.typography.headingSizes.h4"
+    static let headingH5SizeKey = "markdown.typography.headingSizes.h5"
+    static let headingH6SizeKey = "markdown.typography.headingSizes.h6"
+    static let codeBlockFontFamilyKey = "markdown.typography.codeBlockFontFamily"
+    static let codeBlockFontSizeKey = "markdown.typography.codeBlockFontSize"
+
+    static let defaultFontFamily = "-apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Noto Sans\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\""
+    static let defaultFontSize: Double = 15
+    static let defaultHeadingSizes = HeadingSizes(
+        h1: 30,
+        h2: 22.5,
+        h3: 18.75,
+        h4: 15,
+        h5: 13.13,
+        h6: 12.75
+    )
+    static let defaultCodeBlockFontFamily = "ui-monospace, SFMono-Regular, \"SF Mono\", Menlo, Consolas, \"Liberation Mono\", monospace"
+    static let defaultCodeBlockFontSize: Double = 13.5
+
+    static let fontSizeRange: ClosedRange<Double> = 8...32
+    static let headingSizeRange: ClosedRange<Double> = 8...72
+    static let codeBlockFontSizeRange: ClosedRange<Double> = 8...32
+
+    static func resolved(defaults: UserDefaults = .standard) -> MarkdownWebTypography {
+        MarkdownWebTypography(
+            fontFamily: resolvedFontFamily(
+                defaults.string(forKey: fontFamilyKey),
+                fallback: defaultFontFamily
+            ),
+            fontSize: resolvedSize(
+                defaults.object(forKey: fontSizeKey),
+                fallback: defaultFontSize,
+                range: fontSizeRange
+            ),
+            headingSizes: MarkdownWebTypography.HeadingSizes(
+                h1: resolvedSize(defaults.object(forKey: headingH1SizeKey), fallback: defaultHeadingSizes.h1, range: headingSizeRange),
+                h2: resolvedSize(defaults.object(forKey: headingH2SizeKey), fallback: defaultHeadingSizes.h2, range: headingSizeRange),
+                h3: resolvedSize(defaults.object(forKey: headingH3SizeKey), fallback: defaultHeadingSizes.h3, range: headingSizeRange),
+                h4: resolvedSize(defaults.object(forKey: headingH4SizeKey), fallback: defaultHeadingSizes.h4, range: headingSizeRange),
+                h5: resolvedSize(defaults.object(forKey: headingH5SizeKey), fallback: defaultHeadingSizes.h5, range: headingSizeRange),
+                h6: resolvedSize(defaults.object(forKey: headingH6SizeKey), fallback: defaultHeadingSizes.h6, range: headingSizeRange)
+            ),
+            codeBlockFontFamily: resolvedFontFamily(
+                defaults.string(forKey: codeBlockFontFamilyKey),
+                fallback: defaultCodeBlockFontFamily
+            ),
+            codeBlockFontSize: resolvedSize(
+                defaults.object(forKey: codeBlockFontSizeKey),
+                fallback: defaultCodeBlockFontSize,
+                range: codeBlockFontSizeRange
+            )
+        )
+    }
+
+    static func normalizedFontFamily(_ raw: String) -> String? {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty,
+              trimmed.rangeOfCharacter(from: .newlines) == nil,
+              trimmed.rangeOfCharacter(from: CharacterSet(charactersIn: "{};")) == nil else {
+            return nil
+        }
+        return trimmed
+    }
+
+    static func normalizedSize(_ raw: Double, range: ClosedRange<Double>) -> Double? {
+        guard raw.isFinite, range.contains(raw) else { return nil }
+        return (raw * 100).rounded() / 100
+    }
+
+    private static func resolvedFontFamily(_ raw: String?, fallback: String) -> String {
+        guard let raw,
+              let normalized = normalizedFontFamily(raw) else {
+            return fallback
+        }
+        return normalized
+    }
+
+    private static func resolvedSize(_ raw: Any?, fallback: Double, range: ClosedRange<Double>) -> Double {
+        guard let number = raw as? NSNumber,
+              CFGetTypeID(number) != CFBooleanGetTypeID(),
+              let normalized = normalizedSize(number.doubleValue, range: range) else {
+            return fallback
+        }
+        return normalized
+    }
+}

--- a/Sources/Panels/MarkdownTypographySettings.swift
+++ b/Sources/Panels/MarkdownTypographySettings.swift
@@ -1,7 +1,7 @@
 import Foundation
 
-struct MarkdownWebTypography: Equatable {
-    struct HeadingSizes: Equatable {
+nonisolated struct MarkdownWebTypography: Equatable, Sendable {
+    struct HeadingSizes: Equatable, Sendable {
         let h1: Double
         let h2: Double
         let h3: Double
@@ -55,16 +55,7 @@ struct MarkdownWebTypography: Equatable {
     }
 }
 
-enum MarkdownTypographySettings {
-    struct HeadingSizes: Equatable {
-        let h1: Double
-        let h2: Double
-        let h3: Double
-        let h4: Double
-        let h5: Double
-        let h6: Double
-    }
-
+nonisolated enum MarkdownTypographySettings {
     static let fontFamilyKey = "markdown.typography.fontFamily"
     static let fontSizeKey = "markdown.typography.fontSize"
     static let headingH1SizeKey = "markdown.typography.headingSizes.h1"
@@ -78,39 +69,34 @@ enum MarkdownTypographySettings {
 
     static let defaultFontFamily = "-apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Noto Sans\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\""
     static let defaultFontSize: Double = 15
-    static let defaultHeadingSizes = HeadingSizes(
-        h1: 30,
-        h2: 22.5,
-        h3: 18.75,
-        h4: 15,
-        h5: 13.13,
-        h6: 12.75
-    )
     static let defaultCodeBlockFontFamily = "ui-monospace, SFMono-Regular, \"SF Mono\", Menlo, Consolas, \"Liberation Mono\", monospace"
     static let defaultCodeBlockFontSize: Double = 13.5
 
     static let fontSizeRange: ClosedRange<Double> = 8...32
     static let headingSizeRange: ClosedRange<Double> = 8...72
     static let codeBlockFontSizeRange: ClosedRange<Double> = 8...32
+    static let defaultHeadingSizes = defaultHeadingSizes(forFontSize: defaultFontSize)
 
     static func resolved(defaults: UserDefaults = .standard) -> MarkdownWebTypography {
-        MarkdownWebTypography(
+        let bodyFontSize = resolvedSize(
+            defaults.object(forKey: fontSizeKey),
+            fallback: defaultFontSize,
+            range: fontSizeRange
+        )
+        let derivedHeadingSizes = defaultHeadingSizes(forFontSize: bodyFontSize)
+        return MarkdownWebTypography(
             fontFamily: resolvedFontFamily(
                 defaults.string(forKey: fontFamilyKey),
                 fallback: defaultFontFamily
             ),
-            fontSize: resolvedSize(
-                defaults.object(forKey: fontSizeKey),
-                fallback: defaultFontSize,
-                range: fontSizeRange
-            ),
+            fontSize: bodyFontSize,
             headingSizes: MarkdownWebTypography.HeadingSizes(
-                h1: resolvedSize(defaults.object(forKey: headingH1SizeKey), fallback: defaultHeadingSizes.h1, range: headingSizeRange),
-                h2: resolvedSize(defaults.object(forKey: headingH2SizeKey), fallback: defaultHeadingSizes.h2, range: headingSizeRange),
-                h3: resolvedSize(defaults.object(forKey: headingH3SizeKey), fallback: defaultHeadingSizes.h3, range: headingSizeRange),
-                h4: resolvedSize(defaults.object(forKey: headingH4SizeKey), fallback: defaultHeadingSizes.h4, range: headingSizeRange),
-                h5: resolvedSize(defaults.object(forKey: headingH5SizeKey), fallback: defaultHeadingSizes.h5, range: headingSizeRange),
-                h6: resolvedSize(defaults.object(forKey: headingH6SizeKey), fallback: defaultHeadingSizes.h6, range: headingSizeRange)
+                h1: resolvedSize(defaults.object(forKey: headingH1SizeKey), fallback: derivedHeadingSizes.h1, range: headingSizeRange),
+                h2: resolvedSize(defaults.object(forKey: headingH2SizeKey), fallback: derivedHeadingSizes.h2, range: headingSizeRange),
+                h3: resolvedSize(defaults.object(forKey: headingH3SizeKey), fallback: derivedHeadingSizes.h3, range: headingSizeRange),
+                h4: resolvedSize(defaults.object(forKey: headingH4SizeKey), fallback: derivedHeadingSizes.h4, range: headingSizeRange),
+                h5: resolvedSize(defaults.object(forKey: headingH5SizeKey), fallback: derivedHeadingSizes.h5, range: headingSizeRange),
+                h6: resolvedSize(defaults.object(forKey: headingH6SizeKey), fallback: derivedHeadingSizes.h6, range: headingSizeRange)
             ),
             codeBlockFontFamily: resolvedFontFamily(
                 defaults.string(forKey: codeBlockFontFamilyKey),
@@ -121,6 +107,17 @@ enum MarkdownTypographySettings {
                 fallback: defaultCodeBlockFontSize,
                 range: codeBlockFontSizeRange
             )
+        )
+    }
+
+    static func defaultHeadingSizes(forFontSize fontSize: Double) -> MarkdownWebTypography.HeadingSizes {
+        MarkdownWebTypography.HeadingSizes(
+            h1: scaledHeadingSize(fontSize, scale: 2),
+            h2: scaledHeadingSize(fontSize, scale: 1.5),
+            h3: scaledHeadingSize(fontSize, scale: 1.25),
+            h4: scaledHeadingSize(fontSize, scale: 1),
+            h5: scaledHeadingSize(fontSize, scale: 0.875),
+            h6: scaledHeadingSize(fontSize, scale: 0.85)
         )
     }
 
@@ -137,6 +134,11 @@ enum MarkdownTypographySettings {
     static func normalizedSize(_ raw: Double, range: ClosedRange<Double>) -> Double? {
         guard raw.isFinite, range.contains(raw) else { return nil }
         return (raw * 100).rounded() / 100
+    }
+
+    private static func scaledHeadingSize(_ fontSize: Double, scale: Double) -> Double {
+        let rounded = (fontSize * scale * 100).rounded() / 100
+        return min(max(rounded, headingSizeRange.lowerBound), headingSizeRange.upperBound)
     }
 
     private static func resolvedFontFamily(_ raw: String?, fallback: String) -> String {

--- a/Sources/Panels/MarkdownTypographySettings.swift
+++ b/Sources/Panels/MarkdownTypographySettings.swift
@@ -75,6 +75,7 @@ nonisolated enum MarkdownTypographySettings {
     static let fontSizeRange: ClosedRange<Double> = 8...32
     static let headingSizeRange: ClosedRange<Double> = 8...72
     static let codeBlockFontSizeRange: ClosedRange<Double> = 8...32
+    static let unsetHeadingSize = Double.nan
     static let defaultHeadingSizes = defaultHeadingSizes(forFontSize: defaultFontSize)
 
     static func resolved(defaults: UserDefaults = .standard) -> MarkdownWebTypography {

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -9,8 +9,12 @@ struct MarkdownWebTheme: Equatable {
     let neutralMutedBackground: String
     let border: String
     let mutedBorder: String
+    let typography: MarkdownWebTypography
 
-    static func resolve(backgroundColor: NSColor) -> MarkdownWebTheme {
+    static func resolve(
+        backgroundColor: NSColor,
+        typography: MarkdownWebTypography = .default
+    ) -> MarkdownWebTheme {
         let base = backgroundColor.markdownOpaqueSRGB
         let isDark = !base.isLightColor
         let overlayColor: NSColor = isDark ? .white : .black
@@ -32,8 +36,20 @@ struct MarkdownWebTheme: Equatable {
             mutedBackground: muted.markdownCSSColor,
             neutralMutedBackground: neutralMuted.markdownCSSColor,
             border: border.markdownCSSColor,
-            mutedBorder: border.withAlphaComponent(border.alphaComponent * 0.70).markdownCSSColor
+            mutedBorder: border.withAlphaComponent(border.alphaComponent * 0.70).markdownCSSColor,
+            typography: typography
         )
+    }
+
+    var cssVariables: [String: String] {
+        var payload = typography.cssVariables
+        payload["--bgColor-default"] = background
+        payload["--bgColor-muted"] = mutedBackground
+        payload["--bgColor-neutral-muted"] = neutralMutedBackground
+        payload["--borderColor-default"] = border
+        payload["--borderColor-muted"] = mutedBorder
+        payload["--borderColor-neutral-muted"] = mutedBorder
+        return payload
     }
 }
 
@@ -198,14 +214,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
 
         private func applyTheme(_ theme: MarkdownWebTheme) {
             guard let webView else { return }
-            let payload = [
-                "--bgColor-default": theme.background,
-                "--bgColor-muted": theme.mutedBackground,
-                "--bgColor-neutral-muted": theme.neutralMutedBackground,
-                "--borderColor-default": theme.border,
-                "--borderColor-muted": theme.mutedBorder,
-                "--borderColor-neutral-muted": theme.mutedBorder
-            ]
+            let payload = theme.cssVariables
             guard let data = try? JSONSerialization.data(withJSONObject: payload),
                   let json = String(data: data, encoding: .utf8) else { return }
             let js = """

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -56,6 +56,7 @@ struct MarkdownWebTheme: Equatable {
 struct MarkdownWebRenderer: NSViewRepresentable {
     let markdown: String
     let theme: MarkdownWebTheme
+    let zoomFactor: CGFloat
     let panelId: UUID
     let workspaceId: UUID
     let filePath: String
@@ -93,6 +94,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
 #endif
         }
         applyAppearance(to: webView, isDark: theme.isDark)
+        applyZoom(to: webView)
 
         context.coordinator.webView = webView
         context.coordinator.loadShell(theme: theme, initialMarkdown: markdown)
@@ -108,6 +110,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         context.coordinator.filePath = filePath
         (nsView as? MarkdownWebView)?.onPointerDown = onRequestPanelFocus
         applyAppearance(to: nsView, isDark: theme.isDark)
+        applyZoom(to: nsView)
         context.coordinator.update(markdown: markdown, theme: theme)
     }
 
@@ -128,6 +131,13 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         let appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
         if webView.appearance !== appearance {
             webView.appearance = appearance
+        }
+    }
+
+    private func applyZoom(to webView: WKWebView) {
+        let normalized = ViewZoomControl.normalized(zoomFactor)
+        if abs(webView.pageZoom - normalized) > 0.0001 {
+            webView.pageZoom = normalized
         }
     }
 

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -168,3 +168,92 @@ struct PanelHeaderIconGlyph: View {
             .contentShape(Rectangle())
     }
 }
+
+struct PanelHeaderViewZoomButton: View {
+    @Binding var zoomFactor: CGFloat
+    var isDisabled = false
+
+    @State private var isPresented = false
+
+    private var title: String {
+        String(localized: "view.zoom.controls", defaultValue: "View Zoom")
+    }
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            PanelHeaderIconGlyph(systemName: "textformat.size")
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.secondary)
+        .disabled(isDisabled)
+        .help(title)
+        .accessibilityLabel(title)
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            popoverContent
+        }
+    }
+
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Text(ViewZoomControl.percentText(for: zoomFactor))
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                zoomButton(
+                    systemName: "minus",
+                    label: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"),
+                    action: { apply(.zoomOut) }
+                )
+                Button {
+                    apply(.reset)
+                } label: {
+                    Text(ViewZoomControl.percentText(for: ViewZoomControl.defaultFactor))
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .frame(width: 58, height: 26)
+                }
+                .buttonStyle(.bordered)
+                .help(String(localized: "menu.view.actualSize", defaultValue: "Actual Size"))
+                .accessibilityLabel(String(localized: "menu.view.actualSize", defaultValue: "Actual Size"))
+
+                zoomButton(
+                    systemName: "plus",
+                    label: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"),
+                    action: { apply(.zoomIn) }
+                )
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(ViewZoomControl.normalized(zoomFactor)) },
+                    set: { zoomFactor = ViewZoomControl.normalized(CGFloat($0)) }
+                ),
+                in: Double(ViewZoomControl.minimumFactor)...Double(ViewZoomControl.maximumFactor)
+            )
+        }
+        .padding(14)
+        .frame(width: 220)
+    }
+
+    private func zoomButton(systemName: String, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.bordered)
+        .help(label)
+        .accessibilityLabel(label)
+    }
+
+    private func apply(_ command: ViewZoomCommand) {
+        zoomFactor = ViewZoomControl.applying(command, to: zoomFactor)
+    }
+}

--- a/Sources/Panels/ViewZoomControls.swift
+++ b/Sources/Panels/ViewZoomControls.swift
@@ -1,0 +1,93 @@
+import AppKit
+import Foundation
+
+enum ViewZoomCommand: Equatable {
+    case zoomIn
+    case zoomOut
+    case reset
+}
+
+enum ViewZoomControl {
+    static let defaultFactor: CGFloat = 1.0
+    static let step: CGFloat = 0.10
+    static let minimumFactor: CGFloat = 0.50
+    static let maximumFactor: CGFloat = 3.00
+
+    static func normalized(_ factor: CGFloat) -> CGFloat {
+        guard factor.isFinite else { return defaultFactor }
+        return min(max(factor, minimumFactor), maximumFactor)
+    }
+
+    static func applying(_ command: ViewZoomCommand, to factor: CGFloat) -> CGFloat {
+        switch command {
+        case .zoomIn:
+            return normalized(factor + step)
+        case .zoomOut:
+            return normalized(factor - step)
+        case .reset:
+            return defaultFactor
+        }
+    }
+
+    static func percentText(for factor: CGFloat) -> String {
+        "\(Int((normalized(factor) * 100).rounded()))%"
+    }
+
+    static func textEditorFontSize(for factor: CGFloat) -> CGFloat {
+        normalized(factor) * textEditorDefaultFontSize
+    }
+
+    static func textEditorZoomFactor(forFontSize fontSize: CGFloat) -> CGFloat {
+        normalized(fontSize / textEditorDefaultFontSize)
+    }
+
+    static func command(for event: NSEvent) -> ViewZoomCommand? {
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomIn).matches(event: event) {
+            return .zoomIn
+        }
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomOut).matches(event: event) {
+            return .zoomOut
+        }
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomReset).matches(event: event) {
+            return .reset
+        }
+
+        let defaultAction = browserZoomShortcutAction(
+            flags: event.modifierFlags,
+            chars: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode,
+            literalChars: event.characters
+        )
+
+        switch defaultAction {
+        case .zoomIn where KeyboardShortcutSettings.shortcut(for: .browserZoomIn) == KeyboardShortcutSettings.Action.browserZoomIn.defaultShortcut:
+            return .zoomIn
+        case .zoomOut where KeyboardShortcutSettings.shortcut(for: .browserZoomOut) == KeyboardShortcutSettings.Action.browserZoomOut.defaultShortcut:
+            return .zoomOut
+        case .reset where KeyboardShortcutSettings.shortcut(for: .browserZoomReset) == KeyboardShortcutSettings.Action.browserZoomReset.defaultShortcut:
+            return .reset
+        default:
+            return nil
+        }
+    }
+
+    static let textEditorDefaultFontSize: CGFloat = 13
+}
+
+@MainActor
+protocol ViewZoomControlling: AnyObject {
+    var viewZoomFactor: CGFloat { get }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool
+}
+
+extension ViewZoomControlling {
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        setViewZoomFactor(ViewZoomControl.applying(command, to: viewZoomFactor))
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4845,19 +4845,18 @@ class TabManager: ObservableObject {
         return tab.panels[panelId] as? BrowserPanel
     }
 
-    @discardableResult
-    func zoomInFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.zoomIn() ?? false
+    var focusedPanel: (any Panel)? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId]
     }
 
     @discardableResult
-    func zoomOutFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.zoomOut() ?? false
-    }
-
-    @discardableResult
-    func resetZoomFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.resetZoom() ?? false
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        guard let controller = focusedPanel as? any ViewZoomControlling else {
+            return false
+        }
+        return controller.performViewZoomCommand(command)
     }
 
     @discardableResult

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -700,15 +700,15 @@ struct cmuxApp: App {
             }
 
             splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
-                _ = activeTabManager.zoomInFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.zoomIn)
             }
 
             splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
-                _ = activeTabManager.zoomOutFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.zoomOut)
             }
 
             splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
-                _ = activeTabManager.resetZoomFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.reset)
             }
 
             Button(String(localized: "menu.view.clearBrowserHistory", defaultValue: "Clear Browser History")) {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Combine
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -3128,6 +3129,28 @@ final class BrowserZoomShortcutActionTests: XCTestCase {
             browserZoomShortcutAction(flags: [.command], chars: "0", keyCode: 29),
             .reset
         )
+    }
+
+    @MainActor
+    func testViewZoomCommandRespectsUnboundZoomShortcut() throws {
+        KeyboardShortcutSettings.resetAll()
+        defer { KeyboardShortcutSettings.resetAll() }
+        KeyboardShortcutSettings.clearShortcut(for: .browserZoomIn)
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+
+        XCTAssertNil(ViewZoomControl.command(for: event))
     }
 }
 

--- a/cmuxTests/KeyboardShortcutContextTests.swift
+++ b/cmuxTests/KeyboardShortcutContextTests.swift
@@ -141,6 +141,12 @@ final class KeyboardShortcutContextTests: XCTestCase {
         XCTAssertEqual(KeyboardShortcutSettings.Action.toggleReactGrab.shortcutContext, .application)
     }
 
+    func testViewZoomShortcutsAreApplicationScoped() {
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomIn.shortcutContext, .application)
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomOut.shortcutContext, .application)
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomReset.shortcutContext, .application)
+    }
+
     func testShortcutSettingsFilePreservesConfiguredShortcutWithoutGlobalConflictLookup() throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -65,7 +65,11 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-font-family"], "Avenir Next, sans-serif")
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-font-size"], "16.25px")
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-h1-font-size"], "34px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h2-font-size"], "26px")
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-h3-font-size"], "21px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h4-font-size"], "17px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h5-font-size"], "14px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h6-font-size"], "12px")
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-code-block-font-family"], "JetBrains Mono, ui-monospace, monospace")
         XCTAssertEqual(theme.cssVariables["--cmux-markdown-code-block-font-size"], "14.5px")
     }

--- a/cmuxTests/MarkdownPanelTests.swift
+++ b/cmuxTests/MarkdownPanelTests.swift
@@ -42,6 +42,34 @@ final class MarkdownPanelTests: XCTestCase {
         XCTAssertEqual(overlay.alphaComponent, 1, accuracy: 0.0001)
     }
 
+    func testMarkdownThemeIncludesConfiguredTypographyVariables() {
+        let typography = MarkdownWebTypography(
+            fontFamily: "Avenir Next, sans-serif",
+            fontSize: 16.25,
+            headingSizes: MarkdownWebTypography.HeadingSizes(
+                h1: 34,
+                h2: 26,
+                h3: 21,
+                h4: 17,
+                h5: 14,
+                h6: 12
+            ),
+            codeBlockFontFamily: "JetBrains Mono, ui-monospace, monospace",
+            codeBlockFontSize: 14.5
+        )
+        let theme = MarkdownWebTheme.resolve(
+            backgroundColor: NSColor(srgbRed: 0.10, green: 0.12, blue: 0.14, alpha: 1),
+            typography: typography
+        )
+
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-font-family"], "Avenir Next, sans-serif")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-font-size"], "16.25px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h1-font-size"], "34px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-h3-font-size"], "21px")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-code-block-font-family"], "JetBrains Mono, ui-monospace, monospace")
+        XCTAssertEqual(theme.cssVariables["--cmux-markdown-code-block-font-size"], "14.5px")
+    }
+
     func testFileOpenRoutesMarkdownFilesToPreviewMarkdownPanel() throws {
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2330,6 +2330,117 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "original")
     }
 
+    func testSavingTextViewHandlesCommandPlusViewZoom() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        let textView = SavingTextView()
+        textView.panel = panel
+        panel.attachTextView(textView)
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+
+        XCTAssertTrue(textView.performKeyEquivalent(with: event))
+        XCTAssertGreaterThan(panel.viewZoomFactor, ViewZoomControl.defaultFactor)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor), accuracy: 0.001)
+    }
+
+    func testSavingTextViewFontSizeTracksViewZoomBounds() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        let textView = SavingTextView()
+        textView.panel = panel
+        panel.attachTextView(textView)
+
+        let zoomOutEvent = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "-",
+            charactersIgnoringModifiers: "-",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Minus)
+        ))
+        for _ in 0..<10 {
+            XCTAssertTrue(textView.performKeyEquivalent(with: zoomOutEvent))
+        }
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.minimumFactor, accuracy: 0.001)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: ViewZoomControl.minimumFactor), accuracy: 0.001)
+
+        let zoomInEvent = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+        for _ in 0..<40 {
+            XCTAssertTrue(textView.performKeyEquivalent(with: zoomInEvent))
+        }
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.maximumFactor, accuracy: 0.001)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: ViewZoomControl.maximumFactor), accuracy: 0.001)
+    }
+
+    func testFilePreviewViewZoomOnlyHandlesTextMode() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomIn))
+        XCTAssertEqual(panel.viewZoomFactor, 1.1, accuracy: 0.001)
+        XCTAssertTrue(panel.performViewZoomCommand(.reset))
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.defaultFactor, accuracy: 0.001)
+
+        let imageURL = url.deletingLastPathComponent().appendingPathComponent("image.png")
+        let imagePanel = FilePreviewPanel(workspaceId: UUID(), filePath: imageURL.path)
+        XCTAssertFalse(imagePanel.performViewZoomCommand(.zoomIn))
+    }
+
+    func testMarkdownPanelViewZoomPersistsAcrossPreviewAndTextModes() throws {
+        let url = try temporaryTextFile(contents: "# Title", encoding: .utf8, pathExtension: "md")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.displayMode, .preview)
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomIn))
+        XCTAssertEqual(panel.viewZoomFactor, 1.1, accuracy: 0.001)
+
+        panel.setDisplayMode(.text)
+        XCTAssertEqual(panel.displayMode, .text)
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomOut))
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.defaultFactor, accuracy: 0.001)
+    }
+
     func testSaveTextContentPreservesLoadedEncoding() async throws {
         let url = try temporaryTextFile(contents: "original", encoding: .utf16)
         defer { try? FileManager.default.removeItem(at: url) }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -1742,11 +1742,15 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         )
 
         let typography = MarkdownTypographySettings.resolved(defaults: defaults)
+        let derivedHeadingSizes = MarkdownTypographySettings.defaultHeadingSizes(forFontSize: 16.5)
         XCTAssertEqual(typography.fontFamily, MarkdownTypographySettings.defaultFontFamily)
         XCTAssertEqual(typography.fontSize, 16.5)
-        XCTAssertEqual(typography.headingSizes.h1, MarkdownTypographySettings.defaultHeadingSizes.h1)
+        XCTAssertEqual(typography.headingSizes.h1, derivedHeadingSizes.h1)
         XCTAssertEqual(typography.headingSizes.h2, 24)
-        XCTAssertEqual(typography.headingSizes.h3, MarkdownTypographySettings.defaultHeadingSizes.h3)
+        XCTAssertEqual(typography.headingSizes.h3, derivedHeadingSizes.h3)
+        XCTAssertEqual(typography.headingSizes.h4, derivedHeadingSizes.h4)
+        XCTAssertEqual(typography.headingSizes.h5, derivedHeadingSizes.h5)
+        XCTAssertEqual(typography.headingSizes.h6, derivedHeadingSizes.h6)
         XCTAssertEqual(typography.codeBlockFontFamily, MarkdownTypographySettings.defaultCodeBlockFontFamily)
         XCTAssertEqual(typography.codeBlockFontSize, 14.25)
     }

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -690,6 +690,18 @@ final class WorkspaceRenameShortcutDefaultsTests: XCTestCase {
 final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
     private var originalSettingsFileStore: KeyboardShortcutSettingsFileStore!
     private let settingsFileBackupsDefaultsKey = "cmux.settingsFile.backups.v1"
+    private let markdownTypographyManagedKeys = [
+        MarkdownTypographySettings.fontFamilyKey,
+        MarkdownTypographySettings.fontSizeKey,
+        MarkdownTypographySettings.headingH1SizeKey,
+        MarkdownTypographySettings.headingH2SizeKey,
+        MarkdownTypographySettings.headingH3SizeKey,
+        MarkdownTypographySettings.headingH4SizeKey,
+        MarkdownTypographySettings.headingH5SizeKey,
+        MarkdownTypographySettings.headingH6SizeKey,
+        MarkdownTypographySettings.codeBlockFontFamilyKey,
+        MarkdownTypographySettings.codeBlockFontSizeKey,
+    ]
 
     func testShortcutConfigStringCanonicalizesNumberedDigitsWhenRequested() {
         let stroke = ShortcutStroke(
@@ -1596,6 +1608,147 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
         XCTAssertEqual(restored.first(where: { $0.name == "Blue" })?.hex, "#010203")
         XCTAssertEqual(restored.first(where: { $0.name == "Custom 1" })?.hex, "#778899")
         XCTAssertNil(defaults.data(forKey: settingsFileBackupsDefaultsKey))
+    }
+
+    func testSettingsFileStoreAppliesMarkdownTypographySettings() throws {
+        let defaults = UserDefaults.standard
+        let managedKeys = markdownTypographyManagedKeys
+        var previousValues: [String: Any] = [:]
+        for key in managedKeys {
+            if let value = defaults.object(forKey: key) {
+                previousValues[key] = value
+            }
+        }
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            for key in managedKeys {
+                if let value = previousValues[key] {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        managedKeys.forEach { defaults.removeObject(forKey: $0) }
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "markdown": {
+                "fontFamily": "Avenir Next, sans-serif",
+                "fontSize": 16.25,
+                "headingSizes": {
+                  "h1": 34,
+                  "h2": 26,
+                  "h3": 21,
+                  "h4": 17,
+                  "h5": 14,
+                  "h6": 12
+                },
+                "codeBlockFontFamily": "JetBrains Mono, ui-monospace, monospace",
+                "codeBlockFontSize": 14.5
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        let typography = MarkdownTypographySettings.resolved(defaults: defaults)
+        XCTAssertEqual(typography.fontFamily, "Avenir Next, sans-serif")
+        XCTAssertEqual(typography.fontSize, 16.25)
+        XCTAssertEqual(typography.headingSizes.h1, 34)
+        XCTAssertEqual(typography.headingSizes.h2, 26)
+        XCTAssertEqual(typography.headingSizes.h3, 21)
+        XCTAssertEqual(typography.headingSizes.h4, 17)
+        XCTAssertEqual(typography.headingSizes.h5, 14)
+        XCTAssertEqual(typography.headingSizes.h6, 12)
+        XCTAssertEqual(typography.codeBlockFontFamily, "JetBrains Mono, ui-monospace, monospace")
+        XCTAssertEqual(typography.codeBlockFontSize, 14.5)
+    }
+
+    func testSettingsFileStoreIgnoresInvalidMarkdownTypographySettings() throws {
+        let defaults = UserDefaults.standard
+        let managedKeys = markdownTypographyManagedKeys
+        var previousValues: [String: Any] = [:]
+        for key in managedKeys {
+            if let value = defaults.object(forKey: key) {
+                previousValues[key] = value
+            }
+        }
+        let previousBackups = defaults.data(forKey: settingsFileBackupsDefaultsKey)
+        defer {
+            for key in managedKeys {
+                if let value = previousValues[key] {
+                    defaults.set(value, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+            }
+
+            if let previousBackups {
+                defaults.set(previousBackups, forKey: settingsFileBackupsDefaultsKey)
+            } else {
+                defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            }
+        }
+
+        managedKeys.forEach { defaults.removeObject(forKey: $0) }
+        defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+
+        let directoryURL = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+        let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+        try writeSettingsFile(
+            """
+            {
+              "markdown": {
+                "fontFamily": "Body; color: red",
+                "fontSize": 16.5,
+                "headingSizes": {
+                  "h1": 96,
+                  "h2": 24
+                },
+                "codeBlockFontFamily": "",
+                "codeBlockFontSize": 14.25
+              }
+            }
+            """,
+            to: settingsFileURL
+        )
+
+        _ = KeyboardShortcutSettingsFileStore(
+            primaryPath: settingsFileURL.path,
+            fallbackPath: nil,
+            startWatching: false
+        )
+
+        let typography = MarkdownTypographySettings.resolved(defaults: defaults)
+        XCTAssertEqual(typography.fontFamily, MarkdownTypographySettings.defaultFontFamily)
+        XCTAssertEqual(typography.fontSize, 16.5)
+        XCTAssertEqual(typography.headingSizes.h1, MarkdownTypographySettings.defaultHeadingSizes.h1)
+        XCTAssertEqual(typography.headingSizes.h2, 24)
+        XCTAssertEqual(typography.headingSizes.h3, MarkdownTypographySettings.defaultHeadingSizes.h3)
+        XCTAssertEqual(typography.codeBlockFontFamily, MarkdownTypographySettings.defaultCodeBlockFontFamily)
+        XCTAssertEqual(typography.codeBlockFontSize, 14.25)
     }
 
     @MainActor

--- a/web/app/[locale]/docs/configuration/page.tsx
+++ b/web/app/[locale]/docs/configuration/page.tsx
@@ -45,6 +45,7 @@ const sectionOrder = [
   "ui",
   "commands",
   "browser",
+  "markdown",
   "shortcuts",
 ] as const;
 
@@ -69,6 +70,18 @@ const settingsFileExample = `{
   // "browser": {
   //   "openTerminalLinksInCmuxBrowser": true,
   //   "hostsToOpenInEmbeddedBrowser": ["localhost", "*.internal.example"]
+  // },
+
+  // "markdown": {
+  //   "fontFamily": "Avenir Next",
+  //   "fontSize": 16,
+  //   "headingSizes": {
+  //     "h1": 34,
+  //     "h2": 26,
+  //     "h3": 21
+  //   },
+  //   "codeBlockFontFamily": "JetBrains Mono, ui-monospace, monospace",
+  //   "codeBlockFontSize": 14
   // },
 
   // "workspaceColors": {
@@ -303,8 +316,8 @@ working-directory = ~/code`}</CodeBlock>
       <h2>Schema reference</h2>
       <p>
         This reference covers every supported global settings key in <code>cmux.json</code>. The embedded
-        browser, terminal, sidebar, notifications, automation, and cmux-owned keyboard shortcuts
-        all live here. Actions and workspace commands are documented on the{" "}
+        browser, markdown, terminal, sidebar, notifications, automation, and cmux-owned keyboard
+        shortcuts all live here. Actions and workspace commands are documented on the{" "}
         <Link href="/docs/custom-commands">custom commands page</Link>.
       </p>
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -755,6 +755,81 @@
         }
       }
     },
+    "markdown": {
+      "title": "markdown",
+      "description": "Markdown preview typography settings.",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "fontFamily": {
+          "type": "string",
+          "default": "-apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Noto Sans\", Helvetica, Arial, sans-serif, \"Apple Color Emoji\", \"Segoe UI Emoji\"",
+          "description": "CSS font-family stack for markdown body text. Use a single family name or a full CSS stack."
+        },
+        "fontSize": {
+          "type": "number",
+          "minimum": 8,
+          "maximum": 32,
+          "default": 15,
+          "description": "Markdown body font size in pixels."
+        },
+        "headingSizes": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Markdown heading font sizes in pixels.",
+          "properties": {
+            "h1": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 30
+            },
+            "h2": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 22.5
+            },
+            "h3": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 18.75
+            },
+            "h4": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 15
+            },
+            "h5": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 13.13
+            },
+            "h6": {
+              "type": "number",
+              "minimum": 8,
+              "maximum": 72,
+              "default": 12.75
+            }
+          }
+        },
+        "codeBlockFontFamily": {
+          "type": "string",
+          "default": "ui-monospace, SFMono-Regular, \"SF Mono\", Menlo, Consolas, \"Liberation Mono\", monospace",
+          "description": "CSS font-family stack for fenced code blocks and frontmatter blocks."
+        },
+        "codeBlockFontSize": {
+          "type": "number",
+          "minimum": 8,
+          "maximum": 32,
+          "default": 13.5,
+          "description": "Fenced code block font size in pixels."
+        }
+      }
+    },
     "shortcuts": {
       "title": "shortcuts",
       "description": "Keyboard shortcut settings from Settings > Keyboard Shortcuts.",

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -771,12 +771,12 @@
           "minimum": 8,
           "maximum": 32,
           "default": 15,
-          "description": "Markdown body font size in pixels."
+          "description": "Markdown body font size in pixels. Heading defaults scale from this size when headingSizes are omitted."
         },
         "headingSizes": {
           "type": "object",
           "additionalProperties": false,
-          "description": "Markdown heading font sizes in pixels.",
+          "description": "Markdown heading font sizes in pixels. Omitted heading levels scale from fontSize using the default GitHub ratios.",
           "properties": {
             "h1": {
               "type": "number",


### PR DESCRIPTION
Summary
- Adds cmux.json markdown typography settings for body font family, body size, per-heading sizes, code block font family, and code block size.
- Routes those settings into the markdown WebView through theme CSS variables so open panels update through UserDefaults/AppStorage after config reload.
- Documents the new markdown section in the configuration docs and JSON schema.

Acceptance criteria
- Markdown preview uses existing typography by default.
- Users can configure markdown.fontFamily, markdown.fontSize, markdown.headingSizes.h1 through h6, markdown.codeBlockFontFamily, and markdown.codeBlockFontSize.
- Invalid markdown typography values are ignored per field while valid sibling settings still apply.
- cmux open and cmux markdown open continue to use the markdown preview surface by default.

Verification
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-mdtypo-tests -only-testing:cmuxTests/MarkdownPanelTests -only-testing:cmuxTests/KeyboardShortcutSettingsFileStoreTests/testSettingsFileStoreAppliesMarkdownTypographySettings -only-testing:cmuxTests/KeyboardShortcutSettingsFileStoreTests/testSettingsFileStoreIgnoresInvalidMarkdownTypographySettings test
- bun run lint (passes with existing warnings outside this change)
- VERCEL_ENV=preview SKIP_ENV_VALIDATION=1 ... bun run build
- ./scripts/reload.sh --tag mdtypo

Demo
- Tagged local dogfood build: http://127.0.0.1:17320/mdtypo
- Full cloud recording not captured yet. This is a config/rendering follow-up and the PR includes unit coverage plus tagged local build verification.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it adds new settings parsing/validation and pushes additional CSS variables into the Markdown WebView theme, which could affect markdown rendering and live updates if misapplied.
> 
> **Overview**
> Adds a new `markdown` section to `cmux.json` to configure Markdown preview typography (body/heading/code-block font families and sizes), with per-field validation so invalid values are ignored while valid siblings still apply.
> 
> Threads the resolved typography from `UserDefaults`/`@AppStorage` through `MarkdownPanelView` into `MarkdownWebTheme`, and updates the markdown viewer `shell.html` to consume the new CSS variables for font stacks and heading/code sizes.
> 
> Updates the config template, JSON schema, docs, and unit tests to cover CSS-variable output and settings-file application/invalid-value handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34bd19bea7990bbc19f5f8b316bbf1f698586a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds configurable Markdown typography in `cmux.json` and introduces unified View Zoom controls across Markdown, Browser, and text previews. Settings apply live via CSS variables and WebView zoom; zoom is accessible by shortcuts, menu, command palette, and a new header popover.

- New Features
  - Markdown typography: `fontFamily`, `fontSize`, `headingSizes.h1`–`h6`, `codeBlockFontFamily`, `codeBlockFontSize`; unset headings derive from `fontSize`; frontmatter uses code font/size.
  - Live updates: `@AppStorage` → Markdown theme CSS variables and `shell.html` font/size variables; docs, `cmux.schema.json`, template updated; tests cover parsing and CSS output.
  - View Zoom: app-scoped zoom commands unify `browserZoomIn/Out/Reset` across Browser, Markdown, and text preview; per-panel zoom factor persists and updates `WKWebView.pageZoom` and text editor font size; command palette entries appear when supported; new header “View Zoom” popover with +/- buttons, reset, and slider; PDF/image viewers handle zoom key equivalents.

- Bug Fixes
  - Markdown preview observes `@AppStorage` typography so open panels update without reload.
  - Zoom shortcuts are ignored when a focused terminal should handle them.

<sup>Written for commit 314a3c9beaa53e0a8146f9e23cdd9615e24d6d09. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Customizable markdown typography: body font, heading sizes (h1–h6), and code block font persisted and applied via CSS variables.
  * Unified view zoom: per-panel zoom controls, header zoom button, keyboard shortcuts routed to focused view, and zoom for browser/markdown/text/image/PDF previews.

* **Documentation**
  * Added markdown settings to docs, example configuration, and JSON schema.

* **Tests**
  * Added tests for typography parsing/validation, theme CSS variables, and view-zoom shortcut behavior.

* **Localization**
  * Added localized strings for zoom controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4106)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->