### PR TITLE
Fix PDF open-with chrome button

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,6 +207,14 @@ When adding a regression test for a bug fix, use a two-commit structure so CI pr
 
 This makes it visible in the GitHub PR UI (Commits tab, check statuses) that the test genuinely fails without the fix.
 
+## Dogfood merge gate
+
+For app, runtime, and UI changes, never merge a PR after checks or review alone. Build the tagged app, hand the tag to the user, and wait for the user to explicitly confirm that the dogfood build is OK to merge.
+
+This applies even when an earlier request said to iterate and merge. Once a tagged dogfood build is handed off, stop at ready-to-merge until the user approves merge after dogfooding. CI, review bots, screenshots, recordings, and self-verification do not replace user dogfood approval.
+
+Documentation-only, metadata-only, and workflow-only changes can merge as requested after checks pass if they do not change app/runtime behavior.
+
 ## Shared behavior policy
 
 - When a behavior is exposed through multiple entrypoints (keyboard shortcut, command palette, context menu, CLI, settings, debug menu), implement one shared action/model path and verify every entrypoint that should invoke it. Do not patch one surface while leaving the others with duplicated logic.

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -171,38 +171,19 @@ struct FileExternalOpenMenu: View {
                     isDisabled: isDisabled
                 )
             case .chrome:
-                Button {
-                    presentMenu(
-                        applications: applications,
-                        currentPrimaryApplication: primaryApplication,
-                        otherApplications: otherApplications
-                    )
-                } label: {
-                    label
-                }
-                .contentShape(Rectangle())
-                .disabled(isDisabled)
-                .help(helpText)
-                .accessibilityLabel(helpText)
+                FileExternalOpenChromeMenuButton(
+                    fileURL: fileURL,
+                    applications: applications,
+                    currentPrimaryApplication: primaryApplication,
+                    otherApplications: otherApplications,
+                    helpText: helpText,
+                    isDisabled: isDisabled
+                )
+                .frame(width: style.buttonSize.width, height: style.buttonSize.height)
             }
         }
         .task(id: fileURL) {
             await refreshApplications()
-        }
-    }
-
-    @ViewBuilder
-    private var label: some View {
-        switch style {
-        case .header:
-            PanelHeaderIconGlyph(systemName: "square.and.arrow.up")
-        case .chrome:
-            Image(systemName: "square.and.arrow.up")
-                .font(.system(size: 16, weight: .semibold))
-                .foregroundStyle(.secondary)
-                .frame(width: style.buttonSize.width, height: style.buttonSize.height)
-                .contentShape(Rectangle())
-                .accessibilityHidden(true)
         }
     }
 
@@ -231,36 +212,44 @@ struct FileExternalOpenMenu: View {
         guard !Task.isCancelled else { return }
         resolvedApplications = applications
     }
+}
 
