### PR TITLE
Inherit stdin in backgrounded ssh inside startup wrapper

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -6305,14 +6305,19 @@ struct CMUXCLI {
         if let trimmedControlPathPreflight, !trimmedControlPathPreflight.isEmpty {
             scriptLines.append("  cmux_ssh_preflight_control_path")
         }
+        // POSIX sh redirects stdin of an async command (`&`) to /dev/null when
+        // job control is off (the default for `/bin/sh -c …`), so ssh would
+        // never receive keystrokes from the surface PTY. Inheriting fd 0
+        // explicitly with `<&0` overrides that default and keeps the wrapper's
+        // own stdin (the terminal) wired into the backgrounded ssh process.
         if isShellSnippet {
             scriptLines += [
                 "  (",
                 "    \(sshCommand)",
-                "  ) &",
+                "  ) <&0 &",
             ]
         } else {
-            scriptLines.append("  command \(sshCommand) &")
+            scriptLines.append("  command \(sshCommand) <&0 &")
         }
         scriptLines += [
             "  CMUX_SSH_CHILD_PID=$!",

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -469,6 +469,70 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertTrue(result.stderr.contains("[cmux] press Enter to close this pane."), result.stderr)
     }
 
+    func testSSHStartupForwardsStdinToBackgroundedSSH() throws {
+        // Regression test for cmux ssh sessions where output flowed back from
+        // the remote (prompt rendered) but typed keystrokes never reached the
+        // remote shell after PR #3786 backgrounded `ssh` inside the startup
+        // wrapper. POSIX sh redirects stdin of an async command to /dev/null
+        // when job control is off, so without an explicit `<&0` on the `&`'d
+        // ssh invocation, the local PTY stdin is dropped and the user types
+        // into a dead pipe.
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-stdin-forward-\(UUID().uuidString)", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let sessionEndLog = root.appendingPathComponent("ssh-session-end.log")
+        let stdinCapture = root.appendingPathComponent("ssh-stdin.txt")
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: root) }
+
+        try writeShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "printf '%s\\n' \"$*\" >> \"${CMUX_TEST_SESSION_END_LOG}\"",
+        ])
+        // Fake ssh reads one line from stdin and records it so the test can
+        // verify the wrapper's stdin reached the backgrounded ssh process.
+        try writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "IFS= read -r line || line='<EOF>'",
+            "printf '%s\\n' \"$line\" > \"${CMUX_TEST_STDIN_LOG}\"",
+            "exit 0",
+        ])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLI.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+
+        let startupCommand = try generatedSSHStartupCommand()
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_SESSION_END_LOG"] = sessionEndLog.path
+        environment["CMUX_TEST_STDIN_LOG"] = stdinCapture.path
+        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: environment,
+            standardInput: "FORWARDED_KEYSTROKE\n",
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let recorded = (try? String(contentsOf: stdinCapture, encoding: .utf8))?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        XCTAssertEqual(
+            recorded,
+            "FORWARDED_KEYSTROKE",
+            "Backgrounded ssh in the startup wrapper must inherit the wrapper's stdin so that keystrokes from the surface PTY reach the remote shell. Got: \(recorded.isEmpty ? \"<empty>\" : recorded)"
+        )
+    }
+
     private func generatedSSHStartupCommand(
         sshOptions: [String] = [
             "ControlMaster no",


### PR DESCRIPTION
## Summary

Fix `cmux ssh <host>` sessions (and `cmux vm ssh` via the shared path) that, after #3786, render the remote prompt but never deliver keystrokes to the remote shell.

PR #3786 wrapped the ssh invocation in `while :; do … & wait` to support SIGHUP/INT/TERM trap handling and reconnect-on-exit-255. Backgrounding ssh, however, drops its stdin: **POSIX sh redirects fd 0 of any async command to `/dev/null` when job control is off**, which is the default for the `/bin/sh -c …` host that runs the startup wrapper.

Output from the remote still flows back fine (ssh's stdout/stderr stay wired to the surface PTY), but the user's keystrokes never reach the far side — they land on `ttysNNN` on the Mac, kernel echoes them locally, ssh's stdin is `/dev/null` so nothing is forwarded, and zsh on the remote sits in `do_poll` forever.

Adding `<&0` to both the `command` line and the `( … )` shell-snippet form re-attaches the wrapper's own stdin (the surface PTY) to the backgrounded ssh process.

## Repro on the affected build

```
$ /bin/sh -c 'cat &  wait'        # fd 0 → /dev/null (the bug — type, nothing happens)
$ /bin/sh -c 'cat <&0 &  wait'    # fd 0 → parent stdin (the fix — input flows)
```

In an affected `cmux ssh ovh-vps` session, `lsof -p <ssh-tt-pid>` shows:

```
ssh  …  0r  CHR  3,2   …  /dev/null      ← stdin closed off
ssh  …  1u  CHR 16,17  …  /dev/ttys017
ssh  …  2u  CHR 16,17  …  /dev/ttys017
```

The remote `cmuxd-remote serve --stdio` channel and the local pipe to the cmux app are intact, the auth file is fresh, the relay port listens, and `zsh -il` is alive on the remote pts in `do_poll` — confirming the break is purely on the inbound side of the backgrounded ssh.

## How this was missed

The existing `SSHStartupSignalLifecycleTests` cover signal-derived exits, reconnect counts, and session-end behavior, but the fake `ssh` shims they install never try to read from stdin. With nothing reading, `/dev/null` and the parent's stdin are indistinguishable.

The new regression test wires a fake ssh that does `IFS= read -r line` and records the result, then runs the generated startup command with a known string piped in via `runProcess(standardInput:)`. The test fails on `main` (no bytes captured, `read` hits EOF on `/dev/null`) and passes with the fix (records `FORWARDED_KEYSTROKE`).

## Test plan

- New regression test: `SSHStartupSignalLifecycleTests.testSSHStartupForwardsStdinToBackgroundedSSH` — fails on parent, passes after the fix. Two-commit structure per `CLAUDE.md`.
- Existing signal/reconnect/banner tests still pass (no behavioral overlap; `<&0` only affects stdin source).
- Manual repro against an affected build cleared once the patched wrapper is generated.

## Risk

Low. `<&0` is a POSIX shell redirection supported across all targeted shells. It only changes which file descriptor the backgrounded process reads from; output direction and signal/wait semantics are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmux SSH sessions where the prompt appeared but typed input didn’t reach the remote shell. The startup wrapper now keeps stdin attached to the backgrounded `ssh` process so keystrokes are forwarded.

- **Bug Fixes**
  - Inherit stdin with `<&0>` for both `command` and subshell forms of the backgrounded `ssh`.
  - Added a regression test to confirm stdin is forwarded; no changes to output, signal handling, or reconnect behavior.

<sup>Written for commit 2a730207247ed35f0ee2dc4259ce8126da58dd25. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where SSH keystrokes could be missed when launching connections in the background. The fix ensures stdin is properly forwarded in all scenarios, preventing keystroke loss under default shell job-control conditions.

* **Tests**
  * Added regression test to verify stdin forwarding to backgrounded SSH processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4135)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->