### PR TITLE
Add browser tools popover

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -13475,19 +13475,240 @@
         }
       }
     },
-    "browser.tools.showDeviceToolbar.unavailable": {
+    "browser.tools.hideDeviceToolbar": {
       "extractionState": "manual",
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Device toolbar is not available in WKWebView."
+            "value": "Hide device toolbar"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "WKWebViewではデバイスツールバーを使用できません。"
+            "value": "デバイスツールバーを非表示"
+          }
+        }
+      }
+    },
+    "browser.device.close": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close device toolbar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイスツールバーを閉じる"
+          }
+        }
+      }
+    },
+    "browser.device.height": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Height"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高さ"
+          }
+        }
+      }
+    },
+    "browser.device.height.short": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "H"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高"
+          }
+        }
+      }
+    },
+    "browser.device.preset": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイス"
+          }
+        }
+      }
+    },
+    "browser.device.preset.desktop": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Desktop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ"
+          }
+        }
+      }
+    },
+    "browser.device.preset.ipad": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPad"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPad"
+          }
+        }
+      }
+    },
+    "browser.device.preset.iphone15": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 15"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone 15"
+          }
+        }
+      }
+    },
+    "browser.device.preset.iphoneSE": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone SE"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "iPhone SE"
+          }
+        }
+      }
+    },
+    "browser.device.preset.responsive": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Responsive"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レスポンシブ"
+          }
+        }
+      }
+    },
+    "browser.device.rotate": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Rotate viewport"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ビューポートを回転"
+          }
+        }
+      }
+    },
+    "browser.device.sizeFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d × %d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%d × %d"
+          }
+        }
+      }
+    },
+    "browser.device.width": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Width"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幅"
+          }
+        }
+      }
+    },
+    "browser.device.width.short": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "W"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "幅"
           }
         }
       }

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -13390,6 +13390,125 @@
         }
       }
     },
+    "browser.tools.buttonHelp": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browser Tools"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウザツール"
+          }
+        }
+      }
+    },
+    "browser.tools.clearCache": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear cache"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キャッシュを消去"
+          }
+        }
+      }
+    },
+    "browser.tools.clearCookies": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear cookies"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cookieを消去"
+          }
+        }
+      }
+    },
+    "browser.tools.forceReload": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Force reload"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "強制再読み込み"
+          }
+        }
+      }
+    },
+    "browser.tools.showDeviceToolbar": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show device toolbar"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デバイスツールバーを表示"
+          }
+        }
+      }
+    },
+    "browser.tools.showDeviceToolbar.unavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Device toolbar is not available in WKWebView."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WKWebViewではデバイスツールバーを使用できません。"
+          }
+        }
+      }
+    },
+    "browser.tools.zoom": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zoom"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ズーム"
+          }
+        }
+      }
+    },
     "browser.reactGrab": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2288,6 +2288,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
     /// Published can go forward state
     @Published private(set) var canGoForward: Bool = false
+    @Published private(set) var pageZoomFactor: CGFloat = 1.0
 
     private var nativeCanGoBack: Bool = false
     private var nativeCanGoForward: Bool = false
@@ -3073,6 +3074,7 @@ final class BrowserPanel: Panel, ObservableObject {
             websiteDataStore: websiteDataStore
         )
         replacement.pageZoom = desiredZoom
+        pageZoomFactor = desiredZoom
         webViewInstanceID = UUID()
         webView = replacement
         currentURL = restoreURL
@@ -3423,6 +3425,7 @@ final class BrowserPanel: Panel, ObservableObject {
             websiteDataStore: websiteDataStore
         )
         replacement.pageZoom = desiredZoom
+        pageZoomFactor = desiredZoom
         webViewInstanceID = UUID()
         webView = replacement
         shouldRenderWebView = wasRenderable
@@ -4514,6 +4517,57 @@ extension BrowserPanel {
             }
         }
         webView.reload()
