### PR TITLE
Restore legacy cmux <agent>-hook aliases and clean them up on reinstall

### DIFF
--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -245,6 +245,21 @@ extension CMUXCLI {
         return agentDefs.first { $0.name == normalized || $0.aliases.contains(normalized) }
     }
 
+    /// Maps the legacy `cmux <agent>-hook` command name (e.g. `cursor-hook`,
+    /// `gemini-hook`) to its agent definition for backwards-compatible
+    /// dispatch. Returns nil for `codex-hook` and `feed-hook` since those
+    /// are handled by their own dedicated cases, and nil for anything that
+    /// doesn't match a registered agent so unknown commands keep falling
+    /// through to the usual error path.
+    static func legacyAgentDef(forLegacyAgentHookCommand command: String) -> AgentHookDef? {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard trimmed.hasSuffix("-hook"), trimmed != "codex-hook", trimmed != "feed-hook", trimmed != "claude-hook" else {
+            return nil
+        }
+        let agentName = String(trimmed.dropLast("-hook".count))
+        return agentDef(named: agentName)
+    }
+
     static func hookCommandString(for def: AgentHookDef, event: AgentHookDef.HookEvent) -> String {
         "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux hooks \(def.name) \(event.cmuxSubcommand) || echo '{}'"
     }
