### PR TITLE
Fix retained Ghostty quicklook font leak

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -261,6 +261,12 @@ jobs:
       - run:
           name: Validate Swift warning budget
           command: python3 scripts/swift_warning_budget.py --log /tmp/cmux-build-output.txt
+      - run:
+          name: Run leak smoke test
+          no_output_timeout: 10m
+          command: scripts/leak-smoke-ci.sh
+      - store_artifacts:
+          path: /tmp/cmux-leak-smoke
       - save-swift-package-cache:
           prefix: debug-build
       - save-zig-cache

--- a/Sources/WorkspaceSurfaceConfig.swift
+++ b/Sources/WorkspaceSurfaceConfig.swift
@@ -73,7 +73,7 @@ func cmuxCurrentSurfaceFontSizePoints(_ surface: ghostty_surface_t) -> Float? {
         return nil
     }
 
-    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeUnretainedValue()
+    let ctFont = Unmanaged<CTFont>.fromOpaque(quicklookFont).takeRetainedValue()
     let points = Float(CTFontGetSize(ctFont))
     guard points > 0 else { return nil }
     return points

--- a/scripts/leak-smoke-ci.sh
+++ b/scripts/leak-smoke-ci.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/leak-smoke-ci.sh [app-path]
+
+Launch a Debug cmux app with malloc stack logging, take a baseline leaks
+snapshot, exercise workspace churn through the socket CLI, and fail if the
+churn introduces new leaks.
+
+Environment:
+  CMUX_LEAK_SMOKE_TAG       Socket/app tag. Default: ci-leaks
+  CMUX_LEAK_SMOKE_CYCLES    Workspace churn cycles. Default: 6
+  CMUX_LEAK_SMOKE_OUT_DIR   Output directory. Default: /tmp/cmux-leak-smoke
+EOF
+}
+
+sanitize_path() {
+  local raw="$1"
+  local cleaned
+  cleaned="$(echo "$raw" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+//; s/-+$//; s/-+/-/g')"
+  if [[ -z "$cleaned" ]]; then
+    cleaned="ci-leaks"
+  fi
+  echo "$cleaned"
+}
+
+find_debug_app() {
+  find "$HOME/Library/Developer/Xcode/DerivedData" \
+    -path "*/Build/Products/Debug/cmux DEV.app" \
+    -exec stat -f '%m %N' {} \; 2>/dev/null \
+    | sort -nr \
+    | head -1 \
+    | cut -d' ' -f2-
+}
+
+parse_leak_summary() {
+  local file="$1"
+  sed -nE 's/^Process [0-9]+: ([0-9]+) leaks for ([0-9]+) total leaked bytes\./\1 \2/p' "$file" | tail -1
+}
+
+wait_for_socket() {
+  local pid="$1"
+  local socket_path="$2"
+  local deadline=$((SECONDS + 45))
+
+  while (( SECONDS < deadline )); do
+    if [[ -S "$socket_path" ]]; then
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: cmux exited while waiting for socket at $socket_path" >&2
+      print_launch_logs
+      return 1
+    fi
+    sleep 0.25
+  done
+
+  echo "ERROR: socket not ready after 45s at $socket_path" >&2
+  print_launch_logs
+  return 1
+}
+
+wait_for_cli() {
+  local cli="$1"
+  local socket_path="$2"
+  local pid="$3"
+  local deadline=$((SECONDS + 20))
+
+  while (( SECONDS < deadline )); do
+    if CMUX_SOCKET_PATH="$socket_path" "$cli" ping >/dev/null 2>&1; then
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "ERROR: cmux exited while waiting for CLI ping" >&2
+      print_launch_logs
+      return 1
+    fi
+    sleep 0.25
+  done
+
+  echo "ERROR: cmux CLI did not respond to ping" >&2
+  print_launch_logs
+  return 1
+}
+
+print_launch_logs() {
+  for log_path in "$STDOUT_LOG" "$STDERR_LOG"; do
+    if [[ -s "$log_path" ]]; then
+      echo "--- ${log_path} ---" >&2
+      tail -80 "$log_path" >&2 || true
+    fi
+  done
+}
+
+launch_direct() {
+  env \
+    MallocStackLogging=1 \
+    MallocStackLoggingNoCompact=1 \
+    CMUX_TAG="$TAG_SLUG" \
+    CMUX_SOCKET_MODE=allowAll \
+    CMUX_ALLOW_SOCKET_OVERRIDE=1 \
+    CMUX_SOCKET_PATH="$SOCKET_PATH" \
+    CMUXD_UNIX_PATH="$CMUXD_SOCKET_PATH" \
+    CMUX_UI_TEST_MODE=1 \
+    CMUX_DISABLE_SESSION_RESTORE=1 \
+    "$BINARY" >"$STDOUT_LOG" 2>"$STDERR_LOG" &
+  APP_PID=$!
+}
+
+launch_open() {
+  open -n -g \
+    --stdout "$STDOUT_LOG" \
+    --stderr "$STDERR_LOG" \
+    --env MallocStackLogging=1 \
+    --env MallocStackLoggingNoCompact=1 \
+    --env CMUX_TAG="$TAG_SLUG" \
+    --env CMUX_SOCKET_MODE=allowAll \
+    --env CMUX_ALLOW_SOCKET_OVERRIDE=1 \
+    --env CMUX_SOCKET_PATH="$SOCKET_PATH" \
+    --env CMUXD_UNIX_PATH="$CMUXD_SOCKET_PATH" \
+    --env CMUX_UI_TEST_MODE=1 \
+    --env CMUX_DISABLE_SESSION_RESTORE=1 \
+    "$APP"
+
+  for _ in $(seq 1 40); do
+    APP_PID="$(pgrep -n -f "$APP/Contents/MacOS/cmux DEV" || true)"
+    if [[ -n "$APP_PID" ]]; then
+      return 0
+    fi
+    sleep 0.25
+  done
+
+  echo "ERROR: launched with open, but could not find cmux process for $APP" >&2
+  print_launch_logs
+  return 1
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+APP="${1:-${CMUX_LEAK_SMOKE_APP:-}}"
+if [[ -z "$APP" ]]; then
+  APP="$(find_debug_app)"
+fi
+
+if [[ -z "$APP" || ! -d "$APP" ]]; then
+  echo "ERROR: Debug cmux app not found. Pass app-path or set CMUX_LEAK_SMOKE_APP." >&2
+  exit 1
+fi
+
+BINARY="$APP/Contents/MacOS/cmux DEV"
+CLI="$APP/Contents/Resources/bin/cmux"
+if [[ ! -x "$BINARY" ]]; then
+  echo "ERROR: app binary not executable: $BINARY" >&2
+  exit 1
+fi
+if [[ ! -x "$CLI" ]]; then
+  echo "ERROR: bundled cmux CLI not executable: $CLI" >&2
+  exit 1
+fi
+if ! command -v leaks >/dev/null 2>&1; then
+  echo "ERROR: leaks tool not found" >&2
+  exit 1
+fi
+
+TAG="${CMUX_LEAK_SMOKE_TAG:-ci-leaks}"
+TAG_SLUG="$(sanitize_path "$TAG")"
+CYCLES="${CMUX_LEAK_SMOKE_CYCLES:-6}"
+OUT_DIR="${CMUX_LEAK_SMOKE_OUT_DIR:-/tmp/cmux-leak-smoke}"
+SOCKET_PATH="/tmp/cmux-debug-${TAG_SLUG}.sock"
+CMUXD_SOCKET_PATH="$HOME/Library/Application Support/cmux/cmuxd-dev-${TAG_SLUG}.sock"
+STDOUT_LOG="$OUT_DIR/cmux.log"
+STDERR_LOG="$OUT_DIR/cmux.err"
+BASELINE_LOG="$OUT_DIR/leaks-baseline.txt"
+BASELINE_GRAPH="$OUT_DIR/baseline.memgraph"
+DIFF_LOG="$OUT_DIR/leaks-diff.txt"
+
+if [[ ! "$CYCLES" =~ ^[0-9]+$ || "$CYCLES" -lt 1 ]]; then
+  echo "ERROR: CMUX_LEAK_SMOKE_CYCLES must be a positive integer" >&2
+  exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+rm -f "$SOCKET_PATH" "$CMUXD_SOCKET_PATH" "$BASELINE_LOG" "$BASELINE_GRAPH" "$DIFF_LOG" "$STDOUT_LOG" "$STDERR_LOG"
+
+APP_PID=""
+cleanup() {
+  if [[ -n "$APP_PID" ]]; then
+    kill "$APP_PID" >/dev/null 2>&1 || true
+    wait "$APP_PID" >/dev/null 2>&1 || true
+  fi
+  rm -f "$SOCKET_PATH" "$CMUXD_SOCKET_PATH"
+}
+trap cleanup EXIT
+
+echo "=== cmux leak smoke ==="
+echo "app: $APP"
+echo "tag: $TAG_SLUG"
+echo "socket: $SOCKET_PATH"
+echo "out: $OUT_DIR"
+
+launch_direct
+echo "pid: $APP_PID"
+
+if ! wait_for_socket "$APP_PID" "$SOCKET_PATH"; then
+  echo "Direct executable launch did not reach the socket; retrying via LaunchServices..."
+  kill "$APP_PID" >/dev/null 2>&1 || true
+  wait "$APP_PID" >/dev/null 2>&1 || true
+  APP_PID=""
+  rm -f "$SOCKET_PATH" "$CMUXD_SOCKET_PATH" "$STDOUT_LOG" "$STDERR_LOG"
+  launch_open
+  echo "pid: $APP_PID"
+  wait_for_socket "$APP_PID" "$SOCKET_PATH"
+fi
+wait_for_cli "$CLI" "$SOCKET_PATH" "$APP_PID"
+
+echo "Capturing baseline leaks graph..."
+set +e
+leaks --quiet --outputGraph="$BASELINE_GRAPH" "$APP_PID" >"$BASELINE_LOG" 2>&1
+BASELINE_STATUS=$?
+set -e
+cat "$BASELINE_LOG"
+if [[ ! -f "$BASELINE_GRAPH" ]]; then
+  echo "ERROR: leaks did not produce baseline graph: $BASELINE_GRAPH" >&2
+  exit 1
+fi
+if [[ "$BASELINE_STATUS" -ne 0 ]]; then
+  echo "Baseline leaks status was $BASELINE_STATUS; continuing because the diff gate only fails on new leaks."
+fi
+
+echo "Running workspace churn..."
+refs=()
+for i in $(seq 1 "$CYCLES"); do
+  out="$(
+    CMUX_SOCKET_PATH="$SOCKET_PATH" "$CLI" \
+      new-workspace \
+      --name "leak-smoke-$i" \
+      --cwd "$PWD" \
+      --command "printf 'leak-smoke-$i\\n'" \
+      --focus true
+  )"
+  ref="$(printf '%s\n' "$out" | awk '/OK/{print $2}')"
+  if [[ -z "$ref" ]]; then
+    echo "ERROR: failed to parse workspace ref from: $out" >&2
+    exit 1
+  fi
+  refs+=("$ref")
+  CMUX_SOCKET_PATH="$SOCKET_PATH" "$CLI" send --workspace "$ref" "printf 'typed-$i\\n'" >/dev/null
+  CMUX_SOCKET_PATH="$SOCKET_PATH" "$CLI" read-screen --workspace "$ref" --lines 5 >/dev/null || true
+done
+
+CMUX_SOCKET_PATH="$SOCKET_PATH" "$CLI" select-workspace --workspace workspace:1 >/dev/null || true
+for ref in "${refs[@]}"; do
+  CMUX_SOCKET_PATH="$SOCKET_PATH" "$CLI" close-workspace --workspace "$ref" >/dev/null || true
+done
+
+echo "Checking for new leaks..."
+set +e
+leaks --quiet --list --diffFrom="$BASELINE_GRAPH" "$APP_PID" >"$DIFF_LOG" 2>&1
+DIFF_STATUS=$?
+set -e
+cat "$DIFF_LOG"
+
+summary="$(parse_leak_summary "$DIFF_LOG" || true)"
+if [[ -z "$summary" ]]; then
+  if [[ "$DIFF_STATUS" -ne 0 ]]; then
+    echo "ERROR: leaks failed without a parseable summary" >&2
+    exit "$DIFF_STATUS"
+  fi
+  echo "ERROR: leaks output did not include a parseable summary" >&2
+  exit 1
+fi
+
+read -r leak_count leaked_bytes <<<"$summary"
+if [[ "$leak_count" -ne 0 || "$leaked_bytes" -ne 0 ]]; then
+  echo "ERROR: leak smoke introduced $leak_count leaks ($leaked_bytes bytes)" >&2
+  exit 1
+fi
+
+echo "=== cmux leak smoke passed: no new leaks ==="


