### PR TITLE
Preserve unread indicators across session restore

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1346,7 +1346,8 @@ struct ContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panelId
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId),
+                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId) ||
+                        workspace.restoredUnreadPanelIds.contains(panelId),
                     isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                     isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId
                 )
@@ -6058,7 +6059,9 @@ struct ContentView: View {
             snapshot.setBool(CommandPaletteContextKeys.panelHasCustomName, workspace.panelCustomTitles[panelId] != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelShouldPin, !workspace.isPanelPinned(panelId))
             snapshot.setBool(CommandPaletteContextKeys.panelCanMoveToNewWorkspace, workspace.panels.count > 1)
-            let hasUnread = workspace.manualUnreadPanelIds.contains(panelId) || notificationStore.hasUnreadNotification(forTabId: workspace.id, surfaceId: panelId)
+            let hasUnread = workspace.manualUnreadPanelIds.contains(panelId) ||
+                workspace.restoredUnreadPanelIds.contains(panelId) ||
+                notificationStore.hasUnreadNotification(forTabId: workspace.id, surfaceId: panelId)
             snapshot.setBool(CommandPaletteContextKeys.panelHasUnread, hasUnread)
 
             if panelIsTerminal {
@@ -7385,8 +7388,9 @@ struct ContentView: View {
                 NSSound.beep()
                 return
             }
-            let hasUnread = panelContext.workspace.manualUnreadPanelIds.contains(panelContext.panelId)
-                || notificationStore.hasUnreadNotification(forTabId: panelContext.workspace.id, surfaceId: panelContext.panelId)
+            let hasUnread = panelContext.workspace.manualUnreadPanelIds.contains(panelContext.panelId) ||
+                panelContext.workspace.restoredUnreadPanelIds.contains(panelContext.panelId) ||
+                notificationStore.hasUnreadNotification(forTabId: panelContext.workspace.id, surfaceId: panelContext.panelId)
             if hasUnread {
                 panelContext.workspace.markPanelRead(panelContext.panelId)
             } else {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1346,7 +1346,7 @@ struct ContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panelId
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId) ||
+                    hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panelId) ||
                         workspace.restoredUnreadPanelIds.contains(panelId),
                     isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                     isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -344,6 +344,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customDescription: String?
     var customColor: String?
     var isPinned: Bool
+    var isManuallyUnread: Bool? = nil
     var hasUnreadIndicator: Bool? = nil
     var terminalScrollBarHidden: Bool?
     var currentDirectory: String

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -256,6 +256,7 @@ struct SessionPanelSnapshot: Codable, Sendable {
     var directory: String?
     var isPinned: Bool
     var isManuallyUnread: Bool
+    var hasUnreadIndicator: Bool? = nil
     var gitBranch: SessionGitBranchSnapshot?
     var listeningPorts: [Int]
     var ttyName: String?
@@ -343,6 +344,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customDescription: String?
     var customColor: String?
     var isPinned: Bool
+    var hasUnreadIndicator: Bool? = nil
     var terminalScrollBarHidden: Bool?
     var currentDirectory: String
     var focusedPanelId: UUID?

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -7284,6 +7284,7 @@ extension TabManager {
         var hasher = Hasher()
         hasher.combine(selectedTabId)
         hasher.combine(tabs.count)
+        let notificationStore = AppDelegate.shared?.notificationStore
 
         for workspace in tabs.prefix(SessionPersistencePolicy.maxWorkspacesPerWindow) {
             hasher.combine(workspace.id)
@@ -7303,11 +7304,19 @@ extension TabManager {
             hasher.combine(workspace.panelPullRequests.count)
             hasher.combine(workspace.panelGitBranches.count)
             hasher.combine(workspace.surfaceListeningPorts.count)
+            hasher.combine(notificationStore?.workspaceIsUnread(forTabId: workspace.id) ?? false)
 
             let panelIds = workspace.panels.keys.sorted { $0.uuidString < $1.uuidString }
             hasher.combine(panelIds.count)
             for panelId in panelIds {
                 hasher.combine(panelId)
+                hasher.combine(workspace.manualUnreadPanelIds.contains(panelId))
+                hasher.combine(
+                    notificationStore?.hasVisibleNotificationIndicator(
+                        forTabId: workspace.id,
+                        surfaceId: panelId
+                    ) ?? false
+                )
                 Self.hashRestorableAgentSnapshot(
                     restorableAgentIndex.snapshot(
                         workspaceId: workspace.id,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5117,8 +5117,10 @@ class TabManager: ObservableObject {
         guard let notificationStore = AppDelegate.shared?.notificationStore else { return false }
         let workspace = tabs.first(where: { $0.id == tabId })
         let hasManualPanelUnread = surfaceId.map { workspace?.manualUnreadPanelIds.contains($0) ?? false } ?? false
+        let hasRestoredPanelUnread = surfaceId.map { workspace?.hasRestoredUnreadIndicator(panelId: $0) ?? false } ?? false
         let hasManualWorkspaceUnread = notificationStore.hasManualUnread(forTabId: tabId)
-        let canDismissManualUnread = context == .terminalInteraction && (hasManualPanelUnread || hasManualWorkspaceUnread)
+        let canDismissManualUnread = context == .terminalInteraction &&
+            (hasManualPanelUnread || hasRestoredPanelUnread || hasManualWorkspaceUnread)
         let hasUnreadNotification = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         let hasFocusedIndicator = notificationStore.hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: surfaceId)
         guard hasUnreadNotification || hasFocusedIndicator || canDismissManualUnread else { return false }
@@ -5129,6 +5131,10 @@ class TabManager: ObservableObject {
         if context == .terminalInteraction {
             if let panelId = surfaceId, hasManualPanelUnread {
                 workspace?.clearManualUnread(panelId: panelId)
+                didDismissManualUnread = true
+            }
+            if let panelId = surfaceId, hasRestoredPanelUnread {
+                workspace?.clearRestoredUnreadIndicator(panelId: panelId)
                 didDismissManualUnread = true
             }
             if hasManualWorkspaceUnread {
@@ -7304,6 +7310,7 @@ extension TabManager {
             hasher.combine(workspace.panelPullRequests.count)
             hasher.combine(workspace.panelGitBranches.count)
             hasher.combine(workspace.surfaceListeningPorts.count)
+            hasher.combine(notificationStore?.hasManualUnread(forTabId: workspace.id) ?? false)
             hasher.combine(notificationStore?.workspaceIsUnread(forTabId: workspace.id) ?? false)
 
             let panelIds = workspace.panels.keys.sorted { $0.uuidString < $1.uuidString }
@@ -7311,6 +7318,7 @@ extension TabManager {
             for panelId in panelIds {
                 hasher.combine(panelId)
                 hasher.combine(workspace.manualUnreadPanelIds.contains(panelId))
+                hasher.combine(workspace.restoredUnreadPanelIds.contains(panelId))
                 hasher.combine(
                     notificationStore?.hasVisibleNotificationIndicator(
                         forTabId: workspace.id,

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -5119,26 +5119,31 @@ class TabManager: ObservableObject {
         let hasManualPanelUnread = surfaceId.map { workspace?.manualUnreadPanelIds.contains($0) ?? false } ?? false
         let hasRestoredPanelUnread = surfaceId.map { workspace?.hasRestoredUnreadIndicator(panelId: $0) ?? false } ?? false
         let hasManualWorkspaceUnread = notificationStore.hasManualUnread(forTabId: tabId)
-        let canDismissManualUnread = context == .terminalInteraction &&
-            (hasManualPanelUnread || hasRestoredPanelUnread || hasManualWorkspaceUnread)
+        let hasRestoredWorkspaceUnread = notificationStore.hasRestoredUnreadIndicator(forTabId: tabId)
+        let canDismissUnreadIndicator = context == .terminalInteraction &&
+            (hasManualPanelUnread || hasRestoredPanelUnread || hasManualWorkspaceUnread || hasRestoredWorkspaceUnread)
         let hasUnreadNotification = notificationStore.hasUnreadNotification(forTabId: tabId, surfaceId: surfaceId)
         let hasFocusedIndicator = notificationStore.hasVisibleNotificationIndicator(forTabId: tabId, surfaceId: surfaceId)
-        guard hasUnreadNotification || hasFocusedIndicator || canDismissManualUnread else { return false }
+        guard hasUnreadNotification || hasFocusedIndicator || canDismissUnreadIndicator else { return false }
         if hasUnreadNotification {
             notificationStore.markRead(forTabId: tabId, surfaceId: surfaceId)
         }
-        var didDismissManualUnread = false
+        var didDismissUnreadIndicator = false
         if context == .terminalInteraction {
             if let panelId = surfaceId, hasManualPanelUnread {
                 workspace?.clearManualUnread(panelId: panelId)
-                didDismissManualUnread = true
+                didDismissUnreadIndicator = true
             }
             if let panelId = surfaceId, hasRestoredPanelUnread {
                 workspace?.clearRestoredUnreadIndicator(panelId: panelId)
-                didDismissManualUnread = true
+                didDismissUnreadIndicator = true
             }
             if hasManualWorkspaceUnread {
-                didDismissManualUnread = notificationStore.clearManualUnread(forTabId: tabId) || didDismissManualUnread
+                didDismissUnreadIndicator = notificationStore.clearManualUnread(forTabId: tabId) || didDismissUnreadIndicator
+            }
+            if hasRestoredWorkspaceUnread {
+                didDismissUnreadIndicator = notificationStore.clearRestoredUnreadIndicator(forTabId: tabId) ||
+                    didDismissUnreadIndicator
             }
         }
         notificationStore.clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
@@ -5146,7 +5151,7 @@ class TabManager: ObservableObject {
            let workspace {
             if hasUnreadNotification || hasFocusedIndicator {
                 workspace.triggerNotificationDismissFlash(panelId: panelId)
-            } else if didDismissManualUnread {
+            } else if didDismissUnreadIndicator {
                 workspace.triggerManualUnreadDismissFlash(panelId: panelId)
             }
         }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -711,6 +711,7 @@ final class TerminalNotificationStore: ObservableObject {
     // Workspace-level manual unread drives sidebar workspace badges; pane-level
     // manual unread remains owned by Workspace.manualUnreadPanelIds.
     @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
+    @Published private(set) var restoredUnreadWorkspaceIds: Set<UUID> = []
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
     private var suppressNotificationDiffPublishing = false
@@ -915,8 +916,41 @@ final class TerminalNotificationStore: ObservableObject {
         manualUnreadWorkspaceIds = []
     }
 
+    @discardableResult
+    private func setWorkspaceRestoredUnread(_ isUnread: Bool, forTabId tabId: UUID) -> Bool {
+        var nextIds = restoredUnreadWorkspaceIds
+        let didChange: Bool
+        if isUnread {
+            didChange = nextIds.insert(tabId).inserted
+        } else {
+            didChange = nextIds.remove(tabId) != nil
+        }
+        guard didChange else { return false }
+        restoredUnreadWorkspaceIds = nextIds
+        return true
+    }
+
+    private func clearWorkspaceRestoredUnread() {
+        guard !restoredUnreadWorkspaceIds.isEmpty else { return }
+        restoredUnreadWorkspaceIds = []
+    }
+
     func hasManualUnread(forTabId tabId: UUID) -> Bool {
         manualUnreadWorkspaceIds.contains(tabId)
+    }
+
+    func hasRestoredUnreadIndicator(forTabId tabId: UUID) -> Bool {
+        restoredUnreadWorkspaceIds.contains(tabId)
+    }
+
+    @discardableResult
+    func restoreUnreadIndicator(forTabId tabId: UUID) -> Bool {
+        setWorkspaceRestoredUnread(true, forTabId: tabId)
+    }
+
+    @discardableResult
+    func clearRestoredUnreadIndicator(forTabId tabId: UUID) -> Bool {
+        setWorkspaceRestoredUnread(false, forTabId: tabId)
     }
 
     @discardableResult
@@ -924,10 +958,12 @@ final class TerminalNotificationStore: ObservableObject {
         setWorkspaceManualUnread(false, forTabId: tabId)
     }
 
-    // Per-workspace badges treat manualUnreadWorkspaceIds as "has unread
+    // Per-workspace badges treat manual/restored workspace IDs as "has unread
     // activity"; summing these counts can exceed indexes.unreadCount.
     func unreadCount(forTabId tabId: UUID) -> Int {
-        (indexes.unreadCountByTabId[tabId] ?? 0) + (manualUnreadWorkspaceIds.contains(tabId) ? 1 : 0)
+        let hasWorkspaceUnreadIndicator = manualUnreadWorkspaceIds.contains(tabId) ||
+            restoredUnreadWorkspaceIds.contains(tabId)
+        return (indexes.unreadCountByTabId[tabId] ?? 0) + (hasWorkspaceUnreadIndicator ? 1 : 0)
     }
 
     func workspaceIsUnread(forTabId tabId: UUID) -> Bool {
@@ -1344,6 +1380,7 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         setWorkspaceManualUnread(false, forTabId: tabId)
+        setWorkspaceRestoredUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1370,6 +1407,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     func markUnread(forTabId tabId: UUID) {
         setWorkspaceManualUnread(true, forTabId: tabId)
+        setWorkspaceRestoredUnread(false, forTabId: tabId)
     }
 
     @discardableResult
@@ -1923,6 +1961,7 @@ final class TerminalNotificationStore: ObservableObject {
         TerminalMutationBus.shared.discardPendingNotifications()
         self.notifications = notifications
         clearWorkspaceManualUnread()
+        clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
     }
 #endif

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1398,6 +1398,9 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        if surfaceId == nil {
+            setWorkspaceRestoredUnread(false, forTabId: tabId)
+        }
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1468,6 +1471,7 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         clearWorkspaceManualUnread()
+        clearWorkspaceRestoredUnread()
         if !idsToClear.isEmpty {
             notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
@@ -1492,10 +1496,14 @@ final class TerminalNotificationStore: ObservableObject {
 
     func clearAll(discardQueuedNotifications: Bool = true) {
         if discardQueuedNotifications { TerminalMutationBus.shared.discardPendingNotifications() }
-        guard !notifications.isEmpty || !focusedReadIndicatorByTabId.isEmpty || !manualUnreadWorkspaceIds.isEmpty else { return }
+        guard !notifications.isEmpty ||
+            !focusedReadIndicatorByTabId.isEmpty ||
+            !manualUnreadWorkspaceIds.isEmpty ||
+            !restoredUnreadWorkspaceIds.isEmpty else { return }
         let ids = notifications.map { $0.id.uuidString }
         replaceNotificationsForClear([])
         clearWorkspaceManualUnread()
+        clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
         center.removeDeliveredNotificationsOffMain(withIdentifiers: ids)
@@ -1509,6 +1517,7 @@ final class TerminalNotificationStore: ObservableObject {
     ) {
         if discardQueuedNotifications { TerminalMutationBus.shared.discardPendingNotifications(forTabId: tabId, surfaceId: surfaceId) }
         let hadFocusedReadIndicator = focusedReadIndicatorByTabId[tabId].map { $0 == surfaceId } ?? false
+        let hadRestoredWorkspaceUnread = surfaceId == nil && restoredUnreadWorkspaceIds.contains(tabId)
         var updated: [TerminalNotification] = []
         updated.reserveCapacity(notifications.count)
         var idsToClear: [String] = []
@@ -1519,9 +1528,12 @@ final class TerminalNotificationStore: ObservableObject {
                 updated.append(notification)
             }
         }
-        guard !idsToClear.isEmpty || hadFocusedReadIndicator else { return }
+        guard !idsToClear.isEmpty || hadFocusedReadIndicator || hadRestoredWorkspaceUnread else { return }
         if !idsToClear.isEmpty {
             replaceNotificationsForClear(updated)
+        }
+        if surfaceId == nil {
+            setWorkspaceRestoredUnread(false, forTabId: tabId)
         }
         clearFocusedReadIndicator(forTabId: tabId, surfaceId: surfaceId)
         if !idsToClear.isEmpty {
@@ -1579,6 +1591,7 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         setWorkspaceManualUnread(false, forTabId: tabId)
+        setWorkspaceRestoredUnread(false, forTabId: tabId)
         guard !idsToClear.isEmpty || hadFocusedReadIndicator else { return }
         if !idsToClear.isEmpty {
             replaceNotificationsForClear(updated)

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -24,6 +24,7 @@ extension Workspace {
         let cachedTitle: String?
         let customTitle: String?
         let manuallyUnread: Bool
+        let restoredUnread: Bool
         let restorableAgent: SessionRestorableAgentSnapshot?
         let restorableAgentResumeState: RestoredAgentResumeState?
         let agentRuntime: DetachedAgentRuntimeState?
@@ -47,6 +48,7 @@ extension Workspace {
                 cachedTitle: cachedTitle,
                 customTitle: customTitle,
                 manuallyUnread: manuallyUnread,
+                restoredUnread: restoredUnread,
                 restorableAgent: restorableAgent,
                 restorableAgentResumeState: restorableAgentResumeState,
                 agentRuntime: agentRuntime,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -213,6 +213,7 @@ extension Workspace {
         let gitBranchSnapshot = gitBranch.map { branch in
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
+        let hasUnreadIndicator = AppDelegate.shared?.notificationStore?.workspaceIsUnread(forTabId: id) ?? false
 
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
@@ -220,6 +221,7 @@ extension Workspace {
             customDescription: customDescription,
             customColor: customColor,
             isPinned: isPinned,
+            hasUnreadIndicator: hasUnreadIndicator,
             terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -311,6 +313,7 @@ extension Workspace {
         } else {
             scheduleFocusReconcile()
         }
+        restoreWorkspaceUnreadIndicator(snapshot.hasUnreadIndicator == true)
     }
 
     private func sessionLayoutSnapshot(from node: ExternalTreeNode) -> SessionWorkspaceLayoutSnapshot {
@@ -414,6 +417,7 @@ extension Workspace {
         }()
         let isPinned = pinnedPanelIds.contains(panelId)
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
+        let hasUnreadIndicator = isManuallyUnread || hasUnreadNotification(panelId: panelId)
         let branchSnapshot = panelGitBranches[panelId].map {
             SessionGitBranchSnapshot(branch: $0.branch, isDirty: $0.isDirty)
         }
@@ -518,6 +522,7 @@ extension Workspace {
             directory: directory,
             isPinned: isPinned,
             isManuallyUnread: isManuallyUnread,
+            hasUnreadIndicator: hasUnreadIndicator,
             gitBranch: branchSnapshot,
             listeningPorts: listeningPorts,
             ttyName: ttyName,
@@ -879,7 +884,7 @@ extension Workspace {
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle)
         setPanelPinned(panelId: panelId, pinned: snapshot.isPinned)
 
-        if snapshot.isManuallyUnread {
+        if snapshot.hasUnreadIndicator ?? snapshot.isManuallyUnread {
             markPanelUnread(panelId)
         } else {
             clearManualUnread(panelId: panelId)
@@ -920,6 +925,16 @@ extension Workspace {
                 _ = browserPanel.hideDeveloperTools()
             }
         }
+    }
+
+    private func restoreWorkspaceUnreadIndicator(_ hasUnreadIndicator: Bool) {
+        guard let notificationStore = AppDelegate.shared?.notificationStore else { return }
+        if hasUnreadIndicator {
+            notificationStore.markUnread(forTabId: id)
+        } else {
+            _ = notificationStore.clearManualUnread(forTabId: id)
+        }
+        syncUnreadBadgeStateForAllPanels()
     }
 
     private func applySessionDividerPositions(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -213,7 +213,11 @@ extension Workspace {
         let gitBranchSnapshot = gitBranch.map { branch in
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
-        let isWorkspaceManuallyUnread = AppDelegate.shared?.notificationStore?.hasManualUnread(forTabId: id) ?? false
+        let notificationStore = AppDelegate.shared?.notificationStore
+        let isWorkspaceManuallyUnread = notificationStore?.hasManualUnread(forTabId: id) ?? false
+        let hasWorkspaceUnreadIndicator = isWorkspaceManuallyUnread ||
+            (notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: nil) ?? false) ||
+            (notificationStore?.hasRestoredUnreadIndicator(forTabId: id) ?? false)
 
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
@@ -222,7 +226,7 @@ extension Workspace {
             customColor: customColor,
             isPinned: isPinned,
             isManuallyUnread: isWorkspaceManuallyUnread,
-            hasUnreadIndicator: isWorkspaceManuallyUnread,
+            hasUnreadIndicator: hasWorkspaceUnreadIndicator,
             terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -314,8 +318,15 @@ extension Workspace {
         } else {
             scheduleFocusReconcile()
         }
-        let isWorkspaceManuallyUnread = snapshot.isManuallyUnread ?? (snapshot.hasUnreadIndicator == true)
+        let isWorkspaceManuallyUnread = snapshot.isManuallyUnread == true
         restoreWorkspaceManualUnread(isWorkspaceManuallyUnread)
+        if !isWorkspaceManuallyUnread {
+            if snapshot.hasUnreadIndicator == true {
+                AppDelegate.shared?.notificationStore?.restoreUnreadIndicator(forTabId: id)
+            } else {
+                AppDelegate.shared?.notificationStore?.clearRestoredUnreadIndicator(forTabId: id)
+            }
+        }
     }
 
     private func sessionLayoutSnapshot(from node: ExternalTreeNode) -> SessionWorkspaceLayoutSnapshot {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -215,7 +215,7 @@ extension Workspace {
         }
         let notificationStore = AppDelegate.shared?.notificationStore
         let isWorkspaceManuallyUnread = notificationStore?.hasManualUnread(forTabId: id) ?? false
-        let hasWorkspaceUnreadIndicator = isWorkspaceManuallyUnread ||
+        let hasWorkspaceUnreadIndicator =
             (notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: nil) ?? false) ||
             (notificationStore?.hasRestoredUnreadIndicator(forTabId: id) ?? false)
 
@@ -320,12 +320,10 @@ extension Workspace {
         }
         let isWorkspaceManuallyUnread = snapshot.isManuallyUnread == true
         restoreWorkspaceManualUnread(isWorkspaceManuallyUnread)
-        if !isWorkspaceManuallyUnread {
-            if snapshot.hasUnreadIndicator == true {
-                AppDelegate.shared?.notificationStore?.restoreUnreadIndicator(forTabId: id)
-            } else {
-                AppDelegate.shared?.notificationStore?.clearRestoredUnreadIndicator(forTabId: id)
-            }
+        if snapshot.hasUnreadIndicator == true {
+            AppDelegate.shared?.notificationStore?.restoreUnreadIndicator(forTabId: id)
+        } else {
+            AppDelegate.shared?.notificationStore?.clearRestoredUnreadIndicator(forTabId: id)
         }
     }
 
@@ -430,7 +428,7 @@ extension Workspace {
         }()
         let isPinned = pinnedPanelIds.contains(panelId)
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
-        let hasUnreadIndicator = isManuallyUnread ||
+        let hasUnreadIndicator =
             restoredUnreadPanelIds.contains(panelId) ||
             hasUnreadNotification(panelId: panelId)
         let branchSnapshot = panelGitBranches[panelId].map {
@@ -901,10 +899,12 @@ extension Workspace {
 
         if snapshot.isManuallyUnread {
             markPanelUnread(panelId)
-        } else if snapshot.hasUnreadIndicator == true {
-            restorePanelUnreadIndicator(panelId)
         } else {
             clearManualUnread(panelId: panelId)
+        }
+        if snapshot.hasUnreadIndicator == true {
+            restorePanelUnreadIndicator(panelId)
+        } else {
             clearRestoredUnreadIndicator(panelId: panelId)
         }
 
@@ -11796,6 +11796,9 @@ final class Workspace: Identifiable, ObservableObject {
                 previousTerminalHostedView: previousTerminalHostedView
             )
         }
+        if currentlyFocusedPanelId != panelId {
+            syncUnreadBadgeStateForAllPanels()
+        }
 
         if let browserPanel = panels[panelId] as? BrowserPanel {
             maybeAutoFocusBrowserAddressBarOnPanelFocus(browserPanel, trigger: trigger)
@@ -14413,7 +14416,7 @@ extension Workspace: BonsplitDelegate {
             setPanelPinned(panelId: panelId, pinned: shouldPin)
         case .markAsRead:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
-            clearManualUnread(panelId: panelId)
+            markPanelRead(panelId)
         case .markAsUnread:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             markPanelUnread(panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -213,7 +213,7 @@ extension Workspace {
         let gitBranchSnapshot = gitBranch.map { branch in
             SessionGitBranchSnapshot(branch: branch.branch, isDirty: branch.isDirty)
         }
-        let hasUnreadIndicator = AppDelegate.shared?.notificationStore?.workspaceIsUnread(forTabId: id) ?? false
+        let isWorkspaceManuallyUnread = AppDelegate.shared?.notificationStore?.hasManualUnread(forTabId: id) ?? false
 
         return SessionWorkspaceSnapshot(
             processTitle: processTitle,
@@ -221,7 +221,8 @@ extension Workspace {
             customDescription: customDescription,
             customColor: customColor,
             isPinned: isPinned,
-            hasUnreadIndicator: hasUnreadIndicator,
+            isManuallyUnread: isWorkspaceManuallyUnread,
+            hasUnreadIndicator: isWorkspaceManuallyUnread,
             terminalScrollBarHidden: terminalScrollBarHidden ? true : nil,
             currentDirectory: currentDirectory,
             focusedPanelId: focusedPanelId,
@@ -313,7 +314,8 @@ extension Workspace {
         } else {
             scheduleFocusReconcile()
         }
-        restoreWorkspaceUnreadIndicator(snapshot.hasUnreadIndicator == true)
+        let isWorkspaceManuallyUnread = snapshot.isManuallyUnread ?? (snapshot.hasUnreadIndicator == true)
+        restoreWorkspaceManualUnread(isWorkspaceManuallyUnread)
     }
 
     private func sessionLayoutSnapshot(from node: ExternalTreeNode) -> SessionWorkspaceLayoutSnapshot {
@@ -417,7 +419,9 @@ extension Workspace {
         }()
         let isPinned = pinnedPanelIds.contains(panelId)
         let isManuallyUnread = manualUnreadPanelIds.contains(panelId)
-        let hasUnreadIndicator = isManuallyUnread || hasUnreadNotification(panelId: panelId)
+        let hasUnreadIndicator = isManuallyUnread ||
+            restoredUnreadPanelIds.contains(panelId) ||
+            hasUnreadNotification(panelId: panelId)
         let branchSnapshot = panelGitBranches[panelId].map {
             SessionGitBranchSnapshot(branch: $0.branch, isDirty: $0.isDirty)
         }
@@ -884,10 +888,13 @@ extension Workspace {
         setPanelCustomTitle(panelId: panelId, title: snapshot.customTitle)
         setPanelPinned(panelId: panelId, pinned: snapshot.isPinned)
 
-        if snapshot.hasUnreadIndicator ?? snapshot.isManuallyUnread {
+        if snapshot.isManuallyUnread {
             markPanelUnread(panelId)
+        } else if snapshot.hasUnreadIndicator == true {
+            restorePanelUnreadIndicator(panelId)
         } else {
             clearManualUnread(panelId: panelId)
+            clearRestoredUnreadIndicator(panelId: panelId)
         }
 
         if let directory = snapshot.directory?.trimmingCharacters(in: .whitespacesAndNewlines), !directory.isEmpty {
@@ -927,12 +934,12 @@ extension Workspace {
         }
     }
 
-    private func restoreWorkspaceUnreadIndicator(_ hasUnreadIndicator: Bool) {
+    private func restoreWorkspaceManualUnread(_ isManuallyUnread: Bool) {
         guard let notificationStore = AppDelegate.shared?.notificationStore else { return }
-        if hasUnreadIndicator {
+        if isManuallyUnread {
             notificationStore.markUnread(forTabId: id)
         } else {
-            _ = notificationStore.clearManualUnread(forTabId: id)
+            notificationStore.clearManualUnread(forTabId: id)
         }
         syncUnreadBadgeStateForAllPanels()
     }
@@ -7255,6 +7262,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var panelCustomTitles: [UUID: String] = [:]
     @Published var pinnedPanelIds: Set<UUID> = []
     @Published var manualUnreadPanelIds: Set<UUID> = []
+    @Published private(set) var restoredUnreadPanelIds: Set<UUID> = []
     @Published private(set) var tmuxLayoutSnapshot: LayoutSnapshot?
     @Published private(set) var tmuxWorkspaceFlashPanelId: UUID?
     @Published private(set) var tmuxWorkspaceFlashReason: WorkspaceAttentionFlashReason?
@@ -8319,7 +8327,8 @@ final class Workspace: Identifiable, ObservableObject {
         let notificationStore = AppDelegate.shared?.notificationStore
         let unreadPanelIDs = Set(
             panels.keys.filter {
-                notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: $0) ?? false
+                restoredUnreadPanelIds.contains($0) ||
+                    (notificationStore?.hasUnreadNotification(forTabId: id, surfaceId: $0) ?? false)
             }
         )
         return WorkspaceAttentionPersistentState(
@@ -8344,7 +8353,7 @@ final class Workspace: Identifiable, ObservableObject {
         let notificationStore = AppDelegate.shared?.notificationStore
         let shouldShowUnread = Self.shouldShowUnreadIndicator(
             hasUnreadNotification: hasUnreadNotification(panelId: panelId),
-            isManuallyUnread: manualUnreadPanelIds.contains(panelId),
+            isManuallyUnread: manualUnreadPanelIds.contains(panelId) || restoredUnreadPanelIds.contains(panelId),
             isWorkspaceManuallyUnread: notificationStore?.hasManualUnread(forTabId: id) ?? false,
             isWorkspaceManualUnreadRepresentative: representativePanelIdForWorkspaceManualUnread() == panelId
         )
@@ -8495,7 +8504,9 @@ final class Workspace: Identifiable, ObservableObject {
 
     func markPanelUnread(_ panelId: UUID) {
         guard panels[panelId] != nil else { return }
-        guard manualUnreadPanelIds.insert(panelId).inserted else { return }
+        let didClearRestored = restoredUnreadPanelIds.remove(panelId) != nil
+        let didInsertManual = manualUnreadPanelIds.insert(panelId).inserted
+        guard didInsertManual || didClearRestored else { return }
         manualUnreadMarkedAt[panelId] = Date()
         syncUnreadBadgeStateForPanel(panelId)
     }
@@ -8503,14 +8514,42 @@ final class Workspace: Identifiable, ObservableObject {
     func markPanelRead(_ panelId: UUID) {
         guard panels[panelId] != nil else { return }
         AppDelegate.shared?.notificationStore?.markRead(forTabId: id, surfaceId: panelId)
-        clearManualUnread(panelId: panelId)
+        let didClearManual = clearManualUnreadState(panelId: panelId)
+        let didClearRestored = clearRestoredUnreadIndicatorState(panelId: panelId)
+        guard didClearManual || didClearRestored else { return }
+        syncUnreadBadgeStateForPanel(panelId)
     }
 
     func clearManualUnread(panelId: UUID) {
-        let didRemoveUnread = manualUnreadPanelIds.remove(panelId) != nil
-        manualUnreadMarkedAt.removeValue(forKey: panelId)
+        let didRemoveUnread = clearManualUnreadState(panelId: panelId)
         guard didRemoveUnread else { return }
         syncUnreadBadgeStateForPanel(panelId)
+    }
+
+    private func clearManualUnreadState(panelId: UUID) -> Bool {
+        let didRemoveUnread = manualUnreadPanelIds.remove(panelId) != nil
+        manualUnreadMarkedAt.removeValue(forKey: panelId)
+        return didRemoveUnread
+    }
+
+    func restorePanelUnreadIndicator(_ panelId: UUID) {
+        guard panels[panelId] != nil else { return }
+        guard restoredUnreadPanelIds.insert(panelId).inserted else { return }
+        syncUnreadBadgeStateForPanel(panelId)
+    }
+
+    func clearRestoredUnreadIndicator(panelId: UUID) {
+        let didRemoveUnread = clearRestoredUnreadIndicatorState(panelId: panelId)
+        guard didRemoveUnread else { return }
+        syncUnreadBadgeStateForPanel(panelId)
+    }
+
+    func hasRestoredUnreadIndicator(panelId: UUID) -> Bool {
+        restoredUnreadPanelIds.contains(panelId)
+    }
+
+    private func clearRestoredUnreadIndicatorState(panelId: UUID) -> Bool {
+        restoredUnreadPanelIds.remove(panelId) != nil
     }
 
     static func shouldShowUnreadIndicator(
@@ -8920,6 +8959,7 @@ final class Workspace: Identifiable, ObservableObject {
         panelCustomTitles = panelCustomTitles.filter { validSurfaceIds.contains($0.key) }
         pinnedPanelIds = pinnedPanelIds.filter { validSurfaceIds.contains($0) }
         manualUnreadPanelIds = manualUnreadPanelIds.filter { validSurfaceIds.contains($0) }
+        restoredUnreadPanelIds = restoredUnreadPanelIds.filter { validSurfaceIds.contains($0) }
         panelGitBranches = panelGitBranches.filter { validSurfaceIds.contains($0.key) }
         manualUnreadMarkedAt = manualUnreadMarkedAt.filter { validSurfaceIds.contains($0.key) }
         surfaceListeningPorts = surfaceListeningPorts.filter { validSurfaceIds.contains($0.key) }
@@ -11450,6 +11490,11 @@ final class Workspace: Identifiable, ObservableObject {
             manualUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
         }
+        if detached.restoredUnread {
+            restoredUnreadPanelIds.insert(detached.panelId)
+        } else {
+            restoredUnreadPanelIds.remove(detached.panelId)
+        }
 
         guard let newTabId = bonsplitController.createTab(
             title: detached.title,
@@ -11471,6 +11516,7 @@ final class Workspace: Identifiable, ObservableObject {
             panelCustomTitles.removeValue(forKey: detached.panelId)
             pinnedPanelIds.remove(detached.panelId)
             manualUnreadPanelIds.remove(detached.panelId)
+            restoredUnreadPanelIds.remove(detached.panelId)
             manualUnreadMarkedAt.removeValue(forKey: detached.panelId)
             panelSubscriptions.removeValue(forKey: detached.panelId)
 #if DEBUG
@@ -13771,6 +13817,7 @@ extension Workspace: BonsplitDelegate {
                 cachedTitle: cachedTitle,
                 customTitle: panelCustomTitles[panelId],
                 manuallyUnread: manualUnreadPanelIds.contains(panelId),
+                restoredUnread: restoredUnreadPanelIds.contains(panelId),
                 restorableAgent: restorableAgent,
                 restorableAgentResumeState: restorableAgentResumeState,
                 agentRuntime: agentRuntime,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8353,7 +8353,7 @@ final class Workspace: Identifiable, ObservableObject {
         let notificationStore = AppDelegate.shared?.notificationStore
         let shouldShowUnread = Self.shouldShowUnreadIndicator(
             hasUnreadNotification: hasUnreadNotification(panelId: panelId),
-            isManuallyUnread: manualUnreadPanelIds.contains(panelId) || restoredUnreadPanelIds.contains(panelId),
+            hasPanelUnreadIndicator: manualUnreadPanelIds.contains(panelId) || restoredUnreadPanelIds.contains(panelId),
             isWorkspaceManuallyUnread: notificationStore?.hasManualUnread(forTabId: id) ?? false,
             isWorkspaceManualUnreadRepresentative: representativePanelIdForWorkspaceManualUnread() == panelId
         )
@@ -8514,15 +8514,15 @@ final class Workspace: Identifiable, ObservableObject {
     func markPanelRead(_ panelId: UUID) {
         guard panels[panelId] != nil else { return }
         AppDelegate.shared?.notificationStore?.markRead(forTabId: id, surfaceId: panelId)
-        let didClearManual = clearManualUnreadState(panelId: panelId)
-        let didClearRestored = clearRestoredUnreadIndicatorState(panelId: panelId)
-        guard didClearManual || didClearRestored else { return }
+        _ = clearManualUnreadState(panelId: panelId)
+        _ = clearRestoredUnreadIndicatorState(panelId: panelId)
         syncUnreadBadgeStateForPanel(panelId)
     }
 
     func clearManualUnread(panelId: UUID) {
-        let didRemoveUnread = clearManualUnreadState(panelId: panelId)
-        guard didRemoveUnread else { return }
+        let didRemoveManual = clearManualUnreadState(panelId: panelId)
+        let didRemoveRestored = clearRestoredUnreadIndicatorState(panelId: panelId)
+        guard didRemoveManual || didRemoveRestored else { return }
         syncUnreadBadgeStateForPanel(panelId)
     }
 
@@ -8554,12 +8554,12 @@ final class Workspace: Identifiable, ObservableObject {
 
     static func shouldShowUnreadIndicator(
         hasUnreadNotification: Bool,
-        isManuallyUnread: Bool,
+        hasPanelUnreadIndicator: Bool,
         isWorkspaceManuallyUnread: Bool = false,
         isWorkspaceManualUnreadRepresentative: Bool = false
     ) -> Bool {
         hasUnreadNotification ||
-            isManuallyUnread ||
+            hasPanelUnreadIndicator ||
             (isWorkspaceManuallyUnread && isWorkspaceManualUnreadRepresentative)
     }
 

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -231,7 +231,8 @@ struct WorkspaceContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panel.id
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id),
+                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id) ||
+                        workspace.restoredUnreadPanelIds.contains(panel.id),
                     isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                     isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
                 )
@@ -453,7 +454,8 @@ struct WorkspaceContentView: View {
                     forTabId: workspace.id,
                     surfaceId: panelId
                 ),
-                isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId),
+                isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId) ||
+                    workspace.restoredUnreadPanelIds.contains(panelId),
                 isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                 isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId
             )

--- a/Sources/WorkspaceContentView.swift
+++ b/Sources/WorkspaceContentView.swift
@@ -231,7 +231,7 @@ struct WorkspaceContentView: View {
                         forTabId: workspace.id,
                         surfaceId: panel.id
                     ),
-                    isManuallyUnread: workspace.manualUnreadPanelIds.contains(panel.id) ||
+                    hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panel.id) ||
                         workspace.restoredUnreadPanelIds.contains(panel.id),
                     isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                     isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panel.id
@@ -301,6 +301,9 @@ struct WorkspaceContentView: View {
         .onChange(of: workspace.manualUnreadPanelIds) { _, _ in
             syncBonsplitNotificationBadges()
         }
+        .onChange(of: workspace.restoredUnreadPanelIds) { _, _ in
+            syncBonsplitNotificationBadges()
+        }
         .onChange(of: isWorkspaceManuallyUnread) { _, _ in
             syncBonsplitNotificationBadges()
         }
@@ -339,6 +342,7 @@ struct WorkspaceContentView: View {
 
     private func syncBonsplitNotificationBadges() {
         let manualUnread = workspace.manualUnreadPanelIds
+        let restoredUnread = workspace.restoredUnreadPanelIds
         let isWorkspaceManuallyUnread = notificationStore.hasManualUnread(forTabId: workspace.id)
         let workspaceManualUnreadPanelId = workspace.representativePanelIdForWorkspaceManualUnread()
 
@@ -353,7 +357,7 @@ struct WorkspaceContentView: View {
                             forTabId: workspace.id,
                             surfaceId: $0
                         ),
-                        isManuallyUnread: manualUnread.contains($0),
+                        hasPanelUnreadIndicator: manualUnread.contains($0) || restoredUnread.contains($0),
                         isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                         isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == $0
                     )
@@ -454,7 +458,7 @@ struct WorkspaceContentView: View {
                     forTabId: workspace.id,
                     surfaceId: panelId
                 ),
-                isManuallyUnread: workspace.manualUnreadPanelIds.contains(panelId) ||
+                hasPanelUnreadIndicator: workspace.manualUnreadPanelIds.contains(panelId) ||
                     workspace.restoredUnreadPanelIds.contains(panelId),
                 isWorkspaceManuallyUnread: isWorkspaceManuallyUnread,
                 isWorkspaceManualUnreadRepresentative: workspaceManualUnreadPanelId == panelId

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -310,6 +310,126 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(splitPanel.id))
     }
 
+    func testSessionRestorePreservesNotificationUnreadIndicator() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: panelId,
+                title: "Unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+
+        XCTAssertTrue(store.hasVisibleNotificationIndicator(forTabId: workspace.id, surfaceId: panelId))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(restoredPanelId))
+        XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertTrue(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? false)
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+    }
+
+    func testSessionRestorePreservesFocusedReadIndicator() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        store.setFocusedReadIndicator(forTabId: workspace.id, surfaceId: panelId)
+
+        XCTAssertTrue(store.hasVisibleNotificationIndicator(forTabId: workspace.id, surfaceId: panelId))
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(restoredPanelId))
+        XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertTrue(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? false)
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+    }
+
+    func testSessionAutosaveFingerprintChangesWhenUnreadIndicatorsChange() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        let cleanFingerprint = manager.sessionAutosaveFingerprint()
+
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: panelId,
+                title: "Unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+        XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
+
+        store.replaceNotificationsForTesting([])
+        store.setFocusedReadIndicator(forTabId: workspace.id, surfaceId: panelId)
+        XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
+
+        store.replaceNotificationsForTesting([])
+        store.markUnread(forTabId: workspace.id)
+        XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
+
+        store.replaceNotificationsForTesting([])
+        workspace.markPanelUnread(panelId)
+        XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
+    }
+
     func testShouldShowUnreadIndicatorWhenNotificationIsUnread() {
         XCTAssertTrue(
             Workspace.shouldShowUnreadIndicator(

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -448,6 +448,8 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         let panelId = try XCTUnwrap(workspace.focusedPanelId)
         func resetUnreadState() {
             store.replaceNotificationsForTesting([])
+            store.clearFocusedReadIndicator(forTabId: workspace.id, surfaceId: panelId)
+            store.markRead(forTabId: workspace.id)
             workspace.clearManualUnread(panelId: panelId)
             workspace.clearRestoredUnreadIndicator(panelId: panelId)
         }
@@ -490,7 +492,7 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: true,
-                isManuallyUnread: false
+                hasPanelUnreadIndicator: false
             )
         )
     }
@@ -499,7 +501,7 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: false,
-                isManuallyUnread: true
+                hasPanelUnreadIndicator: true
             )
         )
     }
@@ -508,7 +510,7 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: false,
-                isManuallyUnread: false,
+                hasPanelUnreadIndicator: false,
                 isWorkspaceManuallyUnread: true,
                 isWorkspaceManualUnreadRepresentative: true
             )
@@ -519,7 +521,7 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: false,
-                isManuallyUnread: false,
+                hasPanelUnreadIndicator: false,
                 isWorkspaceManuallyUnread: true,
                 isWorkspaceManualUnreadRepresentative: false
             )
@@ -530,7 +532,7 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(
             Workspace.shouldShowUnreadIndicator(
                 hasUnreadNotification: false,
-                isManuallyUnread: false
+                hasPanelUnreadIndicator: false
             )
         )
     }

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -100,6 +100,40 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
     }
 
+    func testRestoredWorkspaceUnreadClearsOnDirectTerminalInteraction() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        guard let workspace = manager.selectedWorkspace,
+              let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        store.restoreUnreadIndicator(forTabId: workspace.id)
+
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
+        XCTAssertTrue(manager.dismissNotificationOnTerminalInteraction(tabId: workspace.id, surfaceId: panelId))
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
+    }
+
     func testManualWorkspaceUnreadSurvivesNonTerminalDirectInteraction() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()
@@ -428,6 +462,49 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertTrue(store.hasManualUnread(forTabId: restored.id))
         XCTAssertTrue(restored.bonsplitController.tab(representativeTabId)?.showsNotificationBadge ?? false)
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+    }
+
+    func testSessionRestorePreservesWorkspaceNotificationUnreadIndicatorWithoutManualState() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: nil,
+                title: "Workspace unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+
+        store.markRead(forTabId: restored.id)
+
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
     }
 
     func testSessionAutosaveFingerprintChangesWhenUnreadIndicatorsChange() throws {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -348,9 +348,18 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
         let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(restoredPanelId))
-        XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
         XCTAssertTrue(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? false)
-        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+        XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+
+        restored.markPanelRead(restoredPanelId)
+
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertFalse(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? true)
+        XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
     }
 
     func testSessionRestorePreservesFocusedReadIndicator() throws {
@@ -380,9 +389,45 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
         let restoredTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(restoredPanelId))
-        XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
         XCTAssertTrue(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? false)
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+
+        restored.markPanelRead(restoredPanelId)
+
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+        XCTAssertFalse(restored.bonsplitController.tab(restoredTabId)?.showsNotificationBadge ?? true)
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+    }
+
+    func testSessionRestorePreservesWorkspaceManualUnreadIndicator() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        store.markUnread(forTabId: workspace.id)
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let representativePanelId = try XCTUnwrap(restored.representativePanelIdForWorkspaceManualUnread())
+        let representativeTabId = try XCTUnwrap(restored.surfaceIdFromPanelId(representativePanelId))
+        XCTAssertTrue(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertTrue(restored.bonsplitController.tab(representativeTabId)?.showsNotificationBadge ?? false)
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
     }
 
     func testSessionAutosaveFingerprintChangesWhenUnreadIndicatorsChange() throws {
@@ -401,6 +446,13 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         let workspace = try XCTUnwrap(manager.selectedWorkspace)
         let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        func resetUnreadState() {
+            store.replaceNotificationsForTesting([])
+            workspace.clearManualUnread(panelId: panelId)
+            workspace.clearRestoredUnreadIndicator(panelId: panelId)
+        }
+
+        resetUnreadState()
         let cleanFingerprint = manager.sessionAutosaveFingerprint()
 
         store.replaceNotificationsForTesting([
@@ -417,16 +469,20 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         ])
         XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
 
-        store.replaceNotificationsForTesting([])
+        resetUnreadState()
         store.setFocusedReadIndicator(forTabId: workspace.id, surfaceId: panelId)
         XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
 
-        store.replaceNotificationsForTesting([])
+        resetUnreadState()
         store.markUnread(forTabId: workspace.id)
         XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
 
-        store.replaceNotificationsForTesting([])
+        resetUnreadState()
         workspace.markPanelUnread(panelId)
+        XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
+
+        resetUnreadState()
+        workspace.restorePanelUnreadIndicator(panelId)
         XCTAssertNotEqual(cleanFingerprint, manager.sessionAutosaveFingerprint())
     }
 

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -134,6 +134,40 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 0)
     }
 
+    func testRestoredWorkspaceUnreadClearsFromReadAndClearFlows() {
+        let store = TerminalNotificationStore.shared
+
+        func assertRestoredUnreadClears(_ action: (UUID) -> Void, line: UInt = #line) {
+            let workspaceId = UUID()
+            store.replaceNotificationsForTesting([])
+            store.restoreUnreadIndicator(forTabId: workspaceId)
+
+            XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: workspaceId), line: line)
+            XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 1, line: line)
+
+            action(workspaceId)
+
+            XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: workspaceId), line: line)
+            XCTAssertEqual(store.unreadCount(forTabId: workspaceId), 0, line: line)
+        }
+
+        assertRestoredUnreadClears { workspaceId in
+            store.markRead(forTabId: workspaceId, surfaceId: nil)
+        }
+        assertRestoredUnreadClears { _ in
+            store.markAllRead()
+        }
+        assertRestoredUnreadClears { workspaceId in
+            store.clearNotifications(forTabId: workspaceId, surfaceId: nil, discardQueuedNotifications: false)
+        }
+        assertRestoredUnreadClears { workspaceId in
+            store.clearNotifications(forTabId: workspaceId, discardQueuedNotifications: false)
+        }
+        assertRestoredUnreadClears { _ in
+            store.clearAll(discardQueuedNotifications: false)
+        }
+    }
+
     func testManualWorkspaceUnreadSurvivesNonTerminalDirectInteraction() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()
@@ -396,6 +430,51 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
     }
 
+    func testSessionRestorePreservesManualAndNotificationPanelUnreadIndependently() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+        workspace.markPanelUnread(panelId)
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: panelId,
+                title: "Unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        let restoredPanelId = try XCTUnwrap(restored.focusedPanelId)
+        XCTAssertTrue(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertTrue(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+
+        restored.markPanelRead(restoredPanelId)
+
+        XCTAssertFalse(restored.manualUnreadPanelIds.contains(restoredPanelId))
+        XCTAssertFalse(restored.hasRestoredUnreadIndicator(panelId: restoredPanelId))
+    }
+
     func testSessionRestorePreservesFocusedReadIndicator() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared
@@ -496,6 +575,56 @@ final class WorkspaceManualUnreadTests: XCTestCase {
 
         let restored = Workspace()
         restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+
+        store.markRead(forTabId: restored.id)
+
+        XCTAssertFalse(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 0)
+    }
+
+    func testSessionRestorePreservesManualAndNotificationWorkspaceUnreadIndependently() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: nil,
+                title: "Workspace unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+        store.markUnread(forTabId: workspace.id)
+
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false)
+        store.replaceNotificationsForTesting([])
+
+        let restored = Workspace()
+        restored.restoreSessionSnapshot(snapshot)
+
+        XCTAssertTrue(store.hasManualUnread(forTabId: restored.id))
+        XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))
+        XCTAssertEqual(store.unreadCount(forTabId: restored.id), 1)
+
+        store.clearManualUnread(forTabId: restored.id)
 
         XCTAssertFalse(store.hasManualUnread(forTabId: restored.id))
         XCTAssertTrue(store.hasRestoredUnreadIndicator(forTabId: restored.id))

--- a/cmuxTests/WorkspaceUnitTests.swift
+++ b/cmuxTests/WorkspaceUnitTests.swift
@@ -2468,6 +2468,7 @@ final class WorkspaceCreationWorkingDirectoryInheritanceTests: XCTestCase {
             cachedTitle: nil,
             customTitle: nil,
             manuallyUnread: false,
+            restoredUnread: false,
             restorableAgent: nil,
             restorableAgentResumeState: nil,
             agentRuntime: nil,


### PR DESCRIPTION
Summary:
- Persist visible panel unread indicators and workspace unread state in session snapshots.
- Restore those indicators onto the rebuilt workspace and panel UUIDs after session restoration.
- Include unread indicator state in the session autosave fingerprint so unread-only changes are saved.

Red failure:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-unreadrestore-red -only-testing:cmuxTests/WorkspaceManualUnreadTests test` failed on the new restore assertions before the fix.
- New failing cases: `WorkspaceManualUnreadTests.testSessionRestorePreservesFocusedReadIndicator`, `WorkspaceManualUnreadTests.testSessionRestorePreservesNotificationUnreadIndicator`, and autosave fingerprint coverage.

Green pass:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-unreadrestore-green -only-testing:cmuxTests/WorkspaceManualUnreadTests/testSessionRestorePreservesNotificationUnreadIndicator -only-testing:cmuxTests/WorkspaceManualUnreadTests/testSessionRestorePreservesFocusedReadIndicator -only-testing:cmuxTests/WorkspaceManualUnreadTests/testSessionAutosaveFingerprintChangesWhenUnreadIndicatorsChange test` passed.
- Tagged reload passed: `./scripts/reload.sh --tag unreadrestore`.

Additional check:
- Full `WorkspaceManualUnreadTests` still has `testWorkspaceManualUnreadBadgeMovesWhenFocusChanges` failing locally. The same existing test failed in the red run before the implementation change.

Cloud proof:
- Cloud Mac provisioned: https://github.com/manaflow-ai/cmux-loader/actions/runs/25832873956
- CUA SSH bootstrap reached TCC setup, but app-state automation failed with `cgWindowNotFound` and only wallpaper display captures were available, so no cursor before/after video is claimed for this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches session snapshot/restore and notification badge logic across workspaces/panels; mistakes could cause unread badges to stick or clear incorrectly, but changes are localized and covered by new unit tests.
> 
> **Overview**
> Unread indicator state is now **persisted and restored across session restore** for both panels and workspaces, distinct from manual-unread, by adding optional `hasUnreadIndicator` (and workspace `isManuallyUnread`) to session snapshots and replaying that state onto new IDs.
> 
> Introduces *restored unread* tracking (`restoredUnreadPanelIds` on `Workspace`, `restoredUnreadWorkspaceIds` on `TerminalNotificationStore`) and updates UI/badge/command-palette logic, read/clear flows, terminal-interaction dismissal, and detach/attach transfer to treat manual + restored unread consistently.
> 
> Session autosave fingerprinting now includes unread-indicator inputs (manual/restored + visible indicators) so unread-only changes trigger saves, with expanded tests covering restore behavior and clearing semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe770c0f4ea8507868d5c81f83e5a46cc96e6bcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves workspace and panel unread indicators across session restore, separate from manual unread. Autosave now fingerprints unread-only changes, and badges/command palette update live.

- **Bug Fixes**
  - Snapshot and restore unread: add optional `hasUnreadIndicator` (panel/workspace) and workspace `isManuallyUnread`; on restore, set workspace manual unread or a restored workspace indicator, and set per‑panel restored indicators without marking panels manually unread.
  - Clear and sync restored indicators across flows: terminal interaction, mark read (`markRead`, `markAllRead`), clear (`clearNotifications`, `clearAll`), detach/attach, focus changes, and panel “Mark as Read” all clear restored/manual state as appropriate; Bonsplit badges, overlays, and command palette reflect restored state; unread counts include restored workspace indicators.
  - Autosave: fingerprint now includes workspace manual/restored, per‑panel manual/restored, and visible indicators so unread‑only changes trigger autosave; tests cover notification and focused‑read restore, manual vs restored independence, dismissal, and fingerprint changes.

- **Migration**
  - No action needed. Snapshot fields are optional and backward compatible.

<sup>Written for commit fe770c0f4ea8507868d5c81f83e5a46cc96e6bcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session save/restore now preserves per-workspace and per-panel restored-unread indicators and includes unread indicators in autosave/session fingerprints.
  * Detach/attach transfers now carry restored-unread state so indicators survive moves.

* **Bug Fixes**
  * Restored unread indicators display and clear consistently across overlays, command palette, badges, terminal dismissal, and read/clear flows.

* **Tests**
  * Added/updated tests for unread persistence, restore behavior, dismissal, and fingerprint changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4130)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->