### PR TITLE
Add clean copy as default terminal copy behavior

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -86962,6 +86962,40 @@
         }
       }
     },
+    "shortcut.copyRawText.label": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Raw Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生テキストをコピー"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.copyRawText": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy Raw Text"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "生テキストをコピー"
+          }
+        }
+      }
+    },
     "sidebar.closeWorkspace.tooltip": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -11642,6 +11642,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return handled
         }
 
+        if matchConfiguredShortcut(event: event, action: .copyRawText) {
+            let handled = tabManager?.copyRawTextFromFocusedTerminal() ?? false
+            return handled
+        }
+
         // Workspace navigation: Cmd+Ctrl+] / Cmd+Ctrl+[
         if matchConfiguredShortcut(event: event, action: .nextSidebarTab) {
 #if DEBUG

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7087,6 +7087,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
 
         var result: [String] = []
+        var inCodeFence = false
         var i = 0
         while i < lines.count {
             let line = lines[i]
@@ -7098,14 +7099,30 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 continue
             }
 
+            if trimmed.hasPrefix("```") {
+                inCodeFence.toggle()
+                result.append(trimmed)
+                i += 1
+                continue
+            }
+
+            if inCodeFence {
+                result.append(line)
+                i += 1
+                continue
+            }
+
             if Self.isHardBreakLine(trimmed) {
-                result.append(line.trimmingCharacters(in: .whitespaces))
+                result.append(trimmed)
                 i += 1
                 continue
             }
 
             var paragraph = trimmed
             let startIndent = line.prefix(while: { $0 == " " }).count
+            let isURL = paragraph.hasPrefix("http://") ||
+                paragraph.hasPrefix("https://") ||
+                paragraph.hasPrefix("www.")
             while i + 1 < lines.count {
                 let nextLine = lines[i + 1]
                 let nextTrimmed = nextLine.trimmingCharacters(in: .whitespaces)
@@ -7116,8 +7133,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 let nextIndent = nextLine.prefix(while: { $0 == " " }).count
                 if nextIndent > startIndent + 4 { break }
 
-                let separator = paragraph.contains(" ") ? " " : ""
-                paragraph += separator + nextTrimmed
+                paragraph += (isURL ? "" : " ") + nextTrimmed
                 i += 1
             }
             result.append(paragraph)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7060,16 +7060,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         var lines = text.components(separatedBy: "\n")
         if lines.last == "" { lines.removeLast() }
 
-        lines = lines.map { line in
-            var s = line
-            while let first = s.unicodeScalars.first,
-                  Self.terminalDecorationChars.contains(first) {
-                s = String(s.dropFirst())
-            }
-            if s.first == " " && s.count < line.count { s = String(s.dropFirst()) }
-            return s
-        }
-
         let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
         guard !nonEmptyLines.isEmpty else { return text }
 
@@ -7084,6 +7074,20 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 }
                 return line
             }
+        }
+
+        lines = lines.map { line in
+            var s = line
+            let leading = s.prefix(while: { $0 == " " })
+            s = String(s.dropFirst(leading.count))
+            var stripped = false
+            while let first = s.unicodeScalars.first,
+                  Self.terminalDecorationChars.contains(first) {
+                s = String(s.dropFirst())
+                stripped = true
+            }
+            if stripped && s.first == " " { s = String(s.dropFirst()) }
+            return String(leading) + s
         }
 
         var result: [String] = []

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5918,6 +5918,14 @@ final class TerminalSurface: Identifiable, ObservableObject {
         return handled
     }
 
