### PR TITLE
Fix duplicate Codex monitor helpers

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -18505,7 +18505,12 @@ struct CMUXCLI {
         }
     }
 
-    private func retireCodexMonitorLeases(sessionId: String, turnId: String?, env: [String: String]) {
+    private func retireCodexMonitorLeases(
+        sessionId: String,
+        turnId: String?,
+        preservingLeasePath: String? = nil,
+        env: [String: String]
+    ) {
         let normalizedSessionId = sessionId.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalizedSessionId.isEmpty else { return }
 
@@ -18513,6 +18518,9 @@ struct CMUXCLI {
         let now = Date().timeIntervalSince1970
         let normalizedTurnId = turnId?.trimmingCharacters(in: .whitespacesAndNewlines)
         let shouldMatchTurn = normalizedTurnId?.isEmpty == false
+        let preservingPath = preservingLeasePath.map {
+            URL(fileURLWithPath: $0, isDirectory: false).standardizedFileURL.path
+        }
         let directory = codexMonitorLeaseDirectory(env: env)
         let targetPaths = ((try? fileManager.contentsOfDirectory(
             at: directory,
@@ -18521,6 +18529,10 @@ struct CMUXCLI {
         )) ?? []).map(\.path)
 
         for path in targetPaths {
+            let standardizedPath = URL(fileURLWithPath: path, isDirectory: false).standardizedFileURL.path
+            guard preservingPath == nil || standardizedPath != preservingPath else {
+                continue
+            }
             guard var record = readCodexMonitorLease(path: path),
                   record.sessionId == normalizedSessionId,
                   !shouldMatchTurn || record.turnId == normalizedTurnId,
@@ -20861,6 +20873,13 @@ export default function cmuxPiSessionExtension(pi: ExtensionAPI) {
                     telemetry.breadcrumb(
                         "codex-hook.monitor.lease-unavailable",
                         data: ["has_turn_id": normalizedHookValue(input.turnId) != nil]
+                    )
+                } else {
+                    retireCodexMonitorLeases(
+                        sessionId: sessionId,
+                        turnId: nil,
+                        preservingLeasePath: leasePath,
+                        env: env
                     )
                 }
                 startCodexTranscriptMonitor(

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -2135,6 +2135,84 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         )
     }
 
+    func testCodexPromptSubmitRetiresPreviousMonitorLeaseForSameSession() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath("codex")
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-monitor-leases-\(UUID().uuidString)", isDirectory: true)
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        let sessionId = "codex-session-lease-dedupe"
+
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        startMockServerAccepting(listenerFD: listenerFD, state: state, connectionLimit: 6) { line in
+            guard let data = line.data(using: .utf8),
+                  let payload = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+                  let id = payload["id"] as? String else {
+                return "OK"
+            }
+            return self.v2Response(
+                id: id,
+                ok: true,
+                result: ["surfaces": [["id": surfaceId, "ref": surfaceId, "focused": true]]]
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_WORKSPACE_ID"] = workspaceId
+        environment["CMUX_SURFACE_ID"] = surfaceId
+        environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CODEX_HOME"] = root.appendingPathComponent("codex-home", isDirectory: true).path
+
+        let firstInput = """
+        {"session_id":"\(sessionId)","turn_id":"turn-one","cwd":"\(root.path)","hook_event_name":"UserPromptSubmit","prompt":"first"}
+        """
+        let firstResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "prompt-submit"],
+            environment: environment,
+            standardInput: firstInput,
+            timeout: 5
+        )
+
+        XCTAssertFalse(firstResult.timedOut, firstResult.stderr)
+        XCTAssertEqual(firstResult.status, 0, firstResult.stderr)
+        XCTAssertEqual(firstResult.stdout, "{}\n")
+        XCTAssertTrue(
+            waitForCodexMonitorActiveLeaseTurns(in: root, expected: ["turn-one"], timeout: 3),
+            "Expected first prompt to leave one active monitor lease, saw \(codexMonitorActiveLeaseTurns(in: root))"
+        )
+
+        let secondInput = """
+        {"session_id":"\(sessionId)","turn_id":"turn-two","cwd":"\(root.path)","hook_event_name":"UserPromptSubmit","prompt":"second"}
+        """
+        let secondResult = runProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "prompt-submit"],
+            environment: environment,
+            standardInput: secondInput,
+            timeout: 5
+        )
+
+        XCTAssertFalse(secondResult.timedOut, secondResult.stderr)
+        XCTAssertEqual(secondResult.status, 0, secondResult.stderr)
+        XCTAssertEqual(secondResult.stdout, "{}\n")
+        XCTAssertTrue(
+            waitForCodexMonitorActiveLeaseTurns(in: root, expected: ["turn-two"], timeout: 3),
+            "Expected a new turn to retire the prior Codex monitor lease, saw \(codexMonitorActiveLeaseTurns(in: root))"
+        )
+    }
+
     func testCodexHookStopTreatsCodexErrorInfoPayloadAsFailure() throws {
         let cliPath = try bundledCLIPath()
         let socketPath = makeSocketPath("codex")
@@ -3474,6 +3552,55 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         return handled
     }
 
+    private func startMockServerAccepting(
+        listenerFD: Int32,
+        state: MockSocketServerState,
+        connectionLimit: Int,
+        handler: @escaping @Sendable (String) -> String
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            var accepted = 0
+            while accepted < connectionLimit {
+                var clientAddr = sockaddr_un()
+                var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+                let clientFD = withUnsafeMutablePointer(to: &clientAddr) { ptr in
+                    ptr.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                        Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                    }
+                }
+                if clientFD < 0 {
+                    if errno == EINTR { continue }
+                    return
+                }
+                accepted += 1
+
+                DispatchQueue.global(qos: .userInitiated).async {
+                    defer { Darwin.close(clientFD) }
+                    var pending = Data()
+                    var buffer = [UInt8](repeating: 0, count: 4096)
+
+                    while true {
+                        let count = Darwin.read(clientFD, &buffer, buffer.count)
+                        if count < 0 {
+                            if errno == EINTR { continue }
+                            return
+                        }
+                        if count == 0 { return }
+                        pending.append(buffer, count: count)
+
+                        while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                            let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                            pending.removeSubrange(0...newlineRange.lowerBound)
+                            guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                            state.append(line)
+                            guard self.writeAll(handler(line) + "\n", to: clientFD) else { return }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     private func runMockServer(
         listenerFD: Int32,
         state: MockSocketServerState,
@@ -3514,13 +3641,32 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                     pending.removeSubrange(0...newlineRange.lowerBound)
                     guard let line = String(data: lineData, encoding: .utf8) else { continue }
                     state.append(line)
-                    let response = handler(line) + "\n"
-                    _ = response.withCString { ptr in
-                        Darwin.write(clientFD, ptr, strlen(ptr))
-                    }
+                    guard self.writeAll(handler(line) + "\n", to: clientFD) else { return }
                 }
             }
         }
+    }
+
+    private func writeAll(_ string: String, to fd: Int32) -> Bool {
+        let bytes = Array(string.utf8)
+        var offset = 0
+        while offset < bytes.count {
+            let written = bytes.withUnsafeBytes { buffer in
+                Darwin.write(fd, buffer.baseAddress!.advanced(by: offset), bytes.count - offset)
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            if written == 0 {
+                return false
+            }
+            if errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK {
+                continue
+            }
+            return false
+        }
+        return true
     }
 
     private func v2Response(
@@ -3538,6 +3684,41 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
         }
         let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
         return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    private func codexMonitorActiveLeaseTurns(in root: URL) -> [String] {
+        let directory = root.appendingPathComponent("codex-monitor-leases", isDirectory: true)
+        let urls = (try? FileManager.default.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )) ?? []
+
+        return urls.compactMap { url -> String? in
+            guard let data = try? Data(contentsOf: url),
+                  let lease = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] else {
+                return nil
+            }
+            if let retiredAt = lease["retiredAt"], !(retiredAt is NSNull) {
+                return nil
+            }
+            return lease["turnId"] as? String
+        }.sorted()
+    }
+
+    private func waitForCodexMonitorActiveLeaseTurns(
+        in root: URL,
+        expected: [String],
+        timeout: TimeInterval
+    ) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if codexMonitorActiveLeaseTurns(in: root) == expected.sorted() {
+                return true
+            }
+            _ = DispatchSemaphore(value: 0).wait(timeout: .now() + 0.05)
+        }
+        return codexMonitorActiveLeaseTurns(in: root) == expected.sorted()
     }
 
     @MainActor