+    }
+
+    var canForceReloadCurrentPage: Bool {
+        currentURL != nil || webView.url != nil
+    }
+
+    /// Reload the current page while bypassing WebKit's cache when possible.
+    func forceReload() {
+        guard canForceReloadCurrentPage else { return }
+        webView.customUserAgent = BrowserUserAgentSettings.safariUserAgent
+        if webView.url == nil {
+            reload()
+            return
+        }
+        webView.reloadFromOrigin()
+    }
+
+    @discardableResult
+    func clearCookies() async -> Int {
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+        let cookies = await withCheckedContinuation { continuation in
+            cookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+
+        var removed = 0
+        for cookie in cookies {
+            await withCheckedContinuation { continuation in
+                cookieStore.delete(cookie) {
+                    continuation.resume()
+                }
+            }
+            removed += 1
+        }
+        return removed
+    }
+
+    @discardableResult
+    func clearCache() async -> [String] {
+        let dataTypes = Self.cacheWebsiteDataTypes(from: WKWebsiteDataStore.allWebsiteDataTypes())
+        guard !dataTypes.isEmpty else { return [] }
+        await withCheckedContinuation { continuation in
+            webView.configuration.websiteDataStore.removeData(
+                ofTypes: dataTypes,
+                modifiedSince: .distantPast
+            ) {
+                continuation.resume()
+            }
+        }
+        return Array(dataTypes).sorted()
     }
 
     /// Stop loading
@@ -5890,6 +5944,12 @@ extension BrowserPanel {
 #endif
 
 private extension BrowserPanel {
+    static func cacheWebsiteDataTypes(from availableDataTypes: Set<String>) -> Set<String> {
+        availableDataTypes.filter {
+            $0.range(of: "cache", options: [.caseInsensitive, .diacriticInsensitive]) != nil
+        }
+    }
+
     @discardableResult
     func applyPageZoom(_ candidate: CGFloat) -> Bool {
         let clamped = max(minPageZoom, min(maxPageZoom, candidate))
@@ -5897,6 +5957,7 @@ private extension BrowserPanel {
             return false
         }
         webView.pageZoom = clamped
+        pageZoomFactor = clamped
         return true
     }
 

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -428,6 +428,9 @@ struct BrowserPanelView: View {
     @State private var omnibarSelectAllRequestId: UInt64 = 0
     @State private var isBrowserProfileMenuPresented = false
     @State private var isBrowserThemeMenuPresented = false
+    @State private var isBrowserToolsMenuPresented = false
+    @State private var isBrowserToolsClearingCookies = false
+    @State private var isBrowserToolsClearingCache = false
     @State private var browserChromeStyle = BrowserChromeStyle.resolve(
         for: .light,
         themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
@@ -439,6 +442,8 @@ struct BrowserPanelView: View {
     private let addressBarButtonHitSize: CGFloat = 26
     private let addressBarVerticalPadding: CGFloat = 4
     private let devToolsButtonIconSize: CGFloat = 11
+    private let browserToolsPopoverWidth: CGFloat = 276
+    private let browserToolsRowHeight: CGFloat = 32
 
     private var searchEngine: BrowserSearchEngine {
         BrowserSearchEngine(rawValue: searchEngineRaw) ?? BrowserSearchSettings.defaultSearchEngine
@@ -856,6 +861,7 @@ struct BrowserPanelView: View {
                 browserProfileButton
                 browserThemeModeButton
                 developerToolsButton
+                browserToolsButton
             }
         }
         .padding(.horizontal, 8)
@@ -1033,6 +1039,193 @@ struct BrowserPanelView: View {
             )
         )
         .accessibilityIdentifier("BrowserThemeModeButton")
+    }
+
+    private var browserToolsButton: some View {
+        Button(action: {
+            isBrowserToolsMenuPresented.toggle()
+        }) {
+            Image(systemName: "ellipsis")
+                .symbolRenderingMode(.monochrome)
+                .cmuxFlatSymbolColorRendering()
+                .font(.system(size: devToolsButtonIconSize, weight: .semibold))
+                .foregroundStyle(devToolsColorOption.color)
+                .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        }
+        .buttonStyle(OmnibarAddressButtonStyle())
+        .frame(width: addressBarButtonSize, height: addressBarButtonSize, alignment: .center)
+        .popover(isPresented: $isBrowserToolsMenuPresented, arrowEdge: .bottom) {
+            browserToolsPopover
+        }
+        .safeHelp(String(localized: "browser.tools.buttonHelp", defaultValue: "Browser Tools"))
+        .accessibilityIdentifier("BrowserToolsButton")
+    }
+
+    private var browserToolsPopover: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            browserToolsTextButton(
+                title: String(localized: "browser.tools.forceReload", defaultValue: "Force reload"),
+                isDisabled: !panel.canForceReloadCurrentPage,
+                accessibilityIdentifier: "BrowserToolsForceReloadButton"
+            ) {
+                panel.forceReload()
+                isBrowserToolsMenuPresented = false
+            }
+
+            browserToolsTextButton(
+                title: String(localized: "browser.tools.showDeviceToolbar", defaultValue: "Show device toolbar"),
+                isDisabled: true,
+                accessibilityIdentifier: "BrowserToolsDeviceToolbarButton"
+            ) {}
+            .safeHelp(String(localized: "browser.tools.showDeviceToolbar.unavailable", defaultValue: "Device toolbar is not available in WKWebView."))
+
+            browserToolsDivider
+
+            browserToolsZoomRow
+
+            browserToolsDivider
+
+            browserToolsTextButton(
+                title: String(localized: "browser.tools.clearCookies", defaultValue: "Clear cookies"),
+                isDisabled: isBrowserToolsClearingCookies,
+                accessibilityIdentifier: "BrowserToolsClearCookiesButton"
+            ) {
+                clearBrowserToolsCookies()
+            }
+
+            browserToolsTextButton(
+                title: String(localized: "browser.tools.clearCache", defaultValue: "Clear cache"),
+                isDisabled: isBrowserToolsClearingCache,
+                accessibilityIdentifier: "BrowserToolsClearCacheButton"
+            ) {
+                clearBrowserToolsCache()
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .frame(width: browserToolsPopoverWidth)
+        .accessibilityIdentifier("BrowserToolsPopover")
+    }
+
+    private var browserToolsDivider: some View {
+        Divider()
+            .padding(.vertical, 6)
+    }
+
+    private var browserToolsZoomRow: some View {
+        HStack(spacing: 10) {
+            Text(String(localized: "browser.tools.zoom", defaultValue: "Zoom"))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            HStack(spacing: 0) {
+                Button {
+                    _ = panel.zoomOut()
+                } label: {
+                    Image(systemName: "minus")
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 34, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .safeHelp(String(localized: "menu.view.zoomOut", defaultValue: "Zoom Out"))
+                .accessibilityIdentifier("BrowserToolsZoomOutButton")
+
+                browserToolsZoomDivider
+
+                Text(browserToolsZoomPercent)
+                    .font(.system(size: 13, weight: .medium, design: .monospaced))
+                    .frame(width: 62, height: 26)
+                    .accessibilityIdentifier("BrowserToolsZoomPercent")
+
+                browserToolsZoomDivider
+
+                Button {
+                    _ = panel.zoomIn()
+                } label: {
+                    Image(systemName: "plus")
+                        .font(.system(size: 11, weight: .medium))
+                        .frame(width: 34, height: 26)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .safeHelp(String(localized: "menu.view.zoomIn", defaultValue: "Zoom In"))
+                .accessibilityIdentifier("BrowserToolsZoomInButton")
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(Color.primary.opacity(0.12), lineWidth: 1)
+                    .background(
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(Color.primary.opacity(0.04))
+                    )
+            )
+
+            Button {
+                _ = panel.resetZoom()
+            } label: {
+                Image(systemName: "arrow.counterclockwise")
+                    .font(.system(size: 12, weight: .medium))
+                    .frame(width: 26, height: 26)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .safeHelp(String(localized: "menu.view.actualSize", defaultValue: "Actual Size"))
+            .accessibilityIdentifier("BrowserToolsZoomResetButton")
+        }
+        .frame(height: browserToolsRowHeight)
+    }
+
+    private var browserToolsZoomDivider: some View {
+        Rectangle()
+            .fill(Color.primary.opacity(0.12))
+            .frame(width: 1, height: 18)
+    }
+
+    private var browserToolsZoomPercent: String {
+        "\(Int((panel.pageZoomFactor * 100).rounded()))%"
+    }
+
+    private func browserToolsTextButton(
+        title: String,
+        isDisabled: Bool,
+        accessibilityIdentifier: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            HStack(spacing: 8) {
+                Text(title)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.primary)
+                Spacer(minLength: 0)
+            }
+            .frame(height: browserToolsRowHeight)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .disabled(isDisabled)
+        .opacity(isDisabled ? 0.45 : 1.0)
+        .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func clearBrowserToolsCookies() {
+        guard !isBrowserToolsClearingCookies else { return }
+        isBrowserToolsClearingCookies = true
+        Task { @MainActor in
+            _ = await panel.clearCookies()
+            isBrowserToolsClearingCookies = false
+            isBrowserToolsMenuPresented = false
+        }
+    }
+
+    private func clearBrowserToolsCache() {
+        guard !isBrowserToolsClearingCache else { return }
+        isBrowserToolsClearingCache = true
+        Task { @MainActor in
+            _ = await panel.clearCache()
+            isBrowserToolsClearingCache = false
+            isBrowserToolsMenuPresented = false
+        }
     }
 
     private var browserImportHintToolbarChip: some View {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -16,6 +16,15 @@ private func browserPanelViewRectDescription(_ rect: NSRect) -> String {
     String(format: "%.1f,%.1f %.1fx%.1f", rect.origin.x, rect.origin.y, rect.width, rect.height)
 }
 
+private struct BrowserDevicePreset: Identifiable, Hashable {
+    static let responsiveID = "responsive"
+
+    let id: String
+    let name: String
+    let width: Int?
+    let height: Int?
+}
+
 private extension NSObject {
     @discardableResult
     func browserPanelCallVoidIfAvailable(_ rawSelector: String) -> Bool {
@@ -423,6 +432,7 @@ struct BrowserPanelView: View {
     @State private var focusFlashAnimationGeneration: Int = 0
     @State private var omnibarPillFrame: CGRect = .zero
     @State private var addressBarHeight: CGFloat = 0
+    @State private var browserDeviceToolbarHeight: CGFloat = 0
     @State private var isBrowserImportHintPopoverPresented = false
     @State private var lastHandledAddressBarFocusRequestId: UUID?
     @State private var omnibarSelectAllRequestId: UInt64 = 0
@@ -431,6 +441,10 @@ struct BrowserPanelView: View {
     @State private var isBrowserToolsMenuPresented = false
     @State private var isBrowserToolsClearingCookies = false
     @State private var isBrowserToolsClearingCache = false
+    @State private var isBrowserDeviceToolbarVisible = false
+    @State private var browserDevicePresetID = BrowserDevicePreset.responsiveID
+    @State private var browserDeviceViewportWidth = 390
+    @State private var browserDeviceViewportHeight = 844
     @State private var browserChromeStyle = BrowserChromeStyle.resolve(
         for: .light,
         themeBackgroundColor: GhosttyBackgroundTheme.currentColor()
@@ -444,6 +458,19 @@ struct BrowserPanelView: View {
     private let devToolsButtonIconSize: CGFloat = 11
     private let browserToolsPopoverWidth: CGFloat = 276
     private let browserToolsRowHeight: CGFloat = 32
+    private let browserDeviceToolbarHorizontalPadding: CGFloat = 8
+    private let browserDeviceToolbarVerticalPadding: CGFloat = 5
+    private let browserDeviceViewportMinDimension = 240
+    private let browserDeviceViewportMaxDimension = 4096
+    private static let browserDeviceDimensionFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .none
+        formatter.allowsFloats = false
+        formatter.minimum = 240
+        formatter.maximum = 4096
+        formatter.usesGroupingSeparator = false
+        return formatter
+    }()
 
     private var searchEngine: BrowserSearchEngine {
         BrowserSearchEngine(rawValue: searchEngineRaw) ?? BrowserSearchSettings.defaultSearchEngine
@@ -517,6 +544,10 @@ struct BrowserPanelView: View {
         browserChromeStyle.colorScheme
     }
 
+    private var browserTopChromeHeight: CGFloat {
+        addressBarHeight + (isBrowserDeviceToolbarVisible ? browserDeviceToolbarHeight : 0)
+    }
+
     private var browserContentAccessibilityIdentifier: String {
         "BrowserPanelContent.\(panel.id.uuidString)"
     }
@@ -560,7 +591,11 @@ struct BrowserPanelView: View {
         VStack(spacing: 0) {
             addressBar
                 .fixedSize(horizontal: false, vertical: true)
-            webView
+            if isBrowserDeviceToolbarVisible {
+                browserDeviceToolbar
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            browserWebContent
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .overlay {
@@ -617,6 +652,9 @@ struct BrowserPanelView: View {
         }
         .onPreferenceChange(BrowserAddressBarHeightPreferenceKey.self) { height in
             addressBarHeight = height
+        }
+        .onPreferenceChange(BrowserDeviceToolbarHeightPreferenceKey.self) { height in
+            browserDeviceToolbarHeight = height
         }
         .onReceive(NotificationCenter.default.publisher(for: .webViewDidReceiveClick).filter { [weak panel] note in
             // Only handle clicks from our own webview.
@@ -1073,11 +1111,13 @@ struct BrowserPanelView: View {
             }
 
             browserToolsTextButton(
-                title: String(localized: "browser.tools.showDeviceToolbar", defaultValue: "Show device toolbar"),
-                isDisabled: true,
+                title: browserDeviceToolbarMenuTitle,
+                isDisabled: false,
                 accessibilityIdentifier: "BrowserToolsDeviceToolbarButton"
-            ) {}
-            .safeHelp(String(localized: "browser.tools.showDeviceToolbar.unavailable", defaultValue: "Device toolbar is not available in WKWebView."))
+            ) {
+                isBrowserDeviceToolbarVisible.toggle()
+                isBrowserToolsMenuPresented = false
+            }
 
             browserToolsDivider
 
@@ -1226,6 +1266,248 @@ struct BrowserPanelView: View {
             isBrowserToolsClearingCache = false
             isBrowserToolsMenuPresented = false
         }
+    }
+
+    private var browserDeviceToolbarMenuTitle: String {
+        if isBrowserDeviceToolbarVisible {
+            return String(localized: "browser.tools.hideDeviceToolbar", defaultValue: "Hide device toolbar")
+        }
+        return String(localized: "browser.tools.showDeviceToolbar", defaultValue: "Show device toolbar")
+    }
+
+    private var browserDevicePresets: [BrowserDevicePreset] {
+        [
+            BrowserDevicePreset(
+                id: BrowserDevicePreset.responsiveID,
+                name: String(localized: "browser.device.preset.responsive", defaultValue: "Responsive"),
+                width: nil,
+                height: nil
+            ),
+            BrowserDevicePreset(
+                id: "iphone-se",
+                name: String(localized: "browser.device.preset.iphoneSE", defaultValue: "iPhone SE"),
+                width: 375,
+                height: 667
+            ),
+            BrowserDevicePreset(
+                id: "iphone-15",
+                name: String(localized: "browser.device.preset.iphone15", defaultValue: "iPhone 15"),
+                width: 393,
+                height: 852
+            ),
+            BrowserDevicePreset(
+                id: "ipad",
+                name: String(localized: "browser.device.preset.ipad", defaultValue: "iPad"),
+                width: 820,
+                height: 1180
+            ),
+            BrowserDevicePreset(
+                id: "desktop",
+                name: String(localized: "browser.device.preset.desktop", defaultValue: "Desktop"),
+                width: 1280,
+                height: 800
+            ),
+        ]
+    }
+
+    private var browserDevicePresetBinding: Binding<String> {
+        Binding(
+            get: { browserDevicePresetID },
+            set: { applyBrowserDevicePreset(id: $0) }
+        )
+    }
+
+    private var browserDeviceViewportWidthBinding: Binding<Int> {
+        Binding(
+            get: { browserDeviceViewportWidth },
+            set: { value in
+                browserDeviceViewportWidth = clampedBrowserDeviceDimension(value)
+                browserDevicePresetID = BrowserDevicePreset.responsiveID
+            }
+        )
+    }
+
+    private var browserDeviceViewportHeightBinding: Binding<Int> {
+        Binding(
+            get: { browserDeviceViewportHeight },
+            set: { value in
+                browserDeviceViewportHeight = clampedBrowserDeviceDimension(value)
+                browserDevicePresetID = BrowserDevicePreset.responsiveID
+            }
+        )
+    }
+
+    @ViewBuilder
+    private var browserWebContent: some View {
+        if isBrowserDeviceToolbarVisible {
+            browserDevicePreviewCanvas
+        } else {
+            webView
+        }
+    }
+
+    private var browserDeviceToolbar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                Image(systemName: "iphone")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 18, height: 22)
+
+                Picker(
+                    String(localized: "browser.device.preset", defaultValue: "Device"),
+                    selection: browserDevicePresetBinding
+                ) {
+                    ForEach(browserDevicePresets) { preset in
+                        Text(preset.name)
+                            .tag(preset.id)
+                    }
+                }
+                .labelsHidden()
+                .pickerStyle(.menu)
+                .controlSize(.small)
+                .frame(width: 142)
+                .accessibilityIdentifier("BrowserDevicePresetPicker")
+
+                browserDeviceDimensionField(
+                    title: String(localized: "browser.device.width.short", defaultValue: "W"),
+                    accessibilityLabel: String(localized: "browser.device.width", defaultValue: "Width"),
+                    accessibilityIdentifier: "BrowserDeviceWidthField",
+                    value: browserDeviceViewportWidthBinding
+                )
+
+                Text(verbatim: "×")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(.secondary)
+
+                browserDeviceDimensionField(
+                    title: String(localized: "browser.device.height.short", defaultValue: "H"),
+                    accessibilityLabel: String(localized: "browser.device.height", defaultValue: "Height"),
+                    accessibilityIdentifier: "BrowserDeviceHeightField",
+                    value: browserDeviceViewportHeightBinding
+                )
+
+                Button {
+                    browserDevicePresetID = BrowserDevicePreset.responsiveID
+                    swap(&browserDeviceViewportWidth, &browserDeviceViewportHeight)
+                } label: {
+                    Image(systemName: "arrow.triangle.2.circlepath")
+                        .font(.system(size: 12, weight: .medium))
+                        .frame(width: 24, height: 22)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .safeHelp(String(localized: "browser.device.rotate", defaultValue: "Rotate viewport"))
+                .accessibilityIdentifier("BrowserDeviceRotateButton")
+
+                Text(browserDeviceViewportSummary)
+                    .font(.system(size: 11, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                    .frame(minWidth: 78, alignment: .leading)
+                    .accessibilityIdentifier("BrowserDeviceViewportSummary")
+
+                Button {
+                    isBrowserDeviceToolbarVisible = false
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .semibold))
+                        .frame(width: 24, height: 22)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .safeHelp(String(localized: "browser.device.close", defaultValue: "Close device toolbar"))
+                .accessibilityIdentifier("BrowserDeviceCloseButton")
+            }
+            .padding(.horizontal, browserDeviceToolbarHorizontalPadding)
+            .padding(.vertical, browserDeviceToolbarVerticalPadding)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(browserChromeBackground)
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .background {
+            GeometryReader { geo in
+                Color.clear
+                    .preference(
+                        key: BrowserDeviceToolbarHeightPreferenceKey.self,
+                        value: geo.size.height
+                    )
+            }
+        }
+        .accessibilityIdentifier("BrowserDeviceToolbar")
+        .environment(\.colorScheme, browserChromeColorScheme)
+        .zIndex(1)
+    }
+
+    private var browserDevicePreviewCanvas: some View {
+        GeometryReader { geometry in
+            let viewportWidth = CGFloat(browserDeviceViewportWidth)
+            let viewportHeight = CGFloat(browserDeviceViewportHeight)
+            let contentWidth = max(geometry.size.width, viewportWidth + 32)
+            let contentHeight = max(geometry.size.height, viewportHeight + 32)
+
+            ScrollView([.horizontal, .vertical]) {
+                ZStack(alignment: .top) {
+                    webView
+                        .frame(width: viewportWidth, height: viewportHeight, alignment: .topLeading)
+                        .background(Color(nsColor: .textBackgroundColor))
+                        .clipShape(Rectangle())
+                        .overlay {
+                            Rectangle()
+                                .stroke(Color.primary.opacity(0.16), lineWidth: 1)
+                        }
+                        .shadow(color: Color.black.opacity(0.14), radius: 12, y: 4)
+                        .padding(16)
+                }
+                .frame(width: contentWidth, height: contentHeight, alignment: .top)
+            }
+            .background(
+                browserChromeBackground
+                    .overlay(Color.primary.opacity(browserChromeColorScheme == .dark ? 0.08 : 0.05))
+            )
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .layoutPriority(1)
+        .accessibilityIdentifier("BrowserDevicePreviewCanvas")
+    }
+
+    private var browserDeviceViewportSummary: String {
+        String(
+            format: String(localized: "browser.device.sizeFormat", defaultValue: "%d × %d"),
+            browserDeviceViewportWidth,
+            browserDeviceViewportHeight
+        )
+    }
+
+    private func browserDeviceDimensionField(
+        title: String,
+        accessibilityLabel: String,
+        accessibilityIdentifier: String,
+        value: Binding<Int>
+    ) -> some View {
+        TextField(title, value: value, formatter: Self.browserDeviceDimensionFormatter)
+            .textFieldStyle(.roundedBorder)
+            .font(.system(size: 11, weight: .medium, design: .monospaced))
+            .frame(width: 56)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityIdentifier(accessibilityIdentifier)
+    }
+
+    private func applyBrowserDevicePreset(id: String) {
+        browserDevicePresetID = id
+        guard let preset = browserDevicePresets.first(where: { $0.id == id }),
+              let width = preset.width,
+              let height = preset.height else {
+            return
+        }
+        browserDeviceViewportWidth = clampedBrowserDeviceDimension(width)
+        browserDeviceViewportHeight = clampedBrowserDeviceDimension(height)
+    }
+
+    private func clampedBrowserDeviceDimension(_ value: Int) -> Int {
+        min(browserDeviceViewportMaxDimension, max(browserDeviceViewportMinDimension, value))
     }
 
     private var browserImportHintToolbarChip: some View {
@@ -1480,7 +1762,7 @@ struct BrowserPanelView: View {
                             onFieldDidFocus: { panel.noteFindFieldFocused() }
                         )
                     },
-                    paneTopChromeHeight: addressBarHeight
+                    paneTopChromeHeight: browserTopChromeHeight
                 )
                 .accessibilityIdentifier("BrowserWebViewSurface")
                 // Keep the host stable for normal pane churn, but force a remount when
@@ -3124,6 +3406,14 @@ private struct OmnibarPillFramePreferenceKey: PreferenceKey {
 }
 
 private struct BrowserAddressBarHeightPreferenceKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = max(value, nextValue())
+    }
+}
+
+private struct BrowserDeviceToolbarHeightPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
 
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -82,6 +82,79 @@ final class BrowserPanelInitialNavigationTests: XCTestCase {
 }
 
 
+@MainActor
+final class BrowserPanelToolsActionsTests: XCTestCase {
+    func testClearCookiesDeletesCookiesInCurrentProfileStore() async throws {
+        let profile = try makeTemporaryBrowserPanelProfile(named: "ToolsCookies")
+        defer { _ = BrowserProfileStore.shared.deleteProfile(id: profile.id) }
+
+        let panel = BrowserPanel(workspaceId: UUID(), profileID: profile.id)
+        let cookie = try makeCookie(name: "cmux_tools_cookie")
+        let cookieStore = panel.webView.configuration.websiteDataStore.httpCookieStore
+        await setCookie(cookie, in: cookieStore)
+
+        let initialCookies = await allCookies(in: cookieStore)
+        XCTAssertTrue(initialCookies.contains { $0.name == cookie.name })
+
+        let removed = await panel.clearCookies()
+
+        XCTAssertEqual(removed, 1)
+        let remainingCookies = await allCookies(in: cookieStore)
+        XCTAssertFalse(remainingCookies.contains { $0.name == cookie.name })
+    }
+
+    func testClearCacheDoesNotClearCookies() async throws {
+        let profile = try makeTemporaryBrowserPanelProfile(named: "ToolsCache")
+        defer { _ = BrowserProfileStore.shared.deleteProfile(id: profile.id) }
+
+        let panel = BrowserPanel(workspaceId: UUID(), profileID: profile.id)
+        let cookie = try makeCookie(name: "cmux_tools_cache_cookie")
+        let cookieStore = panel.webView.configuration.websiteDataStore.httpCookieStore
+        await setCookie(cookie, in: cookieStore)
+
+        let clearedTypes = await panel.clearCache()
+
+        XCTAssertTrue(
+            clearedTypes.allSatisfy {
+                $0.range(of: "cache", options: [.caseInsensitive, .diacriticInsensitive]) != nil
+            }
+        )
+        let remainingCookies = await allCookies(in: cookieStore)
+        XCTAssertTrue(remainingCookies.contains { $0.name == cookie.name })
+        _ = await panel.clearCookies()
+    }
+
+    private func makeCookie(name: String) throws -> HTTPCookie {
+        try XCTUnwrap(
+            HTTPCookie(properties: [
+                .originURL: URL(string: "https://example.com")!,
+                .domain: "example.com",
+                .path: "/",
+                .name: "\(name)-\(UUID().uuidString)",
+                .value: "1",
+                .expires: Date(timeIntervalSinceNow: 3600),
+            ])
+        )
+    }
+
+    private func setCookie(_ cookie: HTTPCookie, in store: WKHTTPCookieStore) async {
+        await withCheckedContinuation { continuation in
+            store.setCookie(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func allCookies(in store: WKHTTPCookieStore) async -> [HTTPCookie] {
+        await withCheckedContinuation { continuation in
+            store.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+    }
+}
+
+
 final class BrowserPanelOmnibarPillBackgroundColorTests: XCTestCase {
     func testLightModeSlightlyDarkensThemeBackground() {
         assertResolvedColorMatchesExpectedBlend(for: .light, darkenMix: 0.04)

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -526,10 +526,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(result.status, 0, result.stderr)
         let recorded = (try? String(contentsOf: stdinCapture, encoding: .utf8))?
             .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let recordedDescription = recorded.isEmpty ? "<empty>" : recorded
         XCTAssertEqual(
             recorded,
             "FORWARDED_KEYSTROKE",
-            "Backgrounded ssh in the startup wrapper must inherit the wrapper's stdin so that keystrokes from the surface PTY reach the remote shell. Got: \(recorded.isEmpty ? \"<empty>\" : recorded)"
+            "Backgrounded ssh in the startup wrapper must inherit the wrapper's stdin so that keystrokes from the surface PTY reach the remote shell. Got: \(recordedDescription)"
         )
     }
 


### PR DESCRIPTION
Summary
- Add a Browser Tools popover with force reload, device toolbar, zoom controls, clear cookies, and clear cache.
- Implement the device toolbar with responsive viewport sizing, presets, editable width and height, rotate, and close controls.
- Wire cookie and cache clearing through the active WKWebView profile data store. Cache clearing only removes WebKit data types whose names contain cache, so cookies stay intact.
- Localize the new browser tool and device toolbar strings in English and Japanese.
- Include a small cmux-unit compile fix for an existing assertion string in SSHStartupSignalLifecycleTests.

Tests
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-btools -only-testing:cmuxTests/BrowserPanelToolsActionsTests test\n- ./scripts/reload.sh --tag btools

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new WebKit data-deletion actions (cookies/cache) and force-reload behavior, which could affect user session state and browsing data if mis-scoped. UI/layout changes also adjust chrome height and webview hosting when device preview is enabled.
> 
> **Overview**
> Adds a `Browser Tools` popover to the browser chrome with actions for **force reload**, **zoom in/out/reset** (showing current percent), toggling a new **device toolbar**, and clearing **cookies** or **cache**.
> 
> Implements a device-viewport preview mode that wraps the existing `webView` in a scrollable canvas with editable width/height, presets (responsive/iPhone/iPad/desktop), rotate, and close controls, and updates layout by accounting for the extra toolbar height.
> 
> Wires `clearCookies()` and `clearCache()` into `BrowserPanel` using the active `WKWebsiteDataStore`, with cache clearing restricted to website data types whose names match “cache” so cookies remain intact; adds unit tests for these behaviors and updates localized strings (EN/JA). Also includes a small test assertion string refactor in `SSHStartupSignalLifecycleTests` to fix compilation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0df24b5bf5d8f10f2060a8cac8a1ac4b2e07261. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Adds a Browser Tools menu (force reload, zoom in/out/reset, show/hide device toolbar, clear cookies/cache) and a device toolbar with presets, rotate, and viewport size controls; page zoom is persisted and shown in UI.
  * Adds English and Japanese localization entries for new browser tooling and device-viewport labels.

* **Tests**
  * Adds tests covering clear cookies and clear cache behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4152)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->