+    func copyCleanText() -> Bool {
+        surfaceView.copyCleanText()
+    }
+
+    func copyRawText() -> Bool {
+        surfaceView.performBindingAction("copy_to_clipboard")
+    }
+
     func setKeyboardCopyModeActive(_ active: Bool) {
         if !Thread.isMainThread {
             DispatchQueue.main.async { [weak self] in
@@ -7024,7 +7032,118 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     // MARK: - Input Handling
 
     @IBAction func copy(_ sender: Any?) {
+        if !copyCleanText() {
+            _ = performBindingAction("copy_to_clipboard")
+        }
+    }
+
+    @objc func copyRawTextMenuAction(_ sender: Any?) {
         _ = performBindingAction("copy_to_clipboard")
+    }
+
+    func copyCleanText() -> Bool {
+        guard let snapshot = readSelectionSnapshot(), !snapshot.string.isEmpty else { return false }
+        let cleaned = Self.cleanCopiedText(snapshot.string)
+        GhosttyPasteboardHelper.writeString(cleaned, to: GHOSTTY_CLIPBOARD_STANDARD)
+        return true
+    }
+
+    private static let terminalDecorationChars: CharacterSet = {
+        var set = CharacterSet()
+        for scalar in "●◆◇○◎■□▪▫▶▷►▻❯❮❱❰⚡★☆✦✧⬤⏺➜➤›»«‣⁃" {
+            for s in scalar.unicodeScalars { set.insert(s) }
+        }
+        return set
+    }()
+
+    static func cleanCopiedText(_ text: String) -> String {
+        var lines = text.components(separatedBy: "\n")
+        if lines.last == "" { lines.removeLast() }
+
+        lines = lines.map { line in
+            var s = line
+            while let first = s.unicodeScalars.first,
+                  Self.terminalDecorationChars.contains(first) {
+                s = String(s.dropFirst())
+            }
+            if s.first == " " && s.count < line.count { s = String(s.dropFirst()) }
+            return s
+        }
+
+        let nonEmptyLines = lines.filter { !$0.trimmingCharacters(in: .whitespaces).isEmpty }
+        guard !nonEmptyLines.isEmpty else { return text }
+
+        let commonIndent = nonEmptyLines
+            .map { $0.prefix(while: { $0 == " " }).count }
+            .min() ?? 0
+
+        if commonIndent > 0 {
+            lines = lines.map { line in
+                if line.count >= commonIndent {
+                    return String(line.dropFirst(commonIndent))
+                }
+                return line
+            }
+        }
+
+        var result: [String] = []
+        var i = 0
+        while i < lines.count {
+            let line = lines[i]
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.isEmpty {
+                result.append("")
+                i += 1
+                continue
+            }
+
+            if Self.isHardBreakLine(trimmed) {
+                result.append(line.trimmingCharacters(in: .whitespaces))
+                i += 1
+                continue
+            }
+
+            var paragraph = trimmed
+            let startIndent = line.prefix(while: { $0 == " " }).count
+            while i + 1 < lines.count {
+                let nextLine = lines[i + 1]
+                let nextTrimmed = nextLine.trimmingCharacters(in: .whitespaces)
+
+                if nextTrimmed.isEmpty { break }
+                if Self.isBlockStartLine(nextTrimmed) { break }
+
+                let nextIndent = nextLine.prefix(while: { $0 == " " }).count
+                if nextIndent > startIndent + 4 { break }
+
+                let separator = paragraph.contains(" ") ? " " : ""
+                paragraph += separator + nextTrimmed
+                i += 1
+            }
+            result.append(paragraph)
+            i += 1
+        }
+
+        return result.joined(separator: "\n")
+    }
+
+    private static func isBlockStartLine(_ trimmed: String) -> Bool {
+        if trimmed.hasPrefix("- ") || trimmed.hasPrefix("* ") || trimmed.hasPrefix("+ ") { return true }
+        if trimmed.hasPrefix("```") { return true }
+        if trimmed.hasPrefix("# ") || trimmed.hasPrefix("## ") || trimmed.hasPrefix("### ") { return true }
+        if trimmed.first?.isNumber == true {
+            let rest = trimmed.drop(while: \.isNumber)
+            if rest.hasPrefix(". ") { return true }
+        }
+        if trimmed.hasPrefix("|") && trimmed.hasSuffix("|") { return true }
+        if trimmed.hasPrefix(">") { return true }
+        return false
+    }
+
+    private static func isHardBreakLine(_ trimmed: String) -> Bool {
+        if trimmed.hasPrefix("```") { return true }
+        if trimmed.hasPrefix("|") && trimmed.hasSuffix("|") { return true }
+        return false
     }
 
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {
@@ -9051,6 +9170,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 keyEquivalent: ""
             )
             item.target = self
+            let rawItem = menu.addItem(
+                withTitle: String(localized: "terminalContextMenu.copyRawText", defaultValue: "Copy Raw Text"),
+                action: #selector(copyRawTextMenuAction(_:)),
+                keyEquivalent: ""
+            )
+            rawItem.target = self
         }
         let pasteItem = menu.addItem(
             withTitle: String(localized: "terminalContextMenu.paste", defaultValue: "Paste"),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7110,7 +7110,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 continue
             }
 
-            var paragraph = cleaned
+            let lineIndent = line.prefix(while: { $0 == " " })
+            let indentedCleaned = lineIndent.isEmpty ? cleaned : String(lineIndent) + cleaned
+            var paragraph = indentedCleaned
             let startIndent = line.prefix(while: { $0 == " " }).count
             let isURL = Self.startsWithURL(paragraph)
             while i + 1 < lines.count {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7112,7 +7112,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
             var paragraph = cleaned
             let startIndent = line.prefix(while: { $0 == " " }).count
-            let isURL = Self.containsURL(paragraph)
+            let isURL = Self.startsWithURL(paragraph)
             while i + 1 < lines.count {
                 let nextLine = lines[i + 1]
                 let nextTrimmed = nextLine.trimmingCharacters(in: .whitespaces)
@@ -7150,6 +7150,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if trimmed.hasPrefix("```") { return true }
         if trimmed.hasPrefix("|") && trimmed.hasSuffix("|") { return true }
         if trimmed.hasPrefix("# ") { return true }
+        if trimmed.hasPrefix("> ") || trimmed == ">" { return true }
         return false
     }
 
@@ -7165,8 +7166,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return s
     }
 
-    private static func containsURL(_ text: String) -> Bool {
-        text.contains("http://") || text.contains("https://") || text.contains("www.")
+    private static func startsWithURL(_ text: String) -> Bool {
+        let s = text.drop(while: { "->*+ ".contains($0) })
+        return s.hasPrefix("http://") || s.hasPrefix("https://") || s.hasPrefix("www.")
     }
 
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7159,6 +7159,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private static func isHardBreakLine(_ trimmed: String) -> Bool {
         if trimmed.hasPrefix("```") { return true }
         if trimmed.hasPrefix("|") && trimmed.hasSuffix("|") { return true }
+        if trimmed.hasPrefix("# ") { return true }
         return false
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7121,11 +7121,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
                 if nextTrimmed.isEmpty { break }
                 if Self.isBlockStartLine(nextTrimmed) { break }
+                if nextTrimmed.unicodeScalars.first.map({ terminalDecorationChars.contains($0) }) == true { break }
 
                 let nextIndent = nextLine.prefix(while: { $0 == " " }).count
                 if nextIndent > startIndent + 4 { break }
 
-                paragraph += (isURL ? "" : " ") + nextTrimmed
+                let skipSpace = isURL && !nextTrimmed.contains(" ")
+                paragraph += (skipSpace ? "" : " ") + nextTrimmed
                 i += 1
             }
             result.append(paragraph)

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7076,20 +7076,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             }
         }
 
-        lines = lines.map { line in
-            var s = line
-            let leading = s.prefix(while: { $0 == " " })
-            s = String(s.dropFirst(leading.count))
-            var stripped = false
-            while let first = s.unicodeScalars.first,
-                  Self.terminalDecorationChars.contains(first) {
-                s = String(s.dropFirst())
-                stripped = true
-            }
-            if stripped && s.first == " " { s = String(s.dropFirst()) }
-            return String(leading) + s
-        }
-
         var result: [String] = []
         var inCodeFence = false
         var i = 0
@@ -7116,17 +7102,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
                 continue
             }
 
