### PR TITLE
feat: Chromium engine spike (planning + scope)

### DIFF
--- a/Packages/CmuxBrowserEngine/Package.swift
+++ b/Packages/CmuxBrowserEngine/Package.swift
@@ -1,0 +1,24 @@
+// swift-tools-version: 6.0
+import PackageDescription
+
+let package = Package(
+    name: "CmuxBrowserEngine",
+    platforms: [
+        .macOS(.v14),
+    ],
+    products: [
+        .library(
+            name: "CmuxBrowserEngine",
+            targets: ["CmuxBrowserEngine"]
+        ),
+    ],
+    targets: [
+        .target(
+            name: "CmuxBrowserEngine"
+        ),
+        .testTarget(
+            name: "CmuxBrowserEngineTests",
+            dependencies: ["CmuxBrowserEngine"]
+        ),
+    ]
+)

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
@@ -33,6 +33,7 @@ final class ChromiumBrowserBackend: NSObject, CmuxBrowserBackend {
 
     var navigationDelegate: CmuxNavigationDelegate?
     var uiDelegate: CmuxUIDelegate?
+    var downloadDelegate: CmuxDownloadDelegate?
     var url: URL? { nil }
     var title: String? { nil }
     var isLoading: Bool { false }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
@@ -18,6 +18,7 @@ final class ChromiumBrowserBackend: NSObject, CmuxBrowserBackend {
     }
 
     let placeholder: NSView
+    let state = CmuxBrowserState()
 
     init(configuration: CmuxBrowserConfiguration) {
         let v = NSView()
@@ -39,6 +40,10 @@ final class ChromiumBrowserBackend: NSObject, CmuxBrowserBackend {
     var canGoBack: Bool { false }
     var canGoForward: Bool { false }
     var customUserAgent: String? { nil }
+    var pageZoom: CGFloat {
+        get { 1.0 }
+        set { _ = newValue }
+    }
 
     private func unavailable() -> Never {
         fatalError(

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
@@ -1,0 +1,64 @@
+import AppKit
+import Foundation
+
+/// Stub backend that will bind to `CmuxCore.framework` once the
+/// Chromium fork builds. Today every method calls `fatalError` so a
+/// misconfigured feature flag fails loudly rather than silently
+/// returning empty data.
+///
+/// Implementation plan: `plans/chromium-engine.md` (P2 milestone).
+/// Once `CmuxCore.framework` ships an embedding API, replace the
+/// `fatalError`s with `cmux_browser_*` calls and the host `NSView`
+/// will be a `CALayerHost`-backed view bound to the GPU helper's
+/// `CAContext`.
+@MainActor
+final class ChromiumBrowserBackend: NSObject, CmuxBrowserBackend {
+    nonisolated static func versionString() -> String {
+        "Chromium (not yet built) — see plans/chromium-engine.md"
+    }
+
+    let placeholder: NSView
+
+    init(configuration: CmuxBrowserConfiguration) {
+        let v = NSView()
+        v.wantsLayer = true
+        v.layer?.backgroundColor = NSColor.systemRed.cgColor
+        self.placeholder = v
+        super.init()
+        _ = configuration
+    }
+
+    var nsView: NSView { placeholder }
+
+    var navigationDelegate: CmuxNavigationDelegate?
+    var uiDelegate: CmuxUIDelegate?
+    var url: URL? { nil }
+    var title: String? { nil }
+    var isLoading: Bool { false }
+    var estimatedProgress: Double { 0 }
+    var canGoBack: Bool { false }
+    var canGoForward: Bool { false }
+    var customUserAgent: String? { nil }
+
+    private func unavailable() -> Never {
+        fatalError(
+            "ChromiumBrowserBackend is not yet implemented. " +
+            "Disable the cmux.browser.engine.chromium flag or wait for " +
+            "the CmuxCore.framework build. See plans/chromium-engine.md."
+        )
+    }
+
+    func load(_ request: URLRequest) -> CmuxNavigation { unavailable() }
+    func loadHTMLString(_ html: String, baseURL: URL?) -> CmuxNavigation { unavailable() }
+    func goBack() -> CmuxNavigation? { unavailable() }
+    func goForward() -> CmuxNavigation? { unavailable() }
+    func reload() -> CmuxNavigation? { unavailable() }
+    func stopLoading() {}
+    func evaluateJavaScript(_ source: String, completionHandler: @escaping (Any?, Error?) -> Void) {
+        completionHandler(nil, CmuxBrowserEngineError.backendUnavailable(.chromium, reason: "Chromium backend not built"))
+    }
+    func setCustomUserAgent(_ userAgent: String?) {}
+    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
+        completionHandler(nil, CmuxBrowserEngineError.backendUnavailable(.chromium, reason: "Chromium backend not built"))
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
@@ -64,7 +64,11 @@ final class ChromiumBrowserBackend: NSObject, CmuxBrowserBackend {
         completionHandler(nil, CmuxBrowserEngineError.backendUnavailable(.chromium, reason: "Chromium backend not built"))
     }
     func setCustomUserAgent(_ userAgent: String?) {}
-    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
+    func takeSnapshot(
+        configuration: CmuxSnapshotConfiguration?,
+        completionHandler: @escaping (CGImage?, Error?) -> Void
+    ) {
+        _ = configuration
         completionHandler(nil, CmuxBrowserEngineError.backendUnavailable(.chromium, reason: "Chromium backend not built"))
     }
 }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
@@ -25,6 +25,7 @@ protocol CmuxBrowserBackend: AnyObject {
 
     var navigationDelegate: CmuxNavigationDelegate? { get set }
     var uiDelegate: CmuxUIDelegate? { get set }
+    var downloadDelegate: CmuxDownloadDelegate? { get set }
 
     func load(_ request: URLRequest) -> CmuxNavigation
     func loadHTMLString(_ html: String, baseURL: URL?) -> CmuxNavigation

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
@@ -41,6 +41,13 @@ protocol CmuxBrowserBackend: AnyObject {
     func setCustomUserAgent(_ userAgent: String?)
     var customUserAgent: String? { get }
 
+    /// Live state mirror. Backends push updates here as the engine
+    /// emits them (KVO in WebKit, delegate callbacks in Chromium).
+    var state: CmuxBrowserState { get }
+
+    /// Page zoom factor. 1.0 = no zoom.
+    var pageZoom: CGFloat { get set }
+
     /// Snapshot the current visible region as a `CGImage`.
     func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void)
 }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Foundation
+
+/// Internal backend protocol. Two implementations:
+/// - `WebKitBrowserBackend`: wraps `WKWebView` (the current engine).
+/// - `ChromiumBrowserBackend`: stub today; will be wired to
+///   `CmuxCore.framework` once the Chromium fork builds (see
+///   `plans/chromium-engine.md`).
+///
+/// Methods are sync where the underlying API is sync, and async-completion
+/// where the underlying API is async. The Swift surface is
+/// `WKWebView`-shaped intentionally; `CmuxBrowserView` forwards to the
+/// backend without translation.
+@MainActor
+protocol CmuxBrowserBackend: AnyObject {
+    /// The host view to insert into the AppKit hierarchy.
+    var nsView: NSView { get }
+
+    var url: URL? { get }
+    var title: String? { get }
+    var isLoading: Bool { get }
+    var estimatedProgress: Double { get }
+    var canGoBack: Bool { get }
+    var canGoForward: Bool { get }
+
+    var navigationDelegate: CmuxNavigationDelegate? { get set }
+    var uiDelegate: CmuxUIDelegate? { get set }
+
+    func load(_ request: URLRequest) -> CmuxNavigation
+    func loadHTMLString(_ html: String, baseURL: URL?) -> CmuxNavigation
+    @discardableResult func goBack() -> CmuxNavigation?
+    @discardableResult func goForward() -> CmuxNavigation?
+    @discardableResult func reload() -> CmuxNavigation?
+    func stopLoading()
+
+    func evaluateJavaScript(
+        _ source: String,
+        completionHandler: @escaping (Any?, Error?) -> Void
+    )
+
+    func setCustomUserAgent(_ userAgent: String?)
+    var customUserAgent: String? { get }
+
+    /// Snapshot the current visible region as a `CGImage`.
+    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void)
+}
+
+/// Errors surfaced to call sites from inside the wrapper.
+public enum CmuxBrowserEngineError: Error, Equatable {
+    /// The selected backend is not yet implemented in this build.
+    case backendUnavailable(CmuxBrowserEngine.Kind, reason: String)
+    /// A native handle returned an unexpected value.
+    case nativeError(String)
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserBackend.swift
@@ -49,8 +49,12 @@ protocol CmuxBrowserBackend: AnyObject {
     /// Page zoom factor. 1.0 = no zoom.
     var pageZoom: CGFloat { get set }
 
-    /// Snapshot the current visible region as a `CGImage`.
-    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void)
+    /// Snapshot the current visible region as a `CGImage`. Passing
+    /// `nil` uses engine defaults (full view, current width).
+    func takeSnapshot(
+        configuration: CmuxSnapshotConfiguration?,
+        completionHandler: @escaping (CGImage?, Error?) -> Void
+    )
 }
 
 /// Errors surfaced to call sites from inside the wrapper.

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
@@ -1,0 +1,101 @@
+import Foundation
+
+/// Engine-neutral configuration for a `CmuxBrowserView`.
+///
+/// Mirrors the subset of `WKWebViewConfiguration` that cmux's BrowserPanel
+/// actually consumes today. Add fields here as migration callsites need
+/// them, not preemptively.
+public final class CmuxBrowserConfiguration: @unchecked Sendable {
+    /// Which engine backend the view should use. Defaults to
+    /// `CmuxBrowserEngine.defaultKind`.
+    public var engineKind: CmuxBrowserEngine.Kind = CmuxBrowserEngine.defaultKind
+
+    /// Optional explicit profile name. Two views with the same profile
+    /// name share cookies, local storage, and service workers. `nil`
+    /// means the default profile.
+    public var profileName: String?
+
+    /// User content controller. Mutating after a view is constructed
+    /// has no effect on existing views; pass a configured controller at
+    /// construction time.
+    public var userContentController: CmuxUserContentController = .init()
+
+    /// Allow JavaScript to open windows without user gesture. Matches
+    /// `WKWebView.configuration.preferences.javaScriptCanOpenWindowsAutomatically`.
+    public var allowsJavaScriptToOpenWindowsAutomatically: Bool = false
+
+    /// Allow inline media playback (no fullscreen requirement).
+    public var allowsInlineMediaPlayback: Bool = true
+
+    /// Require user action to start media playback.
+    public var mediaTypesRequiringUserActionForPlayback: MediaPlaybackRequirement = .none
+
+    /// Allow Picture-in-Picture controls in HTMLMediaElement.
+    public var allowsPictureInPictureMediaPlayback: Bool = true
+
+    /// Custom User-Agent string. `nil` means use the engine's default UA.
+    public var customUserAgent: String?
+
+    /// Custom application name suffix appended to the default User-Agent
+    /// (when `customUserAgent` is `nil`).
+    public var applicationNameForUserAgent: String?
+
+    /// Process-pool sharing tag. Views with the same tag (and same
+    /// profile) share renderer processes when the backend supports it.
+    /// `nil` falls back to the engine default.
+    public var processPoolTag: String?
+
+    /// Suppresses incremental rendering — frames are only flushed once
+    /// the page has finished loading. Almost always `false`.
+    public var suppressesIncrementalRendering: Bool = false
+
+    /// Set of URL schemes the host registers custom handlers for, mapped
+    /// to the handler instance. Engine-specific scheme handling lives in
+    /// the backend.
+    public var urlSchemeHandlers: [String: any CmuxURLSchemeHandler] = [:]
+
+    public init() {}
+
+    public enum MediaPlaybackRequirement: Sendable {
+        case none
+        case audio
+        case video
+        case all
+    }
+}
+
+/// Host-side handler for a custom URL scheme. Backends bridge this to
+/// `WKURLSchemeHandler` (WebKit) or the Chromium custom scheme API.
+public protocol CmuxURLSchemeHandler: AnyObject, Sendable {
+    func startURLSchemeTask(_ task: CmuxURLSchemeTask)
+    func stopURLSchemeTask(_ task: CmuxURLSchemeTask)
+}
+
+/// A single in-flight custom-scheme request. Engine-neutral wrapper
+/// around the engine's task object.
+public final class CmuxURLSchemeTask: @unchecked Sendable {
+    public let request: URLRequest
+    private let respondImpl: @Sendable (URLResponse) -> Void
+    private let dataImpl: @Sendable (Data) -> Void
+    private let finishImpl: @Sendable () -> Void
+    private let failImpl: @Sendable (Error) -> Void
+
+    public init(
+        request: URLRequest,
+        respond: @escaping @Sendable (URLResponse) -> Void,
+        data: @escaping @Sendable (Data) -> Void,
+        finish: @escaping @Sendable () -> Void,
+        fail: @escaping @Sendable (Error) -> Void
+    ) {
+        self.request = request
+        self.respondImpl = respond
+        self.dataImpl = data
+        self.finishImpl = finish
+        self.failImpl = fail
+    }
+
+    public func didReceive(_ response: URLResponse) { respondImpl(response) }
+    public func didReceive(_ data: Data) { dataImpl(data) }
+    public func didFinish() { finishImpl() }
+    public func didFailWithError(_ error: Error) { failImpl(error) }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
@@ -55,6 +55,15 @@ public final class CmuxBrowserConfiguration: @unchecked Sendable {
     /// the page has finished loading. Almost always `false`.
     public var suppressesIncrementalRendering: Bool = false
 
+    /// Whether the view should expose itself to a web inspector / dev
+    /// tools. WebKit: `WKWebView.isInspectable` (macOS 13.3+).
+    /// Chromium: enables the inspector frontend for this WebContents.
+    ///
+    /// Mutating after the view is constructed has no effect; pass
+    /// through the configuration at construction time. cmux call sites
+    /// in `BrowserPanel.swift` toggle this in DEBUG builds.
+    public var isInspectable: Bool = false
+
     /// Set of URL schemes the host registers custom handlers for, mapped
     /// to the handler instance. Engine-specific scheme handling lives in
     /// the backend.

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserConfiguration.swift
@@ -15,6 +15,12 @@ public final class CmuxBrowserConfiguration: @unchecked Sendable {
     /// means the default profile.
     public var profileName: String?
 
+    /// Per-view website data store. `nil` falls back to the engine's
+    /// default persistent store (i.e. `CmuxDataStore.default()`).
+    /// Two views with the same `CmuxDataStore` share cookies, local
+    /// storage, IndexedDB, and service workers.
+    public var dataStore: CmuxDataStore?
+
     /// User content controller. Mutating after a view is constructed
     /// has no effect on existing views; pass a configured controller at
     /// construction time.

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserEngine.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserEngine.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Top-level entrypoint for the cmux browser engine abstraction.
+///
+/// This package is the long-lived seam between cmux's `BrowserPanel` (and
+/// peers) and the underlying web engine. Today it has one real backend that
+/// wraps `WKWebView`. The Chromium backend is wired in but throws on use; it
+/// will be implemented by the `CmuxCore.framework` work tracked in
+/// `plans/chromium-engine.md`.
+///
+/// The Swift surface is intentionally close to `WKWebView` so that
+/// callsites in `Sources/Panels/BrowserPanel.swift` and friends can migrate
+/// with minimal churn. Subtle behavior differences between WebKit and
+/// Chromium are translated inside the backends, not exposed at the API
+/// boundary.
+public enum CmuxBrowserEngine {
+    /// Engine selection.
+    public enum Kind: String, CaseIterable, Sendable {
+        case webKit
+        case chromium
+    }
+
+    /// User-facing feature flag key (read from `UserDefaults.standard`).
+    ///
+    /// Boolean. When `true`, new `CmuxBrowserView` instances default to the
+    /// Chromium backend. Production builds default to `false` until the
+    /// Chromium backend is feature-complete.
+    public static let featureFlagKey = "cmux.browser.engine.chromium"
+
+    /// The engine kind newly-constructed views should default to.
+    ///
+    /// Reads `featureFlagKey` from the shared defaults. Tests can override
+    /// by setting `defaultKindOverride`.
+    public static var defaultKind: Kind {
+        if let override = defaultKindOverride { return override }
+        if UserDefaults.standard.bool(forKey: featureFlagKey) {
+            return .chromium
+        }
+        return .webKit
+    }
+
+    /// Test-only override. Set in `setUp`, clear in `tearDown`.
+    /// Marked `nonisolated(unsafe)` because it is only mutated from tests
+    /// that already serialize their writes; production code only reads.
+    public nonisolated(unsafe) static var defaultKindOverride: Kind?
+
+    /// Returns the underlying engine version string for diagnostics.
+    public static func versionString(for kind: Kind = defaultKind) -> String {
+        switch kind {
+        case .webKit:
+            return WebKitBrowserBackend.versionString()
+        case .chromium:
+            return ChromiumBrowserBackend.versionString()
+        }
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserState.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserState.swift
@@ -1,0 +1,20 @@
+import Combine
+import Foundation
+
+/// Observable mirror of the engine's load state. Today the WebKit
+/// backend pushes values from KVO observations on its `WKWebView`;
+/// the Chromium backend will push from its navigation delegate. Both
+/// hosts subscribe to the same Combine surface.
+@MainActor
+public final class CmuxBrowserState: ObservableObject {
+    @Published public internal(set) var url: URL?
+    @Published public internal(set) var title: String?
+    @Published public internal(set) var isLoading: Bool = false
+    @Published public internal(set) var estimatedProgress: Double = 0
+    @Published public internal(set) var canGoBack: Bool = false
+    @Published public internal(set) var canGoForward: Bool = false
+    /// Page zoom factor, 1.0 = no zoom.
+    @Published public internal(set) var pageZoom: CGFloat = 1.0
+
+    public init() {}
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
@@ -22,6 +22,16 @@ public final class CmuxBrowserView: NSView {
         set { backend.uiDelegate = newValue }
     }
 
+    /// Receives lifecycle callbacks for every download initiated from
+    /// this view. WK semantics: any nav-action or nav-response
+    /// returning `.download` policy creates a `CmuxDownload` and the
+    /// shim attaches this delegate to it. Hosts that don't need
+    /// downloads can leave this `nil`.
+    public var downloadDelegate: (any CmuxDownloadDelegate)? {
+        get { backend.downloadDelegate }
+        set { backend.downloadDelegate = newValue }
+    }
+
     public init(frame frameRect: NSRect, configuration: CmuxBrowserConfiguration) {
         self.configuration = configuration
         self.backend = Self.makeBackend(configuration: configuration)

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
@@ -1,0 +1,138 @@
+import AppKit
+import Foundation
+
+/// Engine-neutral browser view. Hosts the active backend's NSView as a
+/// single subview pinned to the bounds. Public API is `WKWebView`-shaped
+/// so existing call sites in cmux migrate with minimal churn.
+@MainActor
+public final class CmuxBrowserView: NSView {
+    public let configuration: CmuxBrowserConfiguration
+
+    /// The actual engine doing the work. `internal` so tests in this
+    /// package can inspect it directly.
+    let backend: any CmuxBrowserBackend
+
+    public var navigationDelegate: (any CmuxNavigationDelegate)? {
+        get { backend.navigationDelegate }
+        set { backend.navigationDelegate = newValue }
+    }
+
+    public var uiDelegate: (any CmuxUIDelegate)? {
+        get { backend.uiDelegate }
+        set { backend.uiDelegate = newValue }
+    }
+
+    public init(frame frameRect: NSRect, configuration: CmuxBrowserConfiguration) {
+        self.configuration = configuration
+        self.backend = Self.makeBackend(configuration: configuration)
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = true
+        autoresizingMask = [.width, .height]
+        installBackend()
+    }
+
+    @available(*, unavailable)
+    public required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported. Use init(frame:configuration:).")
+    }
+
+    private static func makeBackend(
+        configuration: CmuxBrowserConfiguration
+    ) -> any CmuxBrowserBackend {
+        switch configuration.engineKind {
+        case .webKit:
+            return WebKitBrowserBackend(configuration: configuration)
+        case .chromium:
+            return ChromiumBrowserBackend(configuration: configuration)
+        }
+    }
+
+    private func installBackend() {
+        let inner = backend.nsView
+        inner.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(inner)
+        NSLayoutConstraint.activate([
+            inner.leadingAnchor.constraint(equalTo: leadingAnchor),
+            inner.trailingAnchor.constraint(equalTo: trailingAnchor),
+            inner.topAnchor.constraint(equalTo: topAnchor),
+            inner.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    // MARK: - Public API (WKWebView-shaped)
+
+    public var url: URL? { backend.url }
+    public var title: String? { backend.title }
+    public var isLoading: Bool { backend.isLoading }
+    public var estimatedProgress: Double { backend.estimatedProgress }
+    public var canGoBack: Bool { backend.canGoBack }
+    public var canGoForward: Bool { backend.canGoForward }
+
+    public var customUserAgent: String? {
+        get { backend.customUserAgent }
+        set { backend.setCustomUserAgent(newValue) }
+    }
+
+    /// Diagnostic string identifying the active backend ("WebKit 622..."
+    /// or "Chromium (not yet built) — ..."). Used in About dialogs and
+    /// crash reports.
+    public var engineDescription: String {
+        switch configuration.engineKind {
+        case .webKit: return WebKitBrowserBackend.versionString()
+        case .chromium: return ChromiumBrowserBackend.versionString()
+        }
+    }
+
+    @discardableResult
+    public func load(_ request: URLRequest) -> CmuxNavigation {
+        backend.load(request)
+    }
+
+    @discardableResult
+    public func load(_ url: URL) -> CmuxNavigation {
+        backend.load(URLRequest(url: url))
+    }
+
+    @discardableResult
+    public func loadHTMLString(_ html: String, baseURL: URL? = nil) -> CmuxNavigation {
+        backend.loadHTMLString(html, baseURL: baseURL)
+    }
+
+    @discardableResult public func goBack() -> CmuxNavigation? { backend.goBack() }
+    @discardableResult public func goForward() -> CmuxNavigation? { backend.goForward() }
+    @discardableResult public func reload() -> CmuxNavigation? { backend.reload() }
+    public func stopLoading() { backend.stopLoading() }
+
+    public func evaluateJavaScript(
+        _ source: String,
+        completionHandler: @escaping (Any?, Error?) -> Void
+    ) {
+        backend.evaluateJavaScript(source, completionHandler: completionHandler)
+    }
+
+    /// Async wrapper around `evaluateJavaScript`. Throws on engine
+    /// error; the JS exception value (if any) is rethrown.
+    ///
+    /// The result is `Any?` (mirroring `WKWebView`'s API). Because `Any`
+    /// is not `Sendable`, the continuation hop uses an internal
+    /// `@unchecked Sendable` box. The value never crosses an actor in
+    /// the meantime — the completion handler runs on the same actor as
+    /// `evaluateJavaScript` — so this is safe.
+    public func evaluateJavaScript(_ source: String) async throws -> Any? {
+        struct ResultBox: @unchecked Sendable { let value: Any? }
+        let box: ResultBox = try await withCheckedThrowingContinuation { continuation in
+            backend.evaluateJavaScript(source) { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: ResultBox(value: result))
+                }
+            }
+        }
+        return box.value
+    }
+
+    public func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
+        backend.takeSnapshot(completionHandler: completionHandler)
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
@@ -73,6 +73,19 @@ public final class CmuxBrowserView: NSView {
         set { backend.setCustomUserAgent(newValue) }
     }
 
+    /// Page zoom factor. 1.0 = no zoom. Reads and writes go through
+    /// the backend. State is mirrored on `state.pageZoom` for Combine
+    /// observers.
+    public var pageZoom: CGFloat {
+        get { backend.pageZoom }
+        set { backend.pageZoom = newValue }
+    }
+
+    /// Observable mirror of engine load state. Use this to subscribe
+    /// via Combine instead of polling the view, e.g.
+    /// `view.state.$url.sink { ... }`.
+    public var state: CmuxBrowserState { backend.state }
+
     /// Diagnostic string identifying the active backend ("WebKit 622..."
     /// or "Chromium (not yet built) — ..."). Used in About dialogs and
     /// crash reports.

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxBrowserView.swift
@@ -156,6 +156,15 @@ public final class CmuxBrowserView: NSView {
     }
 
     public func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
-        backend.takeSnapshot(completionHandler: completionHandler)
+        backend.takeSnapshot(configuration: nil, completionHandler: completionHandler)
+    }
+
+    /// Take a snapshot of the current page using `configuration`.
+    /// Pass `nil` for engine defaults.
+    public func takeSnapshot(
+        configuration: CmuxSnapshotConfiguration?,
+        completionHandler: @escaping (CGImage?, Error?) -> Void
+    ) {
+        backend.takeSnapshot(configuration: configuration, completionHandler: completionHandler)
     }
 }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxCookieStore.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxCookieStore.swift
@@ -1,0 +1,106 @@
+import Foundation
+@preconcurrency import WebKit
+
+/// Engine-neutral cookie store. Wraps `WKHTTPCookieStore` today; the
+/// Chromium backend will route to the Network Service Cookie Manager
+/// (`network::mojom::CookieManager`) keyed off the same `CmuxDataStore`
+/// identifier.
+///
+/// All access is `@MainActor` to match WebKit's isolation. Read/write
+/// methods are `async` and return after the engine has acknowledged
+/// the operation.
+@MainActor
+public final class CmuxCookieStore {
+    /// The underlying WebKit cookie store. `nil` only on backends that
+    /// haven't materialized a cookie store yet (e.g. the Chromium stub).
+    let wkStore: WKHTTPCookieStore?
+
+    /// Observers registered via `addObserver`. Strong-referenced so
+    /// caller-side ergonomics match `WKHTTPCookieStore` (which also
+    /// retains observers).
+    private var observers: [ObjectIdentifier: any CmuxCookieStoreObserver] = [:]
+
+    /// Shim that bridges WK observer callbacks back to ours. One shim
+    /// per cookie store keeps registration symmetric.
+    private lazy var wkObserverShim = WKObserverShim(owner: self)
+    private var wkShimRegistered = false
+
+    init(wkStore: WKHTTPCookieStore?) {
+        self.wkStore = wkStore
+    }
+
+    /// All cookies currently stored. Reads from the engine's cookie
+    /// store rather than `HTTPCookieStorage.shared` so it includes
+    /// per-profile cookies.
+    public func allCookies() async -> [HTTPCookie] {
+        guard let wkStore else { return [] }
+        return await withCheckedContinuation { (continuation: CheckedContinuation<[HTTPCookie], Never>) in
+            wkStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+    }
+
+    /// Set (or overwrite) a single cookie. Returns after the engine
+    /// confirms the write.
+    public func setCookie(_ cookie: HTTPCookie) async {
+        guard let wkStore else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            wkStore.setCookie(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Delete a single cookie. The match key is (name, domain, path);
+    /// other attributes are ignored. Returns after deletion completes.
+    public func deleteCookie(_ cookie: HTTPCookie) async {
+        guard let wkStore else { return }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            wkStore.delete(cookie) {
+                continuation.resume()
+            }
+        }
+    }
+
+    /// Register an observer. The observer receives `cookiesDidChange`
+    /// callbacks whenever the underlying store mutates. Hold a strong
+    /// reference to the observer somewhere in your code — this method
+    /// also retains it for symmetry with WKHTTPCookieStore.
+    public func addObserver(_ observer: any CmuxCookieStoreObserver) {
+        let id = ObjectIdentifier(observer)
+        observers[id] = observer
+        if !wkShimRegistered, let wkStore {
+            wkStore.add(wkObserverShim)
+            wkShimRegistered = true
+        }
+    }
+
+    /// Unregister an observer. Idempotent.
+    public func removeObserver(_ observer: any CmuxCookieStoreObserver) {
+        let id = ObjectIdentifier(observer)
+        observers.removeValue(forKey: id)
+    }
+
+    fileprivate func dispatchCookiesDidChange() {
+        for (_, observer) in observers {
+            observer.cookiesDidChange(in: self)
+        }
+    }
+}
+
+public protocol CmuxCookieStoreObserver: AnyObject {
+    @MainActor
+    func cookiesDidChange(in store: CmuxCookieStore)
+}
+
+private final class WKObserverShim: NSObject, WKHTTPCookieStoreObserver {
+    weak var owner: CmuxCookieStore?
+    init(owner: CmuxCookieStore) { self.owner = owner }
+
+    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
+        MainActor.assumeIsolated {
+            owner?.dispatchCookiesDidChange()
+        }
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxDataStore.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxDataStore.swift
@@ -1,0 +1,100 @@
+import Foundation
+@preconcurrency import WebKit
+
+/// Engine-neutral wrapper around a profile's website data store
+/// (cookies, local storage, IndexedDB, service workers, etc.).
+///
+/// `WKWebsiteDataStore` maps to a single underlying instance per
+/// `CmuxDataStore`. Multiple `CmuxBrowserView`s sharing the same
+/// `CmuxDataStore` share their backing storage — that's the whole
+/// point of profiles.
+///
+/// Construction:
+///   * `.default()` — persistent default, shared with `WKWebView()`'s
+///     default. Use for the built-in profile.
+///   * `.nonPersistent()` — in-memory; cleared when no views reference
+///     it. Use for incognito-style sessions.
+///   * `.forIdentifier(_:)` — persistent per-UUID. Two stores with the
+///     same UUID share storage across process restarts. Use for named
+///     profiles created in Settings → Browser → Profiles.
+///
+/// Today the backing implementation is always `WKWebsiteDataStore`.
+/// When the Chromium backend lands, a `CmuxDataStore` constructed via
+/// the same factories will resolve to a Chromium `BrowserContext` keyed
+/// off the same identifier so user profiles are stable across the
+/// engine swap.
+public final class CmuxDataStore: @unchecked Sendable {
+    /// Identifies the kind of store. The Chromium backend uses this to
+    /// pick between in-memory and on-disk `BrowserContext`s and to
+    /// derive on-disk profile paths from the identifier.
+    public enum Kind: Sendable, Hashable {
+        case `default`
+        case nonPersistent
+        case persistent(identifier: UUID)
+    }
+
+    public let kind: Kind
+
+    /// The underlying WebKit store. Backend-private; accessed by
+    /// `WebKitBrowserBackend` when wiring `WKWebViewConfiguration`.
+    /// Chromium backend will keep this `nil` and use its own mapping.
+    let wkStore: WKWebsiteDataStore?
+
+    /// Cached cookie store wrapper. Lazily created so callers don't pay
+    /// the bridge cost until they ask for cookies.
+    private var _cookieStore: CmuxCookieStore?
+
+    @MainActor
+    public var cookieStore: CmuxCookieStore {
+        if let existing = _cookieStore { return existing }
+        let made = CmuxCookieStore(wkStore: wkStore?.httpCookieStore)
+        _cookieStore = made
+        return made
+    }
+
+    private init(kind: Kind, wkStore: WKWebsiteDataStore?) {
+        self.kind = kind
+        self.wkStore = wkStore
+    }
+
+    @MainActor
+    public static func `default`() -> CmuxDataStore {
+        CmuxDataStore(kind: .default, wkStore: .default())
+    }
+
+    @MainActor
+    public static func nonPersistent() -> CmuxDataStore {
+        CmuxDataStore(kind: .nonPersistent, wkStore: .nonPersistent())
+    }
+
+    /// Persistent store keyed by `identifier`. Two stores constructed
+    /// with the same UUID share on-disk storage. Mirrors
+    /// `WKWebsiteDataStore(forIdentifier:)`.
+    @MainActor
+    public static func forIdentifier(_ identifier: UUID) -> CmuxDataStore {
+        CmuxDataStore(
+            kind: .persistent(identifier: identifier),
+            wkStore: WKWebsiteDataStore(forIdentifier: identifier)
+        )
+    }
+
+    /// Every known website-data type the engine can clear. Today this
+    /// is `WKWebsiteDataStore.allWebsiteDataTypes()`. When Chromium
+    /// lands we map these strings to Chromium's `BrowsingDataType` mask.
+    @MainActor
+    public static func allDataTypes() -> Set<String> {
+        WKWebsiteDataStore.allWebsiteDataTypes()
+    }
+
+    /// Removes website data of the given types modified at or after
+    /// `since`. Pass `Date.distantPast` to clear everything.
+    @MainActor
+    public func removeData(ofTypes types: Set<String>, modifiedSince since: Date) async {
+        guard let wkStore else { return }
+        await withCheckedContinuation { continuation in
+            wkStore.removeData(ofTypes: types, modifiedSince: since) {
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxDownload.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxDownload.swift
@@ -1,0 +1,92 @@
+import Foundation
+@preconcurrency import WebKit
+
+/// Engine-neutral download handle. Wraps `WKDownload` today; will wrap
+/// Chromium's `DownloadItem` when the Chromium backend lands. The
+/// identity model matches WK: one `CmuxDownload` per in-flight download,
+/// usable as a dictionary key via `ObjectIdentifier(_:)`.
+@MainActor
+public final class CmuxDownload {
+    /// Process-stable identifier for this download. Survives across
+    /// host-side bookkeeping; not a Chromium download GUID.
+    public let id: UUID
+
+    /// The HTTP request that initiated the download (the navigation
+    /// that triggered it). May be `nil` for engine-initiated downloads
+    /// (e.g. context-menu "Save Image As").
+    public let originalRequest: URLRequest?
+
+    /// Backend-specific download object. WebKit: `WKDownload`.
+    /// Chromium: future `download::DownloadItem` C handle. Backends
+    /// inspect this via internal accessors; hosts never touch it.
+    let wkDownload: WKDownload?
+
+    init(wkDownload: WKDownload?, originalRequest: URLRequest?) {
+        self.id = UUID()
+        self.wkDownload = wkDownload
+        self.originalRequest = originalRequest
+    }
+
+    /// Cancel the download. Engine emits a final
+    /// `download(_:didFailWithError:resumeData:)` with a cancellation
+    /// error so the host's finalization path runs.
+    public func cancel() {
+        guard let wkDownload else { return }
+        wkDownload.cancel { _ in /* resumeData discarded for now */ }
+    }
+}
+
+/// Engine-neutral counterpart to `WKDownloadDelegate`. Conforming
+/// types receive lifecycle callbacks for any `CmuxDownload` they
+/// own. Methods mirror the WK shape with `Cmux*` types.
+@MainActor
+public protocol CmuxDownloadDelegate: AnyObject {
+    /// Pick the on-disk destination for the download. Pass `nil` to
+    /// reject. The destination URL's parent directory must exist.
+    func cmuxDownload(
+        _ download: CmuxDownload,
+        decideDestinationUsing response: URLResponse,
+        suggestedFilename: String,
+        completionHandler: @escaping (URL?) -> Void
+    )
+
+    /// Download succeeded. The file is now at the destination URL
+    /// chosen above.
+    func cmuxDownloadDidFinish(_ download: CmuxDownload)
+
+    /// Download failed. `resumeData` may be `nil`; when present it
+    /// can be passed to a future resume API.
+    func cmuxDownload(
+        _ download: CmuxDownload,
+        didFailWithError error: Error,
+        resumeData: Data?
+    )
+}
+
+public extension CmuxDownloadDelegate {
+    func cmuxDownloadDidFinish(_ download: CmuxDownload) {}
+    func cmuxDownload(_ download: CmuxDownload, didFailWithError error: Error, resumeData: Data?) {}
+}
+
+// MARK: - Navigation delegate extensions for download-initiation hooks
+
+public extension CmuxNavigationDelegate {
+    /// Called after the host returns `.download` for a navigation
+    /// action. The delegate must attach a `CmuxDownloadDelegate` to
+    /// `download.delegate` (when the package exposes it) or store the
+    /// returned `CmuxDownload` somewhere the host's download manager
+    /// can drive.
+    func browserView(
+        _ view: CmuxBrowserView,
+        navigationAction: CmuxNavigationAction,
+        didBecome download: CmuxDownload
+    ) {}
+
+    /// Called after the host returns `.download` for a navigation
+    /// response (i.e. mid-flight: server replied with attachment).
+    func browserView(
+        _ view: CmuxBrowserView,
+        navigationResponse: CmuxNavigationResponse,
+        didBecome download: CmuxDownload
+    ) {}
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxNavigationDelegate.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxNavigationDelegate.swift
@@ -1,0 +1,154 @@
+import AppKit
+import Foundation
+
+/// Engine-neutral navigation delegate. Method shape mirrors
+/// `WKNavigationDelegate`; backends translate.
+@MainActor
+public protocol CmuxNavigationDelegate: AnyObject {
+    func browserView(
+        _ view: CmuxBrowserView,
+        decidePolicyFor navigationAction: CmuxNavigationAction,
+        decisionHandler: @escaping (CmuxNavigationActionPolicy) -> Void
+    )
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        decidePolicyFor navigationResponse: CmuxNavigationResponse,
+        decisionHandler: @escaping (CmuxNavigationResponsePolicy) -> Void
+    )
+
+    func browserView(_ view: CmuxBrowserView, didStartProvisionalNavigation navigation: CmuxNavigation)
+    func browserView(_ view: CmuxBrowserView, didCommit navigation: CmuxNavigation)
+    func browserView(_ view: CmuxBrowserView, didFinish navigation: CmuxNavigation)
+    func browserView(_ view: CmuxBrowserView, didFail navigation: CmuxNavigation, withError error: Error)
+    func browserView(_ view: CmuxBrowserView, didFailProvisionalNavigation navigation: CmuxNavigation, withError error: Error)
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    )
+
+    func browserViewWebContentProcessDidTerminate(_ view: CmuxBrowserView)
+}
+
+// Default no-op implementations so adopters only override what they need.
+public extension CmuxNavigationDelegate {
+    func browserView(
+        _ view: CmuxBrowserView,
+        decidePolicyFor navigationAction: CmuxNavigationAction,
+        decisionHandler: @escaping (CmuxNavigationActionPolicy) -> Void
+    ) {
+        decisionHandler(.allow)
+    }
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        decidePolicyFor navigationResponse: CmuxNavigationResponse,
+        decisionHandler: @escaping (CmuxNavigationResponsePolicy) -> Void
+    ) {
+        decisionHandler(.allow)
+    }
+
+    func browserView(_ view: CmuxBrowserView, didStartProvisionalNavigation navigation: CmuxNavigation) {}
+    func browserView(_ view: CmuxBrowserView, didCommit navigation: CmuxNavigation) {}
+    func browserView(_ view: CmuxBrowserView, didFinish navigation: CmuxNavigation) {}
+    func browserView(_ view: CmuxBrowserView, didFail navigation: CmuxNavigation, withError error: Error) {}
+    func browserView(_ view: CmuxBrowserView, didFailProvisionalNavigation navigation: CmuxNavigation, withError error: Error) {}
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        didReceive challenge: URLAuthenticationChallenge,
+        completionHandler: @escaping (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+    ) {
+        completionHandler(.performDefaultHandling, nil)
+    }
+
+    func browserViewWebContentProcessDidTerminate(_ view: CmuxBrowserView) {}
+}
+
+public struct CmuxNavigation: Sendable, Hashable {
+    public let id: UUID
+    public init(id: UUID = UUID()) { self.id = id }
+}
+
+public enum CmuxNavigationActionPolicy: Sendable {
+    case cancel
+    case allow
+    case download
+}
+
+public enum CmuxNavigationResponsePolicy: Sendable {
+    case cancel
+    case allow
+    case download
+}
+
+public struct CmuxNavigationAction: @unchecked Sendable {
+    public enum NavigationType: Sendable {
+        case linkActivated
+        case formSubmitted
+        case backForward
+        case reload
+        case formResubmitted
+        case other
+    }
+
+    public let request: URLRequest
+    public let sourceFrame: CmuxFrameInfo
+    public let targetFrame: CmuxFrameInfo?
+    public let navigationType: NavigationType
+    public let modifierFlags: NSEvent.ModifierFlags
+    public let buttonNumber: Int
+    public let shouldPerformDownload: Bool
+
+    public init(
+        request: URLRequest,
+        sourceFrame: CmuxFrameInfo,
+        targetFrame: CmuxFrameInfo?,
+        navigationType: NavigationType,
+        modifierFlags: NSEvent.ModifierFlags,
+        buttonNumber: Int,
+        shouldPerformDownload: Bool
+    ) {
+        self.request = request
+        self.sourceFrame = sourceFrame
+        self.targetFrame = targetFrame
+        self.navigationType = navigationType
+        self.modifierFlags = modifierFlags
+        self.buttonNumber = buttonNumber
+        self.shouldPerformDownload = shouldPerformDownload
+    }
+}
+
+public struct CmuxNavigationResponse: Sendable {
+    public let response: URLResponse
+    public let isForMainFrame: Bool
+    public let canShowMIMEType: Bool
+
+    public init(response: URLResponse, isForMainFrame: Bool, canShowMIMEType: Bool) {
+        self.response = response
+        self.isForMainFrame = isForMainFrame
+        self.canShowMIMEType = canShowMIMEType
+    }
+}
+
+public struct CmuxFrameInfo: Sendable {
+    public let isMainFrame: Bool
+    public let request: URLRequest
+    public let securityOriginHost: String?
+    public let securityOriginPort: Int?
+
+    public init(
+        isMainFrame: Bool,
+        request: URLRequest,
+        securityOriginHost: String?,
+        securityOriginPort: Int?
+    ) {
+        self.isMainFrame = isMainFrame
+        self.request = request
+        self.securityOriginHost = securityOriginHost
+        self.securityOriginPort = securityOriginPort
+    }
+}
+

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxSnapshotConfiguration.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxSnapshotConfiguration.swift
@@ -1,0 +1,46 @@
+import CoreGraphics
+import Foundation
+@preconcurrency import WebKit
+
+/// Engine-neutral counterpart to `WKSnapshotConfiguration`. Hosts pass
+/// one when calling `CmuxBrowserView.takeSnapshot(configuration:)`.
+/// Pass `nil` (or use the no-arg `takeSnapshot`) for engine defaults.
+///
+/// Today this bridges to `WKSnapshotConfiguration`; Chromium will map
+/// onto `RenderWidgetHostView::CopyFromSurface` with the same shape.
+public struct CmuxSnapshotConfiguration: Sendable {
+    /// Sub-rectangle of the view to snapshot. `.zero` (the default) is
+    /// interpreted by WebKit as "full view".
+    public var rect: CGRect
+
+    /// Target width in points; height is scaled to preserve aspect.
+    /// `nil` matches the view's bounds.
+    public var snapshotWidth: CGFloat?
+
+    /// If `true` the engine flushes any pending updates before
+    /// capturing. WK defaults to `true`.
+    public var afterScreenUpdates: Bool
+
+    public init(
+        rect: CGRect = .zero,
+        snapshotWidth: CGFloat? = nil,
+        afterScreenUpdates: Bool = true
+    ) {
+        self.rect = rect
+        self.snapshotWidth = snapshotWidth
+        self.afterScreenUpdates = afterScreenUpdates
+    }
+}
+
+extension CmuxSnapshotConfiguration {
+    /// Builds a `WKSnapshotConfiguration` with the same field values.
+    /// Internal — only used by `WebKitBrowserBackend`.
+    @MainActor
+    func makeWKConfiguration() -> WKSnapshotConfiguration {
+        let wk = WKSnapshotConfiguration()
+        wk.rect = rect
+        if let w = snapshotWidth { wk.snapshotWidth = NSNumber(value: Double(w)) }
+        wk.afterScreenUpdates = afterScreenUpdates
+        return wk
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxUIDelegate.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxUIDelegate.swift
@@ -1,0 +1,166 @@
+import AppKit
+import Foundation
+
+/// Engine-neutral UI delegate. Method shape mirrors `WKUIDelegate`.
+/// Backends translate to the engine's equivalent.
+@MainActor
+public protocol CmuxUIDelegate: AnyObject {
+    /// Called when the page requests a new browser view (e.g. `window.open`,
+    /// `target="_blank"` with cmd-click). Return `nil` to suppress; return a
+    /// view to host the new content (the view should be displayed in a new
+    /// window or tab by the host).
+    func browserView(
+        _ view: CmuxBrowserView,
+        createBrowserViewWith configuration: CmuxBrowserConfiguration,
+        for navigationAction: CmuxNavigationAction,
+        windowFeatures: CmuxWindowFeatures
+    ) -> CmuxBrowserView?
+
+    func browserViewDidClose(_ view: CmuxBrowserView)
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping () -> Void
+    )
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping (Bool) -> Void
+    )
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping (String?) -> Void
+    )
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runOpenPanelWith parameters: CmuxOpenPanelParameters,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void
+    )
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        contextMenuConfigurationForElement element: CmuxContextMenuElementInfo,
+        completionHandler: @escaping (NSMenu?) -> Void
+    )
+}
+
+public extension CmuxUIDelegate {
+    func browserView(
+        _ view: CmuxBrowserView,
+        createBrowserViewWith configuration: CmuxBrowserConfiguration,
+        for navigationAction: CmuxNavigationAction,
+        windowFeatures: CmuxWindowFeatures
+    ) -> CmuxBrowserView? {
+        nil
+    }
+
+    func browserViewDidClose(_ view: CmuxBrowserView) {}
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping () -> Void
+    ) {
+        completionHandler()
+    }
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping (Bool) -> Void
+    ) {
+        completionHandler(false)
+    }
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping (String?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        runOpenPanelWith parameters: CmuxOpenPanelParameters,
+        initiatedByFrame frame: CmuxFrameInfo,
+        completionHandler: @escaping ([URL]?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+
+    func browserView(
+        _ view: CmuxBrowserView,
+        contextMenuConfigurationForElement element: CmuxContextMenuElementInfo,
+        completionHandler: @escaping (NSMenu?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+public struct CmuxWindowFeatures: Sendable {
+    public let menuBarVisibility: Bool?
+    public let statusBarVisibility: Bool?
+    public let toolbarsVisibility: Bool?
+    public let allowsResizing: Bool?
+    public let x: CGFloat?
+    public let y: CGFloat?
+    public let width: CGFloat?
+    public let height: CGFloat?
+
+    public init(
+        menuBarVisibility: Bool? = nil,
+        statusBarVisibility: Bool? = nil,
+        toolbarsVisibility: Bool? = nil,
+        allowsResizing: Bool? = nil,
+        x: CGFloat? = nil,
+        y: CGFloat? = nil,
+        width: CGFloat? = nil,
+        height: CGFloat? = nil
+    ) {
+        self.menuBarVisibility = menuBarVisibility
+        self.statusBarVisibility = statusBarVisibility
+        self.toolbarsVisibility = toolbarsVisibility
+        self.allowsResizing = allowsResizing
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+}
+
+public struct CmuxOpenPanelParameters: Sendable {
+    public let allowsMultipleSelection: Bool
+    public let allowsDirectories: Bool
+
+    public init(allowsMultipleSelection: Bool, allowsDirectories: Bool) {
+        self.allowsMultipleSelection = allowsMultipleSelection
+        self.allowsDirectories = allowsDirectories
+    }
+}
+
+public struct CmuxContextMenuElementInfo: Sendable {
+    public let linkURL: URL?
+    public let imageURL: URL?
+    public let mediaURL: URL?
+
+    public init(linkURL: URL?, imageURL: URL?, mediaURL: URL?) {
+        self.linkURL = linkURL
+        self.imageURL = imageURL
+        self.mediaURL = mediaURL
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxUserContentController.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/CmuxUserContentController.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Engine-neutral counterpart to `WKUserContentController`.
+///
+/// Holds the set of injected user scripts and the registry of script
+/// message handlers the host wants exposed to page JavaScript. Backends
+/// translate this into engine-specific machinery at view construction
+/// time.
+public final class CmuxUserContentController: @unchecked Sendable {
+    public private(set) var userScripts: [CmuxUserScript] = []
+    public private(set) var messageHandlers: [String: any CmuxScriptMessageHandler] = [:]
+
+    public init() {}
+
+    public func addUserScript(_ script: CmuxUserScript) {
+        userScripts.append(script)
+    }
+
+    public func removeAllUserScripts() {
+        userScripts.removeAll()
+    }
+
+    /// Register a handler for `window.webkit.messageHandlers.<name>` (or
+    /// the Chromium equivalent the backend wires up). Re-registering an
+    /// existing name replaces the previous handler.
+    public func add(_ handler: any CmuxScriptMessageHandler, name: String) {
+        messageHandlers[name] = handler
+    }
+
+    public func removeScriptMessageHandler(forName name: String) {
+        messageHandlers[name] = nil
+    }
+}
+
+public struct CmuxUserScript: Sendable {
+    public enum InjectionTime: Sendable {
+        case atDocumentStart
+        case atDocumentEnd
+    }
+
+    public let source: String
+    public let injectionTime: InjectionTime
+    public let forMainFrameOnly: Bool
+
+    public init(
+        source: String,
+        injectionTime: InjectionTime,
+        forMainFrameOnly: Bool
+    ) {
+        self.source = source
+        self.injectionTime = injectionTime
+        self.forMainFrameOnly = forMainFrameOnly
+    }
+}
+
+public protocol CmuxScriptMessageHandler: AnyObject, Sendable {
+    func didReceive(_ message: CmuxScriptMessage)
+}
+
+public struct CmuxScriptMessage: Sendable {
+    public let name: String
+    public let body: CmuxScriptMessageBody
+    public let frameURL: URL?
+    public let isMainFrame: Bool
+
+    public init(
+        name: String,
+        body: CmuxScriptMessageBody,
+        frameURL: URL?,
+        isMainFrame: Bool
+    ) {
+        self.name = name
+        self.body = body
+        self.frameURL = frameURL
+        self.isMainFrame = isMainFrame
+    }
+}
+
+/// Type-erased JS-message body. Engine backends marshal native
+/// `NSNumber`/`NSString`/`NSDictionary`/`NSArray` (WebKit) or Mojo
+/// values (Chromium) into this.
+public enum CmuxScriptMessageBody: Sendable {
+    case null
+    case bool(Bool)
+    case int(Int64)
+    case double(Double)
+    case string(String)
+    case array([CmuxScriptMessageBody])
+    case dictionary([String: CmuxScriptMessageBody])
+    case data(Data)
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -1,0 +1,506 @@
+import AppKit
+import Foundation
+@preconcurrency import WebKit
+
+/// Production backend that wraps `WKWebView`. This is the engine
+/// `CmuxBrowserView` uses today and during the entire P3 migration
+/// window — both flag values are valid until `ChromiumBrowserBackend`
+/// is feature-complete.
+@MainActor
+final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
+    nonisolated static func versionString() -> String {
+        // WKWebView ships with the OS WebKit. Surface the bundle version
+        // so it's clear which WebKit the running build is bound to.
+        let bundle = Bundle(identifier: "com.apple.WebKit")
+        let v = bundle?.infoDictionary?["CFBundleShortVersionString"] as? String
+            ?? bundle?.infoDictionary?["CFBundleVersion"] as? String
+            ?? "unknown"
+        return "WebKit \(v)"
+    }
+
+    let webView: WKWebView
+    var navigationDelegate: CmuxNavigationDelegate?
+    var uiDelegate: CmuxUIDelegate?
+
+    /// Maps the engine's underlying `WKNavigation` (whose identity we
+    /// can't observe directly across the delegate methods) to a stable
+    /// `CmuxNavigation` UUID. Strong references; entries cleared in
+    /// the terminal delegate methods.
+    private var navigationMap: [ObjectIdentifier: CmuxNavigation] = [:]
+
+    private lazy var navigationBridge = NavigationBridge(owner: self)
+    private lazy var uiBridge = UIBridge(owner: self)
+
+    init(configuration: CmuxBrowserConfiguration) {
+        let wk = WKWebViewConfiguration()
+        wk.userContentController = configuration.userContentController.makeWKController()
+        wk.preferences.javaScriptCanOpenWindowsAutomatically =
+            configuration.allowsJavaScriptToOpenWindowsAutomatically
+        wk.preferences.isElementFullscreenEnabled = true
+        wk.allowsAirPlayForMediaPlayback = true
+        wk.suppressesIncrementalRendering = configuration.suppressesIncrementalRendering
+        wk.mediaTypesRequiringUserActionForPlayback =
+            configuration.mediaTypesRequiringUserActionForPlayback.wkValue
+        if let app = configuration.applicationNameForUserAgent {
+            wk.applicationNameForUserAgent = app
+        }
+        for (scheme, handler) in configuration.urlSchemeHandlers {
+            wk.setURLSchemeHandler(URLSchemeShim(host: handler), forURLScheme: scheme)
+        }
+        self.webView = WKWebView(frame: .zero, configuration: wk)
+        super.init()
+        if let ua = configuration.customUserAgent {
+            self.webView.customUserAgent = ua
+        }
+        self.webView.navigationDelegate = navigationBridge
+        self.webView.uiDelegate = uiBridge
+    }
+
+    var nsView: NSView { webView }
+    var url: URL? { webView.url }
+    var title: String? { webView.title }
+    var isLoading: Bool { webView.isLoading }
+    var estimatedProgress: Double { webView.estimatedProgress }
+    var canGoBack: Bool { webView.canGoBack }
+    var canGoForward: Bool { webView.canGoForward }
+    var customUserAgent: String? { webView.customUserAgent }
+
+    func load(_ request: URLRequest) -> CmuxNavigation {
+        let wkNav = webView.load(request)
+        return register(wkNav)
+    }
+
+    func loadHTMLString(_ html: String, baseURL: URL?) -> CmuxNavigation {
+        let wkNav = webView.loadHTMLString(html, baseURL: baseURL)
+        return register(wkNav)
+    }
+
+    func goBack() -> CmuxNavigation? { register(webView.goBack()) }
+    func goForward() -> CmuxNavigation? { register(webView.goForward()) }
+    func reload() -> CmuxNavigation? { register(webView.reload()) }
+    func stopLoading() { webView.stopLoading() }
+
+    func evaluateJavaScript(
+        _ source: String,
+        completionHandler: @escaping (Any?, Error?) -> Void
+    ) {
+        // WKWebView's `completionHandler` is declared `@Sendable @MainActor`.
+        // Our protocol's is plain `@escaping`. We close over it as
+        // `@unchecked Sendable` because both callers run on the main
+        // actor and the closure is only invoked there.
+        struct Closure: @unchecked Sendable {
+            let body: (Any?, Error?) -> Void
+        }
+        let box = Closure(body: completionHandler)
+        webView.evaluateJavaScript(source) { value, error in
+            box.body(value, error)
+        }
+    }
+
+    func setCustomUserAgent(_ userAgent: String?) {
+        webView.customUserAgent = userAgent
+    }
+
+    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
+        let config = WKSnapshotConfiguration()
+        webView.takeSnapshot(with: config) { image, error in
+            completionHandler(image?.cgImage(forProposedRect: nil, context: nil, hints: nil), error)
+        }
+    }
+
+    // MARK: navigation map
+
+    private func register(_ wkNav: WKNavigation?) -> CmuxNavigation {
+        let navigation = CmuxNavigation()
+        if let wkNav {
+            navigationMap[ObjectIdentifier(wkNav)] = navigation
+        }
+        return navigation
+    }
+
+    fileprivate func resolve(_ wkNav: WKNavigation?) -> CmuxNavigation {
+        guard let wkNav else { return CmuxNavigation() }
+        if let known = navigationMap[ObjectIdentifier(wkNav)] {
+            return known
+        }
+        let synthesized = CmuxNavigation()
+        navigationMap[ObjectIdentifier(wkNav)] = synthesized
+        return synthesized
+    }
+
+    fileprivate func clearNavigation(_ wkNav: WKNavigation?) {
+        guard let wkNav else { return }
+        navigationMap.removeValue(forKey: ObjectIdentifier(wkNav))
+    }
+}
+
+// MARK: - Delegate bridges (forward WK → Cmux types)
+
+extension WebKitBrowserBackend {
+    final class NavigationBridge: NSObject, WKNavigationDelegate {
+        weak var owner: WebKitBrowserBackend?
+        init(owner: WebKitBrowserBackend) { self.owner = owner }
+
+        @MainActor
+        private func cmuxView() -> CmuxBrowserView? {
+            // Walk up the NSView ancestry: the WKWebView is hosted by
+            // a CmuxBrowserView. If not found, the call is a noop —
+            // helps in unit tests where the WK view is unmounted.
+            guard let owner else { return nil }
+            return owner.webView.superview as? CmuxBrowserView
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            preferences: WKWebpagePreferences,
+            decisionHandler: @escaping @MainActor (WKNavigationActionPolicy, WKWebpagePreferences) -> Void
+        ) {
+            guard let delegate = owner?.navigationDelegate,
+                  let view = cmuxView() else {
+                decisionHandler(.allow, preferences); return
+            }
+            delegate.browserView(view,
+                                 decidePolicyFor: navigationAction.cmux,
+                                 decisionHandler: { policy in
+                                     decisionHandler(policy.wk, preferences)
+                                 })
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationResponse: WKNavigationResponse,
+            decisionHandler: @escaping @MainActor (WKNavigationResponsePolicy) -> Void
+        ) {
+            guard let delegate = owner?.navigationDelegate,
+                  let view = cmuxView() else {
+                decisionHandler(.allow); return
+            }
+            delegate.browserView(view,
+                                 decidePolicyFor: navigationResponse.cmux,
+                                 decisionHandler: { policy in
+                                     decisionHandler(policy.wk)
+                                 })
+        }
+
+        func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
+            guard let owner, let delegate = owner.navigationDelegate, let view = cmuxView() else { return }
+            delegate.browserView(view, didStartProvisionalNavigation: owner.resolve(navigation))
+        }
+
+        func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
+            guard let owner, let delegate = owner.navigationDelegate, let view = cmuxView() else { return }
+            delegate.browserView(view, didCommit: owner.resolve(navigation))
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            guard let owner, let delegate = owner.navigationDelegate, let view = cmuxView() else { return }
+            let nav = owner.resolve(navigation)
+            delegate.browserView(view, didFinish: nav)
+            owner.clearNavigation(navigation)
+        }
+
+        func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+            guard let owner, let delegate = owner.navigationDelegate, let view = cmuxView() else { return }
+            let nav = owner.resolve(navigation)
+            delegate.browserView(view, didFail: nav, withError: error)
+            owner.clearNavigation(navigation)
+        }
+
+        func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+            guard let owner, let delegate = owner.navigationDelegate, let view = cmuxView() else { return }
+            let nav = owner.resolve(navigation)
+            delegate.browserView(view, didFailProvisionalNavigation: nav, withError: error)
+            owner.clearNavigation(navigation)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            didReceive challenge: URLAuthenticationChallenge,
+            completionHandler: @escaping @MainActor (URLSession.AuthChallengeDisposition, URLCredential?) -> Void
+        ) {
+            guard let delegate = owner?.navigationDelegate, let view = cmuxView() else {
+                completionHandler(.performDefaultHandling, nil); return
+            }
+            delegate.browserView(view, didReceive: challenge, completionHandler: completionHandler)
+        }
+
+        func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+            guard let delegate = owner?.navigationDelegate, let view = cmuxView() else { return }
+            delegate.browserViewWebContentProcessDidTerminate(view)
+        }
+    }
+
+    final class UIBridge: NSObject, WKUIDelegate {
+        weak var owner: WebKitBrowserBackend?
+        init(owner: WebKitBrowserBackend) { self.owner = owner }
+
+        @MainActor
+        private func cmuxView() -> CmuxBrowserView? {
+            owner?.webView.superview as? CmuxBrowserView
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            createWebViewWith configuration: WKWebViewConfiguration,
+            for navigationAction: WKNavigationAction,
+            windowFeatures: WKWindowFeatures
+        ) -> WKWebView? {
+            // We do not currently bridge window.open() back through the
+            // protocol. Hosts that need popups can implement
+            // createBrowserViewWith on `CmuxUIDelegate`; the wrapper
+            // returns the new view's underlying NSView/WKWebView.
+            // Today: deny.
+            _ = configuration
+            _ = navigationAction
+            _ = windowFeatures
+            return nil
+        }
+    }
+}
+
+// MARK: - Bridging helpers
+
+private extension WKNavigationActionPolicy {
+    var cmux: CmuxNavigationActionPolicy {
+        switch self {
+        case .allow: return .allow
+        case .cancel: return .cancel
+        case .download: return .download
+        @unknown default: return .allow
+        }
+    }
+}
+
+private extension CmuxNavigationActionPolicy {
+    var wk: WKNavigationActionPolicy {
+        switch self {
+        case .allow: return .allow
+        case .cancel: return .cancel
+        case .download: return .download
+        }
+    }
+}
+
+private extension WKNavigationResponsePolicy {
+    var cmux: CmuxNavigationResponsePolicy {
+        switch self {
+        case .allow: return .allow
+        case .cancel: return .cancel
+        case .download: return .download
+        @unknown default: return .allow
+        }
+    }
+}
+
+private extension CmuxNavigationResponsePolicy {
+    var wk: WKNavigationResponsePolicy {
+        switch self {
+        case .allow: return .allow
+        case .cancel: return .cancel
+        case .download: return .download
+        }
+    }
+}
+
+private extension WKNavigationAction {
+    var cmux: CmuxNavigationAction {
+        CmuxNavigationAction(
+            request: request,
+            sourceFrame: sourceFrame.cmux,
+            targetFrame: targetFrame?.cmux,
+            navigationType: navigationType.cmux,
+            modifierFlags: modifierFlags,
+            buttonNumber: buttonNumber,
+            shouldPerformDownload: shouldPerformDownload
+        )
+    }
+}
+
+private extension WKNavigationType {
+    var cmux: CmuxNavigationAction.NavigationType {
+        switch self {
+        case .linkActivated: return .linkActivated
+        case .formSubmitted: return .formSubmitted
+        case .backForward: return .backForward
+        case .reload: return .reload
+        case .formResubmitted: return .formResubmitted
+        case .other: return .other
+        @unknown default: return .other
+        }
+    }
+}
+
+private extension WKFrameInfo {
+    var cmux: CmuxFrameInfo {
+        CmuxFrameInfo(
+            isMainFrame: isMainFrame,
+            request: request,
+            securityOriginHost: securityOrigin.host,
+            securityOriginPort: securityOrigin.port == 0 ? nil : securityOrigin.port
+        )
+    }
+}
+
+private extension WKNavigationResponse {
+    var cmux: CmuxNavigationResponse {
+        CmuxNavigationResponse(
+            response: response,
+            isForMainFrame: isForMainFrame,
+            canShowMIMEType: canShowMIMEType
+        )
+    }
+}
+
+private extension CmuxBrowserConfiguration.MediaPlaybackRequirement {
+    var wkValue: WKAudiovisualMediaTypes {
+        switch self {
+        case .none: return []
+        case .audio: return .audio
+        case .video: return .video
+        case .all: return .all
+        }
+    }
+}
+
+// MARK: - WKUserContentController shim
+
+extension CmuxUserContentController {
+    /// Builds a fresh `WKUserContentController` from this controller's
+    /// scripts + handlers. The returned controller holds strong
+    /// references to the registered handlers via a shim adapter.
+    @MainActor
+    func makeWKController() -> WKUserContentController {
+        let wk = WKUserContentController()
+        for s in userScripts {
+            let wkScript = WKUserScript(
+                source: s.source,
+                injectionTime: s.injectionTime.wk,
+                forMainFrameOnly: s.forMainFrameOnly
+            )
+            wk.addUserScript(wkScript)
+        }
+        for (name, handler) in messageHandlers {
+            let shim = WKMessageHandlerShim(host: handler)
+            wk.add(shim, name: name)
+        }
+        return wk
+    }
+}
+
+private extension CmuxUserScript.InjectionTime {
+    var wk: WKUserScriptInjectionTime {
+        switch self {
+        case .atDocumentStart: return .atDocumentStart
+        case .atDocumentEnd: return .atDocumentEnd
+        }
+    }
+}
+
+private final class WKMessageHandlerShim: NSObject, WKScriptMessageHandler {
+    let host: any CmuxScriptMessageHandler
+    init(host: any CmuxScriptMessageHandler) { self.host = host }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        let body = CmuxScriptMessageBody.from(any: message.body)
+        let url = message.frameInfo.request.url ?? message.frameInfo.securityOrigin.urlIfAvailable
+        let cmux = CmuxScriptMessage(
+            name: message.name,
+            body: body,
+            frameURL: url,
+            isMainFrame: message.frameInfo.isMainFrame
+        )
+        host.didReceive(cmux)
+    }
+}
+
+private extension WKSecurityOrigin {
+    var urlIfAvailable: URL? {
+        guard !host.isEmpty else { return nil }
+        var c = URLComponents()
+        c.scheme = self.protocol
+        c.host = host
+        c.port = port == 0 ? nil : port
+        return c.url
+    }
+}
+
+extension CmuxScriptMessageBody {
+    /// Walk an `Any` value (the type WKScriptMessage.body returns) into
+    /// the typed enum. Supports the JSON-ish set WebKit hands back.
+    public static func from(any value: Any) -> CmuxScriptMessageBody {
+        if value is NSNull { return .null }
+        if let b = value as? Bool {
+            // NSNumber coerces to Bool too aggressively; check NSNumber first
+            // below. Keep this as a fallback for pure Bool.
+            return .bool(b)
+        }
+        if let n = value as? NSNumber {
+            let cf = CFGetTypeID(n) == CFBooleanGetTypeID()
+            if cf { return .bool(n.boolValue) }
+            // Best-effort: integer if exact, else double.
+            if n.doubleValue == Double(n.int64Value) {
+                return .int(n.int64Value)
+            }
+            return .double(n.doubleValue)
+        }
+        if let s = value as? String { return .string(s) }
+        if let d = value as? Data { return .data(d) }
+        if let a = value as? [Any] {
+            return .array(a.map { CmuxScriptMessageBody.from(any: $0) })
+        }
+        if let dict = value as? [String: Any] {
+            var out: [String: CmuxScriptMessageBody] = [:]
+            out.reserveCapacity(dict.count)
+            for (k, v) in dict {
+                out[k] = CmuxScriptMessageBody.from(any: v)
+            }
+            return .dictionary(out)
+        }
+        // Fallback: stringify
+        return .string(String(describing: value))
+    }
+}
+
+// MARK: - URL scheme handler shim
+
+private final class URLSchemeShim: NSObject, WKURLSchemeHandler {
+    let host: any CmuxURLSchemeHandler
+    init(host: any CmuxURLSchemeHandler) { self.host = host }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: any WKURLSchemeTask) {
+        // WKURLSchemeTask is not Sendable. The completion callbacks
+        // are routed back to the main thread, where WK invokes them,
+        // so we use an unchecked Sendable shim to carry the task
+        // reference into our closures.
+        struct TaskBox: @unchecked Sendable {
+            let task: any WKURLSchemeTask
+        }
+        let box = TaskBox(task: urlSchemeTask)
+        let cmuxTask = CmuxURLSchemeTask(
+            request: urlSchemeTask.request,
+            respond: { response in
+                MainActor.assumeIsolated { box.task.didReceive(response) }
+            },
+            data: { data in
+                MainActor.assumeIsolated { box.task.didReceive(data) }
+            },
+            finish: {
+                MainActor.assumeIsolated { box.task.didFinish() }
+            },
+            fail: { error in
+                MainActor.assumeIsolated { box.task.didFailWithError(error) }
+            }
+        )
+        host.startURLSchemeTask(cmuxTask)
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: any WKURLSchemeTask) {
+        // We don't currently propagate cancellation. Most consumers
+        // don't care; revisit when a callsite needs it.
+        _ = urlSchemeTask
+    }
+}

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -74,6 +74,11 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
         if let ua = configuration.customUserAgent {
             self.webView.customUserAgent = ua
         }
+        if configuration.isInspectable {
+            // macOS 13.3+. Safe to set unconditionally — the package
+            // already requires macOS 14.
+            self.webView.isInspectable = true
+        }
         self.webView.navigationDelegate = navigationBridge
         self.webView.uiDelegate = uiBridge
         installStateObservations()

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -21,12 +21,16 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
     let webView: WKWebView
     var navigationDelegate: CmuxNavigationDelegate?
     var uiDelegate: CmuxUIDelegate?
+    let state = CmuxBrowserState()
 
     /// Maps the engine's underlying `WKNavigation` (whose identity we
     /// can't observe directly across the delegate methods) to a stable
     /// `CmuxNavigation` UUID. Strong references; entries cleared in
     /// the terminal delegate methods.
     private var navigationMap: [ObjectIdentifier: CmuxNavigation] = [:]
+
+    /// KVO tokens. Retained for the lifetime of the backend.
+    private var observations: [NSKeyValueObservation] = []
 
     private lazy var navigationBridge = NavigationBridge(owner: self)
     private lazy var uiBridge = UIBridge(owner: self)
@@ -54,6 +58,43 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
         }
         self.webView.navigationDelegate = navigationBridge
         self.webView.uiDelegate = uiBridge
+        installStateObservations()
+    }
+
+    private func installStateObservations() {
+        let state = self.state
+        // KVO observations push WKWebView state into CmuxBrowserState
+        // synchronously on the main actor (KVO callbacks fire on the
+        // calling thread, which for these properties is always main).
+        observations = [
+            webView.observe(\.url, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.url = wv.url }
+            },
+            webView.observe(\.title, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.title = wv.title }
+            },
+            webView.observe(\.isLoading, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.isLoading = wv.isLoading }
+            },
+            webView.observe(\.estimatedProgress, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.estimatedProgress = wv.estimatedProgress }
+            },
+            webView.observe(\.canGoBack, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.canGoBack = wv.canGoBack }
+            },
+            webView.observe(\.canGoForward, options: [.initial, .new]) { [state] wv, _ in
+                MainActor.assumeIsolated { state.canGoForward = wv.canGoForward }
+            },
+        ]
+        state.pageZoom = webView.pageZoom
+    }
+
+    var pageZoom: CGFloat {
+        get { webView.pageZoom }
+        set {
+            webView.pageZoom = newValue
+            state.pageZoom = newValue
+        }
     }
 
     var nsView: NSView { webView }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -21,7 +21,19 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
     let webView: WKWebView
     var navigationDelegate: CmuxNavigationDelegate?
     var uiDelegate: CmuxUIDelegate?
+    var downloadDelegate: CmuxDownloadDelegate?
     let state = CmuxBrowserState()
+
+    /// Strong references to WKDownloadDelegate shims, one per active
+    /// download. Cleared in the terminal callbacks. Without this the
+    /// shim would deallocate immediately after `didBecome download`
+    /// returns, since WKDownload retains its delegate only weakly.
+    private var downloadShims: [ObjectIdentifier: DownloadShim] = [:]
+
+    /// Maps WKDownload identity → the `CmuxDownload` wrapper for that
+    /// download. Used so terminal callbacks can find the right host
+    /// reference.
+    private var cmuxDownloads: [ObjectIdentifier: CmuxDownload] = [:]
 
     /// Maps the engine's underlying `WKNavigation` (whose identity we
     /// can't observe directly across the delegate methods) to a stable
@@ -179,6 +191,81 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
         guard let wkNav else { return }
         navigationMap.removeValue(forKey: ObjectIdentifier(wkNav))
     }
+
+    // MARK: download wiring
+
+    fileprivate func attachDownload(
+        _ wkDownload: WKDownload,
+        originalRequest: URLRequest?
+    ) -> CmuxDownload {
+        let cmux = CmuxDownload(wkDownload: wkDownload, originalRequest: originalRequest)
+        let shim = DownloadShim(owner: self, cmuxDownload: cmux)
+        let key = ObjectIdentifier(wkDownload)
+        downloadShims[key] = shim
+        cmuxDownloads[key] = cmux
+        wkDownload.delegate = shim
+        return cmux
+    }
+
+    fileprivate func releaseDownload(_ wkDownload: WKDownload) {
+        let key = ObjectIdentifier(wkDownload)
+        downloadShims.removeValue(forKey: key)
+        cmuxDownloads.removeValue(forKey: key)
+    }
+
+    fileprivate func cmuxDownload(for wkDownload: WKDownload) -> CmuxDownload? {
+        cmuxDownloads[ObjectIdentifier(wkDownload)]
+    }
+}
+
+// MARK: - WKDownload shim
+
+extension WebKitBrowserBackend {
+    final class DownloadShim: NSObject, WKDownloadDelegate {
+        weak var owner: WebKitBrowserBackend?
+        let cmuxDownload: CmuxDownload
+
+        init(owner: WebKitBrowserBackend, cmuxDownload: CmuxDownload) {
+            self.owner = owner
+            self.cmuxDownload = cmuxDownload
+        }
+
+        func download(
+            _ download: WKDownload,
+            decideDestinationUsing response: URLResponse,
+            suggestedFilename: String,
+            completionHandler: @escaping @MainActor @Sendable (URL?) -> Void
+        ) {
+            // The host's CmuxDownloadDelegate signature takes a plain
+            // (URL?) -> Void; WK requires @MainActor @Sendable. Both
+            // sides run on the main actor so the conversion is safe.
+            struct Closure: @unchecked Sendable {
+                let body: @MainActor @Sendable (URL?) -> Void
+            }
+            let box = Closure(body: completionHandler)
+            guard let host = owner?.downloadDelegate else {
+                MainActor.assumeIsolated { box.body(nil) }; return
+            }
+            host.cmuxDownload(cmuxDownload,
+                              decideDestinationUsing: response,
+                              suggestedFilename: suggestedFilename,
+                              completionHandler: { url in
+                                  MainActor.assumeIsolated { box.body(url) }
+                              })
+        }
+
+        func downloadDidFinish(_ download: WKDownload) {
+            owner?.downloadDelegate?.cmuxDownloadDidFinish(cmuxDownload)
+            owner?.releaseDownload(download)
+        }
+
+        func download(_ download: WKDownload, didFailWithError error: Error, resumeData: Data?) {
+            owner?.downloadDelegate?.cmuxDownload(cmuxDownload,
+                                                  didFailWithError: error,
+                                                  resumeData: resumeData)
+            owner?.releaseDownload(download)
+        }
+    }
 }
 
 // MARK: - Delegate bridges (forward WK → Cmux types)
@@ -275,6 +362,31 @@ extension WebKitBrowserBackend {
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
             guard let delegate = owner?.navigationDelegate, let view = cmuxView() else { return }
             delegate.browserViewWebContentProcessDidTerminate(view)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            navigationAction: WKNavigationAction,
+            didBecome download: WKDownload
+        ) {
+            guard let owner, let view = cmuxView() else { return }
+            let cmux = owner.attachDownload(download, originalRequest: navigationAction.request)
+            owner.navigationDelegate?.browserView(view,
+                                                  navigationAction: navigationAction.cmux,
+                                                  didBecome: cmux)
+        }
+
+        func webView(
+            _ webView: WKWebView,
+            navigationResponse: WKNavigationResponse,
+            didBecome download: WKDownload
+        ) {
+            guard let owner, let view = cmuxView() else { return }
+            let req: URLRequest? = navigationResponse.response.url.map { URLRequest(url: $0) }
+            let cmux = owner.attachDownload(download, originalRequest: req)
+            owner.navigationDelegate?.browserView(view,
+                                                  navigationResponse: navigationResponse.cmux,
+                                                  didBecome: cmux)
         }
     }
 

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -160,8 +160,11 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
         webView.customUserAgent = userAgent
     }
 
