### PR TITLE
Reconcile provider-deleted Cloud VMs before active limits

### DIFF
--- a/web/services/vms/providerErrors.ts
+++ b/web/services/vms/providerErrors.ts
@@ -1,7 +1,7 @@
 const providerSubjectPattern =
   "(?:vm|virtual machine|sandbox|sandboxes|instance|container|machine|environment|resource)";
 const providerMissingPattern =
-  "(?:not found|does not exist|already deleted|has been deleted|was deleted|no such)";
+  "(?:not found|does not exist|already deleted|has been deleted|was deleted|marked as deleted|no such)";
 
 function hasProviderMissingMessage(message: string): boolean {
   const normalized = message.toLowerCase();
@@ -42,7 +42,15 @@ export function isProviderNotFoundError(err: unknown): boolean {
   if (status === 404) return true;
 
   const code = String(candidate.code ?? candidate.name ?? "").toLowerCase();
-  if (code === "not_found" || code === "notfound" || code === "404") return true;
+  if (
+    code === "not_found" ||
+    code === "notfound" ||
+    code === "404" ||
+    code === "vmdeletederror" ||
+    code === "vm_deleted"
+  ) {
+    return true;
+  }
 
   if (hasProviderMissingMessage(candidate.message ?? "")) return true;
 

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -50,7 +50,7 @@ export type VmRepositoryShape = {
     readonly id: string;
     readonly providerVmId: string;
     readonly status: CloudVmStatus;
-  }) => Effect.Effect<void, VmDatabaseError>;
+  }) => Effect.Effect<boolean, VmDatabaseError>;
   readonly markCreateRunning: (input: {
     readonly id: string;
     readonly providerVmId: string;
@@ -298,7 +298,7 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
   markProviderObservedStatus: (input) =>
     dbEffect("markProviderObservedStatus", async () => {
       const db = cloudDb();
-      await db
+      const updated = await db
         .update(cloudVms)
         .set({
           status: input.status,
@@ -311,7 +311,9 @@ export const VmRepositoryLive = Layer.succeed(VmRepository, {
             eq(cloudVms.providerVmId, input.providerVmId),
             ne(cloudVms.status, "destroyed"),
           ),
-        );
+        )
+        .returning({ id: cloudVms.id });
+      return updated.length > 0;
     }),
 
   markCreateRunning: (input) =>

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -267,11 +267,23 @@ function refreshActiveLimitProviderStatuses(
         if (!providerStatus || providerStatus === "creating") return;
         const dbStatus = dbStatusFromProviderStatus(providerStatus);
         if (dbStatus === vm.status) return;
-        yield* repo.markProviderObservedStatus({
+        const didUpdate = yield* repo.markProviderObservedStatus({
           id: vm.id,
           providerVmId,
           status: dbStatus,
-        }).pipe(Effect.catchAll(() => Effect.void));
+        }).pipe(Effect.catchAll(() => Effect.succeed(false)));
+        if (didUpdate && dbStatus === "destroyed") {
+          yield* repo.recordUsageEvent({
+            userId: vm.userId,
+            billingTeamId: vm.billingTeamId,
+            billingPlanId: vm.billingPlanId,
+            vmId: vm.id,
+            eventType: "vm.destroyed",
+            provider: vm.provider,
+            imageId: vm.imageId,
+            metadata: { source: "provider_status_refresh" },
+          }).pipe(Effect.catchAll(() => Effect.void));
+        }
       });
     }, { concurrency: "unbounded", discard: true });
   });

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -258,7 +258,11 @@ function refreshActiveLimitProviderStatuses(
       if (vm.provider !== "freestyle" || !providerVmId) return Effect.void;
       return Effect.gen(function* () {
         const providerStatus = yield* getStatus(vm.provider, providerVmId).pipe(
-          Effect.catchAll(() => Effect.succeed(null)),
+          Effect.catchAll((err) =>
+            isProviderNotFoundError(err)
+              ? Effect.succeed("destroyed" as const)
+              : Effect.succeed(null),
+          ),
         );
         if (!providerStatus || providerStatus === "creating") return;
         const dbStatus = dbStatusFromProviderStatus(providerStatus);

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -404,6 +404,18 @@ describe("VM Effect workflows", () => {
     `;
     expect(oldVm?.status).toBe("destroyed");
     expect(oldVm?.destroyedAt).toBeInstanceOf(Date);
+
+    const [{ destroyedUsageCount }] = await sql<{ destroyedUsageCount: string }[]>`
+      select count(*)::text as "destroyedUsageCount"
+      from cloud_vm_usage_events
+      where provider = 'freestyle'
+        and event_type = 'vm.destroyed'
+        and vm_id in (
+          select id from cloud_vms
+          where provider_vm_id = 'provider-vm-provider-deleted-old'
+        )
+    `;
+    expect(destroyedUsageCount).toBe("1");
   });
 
   dbTest("refreshes Freestyle running rows concurrently before active limit enforcement", async () => {

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -16,6 +16,7 @@ import {
   VmCreateInProgressError,
   VmLimitExceededError,
   VmNotFoundError,
+  VmProviderOperationError,
 } from "../services/vms/errors";
 import {
   createVm,
@@ -336,6 +337,73 @@ describe("VM Effect workflows", () => {
       where provider_vm_id = 'provider-vm-provider-paused-old'
     `;
     expect(oldVm?.status).toBe("paused");
+  });
+
+  dbTest("marks provider-deleted Freestyle rows destroyed before active limit enforcement", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_billing_grants, cloud_vm_usage_events, cloud_vm_leases, cloud_vms restart identity cascade`;
+    await sql`
+      insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, provider_vm_id, image_id, status)
+      values ('user-workflow-provider-deleted-old', 'team-workflow-provider-deleted', 'free', 'freestyle', 'provider-vm-provider-deleted-old', 'snapshot-test', 'running')
+    `;
+
+    let createCalls = 0;
+    let statusCalls = 0;
+    const provider: VmProviderGatewayShape = {
+      create: () =>
+        Effect.sync(() => {
+          createCalls += 1;
+          return {
+            provider: "freestyle" as const,
+            providerVmId: "provider-vm-provider-deleted-new",
+            status: "running" as const,
+            image: "snapshot-test",
+            createdAt: Date.now(),
+          };
+        }),
+      destroy: () => Effect.void,
+      exec: () => Effect.succeed({ exitCode: 0, stdout: "", stderr: "" }),
+      openAttach: () => Effect.fail(new Error("unused") as never),
+      openSSH: () => Effect.fail(new Error("unused") as never),
+      revokeSSHIdentity: () => Effect.void,
+      getStatus: () =>
+        Effect.suspend(() => {
+          statusCalls += 1;
+          const deleted = new Error(
+            "VM_DELETED: Vm provider-vm-provider-deleted-old is marked as deleted but still exists in the database",
+          );
+          deleted.name = "VmDeletedError";
+          return Effect.fail(new VmProviderOperationError({
+            provider: "freestyle",
+            operation: "getStatus",
+            cause: deleted,
+          }));
+        }),
+    };
+
+    const created = await Effect.runPromise(
+      createVm({
+        userId: "user-workflow-provider-deleted-new",
+        billingCustomerType: "team",
+        billingTeamId: "team-workflow-provider-deleted",
+        billingPlanId: "free",
+        maxActiveVms: 1,
+        provider: "freestyle",
+        image: "snapshot-test",
+        idempotencyKey: "provider-deleted-new",
+      }).pipe(Effect.provide(providerLayer(provider))),
+    );
+
+    expect(created.providerVmId).toBe("provider-vm-provider-deleted-new");
+    expect(statusCalls).toBe(1);
+    expect(createCalls).toBe(1);
+
+    const [oldVm] = await sql<{ status: string; destroyedAt: Date | null }[]>`
+      select status, destroyed_at as "destroyedAt" from cloud_vms
+      where provider_vm_id = 'provider-vm-provider-deleted-old'
+    `;
+    expect(oldVm?.status).toBe("destroyed");
+    expect(oldVm?.destroyedAt).toBeInstanceOf(Date);
   });
 
   dbTest("refreshes Freestyle running rows concurrently before active limit enforcement", async () => {


### PR DESCRIPTION
Fixes stale Freestyle VM rows that keep counting against active Cloud VM limits after the provider reports the VM as deleted.\n\nChanges:\n- Treat Freestyle's deleted-VM errors as provider-not-found errors.\n- Mark provider-deleted Freestyle rows as destroyed during the pre-limit refresh.\n- Add a DB workflow regression for active-limit recovery.\n\nVerified:\n- CMUX_PORT=9183 bun run db:test\n- bun run lint\n- bun tsc --noEmit\n\nLive cleanup performed separately through product delete for stale VMs on Lawrence's team.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes active-limit preflight behavior by interpreting certain provider errors as VM deletion and mutating VM status/usage events, which could affect limit enforcement and billing/analytics if misclassified.
> 
> **Overview**
> Fixes a stale-VM edge case where Freestyle VMs deleted at the provider could keep counting against active VM limits.
> 
> `isProviderNotFoundError` now recognizes additional deletion signals (e.g. “marked as deleted”, `VmDeletedError`/`vm_deleted`). During the pre-limit status refresh in `createVm`, provider-not-found is mapped to `destroyed`, the DB update reports whether it actually changed a row, and a `vm.destroyed` usage event is recorded when a row is newly marked destroyed.
> 
> Adds a DB regression test covering the provider-deleted scenario to ensure the slot is freed before limit enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b24bf21c344e2fb93a36c0b18c0595ac8ec152f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale Freestyle Cloud VMs that kept counting against active limits after the provider deleted them. We now detect these cases, mark the rows destroyed during the pre-limit refresh, and record a destroy usage event.

- **Bug Fixes**
  - Treat Freestyle “VM deleted” errors as provider-not-found (`isProviderNotFoundError` now matches “marked as deleted” and `VmDeletedError`/`vm_deleted` codes).
  - During the pre-limit refresh, convert provider-not-found to `destroyed` and persist `status=destroyed` with `destroyedAt`.
  - Emit a `vm.destroyed` usage event when a VM is marked destroyed by the provider status refresh (source: `provider_status_refresh`).
  - Added a regression test that verifies stale Freestyle rows are cleared before enforcing the active limit and that a destroy usage event is recorded.

<sup>Written for commit 4b24bf21c344e2fb93a36c0b18c0595ac8ec152f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Broadened detection of deleted/missing provider errors so more deletion variants are recognized.
  * Provider-missing errors now cause stale VMs to be marked as "destroyed" instead of being skipped.

* **Tests**
  * Added end-to-end coverage ensuring stale provider VMs are destroyed and new VM creation proceeds.

* **Chores**
  * Status-update operation now returns a success indicator when marking provider-observed statuses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4142)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->