-            if Self.isHardBreakLine(trimmed) {
-                result.append(trimmed)
+            let cleaned = Self.stripDecorationChars(trimmed)
+
+            if Self.isHardBreakLine(cleaned) {
+                result.append(cleaned)
                 i += 1
                 continue
             }
 
-            var paragraph = trimmed
+            var paragraph = cleaned
             let startIndent = line.prefix(while: { $0 == " " }).count
-            let isURL = paragraph.hasPrefix("http://") ||
-                paragraph.hasPrefix("https://") ||
-                paragraph.hasPrefix("www.")
+            let isURL = Self.containsURL(paragraph)
             while i + 1 < lines.count {
                 let nextLine = lines[i + 1]
                 let nextTrimmed = nextLine.trimmingCharacters(in: .whitespaces)
@@ -7165,6 +7151,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         if trimmed.hasPrefix("|") && trimmed.hasSuffix("|") { return true }
         if trimmed.hasPrefix("# ") { return true }
         return false
+    }
+
+    private static func stripDecorationChars(_ trimmed: String) -> String {
+        var s = trimmed
+        var stripped = false
+        while let first = s.unicodeScalars.first,
+              terminalDecorationChars.contains(first) {
+            s = String(s.dropFirst())
+            stripped = true
+        }
+        if stripped && s.first == " " { s = String(s.dropFirst()) }
+        return s
+    }
+
+    private static func containsURL(_ text: String) -> Bool {
+        text.contains("http://") || text.contains("https://") || text.contains("www.")
     }
 
     @IBAction func copyWorkspaceAndSurfaceIdentifiers(_ sender: Any?) {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -105,6 +105,7 @@ enum KeyboardShortcutSettings {
         case reopenClosedBrowserPanel
         case newSurface
         case toggleTerminalCopyMode
+        case copyRawText
 
         // Panes / splits
         case focusLeft
@@ -187,6 +188,7 @@ enum KeyboardShortcutSettings {
             case .reopenClosedBrowserPanel: return String(localized: "menu.file.reopenClosedBrowserPanel", defaultValue: "Reopen Closed Browser Panel")
             case .newSurface: return String(localized: "shortcut.newSurface.label", defaultValue: "New Surface")
             case .toggleTerminalCopyMode: return String(localized: "shortcut.toggleTerminalCopyMode.label", defaultValue: "Toggle Terminal Copy Mode")
+            case .copyRawText: return String(localized: "shortcut.copyRawText.label", defaultValue: "Copy Raw Text")
             case .focusLeft: return String(localized: "shortcut.focusPaneLeft.label", defaultValue: "Focus Pane Left")
             case .focusRight: return String(localized: "shortcut.focusPaneRight.label", defaultValue: "Focus Pane Right")
             case .focusUp: return String(localized: "shortcut.focusPaneUp.label", defaultValue: "Focus Pane Up")
@@ -339,6 +341,8 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: false, control: false)
             case .toggleTerminalCopyMode:
                 return StoredShortcut(key: "m", command: true, shift: true, option: false, control: false)
+            case .copyRawText:
+                return StoredShortcut(key: "c", command: true, shift: true, option: false, control: false)
             case .selectWorkspaceByNumber:
                 return StoredShortcut(key: "1", command: true, shift: false, option: false, control: false)
             case .toggleRightSidebar:

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2031,6 +2031,11 @@ class TabManager: ObservableObject {
         return panel.surface.toggleKeyboardCopyMode()
     }
 
+    func copyRawTextFromFocusedTerminal() -> Bool {
+        guard let panel = selectedTerminalPanel else { return false }
+        return panel.surface.copyRawText()
+    }
+
     func hideFind() {
         if let panel = selectedTerminalPanel {
             panel.searchState = nil

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -809,6 +809,7 @@
               "reopenClosedBrowserPanel",
               "newSurface",
               "toggleTerminalCopyMode",
+              "copyRawText",
               "focusLeft",
               "focusRight",
               "focusUp",


### PR DESCRIPTION
## Summary

Fixes #3096

- **Cmd+C now produces clean text** — strips common leading whitespace, removes terminal decoration characters (●, ◆, ▶, etc.), re-joins hard-wrapped paragraph lines, and joins URL lines without inserting spaces
- **Preserves structure** — code fences, table rows, headings, blockquotes, bullet points maintain their formatting
- **Cmd+Shift+C** and right-click → "Copy Raw Text" provide the old verbatim copy behavior as a fallback

## Test plan

- [ ] Select wrapped paragraph text in terminal, Cmd+C, paste — lines should be joined without extra indentation
- [ ] Select a long URL that wraps across lines, Cmd+C, paste — URL should be one line with no inserted spaces
- [ ] Select bullet list, Cmd+C, paste — each bullet stays on its own line, wrapped continuations rejoin
- [ ] Select text starting with ● or similar decoration, Cmd+C, paste — decoration char stripped
- [ ] Select text with code fences, Cmd+C, paste — code block content preserved verbatim
- [ ] Select text with `> ` blockquotes, Cmd+C, paste — blockquotes stay on own line
- [ ] Cmd+Shift+C still produces raw/verbatim copy
- [ ] Right-click context menu shows "Copy" and "Copy Raw Text"
- [ ] Verify in Settings → Keyboard Shortcuts that "Copy Raw Text" appears and is configurable

🤖 Generated with [Claude Code](https://claude.com/claude-code)