### PR DESCRIPTION
Summary
- Retire older Codex monitor leases for a session when a new prompt-submit hook starts.
- Preserve the newly-created lease so the current turn monitor keeps running.
- Add a regression test that proves a second prompt leaves only the latest active lease.

Validation
- Red before fix: `testCodexPromptSubmitRetiresPreviousMonitorLeaseForSameSession` failed with active turns `["turn-one", "turn-two"]`.
- Green after fix: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination "platform=macOS,arch=arm64" -derivedDataPath /tmp/cmux-cmongreen -only-testing:cmuxTests/CLINotifyProcessIntegrationTests/testCodexPromptSubmitRetiresPreviousMonitorLeaseForSameSession test`
- Green neighboring coverage: same command with `testCodexHookMonitorNotifiesOnRequestUserInput` and `testCodexHookMonitorIgnoresUnscopedTerminalForTurnScopedMonitor`.
- Tagged dogfood build: `./scripts/reload.sh --tag cmon`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents duplicate Codex transcript monitors by retiring previous leases on prompt-submit while preserving the current lease using standardized file paths. Ensures only the newest turn stays active for a session.

- **Bug Fixes**
  - Add `preservingLeasePath` to `retireCodexMonitorLeases` and standardize paths to skip the active lease.
  - Retire older session leases right after acquiring the new lease during `prompt-submit`.
  - Add an integration test plus socket helpers (multi-connection accept, reliable writes, and lease polling) to verify only the latest turn remains active.

<sup>Written for commit f515dbb5bea09435f715e771ea05719dbfe5f8ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts Codex monitor lease retirement logic to preserve the newly-created lease and retire older ones for the same session; issues here could stop monitors prematurely or leave duplicates running. Adds integration coverage to reduce regression risk.
> 
> **Overview**
> Prevents duplicate Codex transcript monitors by retiring any prior monitor leases for the same `session_id` when a new `codex prompt-submit` hook starts, while explicitly *preserving* the newly-created lease via standardized path comparison.
> 
> Adds an integration regression test to verify multi-turn prompt submits leave only the latest active lease, and extends the test socket harness to handle multiple connections and reliably write full responses (`startMockServerAccepting`, `writeAll`, and lease polling helpers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f515dbb5bea09435f715e771ea05719dbfe5f8ad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test verifying monitor lease handoff across multi-turn sessions.
  * Added a reusable mock server helper and polling helpers to support multi-connection lease verification.

* **Refactor**
  * Improved lease-retirement logic so the current active lease is preserved while monitoring configuration is re-established.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4164)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->