### PR TITLE
Fix Slack composer Cmd+C in browser panes

### DIFF
--- a/Sources/App/ShortcutRoutingSupport.swift
+++ b/Sources/App/ShortcutRoutingSupport.swift
@@ -434,6 +434,44 @@ private enum BrowserFindCommandEquivalent: CaseIterable {
     }
 }
 
+private enum BrowserDocumentEditingCommandEquivalent: CaseIterable {
+    case copy
+    case cut
+    case selectAll
+
+    var shortcut: StoredShortcut {
+        switch self {
+        case .copy:
+            return StoredShortcut(
+                key: "c",
+                command: true,
+                shift: false,
+                option: false,
+                control: false,
+                keyCode: 8
+            )
+        case .cut:
+            return StoredShortcut(
+                key: "x",
+                command: true,
+                shift: false,
+                option: false,
+                control: false,
+                keyCode: 7
+            )
+        case .selectAll:
+            return StoredShortcut(
+                key: "a",
+                command: true,
+                shift: false,
+                option: false,
+                control: false,
+                keyCode: 0
+            )
+        }
+    }
+}
+
 func cmuxIsLikelyWebInspectorResponder(_ responder: NSResponder?) -> Bool {
     guard let responder else { return false }
     let responderType = String(describing: type(of: responder))
@@ -460,6 +498,30 @@ private func browserFindCommandEquivalent(
     BrowserFindCommandEquivalent.allCases.first { command in
         shortcutForAction(command.action).matches(event: event)
     }
+}
+
+private func browserDocumentEditingCommandEquivalent(for event: NSEvent) -> BrowserDocumentEditingCommandEquivalent? {
+    BrowserDocumentEditingCommandEquivalent.allCases.first { command in
+        command.shortcut.matches(event: event)
+    }
+}
+
+/// For browser content, let the focused document/editor try native editing commands
+/// before cmux's menu fallback. Rich web apps often implement copy/cut/select-all
+/// in contentEditable handlers that AppKit's Edit menu path cannot reproduce.
+func shouldRouteBrowserDocumentEditingCommandEquivalentThroughWebContentFirst(
+    _ event: NSEvent,
+    responder: NSResponder? = nil
+) -> Bool {
+    guard browserDocumentEditingCommandEquivalent(for: event) != nil else {
+        return false
+    }
+
+    if cmuxIsLikelyWebInspectorResponder(responder) {
+        return false
+    }
+
+    return true
 }
 
 /// For browser content, let the page try browser-local Find-family commands before cmux's menu fallback.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14809,6 +14809,23 @@ private extension NSWindow {
         }
 
         if let firstResponderWebView,
