### PR TITLE
Fix Swift interpolation escape in SSH stdin regression test

### DIFF
--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -529,7 +529,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertEqual(
             recorded,
             "FORWARDED_KEYSTROKE",
-            "Backgrounded ssh in the startup wrapper must inherit the wrapper's stdin so that keystrokes from the surface PTY reach the remote shell. Got: \(recorded.isEmpty ? \"<empty>\" : recorded)"
+            "Backgrounded ssh in the startup wrapper must inherit the wrapper's stdin so that keystrokes from the surface PTY reach the remote shell. Got: \(recorded.isEmpty ? "<empty>" : recorded)"
         )
     }
 


### PR DESCRIPTION
## Summary

- 1-line follow-up to #4135: drop four backslashes from a Swift string interpolation in the new SSH stdin regression test
- `cmuxTests/SSHStartupSignalLifecycleTests.swift` line 532 used `\"<empty>\"` inside `\(...)`, which is a Swift compile error (`Cannot find ')' to match opening '(' in string interpolation` / `Unterminated string literal`). Inside an interpolation, the inner string is a Swift expression and quotes are not escaped.
- Result: `ci/circleci: macos-unit-tests` has been red on every main commit since #4135 merged. `macos-debug-build` and `macos-release-build` still pass because they don't compile the test target.
- The runtime fix (`<&0` on the backgrounded ssh) in `CLI/cmux.swift` is unchanged. It was already verified end-to-end on a cloud Mac (typing flows through to the remote shell).

## Test plan

- [x] `xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHStartupForwardsStdinToBackgroundedSSH` passes locally
- [ ] CircleCI `macos-unit-tests` goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk test-only change that fixes a Swift compile error in the new SSH stdin regression test, unblocking CI without affecting production code paths.
> 
> **Overview**
> Fixes a Swift compile error in `cmuxTests/SSHStartupSignalLifecycleTests.swift` by correcting the string interpolation in the failure message for `testSSHStartupForwardsStdinToBackgroundedSSH` (removing unnecessary escaping around `"<empty>"`).
> 
> No runtime/CLI behavior changes; this is a test-only fix intended to restore `macos-unit-tests` CI green.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6efc912ddfd10ba43809f41e20f13017dc42dc2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Swift string interpolation in the SSH stdin regression test by removing escaped quotes inside `\(...)`. This resolves the compile error in the test target and unblocks `macos-unit-tests` on CircleCI.

<sup>Written for commit f6efc912ddfd10ba43809f41e20f13017dc42dc2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test expectations to address a failure message formatting issue.

**Note:** This release contains internal test maintenance with no user-visible changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4154)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->