-    func takeSnapshot(completionHandler: @escaping (CGImage?, Error?) -> Void) {
-        let config = WKSnapshotConfiguration()
+    func takeSnapshot(
+        configuration: CmuxSnapshotConfiguration?,
+        completionHandler: @escaping (CGImage?, Error?) -> Void
+    ) {
+        let config = configuration?.makeWKConfiguration() ?? WKSnapshotConfiguration()
         webView.takeSnapshot(with: config) { image, error in
             completionHandler(image?.cgImage(forProposedRect: nil, context: nil, hints: nil), error)
         }

--- a/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
+++ b/Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/WebKitBrowserBackend.swift
@@ -48,6 +48,12 @@ final class WebKitBrowserBackend: NSObject, CmuxBrowserBackend {
         if let app = configuration.applicationNameForUserAgent {
             wk.applicationNameForUserAgent = app
         }
+        // Bind a specific WKWebsiteDataStore when the caller wants a
+        // non-default profile. Without this, all views would share the
+        // default cookies/local storage.
+        if let store = configuration.dataStore?.wkStore {
+            wk.websiteDataStore = store
+        }
         for (scheme, handler) in configuration.urlSchemeHandlers {
             wk.setURLSchemeHandler(URLSchemeShim(host: handler), forURLScheme: scheme)
         }

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -252,6 +252,136 @@ struct CmuxBrowserStateSuite {
     }
 }
 
+@Suite("CmuxDataStore")
+@MainActor
+struct CmuxDataStoreSuite {
+    @Test("default + nonPersistent produce distinct backing stores")
+    func testDefaultVsNonPersistent() {
+        let a = CmuxDataStore.default()
+        let b = CmuxDataStore.nonPersistent()
+        #expect(a.kind == .default)
+        #expect(b.kind == .nonPersistent)
+        #expect(a.wkStore !== b.wkStore)
+        #expect(a.wkStore?.isPersistent == true)
+        #expect(b.wkStore?.isPersistent == false)
+    }
+
+    @Test("forIdentifier round-trips the UUID")
+    func testForIdentifier() {
+        let id = UUID()
+        let s = CmuxDataStore.forIdentifier(id)
+        if case .persistent(let identifier) = s.kind {
+            #expect(identifier == id)
+        } else {
+            Issue.record("expected .persistent kind")
+        }
+        #expect(s.wkStore != nil)
+    }
+
+    @Test("allDataTypes is a non-empty WebKit set")
+    func testAllDataTypes() {
+        let types = CmuxDataStore.allDataTypes()
+        #expect(!types.isEmpty)
+        // WKWebsiteDataTypeCookies is the most stable member of the set.
+        #expect(types.contains("WKWebsiteDataTypeCookies"))
+    }
+
+    @Test("cookieStore is cached")
+    func testCookieStoreIsCached() {
+        let s = CmuxDataStore.default()
+        let a = s.cookieStore
+        let b = s.cookieStore
+        #expect(a === b)
+    }
+
+    @Test("removeData succeeds against nonPersistent store")
+    func testRemoveDataNonPersistent() async {
+        let s = CmuxDataStore.nonPersistent()
+        // Smoke test: WK's nonPersistent store accepts removeData for
+        // any subset of types without erroring. We just await completion.
+        await s.removeData(ofTypes: CmuxDataStore.allDataTypes(),
+                           modifiedSince: .distantPast)
+    }
+
+    @Test("WebKit backend honors configuration.dataStore")
+    func testConfigBindsDataStore() {
+        let id = UUID()
+        let store = CmuxDataStore.forIdentifier(id)
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        c.dataStore = store
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: c)
+        let backend = view.backend as? WebKitBrowserBackend
+        #expect(backend?.webView.configuration.websiteDataStore === store.wkStore)
+    }
+}
+
+@Suite("CmuxCookieStore")
+@MainActor
+struct CmuxCookieStoreSuite {
+    @Test("set + read round-trips through nonPersistent store")
+    func testSetAndRead() async throws {
+        let s = CmuxDataStore.nonPersistent()
+        let jar = s.cookieStore
+        let probe = HTTPCookie(properties: [
+            .name: "cmux_engine_probe",
+            .value: "ok",
+            .domain: "cmux.example",
+            .path: "/",
+        ])!
+        await jar.setCookie(probe)
+        let all = await jar.allCookies()
+        let match = all.first(where: { $0.name == "cmux_engine_probe" })
+        #expect(match != nil)
+        #expect(match?.value == "ok")
+    }
+
+    @Test("delete removes a previously-set cookie")
+    func testDelete() async {
+        let s = CmuxDataStore.nonPersistent()
+        let jar = s.cookieStore
+        let cookie = HTTPCookie(properties: [
+            .name: "cmux_engine_delete_me",
+            .value: "v",
+            .domain: "cmux-delete.example",
+            .path: "/",
+        ])!
+        await jar.setCookie(cookie)
+        await jar.deleteCookie(cookie)
+        let all = await jar.allCookies()
+        let stillThere = all.first(where: { $0.name == "cmux_engine_delete_me" })
+        #expect(stillThere == nil)
+    }
+
+    @Test("observer fires on mutation")
+    func testObserver() async throws {
+        let s = CmuxDataStore.nonPersistent()
+        let jar = s.cookieStore
+        final class Counter: CmuxCookieStoreObserver, @unchecked Sendable {
+            nonisolated(unsafe) var count = 0
+            func cookiesDidChange(in store: CmuxCookieStore) { count += 1 }
+        }
+        let o = Counter()
+        jar.addObserver(o)
+        let cookie = HTTPCookie(properties: [
+            .name: "cmux_engine_observer",
+            .value: "v",
+            .domain: "cmux-obs.example",
+            .path: "/",
+        ])!
+        await jar.setCookie(cookie)
+        // Observer fires asynchronously; poll briefly.
+        let deadline = Date().addingTimeInterval(2)
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            if o.count > 0 { break }
+        }
+        #expect(o.count > 0)
+        jar.removeObserver(o)
+    }
+}
+
 @Suite("CmuxBrowserView (Chromium backend stub)")
 @MainActor
 struct CmuxBrowserViewChromiumSuite {

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -382,6 +382,15 @@ struct CmuxCookieStoreSuite {
     }
 }
 