@@ -263,10 +278,13 @@ extension CMUXCLI {
     }
 
     private static func isLegacyCmuxOwnedHookCommand(_ command: String, for def: AgentHookDef) -> Bool {
-        // Legacy cmux codex-hook and feed-hook commands only existed for Codex hooks.
-        guard def.name == "codex" else {
-            return false
-        }
+        // Older `cmux hooks setup` runs wrote `cmux <agent>-hook <sub>` and
+        // `cmux feed-hook --source <agent>` into per-agent hooks files. Both
+        // shapes were renamed under `cmux hooks <agent> <sub>` and
+        // `cmux hooks feed --source <agent> --event <event>`. Recognize the
+        // legacy shapes so reinstall removes them instead of stacking the
+        // new entries next to the old ones (which then fail at runtime and
+        // break the host agent's hook chain).
         let tokens = legacyCmuxCommandTokens(from: command, for: def)
         guard !tokens.isEmpty,
               URL(fileURLWithPath: String(tokens[0])).lastPathComponent == "cmux"
@@ -274,7 +292,7 @@ extension CMUXCLI {
             return false
         }
 
-        if tokens.count >= 2, tokens[1] == "codex-hook" {
+        if tokens.count >= 2, tokens[1] == "\(def.name)-hook" {
             return true
         }
         if tokens.count >= 4, tokens[1] == "feed-hook", tokens[2] == "--source", tokens[3] == def.name {
@@ -303,20 +321,16 @@ extension CMUXCLI {
     }
 
     static func hookMarkers(for def: AgentHookDef) -> [String] {
-        var markers = [def.hookMarker]
-        if def.name == "codex" {
-            markers.append("cmux codex-hook")
-        }
-        return markers
+        // Includes the legacy `cmux <agent>-hook` marker for every agent so
+        // older installs are recognized on reinstall, not just codex.
+        [def.hookMarker, "cmux \(def.name)-hook"]
     }
 
     /// Marker substrings used when removing / upgrading our own Feed bridge
-    /// entries on reinstall or uninstall.
+    /// entries on reinstall or uninstall. The legacy `cmux feed-hook
+    /// --source <agent>` shape applies to every agent that wrote a Feed
+    /// bridge entry, not just codex.
     static func feedHookMarkers(for def: AgentHookDef) -> [String] {
-        var markers = ["cmux hooks feed --source"]
-        if def.name == "codex" {
-            markers.append("cmux feed-hook --source")
-        }
-        return markers
+        ["cmux hooks feed --source", "cmux feed-hook --source"]
     }
 }

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -319,18 +319,4 @@ extension CMUXCLI {
         }
         return body.split(whereSeparator: { $0 == " " || $0 == "\t" })
     }
-
-    static func hookMarkers(for def: AgentHookDef) -> [String] {
-        // Includes the legacy `cmux <agent>-hook` marker for every agent so
-        // older installs are recognized on reinstall, not just codex.
-        [def.hookMarker, "cmux \(def.name)-hook"]
-    }
-
-    /// Marker substrings used when removing / upgrading our own Feed bridge
-    /// entries on reinstall or uninstall. The legacy `cmux feed-hook
-    /// --source <agent>` shape applies to every agent that wrote a Feed
-    /// bridge entry, not just codex.
-    static func feedHookMarkers(for def: AgentHookDef) -> [String] {
-        ["cmux hooks feed --source", "cmux feed-hook --source"]
-    }
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -3885,10 +3885,6 @@ struct CMUXCLI {
             try runGenericAgentHook(def: codexDef, commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
         case "feed-hook": // Backwards compatibility for older installed Feed hooks. Hidden from help.
             try runFeedHook(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
-        case let legacy where Self.legacyAgentDef(forLegacyAgentHookCommand: legacy) != nil: // Backwards compatibility for older `cmux <agent>-hook <sub>` installs. Hidden from help.
-            guard let def = Self.legacyAgentDef(forLegacyAgentHookCommand: legacy) else { print("{}"); return }
-            cliTelemetry.breadcrumb("hooks.\(def.name).legacy-alias.dispatch")
-            try runGenericAgentHook(def: def, commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
         case "hooks":
             try runHooksSocketCommand(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
 
@@ -3989,8 +3985,17 @@ struct CMUXCLI {
             try runMarkdownCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput, idFormat: idFormat)
 
         default:
-            print(usage())
-            throw CLIError(message: "Unknown command: \(command)")
+            // Backwards compatibility for older `cmux <agent>-hook <sub>` hook
+            // installs (e.g. `cmux cursor-hook shell-exec`). The dedicated
+            // `codex-hook` and `feed-hook` cases above handle their own legacy
+            // names; everything else maps through the agent registry.
+            if let legacyDef = Self.legacyAgentDef(forLegacyAgentHookCommand: command) {
+                cliTelemetry.breadcrumb("hooks.\(legacyDef.name).legacy-alias.dispatch")
+                try runGenericAgentHook(def: legacyDef, commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
+            } else {
+                print(usage())
+                throw CLIError(message: "Unknown command: \(command)")
+            }
         }
         } catch {
             if !capturesSocketErrorsInsideCommand {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -2606,7 +2606,8 @@ struct CMUXCLI {
             }
         }
         if command == "setup-hooks" || command == "uninstall-hooks" { try runSetupHooks(uninstall: command == "uninstall-hooks"); return } // Backwards compatibility for old hook setup docs/scripts.
-        if (command == "codex-hook" || command == "feed-hook"), processEnv["CMUX_SURFACE_ID"]?.isEmpty != false, processEnv["CMUX_WORKSPACE_ID"]?.isEmpty != false,
+        if (command == "codex-hook" || command == "feed-hook" || Self.legacyAgentDef(forLegacyAgentHookCommand: command) != nil),
+           processEnv["CMUX_SURFACE_ID"]?.isEmpty != false, processEnv["CMUX_WORKSPACE_ID"]?.isEmpty != false,
            !commandArgs.contains(where: { $0 == "--workspace" || $0 == "--surface" || $0.hasPrefix("--workspace=") || $0.hasPrefix("--surface=") }) { print("{}"); return } // Backwards compatibility for old installed hooks outside cmux terminals.
         if command == "hooks" {
             if try runHooksNoSocketCommand(commandArgs: commandArgs) {
@@ -2712,7 +2713,8 @@ struct CMUXCLI {
             }
         }
 
-        let capturesSocketErrorsInsideCommand = ["claude-hook", "codex-hook", "feed-hook", "hooks"].contains(command) // Backwards compatibility aliases stay hidden from help.
+        let capturesSocketErrorsInsideCommand = ["claude-hook", "codex-hook", "feed-hook", "hooks"].contains(command)
+            || Self.legacyAgentDef(forLegacyAgentHookCommand: command) != nil // Backwards compatibility aliases stay hidden from help.
         do {
         switch command {
         case "ping":
@@ -3883,6 +3885,10 @@ struct CMUXCLI {
             try runGenericAgentHook(def: codexDef, commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
         case "feed-hook": // Backwards compatibility for older installed Feed hooks. Hidden from help.
             try runFeedHook(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
+        case let legacy where Self.legacyAgentDef(forLegacyAgentHookCommand: legacy) != nil: // Backwards compatibility for older `cmux <agent>-hook <sub>` installs. Hidden from help.
+            guard let def = Self.legacyAgentDef(forLegacyAgentHookCommand: legacy) else { print("{}"); return }
+            cliTelemetry.breadcrumb("hooks.\(def.name).legacy-alias.dispatch")
+            try runGenericAgentHook(def: def, commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
         case "hooks":
             try runHooksSocketCommand(commandArgs: commandArgs, client: client, telemetry: cliTelemetry)
 

--- a/GhosttyTabs.xcodeproj/project.pbxproj
+++ b/GhosttyTabs.xcodeproj/project.pbxproj
@@ -214,6 +214,7 @@
 		A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */; };
 		A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */; };
 		A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */; };
+		A5D4120FA1B2C3D4E5F60718 /* CLILegacyHookInstallCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41210A1B2C3D4E5F60718 /* CLILegacyHookInstallCleanupTests.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
 		A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */; };
 		A5001100 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = A5001101 /* Assets.xcassets */; };
@@ -736,6 +737,7 @@
 		A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIGenericHookPersistenceTests.swift; sourceTree = "<group>"; };
 		A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIRovoDevHookPersistenceTests.swift; sourceTree = "<group>"; };
 		A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookAliasTests.swift; sourceTree = "<group>"; };
+		A5D41210A1B2C3D4E5F60718 /* CLILegacyHookInstallCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLILegacyHookInstallCleanupTests.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
 		C0DE35530000000000000102 /* BundledCLILinkageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BundledCLILinkageTests.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
@@ -1527,6 +1529,7 @@
 					A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */,
 					A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 					A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
+					A5D41210A1B2C3D4E5F60718 /* CLILegacyHookInstallCleanupTests.swift */,
 					A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */,
 					C0DE35530000000000000102 /* BundledCLILinkageTests.swift */,
 					C37800000000000000000002 /* VMSSHCommandTests.swift */,
@@ -2247,6 +2250,7 @@
 					A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,
 					A5D41209A1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift in Sources */,
 					A5D4120BA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift in Sources */,
+					A5D4120FA1B2C3D4E5F60718 /* CLILegacyHookInstallCleanupTests.swift in Sources */,
 					A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
 					C0DE35530000000000000101 /* BundledCLILinkageTests.swift in Sources */,
 					C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,

--- a/cmuxTests/CLILegacyHookAliasTests.swift
+++ b/cmuxTests/CLILegacyHookAliasTests.swift
@@ -89,4 +89,161 @@ extension CLINotifyProcessIntegrationRegressionTests {
         XCTAssertFalse(result.stdout.contains("Usage:"), result.stdout)
         XCTAssertFalse(result.stderr.contains("Usage:"), result.stderr)
     }
+
+    /// Regression test for older `~/.cursor/hooks.json` installs that still
+    /// contain `cmux cursor-hook <sub>` entries. The new shape is
+    /// `cmux hooks cursor <sub>` (`cmux hooks setup` rewrites the file on
+    /// install), but until the user reinstalls hooks the legacy alias must
+    /// keep returning valid JSON (`{}`) so Cursor does not block every
+    /// `beforeShellExecution` event with an "invalid JSON" error.
+    func testLegacyCursorHookAliasReturnsJSONWithoutHelpForShellExec() throws {
+        try assertLegacyAgentHookAliasReturnsEmptyJSON(
+            agent: "cursor",
+            subcommand: "shell-exec",
+            launchKind: "cursor",
+            launchExecutable: "/Users/example/.local/bin/cursor-agent",
+            launchArguments: ["/Users/example/.local/bin/cursor-agent", "agent"],
+            launchCwd: "/tmp/cursor-repo",
+            socketLabel: "legacy-cursor-shell"
+        )
+    }
+
+    /// Same regression for `cmux gemini-hook session-start` so we don't
+    /// re-break the next agent that gets renamed under `cmux hooks <agent>`.
+    func testLegacyGeminiHookAliasReturnsJSONWithoutHelpForSessionStart() throws {
+        try assertLegacyAgentHookAliasReturnsEmptyJSON(
+            agent: "gemini",
+            subcommand: "session-start",
+            launchKind: "gemini",
+            launchExecutable: "/Users/example/.bun/bin/gemini",
+            launchArguments: ["/Users/example/.bun/bin/gemini", "--model", "gemini-2.5-pro"],
+            launchCwd: "/tmp/gemini-repo",
+            socketLabel: "legacy-gemini"
+        )
+    }
+
+    /// Older installs also have a Feed-specific legacy entry of the form
+    /// `cmux feed-hook --source cursor` (no `--event`). When invoked inside
+    /// a cmux terminal it must still print `{}` so the Cursor hook chain
+    /// does not break.
+    func testLegacyFeedHookAliasReturnsJSONForCursorSourceInsideCmuxTerminal() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("legacy-feed-cursor")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else {
+                return line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{")
+                    ? self.malformedRequestResponse(raw: line)
+                    : "OK"
+            }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            if method == "surface.list" { return self.surfaceListResponse(id: id, surfaceId: surfaceId) }
+            if method == "feed.push" { return self.v2Response(id: id, ok: true, result: [:]) }
+            return self.v2Response(id: id, ok: false, error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"])
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["feed-hook", "--source", "cursor"],
+            environment: environment,
+            standardInput: #"{"hook_event_name":"PreToolUse","session_id":"legacy-feed-cursor"}"#,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "{}\n")
+        XCTAssertFalse(result.stdout.contains("Usage:"), result.stdout)
+        XCTAssertFalse(result.stderr.contains("Usage:"), result.stderr)
+    }
+
+    private func assertLegacyAgentHookAliasReturnsEmptyJSON(
+        agent: String,
+        subcommand: String,
+        launchKind: String,
+        launchExecutable: String,
+        launchArguments: [String],
+        launchCwd: String,
+        socketLabel: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath(socketLabel)
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-legacy-\(agent)-hook-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line) else {
+                return line.trimmingCharacters(in: .whitespacesAndNewlines).hasPrefix("{")
+                    ? self.malformedRequestResponse(raw: line)
+                    : "OK"
+            }
+            guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+            }
+            if method == "surface.list" { return self.surfaceListResponse(id: id, surfaceId: surfaceId) }
+            if method == "feed.push" { return self.v2Response(id: id, ok: true, result: [:]) }
+            return self.v2Response(id: id, ok: false, error: ["code": "unrecognized_method", "message": "unexpected method: \(method)"])
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_AGENT_LAUNCH_KIND"] = launchKind
+        environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = launchExecutable
+        environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated(launchArguments)
+        environment["CMUX_AGENT_LAUNCH_CWD"] = launchCwd
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["\(agent)-hook", subcommand],
+            environment: environment,
+            timeout: 5
+        )
+
+        wait(for: [serverHandled], timeout: 5)
+        XCTAssertFalse(result.timedOut, result.stderr, file: file, line: line)
+        XCTAssertEqual(result.status, 0, result.stderr, file: file, line: line)
+        XCTAssertEqual(result.stdout, "{}\n", file: file, line: line)
+        XCTAssertFalse(result.stdout.contains("Usage:"), result.stdout, file: file, line: line)
+        XCTAssertFalse(result.stderr.contains("Usage:"), result.stderr, file: file, line: line)
+        XCTAssertFalse(
+            result.stdout.contains("Unknown command"),
+            "stdout should not contain 'Unknown command' but got: \(result.stdout)",
+            file: file,
+            line: line
+        )
+    }
 }

--- a/cmuxTests/CLILegacyHookInstallCleanupTests.swift
+++ b/cmuxTests/CLILegacyHookInstallCleanupTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+import Darwin
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    /// Regression test for the install cleanup logic. Older `cmux hooks
+    /// setup` runs wrote `cmux <agent>-hook <sub>` and `cmux feed-hook
+    /// --source <agent>` into per-agent hooks files. Running install on a
+    /// newer CLI must recognize those legacy entries as cmux-owned and
+    /// remove them, instead of stacking the new entries next to the old
+    /// ones (which then keep firing at runtime).
+    func testCursorHookInstallRemovesLegacyEntriesAndPreservesForeignEntries() throws {
+        let cliPath = try bundledCLIPath()
+        let tempHome = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-cursor-install-cleanup-\(UUID().uuidString)", isDirectory: true)
+        let cursorDir = tempHome.appendingPathComponent(".cursor", isDirectory: true)
+        let hooksPath = cursorDir.appendingPathComponent("hooks.json", isDirectory: false)
+
+        try FileManager.default.createDirectory(at: cursorDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tempHome) }
+
+        let foreignAfter = "/Users/example/.superconductor/hooks/cursor-notify.sh"
+        let foreignBefore = "/Users/example/.vibe-island/bin/vibe-island-bridge --source cursor"
+        let legacyShellExec = "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$CMUX_CURSOR_HOOKS_DISABLED\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux cursor-hook shell-exec || echo '{}'"
+        let legacyFeed = "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$CMUX_CURSOR_HOOKS_DISABLED\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux feed-hook --source cursor || echo '{}'"
+        let legacyPromptSubmit = "[ -n \"$CMUX_SURFACE_ID\" ] && [ \"$CMUX_CURSOR_HOOKS_DISABLED\" != \"1\" ] && command -v cmux >/dev/null 2>&1 && cmux cursor-hook prompt-submit || echo '{}'"
+
+        let seed: [String: Any] = [
+            "version": 1,
+            "hooks": [
+                "beforeShellExecution": [
+                    ["command": foreignBefore],
+                    ["command": legacyShellExec],
+                    ["command": legacyFeed],
+                ],
+                "beforeSubmitPrompt": [
+                    ["command": legacyPromptSubmit],
+                    ["command": foreignAfter],
+                ],
+            ],
+        ]
+        let seedData = try JSONSerialization.data(withJSONObject: seed, options: [.prettyPrinted])
+        try seedData.write(to: hooksPath, options: .atomic)
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["HOME"] = tempHome.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "cursor", "install", "--yes"],
+            environment: environment,
+            timeout: 15
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, "stderr: \(result.stderr)\nstdout: \(result.stdout)")
+
+        let resultData = try Data(contentsOf: hooksPath)
+        let resultJSON = try XCTUnwrap(JSONSerialization.jsonObject(with: resultData) as? [String: Any])
+        let resultHooks = try XCTUnwrap(resultJSON["hooks"] as? [String: Any])
+
+        let shellExecCommands = (resultHooks["beforeShellExecution"] as? [[String: Any]] ?? [])
+            .compactMap { $0["command"] as? String }
+        let promptSubmitCommands = (resultHooks["beforeSubmitPrompt"] as? [[String: Any]] ?? [])
+            .compactMap { $0["command"] as? String }
+
+        XCTAssertFalse(
+            shellExecCommands.contains(legacyShellExec),
+            "Legacy `cmux cursor-hook shell-exec` must be removed; commands: \(shellExecCommands)"
+        )
+        XCTAssertFalse(
+            shellExecCommands.contains(legacyFeed),
+            "Legacy `cmux feed-hook --source cursor` must be removed; commands: \(shellExecCommands)"
+        )
+        XCTAssertFalse(
+            promptSubmitCommands.contains(legacyPromptSubmit),
+            "Legacy `cmux cursor-hook prompt-submit` must be removed; commands: \(promptSubmitCommands)"
+        )
+
+        XCTAssertTrue(
+            shellExecCommands.contains(foreignBefore),
+            "Foreign vibe-island entry must be preserved; commands: \(shellExecCommands)"
+        )
+        XCTAssertTrue(
+            promptSubmitCommands.contains(foreignAfter),
+            "Foreign superconductor entry must be preserved; commands: \(promptSubmitCommands)"
+        )
+
+        let allCommands = (resultHooks.values
+            .compactMap { $0 as? [[String: Any]] }
+            .flatMap { $0 })
+            .compactMap { $0["command"] as? String }
+        XCTAssertTrue(
+            allCommands.contains(where: { $0.contains("cmux hooks cursor shell-exec") }),
+            "Expected new `cmux hooks cursor shell-exec` entry to be written; commands: \(allCommands)"
+        )
+        XCTAssertTrue(
+            allCommands.contains(where: { $0.contains("cmux hooks cursor prompt-submit") }),
+            "Expected new `cmux hooks cursor prompt-submit` entry to be written; commands: \(allCommands)"
+        )
+    }
+}