+           shouldRouteBrowserDocumentEditingCommandEquivalentThroughWebContentFirst(
+               event,
+               responder: self.firstResponder
+           ) {
+            let result = firstResponderWebView.performKeyEquivalent(with: event)
+#if DEBUG
+            cmuxDebugLog(
+                "  → browser document editing command preflight " +
+                (result ? "resolved before window menu path" : "left unclaimed; continuing")
+            )
+#endif
+            if result {
+                return true
+            }
+        }
+
+        if let firstResponderWebView,
            shouldRouteBrowserFindCommandEquivalentThroughWebContentFirst(
                event,
                responder: self.firstResponder,

--- a/Sources/Panels/CmuxWebView.swift
+++ b/Sources/Panels/CmuxWebView.swift
@@ -622,6 +622,18 @@ final class CmuxWebView: WKWebView {
             return finish(result)
         }
 
+        var replayedBrowserDocumentEditingShortcutIntoWebContent = false
+        if shouldRouteBrowserDocumentEditingCommandEquivalentThroughWebContentFirst(
+            event,
+            responder: window?.firstResponder
+        ) {
+            replayedBrowserDocumentEditingShortcutIntoWebContent = true
+            let result = super.performKeyEquivalent(with: event)
+            if result {
+                return finish(true)
+            }
+        }
+
         var replayedBrowserFindShortcutIntoWebContent = false
         if shouldRouteBrowserFindCommandEquivalentThroughWebContentFirst(
             event,
@@ -648,8 +660,8 @@ final class CmuxWebView: WKWebView {
         }
 
         let result: Bool
-        if replayedBrowserFindShortcutIntoWebContent {
-            // A browser-first Find preflight has already exposed this shortcut to WebKit once.
+        if replayedBrowserDocumentEditingShortcutIntoWebContent || replayedBrowserFindShortcutIntoWebContent {
+            // A browser-first preflight has already exposed this shortcut to WebKit once.
             // Avoid a second `super.performKeyEquivalent` replay when menu/app fallback does not claim it.
             result = false
         } else {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -264,6 +264,61 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertTrue(spy.invoked)
     }
 
+    @MainActor
+    func testWindowCmdCCopyPreflightsFocusedBrowserChildIntoWebContentBeforeMainMenu() {
+        _ = NSApplication.shared
+        AppDelegate.installWindowResponderSwizzlesForTesting()
+        installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+        let spy = ActionSpy()
+        installMenu(spy: spy, key: "c", modifiers: [.command])
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        let container = NSView(frame: window.contentRect(forFrameRect: window.frame))
+        window.contentView = container
+
+        let webView = CmuxWebView(frame: container.bounds, configuration: WKWebViewConfiguration())
+        webView.autoresizingMask = [.width, .height]
+        container.addSubview(webView)
+
+        let responder = FirstResponderView(frame: NSRect(x: 0, y: 0, width: 32, height: 20))
+        webView.addSubview(responder)
+
+        var forwardedEvents: [NSEvent] = []
+        cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+            guard currentWebView === webView else { return nil }
+            forwardedEvents.append(event)
+            return true
+        }
+
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil
+            window.orderOut(nil)
+        }
+
+        XCTAssertTrue(window.makeFirstResponder(responder))
+        guard let event = makeKeyDownEvent(
+            key: "c",
+            modifiers: [.command],
+            keyCode: 8,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct Cmd+C event")
+            return
+        }
+
+        XCTAssertTrue(window.performKeyEquivalent(with: event))
+        XCTAssertEqual(forwardedEvents.count, 1)
+        XCTAssertEqual(forwardedEvents.first?.keyCode, 8)
+        XCTAssertFalse(spy.invoked)
+    }
+
     func testReturnDoesNotRouteToMainMenuWhenWebViewIsFirstResponder() {
         let spy = ActionSpy()
         installMenu(spy: spy, key: "\r", modifiers: [])

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -216,6 +216,54 @@ final class CmuxWebViewKeyEquivalentTests: XCTestCase {
         XCTAssertTrue(spy.invoked)
     }
 
+    func testCmdCCopyPreflightsIntoWebContentBeforeMainMenu() {
+        installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+        let spy = ActionSpy()
+        installMenu(spy: spy, key: "c", modifiers: [.command])
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        var forwardedEvents: [NSEvent] = []
+        cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+            guard currentWebView === webView else { return nil }
+            forwardedEvents.append(event)
+            return true
+        }
+        defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+        let event = makeKeyDownEvent(key: "c", modifiers: [.command], keyCode: 8) // kVK_ANSI_C
+        XCTAssertNotNil(event)
+
+        XCTAssertTrue(webView.performKeyEquivalent(with: event!))
+        XCTAssertEqual(forwardedEvents.count, 1)
+        XCTAssertEqual(forwardedEvents.first?.keyCode, 8)
+        XCTAssertFalse(spy.invoked)
+    }
+
+    func testCmdCCopyFallsBackToMainMenuWhenWebContentDoesNotHandleIt() {
+        installCmuxUnitTestWKWebViewPerformKeyEquivalentOverride()
+
+        let spy = ActionSpy()
+        installMenu(spy: spy, key: "c", modifiers: [.command])
+
+        let webView = CmuxWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        var forwardedEvents: [NSEvent] = []
+        cmuxUnitTestWKWebViewPerformKeyEquivalentHook = { currentWebView, event in
+            guard currentWebView === webView else { return nil }
+            forwardedEvents.append(event)
+            return false
+        }
+        defer { cmuxUnitTestWKWebViewPerformKeyEquivalentHook = nil }
+
+        let event = makeKeyDownEvent(key: "c", modifiers: [.command], keyCode: 8) // kVK_ANSI_C
+        XCTAssertNotNil(event)
+
+        XCTAssertTrue(webView.performKeyEquivalent(with: event!))
+        XCTAssertEqual(forwardedEvents.count, 1)
+        XCTAssertEqual(forwardedEvents.first?.keyCode, 8)
+        XCTAssertTrue(spy.invoked)
+    }
+
     func testReturnDoesNotRouteToMainMenuWhenWebViewIsFirstResponder() {
         let spy = ActionSpy()
         installMenu(spy: spy, key: "\r", modifiers: [])


### PR DESCRIPTION
## Summary
- Route browser document editing shortcuts (Cmd+C, Cmd+X, Cmd+A) through WebKit before cmux falls back to the main menu.
- Preserve AppKit menu fallback when WebKit does not claim the editing command.
- Add regression coverage for Cmd+C preflighting into WebKit before the Edit menu, including the focused browser child-responder path that matches contentEditable editors.

## Root cause
Slack's selected message text copied in cmux, but selected text inside Slack's contentEditable composer did not update the pasteboard. A JS copy probe saw copy events for message selections, but no copy event fired when Cmd+C was pressed in the focused composer. That ruled out Slack-specific clipboard permission/configuration as the primary failure and pointed at cmux's command-equivalent routing.

`CmuxWebView.performKeyEquivalent` routed command equivalents to `NSApp.mainMenu.performKeyEquivalent` before WebKit for non-find commands. With Slack's composer focused through a child responder, AppKit's Edit > Copy path could consume Cmd+C before WebKit/page handlers saw the command, so Slack's contentEditable copy handler never ran and the pasteboard stayed unchanged.

## Tests
- Added a test-only first commit that checks Cmd+C must preflight into WebKit before the main menu and still falls back to the menu when WebKit declines.
- Added a focused child-responder regression check with the fix commit.
- Not run locally per repository policy and task instructions; CI should run the checks.

Closes #4123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes key-equivalent routing for browser panes at the window and `WKWebView` level, which could subtly affect other command shortcuts or menu handling across responder chains.
> 
> **Overview**
> Improves browser-pane keyboard routing so document editing command equivalents (**Cmd+C**, **Cmd+X**, **Cmd+A**) are first offered to WebKit/page handlers (e.g., `contentEditable`) before cmux falls back to the AppKit main-menu Edit actions.
> 
> Adds shared shortcut detection (`shouldRouteBrowserDocumentEditingCommandEquivalentThroughWebContentFirst`) and integrates it into both `NSWindow.performKeyEquivalent` and `CmuxWebView.performKeyEquivalent`, including logic to avoid double-replaying the same shortcut. Adds regression tests ensuring Cmd+C preflights into WebKit (including when a focused child view is first responder) and still falls back to the main menu when unhandled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 367cf019c5972bf277dc138297e0d975cbd98940. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes copying from Slack’s composer in browser panes by sending Cmd+C/Cmd+X/Cmd+A to WebKit first, then falling back to the Edit menu. Ensures contentEditable handlers run so the pasteboard updates correctly.

- **Bug Fixes**
  - Route document-editing shortcuts through WebKit before AppKit in Cmux browser panes.
  - Preserve Edit menu fallback when WebKit doesn’t claim the command and avoid double replay after preflight.
  - Add regression tests for Cmd+C preflight and the focused child-responder path that matches contentEditable editors.

<sup>Written for commit 367cf019c5972bf277dc138297e0d975cbd98940. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