### PR DESCRIPTION
Summary
- Release the retained CTFont returned by ghostty_surface_quicklook_font when cmux only needs the font size.
- Prevent repeated font-size inheritance checks from leaking CoreText font objects during terminal surface creation and layout cycles.
- Add a CircleCI leak smoke gate that launches the Debug app with malloc stack logging, snapshots a baseline memory graph, drives workspace churn, and fails on new leaks.

Verification
- ./scripts/reload.sh --tag memfix
- Pre-fix leak pass on tag memchk: 42 leaks, 15792 bytes after create/select/send/read/close workspace cycle.
- Fixed leak pass on tag memfix: 0 leaks, 0 bytes before and after the same cycle.
- bash -n scripts/leak-smoke-ci.sh
- ruby -e 'require "yaml"; YAML.load_file(".circleci/config.yml")'\n- CMUX_LEAK_SMOKE_APP="/Users/lawrence/Library/Developer/Xcode/DerivedData/cmux-memfix/Build/Products/Debug/cmux DEV.app" CMUX_LEAK_SMOKE_TAG=memfixci CMUX_LEAK_SMOKE_OUT_DIR=/tmp/cmux-leak-smoke-local-untagged scripts/leak-smoke-ci.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CoreFoundation/Swift ownership bridging (`takeRetainedValue`) which can crash if the underlying API is not actually returning a retained object, and adds a `leaks`-based CI gate that could introduce platform/tool flakiness.
> 
> **Overview**
> Fixes a memory leak when reading a surface’s quicklook font size by changing the CoreText bridge to `takeRetainedValue()` so the returned `CTFont` is released after size extraction.
> 
> Adds a new `scripts/leak-smoke-ci.sh` workflow and wires it into the CircleCI macOS Debug build to launch the app, churn workspaces via the socket CLI, run `leaks --diffFrom` against a baseline, and store `/tmp/cmux-leak-smoke` artifacts on failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dccc3f47936da3071a51bc7968beed847210411. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory management around font-size handling to prevent resource issues and improve stability.

* **Tests**
  * Added an automated leak-smoke test to the macOS debug CI to catch memory regressions earlier.

* **Chores**
  * Added a CI helper script to run leak smoke checks and produce diagnostic artifacts for investigation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4163)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->