### PR TITLE
Add command palette settings toggles

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -140,9 +140,11 @@
 		62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 		C3408A000000000000000001 /* ContentView+RightSidebarCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000002 /* ContentView+RightSidebarCommandPalette.swift */; };
 		C3408A000000000000000005 /* ContentView+ViewCommandPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000006 /* ContentView+ViewCommandPalette.swift */; };
+		C0DEF4110000000000000001 /* CommandPaletteSettingsToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF4110000000000000002 /* CommandPaletteSettingsToggle.swift */; };
 		D7AB00000000000000000003 /* ContentView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000004 /* ContentView+MoveTabToNewWorkspace.swift */; };
 		C0DE32470000000000000001 /* ContentViewIdentifierCopyCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE32470000000000000002 /* ContentViewIdentifierCopyCommands.swift */; };
 		C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */; };
+		C0DEF4120000000000000001 /* CommandPaletteSettingsToggleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */; };
 		B37A0000000000000000000B /* FileExplorerStateModePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B37A0000000000000000000C /* FileExplorerStateModePersistenceTests.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
 		211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */; };
@@ -576,6 +578,7 @@
 		17C9F5BA0DD14EDC8C3E5002 /* MainWindowVisibilityControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainWindowVisibilityControllerTests.swift; sourceTree = "<group>"; };
 		A11EAA000000000000000001 /* AppearanceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTests.swift; sourceTree = "<group>"; };
 		C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarCommandPaletteTests.swift; sourceTree = "<group>"; };
+		C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPaletteSettingsToggleTests.swift; sourceTree = "<group>"; };
 		61A19A4145F034965110CF87 /* AuthCallbackRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AuthCallbackRouter.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 		71F8ED92A4B55D34BE6A0668 /* WorkspaceSplitStartupCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSplitStartupCommandTests.swift; sourceTree = "<group>"; };
@@ -646,6 +649,7 @@
 		A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Windowing/WindowBackdropController.swift; sourceTree = "<group>"; };
 		D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarState.swift; sourceTree = "<group>"; };
 		38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette/CommandPaletteSearch.swift; sourceTree = "<group>"; };
+		C0DEF4110000000000000002 /* CommandPaletteSettingsToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandPalette/CommandPaletteSettingsToggle.swift; sourceTree = "<group>"; };
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TerminalDirectoryOpenSupport.swift; sourceTree = "<group>"; };
 		8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxCLIPathInstaller.swift; sourceTree = "<group>"; };
@@ -1167,6 +1171,7 @@
 				A5001801A1B2C3D4E5F60718 /* WindowBackdropController.swift */,
 				D1614EAD3CCF70A177A51BD1 /* SidebarState.swift */,
 				38A09EB2E92203B2E95923A7 /* CommandPaletteSearch.swift */,
+				C0DEF4110000000000000002 /* CommandPaletteSettingsToggle.swift */,
 				9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */,
 				6B8E2E03F4A64C61B729CF19 /* TerminalDirectoryOpenSupport.swift */,
 				8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */,
@@ -1496,6 +1501,7 @@
 				A11EAA000000000000000001 /* AppearanceSettingsTests.swift */,
 				6083A7DAD962E287FC2FFE94 /* ShortcutAndCommandPaletteTests.swift */,
 				C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */,
+				C0DEF4120000000000000002 /* CommandPaletteSettingsToggleTests.swift */,
 				B37A0000000000000000000C /* FileExplorerStateModePersistenceTests.swift */,
 				BC39DE4B96D1931C52AF7D68 /* SidebarOrderingTests.swift */,
 				B09C007F42697761B5F1A2AB /* OmnibarAndToolsTests.swift */,
@@ -1843,6 +1849,7 @@
 				A5001800A1B2C3D4E5F60718 /* WindowBackdropController.swift in Sources */,
 				F57072635F25EBCA741E125D /* SidebarState.swift in Sources */,
 				A8CBA43C2DA5AB9E3A1E65A4 /* CommandPaletteSearch.swift in Sources */,
+				C0DEF4110000000000000001 /* CommandPaletteSettingsToggle.swift in Sources */,
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,
 				0D56BE882EAD4B67AC44F96D /* TerminalDirectoryOpenSupport.swift in Sources */,
 				A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */,
@@ -2214,6 +2221,7 @@
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
 				1521D55DC63D5E5FC4955E31 /* ShortcutAndCommandPaletteTests.swift in Sources */,
 				C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */,
