### PR TITLE
Fix tinted/clear Dock icon on macOS 26

### DIFF
--- a/Sources/AppIconDockTilePlugin.swift
+++ b/Sources/AppIconDockTilePlugin.swift
@@ -16,7 +16,12 @@ private enum DockTileAppIconMode: String {
     func imageName(isDarkAppearance: Bool) -> NSImage.Name? {
         switch self {
         case .automatic:
-            return isDarkAppearance ? NSImage.Name("AppIconDark") : NSImage.Name("AppIconLight")
+            // Returning nil makes updateDockTile clear any persisted Finder icon and
+            // call showDefaultAppIcon(), so the bundle's layered AppIcon (Icon
+            // Composer .icon) is used and macOS can apply light/dark/tinted/clear
+            // treatments natively. Replacing the dock tile with a flat NSImage
+            // silently disables Tinted/Clear on macOS 26.
+            return nil
         case .light:
             return NSImage.Name("AppIconLight")
         case .dark:

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -4375,6 +4375,7 @@ enum AppIconSettings {
         let isApplicationFinishedLaunching: () -> Bool
         let imageForMode: (AppIconMode) -> NSImage?
         let setApplicationIconImage: (NSImage) -> Void
+        let resetApplicationIconImage: () -> Void
         let startAppearanceObservation: () -> Void
         let stopAppearanceObservation: () -> Void
         let notifyDockTilePlugin: () -> Void
@@ -4390,6 +4391,11 @@ enum AppIconSettings {
                 },
                 setApplicationIconImage: { icon in
                     NSApplication.shared.applicationIconImage = icon
+                },
+                resetApplicationIconImage: {
+                    // Setting nil restores the bundle's layered AppIcon so macOS
+                    // can apply light/dark/tinted/clear treatments natively.
+                    NSApplication.shared.applicationIconImage = nil
                 },
                 startAppearanceObservation: {
                     AppIconAppearanceObserver.shared.startObserving()
@@ -4427,7 +4433,12 @@ enum AppIconSettings {
 
         switch mode {
         case .automatic:
-            environment.startAppearanceObservation()
+            // Defer to the bundle's layered AppIcon (Icon Composer .icon) so macOS
+            // can apply light/dark/tinted/clear icon treatments natively. Assigning
+            // a runtime NSImage via applicationIconImage replaces the layered icon
+            // with a flat bitmap and silently disables Tinted/Clear on macOS 26.
+            environment.stopAppearanceObservation()
+            environment.resetApplicationIconImage()
         case .light:
             environment.stopAppearanceObservation()
             guard let icon = environment.imageForMode(.light) else { return }

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -153,6 +153,9 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                resetApplicationIconImage: {
+                    runtimeIconSetCount += 1
+                },
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -296,6 +296,9 @@ final class AppIconSettingsTests: XCTestCase {
             setApplicationIconImage: { icon in
                 receivedRuntimeIcon = icon
             },
+            resetApplicationIconImage: {
+                XCTFail("Dark mode should set a runtime icon, not reset to the bundle icon")
+            },
             startAppearanceObservation: {
                 startObservationCallCount += 1
             },
@@ -315,10 +318,14 @@ final class AppIconSettingsTests: XCTestCase {
         XCTAssertEqual(stopObservationCallCount, 1)
     }
 
-    func testApplyAutomaticStartsObservationAndNotifiesDockTilePlugin() {
+    func testApplyAutomaticResetsRuntimeIconAndNotifiesDockTilePlugin() {
+        // Automatic mode must defer entirely to the bundle's layered AppIcon so
+        // macOS can apply tinted/clear/dark icon treatments natively. See
+        // https://github.com/manaflow-ai/cmux/issues/2873.
         var dockTileNotificationCount = 0
         var startObservationCallCount = 0
         var stopObservationCallCount = 0
+        var resetCallCount = 0
 
         let environment = AppIconSettings.Environment(
             isApplicationFinishedLaunching: { true },
@@ -327,7 +334,10 @@ final class AppIconSettingsTests: XCTestCase {
                 return nil
             },
             setApplicationIconImage: { _ in
-                XCTFail("Automatic mode should delegate live updates to the appearance observer")
+                XCTFail("Automatic mode must not replace the bundle's layered icon with a flat NSImage")
+            },
+            resetApplicationIconImage: {
+                resetCallCount += 1
             },
             startAppearanceObservation: {
                 startObservationCallCount += 1
@@ -342,9 +352,10 @@ final class AppIconSettingsTests: XCTestCase {
 
         AppIconSettings.applyIcon(.automatic, environment: environment)
 
+        XCTAssertEqual(resetCallCount, 1)
         XCTAssertEqual(dockTileNotificationCount, 1)
-        XCTAssertEqual(startObservationCallCount, 1)
-        XCTAssertEqual(stopObservationCallCount, 0)
+        XCTAssertEqual(startObservationCallCount, 0)
+        XCTAssertEqual(stopObservationCallCount, 1)
     }
 
     func testApplyDarkBeforeLaunchDoesNotTouchRuntimeIconState() {
@@ -353,6 +364,7 @@ final class AppIconSettingsTests: XCTestCase {
         var dockTileNotificationCount = 0
         var startObservationCallCount = 0
         var stopObservationCallCount = 0
+        var resetCallCount = 0
 
         let environment = AppIconSettings.Environment(
             isApplicationFinishedLaunching: { false },
@@ -362,6 +374,9 @@ final class AppIconSettingsTests: XCTestCase {
             },
             setApplicationIconImage: { _ in
                 runtimeIconSetCount += 1
+            },
+            resetApplicationIconImage: {
+                resetCallCount += 1
             },
             startAppearanceObservation: {
                 startObservationCallCount += 1
@@ -378,6 +393,7 @@ final class AppIconSettingsTests: XCTestCase {
 
         XCTAssertEqual(imageRequestCount, 0)
         XCTAssertEqual(runtimeIconSetCount, 0)
+        XCTAssertEqual(resetCallCount, 0)
         XCTAssertEqual(dockTileNotificationCount, 0)
         XCTAssertEqual(startObservationCallCount, 0)
         XCTAssertEqual(stopObservationCallCount, 0)

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -913,6 +913,9 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                 setApplicationIconImage: { _ in
                     runtimeIconSetCount += 1
                 },
+                resetApplicationIconImage: {
+                    runtimeIconSetCount += 1
+                },
                 startAppearanceObservation: {
                     startObservationCallCount += 1
                 },
@@ -988,6 +991,9 @@ final class KeyboardShortcutSettingsFileStoreTests: XCTestCase {
                     return nil
                 },
                 setApplicationIconImage: { _ in
+                    runtimeIconSetCount += 1
+                },
+                resetApplicationIconImage: {
                     runtimeIconSetCount += 1
                 },
                 startAppearanceObservation: {


### PR DESCRIPTION
## Summary
- In automatic app icon mode, stop overwriting the bundle's layered `AppIcon` (Icon Composer `.icon`) with a flat `AppIconLight`/`AppIconDark` `NSImage`. Replacing `NSApplication.applicationIconImage` with a flat bitmap silently disables the Tinted/Clear Dock icon treatments macOS 26 derives from those layers.
- Apply the same fix in `AppIconDockTilePlugin`: in automatic mode return `nil` from `imageName(...)` so `updateDockTile` clears any persisted Finder icon and falls back to `showDefaultAppIcon()`, letting macOS render the layered bundle icon inside the Dock process as well.
- Explicit Light/Dark settings continue to override at runtime as before — those modes intentionally opt out of Tinted/Clear.
- Update `AppIconSettings.Environment` tests to cover the new behavior (automatic must reset, not set; dark continues to set).

## Verification
- Dock icon style set to **Tinted** and **Clear** in System Settings → Appearance.
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-tinted-clear-icon-on-macos-26` and launched on macOS 26.3.1.
- Confirmed visually:
  - Icon mode **Automatic** → Dock icon renders in the system Tinted/Clear treatment while the app is running (previously reverted to full color on launch).
  - Icon mode **Light/Dark** → still applies the flat override as before.

## Not run
- Local test suite, per repo policy. Tests for `AppIconSettings` were updated and will run on CI.

Fixes #2873

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restore Tinted/Clear Dock icon on macOS 26 by using the app’s layered bundle icon in Automatic mode. Light/Dark modes still override as before. Fixes #2873.

- **Bug Fixes**
  - Automatic mode no longer sets a flat `AppIconLight`/`AppIconDark` on `NSApplication.applicationIconImage`; it now resets to `nil` and stops appearance observation so macOS can apply light/dark/tinted/clear.
  - `AppIconDockTilePlugin`: Automatic now returns `nil` from `imageName(...)`, so `updateDockTile` clears any persisted icon and uses `showDefaultAppIcon()`.
  - Added `resetApplicationIconImage` to `AppIconSettings.Environment`; updated tests to assert reset in Automatic and runtime set in Dark.

<sup>Written for commit 4289850a79570341fa25c33e2ecbe057f488073f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * App icon in dock and Finder now automatically respects macOS system appearance settings (light/dark/tinted/clear modes) for better visual consistency.
  * Automatic icon mode now leverages the system's native layered AppIcon handling instead of manual dark/light icon selection.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4108)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->