+/// Coverage gap (intentionally undocumented in code, recorded here):
+/// the live WKDownload → DownloadShim → host CmuxDownloadDelegate
+/// path is **not** exercised by these tests. Driving a real WKDownload
+/// from a unit test requires hosting a server that streams an
+/// attachment, and WK has no synthetic-download API. The shim's
+/// `@MainActor @Sendable` closure-box bridging is exercised at compile
+/// time but runtime is only proven during dogfood. If you hit a
+/// crash inside `MainActor.assumeIsolated` from the download path,
+/// suspect the box conversion first.
 @Suite("CmuxDownload")
 @MainActor
 struct CmuxDownloadSuite {

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -426,6 +426,38 @@ struct CmuxDownloadSuite {
     }
 }
 
+@Suite("CmuxBrowserConfiguration.isInspectable")
+@MainActor
+struct CmuxInspectableSuite {
+    @Test("isInspectable defaults to false")
+    func testDefault() {
+        #expect(CmuxBrowserConfiguration().isInspectable == false)
+    }
+
+    @Test("WebKit backend honors isInspectable=true")
+    func testWebKitApplies() {
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        c.isInspectable = true
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 50, height: 50),
+                                   configuration: c)
+        let backend = view.backend as? WebKitBrowserBackend
+        #expect(backend?.webView.isInspectable == true)
+    }
+
+    @Test("WebKit backend leaves isInspectable=false when unset")
+    func testWebKitDefaultsFalse() {
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 50, height: 50),
+                                   configuration: c)
+        let backend = view.backend as? WebKitBrowserBackend
+        // We never set isInspectable in init when the flag is off,
+        // so WKWebView's default (false on macOS 13.3+) wins.
+        #expect(backend?.webView.isInspectable == false)
+    }
+}
+
 @Suite("CmuxSnapshotConfiguration")
 @MainActor
 struct CmuxSnapshotConfigurationSuite {

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -417,6 +417,28 @@ struct CmuxDownloadSuite {
     }
 }
 
+@Suite("CmuxSnapshotConfiguration")
+@MainActor
+struct CmuxSnapshotConfigurationSuite {
+    @Test("default config has WK-compatible defaults")
+    func testDefaults() {
+        let c = CmuxSnapshotConfiguration()
+        #expect(c.rect == .zero)
+        #expect(c.snapshotWidth == nil)
+        #expect(c.afterScreenUpdates == true)
+    }
+
+    @Test("forwards rect + width to WKSnapshotConfiguration")
+    func testForwarding() {
+        let r = CGRect(x: 0, y: 0, width: 200, height: 100)
+        let c = CmuxSnapshotConfiguration(rect: r, snapshotWidth: 800, afterScreenUpdates: false)
+        let wk = c.makeWKConfiguration()
+        #expect(wk.rect == r)
+        #expect(wk.snapshotWidth?.doubleValue == 800)
+        #expect(wk.afterScreenUpdates == false)
+    }
+}
+
 @Suite("CmuxBrowserView (Chromium backend stub)")
 @MainActor
 struct CmuxBrowserViewChromiumSuite {

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -1,0 +1,234 @@
+import AppKit
+import Foundation
+import Testing
+import WebKit
+@testable import CmuxBrowserEngine
+
+@Suite("CmuxBrowserEngine")
+struct CmuxBrowserEngineSuite {
+    @Test("featureFlagKey is the cmux convention")
+    func testFlagKey() {
+        #expect(CmuxBrowserEngine.featureFlagKey == "cmux.browser.engine.chromium")
+    }
+
+    @Test("defaultKind respects the override")
+    func testDefaultKindOverride() async {
+        CmuxBrowserEngine.defaultKindOverride = .chromium
+        #expect(CmuxBrowserEngine.defaultKind == .chromium)
+        CmuxBrowserEngine.defaultKindOverride = .webKit
+        #expect(CmuxBrowserEngine.defaultKind == .webKit)
+        CmuxBrowserEngine.defaultKindOverride = nil
+    }
+
+    @Test("versionString surfaces the engine identity")
+    func testVersionString() {
+        let webKit = CmuxBrowserEngine.versionString(for: .webKit)
+        #expect(webKit.contains("WebKit"))
+        let chromium = CmuxBrowserEngine.versionString(for: .chromium)
+        #expect(chromium.contains("Chromium"))
+    }
+}
+
+@Suite("CmuxBrowserConfiguration")
+struct CmuxBrowserConfigurationSuite {
+    @Test("defaults match WKWebView defaults")
+    func testDefaults() {
+        let c = CmuxBrowserConfiguration()
+        #expect(!c.allowsJavaScriptToOpenWindowsAutomatically)
+        #expect(c.allowsInlineMediaPlayback)
+        #expect(c.allowsPictureInPictureMediaPlayback)
+        #expect(c.mediaTypesRequiringUserActionForPlayback == .none)
+        #expect(c.customUserAgent == nil)
+        #expect(c.applicationNameForUserAgent == nil)
+        #expect(!c.suppressesIncrementalRendering)
+        #expect(c.userContentController.userScripts.isEmpty)
+        #expect(c.userContentController.messageHandlers.isEmpty)
+    }
+
+    @Test("engineKind tracks defaultKind at construction time")
+    func testEngineKindFollowsDefault() async {
+        CmuxBrowserEngine.defaultKindOverride = .chromium
+        let c1 = CmuxBrowserConfiguration()
+        #expect(c1.engineKind == .chromium)
+        CmuxBrowserEngine.defaultKindOverride = .webKit
+        let c2 = CmuxBrowserConfiguration()
+        #expect(c2.engineKind == .webKit)
+        CmuxBrowserEngine.defaultKindOverride = nil
+    }
+}
+
+@Suite("CmuxUserContentController")
+struct CmuxUserContentControllerSuite {
+    @Test("adds and removes scripts")
+    func testScripts() {
+        let c = CmuxUserContentController()
+        c.addUserScript(.init(source: "console.log(1)", injectionTime: .atDocumentStart, forMainFrameOnly: true))
+        c.addUserScript(.init(source: "console.log(2)", injectionTime: .atDocumentEnd, forMainFrameOnly: false))
+        #expect(c.userScripts.count == 2)
+        c.removeAllUserScripts()
+        #expect(c.userScripts.isEmpty)
+    }
+
+    @Test("registers and removes message handlers")
+    func testHandlers() {
+        final class H: CmuxScriptMessageHandler, @unchecked Sendable {
+            func didReceive(_ message: CmuxScriptMessage) {}
+        }
+        let c = CmuxUserContentController()
+        let h = H()
+        c.add(h, name: "alpha")
+        c.add(h, name: "beta")
+        #expect(c.messageHandlers.count == 2)
+        c.removeScriptMessageHandler(forName: "alpha")
+        #expect(c.messageHandlers.count == 1)
+        #expect(c.messageHandlers["beta"] != nil)
+    }
+}
+
+@Suite("CmuxScriptMessageBody")
+struct CmuxScriptMessageBodySuite {
+    @Test("walks NSNumber Bool vs Int vs Double")
+    func testNumberWalking() {
+        switch CmuxScriptMessageBody.from(any: NSNumber(value: true)) {
+        case .bool(let v): #expect(v == true)
+        default: Issue.record("expected .bool from NSNumber(true)")
+        }
+        switch CmuxScriptMessageBody.from(any: NSNumber(value: 42)) {
+        case .int(let v): #expect(v == 42)
+        default: Issue.record("expected .int from NSNumber(42)")
+        }
+        switch CmuxScriptMessageBody.from(any: NSNumber(value: 1.5)) {
+        case .double(let v): #expect(v == 1.5)
+        default: Issue.record("expected .double from NSNumber(1.5)")
+        }
+    }
+
+    @Test("walks nested array + dictionary")
+    func testNested() {
+        let value: [String: Any] = [
+            "k": [1, "two", true],
+            "nested": ["a": 1.25]
+        ]
+        let body = CmuxScriptMessageBody.from(any: value)
+        guard case .dictionary(let dict) = body else {
+            Issue.record("expected dictionary")
+            return
+        }
+        guard case .array(let arr) = dict["k"]! else {
+            Issue.record("expected array under k")
+            return
+        }
+        #expect(arr.count == 3)
+        if case .int(let v) = arr[0] { #expect(v == 1) } else { Issue.record("arr[0] != int") }
+        if case .string(let v) = arr[1] { #expect(v == "two") } else { Issue.record("arr[1] != string") }
+        if case .bool(let v) = arr[2] { #expect(v == true) } else { Issue.record("arr[2] != bool") }
+        if case .dictionary(let nested) = dict["nested"]!,
+           case .double(let v) = nested["a"]! {
+            #expect(v == 1.25)
+        } else {
+            Issue.record("nested.a != double")
+        }
+    }
+
+    @Test("handles NSNull as .null")
+    func testNull() {
+        if case .null = CmuxScriptMessageBody.from(any: NSNull()) {} else {
+            Issue.record("expected .null from NSNull")
+        }
+    }
+}
+
+@Suite("CmuxBrowserView (WebKit backend)")
+@MainActor
+struct CmuxBrowserViewWebKitSuite {
+    private func webKitConfig() -> CmuxBrowserConfiguration {
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        return c
+    }
+
+    @Test("constructs with WebKit backend")
+    func testConstruct() {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        #expect(view.engineDescription.contains("WebKit"))
+        #expect(view.url == nil)
+        // WKWebView returns an empty string for a never-loaded title;
+        // expose that quirk explicitly rather than promoting empty → nil.
+        #expect(view.title == nil || view.title?.isEmpty == true)
+        #expect(!view.canGoBack)
+        #expect(!view.canGoForward)
+    }
+
+    @Test("forwards customUserAgent to WKWebView")
+    func testCustomUserAgent() {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        view.customUserAgent = "cmux-test/1.0"
+        #expect(view.customUserAgent == "cmux-test/1.0")
+        let backend = view.backend as? WebKitBrowserBackend
+        #expect(backend != nil)
+        #expect(backend?.webView.customUserAgent == "cmux-test/1.0")
+    }
+
+    @Test("loadHTMLString returns a CmuxNavigation handle")
+    func testLoadHTMLReturnsHandle() {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        let a = view.loadHTMLString("<html><body>a</body></html>", baseURL: nil)
+        let b = view.loadHTMLString("<html><body>b</body></html>", baseURL: nil)
+        #expect(a != b)
+    }
+
+    @Test("evaluateJavaScript completes against a real WKWebView")
+    func testEvaluateJavaScript() async throws {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        _ = view.loadHTMLString("<html><body><div id='x'>42</div></body></html>", baseURL: nil)
+        // Poll up to 5 seconds for the element to appear, since
+        // loadHTMLString completion timing under test parallelism is
+        // not deterministic.
+        let deadline = Date().addingTimeInterval(5)
+        var value: Any?
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            value = try? await view.evaluateJavaScript("document.getElementById('x')?.textContent ?? null")
+            if let s = value as? String, s == "42" { break }
+        }
+        #expect(value as? String == "42")
+    }
+}
+
+@Suite("CmuxBrowserView (Chromium backend stub)")
+@MainActor
+struct CmuxBrowserViewChromiumSuite {
+    private func chromiumConfig() -> CmuxBrowserConfiguration {
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .chromium
+        return c
+    }
+
+    @Test("Chromium backend reports correct version string")
+    func testChromiumVersion() {
+        let kind = CmuxBrowserEngine.Kind.chromium
+        let s = CmuxBrowserEngine.versionString(for: kind)
+        #expect(s.contains("Chromium"))
+    }
+
+    @Test("evaluateJavaScript on Chromium stub returns backendUnavailable")
+    func testChromiumEvaluateUnavailable() async {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: chromiumConfig())
+        await withCheckedContinuation { continuation in
+            view.evaluateJavaScript("1+1") { _, error in
+                if let typed = error as? CmuxBrowserEngineError,
+                   case .backendUnavailable(.chromium, _) = typed {
+                    // ok
+                } else {
+                    Issue.record("expected backendUnavailable error, got \(String(describing: error))")
+                }
+                continuation.resume()
+            }
+        }
+    }
+}

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import Foundation
 import Testing
 import WebKit
@@ -196,6 +197,58 @@ struct CmuxBrowserViewWebKitSuite {
             if let s = value as? String, s == "42" { break }
         }
         #expect(value as? String == "42")
+    }
+}
+
+@Suite("CmuxBrowserState mirrors")
+@MainActor
+struct CmuxBrowserStateSuite {
+    private func webKitConfig() -> CmuxBrowserConfiguration {
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        return c
+    }
+
+    @Test("WebKit backend pushes title to state.title when navigation finishes")
+    func testTitleMirror() async throws {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        _ = view.loadHTMLString("<html><head><title>cmux-title-fixture</title></head><body>x</body></html>", baseURL: nil)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            if view.state.title == "cmux-title-fixture" { break }
+        }
+        #expect(view.state.title == "cmux-title-fixture")
+    }
+
+    @Test("pageZoom round-trips through CmuxBrowserView")
+    func testPageZoom() {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        #expect(view.pageZoom == 1.0)
+        view.pageZoom = 1.5
+        #expect(view.pageZoom == 1.5)
+        #expect(view.state.pageZoom == 1.5)
+    }
+
+    @Test("state.url emits via Combine when WKWebView loads")
+    func testCombinePublisher() async throws {
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 100, height: 100),
+                                   configuration: webKitConfig())
+        // Subscribe before the load to catch the transition.
+        var received: [URL?] = []
+        let cancellable = view.state.$url.sink { url in received.append(url) }
+        defer { cancellable.cancel() }
+
+        let target = URL(string: "data:text/html,<html></html>")!
+        _ = view.load(target)
+        let deadline = Date().addingTimeInterval(5)
+        while Date() < deadline {
+            try await Task.sleep(nanoseconds: 50_000_000)
+            if received.contains(where: { $0 != nil }) { break }
+        }
+        #expect(received.contains(where: { $0 != nil }))
     }
 }
 

--- a/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
+++ b/Packages/CmuxBrowserEngine/Tests/CmuxBrowserEngineTests/CmuxBrowserEngineTests.swift
@@ -382,6 +382,41 @@ struct CmuxCookieStoreSuite {
     }
 }
 
+@Suite("CmuxDownload")
+@MainActor
+struct CmuxDownloadSuite {
+    @Test("constructs with a stable UUID and the original request")
+    func testConstruct() {
+        let req = URLRequest(url: URL(string: "https://cmux.example/file.bin")!)
+        let d = CmuxDownload(wkDownload: nil, originalRequest: req)
+        #expect(d.originalRequest?.url?.absoluteString == "https://cmux.example/file.bin")
+        // UUID is fresh per instance
+        let d2 = CmuxDownload(wkDownload: nil, originalRequest: nil)
+        #expect(d.id != d2.id)
+    }
+
+    @Test("downloadDelegate is settable on CmuxBrowserView (WebKit backend)")
+    func testDelegateAssign() {
+        final class FakeDelegate: CmuxDownloadDelegate {
+            func cmuxDownload(
+                _ download: CmuxDownload,
+                decideDestinationUsing response: URLResponse,
+                suggestedFilename: String,
+                completionHandler: @escaping (URL?) -> Void
+            ) {
+                completionHandler(nil)
+            }
+        }
+        let c = CmuxBrowserConfiguration()
+        c.engineKind = .webKit
+        let view = CmuxBrowserView(frame: NSRect(x: 0, y: 0, width: 50, height: 50),
+                                   configuration: c)
+        let delegate = FakeDelegate()
+        view.downloadDelegate = delegate
+        #expect(view.downloadDelegate === delegate)
+    }
+}
+
 @Suite("CmuxBrowserView (Chromium backend stub)")
 @MainActor
 struct CmuxBrowserViewChromiumSuite {

--- a/embedder/BUILD.gn
+++ b/embedder/BUILD.gn
@@ -16,12 +16,11 @@ import("//content/public/app/mac_helpers.gni")
 # Public C header set. Anything that links the framework can include
 # the header; only the framework target links the source_set.
 source_set("embedder") {
-  visibility = [
-    "//cmux:*",
-  ]
+  visibility = [ "//cmux:*" ]
 
   sources = [
     "cmux_browser.h",
+
     # Stub implementations of the C ABI. Each TU compiles standalone
     # against //base and the system frameworks; the bodies return
     # CMUX_E_NATIVE / sentinel values until the real //content wiring
@@ -54,9 +53,7 @@ source_set("embedder") {
     "QuartzCore.framework",
   ]
 
-  configs += [
-    "//build/config/compiler:enable_arc",
-  ]
+  configs += [ "//build/config/compiler:enable_arc" ]
 }
 
 # Header-only target. Lets external GN consumers depend on the header
@@ -66,7 +63,5 @@ source_set("embedder_headers") {
     "//cmux:*",
     "//cmux/*",
   ]
-  sources = [
-    "cmux_browser.h",
-  ]
+  sources = [ "cmux_browser.h" ]
 }

--- a/embedder/BUILD.gn
+++ b/embedder/BUILD.gn
@@ -1,0 +1,67 @@
+# Copyright 2026 manaflow-ai. All rights reserved.
+#
+# //cmux/embedder/BUILD.gn
+#
+# Builds the cmux embedder C ABI source set. The framework target that
+# wraps it lives at //cmux:cmux_core_framework and pulls this in as a
+# dependency.
+#
+# When the cmux Chromium fork lands at manaflow-ai/cmux-chromium, this
+# file drops into src/cmux/embedder/ as-is.
+
+import("//build/buildflag_header.gni")
+import("//build/config/mac/mac_sdk.gni")
+import("//content/public/app/mac_helpers.gni")
+
+# Public C header set. Anything that links the framework can include
+# the header; only the framework target links the source_set.
+source_set("embedder") {
+  visibility = [
+    "//cmux:*",
+  ]
+
+  sources = [
+    "cmux_browser.h",
+    "cmux_browser.mm",
+    "cmux_layer_host.mm",
+    "cmux_profile.cc",
+    "cmux_session.cc",
+    "cmux_view.cc",
+  ]
+
+  deps = [
+    "//base",
+    "//content/public/browser",
+    "//content/public/common",
+    "//net",
+    "//services/network/public/cpp",
+    "//services/network/public/mojom",
+    "//ui/base",
+    "//ui/gfx",
+    "//ui/gfx/geometry",
+    "//ui/views",
+    "//url",
+  ]
+
+  frameworks = [
+    "AppKit.framework",
+    "CoreFoundation.framework",
+    "QuartzCore.framework",
+  ]
+
+  configs += [
+    "//build/config/compiler:enable_arc",
+  ]
+}
+
+# Header-only target. Lets external GN consumers depend on the header
+# without pulling in the implementation translation units.
+source_set("embedder_headers") {
+  visibility = [
+    "//cmux:*",
+    "//cmux/*",
+  ]
+  sources = [
+    "cmux_browser.h",
+  ]
+}

--- a/embedder/BUILD.gn
+++ b/embedder/BUILD.gn
@@ -8,6 +8,10 @@
 #
 # When the cmux Chromium fork lands at manaflow-ai/cmux-chromium, this
 # file drops into src/cmux/embedder/ as-is.
+#
+# Validation status (M148, 2026-05-14): passes
+#   gn check out/cmux-check //cmux/embedder:embedder   (OK)
+# against the M148 stable chromium-fork checkout on cmux-aws-mac.
 
 import("//build/buildflag_header.gni")
 import("//build/config/mac/mac_sdk.gni")
@@ -53,7 +57,6 @@ source_set("embedder") {
     "QuartzCore.framework",
   ]
 
-  configs += [ "//build/config/compiler:enable_arc" ]
 }
 
 # Header-only target. Lets external GN consumers depend on the header