### PR DESCRIPTION
## Summary

Older `~/.cursor/hooks.json` installs contain `cmux cursor-hook shell-exec` and `cmux feed-hook --source cursor` entries. The current CLI no longer recognizes `cmux cursor-hook`, so the dispatcher hits the unknown-command default, prints `usage()` to stdout, and exits non-zero. The `... || echo '{}'` fallback then emits help text followed by `{}`, which Cursor rejects as "invalid JSON" and uses to block every `beforeShellExecution` (so every Shell tool call fails).

Reinstall does not fix this on its own. `isCmuxOwnedHookCommand` only recognized the legacy `<agent>-hook` and `feed-hook --source <agent>` shapes for codex, so `cmux hooks cursor install` just appended the new entries next to the broken legacy ones.

This PR fixes both:

- Adds `legacyAgentDef(forLegacyAgentHookCommand:)` and routes any `cmux <agent>-hook <sub>` through the same `runGenericAgentHook` path as `cmux hooks <agent> <sub>`. Also extends the pre-socket early-return and `capturesSocketErrorsInsideCommand` set so legacy commands behave the same as `codex-hook`.
- Generalizes `isLegacyCmuxOwnedHookCommand`, `hookMarkers`, and `feedHookMarkers` to recognize legacy shapes for every registered agent (cursor, gemini, copilot, codebuddy, factory, qoder, hermes-agent, etc.), so reinstall removes them.

