### PR TITLE
Add View Zoom controls

### DIFF
--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -83,6 +83,7 @@
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		D0B1001EA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */; };
 		D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */; };
+		D0B10024A1B2C3D4E5F60001 /* ViewZoomControls.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */; };
 		D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10019A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift */; };
 		D7AB34300000000000000001 /* SidebarDropPlanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000002 /* SidebarDropPlanner.swift */; };
 		D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */; };
@@ -685,6 +686,7 @@
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		D0B1001FA1B2C3D4E5F60001 /* BrowserPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPaneDropTargetView.swift; sourceTree = "<group>"; };
 		D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewTextEditor.swift; sourceTree = "<group>"; };
+		D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ViewZoomControls.swift; sourceTree = "<group>"; };
 		A5001016 /* GhosttyKit.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; path = GhosttyKit.xcframework; sourceTree = "<group>"; };
 		A5001017 /* ghostty.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ghostty.h; sourceTree = "<group>"; };
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
@@ -1307,6 +1309,7 @@
 				A50014F4 /* MarkdownWebRenderer.swift */,
 				A50014F6 /* MarkdownTypographySettings.swift */,
 				A50014F1 /* MarkdownViewerAssets.swift */,
+				D0B10025A1B2C3D4E5F60001 /* ViewZoomControls.swift */,
 				A5001423 /* FilePreviewPanel.swift */,
 				D0B10017A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift */,
 				A5001442A5001442A5001442 /* FilePreviewModeSupport.swift */,
@@ -1989,6 +1992,7 @@
 				A50014F3 /* MarkdownViewerAssets.swift in Sources */,
 				A5001422 /* FilePreviewPanel.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
+				D0B10024A1B2C3D4E5F60001 /* ViewZoomControls.swift in Sources */,
 				A5001443A5001443A5001443 /* FilePreviewModeSupport.swift in Sources */,
 				A5001445A5001445A5001445 /* FilePreviewWorkspaceOpenSupport.swift in Sources */,
 				A5001447A5001447A5001447 /* FilePreviewMagnifyingPDFView.swift in Sources */,

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -2,6 +2,8 @@
   "sourceLanguage": "en",
   "version": "1.0",
   "strings": {
+    "filePreview.pdf.zoomControls": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "Zoom Controls" } }, "ja": { "stringUnit": { "state": "translated", "value": "ズームコントロール" } } } },
+    "view.zoom.controls": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "View Zoom" } }, "ja": { "stringUnit": { "state": "translated", "value": "表示ズーム" } } } },
     "cli.error.dismissNotificationSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "dismiss-notification requires exactly one of --id or --all-read" } }, "ja": { "stringUnit": { "state": "translated", "value": "dismiss-notification には --id または --all-read のどちらか一方だけを指定してください" } } } },
     "cli.error.markNotificationReadSelector": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "mark-notification-read requires exactly one selector: --id, --workspace, or --all" } }, "ja": { "stringUnit": { "state": "translated", "value": "mark-notification-read には --id、--workspace、--all のいずれか一つだけを指定してください" } } } },
     "cli.error.markNotificationReadSurfaceRequiresWorkspace": { "extractionState": "manual", "localizations": { "en": { "stringUnit": { "state": "translated", "value": "--surface requires --workspace" } }, "ja": { "stringUnit": { "state": "translated", "value": "--surface には --workspace が必要です" } } } },

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11989,16 +11989,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
 
-        if matchConfiguredShortcut(event: event, action: .browserZoomIn) {
-            return shortcutEventBrowserPanel(event)?.zoomIn() ?? false
-        }
-
-        if matchConfiguredShortcut(event: event, action: .browserZoomOut) {
-            return shortcutEventBrowserPanel(event)?.zoomOut() ?? false
-        }
-
-        if matchConfiguredShortcut(event: event, action: .browserZoomReset) {
-            return shortcutEventBrowserPanel(event)?.resetZoom() ?? false
+        if let viewZoomCommand = configuredViewZoomShortcutCommand(for: event) {
+            if shouldLetFocusedTerminalHandleViewZoomShortcut(event) {
+                return false
+            }
+            let didHandle = shortcutEventTabManager(event)?.performViewZoomCommand(viewZoomCommand) ?? false
+            return didHandle
         }
 
         if matchConfiguredShortcut(event: event, action: .findInDirectory) {
@@ -12092,6 +12088,37 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         )
 #endif
         return true
+    }
+
+    private func configuredViewZoomShortcutCommand(for event: NSEvent) -> ViewZoomCommand? {
+        if matchConfiguredShortcut(event: event, action: .browserZoomIn) {
+            return .zoomIn
+        }
+        if matchConfiguredShortcut(event: event, action: .browserZoomOut) {
+            return .zoomOut
+        }
+        if matchConfiguredShortcut(event: event, action: .browserZoomReset) {
+            return .reset
+        }
+        return ViewZoomControl.command(for: event)
+    }
+
+    private func shouldLetFocusedTerminalHandleViewZoomShortcut(_ event: NSEvent) -> Bool {
+        let targetWindow = resolvedShortcutEventWindow(event) ?? event.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+        guard let firstResponder = targetWindow?.firstResponder,
+              cmuxOwningGhosttyView(for: firstResponder) != nil else {
+            return false
+        }
+        return browserZoomShortcutAction(
+            flags: event.modifierFlags,
+            chars: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode,
+            literalChars: event.characters
+        ) != nil
+    }
+
+    private func shortcutEventTabManager(_ event: NSEvent) -> TabManager? {
+        preferredMainWindowContextForShortcutRouting(event: event)?.tabManager ?? tabManager
     }
 
 #if DEBUG

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6755,27 +6755,24 @@ struct ContentView: View {
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomIn",
                 title: constant(String(localized: "command.browserZoomIn.title", defaultValue: "Zoom In")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "in"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "in", "browser", "markdown", "text"]
             )
         )
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomOut",
                 title: constant(String(localized: "command.browserZoomOut.title", defaultValue: "Zoom Out")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "out"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "out", "browser", "markdown", "text"]
             )
         )
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.browserZoomReset",
                 title: constant(String(localized: "command.browserZoomReset.title", defaultValue: "Actual Size")),