-    private func presentMenu(
+private enum FileExternalOpenMenuBuilder {
+    static func primaryApplication(in applications: [FileExternalOpenApplication]) -> FileExternalOpenApplication? {
+        applications.first { $0.isDefault } ?? applications.first
+    }
+
+    static func normalizedApplications(
+        fileURL: URL,
         applications: [FileExternalOpenApplication],
         currentPrimaryApplication: FileExternalOpenApplication?,
         otherApplications: [FileExternalOpenApplication]
-    ) {
-        guard !isDisabled else { return }
+    ) -> (primary: FileExternalOpenApplication?, others: [FileExternalOpenApplication]) {
         let menuApplications: [FileExternalOpenApplication]
         if applications.isEmpty {
             menuApplications = FileExternalOpenApplicationResolver.live.applications(for: fileURL)
         } else {
             menuApplications = applications
         }
+
         let primary = primaryApplication(in: menuApplications) ?? currentPrimaryApplication
-        let others = menuApplications.filter { application in
-            application.id != primary?.id
-        } + otherApplications.filter { application in
-            application.id != primary?.id
-                && !menuApplications.contains(where: { $0.id == application.id })
+        var seenApplicationIDs = Set<String>()
+        if let primary {
+            seenApplicationIDs.insert(primary.id)
         }
-        let menu = makeMenu(primaryApplication: primary, otherApplications: others)
-        if let event = NSApp.currentEvent, let contentView = event.window?.contentView {
-            let point = contentView.convert(event.locationInWindow, from: nil)
-            menu.popUp(positioning: nil as NSMenuItem?, at: point, in: contentView)
-        } else {
-            menu.popUp(positioning: nil as NSMenuItem?, at: NSEvent.mouseLocation, in: nil as NSView?)
+
+        var others: [FileExternalOpenApplication] = []
+        for application in menuApplications + otherApplications {
+            guard application.id != primary?.id else { continue }
+            guard seenApplicationIDs.insert(application.id).inserted else { continue }
+            others.append(application)
         }
+
+        return (primary, others)
     }
 
-    private func makeMenu(
+    static func makeMenu(
+        fileURL: URL,
         primaryApplication: FileExternalOpenApplication?,
         otherApplications: [FileExternalOpenApplication]
     ) -> NSMenu {
@@ -269,6 +258,7 @@ struct FileExternalOpenMenu: View {
 
         if let primaryApplication {
             menu.addItem(menuItem(
+                fileURL: fileURL,
                 title: openInTitle(primaryApplication.displayName),
                 applicationURL: primaryApplication.url
             ))
@@ -279,6 +269,7 @@ struct FileExternalOpenMenu: View {
                 openWithMenu.autoenablesItems = false
                 for application in otherApplications {
                     openWithMenu.addItem(menuItem(
+                        fileURL: fileURL,
                         title: application.displayName,
                         applicationURL: application.url
                     ))
@@ -292,13 +283,17 @@ struct FileExternalOpenMenu: View {
                 menu.addItem(openWithItem)
             }
         } else {
-            menu.addItem(menuItem(title: FileExternalOpenText.openExternally, applicationURL: nil))
+            menu.addItem(menuItem(
+                fileURL: fileURL,
+                title: FileExternalOpenText.openExternally,
+                applicationURL: nil
+            ))
         }
 
         return menu
     }
 
-    private func menuItem(title: String, applicationURL: URL?) -> NSMenuItem {
+    static func menuItem(fileURL: URL, title: String, applicationURL: URL?) -> NSMenuItem {
         let item = NSMenuItem(
             title: title,
             action: #selector(FileExternalOpenMenuActionTarget.open(_:)),
@@ -310,6 +305,185 @@ struct FileExternalOpenMenu: View {
             applicationURL: applicationURL
         )
         return item
+    }
+
+    private static func openInTitle(_ applicationName: String) -> String {
+        FileExternalOpenText.openInApplication(applicationName)
+    }
+}
+
+private struct FileExternalOpenChromeMenuButton: NSViewRepresentable {
+    let fileURL: URL
+    let applications: [FileExternalOpenApplication]
+    let currentPrimaryApplication: FileExternalOpenApplication?
+    let otherApplications: [FileExternalOpenApplication]
+    let helpText: String
+    let isDisabled: Bool
+
+    func makeNSView(context: Context) -> FileExternalOpenChromeMenuButtonView {
+        let view = FileExternalOpenChromeMenuButtonView()
+        updateNSView(view, context: context)
+        return view
+    }
+
+    func updateNSView(_ nsView: FileExternalOpenChromeMenuButtonView, context: Context) {
+        nsView.configure(
+            fileURL: fileURL,
+            applications: applications,
+            currentPrimaryApplication: currentPrimaryApplication,
+            otherApplications: otherApplications,
+            helpText: helpText,
+            isDisabled: isDisabled
+        )
+    }
+}
+
+final class FileExternalOpenChromeMenuButtonView: NSControl {
+    private let hoverBackgroundView = NSView()
+    private let imageView = NSImageView()
+
+    private var fileURL: URL?
+    private var applications: [FileExternalOpenApplication] = []
+    private var currentPrimaryApplication: FileExternalOpenApplication?
+    private var otherApplications: [FileExternalOpenApplication] = []
+    private var trackingAreaToken: NSTrackingArea?
+    private var isHovered = false {
+        didSet { updateAppearance() }
+    }
+    private var isPressed = false {
+        didSet { updateAppearance() }
+    }
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpViews()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setUpViews()
+    }
+
+    override var intrinsicContentSize: NSSize {
+        NSSize(width: 40, height: 40)
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard !isHidden, alphaValue > 0.01, isEnabled, bounds.contains(point) else {
+            return nil
+        }
+        return self
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingAreaToken {
+            removeTrackingArea(trackingAreaToken)
+        }
+        let trackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited],
+            owner: self,
+            userInfo: nil
+        )
+        trackingAreaToken = trackingArea
+        addTrackingArea(trackingArea)
+    }
+
+    override func layout() {
+        super.layout()
+        hoverBackgroundView.frame = bounds.insetBy(dx: 4, dy: 4)
+        imageView.frame = NSRect(
+            x: floor((bounds.width - 19) / 2),
+            y: floor((bounds.height - 19) / 2),
+            width: 19,
+            height: 19
+        )
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        isPressed = false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard isEnabled, let fileURL else { return }
+        isPressed = true
+        presentMenu(for: event, fileURL: fileURL)
+        isPressed = false
+    }
+
+    func configure(
+        fileURL: URL,
+        applications: [FileExternalOpenApplication],
+        currentPrimaryApplication: FileExternalOpenApplication?,
+        otherApplications: [FileExternalOpenApplication],
+        helpText: String,
+        isDisabled: Bool
+    ) {
+        self.fileURL = fileURL
+        self.applications = applications
+        self.currentPrimaryApplication = currentPrimaryApplication
+        self.otherApplications = otherApplications
+        isEnabled = !isDisabled
+        toolTip = helpText
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(helpText)
+        updateAppearance()
+    }
+
+    private func setUpViews() {
+        wantsLayer = true
+
+        hoverBackgroundView.wantsLayer = true
+        hoverBackgroundView.layer?.cornerRadius = 16
+        hoverBackgroundView.layer?.cornerCurve = .continuous
+        addSubview(hoverBackgroundView)
+
+        imageView.image = NSImage(systemSymbolName: "square.and.arrow.up", accessibilityDescription: nil)?
+            .withSymbolConfiguration(NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold))
+        imageView.imageScaling = .scaleProportionallyUpOrDown
+        imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 16, weight: .semibold)
+        addSubview(imageView)
+
+        updateAppearance()
+    }
+
+    private func updateAppearance() {
+        let isActive = isPressed || isHovered
+        hoverBackgroundView.isHidden = !isActive
+        hoverBackgroundView.layer?.backgroundColor = NSColor.white
+            .withAlphaComponent(isPressed ? 0.24 : 0.14)
+            .cgColor
+        imageView.contentTintColor = isEnabled
+            ? (isActive ? .labelColor : .secondaryLabelColor)
+            : .disabledControlTextColor
+        alphaValue = isEnabled ? 1 : 0.42
+    }
+
+    private func presentMenu(for event: NSEvent, fileURL: URL) {
+        let normalizedApplications = FileExternalOpenMenuBuilder.normalizedApplications(
+            fileURL: fileURL,
+            applications: applications,
+            currentPrimaryApplication: currentPrimaryApplication,
+            otherApplications: otherApplications
+        )
+        let menu = FileExternalOpenMenuBuilder.makeMenu(
+            fileURL: fileURL,
+            primaryApplication: normalizedApplications.primary,
+            otherApplications: normalizedApplications.others
+        )
+        let localPoint = convert(event.locationInWindow, from: nil)
+        menu.popUp(positioning: nil as NSMenuItem?, at: localPoint, in: self)
     }
 }
 
@@ -349,51 +523,11 @@ private struct FileExternalOpenHeaderMenuButton: View {
     }
 
     private func makeMenu() -> NSMenu {
-        let menu = NSMenu(title: FileExternalOpenText.openWithMenu)
-        if let primaryApplication {
-            menu.addItem(menuItem(for: primaryApplication))
-            if !otherApplications.isEmpty {
-                menu.addItem(.separator())
-                let submenuItem = NSMenuItem(
-                    title: FileExternalOpenText.openWithMenu,
-                    action: nil,
-                    keyEquivalent: ""
-                )
-                let submenu = NSMenu(title: FileExternalOpenText.openWithMenu)
-                otherApplications.forEach { application in
-                    submenu.addItem(menuItem(for: application))
-                }
-                submenuItem.submenu = submenu
-                menu.addItem(submenuItem)
-            }
-        } else {
-            let item = NSMenuItem(
-                title: FileExternalOpenText.openExternally,
-                action: #selector(FileExternalOpenMenuActionTarget.open(_:)),
-                keyEquivalent: ""
-            )
-            item.target = FileExternalOpenMenuActionTarget.shared
-            item.representedObject = FileExternalOpenMenuActionPayload(
-                fileURL: fileURL,
-                applicationURL: nil
-            )
-            menu.addItem(item)
-        }
-        return menu
-    }
-
-    private func menuItem(for application: FileExternalOpenApplication) -> NSMenuItem {
-        let item = NSMenuItem(
-            title: FileExternalOpenText.openInApplication(application.displayName),
-            action: #selector(FileExternalOpenMenuActionTarget.open(_:)),
-            keyEquivalent: ""
-        )
-        item.target = FileExternalOpenMenuActionTarget.shared
-        item.representedObject = FileExternalOpenMenuActionPayload(
+        FileExternalOpenMenuBuilder.makeMenu(
             fileURL: fileURL,
-            applicationURL: application.url
+            primaryApplication: primaryApplication,
+            otherApplications: otherApplications
         )
-        return item
     }
 }
 
@@ -1881,30 +2015,21 @@ struct FilePreviewPDFStandaloneChromeStyleModifier: ViewModifier {
 
     @ViewBuilder
     private func liquidGlassChrome(content: Content) -> some View {
-        #if compiler(>=6.3)
-        if #available(macOS 26.0, *) {
-            content
-                .buttonStyle(.borderless)
-                .controlSize(.regular)
-                .foregroundStyle(Color.secondary)
-                .glassEffect(.regular, in: Circle())
-                .overlay {
-                    Circle()
-                        .stroke(Color.white.opacity(0.24), lineWidth: 0.85)
-                }
-                .shadow(color: Color.black.opacity(0.18), radius: 8, y: 1)
-        } else {
-            materialChrome(content: content, material: .regularMaterial, strokeOpacity: 0.28)
-        }
-        #else
-        materialChrome(content: content, material: .regularMaterial, strokeOpacity: 0.28)
-        #endif
+        materialChrome(
+            content: content,
+            material: .regularMaterial,
+            strokeOpacity: 0.28,
+            fillOpacity: 0.86,
+            shadowOpacity: 0.18
+        )
     }
 
     private func materialChrome(
         content: Content,
         material: Material,
-        strokeOpacity: Double
+        strokeOpacity: Double,
+        fillOpacity: Double = 0.04,
+        shadowOpacity: Double = 0
     ) -> some View {
         content
             .buttonStyle(.borderless)
@@ -1914,12 +2039,13 @@ struct FilePreviewPDFStandaloneChromeStyleModifier: ViewModifier {
                 Circle()
                     .fill(material)
                 Circle()
-                    .fill(Color.white.opacity(0.04))
+                    .fill(Color.white.opacity(fillOpacity))
             }
             .overlay {
                 Circle()
                     .stroke(Color(nsColor: .separatorColor).opacity(strokeOpacity), lineWidth: 0.5)
             }
+            .shadow(color: Color.black.opacity(shadowOpacity), radius: 8, y: 1)
     }
 }
 

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1844,7 +1844,15 @@ final class FilePreviewPDFChromeTests: XCTestCase {
     }
 
     func testPDFChromeControlsAreHitTestedAbovePDFContent() throws {
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathExtension("pdf")
+        let document = try makePDFDocument(pageCount: 1)
+        XCTAssertTrue(document.write(to: fileURL))
+        defer { try? FileManager.default.removeItem(at: fileURL) }
+
         let container = FilePreviewPDFContainerView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        container.setURL(fileURL)
         let hostView = NSView(frame: container.frame)
         let window = NSWindow(
             contentRect: container.frame,
@@ -1897,6 +1905,7 @@ final class FilePreviewPDFChromeTests: XCTestCase {
         XCTAssertTrue(isView(leftChromeHit, inside: sidebarChromeHost), debugFrames)
         XCTAssertTrue(isView(rightChromeHit, inside: zoomChromeHost), debugFrames)
         XCTAssertTrue(isView(shareChromeHit, inside: zoomChromeHost), debugFrames)
+        XCTAssertTrue(shareChromeHit is NSControl, debugFrames)
     }
 
     func testThumbnailSidebarUsesFullWidthSingleColumnLayout() throws {


### PR DESCRIPTION
Fixes the PDF preview open-with chrome button after https://github.com/manaflow-ai/cmux/pull/4088.\n\nChanges:\n- Replaces the PDF chrome open-with SwiftUI button with an AppKit control that owns hit testing and menu presentation.\n- Uses the same material-backed circular styling path for the standalone PDF open-with control in dark mode.\n- Adds a regression test that verifies the PDF share control is the hit-test target.\n- Documents the dogfood merge gate in CLAUDE.md.\n\nVerification:\n- git diff --check\n- xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux-unit -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-pdfmenu-test -only-testing:cmuxTests/FilePreviewPDFChromeTests\n- ./scripts/reload.sh --tag pdfbtn\n\nMerge note: this PR must not be merged until Lawrence dogfoods the tagged build and explicitly approves merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PDF preview chrome interaction by swapping a SwiftUI `Button` for a custom AppKit `NSControl` and refactoring menu construction; regressions could affect hit-testing, accessibility, or menu behavior in PDF preview chrome.
> 
> **Overview**
> Fixes the PDF preview chrome "Open With" control by replacing the SwiftUI button with a custom AppKit `NSControl` that owns hit-testing, first-click handling, hover/pressed appearance, accessibility, and event-anchored menu popup.
> 
> Refactors external-open menu construction into a shared `FileExternalOpenMenuBuilder` (including app list normalization/deduping) and reuses it for both header and chrome menus, while also simplifying the standalone "liquid glass" chrome styling to a material-backed circular path.
> 
> Adds a regression test that creates a real temporary PDF, sets it on `FilePreviewPDFContainerView`, and asserts the share/open-with chrome element is the hit-test target (and an `NSControl`). Also documents a new dogfood merge gate in `CLAUDE.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d60efe1e677fd08967de2f2437e1060a3fad9791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the PDF preview Open With button by replacing the SwiftUI control with a custom AppKit `NSControl` that owns hit testing, first-click, hover/press visuals, and a click-anchored menu. Styling is unified in dark mode and menus are built via one shared builder with de-duped apps.

- **Bug Fixes**
  - Replaced the PDF chrome Open With SwiftUI button with an AppKit `NSControl` that handles hit testing, hover/pressed states, first-click, accessibility, tooltips, and a click-anchored `NSMenu`.
  - Normalizes and de-duplicates applications; builds a primary action plus “Open With” submenu and passes the file URL via menu item payloads.
  - Adds a regression test using a real temp PDF; verifies chrome controls are hit-tested above PDF content and that the share/Open With control is an `NSControl`.

- **Refactors**
  - Extracted menu construction into `FileExternalOpenMenuBuilder` and reused it for both header and chrome menus.
  - Unified the standalone chrome “liquid glass” style to a material-backed circular path with tuned fill/stroke/shadow in dark mode.
  - Documented the dogfood merge gate in `CLAUDE.md`.

<sup>Written for commit d60efe1e677fd08967de2f2437e1060a3fad9791. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "dogfood merge gate" policy requiring a tagged dogfood build and explicit user confirmation before merging changes that affect runtime/UI; allows docs/metadata/workflow-only changes to merge after checks.

* **Refactor**
  * Improved external-file open menu behavior and selection, with smarter application fallback and deduplication.
  * Unified PDF preview chrome styling to use consistent material effects.

* **Tests**
  * Tightened PDF preview hit-testing to better validate control interactions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4143)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->