## Testing

Two-commit structure for the regression coverage: the first commit adds the tests (red), the second commit lands the fix (green).

- `swift test` style xctest run via `xcodebuild ... cmux-unit test`:
  - `CLINotifyProcessIntegrationRegressionTests/testLegacyCursorHookAliasReturnsJSONWithoutHelpForShellExec`
  - `CLINotifyProcessIntegrationRegressionTests/testLegacyGeminiHookAliasReturnsJSONWithoutHelpForSessionStart`
  - `CLINotifyProcessIntegrationRegressionTests/testLegacyFeedHookAliasReturnsJSONForCursorSourceInsideCmuxTerminal`
  - `CLINotifyProcessIntegrationRegressionTests/testCursorHookInstallRemovesLegacyEntriesAndPreservesForeignEntries`
  - Plus the existing `testLegacyCodexHookAliasReturnsJSONWithoutHelpAndPersistsSession` and `testLegacyFeedHookAliasReturnsJSONWithoutHelpOutsideCmuxTerminal` continue to pass.

The 2 pre-existing `testRightSidebar*ValidatesBeforeTargetResolution` failures on this scheme reproduce on `origin/main` (`791318f5a`) without these changes; not introduced by this PR.

## Issues

Surfaced while a Cursor agent hit `Hook "[ ... ] && cmux cursor-hook shell-exec || echo '{}'" returned invalid JSON. The command was blocked for safety.` on every Shell tool invocation inside a cmux terminal.


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes CLI command dispatch and hook-install cleanup behavior, which could affect agent hook execution if legacy detection is too broad or misses edge cases. Scope is contained to hook-related commands and is covered by new regression tests.
> 
> **Overview**
> Fixes hook regressions caused by older installs that still invoke legacy commands like `cmux cursor-hook <sub>` and `cmux feed-hook --source <agent>`.
> 
> Adds `legacyAgentDef(forLegacyAgentHookCommand:)` and updates `cmux.swift` to (1) treat legacy `<agent>-hook` commands like other hook commands for early `{}` fallback outside cmux terminals, (2) capture socket errors internally, and (3) dispatch legacy aliases through the generic agent hook runner instead of the unknown-command path.
> 
> Generalizes legacy hook ownership detection so `hooks <agent> install`/reinstall removes legacy `<agent>-hook` and `feed-hook --source <agent>` entries for any registered agent, preventing broken duplicates; adds regression tests covering legacy alias JSON output and install cleanup while preserving non-cmux (foreign) hook entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3271d0cf92f8dcc547f67ade5e1485fde6fd7b58. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores runtime support for legacy `cmux <agent>-hook` aliases and cleans them up on reinstall to stop invalid JSON errors that were blocking hooks. Also recognizes and removes legacy `cmux feed-hook --source <agent>` entries across all agents, with a small cleanup to the dispatch path.

- **Bug Fixes**
  - Routes any `<agent>-hook` to the generic hook handler, including early-return outside cmux terminals, and keeps socket errors internal.
  - Recognizes legacy `<agent>-hook` and `feed-hook --source <agent>` markers for all agents during install/uninstall so old entries are replaced, not duplicated.
  - Removes unused `hookMarkers`/`feedHookMarkers` helpers and simplifies legacy alias dispatch to avoid unreachable guards and keep unknown-command behavior unchanged when no agent matches.

- **Migration**
  - Optional: run `cmux hooks <agent> install --yes` to rewrite `~/.cursor/hooks.json` and remove legacy entries; non-cmux (foreign) commands are preserved.

<sup>Written for commit 3271d0cf92f8dcc547f67ade5e1485fde6fd7b58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Legacy hook aliases are now recognized across all agents (improves backward compatibility).
  * Legacy hook/feed markers are produced for all agents and socket/error handling includes legacy aliases.
  * Installation now removes legacy hook entries while preserving custom/foreign hooks.

* **Tests**
  * Added regression tests covering legacy hook aliases, legacy feed behavior, and install-time cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4157)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->