-                subtitle: browserPanelSubtitle,
-                keywords: ["browser", "zoom", "reset", "actual size"],
-                when: { $0.bool(CommandPaletteContextKeys.panelIsBrowser) }
+                subtitle: panelSubtitle,
+                keywords: ["view", "zoom", "reset", "actual size", "browser", "markdown", "text"]
             )
         )
         contributions.append(
@@ -7438,17 +7435,17 @@ struct ContentView: View {
             }
         }
         registry.register(commandId: "palette.browserZoomIn") {
-            if !tabManager.zoomInFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.zoomIn) {
                 NSSound.beep()
             }
         }
         registry.register(commandId: "palette.browserZoomOut") {
-            if !tabManager.zoomOutFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.zoomOut) {
                 NSSound.beep()
             }
         }
         registry.register(commandId: "palette.browserZoomReset") {
-            if !tabManager.resetZoomFocusedBrowser() {
+            if !tabManager.performViewZoomCommand(.reset) {
                 NSSound.beep()
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1462,6 +1462,7 @@ struct ContentView: View {
         static let panelName = "panel.name"
         static let panelIsBrowser = "panel.isBrowser"
         static let panelIsTerminal = "panel.isTerminal"
+        static let panelSupportsViewZoom = "panel.supportsViewZoom"
         static let panelHasPane = "panel.hasPane"
         static let panelHasCustomName = "panel.hasCustomName"
         static let panelShouldPin = "panel.shouldPin"
@@ -6046,10 +6047,15 @@ struct ContentView: View {
             let workspace = panelContext.workspace
             let panelId = panelContext.panelId
             let panelIsTerminal = panelContext.panel.panelType == .terminal
+            let panelSupportsViewZoom =
+                panelContext.panel is BrowserPanel ||
+                panelContext.panel is MarkdownPanel ||
+                ((panelContext.panel as? FilePreviewPanel)?.previewMode == .text)
             snapshot.setBool(CommandPaletteContextKeys.hasFocusedPanel, true)
             snapshot.setString(CommandPaletteContextKeys.panelName, panelDisplayName(workspace: workspace, panelId: panelId, fallback: panelContext.panel.displayTitle))
             snapshot.setBool(CommandPaletteContextKeys.panelIsBrowser, panelContext.panel.panelType == .browser)
             snapshot.setBool(CommandPaletteContextKeys.panelIsTerminal, panelIsTerminal)
+            snapshot.setBool(CommandPaletteContextKeys.panelSupportsViewZoom, panelSupportsViewZoom)
             snapshot.setBool(CommandPaletteContextKeys.panelHasPane, workspace.paneId(forPanelId: panelId) != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelHasCustomName, workspace.panelCustomTitles[panelId] != nil)
             snapshot.setBool(CommandPaletteContextKeys.panelShouldPin, !workspace.isPanelPinned(panelId))
@@ -6756,7 +6762,8 @@ struct ContentView: View {
                 commandId: "palette.browserZoomIn",
                 title: constant(String(localized: "command.browserZoomIn.title", defaultValue: "Zoom In")),
                 subtitle: panelSubtitle,
-                keywords: ["view", "zoom", "in", "browser", "markdown", "text"]
+                keywords: ["view", "zoom", "in", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(
@@ -6764,7 +6771,8 @@ struct ContentView: View {
                 commandId: "palette.browserZoomOut",
                 title: constant(String(localized: "command.browserZoomOut.title", defaultValue: "Zoom Out")),
                 subtitle: panelSubtitle,
-                keywords: ["view", "zoom", "out", "browser", "markdown", "text"]
+                keywords: ["view", "zoom", "out", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(
@@ -6772,7 +6780,8 @@ struct ContentView: View {
                 commandId: "palette.browserZoomReset",
                 title: constant(String(localized: "command.browserZoomReset.title", defaultValue: "Actual Size")),
                 subtitle: panelSubtitle,
-                keywords: ["view", "zoom", "reset", "actual size", "browser", "markdown", "text"]
+                keywords: ["view", "zoom", "reset", "actual size", "browser", "markdown", "text"],
+                when: { $0.bool(CommandPaletteContextKeys.panelSupportsViewZoom) }
             )
         )
         contributions.append(

--- a/Sources/KeyboardShortcutContext.swift
+++ b/Sources/KeyboardShortcutContext.swift
@@ -53,8 +53,7 @@ extension KeyboardShortcutSettings.Action {
             return .rightSidebarFocus
         case .renameTab, .renameWorkspace:
             return .nonBrowserPanel
-        case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole,
-             .browserZoomIn, .browserZoomOut, .browserZoomReset:
+        case .browserBack, .browserForward, .browserReload, .toggleBrowserDeveloperTools, .showBrowserJavaScriptConsole:
             return .browserPanel
         default:
             return .application

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -1867,7 +1867,7 @@ final class BrowserPortalAnchorView: NSView {
 }
 
 @MainActor
-final class BrowserPanel: Panel, ObservableObject {
+final class BrowserPanel: Panel, ObservableObject, ViewZoomControlling {
     /// Shared process pool for cookie sharing across all browser panels
     private static let sharedProcessPool = WKProcessPool()
 
@@ -5123,6 +5123,27 @@ extension BrowserPanel {
     func setPageZoomFactor(_ pageZoom: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, pageZoom))
         return applyPageZoom(clamped)
+    }
+
+    var viewZoomFactor: CGFloat {
+        currentPageZoomFactor()
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        setPageZoomFactor(ViewZoomControl.normalized(factor))
+    }
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        switch command {
+        case .zoomIn:
+            return zoomIn()
+        case .zoomOut:
+            return zoomOut()
+        case .reset:
+            return resetZoom()
+        }
     }
 
     /// Take a snapshot of the web view

--- a/Sources/Panels/FilePreviewMagnifyingPDFView.swift
+++ b/Sources/Panels/FilePreviewMagnifyingPDFView.swift
@@ -35,7 +35,7 @@ final class FilePreviewMagnifyingPDFView: PDFView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if let command = viewZoomCommand(for: event), let onViewZoomCommand {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
             onViewZoomCommand(command)
             return true
         }
@@ -83,7 +83,4 @@ final class FilePreviewMagnifyingPDFView: PDFView {
         }
     }
 
-    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
-        ViewZoomControl.command(for: event)
-    }
 }

--- a/Sources/Panels/FilePreviewMagnifyingPDFView.swift
+++ b/Sources/Panels/FilePreviewMagnifyingPDFView.swift
@@ -9,6 +9,7 @@ final class FilePreviewMagnifyingPDFView: PDFView {
     var onRotate: ((NSEvent) -> Void)?
     var onSwipe: ((NSEvent) -> Void)?
     var onFocusChanged: ((Bool) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
 
     override var acceptsFirstResponder: Bool { true }
 
@@ -31,6 +32,14 @@ final class FilePreviewMagnifyingPDFView: PDFView {
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         super.mouseDown(with: event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = viewZoomCommand(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 
     override func magnify(with event: NSEvent) {
@@ -72,5 +81,9 @@ final class FilePreviewMagnifyingPDFView: PDFView {
         } else {
             super.swipe(with: event)
         }
+    }
+
+    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
+        ViewZoomControl.command(for: event)
     }
 }

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -1202,7 +1202,7 @@ struct FilePreviewPanelView: View {
                         get: { panel.viewZoomFactor },
                         set: { panel.setViewZoomFactor($0) }
                     ),
-                    isDisabled: panel.isFileUnavailable
+                    isDisabled: panel.isFileUnavailable || panel.previewMode != .text
                 )
             }
 
@@ -3563,10 +3563,6 @@ private final class FilePreviewImageContainerView: NSView {
         }
     }
 
-    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
-        ViewZoomControl.command(for: event)
-    }
-
     @objc private func rotateLeft() {
         rotateImage(by: -90)
     }
@@ -3781,7 +3777,7 @@ private final class FilePreviewImageScrollView: NSScrollView {
     }
 
     override func performKeyEquivalent(with event: NSEvent) -> Bool {
-        if let command = viewZoomCommand(for: event), let onViewZoomCommand {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
             onViewZoomCommand(command)
             return true
         }
@@ -3879,9 +3875,6 @@ private final class FilePreviewImageScrollView: NSScrollView {
         }
     }
 
-    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
-        ViewZoomControl.command(for: event)
-    }
 }
 
 private final class FilePreviewImageDocumentView: NSView {

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -830,7 +830,7 @@ enum FilePreviewTextSaver {
 }
 
 @MainActor
-final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPanel {
+final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPanel, ViewZoomControlling {
     let id: UUID
     let panelType: PanelType = .filePreview
     let filePath: String
@@ -843,6 +843,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     @Published private(set) var isSaving = false
     @Published private(set) var focusFlashToken = 0
     @Published private(set) var previewMode: FilePreviewMode
+    @Published private(set) var viewZoomFactor: CGFloat = ViewZoomControl.defaultFactor
 
     private var originalTextContent = ""
     private var textEncoding: String.Encoding = .utf8
@@ -926,6 +927,21 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
 
     func noteFilePreviewFocusIntent(_ intent: FilePreviewPanelFocusIntent) {
         focusCoordinator.notePreferredIntent(intent)
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        guard previewMode == .text else { return false }
+        let normalized = ViewZoomControl.normalized(factor)
+        guard abs(viewZoomFactor - normalized) > 0.0001 else { return false }
+        viewZoomFactor = normalized
+        return true
+    }
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        guard previewMode == .text else { return false }
+        return setViewZoomFactor(ViewZoomControl.applying(command, to: viewZoomFactor))
     }
 
     func currentFilePreviewFocusIntent(in window: NSWindow?) -> FilePreviewPanelFocusIntent? {
@@ -1179,6 +1195,14 @@ struct FilePreviewPanelView: View {
                     label: String(localized: "filePreview.save", defaultValue: "Save"),
                     isDisabled: !panel.isDirty || panel.isSaving,
                     action: { panel.saveTextContent() }
+                )
+
+                PanelHeaderViewZoomButton(
+                    zoomFactor: Binding(
+                        get: { panel.viewZoomFactor },
+                        set: { panel.setViewZoomFactor($0) }
+                    ),
+                    isDisabled: panel.isFileUnavailable
                 )
             }
 
@@ -1981,6 +2005,7 @@ final class FilePreviewPDFThumbnailSidebarView: NSView, NSCollectionViewDataSour
 
 private final class FilePreviewPDFOutlineView: NSOutlineView {
     var onFocusChanged: ((Bool) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
 
     override var acceptsFirstResponder: Bool { true }
     override var canBecomeKeyView: Bool { true }
@@ -2004,6 +2029,14 @@ private final class FilePreviewPDFOutlineView: NSOutlineView {
     override func mouseDown(with event: NSEvent) {
         window?.makeFirstResponder(self)
         super.mouseDown(with: event)
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = ViewZoomControl.command(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 }
 
@@ -2311,6 +2344,9 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
         pdfView.onSmartMagnify = { [weak self] in
             self?.togglePDFSmartZoom()
         }
+        pdfView.onViewZoomCommand = { [weak self] command in
+            self?.performPDFViewZoomCommand(command)
+        }
         pdfView.onRotate = { [weak self] event in
             self?.rotatePDF(with: event)
         }
@@ -2379,6 +2415,9 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
         outlineView.delegate = self
         outlineView.onFocusChanged = { [weak self] isActive in
             self?.setActivePDFRegion(isActive ? .pdfOutline : nil)
+        }
+        outlineView.onViewZoomCommand = { [weak self] command in
+            self?.performPDFViewZoomCommand(command)
         }
         outlineView.translatesAutoresizingMaskIntoConstraints = false
 
@@ -2533,6 +2572,17 @@ final class FilePreviewPDFContainerView: NSView, NSSplitViewDelegate, NSOutlineV
     @objc private func actualSize() {
         pdfView.autoScales = false
         setPDFScaleFactor(1.0, preservingVisibleCenter: true)
+    }
+
+    private func performPDFViewZoomCommand(_ command: ViewZoomCommand) {
+        switch command {
+        case .zoomIn:
+            zoomIn()
+        case .zoomOut:
+            zoomOut()
+        case .reset:
+            actualSize()
+        }
     }
 
     @objc private func rotateLeft() {
@@ -3448,6 +3498,9 @@ private final class FilePreviewImageContainerView: NSView {
         scrollView.onSmartMagnify = { [weak self] event in
             self?.toggleImageSmartZoom(with: event)
         }
+        scrollView.onViewZoomCommand = { [weak self] command in
+            self?.performImageViewZoomCommand(command)
+        }
         scrollView.onRotate = { [weak self] event in
             self?.rotateImage(with: event)
         }
@@ -3497,6 +3550,21 @@ private final class FilePreviewImageContainerView: NSView {
     @objc private func actualSize() {
         isFitMode = false
         setImageScale(1.0, preservingVisibleCenter: true)
+    }
+
+    private func performImageViewZoomCommand(_ command: ViewZoomCommand) {
+        switch command {
+        case .zoomIn:
+            zoomIn()
+        case .zoomOut:
+            zoomOut()
+        case .reset:
+            actualSize()
+        }
+    }
+
+    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
+        ViewZoomControl.command(for: event)
     }
 
     @objc private func rotateLeft() {
@@ -3696,6 +3764,7 @@ private final class FilePreviewImageScrollView: NSScrollView {
     var onMagnify: ((NSEvent) -> Void)?
     var onScrollZoom: ((NSEvent) -> Void)?
     var onSmartMagnify: ((NSEvent) -> Void)?
+    var onViewZoomCommand: ((ViewZoomCommand) -> Void)?
     var onRotate: ((NSEvent) -> Void)?
     private var panStartClipPoint: CGPoint?
     private var panStartDocumentOrigin: CGPoint?
@@ -3709,6 +3778,14 @@ private final class FilePreviewImageScrollView: NSScrollView {
         } else {
             super.magnify(with: event)
         }
+    }
+
+    override func performKeyEquivalent(with event: NSEvent) -> Bool {
+        if let command = viewZoomCommand(for: event), let onViewZoomCommand {
+            onViewZoomCommand(command)
+            return true
+        }
+        return super.performKeyEquivalent(with: event)
     }
 
     override func scrollWheel(with event: NSEvent) {
@@ -3800,6 +3877,10 @@ private final class FilePreviewImageScrollView: NSScrollView {
             NSCursor.pop()
             hasPushedPanCursor = false
         }
+    }
+
+    private func viewZoomCommand(for event: NSEvent) -> ViewZoomCommand? {
+        ViewZoomControl.command(for: event)
     }
 }
 

--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -160,7 +160,7 @@ final class SavingTextView: NSTextView {
         guard event.type == .keyDown else {
             return super.performKeyEquivalent(with: event)
         }
-        if let zoomCommand = viewZoomShortcutCommand(for: event) {
+        if let zoomCommand = ViewZoomControl.command(for: event) {
             guard let panel else { return false }
             panel.performViewZoomCommand(zoomCommand)
             applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
@@ -220,10 +220,6 @@ final class SavingTextView: NSTextView {
     private static func clampedFontSize(_ fontSize: CGFloat) -> CGFloat {
         guard fontSize.isFinite else { return ViewZoomControl.textEditorDefaultFontSize }
         return min(max(fontSize, minimumPreviewFontSize), maximumPreviewFontSize)
-    }
-
-    private func viewZoomShortcutCommand(for event: NSEvent) -> ViewZoomCommand? {
-        ViewZoomControl.command(for: event)
     }
 
     private func saveShortcutMatch(for event: NSEvent) -> Bool? {

--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -141,9 +141,6 @@ extension NSTextView {
 }
 
 final class SavingTextView: NSTextView {
-    private static let minimumPreviewFontSize: CGFloat = 8
-    private static let maximumPreviewFontSize: CGFloat = 36
-
     weak var panel: (any FilePreviewTextEditingPanel)?
     private var previewFontSize: CGFloat = ViewZoomControl.textEditorDefaultFontSize
     private var pendingSaveShortcutChordPrefix: ShortcutStroke?
@@ -219,7 +216,7 @@ final class SavingTextView: NSTextView {
 
     private static func clampedFontSize(_ fontSize: CGFloat) -> CGFloat {
         guard fontSize.isFinite else { return ViewZoomControl.textEditorDefaultFontSize }
-        return min(max(fontSize, minimumPreviewFontSize), maximumPreviewFontSize)
+        return ViewZoomControl.textEditorFontSize(for: ViewZoomControl.textEditorZoomFactor(forFontSize: fontSize))
     }
 
     private func saveShortcutMatch(for event: NSEvent) -> Bool? {

--- a/Sources/Panels/FilePreviewTextEditor.swift
+++ b/Sources/Panels/FilePreviewTextEditor.swift
@@ -4,10 +4,15 @@ import SwiftUI
 @MainActor
 protocol FilePreviewTextEditingPanel: AnyObject {
     var textContent: String { get }
+    var viewZoomFactor: CGFloat { get }
 
     func attachTextView(_ textView: NSTextView)
     func retryPendingFocus()
     func updateTextContent(_ nextContent: String)
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool
     @discardableResult
     func saveTextContent() -> Task<Void, Never>?
 }
@@ -41,7 +46,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         textView.importsGraphics = false
         textView.usesFindPanel = true
         textView.usesFontPanel = false
-        textView.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        textView.applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
         textView.drawsBackground = false
         textView.minSize = NSSize(width: 0, height: 0)
         textView.maxSize = NSSize(width: CGFloat.greatestFiniteMagnitude, height: CGFloat.greatestFiniteMagnitude)
@@ -69,6 +74,7 @@ struct FilePreviewTextEditor<PanelModel>: NSViewRepresentable where PanelModel: 
         guard let textView = scrollView.documentView as? SavingTextView else { return }
         textView.panel = panel
         textView.applyFilePreviewTextEditorInsets()
+        textView.applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
         panel.attachTextView(textView)
         guard textView.string != panel.textContent else { return }
         context.coordinator.isApplyingPanelUpdate = true
@@ -135,12 +141,11 @@ extension NSTextView {
 }
 
 final class SavingTextView: NSTextView {
-    private static let defaultPreviewFontSize: CGFloat = 13
     private static let minimumPreviewFontSize: CGFloat = 8
     private static let maximumPreviewFontSize: CGFloat = 36
 
     weak var panel: (any FilePreviewTextEditingPanel)?
-    private var previewFontSize: CGFloat = 13
+    private var previewFontSize: CGFloat = ViewZoomControl.textEditorDefaultFontSize
     private var pendingSaveShortcutChordPrefix: ShortcutStroke?
 
     deinit {}
@@ -155,6 +160,13 @@ final class SavingTextView: NSTextView {
         guard event.type == .keyDown else {
             return super.performKeyEquivalent(with: event)
         }
+        if let zoomCommand = viewZoomShortcutCommand(for: event) {
+            guard let panel else { return false }
+            panel.performViewZoomCommand(zoomCommand)
+            applyPreviewFontSize(ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor))
+            return true
+        }
+
         guard let shouldSave = saveShortcutMatch(for: event) else {
             return super.performKeyEquivalent(with: event)
         }
@@ -179,11 +191,20 @@ final class SavingTextView: NSTextView {
     }
 
     override func smartMagnify(with event: NSEvent) {
-        if previewFontSize == Self.defaultPreviewFontSize {
+        if previewFontSize == ViewZoomControl.textEditorDefaultFontSize {
             setPreviewFontSize(18)
         } else {
-            setPreviewFontSize(Self.defaultPreviewFontSize)
+            setPreviewFontSize(ViewZoomControl.textEditorDefaultFontSize)
         }
+    }
+
+    func applyPreviewFontSize(_ nextFontSize: CGFloat) {
+        let clamped = Self.clampedFontSize(nextFontSize)
+        guard abs(previewFontSize - clamped) > 0.001 || font?.pointSize != clamped else { return }
+        previewFontSize = clamped
+        let nextFont = NSFont.monospacedSystemFont(ofSize: clamped, weight: .regular)
+        font = nextFont
+        typingAttributes[.font] = nextFont
     }
 
     private func adjustPreviewFontSize(by factor: CGFloat) {
@@ -191,12 +212,18 @@ final class SavingTextView: NSTextView {
     }
 
     private func setPreviewFontSize(_ nextFontSize: CGFloat) {
-        let clamped = min(max(nextFontSize, Self.minimumPreviewFontSize), Self.maximumPreviewFontSize)
-        guard clamped.isFinite else { return }
-        previewFontSize = clamped
-        let nextFont = NSFont.monospacedSystemFont(ofSize: clamped, weight: .regular)
-        font = nextFont
-        typingAttributes[.font] = nextFont
+        let clamped = Self.clampedFontSize(nextFontSize)
+        panel?.setViewZoomFactor(ViewZoomControl.textEditorZoomFactor(forFontSize: clamped))
+        applyPreviewFontSize(clamped)
+    }
+
+    private static func clampedFontSize(_ fontSize: CGFloat) -> CGFloat {
+        guard fontSize.isFinite else { return ViewZoomControl.textEditorDefaultFontSize }
+        return min(max(fontSize, minimumPreviewFontSize), maximumPreviewFontSize)
+    }
+
+    private func viewZoomShortcutCommand(for event: NSEvent) -> ViewZoomCommand? {
+        ViewZoomControl.command(for: event)
     }
 
     private func saveShortcutMatch(for event: NSEvent) -> Bool? {

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -12,7 +12,7 @@ enum MarkdownPanelDisplayMode: String, CaseIterable, Identifiable {
 /// A panel that renders a markdown file with live file-watching.
 /// When the file changes on disk, the content is automatically reloaded.
 @MainActor
-final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel {
+final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel, ViewZoomControlling {
     let id: UUID
     let panelType: PanelType = .markdown
 
@@ -48,6 +48,9 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     /// Token incremented to trigger focus flash animation.
     @Published private(set) var focusFlashToken: Int = 0
+
+    /// Per-panel view zoom used by both rendered preview and TextEdit mode.
+    @Published private(set) var viewZoomFactor: CGFloat = ViewZoomControl.defaultFactor
 
     // MARK: - File watching
 
@@ -108,6 +111,14 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         if mode == .text {
             focus()
         }
+    }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool {
+        let normalized = ViewZoomControl.normalized(factor)
+        guard abs(viewZoomFactor - normalized) > 0.0001 else { return false }
+        viewZoomFactor = normalized
+        return true
     }
 
     func attachTextView(_ textView: NSTextView) {

--- a/Sources/Panels/MarkdownPanelView.swift
+++ b/Sources/Panels/MarkdownPanelView.swift
@@ -98,6 +98,7 @@ struct MarkdownPanelView: View {
                     backgroundColor: themeBackgroundColor,
                     typography: markdownTypography
                 ),
+                zoomFactor: panel.viewZoomFactor,
                 panelId: panel.id,
                 workspaceId: panel.workspaceId,
                 filePath: panel.filePath,
@@ -143,6 +144,13 @@ struct MarkdownPanelView: View {
                 )
             }
             markdownModeButton
+            PanelHeaderViewZoomButton(
+                zoomFactor: Binding(
+                    get: { panel.viewZoomFactor },
+                    set: { panel.setViewZoomFactor($0) }
+                ),
+                isDisabled: panel.isFileUnavailable
+            )
             MarkdownPanelToolbar(
                 confirmation: copyConfirmation?.label,
                 onCopyMarkdown: { copyAsMarkdown() },

--- a/Sources/Panels/MarkdownWebRenderer.swift
+++ b/Sources/Panels/MarkdownWebRenderer.swift
@@ -56,6 +56,7 @@ struct MarkdownWebTheme: Equatable {
 struct MarkdownWebRenderer: NSViewRepresentable {
     let markdown: String
     let theme: MarkdownWebTheme
+    let zoomFactor: CGFloat
     let panelId: UUID
     let workspaceId: UUID
     let filePath: String
@@ -93,6 +94,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
 #endif
         }
         applyAppearance(to: webView, isDark: theme.isDark)
+        applyZoom(to: webView)
 
         context.coordinator.webView = webView
         context.coordinator.loadShell(theme: theme, initialMarkdown: markdown)
@@ -108,6 +110,7 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         context.coordinator.filePath = filePath
         (nsView as? MarkdownWebView)?.onPointerDown = onRequestPanelFocus
         applyAppearance(to: nsView, isDark: theme.isDark)
+        applyZoom(to: nsView)
         context.coordinator.update(markdown: markdown, theme: theme)
     }
 
@@ -128,6 +131,13 @@ struct MarkdownWebRenderer: NSViewRepresentable {
         let appearance = NSAppearance(named: isDark ? .darkAqua : .aqua)
         if webView.appearance !== appearance {
             webView.appearance = appearance
+        }
+    }
+
+    private func applyZoom(to webView: WKWebView) {
+        let normalized = ViewZoomControl.normalized(zoomFactor)
+        if abs(webView.pageZoom - normalized) > 0.0001 {
+            webView.pageZoom = normalized
         }
     }
 

--- a/Sources/Panels/PanelContentView.swift
+++ b/Sources/Panels/PanelContentView.swift
@@ -168,3 +168,92 @@ struct PanelHeaderIconGlyph: View {
             .contentShape(Rectangle())
     }
 }
+
+struct PanelHeaderViewZoomButton: View {
+    @Binding var zoomFactor: CGFloat
+    var isDisabled = false
+
+    @State private var isPresented = false
+
+    private var title: String {
+        String(localized: "view.zoom.controls", defaultValue: "View Zoom")
+    }
+
+    var body: some View {
+        Button {
+            isPresented.toggle()
+        } label: {
+            PanelHeaderIconGlyph(systemName: "textformat.size")
+        }
+        .buttonStyle(.plain)
+        .foregroundColor(.secondary)
+        .disabled(isDisabled)
+        .help(title)
+        .accessibilityLabel(title)
+        .popover(isPresented: $isPresented, arrowEdge: .bottom) {
+            popoverContent
+        }
+    }
+
+    private var popoverContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Spacer()
+                Text(ViewZoomControl.percentText(for: zoomFactor))
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+
+            HStack(spacing: 8) {
+                zoomButton(
+                    systemName: "minus",
+                    label: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"),
+                    action: { apply(.zoomOut) }
+                )
+                Button {
+                    apply(.reset)
+                } label: {
+                    Text(ViewZoomControl.percentText(for: ViewZoomControl.defaultFactor))
+                        .font(.system(size: 12, weight: .medium, design: .monospaced))
+                        .frame(width: 58, height: 26)
+                }
+                .buttonStyle(.bordered)
+                .help(String(localized: "menu.view.actualSize", defaultValue: "Actual Size"))
+                .accessibilityLabel(String(localized: "menu.view.actualSize", defaultValue: "Actual Size"))
+
+                zoomButton(
+                    systemName: "plus",
+                    label: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"),
+                    action: { apply(.zoomIn) }
+                )
+            }
+
+            Slider(
+                value: Binding(
+                    get: { Double(ViewZoomControl.normalized(zoomFactor)) },
+                    set: { zoomFactor = ViewZoomControl.normalized(CGFloat($0)) }
+                ),
+                in: Double(ViewZoomControl.minimumFactor)...Double(ViewZoomControl.maximumFactor)
+            )
+        }
+        .padding(14)
+        .frame(width: 220)
+    }
+
+    private func zoomButton(systemName: String, label: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemName)
+                .font(.system(size: 12, weight: .semibold))
+                .frame(width: 26, height: 26)
+        }
+        .buttonStyle(.bordered)
+        .help(label)
+        .accessibilityLabel(label)
+    }
+
+    private func apply(_ command: ViewZoomCommand) {
+        zoomFactor = ViewZoomControl.applying(command, to: zoomFactor)
+    }
+}

--- a/Sources/Panels/ViewZoomControls.swift
+++ b/Sources/Panels/ViewZoomControls.swift
@@ -1,0 +1,93 @@
+import AppKit
+import Foundation
+
+enum ViewZoomCommand: Equatable {
+    case zoomIn
+    case zoomOut
+    case reset
+}
+
+enum ViewZoomControl {
+    static let defaultFactor: CGFloat = 1.0
+    static let step: CGFloat = 0.10
+    static let minimumFactor: CGFloat = 0.50
+    static let maximumFactor: CGFloat = 3.00
+
+    static func normalized(_ factor: CGFloat) -> CGFloat {
+        guard factor.isFinite else { return defaultFactor }
+        return min(max(factor, minimumFactor), maximumFactor)
+    }
+
+    static func applying(_ command: ViewZoomCommand, to factor: CGFloat) -> CGFloat {
+        switch command {
+        case .zoomIn:
+            return normalized(factor + step)
+        case .zoomOut:
+            return normalized(factor - step)
+        case .reset:
+            return defaultFactor
+        }
+    }
+
+    static func percentText(for factor: CGFloat) -> String {
+        "\(Int((normalized(factor) * 100).rounded()))%"
+    }
+
+    static func textEditorFontSize(for factor: CGFloat) -> CGFloat {
+        normalized(factor) * textEditorDefaultFontSize
+    }
+
+    static func textEditorZoomFactor(forFontSize fontSize: CGFloat) -> CGFloat {
+        normalized(fontSize / textEditorDefaultFontSize)
+    }
+
+    static func command(for event: NSEvent) -> ViewZoomCommand? {
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomIn).matches(event: event) {
+            return .zoomIn
+        }
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomOut).matches(event: event) {
+            return .zoomOut
+        }
+        if KeyboardShortcutSettings.shortcut(for: .browserZoomReset).matches(event: event) {
+            return .reset
+        }
+
+        let defaultAction = browserZoomShortcutAction(
+            flags: event.modifierFlags,
+            chars: event.charactersIgnoringModifiers ?? "",
+            keyCode: event.keyCode,
+            literalChars: event.characters
+        )
+
+        switch defaultAction {
+        case .zoomIn where KeyboardShortcutSettings.shortcut(for: .browserZoomIn) == KeyboardShortcutSettings.Action.browserZoomIn.defaultShortcut:
+            return .zoomIn
+        case .zoomOut where KeyboardShortcutSettings.shortcut(for: .browserZoomOut) == KeyboardShortcutSettings.Action.browserZoomOut.defaultShortcut:
+            return .zoomOut
+        case .reset where KeyboardShortcutSettings.shortcut(for: .browserZoomReset) == KeyboardShortcutSettings.Action.browserZoomReset.defaultShortcut:
+            return .reset
+        default:
+            return nil
+        }
+    }
+
+    static let textEditorDefaultFontSize: CGFloat = 13
+}
+
+@MainActor
+protocol ViewZoomControlling: AnyObject {
+    var viewZoomFactor: CGFloat { get }
+
+    @discardableResult
+    func setViewZoomFactor(_ factor: CGFloat) -> Bool
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool
+}
+
+extension ViewZoomControlling {
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        setViewZoomFactor(ViewZoomControl.applying(command, to: viewZoomFactor))
+    }
+}

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4845,6 +4845,12 @@ class TabManager: ObservableObject {
         return tab.panels[panelId] as? BrowserPanel
     }
 
+    var focusedPanel: (any Panel)? {
+        guard let tab = selectedWorkspace,
+              let panelId = tab.focusedPanelId else { return nil }
+        return tab.panels[panelId]
+    }
+
     @discardableResult
     func zoomInFocusedBrowser() -> Bool {
         focusedBrowserPanel?.zoomIn() ?? false
@@ -4858,6 +4864,14 @@ class TabManager: ObservableObject {
     @discardableResult
     func resetZoomFocusedBrowser() -> Bool {
         focusedBrowserPanel?.resetZoom() ?? false
+    }
+
+    @discardableResult
+    func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
+        guard let controller = focusedPanel as? any ViewZoomControlling else {
+            return false
+        }
+        return controller.performViewZoomCommand(command)
     }
 
     @discardableResult

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -4852,21 +4852,6 @@ class TabManager: ObservableObject {
     }
 
     @discardableResult
-    func zoomInFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.zoomIn() ?? false
-    }
-
-    @discardableResult
-    func zoomOutFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.zoomOut() ?? false
-    }
-
-    @discardableResult
-    func resetZoomFocusedBrowser() -> Bool {
-        focusedBrowserPanel?.resetZoom() ?? false
-    }
-
-    @discardableResult
     func performViewZoomCommand(_ command: ViewZoomCommand) -> Bool {
         guard let controller = focusedPanel as? any ViewZoomControlling else {
             return false

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -700,15 +700,15 @@ struct cmuxApp: App {
             }
 
             splitCommandButton(title: String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"), shortcut: menuShortcut(for: .browserZoomIn)) {
-                _ = activeTabManager.zoomInFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.zoomIn)
             }
 
             splitCommandButton(title: String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"), shortcut: menuShortcut(for: .browserZoomOut)) {
-                _ = activeTabManager.zoomOutFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.zoomOut)
             }
 
             splitCommandButton(title: String(localized: "menu.view.actualSize", defaultValue: "Actual Size"), shortcut: menuShortcut(for: .browserZoomReset)) {
-                _ = activeTabManager.resetZoomFocusedBrowser()
+                _ = activeTabManager.performViewZoomCommand(.reset)
             }
 
             Button(String(localized: "menu.view.clearBrowserHistory", defaultValue: "Clear Browser History")) {

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 import Combine
 import AppKit
+import Carbon.HIToolbox
 import SwiftUI
 import UniformTypeIdentifiers
 import WebKit
@@ -3128,6 +3129,28 @@ final class BrowserZoomShortcutActionTests: XCTestCase {
             browserZoomShortcutAction(flags: [.command], chars: "0", keyCode: 29),
             .reset
         )
+    }
+
+    @MainActor
+    func testViewZoomCommandRespectsUnboundZoomShortcut() throws {
+        KeyboardShortcutSettings.resetAll()
+        defer { KeyboardShortcutSettings.resetAll() }
+        KeyboardShortcutSettings.clearShortcut(for: .browserZoomIn)
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+
+        XCTAssertNil(ViewZoomControl.command(for: event))
     }
 }
 

--- a/cmuxTests/KeyboardShortcutContextTests.swift
+++ b/cmuxTests/KeyboardShortcutContextTests.swift
@@ -141,6 +141,12 @@ final class KeyboardShortcutContextTests: XCTestCase {
         XCTAssertEqual(KeyboardShortcutSettings.Action.toggleReactGrab.shortcutContext, .application)
     }
 
+    func testViewZoomShortcutsAreApplicationScoped() {
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomIn.shortcutContext, .application)
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomOut.shortcutContext, .application)
+        XCTAssertEqual(KeyboardShortcutSettings.Action.browserZoomReset.shortcutContext, .application)
+    }
+
     func testShortcutSettingsFilePreservesConfiguredShortcutWithoutGlobalConflictLookup() throws {
         let directoryURL = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: directoryURL) }

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2359,6 +2359,54 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor), accuracy: 0.001)
     }
 
+    func testSavingTextViewFontSizeTracksViewZoomBounds() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        let textView = SavingTextView()
+        textView.panel = panel
+        panel.attachTextView(textView)
+
+        let zoomOutEvent = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "-",
+            charactersIgnoringModifiers: "-",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Minus)
+        ))
+        for _ in 0..<10 {
+            XCTAssertTrue(textView.performKeyEquivalent(with: zoomOutEvent))
+        }
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.minimumFactor, accuracy: 0.001)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: ViewZoomControl.minimumFactor), accuracy: 0.001)
+
+        let zoomInEvent = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+        for _ in 0..<40 {
+            XCTAssertTrue(textView.performKeyEquivalent(with: zoomInEvent))
+        }
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.maximumFactor, accuracy: 0.001)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: ViewZoomControl.maximumFactor), accuracy: 0.001)
+    }
+
     func testFilePreviewViewZoomOnlyHandlesTextMode() async throws {
         let url = try temporaryTextFile(contents: "original", encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: url) }

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2330,6 +2330,69 @@ final class FilePreviewPanelTextSavingTests: XCTestCase {
         XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "original")
     }
 
+    func testSavingTextViewHandlesCommandPlusViewZoom() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        let textView = SavingTextView()
+        textView.panel = panel
+        panel.attachTextView(textView)
+
+        let event = try XCTUnwrap(NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [.command, .shift],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: 0,
+            context: nil,
+            characters: "+",
+            charactersIgnoringModifiers: "=",
+            isARepeat: false,
+            keyCode: UInt16(kVK_ANSI_Equal)
+        ))
+
+        XCTAssertTrue(textView.performKeyEquivalent(with: event))
+        XCTAssertGreaterThan(panel.viewZoomFactor, ViewZoomControl.defaultFactor)
+        XCTAssertEqual(textView.font?.pointSize ?? 0, ViewZoomControl.textEditorFontSize(for: panel.viewZoomFactor), accuracy: 0.001)
+    }
+
+    func testFilePreviewViewZoomOnlyHandlesTextMode() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(workspaceId: UUID(), filePath: url.path)
+        await panel.loadTextContent().value
+
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomIn))
+        XCTAssertEqual(panel.viewZoomFactor, 1.1, accuracy: 0.001)
+        XCTAssertTrue(panel.performViewZoomCommand(.reset))
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.defaultFactor, accuracy: 0.001)
+
+        let imageURL = url.deletingLastPathComponent().appendingPathComponent("image.png")
+        let imagePanel = FilePreviewPanel(workspaceId: UUID(), filePath: imageURL.path)
+        XCTAssertFalse(imagePanel.performViewZoomCommand(.zoomIn))
+    }
+
+    func testMarkdownPanelViewZoomPersistsAcrossPreviewAndTextModes() throws {
+        let url = try temporaryTextFile(contents: "# Title", encoding: .utf8, pathExtension: "md")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: url.path)
+        defer { panel.close() }
+
+        XCTAssertEqual(panel.displayMode, .preview)
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomIn))
+        XCTAssertEqual(panel.viewZoomFactor, 1.1, accuracy: 0.001)
+
+        panel.setDisplayMode(.text)
+        XCTAssertEqual(panel.displayMode, .text)
+        XCTAssertTrue(panel.performViewZoomCommand(.zoomOut))
+        XCTAssertEqual(panel.viewZoomFactor, ViewZoomControl.defaultFactor, accuracy: 0.001)
+    }
+
     func testSaveTextContentPreservesLoadedEncoding() async throws {
         let url = try temporaryTextFile(contents: "original", encoding: .utf16)
         defer { try? FileManager.default.removeItem(at: url) }


### PR DESCRIPTION
## Summary

Adds shared View Zoom support across file surfaces.

- Routes Cmd+Plus, Cmd+Minus, and Cmd+0 through a shared View Zoom action.
- Adds a filename-toolbar View Zoom popover with percentage, step buttons, reset, and slider.
- Applies zoom to markdown preview, markdown TextEdit, plain text previews, browser panels, and AppKit PDF/image preview responders where applicable.
- Keeps terminal default zoom chords handled by Ghostty when a terminal has focus.

## Acceptance criteria

- Cmd+Plus increases zoom on supported non-terminal surfaces.
- Cmd+Minus decreases zoom on supported non-terminal surfaces.
- Cmd+0 resets zoom to actual size.
- The filename toolbar exposes the same zoom state for markdown and text preview surfaces.
- Configured browser zoom shortcuts continue to work, including unbound shortcut behavior.

## Tests

- `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-vzoomtests -only-testing:cmuxTests/BrowserZoomShortcutActionTests -only-testing:cmuxTests/KeyboardShortcutContextTests -only-testing:cmuxTests/FilePreviewPanelTextSavingTests test`
- `python3 -m json.tool Resources/Localizable.xcstrings`
- `git diff --check`
- `./scripts/reload.sh --tag vzoom`

## Demo

- Markdown preview demo: `/tmp/cmux-view-zoom-demo/recording-window.mov`
- Plain text preview demo: `/tmp/cmux-view-zoom-demo/recording-window-text.mov`
- Checked frames: `/tmp/cmux-view-zoom-demo/window-frames/04.png`, `/tmp/cmux-view-zoom-demo/window-frames/13.png`, `/tmp/cmux-view-zoom-demo/text-frames/08.png`

Cloud CUA recording on `cmux-macmini` was blocked because CuaDriver still needs macOS Accessibility and Screen/System Audio Recording approval on that host. The local window recordings use the tagged `vzoom` build.

## Tagged build

http://127.0.0.1:17320/vzoom

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global keyboard shortcut routing and dispatch into multiple panel types, so regressions could affect key handling/focus and zoom behavior across the app. Changes are bounded to zoom-related paths with added tests for shortcut and bounds handling.
> 
> **Overview**
> Adds a shared `ViewZoomControl`/`ViewZoomControlling` abstraction and routes zoom shortcuts through `AppDelegate` → `TabManager.performViewZoomCommand`, while explicitly deferring to Ghostty when a terminal has focus.
> 
> Extends zoom support beyond the browser to **Markdown preview + text mode** and **file previews** (text zoom via editor font size; PDF/image responders handle key equivalents), and updates the command palette/menu to act on the focused zoom-capable panel.
> 
> Introduces a filename-toolbar *View Zoom* popover (`PanelHeaderViewZoomButton`) with step/reset/slider UI, adds new localizations, wires the new source file into the Xcode project, and adds/updates unit tests to cover shortcut scoping/unbound behavior and zoom bounds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c428ae3c5548d89e9cb19896516b01d0666943c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add shared View Zoom across panels with a simple toolbar popover and unified shortcuts. Improves readability in markdown, text, browser, and PDF/image views while preserving terminal behavior.

- New Features
  - Unified zoom shortcuts (Cmd+Plus/Minus/0 and configured variants) now control view zoom across supported non-terminal panels.
  - Filename toolbar popover with percent display, step buttons, reset, and slider.
  - Shared zoom state: Markdown preview and TextEdit; text editor zoom maps to font size; `MarkdownWebRenderer` uses `pageZoom`; `BrowserPanel` adopts shared control; PDF/image previews handle zoom key equivalents in outline/scroll views.
  - Command Palette shows zoom actions only when the focused panel supports View Zoom.

- Refactors
  - Centralized zoom model: `ViewZoomControl`, `ViewZoomCommand`, `ViewZoomControlling`.
  - App-wide shortcut routing: `AppDelegate` resolves zoom commands and `TabManager.performViewZoomCommand` dispatches; shortcuts are application-scoped, respect unbound configs, and defer to Ghostty when a terminal is focused.
  - File Preview applies shared zoom only in text mode.
  - Aligned text zoom bounds and mapping; clamp to 50–300% across slider, editor font size, and percent display.
  - Added localized strings for zoom UI (“View Zoom”, “Zoom Controls”).

<sup>Written for commit 6c428ae3c5548d89e9cb19896516b01d0666943c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