--- a/embedder/BUILD.gn
+++ b/embedder/BUILD.gn
@@ -22,15 +22,16 @@ source_set("embedder") {
 
   sources = [
     "cmux_browser.h",
-    # Implementation translation units land here once the fork repo is
-    # created and we can build incrementally against a real //content
-    # toolchain. Keep these commented until each file exists; gn will
-    # otherwise fail with "source file does not exist" at gen time.
-    #   "cmux_browser.mm",
-    #   "cmux_layer_host.mm",
-    #   "cmux_profile.cc",
-    #   "cmux_session.cc",
-    #   "cmux_view.cc",
+    # Stub implementations of the C ABI. Each TU compiles standalone
+    # against //base and the system frameworks; the bodies return
+    # CMUX_E_NATIVE / sentinel values until the real //content wiring
+    # lands. Splitting follows the ABI grouping (session / profile /
+    # view / browser / layer_host); see plans/chromium-engine.md P1.
+    "cmux_browser.mm",
+    "cmux_layer_host.mm",
+    "cmux_profile.cc",
+    "cmux_session.cc",
+    "cmux_view.cc",
   ]
 
   deps = [

--- a/embedder/BUILD.gn
+++ b/embedder/BUILD.gn
@@ -22,11 +22,15 @@ source_set("embedder") {
 
   sources = [
     "cmux_browser.h",
-    "cmux_browser.mm",
-    "cmux_layer_host.mm",
-    "cmux_profile.cc",
-    "cmux_session.cc",
-    "cmux_view.cc",
+    # Implementation translation units land here once the fork repo is
+    # created and we can build incrementally against a real //content
+    # toolchain. Keep these commented until each file exists; gn will
+    # otherwise fail with "source file does not exist" at gen time.
+    #   "cmux_browser.mm",
+    #   "cmux_layer_host.mm",
+    #   "cmux_profile.cc",
+    #   "cmux_session.cc",
+    #   "cmux_view.cc",
   ]
 
   deps = [

--- a/embedder/CHANGELOG.md
+++ b/embedder/CHANGELOG.md
@@ -1,0 +1,20 @@
+# CmuxCore embedder ABI changelog
+
+Tracks every change to `cmux_browser.h`. Bump `CMUX_EMBEDDER_ABI_VERSION`
+on any breaking change (function signature, struct layout, enum
+value semantic). Additive changes (new function appended to header)
+do not require a bump; consumers detect them via `dlsym`/weak-link.
+
+The Swift package's `CmuxBrowserEngine.swift` pins
+`CMUX_EMBEDDER_MIN_ABI` and `CMUX_EMBEDDER_MAX_ABI`. Framework load
+fails with `CMUX_E_ABI_MISMATCH` if the loaded version is outside
+that range.
+
+## v1 — initial (unpublished, fork repo not yet created)
+
+- Sessions: `cmux_session_{init,shutdown,run_once,last_error_string}`.
+- Profiles: `cmux_profile_{open,close,get_cookies,set_cookie,delete_cookie,remove_data}`.
+- Views: `cmux_view_{create,close,load_url,load_html,reload,go_back,go_forward,stop,can_go_back,can_go_forward,url,title,is_loading,estimated_progress,set_page_zoom,page_zoom,evaluate_js,set_script_message_handler,add_user_script,remove_all_user_scripts,set_navigation_action_cb,set_navigation_did_finish_cb,take_snapshot}`.
+- Out of v1 (deferred): downloads, find-in-page, devtools/inspector,
+  print, WebAuthn surface, extensions, WebRTC/getUserMedia permission
+  decisions, push notifications.

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -1,5 +1,37 @@
 # `embedder/` — fork-bound artifacts
 
+> **NOTE — the `BUILD.gn` files are still unvalidated.** They have not
+> been `gn check`-ed against a real Chromium tree (no fork repo
+> exists), but the obvious bugs the earlier WARNING called out are
+> fixed:
+>
+> - `BUILD.gn` no longer lists `cmux_browser.mm` / `cmux_view.cc` /
+>   `cmux_session.cc` / `cmux_profile.cc` / `cmux_layer_host.mm` in
+>   `sources` — those files don't exist yet, so `gn gen` would have
+>   failed at "source file does not exist". They are left as a
+>   commented-out TODO block, to be re-enabled per file as each
+>   implementation lands.
+> - `cmux_BUILD.gn` no longer reads `helper[3]`/`[4]`/`[5]` (the
+>   `content_mac_helpers` tuple is 3-wide; indices 3+ would have
+>   tripped GN's bounds check). The `foreach` body now indexes
+>   `helper_params[0..2]` exactly like upstream
+>   `chrome/BUILD.gn:826`, the helper-target naming matches
+>   what the foreach generates, and the `group("cmux_helpers")`
+>   target list is generated from the same `content_mac_helpers`
+>   list so the names cannot drift.
+> - The helper template is inlined as `template("cmux_helper_app")`,
+>   mirroring `chrome_helper_app` in `chrome/BUILD.gn:730`. Empty
+>   placeholder sources (`cmux_helper_main_mac.cc`,
+>   `cmux_framework_main.cc`) are referenced where mac_app_bundle /
+>   mac_framework_bundle require non-empty source lists; those files
+>   need to land in `//cmux/embedder/` before the first `gn gen`.
+>
+> The `.h` header, branding plists, README, and CHANGELOG remain
+> accurate as-is. First real validation happens when the fork repo
+> exists and these files drop into `src/cmux/`, at which point a
+> `gn check //cmux/...` will surface any remaining issues.
+
+
 This directory is the staging area for files that will eventually live
 under `//cmux/embedder/` in the **manaflow-ai/cmux-chromium** fork.
 

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -1,0 +1,64 @@
+# `embedder/` — fork-bound artifacts
+
+This directory is the staging area for files that will eventually live
+under `//cmux/embedder/` in the **manaflow-ai/cmux-chromium** fork.
+
+The fork repo does not exist yet — it needs user permission to create
+an org-level repo. Until then, the canonical copies live here so:
+
+1. Review is unblocked: the C ABI is a real header, not a sketch
+   embedded in a markdown file.
+2. The moment the fork repo lands, contents drop in with no extra
+   editorial work.
+3. If anything changes in the Swift wrapper's expectations
+   (`Packages/CmuxBrowserEngine/`), the corresponding ABI change is
+   tracked in this directory's git history.
+
+## Contents
+
+- `cmux_browser.h` — the C ABI exported from `CmuxCore.framework`.
+  Source of truth for `CmuxBrowserEngine`'s `ChromiumBrowserBackend`.
+- `BUILD.gn` — GN target wiring for `//cmux/embedder:embedder` and the
+  parent `//cmux:cmux_core_framework`.
+- `CHANGELOG.md` — ABI version history. Bump
+  `CMUX_EMBEDDER_ABI_VERSION` on any breaking change.
+
+## How this maps to the fork
+
+When the fork repo is created from M148 base, the layout is:
+
+```
+manaflow-ai/cmux-chromium/
+└── src/
+    └── cmux/
+        ├── BUILD.gn                    # cmux_core_framework target
+        └── embedder/
+            ├── BUILD.gn                # ← embedder/BUILD.gn from here
+            ├── CHANGELOG.md            # ← embedder/CHANGELOG.md from here
+            ├── cmux_browser.h          # ← embedder/cmux_browser.h from here
+            ├── cmux_browser.mm         # Obj-C++ glue (P1)
+            ├── cmux_view.cc            # WebContentsDelegate (P1)
+            ├── cmux_session.cc         # session lifecycle (P1)
+            ├── cmux_profile.cc         # BrowserContext wrappers (P1)
+            └── cmux_layer_host.mm      # CAContext/CALayerHost (P2)
+```
+
+The `.cc`/`.mm` files are not staged here because they are
+implementation, not interface, and implementing them in advance of
+the fork's content layer toolchain would just rot. Once the fork
+builds an empty `cmux_core_framework`, those files land directly in
+the fork.
+
+## Versioning policy
+
+`CMUX_EMBEDDER_ABI_VERSION` starts at `1`. Bumps:
+
+- **Major**: any function signature change, struct layout change,
+  enum value semantic change. Old framework with new package, or
+  vice versa, fails to load with `CMUX_E_ABI_MISMATCH`.
+- **Additive**: new function at end of header. Use
+  `dlsym`/weak-link from the Swift side to detect.
+
+The package's `CmuxBrowserEngine.swift` pins
+`CMUX_EMBEDDER_MIN_ABI` and `CMUX_EMBEDDER_MAX_ABI`. The framework's
+load-time assertion is the only ABI gate.

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -29,6 +29,11 @@ an org-level repo. Until then, the canonical copies live here so:
   here; the file's contents are the parent BUILD).
 - `CHANGELOG.md` — ABI version history. Bump
   `CMUX_EMBEDDER_ABI_VERSION` on any breaking change.
+- `branding/cmux_core_framework-Info.plist` — Info.plist template for
+  `CmuxCore.framework`. Lands at `src/cmux/branding/`.
+- `branding/cmux_helper-Info.plist` — Info.plist template for the four
+  helpers (main/renderer/gpu/plugin); per-helper substitutions come
+  from `//cmux/BUILD.gn`. Lands at `src/cmux/branding/`.
 
 ## How this maps to the fork
 

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -1,9 +1,15 @@
 # `embedder/` — fork-bound artifacts
 
-> **NOTE — the `BUILD.gn` files are still unvalidated.** They have not
-> been `gn check`-ed against a real Chromium tree (no fork repo
-> exists), but the obvious bugs the earlier WARNING called out are
-> fixed:
+> **NOTE — the `BUILD.gn` files pass `gn format` against the M148 tree
+> on `cmux-aws-mac`** (both files round-trip cleanly through the
+> depot_tools `gn format` parser; the only diffs are GN's single-line
+> collapses for length-1 lists, which have been applied here). They
+> have **not yet been `gn gen`-ed against a real `cmux_core_framework`
+> dep graph** (the framework is not yet reachable from
+> `//chrome:gn_all`), so semantic checks like target-lookup,
+> source-file existence beyond this directory, and template arg
+> types are still unverified. The obvious bugs the earlier WARNING
+> called out are fixed:
 >
 > - `BUILD.gn` no longer lists `cmux_browser.mm` / `cmux_view.cc` /
 >   `cmux_session.cc` / `cmux_profile.cc` / `cmux_layer_host.mm` in

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -1,15 +1,35 @@
 # `embedder/` — fork-bound artifacts
 
-> **NOTE — the `BUILD.gn` files pass `gn format` against the M148 tree
-> on `cmux-aws-mac`** (both files round-trip cleanly through the
-> depot_tools `gn format` parser; the only diffs are GN's single-line
-> collapses for length-1 lists, which have been applied here). They
-> have **not yet been `gn gen`-ed against a real `cmux_core_framework`
-> dep graph** (the framework is not yet reachable from
-> `//chrome:gn_all`), so semantic checks like target-lookup,
-> source-file existence beyond this directory, and template arg
-> types are still unverified. The obvious bugs the earlier WARNING
-> called out are fixed:
+> **VALIDATED — the `BUILD.gn` files pass `gn gen` + `gn check`
+> against M148 stable** on `cmux-aws-mac`:
+>
+>   - `gn gen out/cmux-check` builds the full graph (27,405 targets)
+>     with `//cmux:cmux_core_framework` reachable.
+>   - `gn check out/cmux-check //cmux:cmux_core_framework` → OK
+>   - `gn check out/cmux-check //cmux:cmux_helper_app_default` → OK
+>   - `gn check out/cmux-check //cmux:cmux_helper_app_renderer` → OK
+>   - `gn check out/cmux-check //cmux:cmux_helper_app_gpu` → OK
+>   - `gn check out/cmux-check //cmux:cmux_helper_app_plugin` → OK
+>   - `gn check out/cmux-check //cmux:cmux_helpers` → OK
+>   - `gn check out/cmux-check //cmux/embedder:embedder` → OK
+>
+> The verification path was: drop `embedder/cmux_BUILD.gn` →
+> `src/cmux/BUILD.gn` and `embedder/BUILD.gn` →
+> `src/cmux/embedder/BUILD.gn` in the chromium-fork checkout, add a
+> one-line entry to `//BUILD.gn`'s `gn_all` group so the framework
+> is reachable, then run `gn gen` + `gn check`. The root BUILD.gn
+> change was reverted afterward; that's the **only** mutation the
+> fork repo will need to absorb beyond dropping `embedder/` in.
+>
+> Remaining caveats:
+>
+>   - Ninja link-time validation hasn't been attempted. The framework
+>     compiles in isolation (stub sources, sentinel C ABI) but the
+>     `cmux_core_framework_shared_library` step has not actually
+>     produced a `.dylib`. That's gated on writing real `//content`
+>     consumers, not on BUILD.gn correctness.
+>   - The earlier WARNING block is now historical. The obvious bugs
+>     it called out are fixed:
 >
 > - `BUILD.gn` no longer lists `cmux_browser.mm` / `cmux_view.cc` /
 >   `cmux_session.cc` / `cmux_profile.cc` / `cmux_layer_host.mm` in

--- a/embedder/README.md
+++ b/embedder/README.md
@@ -18,8 +18,15 @@ an org-level repo. Until then, the canonical copies live here so:
 
 - `cmux_browser.h` — the C ABI exported from `CmuxCore.framework`.
   Source of truth for `CmuxBrowserEngine`'s `ChromiumBrowserBackend`.
-- `BUILD.gn` — GN target wiring for `//cmux/embedder:embedder` and the
-  parent `//cmux:cmux_core_framework`.
+  Lands at `src/cmux/embedder/cmux_browser.h` in the fork.
+- `BUILD.gn` — GN target wiring for `//cmux/embedder:embedder` and
+  `//cmux/embedder:embedder_headers`. Lands at
+  `src/cmux/embedder/BUILD.gn` in the fork.
+- `cmux_BUILD.gn` — GN target wiring for `//cmux:cmux_core_framework`
+  itself (mac_framework_bundle) plus the four helpers
+  (renderer/gpu/plugin/main). Lands at `src/cmux/BUILD.gn` in the
+  fork (note the renamed-for-disambiguation prefix only matters
+  here; the file's contents are the parent BUILD).
 - `CHANGELOG.md` — ABI version history. Bump
   `CMUX_EMBEDDER_ABI_VERSION` on any breaking change.
 

--- a/embedder/branding/cmux_core_framework-Info.plist
+++ b/embedder/branding/cmux_core_framework-Info.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Info.plist for CmuxCore.framework. Mirrors upstream
+  chrome/app/framework-Info.plist with cmux substitution variables
+  declared in //cmux/BUILD.gn. Lands at
+  src/cmux/branding/cmux_core_framework-Info.plist in the fork.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${CMUX_CORE_FRAMEWORK_BUNDLE_ID}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>CmuxCore</string>
+	<key>CFBundleShortVersionString</key>
+	<string>${CMUX_CORE_FRAMEWORK_VERSION}</string>
+	<key>CFBundleVersion</key>
+	<string>${CMUX_CORE_FRAMEWORK_VERSION}</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+</dict>
+</plist>

--- a/embedder/branding/cmux_helper-Info.plist
+++ b/embedder/branding/cmux_helper-Info.plist
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  Info.plist for the four cmux helper apps (main/renderer/gpu/plugin).
+  Mirrors upstream chrome/app/helper-Info.plist with cmux substitution
+  variables declared per helper in //cmux/BUILD.gn. Lands at
+  src/cmux/branding/cmux_helper-Info.plist in the fork.
+-->
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleDisplayName</key>
+	<string>${CMUX_HELPER_NAME}</string>
+	<key>CFBundleExecutable</key>
+	<string>${EXECUTABLE_NAME}</string>
+	<key>CFBundleIdentifier</key>
+	<string>${CMUX_HELPER_BUNDLE_ID}</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>${CMUX_HELPER_NAME}</string>
+	<key>CFBundlePackageType</key>
+	<string>${CMUX_PACKAGE_TYPE}</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>LSEnvironment</key>
+	<dict>
+		<key>MallocNanoZone</key>
+		<string>0</string>
+	</dict>
+	<key>LSFileQuarantineEnabled</key>
+	<true/>
+	<key>LSMinimumSystemVersion</key>
+	<string>11.0</string>
+	<key>LSUIElement</key>
+	<string>1</string>
+	<key>NSCameraReactionEffectGesturesEnabledDefault</key>
+	<false/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
+	<key>NSCameraUseContinuityCameraDeviceType</key>
+	<true/>
+</dict>
+</plist>

--- a/embedder/cmux_BUILD.gn
+++ b/embedder/cmux_BUILD.gn
@@ -8,9 +8,24 @@
 # src/cmux/BUILD.gn as-is.
 #
 # Shape mirrors upstream's chrome_framework + chrome_helper_app pattern
-# in chrome/BUILD.gn, but with cmux branding. Until an empty
-# `cmux_core_framework` builds in a real tree, treat the targets here
-# as the *intended* shape, not a tested one.
+# in chrome/BUILD.gn, but with cmux branding.
+#
+# Validation status (M148, 2026-05-14): this file, dropped into
+# src/cmux/BUILD.gn on a chromium-fork tree with a one-line addition
+# to root //BUILD.gn's gn_all group, passes:
+#
+#   gn gen out/cmux-check --args='target_os="mac" ...'      (27,405 targets)
+#   gn check out/cmux-check //cmux:cmux_core_framework      (OK)
+#   gn check out/cmux-check //cmux:cmux_helper_app_default  (OK)
+#   gn check out/cmux-check //cmux:cmux_helper_app_renderer (OK)
+#   gn check out/cmux-check //cmux:cmux_helper_app_gpu      (OK)
+#   gn check out/cmux-check //cmux:cmux_helper_app_plugin   (OK)
+#   gn check out/cmux-check //cmux:cmux_helpers             (OK)
+#
+# Header dependency check passes for every target this file defines,
+# against the real M148 stable graph. The remaining unverified piece
+# is ninja-linking the framework end-to-end (deferred until //content
+# wiring lands).
 
 import("//build/buildflag_header.gni")
 import("//build/config/apple/symbols.gni")
@@ -111,16 +126,17 @@ mac_framework_bundle("cmux_core_framework") {
   # placeholder file gives the linker something concrete to consume.
   sources = [ "//cmux/embedder/cmux_framework_main.cc" ]
 
+  # NOTE: stub framework deps. Real //mojo + //services/network/...
+  # wiring lands once the C ABI implementations move beyond sentinels;
+  # //mojo as a top-level alias is testonly, so granular subtargets
+  # (//mojo/public/cpp/bindings, //services/network/public/mojom:mojom)
+  # come back at that point.
   deps = [
     "//cmux/embedder:embedder",
     "//content/public/app",
-    "//mojo",
-    "//services/network/public/mojom",
   ]
 
   data_deps = [ ":cmux_helpers" ]
-
-  configs += [ "//build/config/compiler:enable_arc" ]
 
   ldflags = [ "-Wl,-install_name,@executable_path/../Frameworks/CmuxCore.framework/Versions/A/CmuxCore" ]
 }

--- a/embedder/cmux_BUILD.gn
+++ b/embedder/cmux_BUILD.gn
@@ -7,8 +7,10 @@
 # fork lands at manaflow-ai/cmux-chromium, this file drops into
 # src/cmux/BUILD.gn as-is.
 #
-# Naming convention is intentional: `cmux_core_framework` mirrors
-# upstream's `chrome_framework` target shape but with cmux branding.
+# Shape mirrors upstream's chrome_framework + chrome_helper_app pattern
+# in chrome/BUILD.gn, but with cmux branding. Until an empty
+# `cmux_core_framework` builds in a real tree, treat the targets here
+# as the *intended* shape, not a tested one.
 
 import("//build/buildflag_header.gni")
 import("//build/config/apple/symbols.gni")
@@ -22,41 +24,67 @@ import("//content/public/app/mac_helpers.gni")
 cmux_core_framework_version = "0.1.cmux.0"
 cmux_core_framework_bundle_id = "ai.manaflow.cmux.browser.framework"
 
-# Helpers come from //content; we re-instantiate them with cmux bundle
-# ids so they sandbox correctly on macOS.
-group("cmux_helpers") {
-  deps = [
-    ":cmux_helper",
-    ":cmux_helper_renderer",
-    ":cmux_helper_gpu",
-    ":cmux_helper_plugin",
-  ]
+# Base name for helper apps. The output is `cmux_helper_name + helper
+# app-name suffix`, so the default helper becomes "cmux Helper" and
+# the renderer helper becomes "cmux Helper (Renderer)".
+cmux_helper_name = "cmux Helper"
+
+# Inlined equivalent of chrome/BUILD.gn's `chrome_helper_app` template,
+# wired to cmux branding. The template lives here (not in a .gni)
+# because cmux only has one consumer (this file).
+template("cmux_helper_app") {
+  mac_app_bundle(target_name) {
+    assert(defined(invoker.helper_name_suffix))
+    assert(defined(invoker.helper_bundle_id_suffix))
+
+    output_name = cmux_helper_name + invoker.helper_name_suffix
+
+    info_plist = "//cmux/branding/cmux_helper-Info.plist"
+
+    extra_substitutions = [
+      "CMUX_HELPER_BUNDLE_ID=${cmux_core_framework_bundle_id}${invoker.helper_bundle_id_suffix}",
+      "CMUX_HELPER_NAME=${cmux_helper_name}${invoker.helper_name_suffix}",
+      # mac_helpers.gni does not provide a CFBundlePackageType
+      # variant. Chrome hard-codes APPL for every helper; cmux does
+      # the same. (See chrome/app/helper-Info.plist.)
+      "CMUX_PACKAGE_TYPE=APPL",
+    ]
+
+    # Real cmux mac helper entry point lands here once the .cc file
+    # is added to //cmux/embedder. For now this is a placeholder
+    # comment so a future `gn gen` doesn't blow up on an empty
+    # sources list (mac_app_bundle requires at least one source).
+    sources = [ "//cmux/embedder/cmux_helper_main_mac.cc" ]
+
+    defines = [ "HELPER_EXECUTABLE" ]
+
+    deps = [
+      "//base/allocator:early_zone_registration_apple",
+      "//content/public/app",
+      "//sandbox/mac:seatbelt",
+    ]
+  }
 }
 
-foreach(helper, content_mac_helpers) {
-  helper_name = helper[0]                                # e.g. "renderer"
-  helper_bundle_id_suffix = helper[1]                    # e.g. "helper.renderer"
-  helper_app_role = helper[2]                            # CFBundlePackageType
-  helper_visibility = helper[3]
-  helper_extra_configs = helper[4]
-  helper_extra_substitutions = helper[5]
+# Instantiate the four helper variants from
+# //content/public/app/mac_helpers.gni. Each `helper_params` tuple is
+# [target_name, bundle_id_suffix, app_name_suffix] -- a 3-element list.
+# GN's foreach binds the whole tuple to the loop variable; element
+# access is by index, not destructuring.
+foreach(helper_params, content_mac_helpers) {
+  cmux_helper_app("cmux_helper_app_${helper_params[0]}") {
+    helper_name_suffix = helper_params[2]
+    helper_bundle_id_suffix = helper_params[1]
+  }
+}
 
-  mac_app_bundle("cmux_helper${helper_name}") {
-    output_name = "cmux Helper${helper_name}"
-    info_plist = "//cmux/branding/cmux_helper-Info.plist"
-    extra_substitutions = [
-      "CMUX_HELPER_BUNDLE_ID=${cmux_core_framework_bundle_id}.${helper_bundle_id_suffix}",
-      "CMUX_HELPER_NAME=cmux Helper${helper_name}",
-      "CMUX_PACKAGE_TYPE=${helper_app_role}",
-    ] + helper_extra_substitutions
-    sources = [ "//content/app/mac/main.cc" ]
-    deps = [
-      ":cmux_core_framework+link",
-      "//content/public/app",
-    ]
-    if (helper_extra_configs != []) {
-      configs += helper_extra_configs
-    }
+# Group target the framework data-deps on. Names match what the
+# foreach above generates (cmux_helper_app_default, _renderer, _gpu,
+# _plugin).
+group("cmux_helpers") {
+  public_deps = []
+  foreach(helper_params, content_mac_helpers) {
+    public_deps += [ ":cmux_helper_app_${helper_params[0]}" ]
   }
 }
 
@@ -72,16 +100,18 @@ mac_framework_bundle("cmux_core_framework") {
   ]
   info_plist = "//cmux/branding/cmux_core_framework-Info.plist"
 
-  sources = [
-    # Stub — the real entry points come from the embedder source_set
-    # and content/'s mac framework template. No sources needed here
-    # beyond the configuration plist; content/app/content_main_mac.mm
-    # is brought in transitively.
+  extra_substitutions = [
+    "CMUX_CORE_FRAMEWORK_BUNDLE_ID=${cmux_core_framework_bundle_id}",
+    "CMUX_CORE_FRAMEWORK_VERSION=${cmux_core_framework_version}",
   ]
+
+  # Real sources come from //cmux/embedder once the .mm/.cc files land.
+  # mac_framework_bundle does not allow an empty sources list; this
+  # placeholder file gives the linker something concrete to consume.
+  sources = [ "//cmux/embedder/cmux_framework_main.cc" ]
 
   deps = [
     "//cmux/embedder:embedder",
-    "//content/app:content_main",
     "//content/public/app",
     "//mojo",
     "//services/network/public/mojom",
@@ -98,10 +128,4 @@ mac_framework_bundle("cmux_core_framework") {
   ldflags = [
     "-Wl,-install_name,@executable_path/../Frameworks/CmuxCore.framework/Versions/A/CmuxCore",
   ]
-
-  if (enable_dsyms) {
-    extra_substitutions = [
-      "CMUX_CORE_FRAMEWORK_BUNDLE_ID=${cmux_core_framework_bundle_id}",
-    ]
-  }
 }

--- a/embedder/cmux_BUILD.gn
+++ b/embedder/cmux_BUILD.gn
@@ -44,6 +44,7 @@ template("cmux_helper_app") {
     extra_substitutions = [
       "CMUX_HELPER_BUNDLE_ID=${cmux_core_framework_bundle_id}${invoker.helper_bundle_id_suffix}",
       "CMUX_HELPER_NAME=${cmux_helper_name}${invoker.helper_name_suffix}",
+
       # mac_helpers.gni does not provide a CFBundlePackageType
       # variant. Chrome hard-codes APPL for every helper; cmux does
       # the same. (See chrome/app/helper-Info.plist.)
@@ -117,15 +118,9 @@ mac_framework_bundle("cmux_core_framework") {
     "//services/network/public/mojom",
   ]
 
-  data_deps = [
-    ":cmux_helpers",
-  ]
+  data_deps = [ ":cmux_helpers" ]
 
-  configs += [
-    "//build/config/compiler:enable_arc",
-  ]
+  configs += [ "//build/config/compiler:enable_arc" ]
 
-  ldflags = [
-    "-Wl,-install_name,@executable_path/../Frameworks/CmuxCore.framework/Versions/A/CmuxCore",
-  ]
+  ldflags = [ "-Wl,-install_name,@executable_path/../Frameworks/CmuxCore.framework/Versions/A/CmuxCore" ]
 }

--- a/embedder/cmux_BUILD.gn
+++ b/embedder/cmux_BUILD.gn
@@ -1,0 +1,107 @@
+# Copyright 2026 manaflow-ai. All rights reserved.
+#
+# //cmux/BUILD.gn (NOT //cmux/embedder/BUILD.gn — see embedder/README.md)
+#
+# Declares the cmux_core_framework target that the cmux macOS app
+# (Packages/CmuxBrowserEngine) links against. When the cmux Chromium
+# fork lands at manaflow-ai/cmux-chromium, this file drops into
+# src/cmux/BUILD.gn as-is.
+#
+# Naming convention is intentional: `cmux_core_framework` mirrors
+# upstream's `chrome_framework` target shape but with cmux branding.
+
+import("//build/buildflag_header.gni")
+import("//build/config/apple/symbols.gni")
+import("//build/config/mac/mac_sdk.gni")
+import("//build/config/mac/rules.gni")
+import("//build/util/process_version.gni")
+import("//content/public/app/mac_helpers.gni")
+
+# Version: cmux's framework version is upstream Chromium's marketing
+# version with a `.cmux.N` suffix bumped per fork release.
+cmux_core_framework_version = "0.1.cmux.0"
+cmux_core_framework_bundle_id = "ai.manaflow.cmux.browser.framework"
+
+# Helpers come from //content; we re-instantiate them with cmux bundle
+# ids so they sandbox correctly on macOS.
+group("cmux_helpers") {
+  deps = [
+    ":cmux_helper",
+    ":cmux_helper_renderer",
+    ":cmux_helper_gpu",
+    ":cmux_helper_plugin",
+  ]
+}
+
+foreach(helper, content_mac_helpers) {
+  helper_name = helper[0]                                # e.g. "renderer"
+  helper_bundle_id_suffix = helper[1]                    # e.g. "helper.renderer"
+  helper_app_role = helper[2]                            # CFBundlePackageType
+  helper_visibility = helper[3]
+  helper_extra_configs = helper[4]
+  helper_extra_substitutions = helper[5]
+
+  mac_app_bundle("cmux_helper${helper_name}") {
+    output_name = "cmux Helper${helper_name}"
+    info_plist = "//cmux/branding/cmux_helper-Info.plist"
+    extra_substitutions = [
+      "CMUX_HELPER_BUNDLE_ID=${cmux_core_framework_bundle_id}.${helper_bundle_id_suffix}",
+      "CMUX_HELPER_NAME=cmux Helper${helper_name}",
+      "CMUX_PACKAGE_TYPE=${helper_app_role}",
+    ] + helper_extra_substitutions
+    sources = [ "//content/app/mac/main.cc" ]
+    deps = [
+      ":cmux_core_framework+link",
+      "//content/public/app",
+    ]
+    if (helper_extra_configs != []) {
+      configs += helper_extra_configs
+    }
+  }
+}
+
+# The framework itself.
+mac_framework_bundle("cmux_core_framework") {
+  output_name = "CmuxCore"
+  framework_version = cmux_core_framework_version
+  framework_contents = [
+    "Frameworks",
+    "Helpers",
+    "Libraries",
+    "Resources",
+  ]
+  info_plist = "//cmux/branding/cmux_core_framework-Info.plist"
+
+  sources = [
+    # Stub — the real entry points come from the embedder source_set
+    # and content/'s mac framework template. No sources needed here
+    # beyond the configuration plist; content/app/content_main_mac.mm
+    # is brought in transitively.
+  ]
+
+  deps = [
+    "//cmux/embedder:embedder",
+    "//content/app:content_main",
+    "//content/public/app",
+    "//mojo",
+    "//services/network/public/mojom",
+  ]
+
+  data_deps = [
+    ":cmux_helpers",
+  ]
+
+  configs += [
+    "//build/config/compiler:enable_arc",
+  ]
+
+  ldflags = [
+    "-Wl,-install_name,@executable_path/../Frameworks/CmuxCore.framework/Versions/A/CmuxCore",
+  ]
+
+  if (enable_dsyms) {
+    extra_substitutions = [
+      "CMUX_CORE_FRAMEWORK_BUNDLE_ID=${cmux_core_framework_bundle_id}",
+    ]
+  }
+}

--- a/embedder/cmux_browser.h
+++ b/embedder/cmux_browser.h
@@ -1,0 +1,276 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_browser.h — C ABI exported from CmuxCore.framework.
+//
+// Source of truth for the Swift wrapper at
+// Packages/CmuxBrowserEngine/Sources/CmuxBrowserEngine/ChromiumBrowserBackend.swift
+// in the manaflow-ai/cmux repo. Consumed via a modulemap.
+//
+// Design constraints (in priority order):
+//
+//   1. C, not C++. Stable, callable from Swift via a module.modulemap
+//      with no bridging types.
+//   2. No std::* or Chromium internals leak. Pointer-by-pointer
+//      ownership, opaque handles. The Swift side never sees a
+//      content::WebContents*.
+//   3. Callable from MainActor Swift. Every method runs on the
+//      browser-process main thread. Threading inside the embedder is
+//      invisible to Swift.
+//   4. Small. The ABI mirrors only what CmuxBrowserEngine's wrapper
+//      actually calls. Every method is maintenance debt across
+//      upstream Chromium rebases.
+//   5. Stable across upstream rebases. No field unions, no exposed
+//      structs that aren't versioned, no opaque pointer reinterpret.
+//
+// All `cmux_*_close()` functions are idempotent. All callbacks run on
+// the browser-process main thread. Strings passed in are copied;
+// strings handed back via accessors are valid until the next message-
+// loop pump.
+
+#ifndef CMUX_EMBEDDER_CMUX_BROWSER_H_
+#define CMUX_EMBEDDER_CMUX_BROWSER_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ABI revision. Bump on any breaking change. The Swift package asserts
+// at framework load.
+#define CMUX_EMBEDDER_ABI_VERSION 1
+
+// ---------- Opaque handles ----------
+
+typedef struct cmux_session_  cmux_session_t;   // process-wide singleton
+typedef struct cmux_profile_  cmux_profile_t;   // ~ WKWebsiteDataStore
+typedef struct cmux_view_     cmux_view_t;      // ~ WKWebView
+typedef struct cmux_nav_      cmux_nav_t;       // ~ WKNavigation handle
+
+// ---------- Status / errors ----------
+
+typedef enum cmux_status_ {
+    CMUX_OK = 0,
+    CMUX_E_ABI_MISMATCH       = 1,
+    CMUX_E_ALREADY_INITIALIZED = 2,
+    CMUX_E_NOT_INITIALIZED    = 3,
+    CMUX_E_INVALID_ARG        = 4,
+    CMUX_E_NATIVE             = 5,  // see cmux_session_last_error_string()
+} cmux_status_t;
+
+// ---------- Session lifecycle ----------
+
+// Called once per process. argv must include the helper-bundle paths
+// resolved by the host so the browser process can hand them to the
+// helper processes. Returns CMUX_OK or CMUX_E_ABI_MISMATCH if
+// abi_version doesn't match the framework's CMUX_EMBEDDER_ABI_VERSION.
+cmux_status_t cmux_session_init(uint32_t abi_version,
+                                int argc,
+                                const char* const* argv,
+                                cmux_session_t** out_session);
+
+// Shutdown is best-effort; on macOS we typically just exit().
+void cmux_session_shutdown(cmux_session_t* session);
+
+// Pump the browser-process message loop once. Hosts that already run
+// a CFRunLoop call this from a CFRunLoopSource. Idempotent and
+// reentrant-safe.
+void cmux_session_run_once(cmux_session_t* session);
+
+// Diagnostic. Caller does not free; lifetime is until the next call.
+const char* cmux_session_last_error_string(cmux_session_t* session);
+
+// ---------- Profiles ----------
+
+// Creates or fetches a profile. Profiles map to disk under
+//   {user-data-dir}/{name}
+// where {user-data-dir} defaults to
+//   {HOME}/Library/Application Support/cmux/CmuxCore
+// Pass NULL for an ephemeral (in-memory) profile.
+cmux_status_t cmux_profile_open(cmux_session_t* session,
+                                const char* name_or_null,
+                                cmux_profile_t** out_profile);
+
+void cmux_profile_close(cmux_profile_t* profile);
+
+// Cookies. Iteration uses a callback because the cookie set is mutable.
+typedef void (*cmux_cookie_visitor)(
+    void* userdata,
+    const char* name, const char* value,
+    const char* domain, const char* path,
+    int64_t expires_unix_ms,
+    bool secure, bool http_only);
+
+cmux_status_t cmux_profile_get_cookies(cmux_profile_t* profile,
+                                       const char* url_or_null,
+                                       void* userdata,
+                                       cmux_cookie_visitor visitor);
+
+cmux_status_t cmux_profile_set_cookie(cmux_profile_t* profile,
+                                      const char* name, const char* value,
+                                      const char* domain, const char* path,
+                                      int64_t expires_unix_ms,
+                                      bool secure, bool http_only);
+
+cmux_status_t cmux_profile_delete_cookie(cmux_profile_t* profile,
+                                         const char* name,
+                                         const char* domain,
+                                         const char* path);
+
+// Clear browsing data for this profile. `data_types_mask` is the OR of
+// cmux_data_type_* below. `since_unix_ms` ≥ 0; pass INT64_MIN for "all
+// time".
+typedef uint32_t cmux_data_type_mask_t;
+#define CMUX_DATA_COOKIES        (1u << 0)
+#define CMUX_DATA_LOCAL_STORAGE  (1u << 1)
+#define CMUX_DATA_INDEXED_DB     (1u << 2)
+#define CMUX_DATA_CACHE          (1u << 3)
+#define CMUX_DATA_SERVICE_WORKERS (1u << 4)
+#define CMUX_DATA_ALL            (~0u)
+
+cmux_status_t cmux_profile_remove_data(cmux_profile_t* profile,
+                                       cmux_data_type_mask_t mask,
+                                       int64_t since_unix_ms);
+
+// ---------- Views ----------
+
+typedef struct cmux_view_config_ {
+    cmux_profile_t* profile;          // required
+    bool javascript_enabled;          // default true
+    bool allows_inline_media;         // default true
+    bool media_requires_user_action;  // default false
+    const char* user_agent_or_null;
+    const char* application_name_or_null;
+} cmux_view_config_t;
+
+// On success, *out_view is owned by the caller. *out_ns_view is a
+// CFTypeRef of an NSView the caller adds to the AppKit hierarchy.
+// The NSView's content is backed by a CALayerHost bound to the GPU
+// helper's CAContext. AppKit refcounts the NSView normally; calling
+// cmux_view_close releases the engine-side WebContents.
+cmux_status_t cmux_view_create(cmux_session_t* session,
+                               const cmux_view_config_t* config,
+                               cmux_view_t** out_view,
+                               void** out_ns_view);
+
+void cmux_view_close(cmux_view_t* view);
+
+// ---------- Navigation ----------
+
+cmux_nav_t* cmux_view_load_url(cmux_view_t* view, const char* url);
+cmux_nav_t* cmux_view_load_html(cmux_view_t* view,
+                                const char* html, size_t html_len,
+                                const char* base_url_or_null);
+cmux_nav_t* cmux_view_reload(cmux_view_t* view);
+cmux_nav_t* cmux_view_go_back(cmux_view_t* view);
+cmux_nav_t* cmux_view_go_forward(cmux_view_t* view);
+void cmux_view_stop(cmux_view_t* view);
+bool cmux_view_can_go_back(cmux_view_t* view);
+bool cmux_view_can_go_forward(cmux_view_t* view);
+
+// URL/title are valid until the next message-loop pump. Copy if you
+// need to outlive that.
+const char* cmux_view_url(cmux_view_t* view);
+const char* cmux_view_title(cmux_view_t* view);
+bool        cmux_view_is_loading(cmux_view_t* view);
+double      cmux_view_estimated_progress(cmux_view_t* view);
+
+// Page zoom factor. 1.0 = no zoom.
+void   cmux_view_set_page_zoom(cmux_view_t* view, double zoom);
+double cmux_view_page_zoom(cmux_view_t* view);
+
+// ---------- JS evaluation ----------
+
+typedef void (*cmux_js_callback)(
+    void* userdata,
+    const char* json_value_or_null,  // JSON-encoded result, NULL on error
+    const char* error_or_null);
+
+void cmux_view_evaluate_js(cmux_view_t* view,
+                           const char* source, size_t source_len,
+                           void* userdata,
+                           cmux_js_callback callback);
+
+// ---------- Script messages (page → host) ----------
+
+typedef void (*cmux_script_message_handler)(
+    void* userdata,
+    const char* name,
+    const char* frame_url_or_null,
+    bool is_main_frame,
+    const char* json_body);
+
+void cmux_view_set_script_message_handler(
+    cmux_view_t* view, void* userdata,
+    cmux_script_message_handler handler);
+
+// ---------- User scripts ----------
+
+typedef enum cmux_injection_time_ {
+    CMUX_INJECT_AT_DOCUMENT_START = 0,
+    CMUX_INJECT_AT_DOCUMENT_END   = 1,
+} cmux_injection_time_t;
+
+void cmux_view_add_user_script(cmux_view_t* view,
+                               const char* source, size_t source_len,
+                               cmux_injection_time_t injection_time,
+                               bool for_main_frame_only);
+
+void cmux_view_remove_all_user_scripts(cmux_view_t* view);
+
+// ---------- Navigation delegate (host ← engine) ----------
+
+typedef struct cmux_navigation_event_ {
+    uint64_t nav_id;
+    const char* url;
+    bool is_main_frame;
+    bool is_provisional;
+    int32_t navigation_type;     // matches CmuxNavigationAction.NavigationType
+    int32_t button_number;
+    uint32_t modifier_flags;
+    bool should_perform_download;
+} cmux_navigation_event_t;
+
+typedef int32_t cmux_nav_decision_t;
+#define CMUX_NAV_ALLOW    0
+#define CMUX_NAV_CANCEL   1
+#define CMUX_NAV_DOWNLOAD 2
+
+typedef cmux_nav_decision_t (*cmux_navigation_action_cb)(
+    void* userdata, const cmux_navigation_event_t* evt);
+
+typedef void (*cmux_navigation_terminal_cb)(
+    void* userdata, uint64_t nav_id,
+    const char* url, bool succeeded,
+    const char* error_message_or_null);
+
+void cmux_view_set_navigation_action_cb(cmux_view_t* view,
+                                        void* userdata,
+                                        cmux_navigation_action_cb cb);
+
+void cmux_view_set_navigation_did_finish_cb(cmux_view_t* view,
+                                            void* userdata,
+                                            cmux_navigation_terminal_cb cb);
+
+// ---------- Snapshot ----------
+
+typedef void (*cmux_snapshot_cb)(
+    void* userdata,
+    const uint8_t* png_bytes,
+    size_t png_len,
+    const char* error_or_null);
+
+// Snapshot the current page. Width/height are device-independent
+// pixels. Pass 0 for either to use the view's current bounds.
+void cmux_view_take_snapshot(cmux_view_t* view,
+                             int32_t width, int32_t height,
+                             void* userdata,
+                             cmux_snapshot_cb cb);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // CMUX_EMBEDDER_CMUX_BROWSER_H_

--- a/embedder/cmux_browser.mm
+++ b/embedder/cmux_browser.mm
@@ -1,0 +1,37 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_browser.mm -- stub implementation of the view-creation portion
+// of the cmux embedder C ABI. This translation unit is Obj-C++ because
+// a real cmux_view_create wires up an NSView that hosts a CALayerHost
+// bound to the GPU helper's CAContext. In the stub it returns
+// CMUX_E_NATIVE and never produces an NSView, but the file still has
+// to compile/link so the framework has something to consume at the
+// platform layer.
+//
+// Lands at src/cmux/embedder/cmux_browser.mm in the fork.
+
+#import <AppKit/AppKit.h>
+
+#include "cmux/embedder/cmux_browser.h"
+
+extern "C" {
+
+void cmux_internal_set_last_error(const char* msg);
+
+cmux_status_t cmux_view_create(cmux_session_t* /*session*/,
+                               const cmux_view_config_t* /*config*/,
+                               cmux_view_t** /*out_view*/,
+                               void** out_ns_view) {
+  // Sentinel: the stub does not produce a backing NSView.
+  if (out_ns_view != nullptr) {
+    *out_ns_view = nullptr;
+  }
+  cmux_internal_set_last_error("cmux_view_create: stub");
+  return CMUX_E_NATIVE;
+}
+
+void cmux_view_close(cmux_view_t* /*view*/) {
+  // No-op in the stub.
+}
+
+}  // extern "C"

--- a/embedder/cmux_framework_main.cc
+++ b/embedder/cmux_framework_main.cc
@@ -1,0 +1,23 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_framework_main.cc -- placeholder TU for the cmux_core_framework
+// target. mac_framework_bundle in chromium's GN templates requires at
+// least one source file directly on the target; the actual framework
+// content comes via :embedder. This file exists only to satisfy the
+// "non-empty sources" constraint until the framework's own glue moves
+// here (entry-point ABI version reporter, etc.).
+//
+// Lands at src/cmux/embedder/cmux_framework_main.cc in the fork.
+
+#include "cmux/embedder/cmux_browser.h"
+
+extern "C" {
+
+// Diagnostic: a real consumer can dlsym this and assert at framework
+// load to confirm the binary was compiled against the ABI version
+// they expect.
+unsigned int cmux_framework_abi_version(void) {
+  return CMUX_EMBEDDER_ABI_VERSION;
+}
+
+}  // extern "C"

--- a/embedder/cmux_helper_main_mac.cc
+++ b/embedder/cmux_helper_main_mac.cc
@@ -1,0 +1,14 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_helper_main_mac.cc -- entry point for the cmux helper apps
+// (renderer/gpu/plugin/default). In a real build this forwards to
+// //content's ContentMainRunner, the same way chrome/app/
+// chrome_exe_main_mac.cc does for Chrome's helpers. In the stub
+// build it simply returns 0 so each Helper.app's executable links
+// and runs.
+//
+// Lands at src/cmux/embedder/cmux_helper_main_mac.cc in the fork.
+
+int main(int /*argc*/, char** /*argv*/) {
+  return 0;
+}

--- a/embedder/cmux_layer_host.mm
+++ b/embedder/cmux_layer_host.mm
@@ -1,0 +1,16 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_layer_host.mm -- stub for the CAContext / CALayerHost wiring
+// that backs cmux_view_t with cross-process compositing. The real
+// implementation lives behind cmux_view_create and is not exposed
+// through the C ABI; this file only exists so the framework's
+// BUILD.gn has a place to put platform-specific compositor glue in
+// future iterations (P2 in plans/chromium-engine.md). In the stub
+// build it is intentionally empty.
+//
+// Lands at src/cmux/embedder/cmux_layer_host.mm in the fork.
+
+#import <AppKit/AppKit.h>
+#import <QuartzCore/QuartzCore.h>
+
+// Intentionally empty in the stub build.

--- a/embedder/cmux_profile.cc
+++ b/embedder/cmux_profile.cc
@@ -1,0 +1,63 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_profile.cc -- stub implementation of the profile / cookie /
+// data-removal portion of the cmux embedder C ABI. Lands at
+// src/cmux/embedder/cmux_profile.cc in the fork. Real implementation
+// wraps content::BrowserContext + a CookieManager from
+// //services/network/public; the stubs here return CMUX_E_NATIVE.
+
+#include "cmux/embedder/cmux_browser.h"
+
+extern "C" {
+
+// Defined in cmux_session.cc. Sets the per-session last-error string
+// readable via cmux_session_last_error_string.
+void cmux_internal_set_last_error(const char* msg);
+
+cmux_status_t cmux_profile_open(cmux_session_t* /*session*/,
+                                const char* /*name_or_null*/,
+                                cmux_profile_t** /*out_profile*/) {
+  cmux_internal_set_last_error("cmux_profile_open: stub");
+  return CMUX_E_NATIVE;
+}
+
+void cmux_profile_close(cmux_profile_t* /*profile*/) {
+  // No-op in the stub.
+}
+
+cmux_status_t cmux_profile_get_cookies(cmux_profile_t* /*profile*/,
+                                       const char* /*url_or_null*/,
+                                       void* /*userdata*/,
+                                       cmux_cookie_visitor /*visitor*/) {
+  cmux_internal_set_last_error("cmux_profile_get_cookies: stub");
+  return CMUX_E_NATIVE;
+}
+
+cmux_status_t cmux_profile_set_cookie(cmux_profile_t* /*profile*/,
+                                      const char* /*name*/,
+                                      const char* /*value*/,
+                                      const char* /*domain*/,
+                                      const char* /*path*/,
+                                      int64_t /*expires_unix_ms*/,
+                                      bool /*secure*/,
+                                      bool /*http_only*/) {
+  cmux_internal_set_last_error("cmux_profile_set_cookie: stub");
+  return CMUX_E_NATIVE;
+}
+
+cmux_status_t cmux_profile_delete_cookie(cmux_profile_t* /*profile*/,
+                                         const char* /*name*/,
+                                         const char* /*domain*/,
+                                         const char* /*path*/) {
+  cmux_internal_set_last_error("cmux_profile_delete_cookie: stub");
+  return CMUX_E_NATIVE;
+}
+
+cmux_status_t cmux_profile_remove_data(cmux_profile_t* /*profile*/,
+                                       cmux_data_type_mask_t /*mask*/,
+                                       int64_t /*since_unix_ms*/) {
+  cmux_internal_set_last_error("cmux_profile_remove_data: stub");
+  return CMUX_E_NATIVE;
+}
+
+}  // extern "C"

--- a/embedder/cmux_session.cc
+++ b/embedder/cmux_session.cc
@@ -1,0 +1,87 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_session.cc -- stub implementation of the session lifecycle
+// portion of the cmux embedder C ABI.
+//
+// Lands at src/cmux/embedder/cmux_session.cc in the fork. The stubs
+// here let the framework link and load cleanly: cmux_session_init
+// accepts a matching abi_version and returns a sentinel session
+// handle; everything else either no-ops or reports
+// CMUX_E_NATIVE via cmux_session_last_error_string. Real
+// integration with //content's BrowserMainRunner replaces these
+// bodies; the goal of the stub is to give the framework a valid
+// link target before the content layer is wired.
+
+#include "cmux/embedder/cmux_browser.h"
+
+#include <cstring>
+
+namespace {
+
+// Stub session handle. A real implementation owns a
+// content::BrowserMainRunner here. The struct shape is opaque to
+// callers; only its address is meaningful.
+struct CmuxSessionImpl {
+  const char* last_error;
+  bool initialized;
+};
+
+// Single process-wide instance. cmux_session_init enforces this:
+// re-init while still initialized returns CMUX_E_ALREADY_INITIALIZED.
+CmuxSessionImpl g_session = {nullptr, false};
+
+constexpr const char* kNotImplemented =
+    "cmux embedder is a stub build; real content layer is not wired";
+
+}  // namespace
+
+extern "C" {
+
+cmux_status_t cmux_session_init(uint32_t abi_version,
+                                int /*argc*/,
+                                const char* const* /*argv*/,
+                                cmux_session_t** out_session) {
+  if (abi_version != CMUX_EMBEDDER_ABI_VERSION) {
+    g_session.last_error = "ABI version mismatch";
+    return CMUX_E_ABI_MISMATCH;
+  }
+  if (out_session == nullptr) {
+    g_session.last_error = "out_session must not be NULL";
+    return CMUX_E_INVALID_ARG;
+  }
+  if (g_session.initialized) {
+    g_session.last_error = "session already initialized";
+    return CMUX_E_ALREADY_INITIALIZED;
+  }
+  g_session.initialized = true;
+  g_session.last_error = nullptr;
+  *out_session = reinterpret_cast<cmux_session_t*>(&g_session);
+  return CMUX_OK;
+}
+
+void cmux_session_shutdown(cmux_session_t* session) {
+  if (session == nullptr) {
+    return;
+  }
+  g_session.initialized = false;
+  g_session.last_error = nullptr;
+}
+
+void cmux_session_run_once(cmux_session_t* /*session*/) {
+  // No-op in the stub. The real implementation pumps the browser
+  // process MessageLoop once.
+}
+
+const char* cmux_session_last_error_string(cmux_session_t* session) {
+  if (session == nullptr) {
+    return "session handle is NULL";
+  }
+  return g_session.last_error == nullptr ? "" : g_session.last_error;
+}
+
+// Helper used by the other stub TUs.
+void cmux_internal_set_last_error(const char* msg) {
+  g_session.last_error = msg == nullptr ? kNotImplemented : msg;
+}
+
+}  // extern "C"

--- a/embedder/cmux_view.cc
+++ b/embedder/cmux_view.cc
@@ -1,0 +1,149 @@
+// Copyright 2026 manaflow-ai. All rights reserved.
+//
+// cmux_view.cc -- stub implementations of the view accessors,
+// navigation, JS, user-script, and snapshot portions of the cmux
+// embedder C ABI. Lands at src/cmux/embedder/cmux_view.cc in the
+// fork. NSView creation and CALayerHost wiring live in the .mm
+// translation units (cmux_browser.mm / cmux_layer_host.mm); this
+// file holds everything pure-C++ so it compiles without the AppKit
+// SDK headers leaking into //content.
+
+#include "cmux/embedder/cmux_browser.h"
+
+extern "C" {
+
+void cmux_internal_set_last_error(const char* msg);
+
+// ---------- Navigation ----------
+
+cmux_nav_t* cmux_view_load_url(cmux_view_t* /*view*/,
+                               const char* /*url*/) {
+  cmux_internal_set_last_error("cmux_view_load_url: stub");
+  return nullptr;
+}
+
+cmux_nav_t* cmux_view_load_html(cmux_view_t* /*view*/,
+                                const char* /*html*/,
+                                size_t /*html_len*/,
+                                const char* /*base_url_or_null*/) {
+  cmux_internal_set_last_error("cmux_view_load_html: stub");
+  return nullptr;
+}
+
+cmux_nav_t* cmux_view_reload(cmux_view_t* /*view*/) {
+  cmux_internal_set_last_error("cmux_view_reload: stub");
+  return nullptr;
+}
+
+cmux_nav_t* cmux_view_go_back(cmux_view_t* /*view*/) {
+  cmux_internal_set_last_error("cmux_view_go_back: stub");
+  return nullptr;
+}
+
+cmux_nav_t* cmux_view_go_forward(cmux_view_t* /*view*/) {
+  cmux_internal_set_last_error("cmux_view_go_forward: stub");
+  return nullptr;
+}
+
+void cmux_view_stop(cmux_view_t* /*view*/) {
+  // No-op in the stub.
+}
+
+bool cmux_view_can_go_back(cmux_view_t* /*view*/) {
+  return false;
+}
+
+bool cmux_view_can_go_forward(cmux_view_t* /*view*/) {
+  return false;
+}
+
+// ---------- View accessors ----------
+
+const char* cmux_view_url(cmux_view_t* /*view*/) {
+  return "";
+}
+
+const char* cmux_view_title(cmux_view_t* /*view*/) {
+  return "";
+}
+
+bool cmux_view_is_loading(cmux_view_t* /*view*/) {
+  return false;
+}
+
+double cmux_view_estimated_progress(cmux_view_t* /*view*/) {
+  return 0.0;
+}
+
+void cmux_view_set_page_zoom(cmux_view_t* /*view*/, double /*zoom*/) {
+  // No-op in the stub.
+}
+
+double cmux_view_page_zoom(cmux_view_t* /*view*/) {
+  return 1.0;
+}
+
+// ---------- JS evaluation ----------
+
+void cmux_view_evaluate_js(cmux_view_t* /*view*/,
+                           const char* /*source*/,
+                           size_t /*source_len*/,
+                           void* userdata,
+                           cmux_js_callback callback) {
+  if (callback != nullptr) {
+    callback(userdata, nullptr, "cmux_view_evaluate_js: stub");
+  }
+}
+
+// ---------- Script messages ----------
+
+void cmux_view_set_script_message_handler(
+    cmux_view_t* /*view*/,
+    void* /*userdata*/,
+    cmux_script_message_handler /*handler*/) {
+  // No-op: the engine never receives postMessage calls in the stub.
+}
+
+// ---------- User scripts ----------
+
+void cmux_view_add_user_script(cmux_view_t* /*view*/,
+                               const char* /*source*/,
+                               size_t /*source_len*/,
+                               cmux_injection_time_t /*injection_time*/,
+                               bool /*for_main_frame_only*/) {
+  // No-op.
+}
+
+void cmux_view_remove_all_user_scripts(cmux_view_t* /*view*/) {
+  // No-op.
+}
+
+// ---------- Navigation callbacks ----------
+
+void cmux_view_set_navigation_action_cb(
+    cmux_view_t* /*view*/,
+    void* /*userdata*/,
+    cmux_navigation_action_cb /*cb*/) {
+  // No-op.
+}
+
+void cmux_view_set_navigation_did_finish_cb(
+    cmux_view_t* /*view*/,
+    void* /*userdata*/,
+    cmux_navigation_terminal_cb /*cb*/) {
+  // No-op.
+}
+
+// ---------- Snapshot ----------
+
+void cmux_view_take_snapshot(cmux_view_t* /*view*/,
+                             int32_t /*width*/,
+                             int32_t /*height*/,
+                             void* userdata,
+                             cmux_snapshot_cb cb) {
+  if (cb != nullptr) {
+    cb(userdata, nullptr, 0, "cmux_view_take_snapshot: stub");
+  }
+}
+
+}  // extern "C"

--- a/patches/0001-angle-metal-wrapper-resolve-via-xcrun.patch
+++ b/patches/0001-angle-metal-wrapper-resolve-via-xcrun.patch
@@ -1,0 +1,98 @@
+From: cmux fork
+Subject: [PATCH] angle: resolve metal toolchain tools via xcrun when Xcode stubs are broken
+
+macOS 15 (Sequoia) + Xcode 26 ship the Metal compiler toolchain as a
+separate downloadable component which gets mounted at runtime under:
+
+    /var/run/com.apple.security.cryptexd/.../Metal.xctoolchain/usr/bin/
+
+The stubs Xcode bundles at:
+
+    /Applications/Xcode.app/Contents/Developer/Toolchains/\
+        XcodeDefault.xctoolchain/usr/bin/metal
+    /Applications/Xcode.app/Contents/Developer/Toolchains/\
+        XcodeDefault.xctoolchain/usr/bin/metallib
+
+(plus other tools in the metal family) do NOT auto-locate the
+cryptex-mounted real toolchain. `metal` errors out with "missing Metal
+Toolchain"; `metallib` does not exist as a stub at all so the
+GN-supplied path is a dangling reference. Only `xcrun --find <tool>`
+finds the real binary.
+
+Any chromium build that touches the ANGLE Metal renderer (including
+content_shell and chrome itself) trips two GN actions:
+
+  //third_party/angle/src/libANGLE/renderer/metal:angle_metal_internal_shaders_to_air
+  //third_party/angle/src/libANGLE/renderer/metal:angle_metal_internal_shaders_to_mtllib
+
+Both shell out via third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py
+with a hardcoded XcodeDefault.xctoolchain path as args[0].
+
+This patch teaches metal_wrapper.py to detect when args[0] is one of
+the broken Xcode metal-family stubs and substitute the xcrun-resolved
+real path before exec. Carry in the cmux Chromium fork until upstream
+chromium or angle adopts the same fix.
+
+--- a/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py
++++ b/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py
+@@ -1,15 +1,57 @@
+ #!/usr/bin/python3
+ # Copyright 2023 The ANGLE Project Authors. All rights reserved.
+ # Use of this source code is governed by a BSD-style license that can be
+ # found in the LICENSE file.
++#
++# cmux fork: macOS 15 + Xcode 26 ships the Metal compiler toolchain as a
++# separate downloadable component which is mounted at runtime under
++# /var/run/com.apple.security.cryptexd/.../Metal.xctoolchain/usr/bin/.
++# The Xcode-bundled stubs at XcodeDefault.xctoolchain/usr/bin/metal,
++# metallib, etc. do NOT find that mount (only xcrun --find <tool> does).
++# Worse, some tools (e.g. metallib) do not exist as a stub at all, so the
++# GN-supplied path is a dangling reference. When the first argument
++# looks like a Metal toolchain tool living under
++# XcodeDefault.xctoolchain/usr/bin/, swap it for the xcrun-resolved real
++# path. Carry this patch in the cmux Chromium fork until upstream
++# chromium/angle handles this natively.
++from __future__ import annotations
+ import os
+ import subprocess
+ import sys
+
++_XCODE_BIN_PREFIX = "XcodeDefault.xctoolchain/usr/bin/"
++_METAL_TOOL_PREFIXES = ("metal",)  # metal, metallib, metal-ar, metal-lipo, ...
++
++
++def _looks_like_metal_xcode_stub(path):
++    if not path:
++        return False
++    if _XCODE_BIN_PREFIX not in path:
++        return False
++    base = os.path.basename(path)
++    return any(base == p or base.startswith(p) for p in _METAL_TOOL_PREFIXES)
++
++
++def _xcrun_find(tool):
++    try:
++        r = subprocess.run(
++            ["/usr/bin/xcrun", "--find", tool],
++            stdout=subprocess.PIPE,
++            stderr=subprocess.DEVNULL,
++            text=True,
++            check=False,
++        )
++        path = (r.stdout or "").strip()
++        return path or None
++    except FileNotFoundError:
++        return None
++
++
+ def main(args):
++    if args and _looks_like_metal_xcode_stub(args[0]):
++        tool = os.path.basename(args[0])
++        replacement = _xcrun_find(tool)
++        if replacement and replacement != args[0]:
++            args = [replacement] + list(args[1:])
+     return subprocess.run(args, stdout=subprocess.PIPE, text=True).returncode
+
+
+ if __name__ == '__main__':
+     sys.exit(main(sys.argv[1:]))

--- a/patches/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch
+++ b/patches/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch
@@ -1,0 +1,35 @@
+From: cmux fork
+Subject: [PATCH] webnn/coreml: add default branch for new MLMultiArrayDataType values
+
+The macOS 26.2 SDK adds new enumerators to Apple's `MLMultiArrayDataType`
+(Int8, UInt8, etc.) which upstream Chromium HEAD has not enumerated yet
+in `services/webnn/coreml/utils_coreml.mm`. The switch in
+`GetDataTypeByteSize` has no `default:` case, so `-Werror,-Wswitch`
+fires and `-Wreturn-type` follows.
+
+Symptom on a content_shell build under macOS 15 + Xcode 26 (SDK
+MacOSX26.2.sdk):
+
+    services/webnn/coreml/utils_coreml.mm:27:11:
+    error: enumeration value 'MLMultiArrayDataTypeInt8' not handled in
+    switch [-Werror,-Wswitch]
+
+Fix adds a `default:` branch that returns 0. WebNN is not on cmux's
+critical path; a correct byte-size for the new types would just be
+future-rebase debt against upstream's own forthcoming fix. Drop this
+patch the moment upstream lands a fix.
+
+--- a/services/webnn/coreml/utils_coreml.mm
++++ b/services/webnn/coreml/utils_coreml.mm
+@@ -23,6 +23,12 @@ uint32_t GetDataTypeByteSize(MLMultiArrayDataType data_type) {
+       return 4;
+     case MLMultiArrayDataTypeFloat16:
+       return 2;
++    default:
++      // cmux fork: macOS 26 SDK introduced new MLMultiArrayDataType values
++      // (Int8, UInt8, etc.) that upstream Chromium has not enumerated yet.
++      // Treat unknown types conservatively; webnn is not on cmux's critical
++      // path so an exact byte-size here would just be future-rebase debt.
++      return 0;
+   }
+ }

--- a/patches/0003-ax-inspect-mac-suppress-new-availability.patch
+++ b/patches/0003-ax-inspect-mac-suppress-new-availability.patch
@@ -1,0 +1,47 @@
+From: cmux fork
+Subject: [PATCH] ui/accessibility: suppress -Wunguarded-availability-new in IsValidAXAttribute
+
+The macOS 26.2 SDK marks several `NSAccessibility*` string constants as
+introduced in macOS 26.0:
+
+    NSAccessibilityBlockQuoteLevelAttribute
+    NSAccessibilityVisitedAttribute
+
+`ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm` builds a
+`NSSet` of all valid accessibility attribute names at file scope inside
+`IsValidAXAttribute()`. Chromium's deployment target is macOS 11.0, so
+the new availability annotations fire `-Werror,-Wunguarded-availability-new`.
+
+A proper fix would `@available`-gate each entry but Objective-C++ does
+not allow `@available` inside an array literal. The pragmatic patch
+wraps the function with a local clang diagnostic suppression. This
+function is dev-tools/inspection plumbing on the content_shell path,
+not on cmux's critical path. Drop the patch when upstream chromium
+bumps its deployment target or @available-gates these entries.
+
+--- a/ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm
++++ b/ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm
+@@ -62,6 +62,14 @@ static bool IDOrClassMatches(const ax::mojom::AXNode& node, NSString* nsIDOrCla
+
+ }  // namespace
+
++// cmux fork: macOS 26 SDK marks some NSAccessibility* constants as
++// introduced in macOS 26.0 only, but chromium's deployment target is
++// macOS 11.0. Since this function is dev-tools/inspection plumbing
++// gated by content_shell flags (not on cmux's critical path), suppress
++// the -Wunguarded-availability-new diagnostic locally. Drop when
++// upstream chromium bumps its deployment target or @available-gates
++// these entries.
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wunguarded-availability-new"
+ bool IsValidAXAttribute(const std::string& attribute) {
+   static NSSet<NSString*>* valid_attributes = [NSSet setWithArray:@[
+     NSAccessibilityAccessKeyAttribute,
+@@ -116,6 +124,7 @@ bool IsValidAXAttribute(const std::string& attribute) {
+
+   return [valid_attributes containsObject:base::SysUTF8ToNSString(attribute)];
+ }
++#pragma clang diagnostic pop
+
+ base::apple::ScopedCFTypeRef<AXUIElementRef> FindAXUIElement(
+     const AXUIElementRef node,

--- a/patches/0004-ax-platform-node-cocoa-suppress-new-availability.patch
+++ b/patches/0004-ax-platform-node-cocoa-suppress-new-availability.patch
@@ -1,0 +1,44 @@
+From: cmux fork
+Subject: [PATCH] ui/accessibility: file-level suppress -Wunguarded-availability-new in ax_platform_node_cocoa.mm
+
+`ui/accessibility/platform/ax_platform_node_cocoa.mm` references
+several `NSAccessibility*` role and attribute constants that the
+macOS 26.2 SDK marks as introduced in macOS 26.0:
+
+    NSAccessibilityWebAreaRole
+    NSAccessibilityBlockQuoteLevelAttribute
+    NSAccessibilityVisitedAttribute
+
+Chromium's deployment target is macOS 11.0. The references span ~6
+lines across the file (943, 1505, 1518, 1623, 2918, 3512). Adding a
+function-scoped pragma to each would require six push/pop pairs, so a
+file-scoped suppression is the pragmatic choice: this file is OS-level
+accessibility plumbing and these new symbols just unblock the build.
+
+Companion to patch 0003 (which scoped the same suppression to a
+single function in `ax_inspect_utils_mac.mm`). Drop both when upstream
+chromium @available-gates these references or bumps the deployment
+target.
+
+--- a/ui/accessibility/platform/ax_platform_node_cocoa.mm
++++ b/ui/accessibility/platform/ax_platform_node_cocoa.mm
+@@ -1,3 +1,14 @@
++// cmux fork: macOS 26 SDK marks a number of NSAccessibility role and
++// attribute constants (WebAreaRole, BlockQuoteLevelAttribute,
++// VisitedAttribute, ...) as introduced in macOS 26.0. Chromium's
++// deployment target is macOS 11.0, so they fire
++// -Werror,-Wunguarded-availability-new across this file. File-level
++// suppression is the pragmatic choice: this file is OS-level
++// accessibility plumbing and the new symbols just unblock the build.
++// Drop when upstream chromium @available-gates these references or
++// bumps the deployment target.
++#pragma clang diagnostic push
++#pragma clang diagnostic ignored "-Wunguarded-availability-new"
++
+ // Copyright 2018 The Chromium Authors
+ // Use of this source code is governed by a BSD-style license that can be
+ // found in the LICENSE file.
+@@ -EOF,5 +EOF,7 @@
+ // end of file additions:
++
++#pragma clang diagnostic pop

--- a/patches/0005-ax-cocoa-rename-private-symbol-backports.patch
+++ b/patches/0005-ax-cocoa-rename-private-symbol-backports.patch
@@ -1,0 +1,88 @@
+From: cmux fork
+Subject: [PATCH] ui/accessibility: rename anon-namespace SDK-shadow backports in browser_accessibility_cocoa.mm
+
+`ui/accessibility/platform/browser_accessibility_cocoa.mm` defines several
+"private WebKit accessibility" constants in an anonymous namespace as local
+backports for macOS versions where those constants were not in the public
+SDK. The macOS 26.2 SDK now declares the same identifiers publicly
+(@available(macos 26.0)). Unqualified use sites in this file therefore
+trigger:
+
+    error: reference to 'NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute' is ambiguous
+    error: reference to 'NSAccessibilityScrollToVisibleAction' is ambiguous
+
+Unlike patches 0003/0004 (`-Wunguarded-availability-new`), this is a
+hard name-collision error, not a warning -- a diagnostic pragma cannot
+silence it. The minimal fix is to rename the anonymous-namespace
+backports so they no longer shadow the SDK names. The string literal
+values are unchanged, so runtime behavior is preserved, and the file
+keeps working on macOS deployment target 11.0 (Chromium's floor).
+
+Only the two identifiers the SDK now provides are renamed; the other
+private backports in the same anonymous namespace
+(`UIElementCountForSearchPredicate...`, text-marker attrs, value-autofill
+attrs) are left untouched because the SDK does not (yet) collide on them.
+
+Drop when upstream chromium either deletes these backports (now that the
+SDK provides them and the deployment target allows it) or guards them
+with `__has_attribute(availability)` / `@available` checks.
+
+--- a/ui/accessibility/platform/browser_accessibility_cocoa.mm
++++ b/ui/accessibility/platform/browser_accessibility_cocoa.mm
+@@ -74,8 +74,12 @@ namespace {
+ NSString* const
+     NSAccessibilityUIElementCountForSearchPredicateParameterizedAttribute =
+         @"AXUIElementCountForSearchPredicate";
++// cmux fork: renamed from NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute
++// to avoid a name collision with the macOS 26.2 SDK, which now declares the
++// same identifier publicly with @available(macos 26.0). String literal value
++// unchanged.
+ NSString* const
+-    NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute =
++    CmuxNSAccessibilityUIElementsForSearchPredicateParameterizedAttribute =
+         @"AXUIElementsForSearchPredicate";
+
+ // Private attributes for text markers.
+@@ -201,7 +205,9 @@ NSString* const NSAccessibilityValueAutofillAvailableAttribute =
+ // const NSAccessibilityValueAutofillTypeAttribute = @"AXValueAutofillType";
+
+ // Actions.
+-NSString* const NSAccessibilityScrollToVisibleAction = @"AXScrollToVisible";
++// cmux fork: renamed from NSAccessibilityScrollToVisibleAction to avoid a
++// name collision with the macOS 26.2 SDK (introduced in macOS 26.0).
++NSString* const CmuxNSAccessibilityScrollToVisibleAction = @"AXScrollToVisible";
+
+ // A mapping from an accessibility attribute to its method name.
+ NSDictionary* gAttributeToMethodNameMap = nil;
+@@ -2189,7 +2195,7 @@ class V8ScopedHandleScope {
+   if ([attribute
+           isEqualToString:
+-              NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute]) {
++              CmuxNSAccessibilityUIElementsForSearchPredicateParameterizedAttribute]) {
+     return [self accessibilityUIElementsForSearchPredicate:parameter];
+   }
+   if ([attribute isEqualToString:NSAccessibilityCellForColumnAndRowParameterizedAttribute]) {
+@@ -2369,7 +2375,7 @@ class V8ScopedHandleScope {
+   return @[
+     NSAccessibilityUIElementCountForSearchPredicateParameterizedAttribute,
+-    NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute,
++    CmuxNSAccessibilityUIElementsForSearchPredicateParameterizedAttribute,
+     NSAccessibilityEndTextMarkerAttribute,
+     NSAccessibilityStartTextMarkerAttribute,
+     NSAccessibilitySelectedTextMarkerRangeAttribute,
+@@ -2417,7 +2423,7 @@ class V8ScopedHandleScope {
+   return [actions arrayByAddingObjectsFromArray:@[
+                        NSAccessibilityShowMenuAction,
+-                       NSAccessibilityScrollToVisibleAction, nil];
++                       CmuxNSAccessibilityScrollToVisibleAction, nil];
+ }
+
+ - (NSArray*)accessibilityAttributeNames {
+@@ -2720,7 +2726,7 @@ class V8ScopedHandleScope {
+   } else if ([action isEqualToString:NSAccessibilityShowMenuAction]) {
+     [self accessibilityShowMenuAction];
+-  } else if ([action isEqualToString:NSAccessibilityScrollToVisibleAction]) {
++  } else if ([action isEqualToString:CmuxNSAccessibilityScrollToVisibleAction]) {
+     [self accessibilityScrollToVisibleAction];
+   } else {
+     // Do nothing.

--- a/patches/README.md
+++ b/patches/README.md
@@ -24,3 +24,7 @@ Until the fork repo exists, the workflow is:
   default branch to `GetDataTypeByteSize` so the macOS 26.2 SDK's
   new `MLMultiArrayDataType` values (Int8, UInt8, …) don't trip
   `-Werror,-Wswitch`. Drop when upstream lands the proper fix.
+- `0003-ax-inspect-mac-suppress-new-availability.patch` — locally
+  suppresses `-Wunguarded-availability-new` in `IsValidAXAttribute`
+  so the macOS 26-introduced `NSAccessibility*` attribute constants
+  don't break the build when chromium's deployment target is 11.0.

--- a/patches/README.md
+++ b/patches/README.md
@@ -20,3 +20,7 @@ Until the fork repo exists, the workflow is:
   Metal shader compilation under macOS 15 + Xcode 26, where the
   Xcode-shipped metal stub cannot locate the cryptex-mounted Metal
   Toolchain (only `xcrun` can).
+- `0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch` — adds a
+  default branch to `GetDataTypeByteSize` so the macOS 26.2 SDK's
+  new `MLMultiArrayDataType` values (Int8, UInt8, …) don't trip
+  `-Werror,-Wswitch`. Drop when upstream lands the proper fix.

--- a/patches/README.md
+++ b/patches/README.md
@@ -28,3 +28,24 @@ Until the fork repo exists, the workflow is:
   suppresses `-Wunguarded-availability-new` in `IsValidAXAttribute`
   so the macOS 26-introduced `NSAccessibility*` attribute constants
   don't break the build when chromium's deployment target is 11.0.
+- `0004-ax-platform-node-cocoa-suppress-new-availability.patch` —
+  file-level suppression of the same diagnostic in
+  `ax_platform_node_cocoa.mm`, where ~6 spread-out usages would
+  require many per-function pragma pairs.
+
+## Strategic note for next session
+
+These availability-suppression patches (0003, 0004) and the SDK
+forward-compat patches (0001 metal, 0002 webnn) are accumulating
+because the current checkout is at Chromium **main HEAD** (commit
+`72a51d14d794ce9211145ecc9b7464e222d40153`, a ChromeOS LKGM from
+2026-04-16) rather than the **M148 stable branch** the build host
+script targets (`refs/branch-heads/7204`).
+
+The handoff plan was to repoint to `7204` once the fork repo lands.
+Doing it sooner — even before the fork repo exists — would likely
+eliminate most of the SDK-forward-compat noise because M148 stable
+was tested against earlier SDKs. The cost is one git checkout + a
+`gclient sync` (hours, but cached). The benefit is fewer patches to
+maintain. Worth investigating at the start of session 3 as an
+alternative to chasing every new failure.

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,22 @@
+# cmux Chromium fork patches
+
+Patches that must be applied to the upstream Chromium tree to make
+content_shell / cmux_core_framework build on the cmux fork's hosts.
+Each file documents the symptom, target, and rationale. When the fork
+repo at `manaflow-ai/cmux-chromium` exists, these will be committed
+directly to that tree and this directory will become an audit trail
+of what changed and why.
+
+Until the fork repo exists, the workflow is:
+1. Patch lives here in cmuxterm-hq.
+2. `scripts/chromium-build-host.sh` applies it to the build host's
+   `~/chromium-fork/src/` checkout as part of `setup`.
+3. When the fork repo lands, the patches get squashed into the
+   fork's M148 base and this directory is deleted.
+
+## Index
+
+- `0001-angle-metal-wrapper-resolve-via-xcrun.patch` — fixes ANGLE
+  Metal shader compilation under macOS 15 + Xcode 26, where the
+  Xcode-shipped metal stub cannot locate the cryptex-mounted Metal
+  Toolchain (only `xcrun` can).

--- a/patches/README.md
+++ b/patches/README.md
@@ -32,20 +32,26 @@ Until the fork repo exists, the workflow is:
   file-level suppression of the same diagnostic in
   `ax_platform_node_cocoa.mm`, where ~6 spread-out usages would
   require many per-function pragma pairs.
+- `0005-ax-cocoa-rename-private-symbol-backports.patch` — renames
+  anonymous-namespace `NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute`
+  and `NSAccessibilityScrollToVisibleAction` in
+  `browser_accessibility_cocoa.mm` to `CmuxNS…` prefixes. The macOS
+  26.2 SDK now publishes the same identifiers (@available(macos 26.0)),
+  causing a hard *ambiguous reference* compile error that a diagnostic
+  pragma cannot silence. Rename preserves the string-literal values
+  and behavior; older deployment targets still work.
 
-## Strategic note for next session
+## Note on Chromium base
 
-These availability-suppression patches (0003, 0004) and the SDK
-forward-compat patches (0001 metal, 0002 webnn) are accumulating
-because the current checkout is at Chromium **main HEAD** (commit
-`72a51d14d794ce9211145ecc9b7464e222d40153`, a ChromeOS LKGM from
-2026-04-16) rather than the **M148 stable branch** the build host
-script targets (`refs/branch-heads/7204`).
-
-The handoff plan was to repoint to `7204` once the fork repo lands.
-Doing it sooner — even before the fork repo exists — would likely
-eliminate most of the SDK-forward-compat noise because M148 stable
-was tested against earlier SDKs. The cost is one git checkout + a
-`gclient sync` (hours, but cached). The benefit is fewer patches to
-maintain. Worth investigating at the start of session 3 as an
-alternative to chasing every new failure.
+The earlier README revision claimed the checkout was at Chromium main
+HEAD rather than M148 stable, and that switching to `refs/branch-heads/7204`
+would likely eliminate the SDK forward-compat noise. **That claim was
+wrong**: `git ls-remote origin refs/branch-heads/7204` resolves to the
+same commit (`72a51d14d794ce9211145ecc9b7464e222d40153`) that the
+checkout is already on. The HEAD-shaped output of
+`git log --oneline -1` shows `LKGM 16295.95.0 for chromeos.` because
+that LKGM happens to be the tip of `branch-heads/7204` at the time it
+was cut. So M148-stable and "the LKGM the checkout is on" are
+literally the same commit, and there is no cheaper base to switch to.
+The five patches in this directory are needed against M148 stable as
+shipped today.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -205,4 +205,33 @@ Each pattern is now demonstrated; subsequent SDK forward-compat errors should ma
 
 Session 4 should open by checking `~/chromium-fork/build-content-shell.log`'s tail. If `Content Shell.app` exists at `~/chromium-fork/src/out/cmux_release/Content\ Shell.app`, build round 7 succeeded and P0 is decisively done; otherwise diagnose the next failure under the four-pattern taxonomy above.
 
-P1 still requires user permission to create `manaflow-ai/cmux-chromium` org-level repo. Until that exists, the `embedder/` tree cannot move into a real `gn gen` graph and the framework cannot be evaluated end-to-end.
+P1 still requires user permission to create `manaflow-ai/cmux-chromium` org-level repo. Until that exists, the `embedder/` tree cannot ship to its final home in the fork, but **`gn gen` + `gn check` semantic validation against the real M148 dep graph has now been completed** by temporarily dropping it into the cmux-aws-mac chromium-fork checkout (see below).
+
+#### Session 3 follow-up: real `gn gen` + `gn check` validation
+
+After the wakeup-block window, ran the next-most-honest test the advisor suggested: drop the `embedder/` tree into the chromium-fork checkout, hand-modify root `//BUILD.gn`'s `gn_all` group to include `//cmux:cmux_core_framework`, then `gn gen out/cmux-check`. Two real semantic errors surfaced (only catchable via `gn gen`, not via `gn format`):
+
+  1. `Duplicate item "//build/config/compiler:enable_arc" in list` — the default `default_compiler_configs` for `mac_framework_bundle` and `source_set` already includes `enable_arc`. Adding it explicitly is a duplicate. Fixed: dropped the `configs +=` lines from both `cmux_BUILD.gn` and `embedder/BUILD.gn`.
+  2. `//cmux:cmux_core_framework_shared_library which is NOT marked testonly can't depend on //mojo:mojo which is marked testonly` — `//mojo` is a top-level testonly umbrella; non-testonly framework deps must use granular subtargets. Fixed for the stub build by removing both `//mojo` and `//services/network/public/mojom` from the framework deps (the sentinel C ABI doesn't need them); annotated with a comment about which granular subtargets come back when real //content wiring lands.
+
+After those two fixes, `gn gen` succeeded:
+
+```
+Done. Made 27405 targets from 4066 files in 9952ms
+```
+
+`gn check` then passed for every cmux target this BUILD.gn pair defines:
+
+  - `//cmux:cmux_core_framework` → Header dependency check OK
+  - `//cmux:cmux_helper_app_default` → OK
+  - `//cmux:cmux_helper_app_renderer` → OK
+  - `//cmux:cmux_helper_app_gpu` → OK
+  - `//cmux:cmux_helper_app_plugin` → OK
+  - `//cmux:cmux_helpers` → OK
+  - `//cmux/embedder:embedder` → OK
+
+The chromium-fork tree was reverted (root `//BUILD.gn` restored from backup) so the running content_shell build remains undisturbed. Pulled the fixed `embedder/BUILD.gn` and `embedder/cmux_BUILD.gn` back to the worktree as canonical.
+
+**This decisively rules out the previously-suspected class of BUILD.gn correctness errors.** Any remaining BUILD.gn risk is in semantic categories that `gn gen` + `gn check` do not exercise (ninja linker step, runtime framework loading, ABI-version assertion at framework load). Those are gated on writing real `//content` consumers and on the fork repo existing.
+
+When the fork repo lands, the BUILD.gn pair drops in *as-is*; the only sequenced step the fork repo needs to absorb beyond the file drop is the one-line addition to root `//BUILD.gn`'s `gn_all` group entry (`"//cmux:cmux_core_framework",`).

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -4,7 +4,7 @@ Read this first when starting any session on `feat-chromium-engine`. Append a ne
 
 ## Next steps (always current)
 
-- [ ] Confirm the `:base` smoke build finished green on `cmux-aws-mac` (started 2026-05-14 session 1). Check `cat ~/chromium-fork/build-base.log` and that `ninja: build stopped` is absent. If failed, debug toolchain (Xcode CLT path, sysroot) before proceeding.
+- [x] Confirm the `:base` smoke build finished green on `cmux-aws-mac`. ✅ 2026-05-14 session 1: `1m33.11s Build Succeeded: 2192 steps - 23.54/s` in `~/chromium-fork/build-base.log`. Toolchain validated end-to-end.
 - [ ] Build `content_shell` next: `./scripts/chromium-build-host.sh build content_shell`. Roughly 30-60 min on M1 Ultra at -j16. This is upstream's minimal embedder; if it builds, the fork's `cmux_core_framework` target will too.
 - [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux's main target picks it up. Today the package compiles standalone but isn't a dependency. Pattern: see how `Packages/CMUXAuthCore` is referenced in `project.pbxproj`.
 - [ ] Continue Packages/CmuxBrowserEngine expansions from `plans/wkwebview-surface-audit.md` "Migration order recommended". DONE so far: KVO/Combine mirrors, pageZoom. NEXT: CmuxDataStore + CmuxCookieStore (wraps `WKWebsiteDataStore(forIdentifier:)` and `httpCookieStore` — see `Sources/Panels/BrowserPanel.swift:383-3010` for the cmux-specific profile/data-store dance that needs neutralizing).
@@ -85,9 +85,24 @@ User set `/goal i have reviewed it, use your best judgment and implement fully` 
 - Wrote `plans/cmux-embedder-c-abi.md` (C ABI sketch the cmux Chromium fork will export).
 - Kicked off `gclient sync` on `cmux-aws-mac`. First attempt died because macOS `nohup` doesn't support ssh-exec heredoc (no real tty). Fixed the script to use the subshell-then-background pattern, restarted. **Fetch completed: 26 GB, all runhooks ran, exit clean.**
 - Ran `gn gen out/cmux_release`: success, 27,361 targets parsed from 4,064 .gn files.
-- Kicked off `:base` smoke build via `autoninja` in a detached subshell; monitor armed. (Outcome captured in `~/chromium-fork/build-base.log`; check on session-2 entry.)
+- Kicked off `:base` smoke build via `autoninja` in a detached subshell. **Result: `1m33.11s Build Succeeded: 2192 steps - 23.54/s`.** Toolchain validated: Xcode CLT, sysroot, siso, ANGLE shaders, base/ all compile. Artifact `out/cmux_release/obj/base/...` confirmed.
 - **Did not** create `manaflow-ai/cmux-chromium` GitHub repo (needs user OK).
 - **Did not** wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` (pbxproj edits are touchy; deferred).
-- Pushed five commits to `feat-chromium-engine`; draft PR #4159 has them.
+- **Did not** implement the Chromium backend. `ChromiumBrowserBackend` is still the documented stub.
+- **Did not** take screenshots of Chromium-in-cmux (cannot — backend unimplemented, package unwired).
+- Pushed six commits to `feat-chromium-engine`; draft PR #4159 has them.
 
-Next session: see "Next steps" above. Start by verifying the `:base` build finished green.
+### What session 1 proved vs did not prove
+
+Proved:
+- Engine-neutral Swift wrapper compiles and tests pass against WebKit backend (19/19, 0 warnings, swift 6 strict).
+- Chromium toolchain on `cmux-aws-mac` is sound: fetch (26 GB) → `gn gen` (27,361 targets) → `autoninja :base` (clean build) all green.
+- The architectural seam (CmuxBrowserEngine package + backend protocol + Chromium stub) is shaped so a Chromium backend can drop in without touching cmux call sites.
+
+Did NOT prove:
+- The Chromium backend works. It's a `fatalError` stub.
+- CmuxBrowserEngine is reachable from cmux. `GhosttyTabs.xcodeproj` does not depend on the package yet.
+- Anything renders inside cmux from Chromium. No screenshots possible until P1-P3 land.
+- The fork repo exists. `manaflow-ai/cmux-chromium` is not created; the embedder C ABI is design-only.
+
+Next session: see "Next steps" above. Start with `content_shell` build to validate the wider Chromium target graph before the fork-specific `cmux_core_framework` target.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -121,19 +121,33 @@ Continued under the same `/goal i have reviewed it, use your best judgment and i
   - **CmuxDownload** + **CmuxDownloadDelegate** (step 4) — engine-neutral wrapper around `WKDownload`/`WKDownloadDelegate`. Strong-references shims per-WKDownload and clears them in terminal callbacks. `CmuxNavigationDelegate` gains `didBecome download` extensions; backend's nav bridge invokes them.
   - **CmuxSnapshotConfiguration** (step 6) — bridges `WKSnapshotConfiguration` (rect, snapshotWidth, afterScreenUpdates). `CmuxBrowserView.takeSnapshot(configuration:completionHandler:)` overload added.
 - **Tests:** 32 total (was 19), all green, 0 warnings, swift 6 strict concurrency.
+- Round 4 of content_shell hit `services/webnn/coreml/utils_coreml.mm`: macOS 26.2 SDK introduced new `MLMultiArrayDataType` enumerators that upstream chromium HEAD hasn't enumerated. `-Werror,-Wswitch` broke. Wrote `patches/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch` (adds a default branch returning 0; webnn isn't on cmux's critical path). Wired into `apply-patches`. Restarted round 4 with both patches applied; build progressing through V8 base when monitors were killed for high event volume.
+- Staged drop-in-ready artifacts for the future fork repo under `embedder/`:
+  - `embedder/cmux_browser.h` — full v1 C ABI as a real header (not just a sketch in markdown).
+  - `embedder/BUILD.gn` — `//cmux/embedder:embedder` + `:embedder_headers` source sets.
+  - `embedder/cmux_BUILD.gn` — `//cmux:cmux_core_framework` mac_framework_bundle plus the four helpers (renderer/gpu/plugin/main) re-instantiated with cmux bundle IDs.
+  - `embedder/branding/cmux_core_framework-Info.plist` — Info.plist for `CmuxCore.framework`. Substitutions match `cmux_BUILD.gn`.
+  - `embedder/branding/cmux_helper-Info.plist` — Info.plist for the four helpers; mirrors upstream `chrome/app/helper-Info.plist`.
+  - `embedder/CHANGELOG.md` — ABI v1 surface frozen; what's intentionally out of v1 listed.
+  - `embedder/README.md` — index + the mapping from this directory to the fork's `src/cmux/`.
+- Updated `plans/chromium-engine.md`: P0 marked DONE, P1 marked in-progress and gated on fork repo creation, P2 Swift surface marked DONE with C-side gated on fork repo.
+- Updated `plans/wkwebview-surface-audit.md`: migration order steps 1-4 + 6 marked ✅ shipped; only step 5 (CmuxInspector) remains and is explicitly deferred-last.
 - **Did not** wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` (deferred again — pbxproj edits warrant their own session).
 - **Did not** implement `CmuxInspector` (step 5 in the audit is explicitly last).
 - **Did not** create `manaflow-ai/cmux-chromium` (still needs user OK).
-- Pushed 5 commits to `feat-chromium-engine`; draft PR #4159 has them.
+- **Did not** implement the .mm/.cc impl files (cmux_browser.mm, cmux_view.cc, cmux_session.cc, cmux_profile.cc, cmux_layer_host.mm) — those go straight into the fork rather than staging here; they need content/ as a build-resolvable dep.
+- Pushed 16 commits to `feat-chromium-engine`; draft PR #4159 has them all.
 
 #### What session 2 added to "proved"
 
-- ANGLE Metal shader compilation now works on this host class (the patched wrapper is verified by a successful `:angle_metal_internal_shaders_to_*` step).
+- ANGLE Metal shader compilation works on this host class (patched wrapper verified by successful `:angle_metal_internal_shaders_to_*` steps producing 149 KB `.air` + 359 KB `.metallib`).
+- webnn CoreML compile is unstuck on macOS 26.2 SDK (utils_coreml.o builds at 131 KB after patch #2).
 - Engine-neutral wrappers exist for: data store, cookie store, downloads, snapshot config (in addition to nav, UI, scripts, scheme handlers, state mirror, pageZoom).
-- The fork's `patches/` directory is the durable home for chromium-side patches; `scripts/chromium-build-host.sh apply-patches` is idempotent and exercised.
+- The fork's `patches/` directory is the durable home for chromium-side patches; `scripts/chromium-build-host.sh apply-patches` is idempotent and exercised twice (against both patches).
+- `embedder/` directory holds the complete set of drop-in-ready files for the moment the fork repo exists: C ABI header, both BUILD.gn files (source set + framework), both branding plists (framework + helpers), CHANGELOG, README. The fork's first P1 build only needs the .mm/.cc impl files written.
 
 #### What session 2 did NOT prove
 
-- `content_shell` itself building green end-to-end. Round 3 was still in flight at session 2 close; verify on next session via `tail ~/chromium-fork/build-content-shell.log` and `ls ~/chromium-fork/src/out/cmux_release/Content\ Shell.app`.
+- `content_shell` itself building green end-to-end. Round 4 was in flight at session-2 close (last seen ~1252/20438 steps, no failures). Verify next session via `tail ~/chromium-fork/build-content-shell.log` and `ls ~/chromium-fork/src/out/cmux_release/Content\ Shell.app/Contents/MacOS/`. **If another forward-compat error fires**, follow the same patch-discipline: capture as a numbered patch under `patches/`, wire into `apply-patches`, restart.
 - CmuxBrowserEngine is still **not** linked into `GhosttyTabs.xcodeproj`. The package compiles in isolation but cmux's main target still uses raw WKWebView.
-- The Chromium backend is still a `fatalError` stub. No screenshots of "Chromium-in-cmux" possible.
+- The Chromium backend is still a `fatalError` stub. No screenshots of "Chromium-in-cmux" possible until P1's impl files land in the fork.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -4,11 +4,11 @@ Read this first when starting any session on `feat-chromium-engine`. Append a ne
 
 ## Next steps (always current)
 
-- [x] Confirm the `:base` smoke build finished green on `cmux-aws-mac`. ✅ 2026-05-14 session 1: `1m33.11s Build Succeeded: 2192 steps - 23.54/s` in `~/chromium-fork/build-base.log`. Toolchain validated end-to-end.
-- [ ] Build `content_shell` next: `./scripts/chromium-build-host.sh build content_shell`. Roughly 30-60 min on M1 Ultra at -j16. This is upstream's minimal embedder; if it builds, the fork's `cmux_core_framework` target will too.
-- [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux's main target picks it up. Today the package compiles standalone but isn't a dependency. Pattern: see how `Packages/CMUXAuthCore` is referenced in `project.pbxproj`.
-- [ ] Continue Packages/CmuxBrowserEngine expansions from `plans/wkwebview-surface-audit.md` "Migration order recommended". DONE so far: KVO/Combine mirrors, pageZoom. NEXT: CmuxDataStore + CmuxCookieStore (wraps `WKWebsiteDataStore(forIdentifier:)` and `httpCookieStore` — see `Sources/Panels/BrowserPanel.swift:383-3010` for the cmux-specific profile/data-store dance that needs neutralizing).
-- [ ] Create the Chromium fork repo `manaflow-ai/cmux-chromium` (requires user permission to create org-level repo). Once created, push the M148 base commit + an empty `//cmux/embedder/` skeleton matching the C ABI in `plans/cmux-embedder-c-abi.md`.
+- [x] Confirm the `:base` smoke build finished green on `cmux-aws-mac`. ✅ 2026-05-14 session 1: `1m33.11s Build Succeeded: 2192 steps - 23.54/s`.
+- [ ] Verify the `content_shell` build (started session 2 with metal patch). Build log at `~/chromium-fork/build-content-shell.log`. Round 3 of the build is in flight as of session 2 close. Once it lands green, the wider Chromium target graph is proven.
+- [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux's main target picks it up. Today the package compiles standalone (32 tests green) but isn't a dependency. Pattern: see how `Packages/CMUXAuthCore` is referenced in `project.pbxproj`.
+- [ ] Migrate audit step 5: `CmuxInspector` (the only remaining migration-order item — explicitly last because the inspector is its own subsystem).
+- [ ] Create the Chromium fork repo `manaflow-ai/cmux-chromium` (requires user permission to create org-level repo). Once created, push the M148 base commit + an empty `//cmux/embedder/` skeleton matching the C ABI in `plans/cmux-embedder-c-abi.md`. Patches in `patches/` get squashed in at that point.
 - [ ] Once the fork repo exists, push `//cmux/embedder/cmux_browser.h` (from `plans/cmux-embedder-c-abi.md`) and the matching `BUILD.gn` for a `cmux_core_framework` target. First real build with that target = end of P1.
 
 ## Active milestone
@@ -106,3 +106,34 @@ Did NOT prove:
 - The fork repo exists. `manaflow-ai/cmux-chromium` is not created; the embedder C ABI is design-only.
 
 Next session: see "Next steps" above. Start with `content_shell` build to validate the wider Chromium target graph before the fork-specific `cmux_core_framework` target.
+
+### Session 2 — 2026-05-14 (content_shell + package expansions)
+
+Continued under the same `/goal i have reviewed it, use your best judgment and implement fully` stop-hook from session 1.
+
+- Kicked off `content_shell` build. Round 1 died at `//third_party/angle/.../metal:angle_metal_internal_shaders_to_air` with `error: cannot execute tool 'metal' due to missing Metal Toolchain`. Root cause: macOS 15 + Xcode 26 ships the Metal compiler toolchain as a separate downloadable component mounted under `/var/run/com.apple.security.cryptexd/.../Metal.xctoolchain/usr/bin/`; the Xcode stub at `XcodeDefault.xctoolchain/usr/bin/metal{,lib}` does NOT auto-locate that mount. `xcrun --find <tool>` does. Worse, `metallib` doesn't even exist as a stub.
+- Wrote `patches/0001-angle-metal-wrapper-resolve-via-xcrun.patch` and applied it to the host's checkout: ANGLE's `metal_wrapper.py` now detects the broken Xcode metal-family stub paths and xcrun-resolves the real binary. Round 2 still hit the same wrapper for `metallib`; round 3 covers both. After the third restart, `.air` (149 KB) and `.metallib` (359 KB) produce cleanly and content_shell is compiling through the wider target graph.
+- Added `apply-patches` subcommand to `scripts/chromium-build-host.sh` so a fresh build host can be one-shot-patched.
+- Continued audit migration order in `Packages/CmuxBrowserEngine`:
+  - **CmuxDataStore** (step 3) — wraps `WKWebsiteDataStore` with `.default()`, `.nonPersistent()`, `.forIdentifier(UUID)`. Lazy `cookieStore` accessor. `allDataTypes()` static. `removeData(ofTypes:modifiedSince:)` async.
+  - **CmuxCookieStore** (step 3) — wraps `WKHTTPCookieStore` with `allCookies/setCookie/deleteCookie/addObserver/removeObserver`. Private WK observer shim dispatches `cookiesDidChange(in:)`.
+  - `CmuxBrowserConfiguration.dataStore` plumbed into `WKWebViewConfiguration.websiteDataStore`.
+  - **CmuxDownload** + **CmuxDownloadDelegate** (step 4) — engine-neutral wrapper around `WKDownload`/`WKDownloadDelegate`. Strong-references shims per-WKDownload and clears them in terminal callbacks. `CmuxNavigationDelegate` gains `didBecome download` extensions; backend's nav bridge invokes them.
+  - **CmuxSnapshotConfiguration** (step 6) — bridges `WKSnapshotConfiguration` (rect, snapshotWidth, afterScreenUpdates). `CmuxBrowserView.takeSnapshot(configuration:completionHandler:)` overload added.
+- **Tests:** 32 total (was 19), all green, 0 warnings, swift 6 strict concurrency.
+- **Did not** wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` (deferred again — pbxproj edits warrant their own session).
+- **Did not** implement `CmuxInspector` (step 5 in the audit is explicitly last).
+- **Did not** create `manaflow-ai/cmux-chromium` (still needs user OK).
+- Pushed 5 commits to `feat-chromium-engine`; draft PR #4159 has them.
+
+#### What session 2 added to "proved"
+
+- ANGLE Metal shader compilation now works on this host class (the patched wrapper is verified by a successful `:angle_metal_internal_shaders_to_*` step).
+- Engine-neutral wrappers exist for: data store, cookie store, downloads, snapshot config (in addition to nav, UI, scripts, scheme handlers, state mirror, pageZoom).
+- The fork's `patches/` directory is the durable home for chromium-side patches; `scripts/chromium-build-host.sh apply-patches` is idempotent and exercised.
+
+#### What session 2 did NOT prove
+
+- `content_shell` itself building green end-to-end. Round 3 was still in flight at session 2 close; verify on next session via `tail ~/chromium-fork/build-content-shell.log` and `ls ~/chromium-fork/src/out/cmux_release/Content\ Shell.app`.
+- CmuxBrowserEngine is still **not** linked into `GhosttyTabs.xcodeproj`. The package compiles in isolation but cmux's main target still uses raw WKWebView.
+- The Chromium backend is still a `fatalError` stub. No screenshots of "Chromium-in-cmux" possible.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -4,23 +4,25 @@ Read this first when starting any session on `feat-chromium-engine`. Append a ne
 
 ## Next steps (always current)
 
-- [ ] Run `./scripts/chromium-build-host.sh fetch` to begin the Chromium fetch on `cmux-aws-mac`. Pinned to Chromium M148 stable (`refs/branch-heads/7204`). Mac-only shallow checkout. Disk on host is tight (155 GB free, ~80–100 GB expected), so monitor `./scripts/chromium-build-host.sh status` during the fetch.
-- [ ] After fetch completes: run `./scripts/chromium-build-host.sh build content_shell` to validate the toolchain. `content_shell` is upstream's minimal embedder; if it builds, the fork's cmux-specific target will too.
-- [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux builds against it. Today the package compiles standalone but isn't a dependency of the cmux target. Pattern: see how `Packages/CMUXAuthCore` is wired in `project.pbxproj`.
-- [ ] Begin Packages/CmuxBrowserEngine expansions called out in `plans/wkwebview-surface-audit.md` "Migration order recommended": KVO/Combine mirrors → pageZoom → CmuxDataStore + CmuxCookieStore → CmuxDownload → CmuxInspector.
+- [ ] Confirm the `:base` smoke build finished green on `cmux-aws-mac` (started 2026-05-14 session 1). Check `cat ~/chromium-fork/build-base.log` and that `ninja: build stopped` is absent. If failed, debug toolchain (Xcode CLT path, sysroot) before proceeding.
+- [ ] Build `content_shell` next: `./scripts/chromium-build-host.sh build content_shell`. Roughly 30-60 min on M1 Ultra at -j16. This is upstream's minimal embedder; if it builds, the fork's `cmux_core_framework` target will too.
+- [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux's main target picks it up. Today the package compiles standalone but isn't a dependency. Pattern: see how `Packages/CMUXAuthCore` is referenced in `project.pbxproj`.
+- [ ] Continue Packages/CmuxBrowserEngine expansions from `plans/wkwebview-surface-audit.md` "Migration order recommended". DONE so far: KVO/Combine mirrors, pageZoom. NEXT: CmuxDataStore + CmuxCookieStore (wraps `WKWebsiteDataStore(forIdentifier:)` and `httpCookieStore` — see `Sources/Panels/BrowserPanel.swift:383-3010` for the cmux-specific profile/data-store dance that needs neutralizing).
 - [ ] Create the Chromium fork repo `manaflow-ai/cmux-chromium` (requires user permission to create org-level repo). Once created, push the M148 base commit + an empty `//cmux/embedder/` skeleton matching the C ABI in `plans/cmux-embedder-c-abi.md`.
+- [ ] Once the fork repo exists, push `//cmux/embedder/cmux_browser.h` (from `plans/cmux-embedder-c-abi.md`) and the matching `BUILD.gn` for a `cmux_core_framework` target. First real build with that target = end of P1.
 
 ## Active milestone
 
-**P1 — Custom framework target.** P0 (toolchain) is done; P1 starts when the fork repo exists and the first `gn gen` succeeds with a `cmux_core_framework` target.
+**P1 — Custom framework target.** P0 (toolchain, fetch, gn gen) done. P1 starts when the fork repo exists and `cmux_core_framework` builds.
 
 ## Build host state
 
 - Host: `cmux-aws-mac` (M1 Ultra, 20 cores, 128 GB RAM, macOS 15.7.4, Xcode 26.3).
-- Disk situation: only 155 GB free on `/System/Volumes/Data` (the user's home). The 994 GB `disk3s4` volume mounted at `/private/tmp/tmp-mount-TOmSsz` is the **macOS firmware update volume** — held by `com.apple.MobileSoftwareUpdate.CleanupPreparePathService` and reformatted on OS updates. We do NOT use it. Renamed it to `Chromium` for clarity but the volume itself remains owned by the OS update system.
-- Other AWS Mac state to note (do **not** touch): `/Users/ec2-user/chromium` (70 GB, prior unrelated project), `/Users/ec2-user/actions-runner-chromium-*` (GitHub Actions runners for that other project). Per the user's directive: ignore everything there. We use `/Users/ec2-user/chromium-fork` (fresh) for this project.
-- depot_tools: installed at `/Users/ec2-user/depot_tools`, on PATH via `~/.zshrc` (managed by `./scripts/chromium-build-host.sh setup`).
-- Chromium fork checkout: not started; will live at `/Users/ec2-user/chromium-fork`.
+- Disk: 128 GB free on `/System/Volumes/Data` (was 155 GB before the fetch; the checkout is 26 GB). Comfortable margin remains for a content_shell build (~10 GB build output) and a cmux_core_framework build (~15 GB). Tight for `chrome` itself.
+- The 994 GB `disk3s4` volume is the **macOS firmware update volume** — held by `com.apple.MobileSoftwareUpdate.CleanupPreparePathService` and reformatted on OS updates. Renamed it `Chromium` for clarity, do not put a checkout on it.
+- Other AWS Mac state to ignore (per user directive): `/Users/ec2-user/chromium` (70 GB, prior unrelated project), `/Users/ec2-user/actions-runner-chromium-*` (GitHub Actions runners for that other project). Our fork lives at `/Users/ec2-user/chromium-fork`.
+- depot_tools: installed at `/Users/ec2-user/depot_tools`, on PATH via `~/.zshrc`.
+- Chromium fork checkout: **fetched** at `/Users/ec2-user/chromium-fork`. Tracks Chromium main HEAD as of 2026-05-14, will be re-pointed to `refs/branch-heads/7204` (M148 stable) once the fork repo exists. `gn gen out/cmux_release` succeeds (27,361 targets from 4,064 .gn files).
 
 ## Open blockers
 
@@ -69,18 +71,23 @@ cat plans/chromium-engine-handoff.md
 - **Did not** install depot_tools, **did not** fetch Chromium. Decision: wait for user to confirm scope.
 - Opened draft PR #4159.
 
-### Session 1 — 2026-05-14 (scaffolding)
+### Session 1 — 2026-05-14 (scaffolding + fetch)
+
+User set `/goal i have reviewed it, use your best judgment and implement fully` after reviewing PR #4159. Stop-hook stayed armed throughout the session.
 
 - User confirmed scope (Dia-strategy, full Chromium fork) and approved `/loop`-paced multi-session work.
-- Investigated `disk3s4`: it is the macOS firmware update volume. **Rejected** for Chromium checkout. Pivoted to `/Users/ec2-user` (155 GB free).
+- Investigated `disk3s4`: it is the macOS firmware update volume. **Rejected** for Chromium checkout. Pivoted to `/Users/ec2-user` (155 GB free at start, 128 GB after fetch).
 - Discovered an in-flight Atlas-strategy `cmux-browser` project at `worktrees/task-cmux-browser-pure-mojo/` (127 tests, working dogfood, active Chromium-side work on AWS Mac). Surfaced to user; user directed to **ignore** it and build a new project from scratch with a new Chromium fork. Atlas-project artifacts on AWS Mac (`~/chromium`, `~/actions-runner-chromium-*`) are left untouched.
 - Installed `depot_tools` at `/Users/ec2-user/depot_tools`, fixed `~/.zshrc` perms.
 - Built `scripts/chromium-build-host.sh` (idempotent: setup, remount, fetch, status, build).
-- Built `Packages/CmuxBrowserEngine` SwiftPM package — engine-neutral API surface mirroring WKWebView. WebKit backend is production-shaped; Chromium backend is a documented stub. **16 tests passing, 0 warnings, swift 6 strict concurrency.**
+- Built `Packages/CmuxBrowserEngine` SwiftPM package — engine-neutral API surface mirroring WKWebView. WebKit backend is production-shaped; Chromium backend is a documented stub. Wrapper covers: configuration, navigation delegate, UI delegate, user content controller, script message handler, URL scheme handler, state mirrors (Combine), pageZoom. **19 tests passing, 0 warnings, swift 6 strict concurrency.**
 - Wrote `plans/wkwebview-surface-audit.md` (every WK API cmux uses + migration order).
 - Wrote `plans/cmux-embedder-c-abi.md` (C ABI sketch the cmux Chromium fork will export).
-- **Did not** start the fetch (commits this session first so progress is durable; fetch is the first session-2 task).
+- Kicked off `gclient sync` on `cmux-aws-mac`. First attempt died because macOS `nohup` doesn't support ssh-exec heredoc (no real tty). Fixed the script to use the subshell-then-background pattern, restarted. **Fetch completed: 26 GB, all runhooks ran, exit clean.**
+- Ran `gn gen out/cmux_release`: success, 27,361 targets parsed from 4,064 .gn files.
+- Kicked off `:base` smoke build via `autoninja` in a detached subshell; monitor armed. (Outcome captured in `~/chromium-fork/build-base.log`; check on session-2 entry.)
 - **Did not** create `manaflow-ai/cmux-chromium` GitHub repo (needs user OK).
-- Pushed three commits to `feat-chromium-engine`, draft PR #4159 has them.
+- **Did not** wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` (pbxproj edits are touchy; deferred).
+- Pushed five commits to `feat-chromium-engine`; draft PR #4159 has them.
 
-Next session: see "Next steps" above.
+Next session: see "Next steps" above. Start by verifying the `:base` build finished green.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -151,3 +151,18 @@ Continued under the same `/goal i have reviewed it, use your best judgment and i
 - `content_shell` itself building green end-to-end. Round 4 was in flight at session-2 close (last seen ~1252/20438 steps, no failures). Verify next session via `tail ~/chromium-fork/build-content-shell.log` and `ls ~/chromium-fork/src/out/cmux_release/Content\ Shell.app/Contents/MacOS/`. **If another forward-compat error fires**, follow the same patch-discipline: capture as a numbered patch under `patches/`, wire into `apply-patches`, restart.
 - CmuxBrowserEngine is still **not** linked into `GhosttyTabs.xcodeproj`. The package compiles in isolation but cmux's main target still uses raw WKWebView.
 - The Chromium backend is still a `fatalError` stub. No screenshots of "Chromium-in-cmux" possible until P1's impl files land in the fork.
+
+#### Strategic note for session 3
+
+The `patches/` directory grew from 1 entry (session 1's metal-toolchain xcrun-resolve) to 4 entries during session 2:
+
+  - 0001 metal-wrapper xcrun-resolve (ANGLE)
+  - 0002 webnn CoreML `MLMultiArrayDataType` default-branch
+  - 0003 ax inspect availability suppression (function-scoped)
+  - 0004 ax_platform_node_cocoa availability suppression (file-scoped)
+
+Patches 0002-0004 are all macOS-26-SDK forward-compat issues. The current checkout is at Chromium **main HEAD** (commit `72a51d14d794ce9211145ecc9b7464e222d40153`, a ChromeOS LKGM from 2026-04-16) — NOT at M148 stable (`refs/branch-heads/7204`) the build host script declares as its target branch.
+
+Hypothesis for session 3: **before chasing more SDK forward-compat patches, switch the checkout to `refs/branch-heads/7204` and re-run `gclient sync`.** M148 stable was tested against earlier SDKs and likely compiles cleanly under macOS 26.2 with only patch 0001 (the cryptex Metal-toolchain issue is OS-level, not chromium-version-specific). Cost: one git checkout + gclient sync (hours, but cached). Benefit: fewer patches to maintain across upstream rebases.
+
+If session 3 takes that path: `patches/0002`–`patches/0004` may be removable. Validate by attempting the build without them after the branch switch.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -4,48 +4,83 @@ Read this first when starting any session on `feat-chromium-engine`. Append a ne
 
 ## Next steps (always current)
 
-- [ ] Get plan PR reviewed and approved (or at least eyes on it) so cost/scope is acknowledged.
-- [ ] On `cmux-aws-mac`: rename `disk3s4` to `Chromium` and document the remount procedure (`diskutil mount /dev/disk3s4`, target `/Volumes/Chromium`). Add to `scripts/` if cmuxterm-hq's `scripts/` is the right home, or to a build-host-local doc.
-- [ ] Install `depot_tools` on the persistent volume at `<persistent>/depot_tools`. Export `PATH` in `~/.zshrc`.
-- [ ] Kick off `fetch chromium` in a `Bash run_in_background` with a Monitor armed for `.gclient_entries` appearance and process exit. Expect 4–12 hours.
-- [ ] After fetch: pick a Chromium release branch to track (recommend latest stable when work starts; record the commit SHA in this doc).
-- [ ] First clean `chrome` build (target: full release build under 3 hours on M1 Ultra).
+- [ ] Run `./scripts/chromium-build-host.sh fetch` to begin the Chromium fetch on `cmux-aws-mac`. Pinned to Chromium M148 stable (`refs/branch-heads/7204`). Mac-only shallow checkout. Disk on host is tight (155 GB free, ~80–100 GB expected), so monitor `./scripts/chromium-build-host.sh status` during the fetch.
+- [ ] After fetch completes: run `./scripts/chromium-build-host.sh build content_shell` to validate the toolchain. `content_shell` is upstream's minimal embedder; if it builds, the fork's cmux-specific target will too.
+- [ ] Wire CmuxBrowserEngine into `GhosttyTabs.xcodeproj` so cmux builds against it. Today the package compiles standalone but isn't a dependency of the cmux target. Pattern: see how `Packages/CMUXAuthCore` is wired in `project.pbxproj`.
+- [ ] Begin Packages/CmuxBrowserEngine expansions called out in `plans/wkwebview-surface-audit.md` "Migration order recommended": KVO/Combine mirrors → pageZoom → CmuxDataStore + CmuxCookieStore → CmuxDownload → CmuxInspector.
+- [ ] Create the Chromium fork repo `manaflow-ai/cmux-chromium` (requires user permission to create org-level repo). Once created, push the M148 base commit + an empty `//cmux/embedder/` skeleton matching the C ABI in `plans/cmux-embedder-c-abi.md`.
 
 ## Active milestone
 
-**P0 — Build host and toolchain.** All P1+ items are blocked on P0.
+**P1 — Custom framework target.** P0 (toolchain) is done; P1 starts when the fork repo exists and the first `gn gen` succeeds with a `cmux_core_framework` target.
 
 ## Build host state
 
 - Host: `cmux-aws-mac` (M1 Ultra, 20 cores, 128 GB RAM, macOS 15.7.4, Xcode 26.3).
-- Persistent volume: `disk3s4`, 994 GB total / 972 GB free, currently mounted at `/private/tmp/tmp-mount-TOmSsz`.
-- Risk: that mount point is a non-standard path; the volume is persistent but the mount may not auto-recreate after reboot. Confirm `diskutil mount disk3s4` works on a reboot before relying on it.
-- depot_tools: not installed yet.
-- Chromium checkout: not started.
+- Disk situation: only 155 GB free on `/System/Volumes/Data` (the user's home). The 994 GB `disk3s4` volume mounted at `/private/tmp/tmp-mount-TOmSsz` is the **macOS firmware update volume** — held by `com.apple.MobileSoftwareUpdate.CleanupPreparePathService` and reformatted on OS updates. We do NOT use it. Renamed it to `Chromium` for clarity but the volume itself remains owned by the OS update system.
+- Other AWS Mac state to note (do **not** touch): `/Users/ec2-user/chromium` (70 GB, prior unrelated project), `/Users/ec2-user/actions-runner-chromium-*` (GitHub Actions runners for that other project). Per the user's directive: ignore everything there. We use `/Users/ec2-user/chromium-fork` (fresh) for this project.
+- depot_tools: installed at `/Users/ec2-user/depot_tools`, on PATH via `~/.zshrc` (managed by `./scripts/chromium-build-host.sh setup`).
+- Chromium fork checkout: not started; will live at `/Users/ec2-user/chromium-fork`.
 
 ## Open blockers
 
-None as of session 0.
+- Need user OK to create `manaflow-ai/cmux-chromium` GitHub repo (org-level repo creation).
 
 ## Open PRs
 
-- Draft PR (to be opened in session 0): plan-only, `feat-chromium-engine` → `main`.
+- https://github.com/manaflow-ai/cmux/pull/4159 (draft) — `feat-chromium-engine` → `main`. Contains the plan docs, CmuxBrowserEngine package, build-host script, audit, C ABI design. Should not be merged yet; it's the durable home for the spike's planning + scaffolding.
 
 ## Useful commands
 
-- Re-enter worktree: `cd /Users/lawrence/fun/cmuxterm-hq/worktrees/feat-chromium-engine`
-- SSH to build host: `ssh cmux-aws-mac`
-- Check build-host disk: `ssh cmux-aws-mac 'df -h /private/tmp/tmp-mount-TOmSsz'`
-- Read this ledger: `cat plans/chromium-engine-handoff.md`
+```bash
+# Re-enter worktree
+cd /Users/lawrence/fun/cmuxterm-hq/worktrees/feat-chromium-engine
+
+# Build host operations (idempotent)
+./scripts/chromium-build-host.sh status
+./scripts/chromium-build-host.sh setup
+./scripts/chromium-build-host.sh fetch
+./scripts/chromium-build-host.sh build cmux_core_framework
+
+# CmuxBrowserEngine package
+cd Packages/CmuxBrowserEngine && swift test
+
+# Read the ledger
+cat plans/chromium-engine-handoff.md
+```
+
+## Useful files
+
+- `plans/chromium-engine.md` — master plan: architecture, milestones, risk register.
+- `plans/wkwebview-surface-audit.md` — every WK API cmux touches; migration order.
+- `plans/cmux-embedder-c-abi.md` — C ABI design for the Chromium fork's `//cmux/embedder/`.
+- `Packages/CmuxBrowserEngine/` — engine-neutral Swift wrapper (compiles today on WebKit).
+- `scripts/chromium-build-host.sh` — bootstrap + run commands for `cmux-aws-mac`.
 
 ## Session log
 
-### Session 0 — 2026-05-14
+### Session 0 — 2026-05-14 (planning)
 
-- Verified `cmux-aws-mac` reachable, specs (M1 Ultra, 128 GB, Xcode 26.3).
-- Identified persistent storage candidate (`disk3s4`, 972 GB free).
+- Verified `cmux-aws-mac` reachable (M1 Ultra, 128 GB, Xcode 26.3).
+- Identified persistent storage candidate `disk3s4`.
 - Created worktree `feat-chromium-engine` off `origin/main` at `791318f5a`.
-- Drafted `plans/chromium-engine.md` (this directory) with architecture, milestones, cost, risk register.
+- Drafted `plans/chromium-engine.md` (architecture, milestones, cost, risk register).
 - Drafted this handoff ledger.
-- **Did not** install depot_tools, **did not** fetch Chromium. Decision: wait for plan PR review before spending fetch hours.
-- Next session: see "Next steps" above.
+- **Did not** install depot_tools, **did not** fetch Chromium. Decision: wait for user to confirm scope.
+- Opened draft PR #4159.
+
+### Session 1 — 2026-05-14 (scaffolding)
+
+- User confirmed scope (Dia-strategy, full Chromium fork) and approved `/loop`-paced multi-session work.
+- Investigated `disk3s4`: it is the macOS firmware update volume. **Rejected** for Chromium checkout. Pivoted to `/Users/ec2-user` (155 GB free).
+- Discovered an in-flight Atlas-strategy `cmux-browser` project at `worktrees/task-cmux-browser-pure-mojo/` (127 tests, working dogfood, active Chromium-side work on AWS Mac). Surfaced to user; user directed to **ignore** it and build a new project from scratch with a new Chromium fork. Atlas-project artifacts on AWS Mac (`~/chromium`, `~/actions-runner-chromium-*`) are left untouched.
+- Installed `depot_tools` at `/Users/ec2-user/depot_tools`, fixed `~/.zshrc` perms.
+- Built `scripts/chromium-build-host.sh` (idempotent: setup, remount, fetch, status, build).
+- Built `Packages/CmuxBrowserEngine` SwiftPM package — engine-neutral API surface mirroring WKWebView. WebKit backend is production-shaped; Chromium backend is a documented stub. **16 tests passing, 0 warnings, swift 6 strict concurrency.**
+- Wrote `plans/wkwebview-surface-audit.md` (every WK API cmux uses + migration order).
+- Wrote `plans/cmux-embedder-c-abi.md` (C ABI sketch the cmux Chromium fork will export).
+- **Did not** start the fetch (commits this session first so progress is durable; fetch is the first session-2 task).
+- **Did not** create `manaflow-ai/cmux-chromium` GitHub repo (needs user OK).
+- Pushed three commits to `feat-chromium-engine`, draft PR #4159 has them.
+
+Next session: see "Next steps" above.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -1,0 +1,51 @@
+# Chromium engine — per-session handoff ledger
+
+Read this first when starting any session on `feat-chromium-engine`. Append a new entry at the bottom of "Session log" before exiting. The "Next steps" block at the top is authoritative; update it when you finish a step.
+
+## Next steps (always current)
+
+- [ ] Get plan PR reviewed and approved (or at least eyes on it) so cost/scope is acknowledged.
+- [ ] On `cmux-aws-mac`: rename `disk3s4` to `Chromium` and document the remount procedure (`diskutil mount /dev/disk3s4`, target `/Volumes/Chromium`). Add to `scripts/` if cmuxterm-hq's `scripts/` is the right home, or to a build-host-local doc.
+- [ ] Install `depot_tools` on the persistent volume at `<persistent>/depot_tools`. Export `PATH` in `~/.zshrc`.
+- [ ] Kick off `fetch chromium` in a `Bash run_in_background` with a Monitor armed for `.gclient_entries` appearance and process exit. Expect 4–12 hours.
+- [ ] After fetch: pick a Chromium release branch to track (recommend latest stable when work starts; record the commit SHA in this doc).
+- [ ] First clean `chrome` build (target: full release build under 3 hours on M1 Ultra).
+
+## Active milestone
+
+**P0 — Build host and toolchain.** All P1+ items are blocked on P0.
+
+## Build host state
+
+- Host: `cmux-aws-mac` (M1 Ultra, 20 cores, 128 GB RAM, macOS 15.7.4, Xcode 26.3).
+- Persistent volume: `disk3s4`, 994 GB total / 972 GB free, currently mounted at `/private/tmp/tmp-mount-TOmSsz`.
+- Risk: that mount point is a non-standard path; the volume is persistent but the mount may not auto-recreate after reboot. Confirm `diskutil mount disk3s4` works on a reboot before relying on it.
+- depot_tools: not installed yet.
+- Chromium checkout: not started.
+
+## Open blockers
+
+None as of session 0.
+
+## Open PRs
+
+- Draft PR (to be opened in session 0): plan-only, `feat-chromium-engine` → `main`.
+
+## Useful commands
+
+- Re-enter worktree: `cd /Users/lawrence/fun/cmuxterm-hq/worktrees/feat-chromium-engine`
+- SSH to build host: `ssh cmux-aws-mac`
+- Check build-host disk: `ssh cmux-aws-mac 'df -h /private/tmp/tmp-mount-TOmSsz'`
+- Read this ledger: `cat plans/chromium-engine-handoff.md`
+
+## Session log
+
+### Session 0 — 2026-05-14
+
+- Verified `cmux-aws-mac` reachable, specs (M1 Ultra, 128 GB, Xcode 26.3).
+- Identified persistent storage candidate (`disk3s4`, 972 GB free).
+- Created worktree `feat-chromium-engine` off `origin/main` at `791318f5a`.
+- Drafted `plans/chromium-engine.md` (this directory) with architecture, milestones, cost, risk register.
+- Drafted this handoff ledger.
+- **Did not** install depot_tools, **did not** fetch Chromium. Decision: wait for plan PR review before spending fetch hours.
+- Next session: see "Next steps" above.

--- a/plans/chromium-engine-handoff.md
+++ b/plans/chromium-engine-handoff.md
@@ -166,3 +166,43 @@ Patches 0002-0004 are all macOS-26-SDK forward-compat issues. The current checko
 Hypothesis for session 3: **before chasing more SDK forward-compat patches, switch the checkout to `refs/branch-heads/7204` and re-run `gclient sync`.** M148 stable was tested against earlier SDKs and likely compiles cleanly under macOS 26.2 with only patch 0001 (the cryptex Metal-toolchain issue is OS-level, not chromium-version-specific). Cost: one git checkout + gclient sync (hours, but cached). Benefit: fewer patches to maintain across upstream rebases.
 
 If session 3 takes that path: `patches/0002`–`patches/0004` may be removable. Validate by attempting the build without them after the branch switch.
+
+### Session 3 — 2026-05-14 (M148 reality check + stubs + gn-format)
+
+Continued under the same `/goal i have reviewed it, use your best judgment and implement fully` stop-hook from sessions 1 and 2.
+
+- **Session 2 strategic recommendation was wrong, retracted.** `git ls-remote origin refs/branch-heads/7204` on the cmux-aws-mac chromium-fork checkout resolves to `72a51d14d794ce9211145ecc9b7464e222d40153` — the exact commit the checkout was already on. The LKGM-shaped HEAD commit message ("Automated Commit: LKGM 16295.95.0 for chromeos.") obscured that fact. **M148 stable IS the current base; there is no cheaper branch to switch to.** `patches/README.md` retracts the misleading note.
+- **Patch 5 (rename, not suppress).** Build round 6 failed at `ui/accessibility/platform/browser_accessibility_cocoa.mm:2192` and friends with `error: reference to 'NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute' is ambiguous` — the same identifier was declared in an anonymous namespace as a private backport AND in the macOS 26.2 SDK as `@available(macos 26.0)`. Unlike patches 0003/0004 (`-Wunguarded-availability-new`), this is a hard collision error a diagnostic pragma cannot silence. `patches/0005-ax-cocoa-rename-private-symbol-backports.patch` renames the anonymous-namespace `NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute` and `NSAccessibilityScrollToVisibleAction` to `CmuxNS*` prefixed identifiers; string-literal values unchanged, deployment-target behavior unchanged.
+- **BUILD.gn rewrites against real upstream patterns.** Session 2's `embedder/cmux_BUILD.gn` had three independent bugs: out-of-bounds `helper[3]`/`[4]`/`[5]` (the `content_mac_helpers` tuple is exactly 3-wide), target-name drift between the `foreach` and the `group("cmux_helpers")` deps list, and an over-coupled inline body where the upstream pattern factors a template. Rewrote against `chrome/BUILD.gn:730` (`chrome_helper_app` template body) and `chrome/BUILD.gn:826` (foreach iteration). Group target list is now generated FROM `content_mac_helpers` so names cannot drift.
+- **Stub .cc/.mm files matching every C ABI function.** Added `embedder/cmux_session.cc`, `cmux_profile.cc`, `cmux_view.cc`, `cmux_browser.mm`, `cmux_layer_host.mm` (empty placeholder), `cmux_helper_main_mac.cc`, and `cmux_framework_main.cc`. Session 2 had argued these "would rot" if written speculatively; the session-3 stubs only do trivial sentinels (return `CMUX_E_NATIVE` / NULL / 0 / "") and use a shared `cmux_internal_set_last_error` helper, so there is no implementation surface to rot. The framework can link without any //content wiring. Re-enabled the .mm/.cc paths in `embedder/BUILD.gn`'s source list (session 2 had commented them out because the files didn't exist).
+- **`gn format` validates both BUILD.gn files.** Copied `cmux_BUILD.gn` → `~/chromium-fork/src/cmux/BUILD.gn` and `BUILD.gn` → `~/chromium-fork/src/cmux/embedder/BUILD.gn` on cmux-aws-mac. Round-tripped both through `gn format` (from depot_tools); only diffs were GN's single-line collapses for length-1 lists. Pulled the gn-blessed versions back to the worktree as canonical. This validates GN syntax but NOT semantics (target lookups, source-file existence beyond this directory, template arg type checks) — those require the framework to be reachable from a default `gn_all` target, which it is not yet.
+- **Build round 7 in flight.** With patches 0001–0005 applied, kicked off `autoninja -C out/cmux_release -k 0 content_shell` again on cmux-aws-mac (pid 99363). At session-3 close: 1820/15871 (~11.5%) at 9m55s elapsed, past prior failure point. ScheduleWakeup set for 30 min to react to outcome.
+- Pushed four commits to `feat-chromium-engine`: `136435be` patch 5 + retract M148 note, `75b96402` BUILD.gn rewrites, `cb8a5caa` stub .cc/.mm files, `086fe1f1` gn-format outputs.
+
+#### What session 3 added to "proved"
+
+- M148 stable IS the current chromium-fork base. The session-2 hypothesis that switching branches would reduce SDK forward-compat patches is **falsified**: the LKGM tip and `refs/branch-heads/7204` are literally the same commit.
+- Both embedder BUILD.gn files round-trip cleanly through `gn format` against M148. Syntax is GN-correct.
+- Every function exported by `cmux_browser.h` has a stub body in `embedder/*.{cc,mm}`. The framework has every symbol the linker will look for.
+- `embedder/cmux_BUILD.gn`'s helper-app instantiation pattern matches `chrome/BUILD.gn:826` line-for-line semantically.
+
+#### What session 3 did NOT prove
+
+- `content_shell` itself building green end-to-end. Round 7 was in flight at session-3 close. **If another forward-compat error fires**, follow patch discipline: capture as a numbered patch (this run brought the total to 5), wire into `apply-patches`, restart.
+- The embedder BUILD.gn files compile in a real Chromium build graph. `gn format` is a syntactic check; `gn check` requires the framework to be reachable, which still depends on either (a) creating `manaflow-ai/cmux-chromium` and integrating `//cmux:cmux_core_framework` into `gn_all`, or (b) hand-modifying BUILDCONFIG.gn for a one-off check (deliberately not done — would dirty the chromium-fork tree).
+- The C ABI stubs link against `//content`'s `BrowserMainRunner` — they don't. They are pure-sentinel implementations of the ABI surface, suitable for proving the linker has every symbol, not for proving anything renders.
+
+#### Strategic note for session 4
+
+The patch arc 0001 → 0005 covers four distinct fix classes on macOS 26.2 SDK + M148 stable:
+
+  - **0001** (metal-wrapper): macOS-level toolchain layout. Will recur on every macOS-26-class SDK; consider upstream contribution.
+  - **0002** (webnn CoreML enum): macOS 26.2 SDK adds enum values. Forward-compat default branch; harmless.
+  - **0003 / 0004** (availability suppression): macOS 26 SDK marks pre-existing constants as `@available(macos 26.0)`. Suppression unblocks build.
+  - **0005** (rename SDK-shadow): macOS 26 SDK publishes identifiers Chromium had been backporting in anonymous namespace. Rename is more invasive than the others but the only fix shape that survives a hard name-collision error.
+
+Each pattern is now demonstrated; subsequent SDK forward-compat errors should match one of these four shapes. A new fix class (linker, mojom regeneration, ABI break) is the signal to call the advisor before continuing.
+
+Session 4 should open by checking `~/chromium-fork/build-content-shell.log`'s tail. If `Content Shell.app` exists at `~/chromium-fork/src/out/cmux_release/Content\ Shell.app`, build round 7 succeeded and P0 is decisively done; otherwise diagnose the next failure under the four-pattern taxonomy above.
+
+P1 still requires user permission to create `manaflow-ai/cmux-chromium` org-level repo. Until that exists, the `embedder/` tree cannot move into a real `gn gen` graph and the framework cannot be evaluated end-to-end.

--- a/plans/chromium-engine.md
+++ b/plans/chromium-engine.md
@@ -83,12 +83,13 @@ Each milestone is a sequence of PRs, not a single PR. Each PR is mergeable on it
 
 ### P1 — Custom framework target (2–4 weeks elapsed) — in progress
 
-- [ ] **GATING**: `manaflow-ai/cmux-chromium` fork repo must exist. Org-level repo creation needs user permission. Once it does, `embedder/` artifacts (`BUILD.gn`, `cmux_browser.h`, `CHANGELOG.md`) drop in as session 2's deliverable.
-- [ ] Add a GN build target `//cmux:cmux_core_framework` that produces `CmuxCore.framework`. Skeleton declared in `embedder/BUILD.gn` (session 2). Strip browser UI; keep content/, ANGLE, V8, blink.
-- [ ] Custom branding: bundle IDs `ai.manaflow.cmux.browser.helper*`, plist `CFBundleName = cmux Helper`, version string set to Chromium upstream + `.cmux.N`.
-- [ ] Build all four helper apps with the cmux bundle ID prefix.
-- [ ] Codesign with Developer ID Application identity, embed `embedded.provisionprofile`, notarize via `notarytool`. Helpers and framework signed before the host app.
-- [ ] Smoke test: `CmuxCore` loads in a minimal Swift host that calls `ChromeMain` with `--type=` flags and shuts down cleanly.
+- [ ] **GATING**: `manaflow-ai/cmux-chromium` fork repo must exist. Org-level repo creation needs user permission. Once it does, `embedder/` artifacts (`BUILD.gn`, `cmux_browser.h`, branding plists, stub `.cc`/`.mm` files, `CHANGELOG.md`) drop in as sessions 2+3's deliverable.
+- [x] **GN build target `//cmux:cmux_core_framework`** — declared and validated. `gn gen` + `gn check` against M148 stable on cmux-aws-mac confirms the framework, all four helper apps (`cmux_helper_app_default/_renderer/_gpu/_plugin`), `cmux_helpers` group, and `//cmux/embedder:embedder` all pass `Header dependency check OK`. See `embedder/cmux_BUILD.gn` and `embedder/README.md` for the verification path (one-line entry to root `//BUILD.gn`'s `gn_all` group; tree reverted clean afterward). Real `//content` linking remains; the framework definition is correct against the dep graph.
+- [x] **Stub `.cc`/`.mm` implementations matching the v1 C ABI** — every function declared in `cmux_browser.h` has a sentinel body in `embedder/cmux_{session,profile,view,browser}.{cc,mm}` + `cmux_layer_host.mm` (empty), `cmux_helper_main_mac.cc` (returns 0), `cmux_framework_main.cc` (exposes `cmux_framework_abi_version()`). Stubs return `CMUX_E_NATIVE` / NULL / 0 / "" and use a shared `cmux_internal_set_last_error` helper. The framework can link in isolation against the stubs; real implementations replace bodies per ABI group when //content wiring lands.
+- [x] **Custom branding**: bundle IDs `ai.manaflow.cmux.browser.helper{.renderer,.plugin}` (gpu reuses the default suffix), `cmux_helper_name = "cmux Helper"` so helpers compose as "cmux Helper", "cmux Helper (Renderer)", "cmux Helper (GPU)", "cmux Helper (Plugin)". `embedder/branding/cmux_core_framework-Info.plist` and `embedder/branding/cmux_helper-Info.plist` hold the substitution-templated plists. Version string `0.1.cmux.0` declared in `cmux_BUILD.gn`.
+- [x] **All four helper apps declared with the cmux bundle ID prefix** — `foreach(helper_params, content_mac_helpers)` instantiates them via the inlined `cmux_helper_app` template (mirrors `chrome_helper_app` in `chrome/BUILD.gn:730`). Header dependency check passes for every variant.
+- [ ] Codesign with Developer ID Application identity, embed `embedded.provisionprofile`, notarize via `notarytool`. Helpers and framework signed before the host app. **Gated on fork repo + ninja link success.**
+- [ ] Smoke test: `CmuxCore` loads in a minimal Swift host that calls `ChromeMain` with `--type=` flags and shuts down cleanly. **Gated on fork repo + real //content wiring (stubs return `CMUX_E_NATIVE` for everything but `cmux_session_init`).**
 
 ### P2 — Embedding API (3–6 weeks elapsed) — Swift surface DONE, C-side gated on fork repo
 

--- a/plans/chromium-engine.md
+++ b/plans/chromium-engine.md
@@ -1,0 +1,190 @@
+# Chromium engine spike: scope, architecture, milestones
+
+Branch: `feat-chromium-engine`. Long-lived. Driven across many sessions; no single session completes this.
+
+## Goal
+
+Replace cmux's `WKWebView`-based browser surface (`Sources/Panels/BrowserPanel.swift`, `Sources/Panels/CmuxWebView.swift`, friends) with a Chromium-derived engine shipped as a private framework inside the cmux app bundle. Match the architecture used by Arc and Dia. **No CEF.**
+
+End state, condensed:
+
+- `Contents/Frameworks/CmuxCore.framework` ships a custom-branded build of Chromium's content layer (the same `ChromeMain` entrypoint Dia uses).
+- Four helper apps under `CmuxCore.framework/Versions/A/Helpers/`: `cmux Browser Helper.app`, `cmux Browser Helper (Renderer).app`, `cmux Browser Helper (GPU).app`, `cmux Browser Helper (Alerts).app`. Bundle ID prefix `ai.manaflow.cmux.browser.helper*`.
+- `Sources/Panels/CmuxWebView.swift` is rewritten on top of a thin Swift/Obj-C++ binding layer in a new local SwiftPM target (`Packages/CmuxBrowserEngine`) that wraps `CmuxCore`'s embedding API. Public surface stays close to the current `WKWebView` shape so the rest of `BrowserPanel.swift` keeps working with minimal diff.
+- Rendering goes on screen via `CALayerHost` bound to a `CAContext` `contextId` published by the GPU helper, exactly as confirmed in Dia/Arc. IOSurface carries pixels across the process boundary.
+
+## Why this is hard, stated up front
+
+A reasonable estimate from public information: Arc/Dia's engine team is multiple senior browser engineers, working for years on top of Chromium 100+. We are one human plus AI agents. The path from "fetched chromium" to "ships in cmux" is not one session of work and not one month of sessions. The plan below is structured so each session produces durable, committed progress, with the build host carrying long-running build artifacts between sessions.
+
+Concrete cost knobs:
+
+- **Time**: 5–10 calendar months at full focus for a small team; this project will run slower with one human in the loop.
+- **Compute**: `cmux-aws-mac` EC2 Mac dedicated host at roughly $1.50–1.80/hour. Already running 24/7 (24-hour minimum allocation, dedicated host model), so marginal cost of using it is effectively the per-hour rate continuing. Running for 5 months ≈ $5,500. Stopping it during off-weeks doesn't help because of the 24-hour minimum charge on each re-allocation.
+- **Maintenance after v1**: upstream Chromium ships a new milestone every ~4 weeks; security rolls between them. A long-lived fork without a dedicated rebase rotation diverges fast and ships unpatched CVEs. We need either a near-clean tracking branch or a documented "every release cycle, rebase or accept the security debt" policy.
+- **Distribution size**: cmux app bundle grows from ~100 MB to ~600 MB. The user-facing implication is auto-update bandwidth and disk usage.
+
+If any of these costs change the answer, stop here and revisit.
+
+## Architecture
+
+Mirror Dia's structure exactly (verified by reverse-engineering `/Applications/Dia.app`):
+
+```
+cmux.app/
+├── Contents/MacOS/cmux                 (existing Swift host, links CmuxCore)
+└── Contents/Frameworks/
+    └── CmuxCore.framework/             (Chromium content layer, ~450 MB)
+        └── Versions/A/
+            ├── CmuxCore                (exports _ChromeMain, _CmuxCoreInit, etc.)
+            ├── Helpers/
+            │   ├── cmux Browser Helper.app                (utility process)
+            │   ├── cmux Browser Helper (Renderer).app     (Blink + V8)
+            │   ├── cmux Browser Helper (GPU).app          (Viz, ANGLE, CAContext publisher)
+            │   └── cmux Browser Helper (Alerts).app       (notifications)
+            ├── Libraries/
+            │   ├── libEGL.dylib                           (ANGLE)
+            │   ├── libGLESv2.dylib                        (ANGLE)
+            │   └── libvk_swiftshader.dylib                (SwiftShader fallback)
+            └── Resources/
+                ├── MEIPreload/, PrivacySandboxAttestations/, IwaKeyDistribution/
+                ├── Localizable strings (en, ja for cmux's current locales)
+                └── snapshot_blob.bin, v8_context_snapshot.bin, resources.pak, *.pak
+```
+
+Process model is stock Chromium: browser process = the Swift `cmux` binary, helpers spawned via `posix_spawn` of the helper bundle's `Browser Helper` shim (~170 KB; dlopens the framework, calls `ChromeMain` with the right `--type=` flag).
+
+### Embedding API
+
+A Swift host needs a stable, narrow surface. Two layers:
+
+1. **C++/Obj-C++ binding inside Chromium** (`//cmux/embedder/`, added as an upstream patch): exports a C ABI of view, navigation, JS-bridge, profile, cookie, download, and find-in-page operations on top of `content::WebContents`. This is the equivalent of CEF's C API but Cmux-owned, smaller, and only covers what BrowserPanel needs. Lives in the Chromium fork.
+2. **Swift wrapper in `Packages/CmuxBrowserEngine`**: Swift types that mirror today's `WKWebView`/`WKWebViewConfiguration`/`WKUserContentController`/`WKNavigationDelegate` API shapes (`CmuxBrowserView`, `CmuxBrowserConfiguration`, `CmuxUserContentController`, `CmuxNavigationDelegate`). One-to-one mapping where possible, intentional translation where Chromium and WebKit differ. Lives in cmuxterm-hq / cmux repo.
+
+`Sources/Panels/CmuxWebView.swift` keeps its name and its current consumers, but stops subclassing `WKWebView` and starts subclassing or wrapping `CmuxBrowserView`. The diff to `BrowserPanel.swift` should be small if the wrapper API stays close enough; gaps get filled by adding to the wrapper, not by changing every callsite.
+
+### Rendering integration (CALayerHost, no `drawRect`)
+
+This is the part we already know works because Dia does it. The GPU helper builds a `CARendererLayerTree` of `CALayer`s backed by `IOSurface`s, publishes the tree via `+[CAContext contextWithCGSConnection:options:]`, and IPCs the resulting `contextId` to the browser process. The Swift host hosts each `WebContents` inside an `NSView` that owns a `CALayerHost` whose `contextId` is set to the value received over Mojo. AppKit composites; the browser process never touches the page pixels. This is private API (SPI), like Chrome/Arc/Dia use, and is fine for Developer ID-signed apps outside the Mac App Store.
+
+Input routing stays AppKit: a `RenderWidgetHostViewCocoa`-style `NSView` subclass conforming to `NSTextInputClient` is the first responder; mouse, key, IME, scroll, and gestures are forwarded over Mojo to the renderer process. cmux's `BrowserPanel` first-responder code and `BrowserPaneNavigationKeybindUITests` keep working because the public Swift surface stays the same.
+
+## Milestones
+
+Each milestone is a sequence of PRs, not a single PR. Each PR is mergeable on its own. Naming convention: branches `chromium/<phase>-<slug>`, PRs prefixed `[cmux-chromium]`.
+
+### P0 — Build host and toolchain (target: 1–2 weeks elapsed)
+
+- [ ] Persistent volume layout on `cmux-aws-mac` (use `disk3s4`, 972 GB free, rename for clarity). Document remount procedure for the OS-update reset risk.
+- [ ] Install `depot_tools` on the persistent volume.
+- [ ] `fetch chromium` (4–12 hours, ~100 GB).
+- [ ] First clean release `chrome` build to validate Xcode + toolchain.
+- [ ] Wire build status notifications back into cmuxterm-hq via a `scripts/chromium-build.sh` that knows about Monitor signals.
+
+### P1 — Custom framework target (2–4 weeks elapsed)
+
+- [ ] Add a GN build target `//cmux:CmuxCore_framework` that produces `CmuxCore.framework` instead of `Chromium.app`. Strip browser UI; keep content/, components needed, ANGLE, V8, blink.
+- [ ] Custom branding: bundle IDs `ai.manaflow.cmux.browser.helper*`, plist `CFBundleName = cmux Helper`, version string set to Chromium upstream + `.cmux.N`.
+- [ ] Build all four helper apps with the cmux bundle ID prefix.
+- [ ] Codesign with Developer ID Application identity, embed `embedded.provisionprofile`, notarize via `notarytool`. Helpers and framework signed before the host app.
+- [ ] Smoke test: `CmuxCore` loads in a minimal Swift host that calls `ChromeMain` with `--type=` flags and shuts down cleanly.
+
+### P2 — Embedding API (3–6 weeks elapsed)
+
+- [ ] `//cmux/embedder/cmux_browser_view.{h,mm}` exports a C ABI. Initial surface: create/destroy view, load URL, can/go back/forward, reload, evaluate JS, attach script message handler, set delegate (navigation start/finish/fail, decidePolicyForNavigation, didReceiveAuthChallenge).
+- [ ] CALayerHost-backed `NSView` returned to the embedder by an `(NSView *)hostView` accessor.
+- [ ] Swift wrapper package `Packages/CmuxBrowserEngine`: `CmuxBrowserView`, `CmuxBrowserConfiguration`, `CmuxUserContentController`, `CmuxNavigationDelegate`, `CmuxUIDelegate`. API shape mirrors `WKWebView` modulo intentional translations.
+- [ ] Unit tests on the Swift wrapper using an in-process fake (`CmuxCoreTestStub`) that simulates the C ABI without spawning helpers — fast and reliable for CI.
+
+### P3 — Swap `WKWebView` → `CmuxBrowserEngine` in cmux (4–8 weeks elapsed)
+
+Per-callsite swap, file by file, behind a feature flag (`UserDefaults.standard.bool(forKey: "cmux.browser.engine.chromium")`). Allows rollback per build.
+
+- [ ] `Sources/Panels/CmuxWebView.swift` — engine swap, primary site.
+- [ ] `Sources/Panels/BrowserPanel.swift` — config plumbing, delegate fanout, omnibar.
+- [ ] `Sources/Panels/BrowserPanelView.swift` — find-in-page (`BrowserFindJavaScript.swift` → Chromium find API).
+- [ ] `Sources/Panels/BrowserPopupWindowController.swift` — `WKUIDelegate.createWebViewWith` → `CmuxUIDelegate.createNewBrowserView`.
+- [ ] `Sources/Panels/BrowserWebAuthnSupport.swift` — Chromium's WebAuthn already covers this; migrate from `ASAuthorizationController` bridge.
+- [ ] `Sources/Panels/MarkdownPanelView.swift`, `MarkdownWebRenderer.swift`, `ReactGrab.swift` — secondary surfaces, keep on WKWebView initially or migrate as time allows.
+- [ ] Drag/drop: `BrowserPaneDropTargetView.swift`, `FileDropOverlayView.swift` — `WKWebView` drag handlers re-wired through `CmuxBrowserView`.
+
+XCUITests in `cmuxUITests/Browser*UITests.swift` are the canary. All must pass under both feature flag values during transition.
+
+### P4 — Feature parity + Chromium-only wins (8–16 weeks elapsed)
+
+What WKWebView doesn't do that we get for free with Chromium:
+
+- [ ] Chrome extensions (`chrome.runtime`, MV3). Ship a curated allow-list initially; consider Web Store as a follow-up.
+- [ ] DevTools (`chrome://inspect`-style remote debugger).
+- [ ] PDF viewer using Chromium's built-in.
+- [ ] Better video codecs (VP9, AV1) and DRM (Widevine, conditional on licensing).
+- [ ] WebGPU.
+- [ ] Better autofill (Chrome's address/password autofill is much stronger than `ASAuthorizationController` flows).
+
+Things we explicitly do **not** turn on at first: Chrome Sync (account model is wrong), Privacy Sandbox ad APIs (we're not an ad network), reporting endpoints that phone home to Google.
+
+### P5 — Productionization (4–8 weeks elapsed)
+
+- [ ] Crash reporting wired through Sentry (`Frameworks/Sentry.framework` already in app bundle); replace Chromium's Crashpad upload endpoint with our own collector.
+- [ ] Sparkle update channel handles the larger app bundle; verify delta updates work.
+- [ ] Localization for the engine surface: en, ja (cmux's current locales).
+- [ ] CI: GitHub Actions workflow that pulls the latest `CmuxCore.framework` artifact from `cmux-aws-mac` (uploaded after each successful build) and bakes it into the macOS app, so cmuxterm-hq builds don't need a Chromium tree.
+- [ ] Security review checklist: site isolation enabled, sandbox seatbelt profiles applied, network service in its own process, V8 sandbox on.
+
+## Build host plan
+
+| Item | Decision |
+|---|---|
+| Host | `cmux-aws-mac` (M1 Ultra, 20 cores, 128 GB RAM, Xcode 26.3, macOS 15.7.4) |
+| Persistent volume | `disk3s4` (994 GB, 972 GB free) — currently auto-mounted at `/private/tmp/tmp-mount-TOmSsz`. Rename volume to `Chromium`, document `diskutil mount /dev/disk3s4` as the remount step after reboot. |
+| Checkout path | `/private/tmp/tmp-mount-TOmSsz/chromium` (or `/Volumes/Chromium/chromium` after rename) |
+| depot_tools | `<persistent_volume>/depot_tools`, exported in `~/.zshrc` |
+| Goma / RBE | Not available to us. Local builds only. Plan around full-build times of 60–120 minutes on M1 Ultra. |
+| Build artifact handoff | After a green build, `tar` the framework to S3 (or scp to `cmux-macmini` Tailscale host) so cmuxterm-hq sessions can fetch without rebuilding. |
+
+OS-update risk: if Apple ships a macOS update, `disk3s4` might be reformatted (it's nominally a system update volume). Mitigation: keep the Chromium checkout reproducible (depot_tools-managed) and accept that a re-fetch costs ~12 hours if it gets nuked. After a successful first build, snapshot the framework artifact off-host.
+
+## Cross-session continuity (the "/loop" replacement)
+
+`/loop` lives only inside a single session. This project lives across hundreds. The durable substrate is:
+
+1. **This worktree** (`worktrees/feat-chromium-engine`) — branch `feat-chromium-engine` on the cmux remote. All in-cmuxterm-hq work commits here.
+2. **The Chromium fork** — separate repo `manaflow-ai/cmux-chromium` (not yet created), tracking a Chromium release branch + cmux patches.
+3. **The build host state** — `<persistent_volume>/chromium` checkout, plus `out/cmux_release` build directory. Surviving reboots, surviving sessions, surviving humans logging out.
+4. **`plans/chromium-engine-handoff.md`** — the per-session state ledger (next file written).
+
+A "new session" workflow:
+
+1. User opens cmuxterm-hq, says `continue chromium engine work, see plans/chromium-engine-handoff.md`.
+2. Agent reads the handoff doc, picks up the "Next steps" block, runs.
+3. Agent commits work to `feat-chromium-engine`, updates the handoff ledger, opens or comments on the active PR, and exits.
+
+`/schedule` is appropriate for *scheduled checks* on top of this (e.g. "every hour, run a smoke build on `cmux-aws-mac` and post results"). It is not a substitute for human-initiated work sessions; the agent has no way to make independent product decisions between sessions.
+
+## Risk register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Chromium upstream changes a critical internal API we patched | High over months | Hours of rebase pain per release | Keep the cmux patch set as small as possible; prefer downstream wrappers over inline upstream edits |
+| `cmux-aws-mac` disk gets reset by macOS update | Medium | 12 hours of re-fetch + rebuild | Snapshot framework artifacts off-host after every green build; document remount procedure |
+| Embedding API doesn't actually match WKWebView's behavior subtly (caret position in editable fields, IME, drag selection) | High | Bug long-tail through P3 + P4 | Behavior parity tests under both flag values in XCUITests; canary period with the flag default off |
+| Notarization fails on the new helper bundles (entitlements, hardened runtime) | Medium | Days of signing debugging | Steal Chrome's entitlements verbatim, adjust bundle IDs only |
+| WebAuthn / Sign in with Apple / Passkeys break under Chromium | Medium | User-visible regression | Keep WKWebView fallback for auth-only flows during P3 |
+| App bundle size from 100 MB → 600 MB regresses install/update bandwidth | Certain | User pain | Sparkle delta updates; consider on-demand engine download for new installs |
+| Sandbox profile differences cause file access regressions vs WKWebView | Medium | Bug bucket | Mirror Chrome's seatbelt profiles; cmux-specific extensions go through a documented allow-list |
+| User changes their mind and wants this shipped in 1 month | Medium | Quality cliff | Have a milestone-1 demo (P3 smoke: google.com renders in a cmux pane) so they can see incremental progress and abort earlier with smaller sunk cost |
+
+## Self-verification plan
+
+The user asked for "take screenshots and view them yourself to self-verify." That works once we have an engine producing pixels. Until then, self-verification is build success + unit tests + XCUITest pass. Screenshot-based verification starts at the end of P2 (smoke build of a `CmuxBrowserView` rendering a static page) and is mandatory for every PR after that, captured via `cmux-browser` skill's screenshot command and committed to the PR as evidence.
+
+## What this session produced
+
+This session is **session 0**. Output:
+
+1. Branch `feat-chromium-engine` (this worktree).
+2. `plans/chromium-engine.md` (this file).
+3. `plans/chromium-engine-handoff.md` (state ledger, next file).
+4. Draft PR on `manaflow-ai/cmux` with this plan as the body.
+
+This session **did not** kick off the Chromium fetch on `cmux-aws-mac`. That's a session-1 decision once the plan + cost estimate is approved here.

--- a/plans/chromium-engine.md
+++ b/plans/chromium-engine.md
@@ -73,28 +73,29 @@ Input routing stays AppKit: a `RenderWidgetHostViewCocoa`-style `NSView` subclas
 
 Each milestone is a sequence of PRs, not a single PR. Each PR is mergeable on its own. Naming convention: branches `chromium/<phase>-<slug>`, PRs prefixed `[cmux-chromium]`.
 
-### P0 — Build host and toolchain (target: 1–2 weeks elapsed)
+### P0 — Build host and toolchain (target: 1–2 weeks elapsed) — ✅ DONE
 
-- [ ] Persistent volume layout on `cmux-aws-mac` (use `disk3s4`, 972 GB free, rename for clarity). Document remount procedure for the OS-update reset risk.
-- [ ] Install `depot_tools` on the persistent volume.
-- [ ] `fetch chromium` (4–12 hours, ~100 GB).
-- [ ] First clean release `chrome` build to validate Xcode + toolchain.
-- [ ] Wire build status notifications back into cmuxterm-hq via a `scripts/chromium-build.sh` that knows about Monitor signals.
+- [x] ~~Persistent volume layout~~ Rejected `disk3s4` (it's the macOS firmware update volume — see handoff ledger). Pivoted to `/Users/ec2-user` on the persistent data volume; 128 GB free margin after the 26 GB fetch.
+- [x] Install `depot_tools` at `/Users/ec2-user/depot_tools`, PATH wired through `~/.zshrc`.
+- [x] `fetch chromium` complete (26 GB, M148-base via `--depth=1 --shallow`).
+- [x] First clean release build to validate Xcode + toolchain — `:base` smoke (1m33s, 2192 steps, ✅ session 1) and `:content_shell` in flight session 2 (in-flight at session-2 close). Two patches needed to traverse the macOS 26 SDK forward-compat surface: `patches/0001-angle-metal-wrapper-resolve-via-xcrun.patch` and `patches/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch`.
+- [x] Build status notifications wired via `scripts/chromium-build-host.sh` (setup/remount/fetch/apply-patches/status/build) + the Monitor-friendly probe pattern used in each session's handoff entry.
 
-### P1 — Custom framework target (2–4 weeks elapsed)
+### P1 — Custom framework target (2–4 weeks elapsed) — in progress
 
-- [ ] Add a GN build target `//cmux:CmuxCore_framework` that produces `CmuxCore.framework` instead of `Chromium.app`. Strip browser UI; keep content/, components needed, ANGLE, V8, blink.
+- [ ] **GATING**: `manaflow-ai/cmux-chromium` fork repo must exist. Org-level repo creation needs user permission. Once it does, `embedder/` artifacts (`BUILD.gn`, `cmux_browser.h`, `CHANGELOG.md`) drop in as session 2's deliverable.
+- [ ] Add a GN build target `//cmux:cmux_core_framework` that produces `CmuxCore.framework`. Skeleton declared in `embedder/BUILD.gn` (session 2). Strip browser UI; keep content/, ANGLE, V8, blink.
 - [ ] Custom branding: bundle IDs `ai.manaflow.cmux.browser.helper*`, plist `CFBundleName = cmux Helper`, version string set to Chromium upstream + `.cmux.N`.
 - [ ] Build all four helper apps with the cmux bundle ID prefix.
 - [ ] Codesign with Developer ID Application identity, embed `embedded.provisionprofile`, notarize via `notarytool`. Helpers and framework signed before the host app.
 - [ ] Smoke test: `CmuxCore` loads in a minimal Swift host that calls `ChromeMain` with `--type=` flags and shuts down cleanly.
 
-### P2 — Embedding API (3–6 weeks elapsed)
+### P2 — Embedding API (3–6 weeks elapsed) — Swift surface DONE, C-side gated on fork repo
 
-- [ ] `//cmux/embedder/cmux_browser_view.{h,mm}` exports a C ABI. Initial surface: create/destroy view, load URL, can/go back/forward, reload, evaluate JS, attach script message handler, set delegate (navigation start/finish/fail, decidePolicyForNavigation, didReceiveAuthChallenge).
-- [ ] CALayerHost-backed `NSView` returned to the embedder by an `(NSView *)hostView` accessor.
-- [ ] Swift wrapper package `Packages/CmuxBrowserEngine`: `CmuxBrowserView`, `CmuxBrowserConfiguration`, `CmuxUserContentController`, `CmuxNavigationDelegate`, `CmuxUIDelegate`. API shape mirrors `WKWebView` modulo intentional translations.
-- [ ] Unit tests on the Swift wrapper using an in-process fake (`CmuxCoreTestStub`) that simulates the C ABI without spawning helpers — fast and reliable for CI.
+- [x] **C ABI design** (was P2 first item): `embedder/cmux_browser.h` exists with v1 surface frozen. Covers create/close view, load URL/HTML, back/forward/reload/stop, can-back/can-forward, url/title/is-loading/estimated-progress, page-zoom, evaluate-js, script-message handler, user scripts (add/remove-all), navigation-action callback, navigation-did-finish callback, snapshot. Profiles cover open/close, get/set/delete cookie, remove-data (typed mask). Session covers init/shutdown/run-once.
+- [ ] CALayerHost-backed `NSView` returned by `cmux_view_create`'s `out_ns_view` parameter. **Implementation lives in `cmux_layer_host.mm` of the fork** — gated on fork repo creation.
+- [x] **Swift wrapper package `Packages/CmuxBrowserEngine`**: COMPLETE for the surfaces cmux actually uses. Types implemented: `CmuxBrowserView`, `CmuxBrowserConfiguration`, `CmuxUserContentController`, `CmuxNavigationDelegate`, `CmuxUIDelegate`, `CmuxBrowserState` (Combine mirror), `CmuxDataStore`, `CmuxCookieStore`, `CmuxDownload` + delegate, `CmuxSnapshotConfiguration`. API shape mirrors `WKWebView` per `plans/wkwebview-surface-audit.md` (steps 1-4 + 6 done; step 5 inspector deferred-last).
+- [x] Unit tests on the Swift wrapper: 32 tests in 11 suites, all green under swift 6 strict concurrency, 0 warnings. Tests run against the WebKit backend today. **`CmuxCoreTestStub` (in-process C-ABI fake) for CI is deferred until the C ABI has any real impl** — testing against a stub before the stub matches reality just bakes in a mismatch.
 
 ### P3 — Swap `WKWebView` → `CmuxBrowserEngine` in cmux (4–8 weeks elapsed)
 

--- a/plans/cmux-embedder-c-abi.md
+++ b/plans/cmux-embedder-c-abi.md
@@ -1,0 +1,287 @@
+# cmux embedder C ABI
+
+Design sketch for the C ABI the cmux Chromium fork will export from `//cmux/embedder/`. `Packages/CmuxBrowserEngine`'s `ChromiumBrowserBackend` is the only consumer. The ABI is the long-lived contract between two repos: this one and the fork at `manaflow-ai/cmux-chromium` (to be created).
+
+Design constraints, in priority order:
+
+1. **C, not C++.** Stable, callable from Swift via a `module.modulemap` without bridging types.
+2. **No `std::*` or Chromium internals leaking.** Pointer-by-pointer ownership, opaque handles. The Swift side never sees a `WebContents*`.
+3. **Callable from MainActor Swift.** Every method runs on the browser process main thread. Threading inside the embedder is invisible to Swift.
+4. **Small.** The ABI mirrors only what `CmuxBrowserEngine`'s wrapper actually calls. Less is more — every method is a maintenance debt across upstream Chromium rebases.
+5. **Stable across upstream rebases.** No field unions, no exposed structs that aren't versioned, no opaque pointer reinterpretation.
+
+## Header sketch
+
+```c
+// cmux_browser.h — exported from CmuxCore.framework.
+// Generated and maintained at //cmux/embedder/cmux_browser.h in the
+// cmux Chromium fork. Consumed by CmuxBrowserEngine via a modulemap.
+
+#ifndef CMUX_EMBEDDER_CMUX_BROWSER_H_
+#define CMUX_EMBEDDER_CMUX_BROWSER_H_
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// ABI revision. Bump on any breaking change. CmuxBrowserEngine asserts
+// at framework load.
+#define CMUX_EMBEDDER_ABI_VERSION 1
+
+// Opaque handles. The Swift side never inspects layout.
+typedef struct cmux_session_  cmux_session_t;   // process-wide singleton
+typedef struct cmux_profile_  cmux_profile_t;   // ~= WKWebsiteDataStore
+typedef struct cmux_view_     cmux_view_t;      // ~= WKWebView
+typedef struct cmux_nav_      cmux_nav_t;       // ~= WKNavigation handle
+
+// Errors.
+typedef enum cmux_status_ {
+    CMUX_OK = 0,
+    CMUX_E_ABI_MISMATCH = 1,
+    CMUX_E_ALREADY_INITIALIZED = 2,
+    CMUX_E_NOT_INITIALIZED = 3,
+    CMUX_E_INVALID_ARG = 4,
+    CMUX_E_NATIVE = 5,         // see cmux_session_last_error_string()
+} cmux_status_t;
+
+// --- Lifecycle ---
+
+// Called once per process. argv must include the helper bundle paths
+// resolved by the host (browser process passes them to the helpers).
+// Returns CMUX_OK or CMUX_E_ABI_MISMATCH if abi_version doesn't match
+// the framework's exported CMUX_EMBEDDER_ABI_VERSION.
+cmux_status_t cmux_session_init(uint32_t abi_version,
+                                int argc, const char* const* argv,
+                                cmux_session_t** out_session);
+
+// Shutdown is best-effort; on macOS we typically just exit().
+void cmux_session_shutdown(cmux_session_t* session);
+
+// Pump the browser-process message loop once. Hosts that already run
+// a CFRunLoop call this from a CFRunLoopSource. The implementation is
+// idempotent and reentrant-safe.
+void cmux_session_run_once(cmux_session_t* session);
+
+// Diagnostic. Caller does not free; lifetime is until the next call.
+const char* cmux_session_last_error_string(cmux_session_t* session);
+
+// --- Profiles ---
+
+// Creates or fetches a profile. Profiles map to disk under
+// {user-data-dir}/{name}; default user-data-dir is "{HOME}/Library/
+// Application Support/cmux/CmuxCore". Pass NULL for ephemeral.
+cmux_status_t cmux_profile_open(cmux_session_t* session,
+                                const char* name_or_null,
+                                cmux_profile_t** out_profile);
+
+void cmux_profile_close(cmux_profile_t* profile);
+
+// Cookies. Iteration uses a callback because the cookie set is mutable.
+typedef void (*cmux_cookie_visitor)(
+    void* userdata,
+    const char* name, const char* value,
+    const char* domain, const char* path,
+    int64_t expires_unix_ms,
+    bool secure, bool http_only);
+
+cmux_status_t cmux_profile_get_cookies(cmux_profile_t* profile,
+                                       const char* url_or_null,
+                                       void* userdata,
+                                       cmux_cookie_visitor visitor);
+
+cmux_status_t cmux_profile_set_cookie(cmux_profile_t* profile,
+                                      const char* name, const char* value,
+                                      const char* domain, const char* path,
+                                      int64_t expires_unix_ms,
+                                      bool secure, bool http_only);
+
+// --- Views ---
+
+typedef struct cmux_view_config_ {
+    cmux_profile_t* profile;          // required
+    bool javascript_enabled;          // default true
+    bool allows_inline_media;         // default true
+    bool media_requires_user_action;  // default false
+    const char* user_agent_or_null;
+    const char* application_name_or_null;
+} cmux_view_config_t;
+
+// On return, *out_view is owned by the caller. *out_ns_view is a
+// CFTypeRef of an NSView the caller adds to the AppKit hierarchy.
+// The NSView's content is backed by a CALayerHost bound to the GPU
+// helper's CAContext. Caller releases the NSView normally; calling
+// cmux_view_close releases the engine-side WebContents.
+cmux_status_t cmux_view_create(cmux_session_t* session,
+                               const cmux_view_config_t* config,
+                               cmux_view_t** out_view,
+                               void** out_ns_view);
+
+void cmux_view_close(cmux_view_t* view);
+
+// --- Navigation ---
+
+cmux_nav_t* cmux_view_load_url(cmux_view_t* view, const char* url);
+cmux_nav_t* cmux_view_load_html(cmux_view_t* view,
+                                const char* html, size_t html_len,
+                                const char* base_url_or_null);
+cmux_nav_t* cmux_view_reload(cmux_view_t* view);
+cmux_nav_t* cmux_view_go_back(cmux_view_t* view);
+cmux_nav_t* cmux_view_go_forward(cmux_view_t* view);
+void cmux_view_stop(cmux_view_t* view);
+bool cmux_view_can_go_back(cmux_view_t* view);
+bool cmux_view_can_go_forward(cmux_view_t* view);
+
+// URL/title are valid until the next message-loop pump. Copy if you
+// need to outlive that.
+const char* cmux_view_url(cmux_view_t* view);
+const char* cmux_view_title(cmux_view_t* view);
+
+// --- JS evaluation ---
+
+typedef void (*cmux_js_callback)(
+    void* userdata,
+    const char* json_value_or_null,   // JSON-encoded result, or NULL on error
+    const char* error_or_null);
+
+void cmux_view_evaluate_js(cmux_view_t* view,
+                           const char* source, size_t source_len,
+                           void* userdata,
+                           cmux_js_callback callback);
+
+// --- Script messages (page → host) ---
+
+typedef void (*cmux_script_message_handler)(
+    void* userdata,
+    const char* name,
+    const char* frame_url_or_null,
+    bool is_main_frame,
+    const char* json_body);
+
+void cmux_view_set_script_message_handler(
+    cmux_view_t* view, void* userdata,
+    cmux_script_message_handler handler);
+
+// --- User scripts ---
+
+typedef enum cmux_injection_time_ {
+    CMUX_INJECT_AT_DOCUMENT_START = 0,
+    CMUX_INJECT_AT_DOCUMENT_END = 1,
+} cmux_injection_time_t;
+
+void cmux_view_add_user_script(cmux_view_t* view,
+                               const char* source, size_t source_len,
+                               cmux_injection_time_t injection_time,
+                               bool for_main_frame_only);
+
+void cmux_view_remove_all_user_scripts(cmux_view_t* view);
+
+// --- Navigation delegate (host ← engine) ---
+
+typedef struct cmux_navigation_event_ {
+    uint64_t nav_id;
+    const char* url;
+    bool is_main_frame;
+    bool is_provisional;
+    int32_t navigation_type;  // matches CmuxNavigationAction.NavigationType
+    int32_t button_number;
+    uint32_t modifier_flags;
+    bool should_perform_download;
+} cmux_navigation_event_t;
+
+typedef int32_t cmux_nav_decision_t;
+#define CMUX_NAV_ALLOW    0
+#define CMUX_NAV_CANCEL   1
+#define CMUX_NAV_DOWNLOAD 2
+
+typedef cmux_nav_decision_t (*cmux_navigation_action_cb)(
+    void* userdata, const cmux_navigation_event_t* evt);
+
+typedef void (*cmux_navigation_terminal_cb)(
+    void* userdata, uint64_t nav_id,
+    const char* url, bool succeeded,
+    const char* error_message_or_null);
+
+void cmux_view_set_navigation_action_cb(cmux_view_t* view,
+                                        void* userdata,
+                                        cmux_navigation_action_cb cb);
+
+void cmux_view_set_navigation_did_finish_cb(cmux_view_t* view,
+                                            void* userdata,
+                                            cmux_navigation_terminal_cb cb);
+
+// --- Snapshot ---
+
+typedef void (*cmux_snapshot_cb)(
+    void* userdata,
+    const uint8_t* png_bytes,
+    size_t png_len,
+    const char* error_or_null);
+
+void cmux_view_take_snapshot(cmux_view_t* view,
+                             int32_t width, int32_t height,
+                             void* userdata,
+                             cmux_snapshot_cb cb);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // CMUX_EMBEDDER_CMUX_BROWSER_H_
+```
+
+## Ownership rules
+
+- Sessions, profiles, views are caller-owned via opaque pointers. Caller invokes the corresponding `*_close()` to release.
+- `cmux_view_t` owns no AppKit objects; the `NSView` returned from `cmux_view_create` is reference-counted by AppKit normally. Closing the view releases the engine-side WebContents but the NSView stays alive until AppKit drops it.
+- Strings handed back via accessors (`cmux_view_url`, `cmux_view_title`, `cmux_session_last_error_string`) are valid until the next message-loop pump. Copy if you need to outlive that.
+- Strings passed in are copied by the embedder.
+- Callbacks may be invoked on the browser-process main thread only.
+
+## Why JSON instead of binary for JS / script messages
+
+`cmux_view_evaluate_js` and the script message handler both pass JSON strings rather than typed unions. This is a deliberate compromise:
+
+- The wrapper already walks `WKScriptMessage.body`'s `Any?` into `CmuxScriptMessageBody`. JSON-walk on the Swift side mirrors that.
+- A typed union would need separate ABI types for null, bool, int, double, string, array, dictionary, data, plus length-prefixing for each. That's a lot of surface for a small win.
+- Chromium has well-tested `base::Value` → JSON in both directions; cost of JSON serialize/deserialize is microseconds per call.
+
+If a hot path (e.g. high-frequency mouse events serialized as messages) shows up in profiling, add a binary path then. Don't add it speculatively.
+
+## Versioning
+
+`CMUX_EMBEDDER_ABI_VERSION` is the only required version surface. Bump on any *breaking* change (struct layout, semantic change in an enum value, function signature). New methods may be added at the end of the header without bumping; consumers detect new methods via `dlsym` or weak-link.
+
+The fork keeps a CHANGELOG at `//cmux/embedder/CHANGELOG.md`. CmuxBrowserEngine asserts the loaded framework's version is `>= CMUX_EMBEDDER_MIN_ABI` (the minimum it knows how to talk to) and `<= CMUX_EMBEDDER_MAX_ABI`. The minimum and maximum are pinned in the package's `CmuxBrowserEngine.swift`.
+
+## What's intentionally out
+
+These belong to subsequent ABI revisions, not v1:
+
+- Downloads. Migration order from `wkwebview-surface-audit.md` puts downloads after the data-store work.
+- Find-in-page (Chromium has `FindRequest`/`FindReply` Mojo; expose as `cmux_view_find_*`).
+- DevTools / inspector.
+- Print.
+- WebAuthn surface (Chromium handles internally; verify behavior parity is enough).
+- Extensions (massive surface; only meaningful in P4).
+- WebRTC/getUserMedia permission decisions.
+- Push notifications.
+
+## File layout in the fork
+
+```
+src/cmux/embedder/
+├── BUILD.gn                       # source_set + framework target wiring
+├── CHANGELOG.md                   # ABI version history
+├── cmux_browser.h                 # this header, source of truth
+├── cmux_browser.mm                # Objective-C++ glue, talks to content::
+├── cmux_view.cc                   # WebContentsDelegate impl + NSView host
+├── cmux_session.cc                # process-startup, helper-app spawn
+├── cmux_profile.cc                # BrowserContext wrappers
+└── cmux_layer_host.mm             # CAContext / CALayerHost integration
+```
+
+The framework target itself lives at `//cmux:cmux_core_framework`; `//cmux/embedder` is its only public surface.

--- a/plans/wkwebview-surface-audit.md
+++ b/plans/wkwebview-surface-audit.md
@@ -106,20 +106,20 @@ Live config flags read from cmux code (drives what `CmuxBrowserConfiguration` mu
 | `timeoutIntervalForRequest` | (TBD) | missing |
 | `timeoutIntervalForResource` | (TBD) | missing |
 | `userContentController` | ✓ | done |
-| `websiteDataStore` | (TBD) `CmuxBrowserConfiguration.dataStore` | missing |
-| `websiteDataStore.httpCookieStore` | (TBD) `CmuxBrowserConfiguration.dataStore.cookieStore` | missing |
-| `connectionProxyDictionary` | (TBD) | missing |
+| `websiteDataStore` | ✅ `CmuxBrowserConfiguration.dataStore` (s2) | shipped |
+| `websiteDataStore.httpCookieStore` | ✅ `CmuxDataStore.cookieStore` (s2) | shipped |
+| `connectionProxyDictionary` | (TBD — not yet used) | missing |
 
 ## Migration order recommended
 
 Driven by what unblocks the largest BrowserPanel callsite groups first:
 
-1. **KVO/Combine mirrors on CmuxBrowserView** — unblocks the 9 `webView.observe` sites; small surface, mostly mechanical
-2. **`pageZoom`** — unblocks 5 sites
-3. **`CmuxDataStore` + `CmuxCookieStore`** — unblocks ~25 sites across config and cookie reads
-4. **`CmuxDownload` + `CmuxDownloadDelegate`** — unblocks the download flow (14 sites + delegate impl)
-5. **`CmuxInspector` + the `cmuxInspector*` extensions** — last because the inspector is its own subsystem
-6. **`CmuxSnapshotConfiguration`** — for high-DPI snapshots used by `cmux browser screenshot`
+1. ✅ **KVO/Combine mirrors on CmuxBrowserView** — unblocks the 9 `webView.observe` sites. Done in session 1: `CmuxBrowserState` with `@Published url/title/isLoading/estimatedProgress/canGoBack/canGoForward/pageZoom`. KVO observations push to state.
+2. ✅ **`pageZoom`** — unblocks 5 sites. Done in session 1: `CmuxBrowserView.pageZoom` getter/setter, mirrored on `state.pageZoom`.
+3. ✅ **`CmuxDataStore` + `CmuxCookieStore`** — unblocks ~25 sites across config and cookie reads. Done in session 2: factories (`.default()`, `.nonPersistent()`, `.forIdentifier(_:)`), `removeData(ofTypes:modifiedSince:)`, cookie store with get/set/delete/observer. `CmuxBrowserConfiguration.dataStore` is plumbed.
+4. ✅ **`CmuxDownload` + `CmuxDownloadDelegate`** — unblocks the download flow. Done in session 2: per-WKDownload shim with strong refs cleared in terminal callbacks; `CmuxNavigationDelegate.didBecome download` extensions for both nav-action and nav-response.
+5. ⏳ **`CmuxInspector` + the `cmuxInspector*` extensions** — last because the inspector is its own subsystem. NOT done.
+6. ✅ **`CmuxSnapshotConfiguration`** — for high-DPI snapshots used by `cmux browser screenshot`. Done in session 2: rect/snapshotWidth/afterScreenUpdates bridged to `WKSnapshotConfiguration`.
 
 ## Non-Browser callsites of WKWebView
 

--- a/plans/wkwebview-surface-audit.md
+++ b/plans/wkwebview-surface-audit.md
@@ -1,0 +1,142 @@
+# WKWebView surface audit (P3 migration scope)
+
+Generated from grep over `Sources/Panels/*.swift`, `Sources/Find/*.swift`, and friends. Drives what `Packages/CmuxBrowserEngine` must expose before each callsite can flip to the Chromium backend.
+
+## Scope
+
+Files inside the migration boundary:
+
+| File | Lines |
+|---|---|
+| `Sources/Panels/BrowserPanel.swift` | 10,864 |
+| `Sources/Panels/BrowserPanelView.swift` | 6,862 |
+| `Sources/Panels/CmuxWebView.swift` | 2,472 |
+| `Sources/Panels/BrowserPopupWindowController.swift` | 657 |
+| `Sources/Panels/BrowserWebAuthnSupport.swift` | (small) |
+| `Sources/Find/BrowserFindJavaScript.swift` | (small) |
+| Auxiliary: `AppDelegate.swift`, `ContentView.swift`, `Workspace.swift`, `TerminalController.swift`, `MarkdownPanelView.swift`, `MarkdownWebRenderer.swift`, `ReactGrab.swift`, `FileDropOverlayView.swift`, `BrowserPaneDropTargetView.swift` | various |
+
+The first four files are the primary migration surface (~20 K lines). The rest hold the engine but treat it as opaque.
+
+## WK types touched (alphabetical)
+
+`WKDownload`, `WKDownloadDelegate`, `WKFrameInfo`, `WKHTTPCookieStore`, `WKInspector`, `WKMediaCaptureType`, `WKMenuItemIdentifier*`, `WKNavigation`, `WKNavigationAction`, `WKNavigationActionPolicy`, `WKNavigationDelegate`, `WKNavigationResponse`, `WKNavigationResponsePolicy`, `WKNavigationType`, `WKOpenPanelParameters`, `WKPermissionDecision`, `WKProcessPool`, `WKScriptMessage`, `WKScriptMessageHandler`, `WKScriptMessageHandlerWithReply`, `WKSecurityOrigin`, `WKSnapshotConfiguration`, `WKUIDelegate`, `WKUserContentController`, `WKUserScript`, `WKWebView`, `WKWebViewConfiguration`, `WKWebsiteDataStore`, `WKWindowFeatures`.
+
+`Packages/CmuxBrowserEngine` already exposes engine-neutral analogues for the bold types below. Italic = needs to be added before that callsite migrates. Plain text = not needed at the wrapper layer (delegate-internal).
+
+| WK type | Coverage today |
+|---|---|
+| **WKWebView** | `CmuxBrowserView` |
+| **WKWebViewConfiguration** | `CmuxBrowserConfiguration` |
+| **WKUserContentController** | `CmuxUserContentController` |
+| **WKUserScript** | `CmuxUserScript` |
+| **WKScriptMessage** | `CmuxScriptMessage` + `CmuxScriptMessageBody` |
+| **WKScriptMessageHandler** | `CmuxScriptMessageHandler` |
+| **WKNavigationDelegate** | `CmuxNavigationDelegate` |
+| **WKNavigation** | `CmuxNavigation` |
+| **WKNavigationAction** | `CmuxNavigationAction` |
+| **WKNavigationActionPolicy** | `CmuxNavigationActionPolicy` |
+| **WKNavigationResponse** | `CmuxNavigationResponse` |
+| **WKNavigationResponsePolicy** | `CmuxNavigationResponsePolicy` |
+| **WKNavigationType** | `CmuxNavigationAction.NavigationType` |
+| **WKFrameInfo** | `CmuxFrameInfo` |
+| **WKUIDelegate** | `CmuxUIDelegate` |
+| **WKWindowFeatures** | `CmuxWindowFeatures` |
+| **WKOpenPanelParameters** | `CmuxOpenPanelParameters` |
+| **WKURLSchemeHandler** | `CmuxURLSchemeHandler` + `CmuxURLSchemeTask` |
+| *WKScriptMessageHandlerWithReply* | not yet — used by one inspector path |
+| *WKDownload + WKDownloadDelegate* | not yet — `BrowserPanel` exposes downloads via `webView.cmuxBrowserPanelForceRenderingStateRefresh`-adjacent code; needs `CmuxDownload`, `CmuxDownloadDelegate`, `CmuxDownloadProgress` |
+| *WKHTTPCookieStore + WKWebsiteDataStore* | not yet — needs `CmuxCookieStore`, `CmuxDataStore`, persistence/ephemeral selection, container ID |
+| *WKInspector* | not yet — needs `CmuxInspector.show/hide/attach/detach`; Chromium provides `chrome://inspect` style remote debugger we can wire instead |
+| *WKMediaCaptureType + WKPermissionDecision* | not yet — needs `CmuxMediaCapturePermission` enum |
+| *WKSecurityOrigin* | not yet — exposed via `CmuxFrameInfo` host/port; promote to a proper type if a callsite needs more |
+| *WKSnapshotConfiguration* | not yet — `takeSnapshot` exists but doesn't take config; add `CmuxSnapshotConfiguration` (rect, after-screen-updates, snapshot width) before parity |
+| *WKProcessPool* | not yet — `CmuxBrowserConfiguration.processPoolTag` exists but doesn't bridge to WKProcessPool; production needs that bridge or a documented compromise |
+| *WKMenuItemIdentifier\** | not needed at the wrapper — these are AppKit menu items the host owns |
+
+## High-frequency call sites (sorted by occurrence)
+
+| Count | Call | Coverage |
+|---:|---|---|
+| 131 | `WKWebView` type reference | type lives behind `CmuxBrowserView` |
+| 26 | `webView.window` | inherited from `NSView`; `CmuxBrowserView` is an `NSView` ✓ |
+| 16 | `webView.superview` | inherited from `NSView` ✓ |
+| 15 | `webView.url` | `CmuxBrowserView.url` ✓ |
+| 15 | `evaluateJavaScript` | `CmuxBrowserView.evaluateJavaScript` ✓ |
+| 14 | `WKDownload` type | **needs `CmuxDownload`** |
+| 11 | `WKWebsiteDataStore` | **needs `CmuxDataStore`** |
+| 9 | `webView.observe` | needs KVO on `url`, `title`, `estimatedProgress`, `canGoBack`, `canGoForward`, `isLoading`, `fullscreenState`; add Combine `@Published` mirrors to `CmuxBrowserView` |
+| 8 | `webView.evaluateJavaScript` | ✓ |
+| 8 | `webView.cmuxInspectorObject` | **custom extension; needs migration plan, see below** |
+| 7 | `WKScriptMessage` | ✓ |
+| 7 | `WKNavigationAction` | ✓ |
+| 5 | `WKNavigation` | ✓ |
+| 5 | `webView.pageZoom` | **needs `CmuxBrowserView.pageZoom`** |
+| 5 | `webView.isLoading` | ✓ |
+| 5 | `webView.configuration` | not a 1:1 — config is immutable in the wrapper; callers reading config at runtime need a new accessor |
+
+## Custom `WKWebView` extensions in `CmuxWebView.swift`
+
+`CmuxWebView` adds cmux-specific properties via `extension WKWebView`. Each must move to `CmuxBrowserView`:
+
+- `cmuxBrowserPanelForceRenderingStateRefresh`
+- `cmuxBrowserPanelNotifyHidden`
+- `cmuxBrowserPanelReattachRenderingState`
+- `cmuxInspectorFrontendWebView`
+- `cmuxInspectorObject`
+- `cmuxIsElementFullscreenActiveOrTransitioning`
+- `cmuxIsManagedByExternalFullscreenWindow`
+- `onContextMenuDownloadStateChanged`
+- `onContextMenuOpenLinkInNewTab`
+
+Most of these are coordination hooks the host calls to nudge rendering state during workspace churn. They're not a 1:1 with WKWebView; they're cmux's own protocol over the engine. Cleanest path: a `CmuxBrowserViewLifecycle` protocol that both backends implement, and these stay on `CmuxBrowserView` itself.
+
+## `WKWebViewConfiguration` flags actually consumed
+
+Live config flags read from cmux code (drives what `CmuxBrowserConfiguration` must expose):
+
+| WK flag | Cmux equivalent | Status |
+|---|---|---|
+| `defaultWebpagePreferences.allowsContentJavaScript` | (TBD) `CmuxBrowserConfiguration.allowsContentJavaScript` | missing |
+| `preferences.isElementFullscreenEnabled` | hard-coded `true` in `WebKitBrowserBackend` | promote to config |
+| `preferences.setValue(forKey:)` | not a public WK API; cmux uses it for `developerExtrasEnabled` etc. | replace with explicit named flags |
+| `mediaTypesRequiringUserActionForPlayback` | `CmuxBrowserConfiguration.mediaTypesRequiringUserActionForPlayback` ✓ | done |
+| `processPool` | `processPoolTag` (semantic, not identity) | partial |
+| `requestCachePolicy` | (TBD) `CmuxBrowserConfiguration.requestCachePolicy` | missing |
+| `timeoutIntervalForRequest` | (TBD) | missing |
+| `timeoutIntervalForResource` | (TBD) | missing |
+| `userContentController` | ✓ | done |
+| `websiteDataStore` | (TBD) `CmuxBrowserConfiguration.dataStore` | missing |
+| `websiteDataStore.httpCookieStore` | (TBD) `CmuxBrowserConfiguration.dataStore.cookieStore` | missing |
+| `connectionProxyDictionary` | (TBD) | missing |
+
+## Migration order recommended
+
+Driven by what unblocks the largest BrowserPanel callsite groups first:
+
+1. **KVO/Combine mirrors on CmuxBrowserView** — unblocks the 9 `webView.observe` sites; small surface, mostly mechanical
+2. **`pageZoom`** — unblocks 5 sites
+3. **`CmuxDataStore` + `CmuxCookieStore`** — unblocks ~25 sites across config and cookie reads
+4. **`CmuxDownload` + `CmuxDownloadDelegate`** — unblocks the download flow (14 sites + delegate impl)
+5. **`CmuxInspector` + the `cmuxInspector*` extensions** — last because the inspector is its own subsystem
+6. **`CmuxSnapshotConfiguration`** — for high-DPI snapshots used by `cmux browser screenshot`
+
+## Non-Browser callsites of WKWebView
+
+Outside `BrowserPanel`, these surfaces also use WKWebView and are out of scope for the engine swap (they stay on WebKit):
+
+| File | Why it stays |
+|---|---|
+| `Sources/Panels/MarkdownPanelView.swift` | Renders local markdown; no need for Chromium |
+| `Sources/Panels/MarkdownWebRenderer.swift` | Same |
+| `Sources/Panels/ReactGrab.swift` | React DevTools hook; built around WebKit's JSCore |
+| `Sources/AppDelegate.swift` | Settings sheet; trivial |
+| `Sources/CmuxTopProcessDetails.swift` | Read-only diagnostic page |
+| `Sources/FileDropOverlayView.swift` | Pure WK drag-and-drop hit-test |
+| `Sources/Workspace.swift` | Touches `WKProcessPool` for shared cookies; revisit during data-store work |
+
+## Out of audit scope (deferred)
+
+- `Sources/Panels/BrowserPopupWindowController.swift` (popups) — needs `CmuxBrowserPopupWindowController` thin shim; defer until `CmuxUIDelegate.createBrowserViewWith` is exercised end-to-end
+- `Sources/Panels/BrowserWebAuthnSupport.swift` — Chromium's WebAuthn is feature-complete; need to verify behavior parity with WebKit's `ASAuthorizationController` bridge before flipping
+- `Sources/Find/BrowserFindJavaScript.swift` — find-in-page is a separate subsystem; Chromium has a native find API to bind in `CmuxBrowserView.find(text:options:completion:)`

--- a/plans/wkwebview-surface-audit.md
+++ b/plans/wkwebview-surface-audit.md
@@ -118,7 +118,7 @@ Driven by what unblocks the largest BrowserPanel callsite groups first:
 2. ✅ **`pageZoom`** — unblocks 5 sites. Done in session 1: `CmuxBrowserView.pageZoom` getter/setter, mirrored on `state.pageZoom`.
 3. ✅ **`CmuxDataStore` + `CmuxCookieStore`** — unblocks ~25 sites across config and cookie reads. Done in session 2: factories (`.default()`, `.nonPersistent()`, `.forIdentifier(_:)`), `removeData(ofTypes:modifiedSince:)`, cookie store with get/set/delete/observer. `CmuxBrowserConfiguration.dataStore` is plumbed.
 4. ✅ **`CmuxDownload` + `CmuxDownloadDelegate`** — unblocks the download flow. Done in session 2: per-WKDownload shim with strong refs cleared in terminal callbacks; `CmuxNavigationDelegate.didBecome download` extensions for both nav-action and nav-response.
-5. ⏳ **`CmuxInspector` + the `cmuxInspector*` extensions** — last because the inspector is its own subsystem. NOT done.
+5. 🟡 **`CmuxInspector` + the `cmuxInspector*` extensions** — partially done. `CmuxBrowserConfiguration.isInspectable` shipped (mirrors `WKWebView.isInspectable`, the most common call site at `BrowserPanel.swift:2648`). The deeper SPI surface (`_inspector`, `inspectorWebView`, `WebViewInspectorTeardown.closeAllInspectors`) stays WebKit-only because it walks WebKit's `_inspector` object via `NSSelectorFromString` and has no direct Chromium analogue. cmux's inspector teardown code should gate on `configuration.engineKind == .webKit` rather than expand the wrapper.
 6. ✅ **`CmuxSnapshotConfiguration`** — for high-DPI snapshots used by `cmux browser screenshot`. Done in session 2: rect/snapshotWidth/afterScreenUpdates bridged to `WKSnapshotConfiguration`.
 
 ## Non-Browser callsites of WKWebView

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -237,6 +237,37 @@ PYEOF
         echo "  applied: third_party/angle/.../metal_wrapper.py"
     fi
 
+    if [ -f "${patches_dir}/0003-ax-inspect-mac-suppress-new-availability.patch" ]; then
+        local target="${REMOTE_CHROMIUM_ROOT}/src/ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm"
+        echo ">> Applying ax inspect availability-suppression patch"
+        ssh -o BatchMode=yes "${REMOTE_HOST}" "python3 - <<'PY'
+import pathlib
+p = pathlib.Path('${target}')
+s = p.read_text()
+old = 'bool IsValidAXAttribute(const std::string& attribute) {\n  static NSSet<NSString*>* valid_attributes = [NSSet setWithArray:@['
+new = '''// cmux fork: macOS 26 SDK marks some NSAccessibility* constants as
+// introduced in macOS 26.0 only, but chromium's deployment target is
+// macOS 11.0. Since this function is dev-tools/inspection plumbing
+// gated by content_shell flags (not on cmux's critical path), suppress
+// the -Wunguarded-availability-new diagnostic locally. Drop when
+// upstream chromium bumps its deployment target or @available-gates
+// these entries.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \"-Wunguarded-availability-new\"
+bool IsValidAXAttribute(const std::string& attribute) {
+  static NSSet<NSString*>* valid_attributes = [NSSet setWithArray:@['''
+if old in s and '#pragma clang diagnostic push' not in s.split('IsValidAXAttribute', 1)[0]:
+    s = s.replace(old, new)
+    anchor = '  return [valid_attributes containsObject:base::SysUTF8ToNSString(attribute)];\n}'
+    s = s.replace(anchor, anchor + '\n#pragma clang diagnostic pop', 1)
+    p.write_text(s)
+    print('applied: ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm')
+else:
+    print('already-applied-or-mismatched (no-op)')
+PY
+"
+    fi
+
     if [ -f "${patches_dir}/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch" ]; then
         local target="${REMOTE_CHROMIUM_ROOT}/src/services/webnn/coreml/utils_coreml.mm"
         echo ">> Applying webnn CoreML MLMultiArrayDataType default-branch patch"

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -14,6 +14,8 @@
 #   setup            Mount Chromium volume, install depot_tools, sync .zshrc.
 #   remount          Just re-attach the Chromium APFS volume (after reboot).
 #   fetch            Begin or resume Chromium fetch (Mac-only, shallow).
+#   apply-patches    Push the cmux fork patches from patches/ to the host's src/.
+#                    Idempotent — files are overwritten so re-running is safe.
 #   status           Report build host state (depot_tools, fetch progress).
 #   build [target]   Run a release build (default target: cmux_core_framework).
 #
@@ -151,6 +153,91 @@ echo "  log: ${REMOTE_CHROMIUM_ROOT}/gclient-sync.log"
 EOS
 }
 
+cmd_apply_patches() {
+    local script_dir
+    script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+    local patches_dir="${script_dir}/../patches"
+
+    if [ ! -d "${patches_dir}" ]; then
+        echo "  no patches/ dir at ${patches_dir}, nothing to apply"
+        return 0
+    fi
+
+    # Each patch is a hand-rolled context patch — we don't `git apply`,
+    # we just upload the post-patch file. See patches/README.md.
+    if [ -f "${patches_dir}/0001-angle-metal-wrapper-resolve-via-xcrun.patch" ]; then
+        local target="${REMOTE_CHROMIUM_ROOT}/src/third_party/angle/src/libANGLE/renderer/metal/shaders/metal_wrapper.py"
+        echo ">> Applying ANGLE metal-wrapper xcrun patch"
+        # Recreate the patched file directly from the post-patch content
+        # embedded in the .patch file. We extract the added lines (lines
+        # starting with "+") and reconstruct, but it's simpler to keep a
+        # parallel "applied" copy. For now: rebuild on the host.
+        ssh -o BatchMode=yes "${REMOTE_HOST}" "cat > ${target}" <<'PYEOF'
+#!/usr/bin/python3
+# Copyright 2023 The ANGLE Project Authors. All rights reserved.
+# Use of this source code is governed by a BSD-style license that can be
+# found in the LICENSE file.
+#
+# cmux fork: macOS 15 + Xcode 26 ships the Metal compiler toolchain as a
+# separate downloadable component which is mounted at runtime under
+# /var/run/com.apple.security.cryptexd/.../Metal.xctoolchain/usr/bin/.
+# The Xcode-bundled stubs at XcodeDefault.xctoolchain/usr/bin/metal,
+# metallib, etc. do NOT find that mount (only xcrun --find <tool> does).
+# Worse, some tools (e.g. metallib) do not exist as a stub at all, so the
+# GN-supplied path is a dangling reference. When the first argument
+# looks like a Metal toolchain tool living under
+# XcodeDefault.xctoolchain/usr/bin/, swap it for the xcrun-resolved real
+# path. Carry this patch in the cmux Chromium fork until upstream
+# chromium/angle handles this natively.
+from __future__ import annotations
+import os
+import subprocess
+import sys
+
+_XCODE_BIN_PREFIX = "XcodeDefault.xctoolchain/usr/bin/"
+_METAL_TOOL_PREFIXES = ("metal",)  # metal, metallib, metal-ar, metal-lipo, ...
+
+
+def _looks_like_metal_xcode_stub(path):
+    if not path:
+        return False
+    if _XCODE_BIN_PREFIX not in path:
+        return False
+    base = os.path.basename(path)
+    return any(base == p or base.startswith(p) for p in _METAL_TOOL_PREFIXES)
+
+
+def _xcrun_find(tool):
+    try:
+        r = subprocess.run(
+            ["/usr/bin/xcrun", "--find", tool],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            check=False,
+        )
+        path = (r.stdout or "").strip()
+        return path or None
+    except FileNotFoundError:
+        return None
+
+
+def main(args):
+    if args and _looks_like_metal_xcode_stub(args[0]):
+        tool = os.path.basename(args[0])
+        replacement = _xcrun_find(tool)
+        if replacement and replacement != args[0]:
+            args = [replacement] + list(args[1:])
+    return subprocess.run(args, stdout=subprocess.PIPE, text=True).returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))
+PYEOF
+        echo "  applied: third_party/angle/.../metal_wrapper.py"
+    fi
+}
+
 cmd_status() {
     run_remote bash <<EOS
 set -euo pipefail
@@ -220,11 +307,12 @@ EOS
 }
 
 case "$1" in
-    setup)   cmd_setup ;;
-    remount) cmd_remount ;;
-    fetch)   cmd_fetch ;;
-    status)  cmd_status ;;
-    build)   shift; cmd_build "$@" ;;
-    -h|--help) usage ;;
-    *) usage >&2; exit 2 ;;
+    setup)         cmd_setup ;;
+    remount)       cmd_remount ;;
+    fetch)         cmd_fetch ;;
+    apply-patches) cmd_apply_patches ;;
+    status)        cmd_status ;;
+    build)         shift; cmd_build "$@" ;;
+    -h|--help)     usage ;;
+    *)             usage >&2; exit 2 ;;
 esac

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# chromium-build-host.sh
+#
+# Idempotent bootstrap for the cmux Chromium fork build host.
+# Designed to be re-runnable: each step skips its work if already done.
+#
+# Run from a workstation:
+#   ./scripts/chromium-build-host.sh setup
+#
+# Run from the host itself (ssh cmux-aws-mac, then):
+#   ./chromium-build-host.sh setup
+#
+# Subcommands:
+#   setup            Mount Chromium volume, install depot_tools, sync .zshrc.
+#   remount          Just re-attach the Chromium APFS volume (after reboot).
+#   fetch            Begin or resume Chromium fetch (Mac-only, shallow).
+#   status           Report build host state (depot_tools, fetch progress).
+#   build [target]   Run a release build (default target: cmux_core_framework).
+#
+# Constants — see plans/chromium-engine.md for rationale.
+
+set -euo pipefail
+
+# Build host alias (in ~/.ssh/config).
+readonly REMOTE_HOST="${CMUX_BUILD_HOST:-cmux-aws-mac}"
+
+# Path on the build host where the Chromium fork lives.
+# We use /Users/ec2-user/chromium-fork (a NEW path, not the existing
+# /Users/ec2-user/chromium which has prior unrelated work). The /Volumes
+# layout on this Mac is a topic in plans/chromium-engine.md.
+readonly REMOTE_CHROMIUM_ROOT="/Users/ec2-user/chromium-fork"
+readonly REMOTE_DEPOT_TOOLS="/Users/ec2-user/depot_tools"
+
+# Chromium release branch to track. Update when promoting to a new
+# milestone; record the change in plans/chromium-engine-handoff.md.
+readonly CHROMIUM_BRANCH="refs/branch-heads/7204"   # M148 stable
+readonly CHROMIUM_SRC_URL="https://chromium.googlesource.com/chromium/src.git"
+
+usage() {
+    cat <<EOF
+$(basename "$0") <setup|remount|fetch|status|build [target]>
+
+Targets the build host CMUX_BUILD_HOST=${REMOTE_HOST} via ssh.
+
+Examples:
+    $(basename "$0") setup
+    $(basename "$0") status
+    $(basename "$0") fetch
+    $(basename "$0") build cmux_core_framework
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 2
+fi
+
+run_remote() {
+    ssh -o BatchMode=yes "${REMOTE_HOST}" "$@"
+}
+
+cmd_setup() {
+    echo ">> Ensuring depot_tools on ${REMOTE_HOST}"
+    run_remote bash <<EOS
+set -euo pipefail
+if [ ! -d "${REMOTE_DEPOT_TOOLS}" ]; then
+    git clone --depth=1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "${REMOTE_DEPOT_TOOLS}"
+else
+    echo "  depot_tools present, skipping clone"
+fi
+
+# Fix .zshrc ownership (was created root-owned on this AMI).
+if [ -f /Users/ec2-user/.zshrc ] && [ "\$(stat -f %u /Users/ec2-user/.zshrc)" != "501" ]; then
+    sudo -n chown ec2-user:staff /Users/ec2-user/.zshrc
+fi
+
+# Add depot_tools to PATH idempotently.
+if ! grep -q "depot_tools" /Users/ec2-user/.zshrc 2>/dev/null; then
+    cat >> /Users/ec2-user/.zshrc <<'ZRC'
+
+# cmux Chromium fork build host (managed by scripts/chromium-build-host.sh)
+export PATH="\$HOME/depot_tools:\$PATH"
+export DEPOT_TOOLS_UPDATE=1
+export VPYTHON_BYPASS="manually managed python not supported by chrome operations"
+ZRC
+fi
+
+mkdir -p "${REMOTE_CHROMIUM_ROOT}"
+echo ">> Setup done. depot_tools=\$(which gclient 2>/dev/null || echo missing)"
+EOS
+}
+
+cmd_remount() {
+    # No-op today: the cmux Chromium fork lives under /Users/ec2-user
+    # which is on the persistent data volume. Reserved for the case
+    # where a future host moves the checkout to an APFS volume mounted
+    # at /Volumes/Chromium (see plans/chromium-engine.md "Build host
+    # plan" for context).
+    echo ">> No volume to remount (using /Users/ec2-user). No-op."
+}
+
+cmd_fetch() {
+    echo ">> Beginning Chromium fetch in ${REMOTE_CHROMIUM_ROOT}"
+    run_remote bash <<EOS
+set -euo pipefail
+export PATH="${REMOTE_DEPOT_TOOLS}:\$PATH"
+cd "${REMOTE_CHROMIUM_ROOT}"
+
+if [ ! -f .gclient ]; then
+    cat > .gclient <<'GCLIENT'
+solutions = [
+  {
+    "name": "src",
+    "url": "${CHROMIUM_SRC_URL}",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {
+        "checkout_pgo_profiles": False
+    },
+  },
+]
+target_os = ['mac']
+GCLIENT
+    echo "  wrote .gclient (mac-only, no PGO)"
+fi
+
+if [ ! -d src ]; then
+    echo "  cloning src/ shallow at ${CHROMIUM_BRANCH}"
+    git clone --depth=1 --branch=main "${CHROMIUM_SRC_URL}" src
+fi
+
+cd src
+git fetch --depth=1 origin "${CHROMIUM_BRANCH}"
+git checkout FETCH_HEAD
+
+cd ..
+echo "  running gclient sync (this is hours)"
+exec nohup gclient sync --no-history --shallow -j 16 > "${REMOTE_CHROMIUM_ROOT}/gclient-sync.log" 2>&1 &
+echo "  fetch pid: \$!"
+echo "  log: ${REMOTE_CHROMIUM_ROOT}/gclient-sync.log"
+EOS
+}
+
+cmd_status() {
+    run_remote bash <<EOS
+set -euo pipefail
+echo "== build host: ${REMOTE_HOST} =="
+sw_vers | head -2
+echo "-- disk --"
+df -h /Users/ec2-user 2>/dev/null
+echo "-- depot_tools --"
+if command -v "${REMOTE_DEPOT_TOOLS}/gclient" >/dev/null 2>&1; then
+    "${REMOTE_DEPOT_TOOLS}/gclient" --version 2>&1 | head -1
+else
+    echo "  not installed"
+fi
+echo "-- chromium fork --"
+if [ -d "${REMOTE_CHROMIUM_ROOT}/src" ]; then
+    cd "${REMOTE_CHROMIUM_ROOT}/src"
+    echo "  HEAD: \$(git rev-parse --short HEAD)"
+    echo "  size: \$(du -sh . 2>/dev/null | awk '{print \$1}')"
+else
+    echo "  not fetched"
+fi
+echo "-- sync in flight --"
+if pgrep -fl 'gclient' >/dev/null 2>&1; then
+    pgrep -fl 'gclient' | head -3
+else
+    echo "  none"
+fi
+echo "-- last sync log --"
+if [ -f "${REMOTE_CHROMIUM_ROOT}/gclient-sync.log" ]; then
+    tail -5 "${REMOTE_CHROMIUM_ROOT}/gclient-sync.log"
+else
+    echo "  no log yet"
+fi
+EOS
+}
+
+cmd_build() {
+    local target="${1:-cmux_core_framework}"
+    local out_dir="out/cmux_release"
+    echo ">> Building target ${target} in ${out_dir}"
+    run_remote bash <<EOS
+set -euo pipefail
+export PATH="${REMOTE_DEPOT_TOOLS}:\$PATH"
+cd "${REMOTE_CHROMIUM_ROOT}/src"
+
+if [ ! -f "${out_dir}/args.gn" ]; then
+    mkdir -p "${out_dir}"
+    cat > "${out_dir}/args.gn" <<'ARGS'
+# cmux Chromium fork release args
+is_debug = false
+is_component_build = false
+symbol_level = 1
+target_cpu = "arm64"
+target_os = "mac"
+enable_nacl = false
+proprietary_codecs = true
+ffmpeg_branding = "Chrome"
+# CmuxCore framework target: see //cmux/embedder
+is_chrome_branded = false
+chrome_pgo_phase = 0
+ARGS
+    gn gen "${out_dir}"
+fi
+
+autoninja -C "${out_dir}" "${target}"
+EOS
+}
+
+case "$1" in
+    setup)   cmd_setup ;;
+    remount) cmd_remount ;;
+    fetch)   cmd_fetch ;;
+    status)  cmd_status ;;
+    build)   shift; cmd_build "$@" ;;
+    -h|--help) usage ;;
+    *) usage >&2; exit 2 ;;
+esac

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -135,8 +135,18 @@ git checkout FETCH_HEAD
 
 cd ..
 echo "  running gclient sync (this is hours)"
-exec nohup gclient sync --no-history --shallow -j 16 > "${REMOTE_CHROMIUM_ROOT}/gclient-sync.log" 2>&1 &
-echo "  fetch pid: \$!"
+# Detach via subshell-then-background so the gclient process is
+# orphaned cleanly when this SSH session exits. macOS's nohup needs
+# a real tty for ioctl and breaks under ssh exec heredocs; setsid
+# isn't installed. The subshell-background pattern is the macOS
+# idiom that survives ssh disconnect.
+( cd "${REMOTE_CHROMIUM_ROOT}" && \
+  export PATH="${REMOTE_DEPOT_TOOLS}:\$PATH" && \
+  gclient sync --no-history --shallow -j 16 \
+    > "${REMOTE_CHROMIUM_ROOT}/gclient-sync.log" 2>&1 < /dev/null & )
+sleep 2
+pid=\$(pgrep -f "gclient.py sync" | head -1)
+echo "  fetch pid: \${pid:-unknown}"
 echo "  log: ${REMOTE_CHROMIUM_ROOT}/gclient-sync.log"
 EOS
 }

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -237,6 +237,36 @@ PYEOF
         echo "  applied: third_party/angle/.../metal_wrapper.py"
     fi
 
+    if [ -f "${patches_dir}/0004-ax-platform-node-cocoa-suppress-new-availability.patch" ]; then
+        local target="${REMOTE_CHROMIUM_ROOT}/src/ui/accessibility/platform/ax_platform_node_cocoa.mm"
+        echo ">> Applying ax_platform_node_cocoa file-scope availability suppression"
+        ssh -o BatchMode=yes "${REMOTE_HOST}" "python3 - <<'PY'
+import pathlib
+p = pathlib.Path('${target}')
+s = p.read_text()
+marker = '// cmux fork: macOS 26 SDK marks a number of NSAccessibility role'
+if marker in s:
+    print('already-applied (no-op)')
+else:
+    prefix = '''// cmux fork: macOS 26 SDK marks a number of NSAccessibility role and
+// attribute constants (WebAreaRole, BlockQuoteLevelAttribute,
+// VisitedAttribute, ...) as introduced in macOS 26.0. Chromium\\'s
+// deployment target is macOS 11.0, so they fire
+// -Werror,-Wunguarded-availability-new across this file. File-level
+// suppression is the pragmatic choice: this file is OS-level
+// accessibility plumbing and the new symbols just unblock the build.
+// Drop when upstream chromium @available-gates these references or
+// bumps the deployment target.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored \"-Wunguarded-availability-new\"
+
+'''
+    p.write_text(prefix + s + '\n#pragma clang diagnostic pop\n')
+    print('applied: ui/accessibility/platform/ax_platform_node_cocoa.mm')
+PY
+"
+    fi
+
     if [ -f "${patches_dir}/0003-ax-inspect-mac-suppress-new-availability.patch" ]; then
         local target="${REMOTE_CHROMIUM_ROOT}/src/ui/accessibility/platform/inspect/ax_inspect_utils_mac.mm"
         echo ">> Applying ax inspect availability-suppression patch"

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -236,6 +236,48 @@ if __name__ == "__main__":
 PYEOF
         echo "  applied: third_party/angle/.../metal_wrapper.py"
     fi
+
+    if [ -f "${patches_dir}/0002-webnn-coreml-handle-new-mlmultiarraydatatype.patch" ]; then
+        local target="${REMOTE_CHROMIUM_ROOT}/src/services/webnn/coreml/utils_coreml.mm"
+        echo ">> Applying webnn CoreML MLMultiArrayDataType default-branch patch"
+        ssh -o BatchMode=yes "${REMOTE_HOST}" "python3 - <<'PY'
+import pathlib
+p = pathlib.Path('${target}')
+s = p.read_text()
+old = '''  switch (data_type) {
+    case MLMultiArrayDataTypeDouble:
+      return 8;
+    case MLMultiArrayDataTypeFloat32:
+    case MLMultiArrayDataTypeInt32:
+      return 4;
+    case MLMultiArrayDataTypeFloat16:
+      return 2;
+  }
+'''
+new = '''  switch (data_type) {
+    case MLMultiArrayDataTypeDouble:
+      return 8;
+    case MLMultiArrayDataTypeFloat32:
+    case MLMultiArrayDataTypeInt32:
+      return 4;
+    case MLMultiArrayDataTypeFloat16:
+      return 2;
+    default:
+      // cmux fork: macOS 26 SDK introduced new MLMultiArrayDataType values
+      // (Int8, UInt8, etc.) that upstream Chromium has not enumerated yet.
+      // Treat unknown types conservatively; webnn is not on cmux's critical
+      // path so an exact byte-size here would just be future-rebase debt.
+      return 0;
+  }
+'''
+if old in s:
+    p.write_text(s.replace(old, new))
+    print('applied: services/webnn/coreml/utils_coreml.mm')
+else:
+    print('already-applied-or-mismatched (no-op)')
+PY
+"
+    fi
 }
 
 cmd_status() {

--- a/scripts/chromium-build-host.sh
+++ b/scripts/chromium-build-host.sh
@@ -237,6 +237,47 @@ PYEOF
         echo "  applied: third_party/angle/.../metal_wrapper.py"
     fi
 
+    if [ -f "${patches_dir}/0005-ax-cocoa-rename-private-symbol-backports.patch" ]; then
+        local target="${REMOTE_CHROMIUM_ROOT}/src/ui/accessibility/platform/browser_accessibility_cocoa.mm"
+        echo ">> Applying browser_accessibility_cocoa SDK-shadow rename"
+        ssh -o BatchMode=yes "${REMOTE_HOST}" "python3 - <<'PY'
+import pathlib
+p = pathlib.Path('${target}')
+s = p.read_text()
+# Idempotent rename: only act if the bare names are still present.
+# The bare names declared in the anonymous namespace collide with the
+# macOS 26.2 SDK; rename to CmuxNS* prefix. String literals unchanged.
+old_decl_a = '''NSString* const
+    NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute =
+        @\"AXUIElementsForSearchPredicate\";'''
+new_decl_a = '''// cmux fork: renamed to avoid collision with macOS 26.2 SDK
+// (which now declares the same identifier @available(macos 26.0)).
+NSString* const
+    CmuxNSAccessibilityUIElementsForSearchPredicateParameterizedAttribute =
+        @\"AXUIElementsForSearchPredicate\";'''
+old_decl_b = 'NSString* const NSAccessibilityScrollToVisibleAction = @\"AXScrollToVisible\";'
+new_decl_b = '''// cmux fork: renamed to avoid collision with macOS 26.2 SDK.
+NSString* const CmuxNSAccessibilityScrollToVisibleAction = @\"AXScrollToVisible\";'''
+changed = False
+if old_decl_a in s:
+    s = s.replace(old_decl_a, new_decl_a, 1)
+    s = s.replace('NSAccessibilityUIElementsForSearchPredicateParameterizedAttribute',
+                  'CmuxNSAccessibilityUIElementsForSearchPredicateParameterizedAttribute')
+    changed = True
+if old_decl_b in s:
+    s = s.replace(old_decl_b, new_decl_b, 1)
+    s = s.replace('NSAccessibilityScrollToVisibleAction',
+                  'CmuxNSAccessibilityScrollToVisibleAction')
+    changed = True
+if changed:
+    p.write_text(s)
+    print('applied: ui/accessibility/platform/browser_accessibility_cocoa.mm')
+else:
+    print('already-applied (no-op)')
+PY
+"
+    fi
+
     if [ -f "${patches_dir}/0004-ax-platform-node-cocoa-suppress-new-availability.patch" ]; then
         local target="${REMOTE_CHROMIUM_ROOT}/src/ui/accessibility/platform/ax_platform_node_cocoa.mm"
         echo ">> Applying ax_platform_node_cocoa file-scope availability suppression"


### PR DESCRIPTION
## Summary

Long-running spike to replace cmux's `WKWebView`-based browser surface with a custom Chromium-derived engine, shipped as a private `CmuxCore.framework` inside the cmux app bundle. Same architecture as Arc/Dia. **No CEF.**

This PR is **planning only**. No fetch, no build, no engine code. Two files:

- `plans/chromium-engine.md` — architecture, milestones (P0–P5), build host plan, cost estimate, risk register, cross-session continuity model
- `plans/chromium-engine-handoff.md` — per-session state ledger; the carryover substrate since `/loop` does not span sessions

## What this commits us to

Real numbers, stated up front so we can abort before sunk cost:

- 5–10 calendar months of focused work at a small-team pace; longer with one human in the loop
- ~\$5,500 in `cmux-aws-mac` EC2 Mac dedicated-host time over the project (continuous billing, 24-hour minimum allocation)
- App bundle grows from ~100 MB → ~600 MB
- Ongoing rebase tax against Chromium upstream every ~4 weeks, indefinitely

If any of those change the answer, kill the spike now.

## Architecture (one-liner)

`Sources/Panels/CmuxWebView.swift` stops subclassing `WKWebView`. A new `Packages/CmuxBrowserEngine` Swift package wraps a C ABI exported from a Chromium fork. Helper processes (Renderer/GPU/Utility/Alerts) live in `CmuxCore.framework/Helpers/`. GPU helper publishes a `CAContext`, browser process binds `CALayerHost.contextId` — same path Dia and Arc use. Verified by reverse-engineering `/Applications/Dia.app`.

## Test plan

- [ ] Plan doc reviewed; cost and scope acknowledged
- [ ] Decision made on which Chromium release branch to track
- [ ] `cmux-aws-mac` persistent volume layout finalized
- [ ] (Future) P0 builds: depot_tools installed, `fetch chromium` complete, first clean `chrome` release build green
- [ ] (Future) P1: `CmuxCore.framework` builds with cmux branding
- [ ] (Future) P2: minimal Swift host renders `google.com` via `CmuxBrowserView` in a `CALayerHost`-backed `NSView`
- [ ] (Future) P3: feature flag `cmux.browser.engine.chromium`, all `cmuxUITests/Browser*UITests.swift` pass under both flag values

## Continuing this work

`/loop` runs only inside one session. This project spans many sessions. The per-session protocol:

1. Open cmuxterm-hq, `cd worktrees/feat-chromium-engine`
2. Read `plans/chromium-engine-handoff.md` "Next steps" first
3. Do the next concrete step
4. Commit. Update the ledger. Push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an engine-neutral browser layer with `WKWebView` in production and a Chromium path behind a flag. Toolchain and GN graphs are validated; the embedder C ABI stubs let the future forked framework link and load once the fork exists.

- **New Features**
  - `Packages/CmuxBrowserEngine`: `CmuxBrowserView`, config, user content, WK-shaped navigation/UI delegates; engine picked via `CmuxBrowserEngine.Kind` and `cmux.browser.engine.chromium` (test override supported). `WebKitBrowserBackend` is production; `ChromiumBrowserBackend` is a loud stub.
  - State mirrors via `CmuxBrowserState` (url/title/loading/progress/back/forward + `pageZoom`), exposed as `view.state`; WebKit wires via KVO.
  - `CmuxDataStore` (default/nonPersistent/forIdentifier) and `CmuxCookieStore` (get/set/delete + observer).
  - `CmuxDownload` + delegate wiring, and `CmuxSnapshotConfiguration` with `takeSnapshot(configuration:)`.
  - `CmuxBrowserConfiguration.isInspectable` (macOS 13.3+), mapped to `WKWebView.isInspectable`.
  - Fork-bound `embedder/` is drop-in with a v1 C ABI and stubbed implementations; the framework target and helper apps are GN-wired and ready to live in the fork.
  - Tests: 35 total covering flags, config (incl. `isInspectable`), script-message parsing, WebKit ops, Chromium-stub error contract, state mirrors, `pageZoom`, cookies/data store, downloads, snapshotting, and Combine emits.
  - Planning docs: `plans/chromium-engine-handoff.md` logs session 3 (M148 base confirmed, patch taxonomy captured, `content_shell` still in flight); `plans/chromium-engine.md` marks P1 GN/branding/helpers DONE after `gn check` pass.

- **Bug Fixes**
  - `scripts/chromium-build-host.sh`: macOS-safe background fetch (replace `nohup` with subshell + background); `apply-patches` now applies patches 0001–0005 idempotently, including the AX Cocoa backport rename.
  - `embedder/cmux_BUILD.gn` and `embedder/BUILD.gn`: validated via `gn gen` + `gn check` on M148; removed duplicate `enable_arc`, dropped test-only `//mojo` deps; all `//cmux:*` targets pass check; README updated to VALIDATED.

<sup>Written for commit 3678edabd5932fb4bfbab27ca95fd4cb62370658. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

