### PR TITLE
Fix Pi Vault icon and JSONL titles

### DIFF
--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -151,17 +151,16 @@ extension SessionIndexStore {
                 metadata.branch = firstString(in: object, keys: ["gitBranch", "branch"])
             }
             if metadata.title.isEmpty {
-                metadata.title = firstText(in: object, keys: ["title", "prompt", "text", "content"]) ?? ""
+                metadata.title = firstTopLevelTitle(in: object) ?? ""
             }
             if metadata.title.isEmpty, let message = object["message"] as? [String: Any] {
-                let role = firstString(in: message, keys: ["role"])
-                if role == nil || isUserRole(role) {
+                if shouldUseMessageAsTitle(message) {
                     metadata.title = firstText(in: message, keys: ["content", "text"]) ?? ""
                 }
             }
             if metadata.title.isEmpty, let messages = object["messages"] as? [[String: Any]] {
                 metadata.title = messages.compactMap { message in
-                    isUserRole(firstString(in: message, keys: ["role"]))
+                    shouldUseMessageAsTitle(message)
                         ? firstText(in: message, keys: ["content", "text"])
                         : nil
                 }.first ?? ""
@@ -219,6 +218,14 @@ extension SessionIndexStore {
         return nil
     }
 
+    nonisolated private static func firstTopLevelTitle(in object: [String: Any]) -> String? {
+        if let title = firstText(in: object, keys: ["title", "prompt"]) {
+            return title
+        }
+        guard shouldUseMessageAsTitle(object) else { return nil }
+        return firstText(in: object, keys: ["text", "content"])
+    }
+
     nonisolated private static func firstTextValue(_ value: Any?) -> String? {
         if let string = value as? String {
             return trimmedNonEmpty(string)
@@ -251,6 +258,11 @@ extension SessionIndexStore {
     nonisolated private static func trimmedNonEmpty(_ value: String) -> String? {
         let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func shouldUseMessageAsTitle(_ message: [String: Any]) -> Bool {
+        let role = firstString(in: message, keys: ["role"])
+        return role == nil || isUserRole(role)
     }
 
     nonisolated private static func isUserRole(_ role: String?) -> Bool {

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -151,15 +151,18 @@ extension SessionIndexStore {
                 metadata.branch = firstString(in: object, keys: ["gitBranch", "branch"])
             }
             if metadata.title.isEmpty {
-                metadata.title = firstString(in: object, keys: ["title", "prompt", "text", "content"]) ?? ""
+                metadata.title = firstText(in: object, keys: ["title", "prompt", "text", "content"]) ?? ""
             }
             if metadata.title.isEmpty, let message = object["message"] as? [String: Any] {
-                metadata.title = firstString(in: message, keys: ["content", "text"]) ?? ""
+                let role = firstString(in: message, keys: ["role"])
+                if role == nil || isUserRole(role) {
+                    metadata.title = firstText(in: message, keys: ["content", "text"]) ?? ""
+                }
             }
             if metadata.title.isEmpty, let messages = object["messages"] as? [[String: Any]] {
                 metadata.title = messages.compactMap { message in
-                    firstString(in: message, keys: ["role"]) == "user"
-                        ? firstString(in: message, keys: ["content", "text"])
+                    isUserRole(firstString(in: message, keys: ["role"]))
+                        ? firstText(in: message, keys: ["content", "text"])
                         : nil
                 }.first ?? ""
             }
@@ -206,6 +209,52 @@ extension SessionIndexStore {
             if !trimmed.isEmpty { return trimmed }
         }
         return nil
+    }
+
+    nonisolated private static func firstText(in object: [String: Any], keys: [String]) -> String? {
+        for key in keys {
+            guard let text = firstTextValue(object[key]) else { continue }
+            return text
+        }
+        return nil
+    }
+
+    nonisolated private static func firstTextValue(_ value: Any?) -> String? {
+        if let string = value as? String {
+            return trimmedNonEmpty(string)
+        }
+        if let values = value as? [Any] {
+            for value in values {
+                if let text = firstTextBlock(value) {
+                    return text
+                }
+            }
+        }
+        if let block = value as? [String: Any] {
+            return firstTextBlock(block)
+        }
+        return nil
+    }
+
+    nonisolated private static func firstTextBlock(_ value: Any) -> String? {
+        if let string = value as? String {
+            return trimmedNonEmpty(string)
+        }
+        guard let block = value as? [String: Any] else { return nil }
+        if let type = firstString(in: block, keys: ["type"]),
+           type.caseInsensitiveCompare("text") != .orderedSame {
+            return nil
+        }
+        return firstString(in: block, keys: ["text"])
+    }
+
+    nonisolated private static func trimmedNonEmpty(_ value: String) -> String? {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    nonisolated private static func isUserRole(_ role: String?) -> Bool {
+        role?.caseInsensitiveCompare("user") == .orderedSame
     }
 
     nonisolated private static func piCWDInferred(from url: URL) -> String? {

--- a/Sources/SessionIndexRegisteredAgents.swift
+++ b/Sources/SessionIndexRegisteredAgents.swift
@@ -248,8 +248,8 @@ extension SessionIndexStore {
             return trimmedNonEmpty(string)
         }
         guard let block = value as? [String: Any] else { return nil }
-        if let type = firstString(in: block, keys: ["type"]),
-           type.caseInsensitiveCompare("text") != .orderedSame {
+        guard let type = firstString(in: block, keys: ["type"]),
+              type.caseInsensitiveCompare("text") == .orderedSame else {
             return nil
         }
         return firstString(in: block, keys: ["text"])

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -294,6 +294,67 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(entry.cwd, cwd)
     }
 
+    func testPiJSONLTopLevelAssistantTypedContentDoesNotBecomeTitle() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-vault-top-level-role-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let cwd = "/tmp/pi top level role"
+        let projectDirectory = try XCTUnwrap(PiSessionLocator.projectDirectoryName(for: cwd))
+        let sessionDir = tempDir.appendingPathComponent(projectDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let sessionFile = sessionDir.appendingPathComponent("019e1c86-def0-72c9-90d4-8543db20f982.jsonl")
+        try """
+        {"role":"assistant","content":[{"type":"text","text":"assistant preface"}]}
+        {"role":"user","content":[{"type":"text","text":"implement the vault view"}]}
+        """.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        var registration = CmuxVaultAgentRegistration.builtInPi
+        registration.sessionDirectory = tempDir.path
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: cwd,
+            offset: 0,
+            limit: 10
+        )
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.title, "implement the vault view")
+        XCTAssertEqual(entry.cwd, cwd)
+    }
+
+    func testPiJSONLMessagesArrayUsesNilRoleTextAsTitle() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-vault-messages-nil-role-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let cwd = "/tmp/pi nil role"
+        let projectDirectory = try XCTUnwrap(PiSessionLocator.projectDirectoryName(for: cwd))
+        let sessionDir = tempDir.appendingPathComponent(projectDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let sessionFile = sessionDir.appendingPathComponent("019e1c86-def0-72c9-90d4-8543db20f983.jsonl")
+        try """
+        {"messages":[{"content":[{"type":"text","text":"restore without role"}]},{"role":"assistant","content":[{"type":"text","text":"assistant reply"}]}]}
+        """.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        var registration = CmuxVaultAgentRegistration.builtInPi
+        registration.sessionDirectory = tempDir.path
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: cwd,
+            offset: 0,
+            limit: 10
+        )
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.title, "restore without role")
+        XCTAssertEqual(entry.cwd, cwd)
+    }
+
     func testPiVaultAgentSnapshotRoundTripBuildsTargetedSessionCommand() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-pi-vault-agent-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -263,6 +263,37 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(entry.gitBranch, "issue-3575-vault-pi-agent-support")
     }
 
+    func testPiJSONLTypedContentBlocksUseFirstUserTextAsTitle() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-vault-title-blocks-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let cwd = "/tmp/pi typed blocks"
+        let projectDirectory = try XCTUnwrap(PiSessionLocator.projectDirectoryName(for: cwd))
+        let sessionDir = tempDir.appendingPathComponent(projectDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let sessionFile = sessionDir.appendingPathComponent("019e1c86-def0-72c9-90d4-8543db20f981.jsonl")
+        try """
+        {"type":"message","message":{"role":"assistant","content":[{"type":"text","text":"assistant preface"}]}}
+        {"type":"message","message":{"role":"user","content":[{"type":"text","text":"ping"}]}}
+        """.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        var registration = CmuxVaultAgentRegistration.builtInPi
+        registration.sessionDirectory = tempDir.path
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: cwd,
+            offset: 0,
+            limit: 10
+        )
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.title, "ping")
+        XCTAssertEqual(entry.cwd, cwd)
+    }
+
     func testPiVaultAgentSnapshotRoundTripBuildsTargetedSessionCommand() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-pi-vault-agent-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/PiVaultAgentPersistenceTests.swift
+++ b/cmuxTests/PiVaultAgentPersistenceTests.swift
@@ -355,6 +355,36 @@ final class PiVaultAgentPersistenceTests: XCTestCase {
         XCTAssertEqual(entry.cwd, cwd)
     }
 
+    func testPiJSONLTypedContentBlocksRequireTextType() async throws {
+        let tempDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-pi-vault-typed-content-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempDir) }
+
+        let cwd = "/tmp/pi typed content"
+        let projectDirectory = try XCTUnwrap(PiSessionLocator.projectDirectoryName(for: cwd))
+        let sessionDir = tempDir.appendingPathComponent(projectDirectory, isDirectory: true)
+        try FileManager.default.createDirectory(at: sessionDir, withIntermediateDirectories: true)
+        let sessionFile = sessionDir.appendingPathComponent("019e1c86-def0-72c9-90d4-8543db20f984.jsonl")
+        try """
+        {"message":{"role":"user","content":[{"text":"untyped object"},{"type":"image","text":"image fallback"},{"type":"text","text":"typed text title"}]}}
+        """.write(to: sessionFile, atomically: true, encoding: .utf8)
+
+        var registration = CmuxVaultAgentRegistration.builtInPi
+        registration.sessionDirectory = tempDir.path
+        let entries = await SessionIndexStore.loadRegisteredAgentEntries(
+            registration: registration,
+            needle: "",
+            cwdFilter: cwd,
+            offset: 0,
+            limit: 10
+        )
+
+        let entry = try XCTUnwrap(entries.first)
+        XCTAssertEqual(entry.title, "typed text title")
+        XCTAssertEqual(entry.cwd, cwd)
+    }
+
     func testPiVaultAgentSnapshotRoundTripBuildsTargetedSessionCommand() throws {
         let tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-pi-vault-agent-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Parse typed JSONL content blocks from Pi user messages when deriving registered Vault session titles
- Keep non-user typed message blocks from becoming the Vault title
- Preserve the existing built-in Pi branded icon presentation path

Fixes #4004

## Testing
- Not run locally per repo instruction; CI will run the regression test.

## Notes
- Regression test was committed before the fix so CI can demonstrate the old parser fails on Pi typed content blocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Vault session titles are derived from Pi JSONL logs, which could affect session indexing/search results if parsing is wrong; mitigated by added regression tests covering typed content blocks and role filtering.
> 
> **Overview**
> Fixes Pi Vault JSONL title extraction to handle *typed* `content` blocks (arrays/objects with `{type:"text", text:...}`) and to prefer the first **user or nil-role** text when deriving `SessionEntry.title`.
> 
> Adds regression tests ensuring assistant messages/top-level assistant entries don’t become titles, `messages` arrays without roles still work, and only `type:"text"` blocks are considered when multiple block types are present.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e1d23391e1266b15b65d6037821dd7f3e1fd68d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Pi Vault session titles in JSONL by using the first typed `text` block from user or nil-role messages and ignoring assistant or non-text content. Keep the built-in Pi icon path unchanged. Fixes #4004.

- **Bug Fixes**
  - Require `type: "text"` blocks when parsing JSONL and use the first user-or-nil-role text from top-level entries, `message`, or `messages`.
  - Ignore assistant roles and non-text/untyped blocks; add tests for typed filtering, top-level assistant entries, and nil-role messages.

<sup>Written for commit 1e1d23391e1266b15b65d6037821dd7f3e1fd68d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

