### PR TITLE
fix: avoid broken pipe on socket access denial

### DIFF
--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -19,6 +19,57 @@ nonisolated private struct SocketLineProcessingResult: Sendable {
     let authenticated: Bool
 }
 
+nonisolated enum SocketAccessDeniedRequestDrain {
+    /// After an access-denied response has been written and the server has
+    /// half-closed its write side, briefly consume the peer's initial request.
+    /// This keeps normal CLI clients from observing EPIPE while preserving a
+    /// bounded unauthorized-socket path: the helper stops at newline, EOF,
+    /// temporary quiescence, or maxBytesToDrain.
+    static func drainInitialRequestIfAvailable(
+        _ socket: Int32,
+        timeoutMilliseconds: Int32,
+        maxBytesToDrain: Int = 64 * 1024
+    ) -> Bool {
+        guard maxBytesToDrain > 0 else { return false }
+
+        var pollDescriptor = pollfd(fd: socket, events: Int16(POLLIN), revents: 0)
+        let pollResult = poll(&pollDescriptor, 1, timeoutMilliseconds)
+        guard pollResult > 0, pollDescriptor.revents & Int16(POLLIN) != 0 else {
+            return false
+        }
+
+        var drainedAnyBytes = false
+        var totalBytesDrained = 0
+        var buffer = [UInt8](repeating: 0, count: min(4096, maxBytesToDrain))
+        while totalBytesDrained < maxBytesToDrain {
+            let remainingLimit = maxBytesToDrain - totalBytesDrained
+            let bytesRead = read(socket, &buffer, min(buffer.count, remainingLimit))
+            if bytesRead < 0 {
+                if errno == EINTR {
+                    continue
+                }
+                return drainedAnyBytes
+            }
+            guard bytesRead > 0 else {
+                return drainedAnyBytes
+            }
+
+            drainedAnyBytes = true
+            totalBytesDrained += bytesRead
+            if buffer[0..<bytesRead].contains(UInt8(ascii: "\n")) {
+                return true
+            }
+
+            var nextPollDescriptor = pollfd(fd: socket, events: Int16(POLLIN), revents: 0)
+            let nextPollResult = poll(&nextPollDescriptor, 1, 0)
+            guard nextPollResult > 0, nextPollDescriptor.revents & Int16(POLLIN) != 0 else {
+                return drainedAnyBytes
+            }
+        }
+        return drainedAnyBytes
+    }
+}
+
 /// Unix socket-based controller for programmatic terminal control
 /// Allows automated testing and external control of terminal tabs
 @MainActor