+				C0DEF4120000000000000001 /* CommandPaletteSettingsToggleTests.swift in Sources */,
 				B37A0000000000000000000B /* FileExplorerStateModePersistenceTests.swift in Sources */,
 				CB23911D7E131E8FBC9B82B6 /* SidebarOrderingTests.swift in Sources */,
 					4378399A7C0245EF8186F306 /* OmnibarAndToolsTests.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -21213,6 +21213,91 @@
         }
       }
     },
+    "command.toggleSetting.disableTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を無効化"
+          }
+        }
+      }
+    },
+    "command.toggleSetting.enableTitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@を有効化"
+          }
+        }
+      }
+    },
+    "command.toggleSetting.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ • %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ • %@"
+          }
+        }
+      }
+    },
+    "command.toggleSetting.state.on": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "On"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オン"
+          }
+        }
+      }
+    },
+    "command.toggleSetting.state.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Off"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "オフ"
+          }
+        }
+      }
+    },
     "command.enableMinimalMode.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 enum SidebarWorkspaceDetailDefaults {
     static let showBranchDirectoryKey = "sidebarShowBranchDirectory"
     static let showPullRequestsKey = "sidebarShowPullRequest"
@@ -14,6 +16,19 @@ enum SidebarWorkspaceDetailDefaults {
     static let showLog = true
     static let showProgress = true
     static let showCustomMetadata = true
+}
+
+extension SidebarWorkspaceDetailDefaults {
+    static func boolValue(defaults: UserDefaults, key: String, defaultValue: Bool) -> Bool {
+        if defaults.object(forKey: key) == nil {
+            return defaultValue
+        }
+        return defaults.bool(forKey: key)
+    }
+
+    static func showPullRequestsValue(defaults: UserDefaults) -> Bool {
+        boolValue(defaults: defaults, key: showPullRequestsKey, defaultValue: showPullRequests)
+    }
 }
 
 enum AutomationSettings {

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -1,4 +1,12 @@
 enum SidebarWorkspaceDetailDefaults {
+    static let showBranchDirectoryKey = "sidebarShowBranchDirectory"
+    static let showPullRequestsKey = "sidebarShowPullRequest"
+    static let showSSHKey = "sidebarShowSSH"
+    static let showPortsKey = "sidebarShowPorts"
+    static let showLogKey = "sidebarShowLog"
+    static let showProgressKey = "sidebarShowProgress"
+    static let showCustomMetadataKey = "sidebarShowStatusPills"
+
     static let showBranchDirectory = true
     static let showPullRequests = true
     static let showSSH = true

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -1,25 +1,25 @@
 import Foundation
 
-struct CommandPaletteSettingToggleDescriptor {
+struct CommandPaletteSettingToggleDescriptor: Sendable {
     let commandId: String
     let settingsKey: String
-    let title: () -> String
-    let sectionTitle: () -> String
+    let title: @Sendable () -> String
+    let sectionTitle: @Sendable () -> String
     let keywords: [String]
-    let isOn: (UserDefaults) -> Bool
-    let setOn: (Bool, UserDefaults, NotificationCenter) -> Void
-    let isAvailable: (UserDefaults) -> Bool
+    let isOn: @Sendable (UserDefaults) -> Bool
+    let setOn: @Sendable (Bool, UserDefaults, NotificationCenter) -> Void
+    let isAvailable: @Sendable (UserDefaults) -> Bool
 
     init(
         commandId: String,
         settingsKey: String,
-        title: @escaping () -> String,
-        sectionTitle: @escaping () -> String,
+        title: @escaping @Sendable () -> String,
+        sectionTitle: @escaping @Sendable () -> String,
         keywords: [String],
         defaultValue: Bool,
         defaultsKey: String,
-        isAvailable: @escaping (UserDefaults) -> Bool = { _ in true },
-        didSet: @escaping (Bool, UserDefaults, NotificationCenter) -> Void = { _, _, _ in }
+        isAvailable: @escaping @Sendable (UserDefaults) -> Bool = { _ in true },
+        didSet: @escaping @Sendable (Bool, UserDefaults, NotificationCenter) -> Void = { _, _, _ in }
     ) {
         self.commandId = commandId
         self.settingsKey = settingsKey
@@ -42,12 +42,12 @@ struct CommandPaletteSettingToggleDescriptor {
     init(
         commandId: String,
         settingsKey: String,
-        title: @escaping () -> String,
-        sectionTitle: @escaping () -> String,
+        title: @escaping @Sendable () -> String,
+        sectionTitle: @escaping @Sendable () -> String,
         keywords: [String],
-        isOn: @escaping (UserDefaults) -> Bool,
-        setOn: @escaping (Bool, UserDefaults, NotificationCenter) -> Void,
-        isAvailable: @escaping (UserDefaults) -> Bool = { _ in true }
+        isOn: @escaping @Sendable (UserDefaults) -> Bool,
+        setOn: @escaping @Sendable (Bool, UserDefaults, NotificationCenter) -> Void,
+        isAvailable: @escaping @Sendable (UserDefaults) -> Bool = { _ in true }
     ) {
         self.commandId = commandId
         self.settingsKey = settingsKey
@@ -90,18 +90,28 @@ enum CommandPaletteSettingsToggleCommands {
     }
 
     static let descriptors: [CommandPaletteSettingToggleDescriptor] = {
-        let app = { String(localized: "settings.section.app", defaultValue: "App") }
-        let terminal = { String(localized: "settings.section.terminal", defaultValue: "Terminal") }
-        let sidebar = { String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar") }
-        let beta = { String(localized: "settings.section.betaFeatures", defaultValue: "Beta Features") }
-        let automation = { String(localized: "settings.section.automation", defaultValue: "Automation") }
-        let browser = { String(localized: "settings.section.browser", defaultValue: "Browser") }
-        let browserImport = { String(localized: "settings.section.browserImport", defaultValue: "Browser Import") }
-        let globalHotkey = { String(localized: "settings.section.globalHotkey", defaultValue: "Global Hotkey") }
-        let sidebarDetailsAvailable: (UserDefaults) -> Bool = { defaults in
+        let app: @Sendable () -> String = { String(localized: "settings.section.app", defaultValue: "App") }
+        let terminal: @Sendable () -> String = { String(localized: "settings.section.terminal", defaultValue: "Terminal") }
+        let sidebar: @Sendable () -> String = {
+            String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar")
+        }
+        let beta: @Sendable () -> String = {
+            String(localized: "settings.section.betaFeatures", defaultValue: "Beta Features")
+        }
+        let automation: @Sendable () -> String = {
+            String(localized: "settings.section.automation", defaultValue: "Automation")
+        }
+        let browser: @Sendable () -> String = { String(localized: "settings.section.browser", defaultValue: "Browser") }
+        let browserImport: @Sendable () -> String = {
+            String(localized: "settings.section.browserImport", defaultValue: "Browser Import")
+        }
+        let globalHotkey: @Sendable () -> String = {
+            String(localized: "settings.section.globalHotkey", defaultValue: "Global Hotkey")
+        }
+        let sidebarDetailsAvailable: @Sendable (UserDefaults) -> Bool = { defaults in
             !SidebarWorkspaceDetailSettings.hidesAllDetails(defaults: defaults)
         }
-        let sidebarPullRequestLinksAvailable: (UserDefaults) -> Bool = { defaults in
+        let sidebarPullRequestLinksAvailable: @Sendable (UserDefaults) -> Bool = { defaults in
             sidebarDetailsAvailable(defaults)
                 && SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: defaults)
                 && SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults)
@@ -596,7 +606,13 @@ enum CommandPaletteSettingsToggleCommands {
                 sectionTitle: browser,
                 keywords: ["browser.interceptTerminalOpenCommandInCmuxBrowser", "browser", "terminal", "open", "http", "https", "intercept"],
                 isOn: { defaults in
-                    BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+                    if defaults.object(forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey) != nil {
+                        return defaults.bool(forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+                    }
+                    if defaults.object(forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey) != nil {
+                        return defaults.bool(forKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey)
+                    }
+                    return BrowserLinkOpenSettings.defaultInterceptTerminalOpenCommandInCmuxBrowser
                 },
                 setOn: { newValue, defaults, _ in
                     defaults.set(newValue, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -663,19 +663,6 @@ enum CommandPaletteSettingsToggleCommands {
     }()
 }
 
-extension SidebarWorkspaceDetailDefaults {
-    static func boolValue(defaults: UserDefaults, key: String, defaultValue: Bool) -> Bool {
-        if defaults.object(forKey: key) == nil {
-            return defaultValue
-        }
-        return defaults.bool(forKey: key)
-    }
-
-    static func showPullRequestsValue(defaults: UserDefaults) -> Bool {
-        boolValue(defaults: defaults, key: showPullRequestsKey, defaultValue: showPullRequests)
-    }
-}
-
 extension ContentView {
     nonisolated static func commandPaletteSettingsToggleCommandContributions() -> [CommandPaletteCommandContribution] {
         CommandPaletteSettingsToggleCommands.descriptors.map { descriptor in

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -1,0 +1,674 @@
+import Foundation
+
+struct CommandPaletteSettingToggleDescriptor {
+    let commandId: String
+    let settingsKey: String
+    let title: () -> String
+    let sectionTitle: () -> String
+    let keywords: [String]
+    let isOn: (UserDefaults) -> Bool
+    let setOn: (Bool, UserDefaults, NotificationCenter) -> Void
+    let isAvailable: (UserDefaults) -> Bool
+
+    init(
+        commandId: String,
+        settingsKey: String,
+        title: @escaping () -> String,
+        sectionTitle: @escaping () -> String,
+        keywords: [String],
+        defaultValue: Bool,
+        defaultsKey: String,
+        isAvailable: @escaping (UserDefaults) -> Bool = { _ in true },
+        didSet: @escaping (Bool, UserDefaults, NotificationCenter) -> Void = { _, _, _ in }
+    ) {
+        self.commandId = commandId
+        self.settingsKey = settingsKey
+        self.title = title
+        self.sectionTitle = sectionTitle
+        self.keywords = keywords
+        self.isOn = { defaults in
+            if defaults.object(forKey: defaultsKey) == nil {
+                return defaultValue
+            }
+            return defaults.bool(forKey: defaultsKey)
+        }
+        self.setOn = { newValue, defaults, notificationCenter in
+            defaults.set(newValue, forKey: defaultsKey)
+            didSet(newValue, defaults, notificationCenter)
+        }
+        self.isAvailable = isAvailable
+    }
+
+    init(
+        commandId: String,
+        settingsKey: String,
+        title: @escaping () -> String,
+        sectionTitle: @escaping () -> String,
+        keywords: [String],
+        isOn: @escaping (UserDefaults) -> Bool,
+        setOn: @escaping (Bool, UserDefaults, NotificationCenter) -> Void,
+        isAvailable: @escaping (UserDefaults) -> Bool = { _ in true }
+    ) {
+        self.commandId = commandId
+        self.settingsKey = settingsKey
+        self.title = title
+        self.sectionTitle = sectionTitle
+        self.keywords = keywords
+        self.isOn = isOn
+        self.setOn = setOn
+        self.isAvailable = isAvailable
+    }
+
+    func commandTitle(defaults: UserDefaults = .standard) -> String {
+        let format = isOn(defaults)
+            ? String(localized: "command.toggleSetting.disableTitle", defaultValue: "Disable %@")
+            : String(localized: "command.toggleSetting.enableTitle", defaultValue: "Enable %@")
+        return String(format: format, title())
+    }
+
+    func commandSubtitle(defaults: UserDefaults = .standard) -> String {
+        let state = isOn(defaults)
+            ? String(localized: "command.toggleSetting.state.on", defaultValue: "On")
+            : String(localized: "command.toggleSetting.state.off", defaultValue: "Off")
+        let format = String(localized: "command.toggleSetting.subtitle", defaultValue: "%@ • %@")
+        return String(format: format, sectionTitle(), state)
+    }
+
+    func toggle(
+        defaults: UserDefaults = .standard,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        setOn(!isOn(defaults), defaults, notificationCenter)
+    }
+}
+
+enum CommandPaletteSettingsToggleCommands {
+    static let commandIdPrefix = "palette.toggleSetting."
+
+    static func descriptor(commandId: String) -> CommandPaletteSettingToggleDescriptor? {
+        descriptors.first { $0.commandId == commandId }
+    }
+
+    static let descriptors: [CommandPaletteSettingToggleDescriptor] = {
+        let app = { String(localized: "settings.section.app", defaultValue: "App") }
+        let terminal = { String(localized: "settings.section.terminal", defaultValue: "Terminal") }
+        let sidebar = { String(localized: "settings.section.sidebarAppearance", defaultValue: "Sidebar") }
+        let beta = { String(localized: "settings.section.betaFeatures", defaultValue: "Beta Features") }
+        let automation = { String(localized: "settings.section.automation", defaultValue: "Automation") }
+        let browser = { String(localized: "settings.section.browser", defaultValue: "Browser") }
+        let browserImport = { String(localized: "settings.section.browserImport", defaultValue: "Browser Import") }
+        let globalHotkey = { String(localized: "settings.section.globalHotkey", defaultValue: "Global Hotkey") }
+        let sidebarDetailsAvailable: (UserDefaults) -> Bool = { defaults in
+            !SidebarWorkspaceDetailSettings.hidesAllDetails(defaults: defaults)
+        }
+        let sidebarPullRequestLinksAvailable: (UserDefaults) -> Bool = { defaults in
+            sidebarDetailsAvailable(defaults)
+                && SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: defaults)
+                && SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults)
+        }
+
+        return [
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "workspaceInheritWorkingDirectory",
+                settingsKey: "app.workspaceInheritWorkingDirectory",
+                title: {
+                    String(
+                        localized: "settings.app.workspaceInheritWorkingDirectory",
+                        defaultValue: "Inherit Workspace Working Directory"
+                    )
+                },
+                sectionTitle: app,
+                keywords: ["app.workspaceInheritWorkingDirectory", "workspace", "working", "directory", "cwd", "inherit"],
+                defaultValue: WorkspaceWorkingDirectoryInheritanceSettings.defaultValue,
+                defaultsKey: WorkspaceWorkingDirectoryInheritanceSettings.key
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "keepWorkspaceOpenWhenClosingLastSurface",
+                settingsKey: "app.keepWorkspaceOpenWhenClosingLastSurface",
+                title: {
+                    String(
+                        localized: "settings.app.closeWorkspaceOnLastSurfaceShortcut",
+                        defaultValue: "Keep Workspace Open When Closing Last Surface"
+                    )
+                },
+                sectionTitle: app,
+                keywords: ["app.keepWorkspaceOpenWhenClosingLastSurface", "close", "last", "surface", "pane", "workspace"],
+                isOn: { defaults in !LastSurfaceCloseShortcutSettings.closesWorkspace(defaults: defaults) },
+                setOn: { newValue, defaults, _ in
+                    defaults.set(!newValue, forKey: LastSurfaceCloseShortcutSettings.key)
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "focusPaneOnFirstClick",
+                settingsKey: "app.focusPaneOnFirstClick",
+                title: {
+                    String(localized: "settings.app.paneFirstClickFocus", defaultValue: "Focus Pane on First Click")
+                },
+                sectionTitle: app,
+                keywords: ["app.focusPaneOnFirstClick", "pane", "focus", "click", "activation", "mouse"],
+                defaultValue: PaneFirstClickFocusSettings.defaultEnabled,
+                defaultsKey: PaneFirstClickFocusSettings.enabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "openMarkdownInCmuxViewer",
+                settingsKey: "app.openMarkdownInCmuxViewer",
+                title: {
+                    String(
+                        localized: "settings.app.openMarkdownInCmuxViewer",
+                        defaultValue: "Open Markdown in cmux Viewer"
+                    )
+                },
+                sectionTitle: app,
+                keywords: ["app.openMarkdownInCmuxViewer", "markdown", "md", "viewer", "preview", "file"],
+                defaultValue: CmdClickMarkdownRouteSettings.defaultValue,
+                defaultsKey: CmdClickMarkdownRouteSettings.key
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "iMessageMode",
+                settingsKey: "app.iMessageMode",
+                title: {
+                    String(localized: "settings.app.iMessageMode", defaultValue: "iMessage Mode")
+                },
+                sectionTitle: app,
+                keywords: ["app.iMessageMode", "imessage", "message", "chat", "prompt", "agent", "workspace", "reorder"],
+                defaultValue: IMessageModeSettings.defaultValue,
+                defaultsKey: IMessageModeSettings.key
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "reorderOnNotification",
+                settingsKey: "app.reorderOnNotification",
+                title: {
+                    String(localized: "settings.app.reorderOnNotification", defaultValue: "Reorder on Notification")
+                },
+                sectionTitle: app,
+                keywords: ["app.reorderOnNotification", "notification", "reorder", "workspace", "unread", "sort"],
+                defaultValue: WorkspaceAutoReorderSettings.defaultValue,
+                defaultsKey: WorkspaceAutoReorderSettings.key
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "dockBadge",
+                settingsKey: "notifications.dockBadge",
+                title: {
+                    String(localized: "settings.app.dockBadge", defaultValue: "Dock Badge")
+                },
+                sectionTitle: app,
+                keywords: ["notifications.dockBadge", "dock", "badge", "notification", "unread", "count"],
+                defaultValue: NotificationBadgeSettings.defaultDockBadgeEnabled,
+                defaultsKey: NotificationBadgeSettings.dockBadgeEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "menuBarOnly",
+                settingsKey: "app.menuBarOnly",
+                title: {
+                    String(localized: "settings.app.menuBarOnly", defaultValue: "Menu Bar Only")
+                },
+                sectionTitle: app,
+                keywords: ["app.menuBarOnly", "menu", "bar", "dock", "cmd-tab", "app", "switcher"],
+                defaultValue: MenuBarOnlySettings.defaultMenuBarOnly,
+                defaultsKey: MenuBarOnlySettings.menuBarOnlyKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showInMenuBar",
+                settingsKey: "notifications.showInMenuBar",
+                title: {
+                    String(localized: "settings.app.showInMenuBar", defaultValue: "Show in Menu Bar")
+                },
+                sectionTitle: app,
+                keywords: ["notifications.showInMenuBar", "menu", "bar", "status", "tray", "extra"],
+                defaultValue: MenuBarExtraSettings.defaultShowInMenuBar,
+                defaultsKey: MenuBarExtraSettings.showInMenuBarKey,
+                isAvailable: { defaults in !MenuBarOnlySettings.isEnabled(defaults: defaults) }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "unreadPaneRing",
+                settingsKey: "notifications.unreadPaneRing",
+                title: {
+                    String(localized: "settings.notifications.paneRing.title", defaultValue: "Unread Pane Ring")
+                },
+                sectionTitle: app,
+                keywords: ["notifications.unreadPaneRing", "notification", "unread", "pane", "ring", "outline"],
+                defaultValue: NotificationPaneRingSettings.defaultEnabled,
+                defaultsKey: NotificationPaneRingSettings.enabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "paneFlash",
+                settingsKey: "notifications.paneFlash",
+                title: {
+                    String(localized: "settings.notifications.paneFlash.title", defaultValue: "Pane Flash")
+                },
+                sectionTitle: app,
+                keywords: ["notifications.paneFlash", "notification", "pane", "flash", "highlight", "pulse"],
+                defaultValue: NotificationPaneFlashSettings.defaultEnabled,
+                defaultsKey: NotificationPaneFlashSettings.enabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "sendAnonymousTelemetry",
+                settingsKey: "app.sendAnonymousTelemetry",
+                title: {
+                    String(localized: "settings.app.telemetry", defaultValue: "Send anonymous telemetry")
+                },
+                sectionTitle: app,
+                keywords: ["app.sendAnonymousTelemetry", "telemetry", "analytics", "crash", "reports", "privacy"],
+                defaultValue: TelemetrySettings.defaultSendAnonymousTelemetry,
+                defaultsKey: TelemetrySettings.sendAnonymousTelemetryKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "warnBeforeQuit",
+                settingsKey: "app.warnBeforeQuit",
+                title: {
+                    String(localized: "settings.app.warnBeforeQuit", defaultValue: "Warn Before Quit")
+                },
+                sectionTitle: app,
+                keywords: ["app.warnBeforeQuit", "warn", "quit", "confirmation", "cmd-q", "exit"],
+                defaultValue: QuitWarningSettings.defaultWarnBeforeQuit,
+                defaultsKey: QuitWarningSettings.warnBeforeQuitKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "warnBeforeClosingTab",
+                settingsKey: "app.warnBeforeClosingTab",
+                title: {
+                    String(localized: "settings.app.warnBeforeClosingTab", defaultValue: "Warn Before Closing Tab")
+                },
+                sectionTitle: app,
+                keywords: ["app.warnBeforeClosingTab", "warn", "close", "tab", "confirmation", "cmd-w"],
+                defaultValue: CloseTabWarningSettings.defaultWarnBeforeClosingTab,
+                defaultsKey: CloseTabWarningSettings.warnBeforeClosingTabKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "renameSelectsExistingName",
+                settingsKey: "app.renameSelectsExistingName",
+                title: {
+                    String(localized: "settings.app.renameSelectsName", defaultValue: "Rename Selects Existing Name")
+                },
+                sectionTitle: app,
+                keywords: ["app.renameSelectsExistingName", "rename", "select", "name", "title", "command", "palette"],
+                defaultValue: CommandPaletteRenameSelectionSettings.defaultSelectAllOnFocus,
+                defaultsKey: CommandPaletteRenameSelectionSettings.selectAllOnFocusKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "commandPaletteSearchesAllSurfaces",
+                settingsKey: "app.commandPaletteSearchesAllSurfaces",
+                title: {
+                    String(
+                        localized: "settings.app.commandPaletteSearchAllSurfaces",
+                        defaultValue: "Command Palette Searches All Surfaces"
+                    )
+                },
+                sectionTitle: app,
+                keywords: ["app.commandPaletteSearchesAllSurfaces", "command", "palette", "search", "surfaces", "workspace"],
+                defaultValue: CommandPaletteSwitcherSearchSettings.defaultSearchAllSurfaces,
+                defaultsKey: CommandPaletteSwitcherSearchSettings.searchAllSurfacesKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "terminalShowScrollBar",
+                settingsKey: "terminal.showScrollBar",
+                title: {
+                    String(localized: "settings.terminal.scrollBar", defaultValue: "Show Terminal Scroll Bar")
+                },
+                sectionTitle: terminal,
+                keywords: ["terminal.showScrollBar", "terminal", "scroll", "scrollbar", "scrollback"],
+                defaultValue: TerminalScrollBarSettings.defaultShowScrollBar,
+                defaultsKey: TerminalScrollBarSettings.showScrollBarKey,
+                didSet: { _, _, notificationCenter in
+                    TerminalScrollBarSettings.notifyDidChange(notificationCenter: notificationCenter)
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "autoResumeAgentSessions",
+                settingsKey: "terminal.autoResumeAgentSessions",
+                title: {
+                    String(
+                        localized: "settings.terminal.agentAutoResume",
+                        defaultValue: "Resume Agent Sessions on Reopen"
+                    )
+                },
+                sectionTitle: terminal,
+                keywords: ["terminal.autoResumeAgentSessions", "terminal", "agent", "resume", "sessions", "reopen", "restore"],
+                isOn: { defaults in AgentSessionAutoResumeSettings.isEnabled(defaults: defaults) },
+                setOn: { newValue, defaults, notificationCenter in
+                    AgentSessionAutoResumeSettings.setEnabled(
+                        newValue,
+                        defaults: defaults,
+                        notificationCenter: notificationCenter
+                    )
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "hideAllSidebarDetails",
+                settingsKey: "sidebar.hideAllDetails",
+                title: {
+                    String(localized: "settings.app.hideAllSidebarDetails", defaultValue: "Hide All Sidebar Details")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.hideAllDetails", "sidebar", "hide", "details", "compact", "title"],
+                defaultValue: SidebarWorkspaceDetailSettings.defaultHideAllDetails,
+                defaultsKey: SidebarWorkspaceDetailSettings.hideAllDetailsKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showWorkspaceDescriptionInSidebar",
+                settingsKey: "sidebar.showWorkspaceDescription",
+                title: {
+                    String(
+                        localized: "settings.app.showWorkspaceDescription",
+                        defaultValue: "Show Workspace Description in Sidebar"
+                    )
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showWorkspaceDescription", "sidebar", "workspace", "description", "notes"],
+                defaultValue: SidebarWorkspaceDetailSettings.defaultShowWorkspaceDescription,
+                defaultsKey: SidebarWorkspaceDetailSettings.showWorkspaceDescriptionKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "sidebarBranchVerticalLayout",
+                settingsKey: "sidebar.branchLayout",
+                title: {
+                    String(localized: "settings.app.sidebarBranchLayout", defaultValue: "Sidebar Branch Layout")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.branchLayout", "sidebar", "branch", "layout", "vertical", "inline", "directory"],
+                defaultValue: SidebarBranchLayoutSettings.defaultVerticalLayout,
+                defaultsKey: SidebarBranchLayoutSettings.key,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showNotificationMessageInSidebar",
+                settingsKey: "sidebar.showNotificationMessage",
+                title: {
+                    String(
+                        localized: "settings.app.showNotificationMessage",
+                        defaultValue: "Show Notification Message in Sidebar"
+                    )
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showNotificationMessage", "sidebar", "notification", "message", "latest", "unread"],
+                defaultValue: SidebarWorkspaceDetailSettings.defaultShowNotificationMessage,
+                defaultsKey: SidebarWorkspaceDetailSettings.showNotificationMessageKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showBranchDirectoryInSidebar",
+                settingsKey: "sidebar.showBranchDirectory",
+                title: {
+                    String(localized: "settings.app.showBranchDirectory", defaultValue: "Show Branch + Directory in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showBranchDirectory", "sidebar", "branch", "directory", "cwd", "path", "repo"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showBranchDirectory,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showBranchDirectoryKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showPullRequestsInSidebar",
+                settingsKey: "sidebar.showPullRequests",
+                title: {
+                    String(localized: "settings.app.showPullRequests", defaultValue: "Show Pull Requests in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showPullRequests", "sidebar", "pull", "request", "pr", "review", "github"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showPullRequests,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showPullRequestsKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "makeSidebarPullRequestsClickable",
+                settingsKey: "sidebar.makePullRequestsClickable",
+                title: {
+                    String(
+                        localized: "settings.app.makeSidebarPullRequestClickable",
+                        defaultValue: "Make Sidebar PR Clickable"
+                    )
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.makePullRequestsClickable", "sidebar", "pull", "request", "pr", "click", "link"],
+                defaultValue: SidebarPullRequestClickabilitySettings.defaultClickable,
+                defaultsKey: SidebarPullRequestClickabilitySettings.key,
+                isAvailable: { defaults in
+                    sidebarDetailsAvailable(defaults)
+                        && SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: defaults)
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "openSidebarPullRequestLinksInCmuxBrowser",
+                settingsKey: "sidebar.openPullRequestLinksInCmuxBrowser",
+                title: {
+                    String(
+                        localized: "settings.app.openSidebarPRLinks",
+                        defaultValue: "Open Sidebar PR Links in cmux Browser"
+                    )
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.openPullRequestLinksInCmuxBrowser", "sidebar", "pull", "request", "pr", "browser", "link"],
+                defaultValue: BrowserLinkOpenSettings.defaultOpenSidebarPullRequestLinksInCmuxBrowser,
+                defaultsKey: BrowserLinkOpenSettings.openSidebarPullRequestLinksInCmuxBrowserKey,
+                isAvailable: sidebarPullRequestLinksAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "openSidebarPortLinksInCmuxBrowser",
+                settingsKey: "sidebar.openPortLinksInCmuxBrowser",
+                title: {
+                    String(
+                        localized: "settings.app.openSidebarPortLinks",
+                        defaultValue: "Open Sidebar Port Links in cmux Browser"
+                    )
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.openPortLinksInCmuxBrowser", "sidebar", "port", "localhost", "browser", "link"],
+                defaultValue: BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser,
+                defaultsKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showSSHInSidebar",
+                settingsKey: "sidebar.showSSH",
+                title: {
+                    String(localized: "settings.app.showSSH", defaultValue: "Show SSH in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showSSH", "sidebar", "ssh", "remote", "host", "target"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showSSH,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showSSHKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showPortsInSidebar",
+                settingsKey: "sidebar.showPorts",
+                title: {
+                    String(localized: "settings.app.showPorts", defaultValue: "Show Listening Ports in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showPorts", "sidebar", "ports", "localhost", "server", "url"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showPorts,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showPortsKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showLogInSidebar",
+                settingsKey: "sidebar.showLog",
+                title: {
+                    String(localized: "settings.app.showLog", defaultValue: "Show Latest Log in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showLog", "sidebar", "log", "status", "latest", "message"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showLog,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showLogKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showProgressInSidebar",
+                settingsKey: "sidebar.showProgress",
+                title: {
+                    String(localized: "settings.app.showProgress", defaultValue: "Show Progress in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showProgress", "sidebar", "progress", "bar", "status"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showProgress,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showProgressKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showCustomMetadataInSidebar",
+                settingsKey: "sidebar.showCustomMetadata",
+                title: {
+                    String(localized: "settings.app.showMetadata", defaultValue: "Show Custom Metadata in Sidebar")
+                },
+                sectionTitle: sidebar,
+                keywords: ["sidebar.showCustomMetadata", "sidebar", "metadata", "meta", "custom", "status"],
+                defaultValue: SidebarWorkspaceDetailDefaults.showCustomMetadata,
+                defaultsKey: SidebarWorkspaceDetailDefaults.showCustomMetadataKey,
+                isAvailable: sidebarDetailsAvailable
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "rightSidebarDock",
+                settingsKey: "betaFeatures.dock",
+                title: {
+                    String(localized: "settings.betaFeatures.dock", defaultValue: "Dock")
+                },
+                sectionTitle: beta,
+                keywords: ["betaFeatures.dock", "dock", "right", "sidebar", "beta", "terminal", "controls"],
+                defaultValue: RightSidebarBetaFeatureSettings.defaultDockEnabled,
+                defaultsKey: RightSidebarBetaFeatureSettings.dockEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "claudeCodeIntegration",
+                settingsKey: "automation.claudeCodeIntegration",
+                title: {
+                    String(localized: "settings.automation.claudeCode", defaultValue: "Claude Code Integration")
+                },
+                sectionTitle: automation,
+                keywords: ["automation.claudeCodeIntegration", "claude", "code", "hooks", "agent", "integration"],
+                defaultValue: ClaudeCodeIntegrationSettings.defaultHooksEnabled,
+                defaultsKey: ClaudeCodeIntegrationSettings.hooksEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "cursorIntegration",
+                settingsKey: "automation.cursorIntegration",
+                title: {
+                    String(localized: "settings.automation.cursor", defaultValue: "Cursor Integration")
+                },
+                sectionTitle: automation,
+                keywords: ["automation.cursorIntegration", "cursor", "hooks", "agent", "integration"],
+                defaultValue: CursorIntegrationSettings.defaultHooksEnabled,
+                defaultsKey: CursorIntegrationSettings.hooksEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "geminiIntegration",
+                settingsKey: "automation.geminiIntegration",
+                title: {
+                    String(localized: "settings.automation.gemini", defaultValue: "Gemini CLI Integration")
+                },
+                sectionTitle: automation,
+                keywords: ["automation.geminiIntegration", "gemini", "hooks", "agent", "integration"],
+                defaultValue: GeminiIntegrationSettings.defaultHooksEnabled,
+                defaultsKey: GeminiIntegrationSettings.hooksEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "browserSearchSuggestions",
+                settingsKey: "browser.showSearchSuggestions",
+                title: {
+                    String(localized: "settings.browser.searchSuggestions", defaultValue: "Show Search Suggestions")
+                },
+                sectionTitle: browser,
+                keywords: ["browser.showSearchSuggestions", "browser", "search", "suggestions", "autocomplete", "address", "bar"],
+                defaultValue: BrowserSearchSettings.defaultSearchSuggestionsEnabled,
+                defaultsKey: BrowserSearchSettings.searchSuggestionsEnabledKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "openTerminalLinksInCmuxBrowser",
+                settingsKey: "browser.openTerminalLinksInCmuxBrowser",
+                title: {
+                    String(
+                        localized: "settings.browser.openTerminalLinks",
+                        defaultValue: "Open Terminal Links in cmux Browser"
+                    )
+                },
+                sectionTitle: browser,
+                keywords: ["browser.openTerminalLinksInCmuxBrowser", "browser", "terminal", "links", "url", "click"],
+                defaultValue: BrowserLinkOpenSettings.defaultOpenTerminalLinksInCmuxBrowser,
+                defaultsKey: BrowserLinkOpenSettings.openTerminalLinksInCmuxBrowserKey
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "interceptTerminalOpenCommandInCmuxBrowser",
+                settingsKey: "browser.interceptTerminalOpenCommandInCmuxBrowser",
+                title: {
+                    String(localized: "settings.browser.interceptOpen", defaultValue: "Intercept open http(s) in Terminal")
+                },
+                sectionTitle: browser,
+                keywords: ["browser.interceptTerminalOpenCommandInCmuxBrowser", "browser", "terminal", "open", "http", "https", "intercept"],
+                isOn: { defaults in
+                    BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowser(defaults: defaults)
+                },
+                setOn: { newValue, defaults, _ in
+                    defaults.set(newValue, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "showBrowserImportHintOnBlankTabs",
+                settingsKey: "browser.showImportHintOnBlankTabs",
+                title: {
+                    String(
+                        localized: "settings.browser.import.hint.show",
+                        defaultValue: "Show import hint on blank browser tabs"
+                    )
+                },
+                sectionTitle: browserImport,
+                keywords: ["browser.showImportHintOnBlankTabs", "browser", "import", "hint", "blank", "tabs", "onboarding"],
+                defaultValue: BrowserImportHintSettings.defaultShowOnBlankTabs,
+                defaultsKey: BrowserImportHintSettings.showOnBlankTabsKey,
+                didSet: { newValue, defaults, _ in
+                    if newValue {
+                        defaults.set(false, forKey: BrowserImportHintSettings.dismissedKey)
+                    }
+                }
+            ),
+            CommandPaletteSettingToggleDescriptor(
+                commandId: commandIdPrefix + "systemWideHotkey",
+                settingsKey: "globalHotkey.enable",
+                title: {
+                    String(localized: "settings.globalHotkey.enable", defaultValue: "Enable System-Wide Hotkey")
+                },
+                sectionTitle: globalHotkey,
+                keywords: ["globalHotkey.enable", "global", "hotkey", "system", "wide", "show", "hide", "windows"],
+                isOn: { defaults in SystemWideHotkeySettings.isEnabled(defaults: defaults) },
+                setOn: { newValue, defaults, _ in
+                    SystemWideHotkeySettings.setEnabled(newValue, defaults: defaults)
+                }
+            ),
+        ]
+    }()
+}
+
+extension SidebarWorkspaceDetailDefaults {
+    static func boolValue(defaults: UserDefaults, key: String, defaultValue: Bool) -> Bool {
+        if defaults.object(forKey: key) == nil {
+            return defaultValue
+        }
+        return defaults.bool(forKey: key)
+    }
+
+    static func showPullRequestsValue(defaults: UserDefaults) -> Bool {
+        boolValue(defaults: defaults, key: showPullRequestsKey, defaultValue: showPullRequests)
+    }
+}
+
+extension ContentView {
+    static func commandPaletteSettingsToggleCommandContributions() -> [CommandPaletteCommandContribution] {
+        CommandPaletteSettingsToggleCommands.descriptors.map { descriptor in
+            CommandPaletteCommandContribution(
+                commandId: descriptor.commandId,
+                title: { _ in descriptor.commandTitle() },
+                subtitle: { _ in descriptor.commandSubtitle() },
+                keywords: descriptor.keywords + ["settings", "toggle", descriptor.settingsKey],
+                when: { _ in descriptor.isAvailable(.standard) }
+            )
+        }
+    }
+
+    func registerSettingsToggleCommandHandlers(_ registry: inout CommandPaletteHandlerRegistry) {
+        for descriptor in CommandPaletteSettingsToggleCommands.descriptors {
+            registry.register(commandId: descriptor.commandId) {
+                descriptor.toggle()
+            }
+        }
+    }
+}

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -78,6 +78,7 @@ struct CommandPaletteSettingToggleDescriptor: Sendable {
         defaults: UserDefaults = .standard,
         notificationCenter: NotificationCenter = .default
     ) {
+        guard isAvailable(defaults) else { return }
         setOn(!isOn(defaults), defaults, notificationCenter)
     }
 }
@@ -676,7 +677,7 @@ extension SidebarWorkspaceDetailDefaults {
 }
 
 extension ContentView {
-    static func commandPaletteSettingsToggleCommandContributions() -> [CommandPaletteCommandContribution] {
+    nonisolated static func commandPaletteSettingsToggleCommandContributions() -> [CommandPaletteCommandContribution] {
         CommandPaletteSettingsToggleCommands.descriptors.map { descriptor in
             CommandPaletteCommandContribution(
                 commandId: descriptor.commandId,

--- a/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
+++ b/Sources/CommandPalette/CommandPaletteSettingsToggle.swift
@@ -63,7 +63,7 @@ struct CommandPaletteSettingToggleDescriptor: Sendable {
         let format = isOn(defaults)
             ? String(localized: "command.toggleSetting.disableTitle", defaultValue: "Disable %@")
             : String(localized: "command.toggleSetting.enableTitle", defaultValue: "Enable %@")
-        return String(format: format, title())
+        return String.localizedStringWithFormat(format, title())
     }
 
     func commandSubtitle(defaults: UserDefaults = .standard) -> String {
@@ -71,7 +71,7 @@ struct CommandPaletteSettingToggleDescriptor: Sendable {
             ? String(localized: "command.toggleSetting.state.on", defaultValue: "On")
             : String(localized: "command.toggleSetting.state.off", defaultValue: "Off")
         let format = String(localized: "command.toggleSetting.subtitle", defaultValue: "%@ • %@")
-        return String(format: format, sectionTitle(), state)
+        return String.localizedStringWithFormat(format, sectionTitle(), state)
     }
 
     func toggle(
@@ -115,6 +115,14 @@ enum CommandPaletteSettingsToggleCommands {
             sidebarDetailsAvailable(defaults)
                 && SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: defaults)
                 && SidebarPullRequestClickabilitySettings.isClickable(defaults: defaults)
+        }
+        let sidebarPortLinksAvailable: @Sendable (UserDefaults) -> Bool = { defaults in
+            sidebarDetailsAvailable(defaults)
+                && SidebarWorkspaceDetailDefaults.boolValue(
+                    defaults: defaults,
+                    key: SidebarWorkspaceDetailDefaults.showPortsKey,
+                    defaultValue: SidebarWorkspaceDetailDefaults.showPorts
+                )
         }
 
         return [
@@ -466,7 +474,7 @@ enum CommandPaletteSettingsToggleCommands {
                 keywords: ["sidebar.openPortLinksInCmuxBrowser", "sidebar", "port", "localhost", "browser", "link"],
                 defaultValue: BrowserLinkOpenSettings.defaultOpenSidebarPortLinksInCmuxBrowser,
                 defaultsKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey,
-                isAvailable: sidebarDetailsAvailable
+                isAvailable: sidebarPortLinksAvailable
             ),
             CommandPaletteSettingToggleDescriptor(
                 commandId: commandIdPrefix + "showSSHInSidebar",

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6423,6 +6423,7 @@ struct ContentView: View {
                 when: { $0.bool(CommandPaletteContextKeys.supportedFileRoutingDisabled) }
             )
         )
+        contributions.append(contentsOf: Self.commandPaletteSettingsToggleCommandContributions())
 
         contributions.append(
             CommandPaletteCommandContribution(
@@ -7264,6 +7265,7 @@ struct ContentView: View {
         registry.register(commandId: "palette.enableSupportedFileRouting") {
             CmdClickSupportedFileRouteSettings.setEnabled(true)
         }
+        registerSettingsToggleCommandHandlers(&registry)
 
         registry.register(commandId: "palette.renameWorkspace") {
             beginRenameWorkspaceFlow()

--- a/cmuxTests/CommandPaletteSettingsToggleTests.swift
+++ b/cmuxTests/CommandPaletteSettingsToggleTests.swift
@@ -79,6 +79,25 @@ final class CommandPaletteSettingsToggleTests: XCTestCase {
         }
     }
 
+    func testInterceptTerminalOpenCommandReadsRawSettingWhenBrowserIsDisabled() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.interceptTerminalOpenCommandInCmuxBrowser"
+                )
+            )
+            defaults.set(true, forKey: BrowserAvailabilitySettings.disabledKey)
+            defaults.set(true, forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey)
+
+            XCTAssertTrue(descriptor.isOn(defaults))
+
+            descriptor.toggle(defaults: defaults, notificationCenter: NotificationCenter())
+
+            XCTAssertFalse(defaults.bool(forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey))
+            XCTAssertFalse(descriptor.isOn(defaults))
+        }
+    }
+
     func testSettingsToggleContributionsIncludeEveryDescriptor() {
         let descriptorIds = Set(CommandPaletteSettingsToggleCommands.descriptors.map(\.commandId))
         let contributionIds = Set(ContentView.commandPaletteSettingsToggleCommandContributions().map(\.commandId))

--- a/cmuxTests/CommandPaletteSettingsToggleTests.swift
+++ b/cmuxTests/CommandPaletteSettingsToggleTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+final class CommandPaletteSettingsToggleTests: XCTestCase {
+    func testIMessageModeCommandTogglesDefaultAndReportsState() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.iMessageMode"
+                )
+            )
+
+            let settingTitle = String(localized: "settings.app.iMessageMode", defaultValue: "iMessage Mode")
+            let enableTitle = String(
+                format: String(localized: "command.toggleSetting.enableTitle", defaultValue: "Enable %@"),
+                settingTitle
+            )
+            let disableTitle = String(
+                format: String(localized: "command.toggleSetting.disableTitle", defaultValue: "Disable %@"),
+                settingTitle
+            )
+            let offState = String(localized: "command.toggleSetting.state.off", defaultValue: "Off")
+            let onState = String(localized: "command.toggleSetting.state.on", defaultValue: "On")
+            XCTAssertFalse(descriptor.isOn(defaults))
+            XCTAssertEqual(descriptor.commandTitle(defaults: defaults), enableTitle)
+            XCTAssertTrue(descriptor.commandSubtitle(defaults: defaults).contains(offState))
+
+            descriptor.toggle(defaults: defaults, notificationCenter: NotificationCenter())
+
+            XCTAssertTrue(defaults.bool(forKey: IMessageModeSettings.key))
+            XCTAssertTrue(descriptor.isOn(defaults))
+            XCTAssertEqual(descriptor.commandTitle(defaults: defaults), disableTitle)
+            XCTAssertTrue(descriptor.commandSubtitle(defaults: defaults).contains(onState))
+        }
+    }
+
+    func testTerminalScrollBarTogglePostsChangeNotification() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.terminalShowScrollBar"
+                )
+            )
+            let notificationCenter = NotificationCenter()
+            var didNotify = false
+            let token = notificationCenter.addObserver(
+                forName: TerminalScrollBarSettings.didChangeNotification,
+                object: nil,
+                queue: nil
+            ) { _ in
+                didNotify = true
+            }
+            defer { notificationCenter.removeObserver(token) }
+
+            XCTAssertTrue(descriptor.isOn(defaults))
+            descriptor.toggle(defaults: defaults, notificationCenter: notificationCenter)
+
+            XCTAssertFalse(defaults.bool(forKey: TerminalScrollBarSettings.showScrollBarKey))
+            XCTAssertTrue(didNotify)
+        }
+    }
+
+    func testShowMenuBarCommandIsUnavailableWhenMenuBarOnlyIsEnabled() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.showInMenuBar"
+                )
+            )
+
+            XCTAssertTrue(descriptor.isAvailable(defaults))
+            defaults.set(true, forKey: MenuBarOnlySettings.menuBarOnlyKey)
+            XCTAssertFalse(descriptor.isAvailable(defaults))
+        }
+    }
+
+    func testSettingsToggleContributionsIncludeEveryDescriptor() {
+        let descriptorIds = Set(CommandPaletteSettingsToggleCommands.descriptors.map(\.commandId))
+        let contributionIds = Set(ContentView.commandPaletteSettingsToggleCommandContributions().map(\.commandId))
+
+        XCTAssertEqual(contributionIds, descriptorIds)
+    }
+
+    func testSettingsToggleCommandIdsAreUnique() {
+        let commandIds = CommandPaletteSettingsToggleCommands.descriptors.map(\.commandId)
+        XCTAssertEqual(Set(commandIds).count, commandIds.count)
+    }
+
+    private func withTemporaryDefaults(_ body: (UserDefaults) throws -> Void) throws {
+        let suiteName = "cmux.commandPaletteSettingsToggle.\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+        try body(defaults)
+    }
+}

--- a/cmuxTests/CommandPaletteSettingsToggleTests.swift
+++ b/cmuxTests/CommandPaletteSettingsToggleTests.swift
@@ -112,6 +112,22 @@ final class CommandPaletteSettingsToggleTests: XCTestCase {
         }
     }
 
+    func testUnavailableCommandDoesNotToggleStoredValue() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.openSidebarPortLinksInCmuxBrowser"
+                )
+            )
+            defaults.set(false, forKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey)
+            defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.showPortsKey)
+
+            descriptor.toggle(defaults: defaults, notificationCenter: NotificationCenter())
+
+            XCTAssertFalse(defaults.bool(forKey: BrowserLinkOpenSettings.openSidebarPortLinksInCmuxBrowserKey))
+        }
+    }
+
     func testSettingsToggleContributionsIncludeEveryDescriptor() {
         let descriptorIds = Set(CommandPaletteSettingsToggleCommands.descriptors.map(\.commandId))
         let contributionIds = Set(ContentView.commandPaletteSettingsToggleCommandContributions().map(\.commandId))

--- a/cmuxTests/CommandPaletteSettingsToggleTests.swift
+++ b/cmuxTests/CommandPaletteSettingsToggleTests.swift
@@ -16,12 +16,12 @@ final class CommandPaletteSettingsToggleTests: XCTestCase {
             )
 
             let settingTitle = String(localized: "settings.app.iMessageMode", defaultValue: "iMessage Mode")
-            let enableTitle = String(
-                format: String(localized: "command.toggleSetting.enableTitle", defaultValue: "Enable %@"),
+            let enableTitle = String.localizedStringWithFormat(
+                String(localized: "command.toggleSetting.enableTitle", defaultValue: "Enable %@"),
                 settingTitle
             )
-            let disableTitle = String(
-                format: String(localized: "command.toggleSetting.disableTitle", defaultValue: "Disable %@"),
+            let disableTitle = String.localizedStringWithFormat(
+                String(localized: "command.toggleSetting.disableTitle", defaultValue: "Disable %@"),
                 settingTitle
             )
             let offState = String(localized: "command.toggleSetting.state.off", defaultValue: "Off")
@@ -95,6 +95,20 @@ final class CommandPaletteSettingsToggleTests: XCTestCase {
 
             XCTAssertFalse(defaults.bool(forKey: BrowserLinkOpenSettings.interceptTerminalOpenCommandInCmuxBrowserKey))
             XCTAssertFalse(descriptor.isOn(defaults))
+        }
+    }
+
+    func testOpenSidebarPortLinksCommandIsUnavailableWhenPortsAreHidden() throws {
+        try withTemporaryDefaults { defaults in
+            let descriptor = try XCTUnwrap(
+                CommandPaletteSettingsToggleCommands.descriptor(
+                    commandId: "palette.toggleSetting.openSidebarPortLinksInCmuxBrowser"
+                )
+            )
+
+            XCTAssertTrue(descriptor.isAvailable(defaults))
+            defaults.set(false, forKey: SidebarWorkspaceDetailDefaults.showPortsKey)
+            XCTAssertFalse(descriptor.isAvailable(defaults))
         }
     }
 


### PR DESCRIPTION
Summary:
- Adds generated command palette commands for boolean Settings toggles, including iMessage Mode.
- Uses the same UserDefaults/settings helpers as Settings rows, with stateful Enable/Disable titles.
- Keeps existing specialized commands for minimal mode, browser enablement, supported file previews, and sidebar background matching.

Acceptance criteria:
- Cmd+Shift+P command mode can find `imessage` and toggle iMessage Mode.
- Command palette also exposes the remaining boolean Settings rows that do not already have specialized palette commands.
- Dependent rows stay unavailable when the corresponding Settings UI row is disabled.
- User-facing command copy is localized in English and Japanese.

Verification:
- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-palsettests -only-testing:cmuxTests/CommandPaletteSettingsToggleTests test`
- `jq empty Resources/Localizable.xcstrings`
- `plutil -lint GhosttyTabs.xcodeproj/project.pbxproj`
- `git diff --check`
- `./scripts/reload.sh --tag palset`

Cloud proof:
- Cloud Mac run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25833707196
- Feature demo movie: `/tmp/auto-feature-toggle-settings-demo-clean/recording/recording.mov`
- Checked frames: `/tmp/auto-feature-toggle-settings-demo-clean/state-enable/screenshot.png`, `/tmp/auto-feature-toggle-settings-demo-clean/state-disable/screenshot.png`, `/tmp/auto-feature-toggle-settings-demo-clean/recording/frame-final.png`
- The clean demo shows `Enable iMessage Mode`, runs the command, then shows `Disable iMessage Mode`.
- `record-end` returned the known Retina validation mismatch (`1920x1440` movie vs `960x720` logical display), but the movie, ffprobe metadata, and final frame were written and inspected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it introduces a broad set of new command handlers that mutate `UserDefaults` and gate availability based on other settings; mistakes could lead to incorrect toggles or stale UI behavior.
> 
> **Overview**
> Adds a new `CommandPaletteSettingsToggle` system that generates command palette commands for many boolean settings, with stateful **Enable/Disable** titles and **On/Off** subtitles, plus keywords and dependency-based availability checks (e.g., sidebar details/ports/PR link conditions).
> 
> Wires these contributions and handlers into `ContentView`, extends sidebar detail defaults with explicit keys and helpers for default-vs-stored behavior, and adds new localized strings (en/ja) for the toggle command copy.
> 
> Updates the Xcode project to include the new source and adds `CommandPaletteSettingsToggleTests` covering toggling behavior, notifications, availability gating, and descriptor/contribution consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78cc556f4a1f1e63bf2e38758650e97f1b2ace0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add command palette toggles for all remaining boolean Settings (including iMessage Mode) with live Enable/Disable titles and On/Off subtitles. Localized (en, ja), availability-aware, wired into `ContentView`, and backed by tests.

- New Features
  - Generated toggle commands with dynamic titles/subtitles (includes section label); localized (en, ja).
  - Availability mirrors Settings UI and dependencies (e.g., PR/Ports links, sidebar details); contributions and handlers registered in `ContentView`.
  - Added persisted keys and helpers in `SidebarWorkspaceDetailDefaults`; tests cover toggling, notifications, availability gating, unique IDs, and descriptor↔contribution coverage.

- Bug Fixes
  - Guarded unavailable settings toggle commands so handlers are no-op; added test to ensure values do not change when unavailable.
  - Tightened availability rules and colocated sidebar detail defaults helpers (e.g., “Show in Menu Bar” is unavailable when Menu Bar Only is enabled; PR/Ports link commands respect detail visibility).
  - Corrected toggle side effects and defaults (terminal scroll bar posts change notification; terminal open interception reads/writes the dedicated key and falls back correctly).

<sup>Written for commit 78cc556f4a1f1e63bf2e38758650e97f1b2ace0c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Adds a suite of command-palette toggle commands for many workspace/UI settings with on/off titles, subtitles, keywords and quick toggle actions.

* **Localization**
  * Added English and Japanese strings for toggle enable/disable titles, subtitles and On/Off labels.

* **Tests**
  * Added end-to-end tests covering toggle behavior, availability rules, persistence, uniqueness, and command contributions/handlers.

* **Chores**
  * Wired the new toggle implementation and its tests into the project build.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4134)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->