@@ -1932,9 +1983,16 @@ class TerminalController {
             let pid = peerPid ?? getPeerPid(socket)
             if let pid {
                 guard isDescendant(pid) else {
-                    _ = writeSocketResponse(
+                    guard writeSocketResponse(
                         "ERROR: Access denied — only processes started inside cmux can connect",
                         to: socket
+                    ) else {
+                        return
+                    }
+                    _ = shutdown(socket, SHUT_WR)
+                    _ = SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(
+                        socket,
+                        timeoutMilliseconds: 0
                     )
                     return
                 }

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -4750,6 +4750,110 @@ final class TerminalControllerSocketListenerHealthTests: XCTestCase {
         XCTAssertFalse(health.isHealthy)
     }
 
+    func testDrainInitialSocketRequestConsumesPendingCommandLineBeforeAccessDeniedReply() throws {
+        var sockets: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            Darwin.close(sockets[0])
+            Darwin.close(sockets[1])
+        }
+
+        let command = "ping\n"
+        _ = command.withCString { ptr in
+            write(sockets[0], ptr, strlen(ptr))
+        }
+
+        XCTAssertTrue(
+            SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(
+                sockets[1],
+                timeoutMilliseconds: 100
+            )
+        )
+
+        var pollDescriptor = pollfd(fd: sockets[1], events: Int16(POLLIN), revents: 0)
+        XCTAssertEqual(poll(&pollDescriptor, 1, 0), 0)
+
+        let response = "ERROR: Access denied — only processes started inside cmux can connect\n"
+        XCTAssertTrue(TerminalController.writeAllToSocket(Data(response.utf8), to: sockets[1]))
+        var buffer = [UInt8](repeating: 0, count: 256)
+        let count = read(sockets[0], &buffer, buffer.count)
+        XCTAssertGreaterThan(count, 0)
+        XCTAssertEqual(String(bytes: buffer[0..<count], encoding: .utf8), response)
+    }
+
+    func testDrainInitialSocketRequestCapsBytesWithoutNewline() throws {
+        var sockets: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            Darwin.close(sockets[0])
+            Darwin.close(sockets[1])
+        }
+
+        let payload = Data(repeating: UInt8(ascii: "x"), count: 512)
+        _ = payload.withUnsafeBytes { rawBuffer in
+            write(sockets[0], rawBuffer.baseAddress, rawBuffer.count)
+        }
+
+        XCTAssertTrue(
+            SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(
+                sockets[1],
+                timeoutMilliseconds: 100,
+                maxBytesToDrain: 128
+            )
+        )
+
+        var pollDescriptor = pollfd(fd: sockets[1], events: Int16(POLLIN), revents: 0)
+        XCTAssertEqual(poll(&pollDescriptor, 1, 0), 1)
+    }
+
+    func testAccessDeniedHalfCloseAllowsAlreadyQueuedClientRequestWrite() throws {
+        var sockets: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            Darwin.close(sockets[0])
+            Darwin.close(sockets[1])
+        }
+
+        let response = "ERROR: Access denied — only processes started inside cmux can connect\n"
+        XCTAssertTrue(TerminalController.writeAllToSocket(Data(response.utf8), to: sockets[1]))
+        XCTAssertEqual(shutdown(sockets[1], SHUT_WR), 0)
+
+        let command = "ping\n"
+        let sent = command.withCString { ptr in
+            write(sockets[0], ptr, strlen(ptr))
+        }
+        XCTAssertEqual(sent, command.utf8.count)
+        XCTAssertTrue(
+            SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(
+                sockets[1],
+                timeoutMilliseconds: 0
+            )
+        )
+
+        var buffer = [UInt8](repeating: 0, count: 256)
+        let count = read(sockets[0], &buffer, buffer.count)
+        XCTAssertGreaterThan(count, 0)
+        XCTAssertEqual(String(bytes: buffer[0..<count], encoding: .utf8), response)
+    }
+
+    func testDrainInitialSocketRequestReturnsFalseWhenNoClientLineArrives() throws {
+        var sockets: [Int32] = [-1, -1]
+        XCTAssertEqual(socketpair(AF_UNIX, SOCK_STREAM, 0, &sockets), 0)
+        defer {
+            Darwin.close(sockets[0])
+            Darwin.close(sockets[1])
+        }
+
+        let startedAt = Date()
+        XCTAssertFalse(
+            SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(
+                sockets[1],
+                timeoutMilliseconds: 20
+            )
+        )
+        XCTAssertLessThan(Date().timeIntervalSince(startedAt), 0.25)
+    }
+
     func testProbeSocketCommandReturnsFirstLineResponse() throws {
         let path = makeTempSocketPath()
         let listenerFD = try bindUnixSocket(at: path)


### PR DESCRIPTION
## Summary
- drain an immediately available first client request line before replying to a `cmuxOnly` ancestry denial
- keeps unauthorized CLI calls on the normal `ERROR: Access denied — only processes started inside cmux can connect` path instead of racing into `Failed to write to socket (Broken pipe, errno 32)`
- adds socketpair regression coverage for the drain/no-data behavior

## Test Plan
- `git diff --check`
- `swiftc -parse Sources/TerminalController.swift cmuxTests/TerminalAndGhosttyTests.swift`
- attempted targeted Xcode test:
  - `xcodebuild test -project GhosttyTabs.xcodeproj -scheme cmux -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/TerminalControllerSocketListenerHealthTests/testDrainInitialSocketRequestConsumesPendingCommandLineBeforeAccessDeniedReply`
  - blocked locally because this machine has only Command Line Tools selected/installed: `xcode-select: error: tool 'xcodebuild' requires Xcode, but active developer directory '/Library/Developer/CommandLineTools' is a command line tools instance`

## Notes
The local production app currently returns `Failed to write to socket (Broken pipe, errno 32)` for `cmux ping`/`cmux identify` from outside cmux. A raw UNIX socket client can receive the intended access-denied reply, which points to a race where the denied peer closes before the CLI finishes writing its first request.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents Broken pipe errors on socket access denial by half-closing the server write side after sending the denial and briefly draining the client’s first line. Unauthorized `cmux` CLI calls now get the expected access-denied message without EPIPE.

- **Bug Fixes**
  - Added `SocketAccessDeniedRequestDrain.drainInitialRequestIfAvailable(...)` that polls and drains up to a byte cap, stopping at newline, EOF, quiescence, or limit.
  - On denial: write error, `shutdown(..., SHUT_WR)`, then drain with zero-timeout.
  - Tests cover queued-line drain, byte-cap without newline, half-close allowing queued client write, and no-data.

<sup>Written for commit d47c4bc3d26805f6a249c637127fa8424a960baa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access-denied handling to consume any immediately-pending client bytes before completing the denial, preventing leftover data from interfering with subsequent I/O.

* **Tests**
  * Added regression tests covering draining behavior, byte limits, newline-terminated input, half-closed sockets, and timeout cases for access-denied paths.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4146)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->