### PR TITLE
Fix Cursor agent restore commands

### DIFF
--- a/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -392,6 +392,7 @@ extension AgentLaunchSanitizer {
             "--header",
             "--continue",
             "--resume",
+            "--use-system-ca",
             "--workspace",
             "-w",
             "--worktree",
@@ -403,6 +404,7 @@ extension AgentLaunchSanitizer {
             "--header=",
             "-H=",
             "--resume=",
+            "--use-system-ca=",
             "--workspace=",
             "--worktree=",
             "--worktree-base="

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -46,9 +46,13 @@ enum AgentResumeCommandBuilder {
         commandParts.append(contentsOf: argv)
 
         var shellCommand = commandParts.map(shellSingleQuoted).joined(separator: " ")
-        let cwd = !includeWorkingDirectoryPrefix || customRegistration?.cwd == .ignore
-            ? nil
-            : normalized(workingDirectory ?? launchCommand?.workingDirectory)
+        let cwd = resumeWorkingDirectory(
+            kind: kind,
+            launchCommand: launchCommand,
+            workingDirectory: workingDirectory,
+            customRegistration: customRegistration,
+            includeWorkingDirectoryPrefix: includeWorkingDirectoryPrefix
+        )
         if let cwd {
             shellCommand = "cd \(shellSingleQuoted(cwd)) && \(shellCommand)"
         }
@@ -350,6 +354,57 @@ enum AgentResumeCommandBuilder {
             ?? fallbackExecutable
         let tail = arguments.isEmpty ? [] : Array(arguments.dropFirst())
         return (executable, tail)
+    }
+
+    private static func resumeWorkingDirectory(
+        kind: RestorableAgentKind,
+        launchCommand: AgentLaunchCommandSnapshot?,
+        workingDirectory: String?,
+        customRegistration: CmuxVaultAgentRegistration?,
+        includeWorkingDirectoryPrefix: Bool
+    ) -> String? {
+        guard includeWorkingDirectoryPrefix, customRegistration?.cwd != .ignore else {
+            return nil
+        }
+
+        let fallback = normalized(workingDirectory ?? launchCommand?.workingDirectory)
+        guard kind == .cursor else {
+            return fallback
+        }
+
+        let workspace = cursorWorkspaceDirectory(from: launchCommand?.arguments)
+        guard let fallback else {
+            return workspace
+        }
+
+        return isCursorConfigDirectory(fallback) ? workspace : fallback
+    }
+
+    private static func cursorWorkspaceDirectory(from arguments: [String]?) -> String? {
+        guard let arguments, !arguments.isEmpty else {
+            return nil
+        }
+
+        var index = 1
+        while index < arguments.count {
+            let argument = arguments[index]
+            if argument == "--workspace" {
+                guard index + 1 < arguments.count else {
+                    return nil
+                }
+                return normalized(arguments[index + 1])
+            }
+            if argument.hasPrefix("--workspace=") {
+                return normalized(String(argument.dropFirst("--workspace=".count)))
+            }
+            index += 1
+        }
+        return nil
+    }
+
+    private static func isCursorConfigDirectory(_ path: String) -> Bool {
+        let expanded = (path as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL.lastPathComponent == ".cursor"
     }
 
     private static func normalized(_ value: String?) -> String? {

--- a/cmuxTests/RestorableAgentHookProviderResumeTests.swift
+++ b/cmuxTests/RestorableAgentHookProviderResumeTests.swift
@@ -272,6 +272,33 @@ extension SocketListenerAcceptPolicyTests {
         )
     }
 
+    func testCursorResumeDropsRemovedSystemCAFlagAndConfigDirectoryCwd() {
+        let cursor = SessionRestorableAgentSnapshot(
+            kind: .cursor,
+            sessionId: "DF1085A7-E46A-453E-8540-2CCF6365D35E",
+            workingDirectory: "/Users/example/.cursor",
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "cursor",
+                executablePath: "/Users/example/.local/bin/agent",
+                arguments: [
+                    "/Users/example/.local/bin/agent",
+                    "--use-system-ca",
+                ],
+                workingDirectory: "/Users/example/.cursor",
+                environment: [
+                    "CLAUDE_CONFIG_DIR": "/Users/example/.codex-accounts/claude/_p1775010019397",
+                ],
+                capturedAt: 123,
+                source: "process"
+            )
+        )
+
+        XCTAssertEqual(
+            cursor.resumeCommand,
+            "'env' 'CLAUDE_CONFIG_DIR=/Users/example/.codex-accounts/claude/_p1775010019397' '/Users/example/.local/bin/agent' '--resume' 'DF1085A7-E46A-453E-8540-2CCF6365D35E'"
+        )
+    }
+
     func testAgentLaunchSanitizerMatchesGeminiAndRovoResumePolicies() {
         XCTAssertEqual(
             AgentLaunchSanitizer.sanitizedLaunchArguments(


### PR DESCRIPTION
Summary:
- Drop Cursor Agent's removed `--use-system-ca` flag when building resume commands.
- Stop restoring Cursor Agent sessions with a forced `cd ~/.cursor`; use a captured `--workspace` only when the saved cwd is Cursor's config directory.

Testing:
- Red regression: `xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS,arch=arm64 -derivedDataPath /tmp/cmux-cursorrestore-red -only-testing:cmuxTests/SocketListenerAcceptPolicyTests/testCursorResumeDropsRemovedSystemCAFlagAndConfigDirectoryCwd test` failed before the fix with `cd ~/.cursor` and `--use-system-ca` still present.
- Green regression after fix and rebase: same focused `cmux-unit` test passed with `/tmp/cmux-cursorrestore-green`.
- Tagged build: `./scripts/reload.sh --tag cursorfix` passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how Cursor resume shell commands are built (sanitization + `cd` behavior), which could affect session restoration paths/flags for existing saved sessions. Scope is limited to Cursor-specific handling and adds a targeted regression test.
> 
> **Overview**
> Fixes Cursor agent session restoration to better match current CLI behavior.
> 
> Cursor resume argument sanitization now drops the removed `--use-system-ca` flag, and resume commands no longer force `cd` into `~/.cursor` (or any `.cursor` config directory); when the captured cwd is Cursor’s config dir, it prefers the captured `--workspace` path instead. Adds a regression test covering both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8e2c242392fa4fdf851e03d39b8ad11858febdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Cursor Agent resume commands by stripping the removed `--use-system-ca` flag and stopping the forced `cd ~/.cursor`. If the saved cwd is the Cursor config folder, resume uses the captured `--workspace`; otherwise it keeps the saved cwd.

- **Bug Fixes**
  - Remove `--use-system-ca` and `--use-system-ca=` in the launch argument sanitizer.
  - Decide resume cwd via new logic: keep saved cwd; if it’s the `.cursor` config dir, switch to `--workspace` when available.
  - Add unit test covering flag removal and cwd behavior.

<sup>Written for commit a8e2c242392fa4fdf851e03d39b8ad11858febdc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session resume command handling with enhanced flag sanitization
  * Enhanced working directory resolution during session restoration with better fallback logic

* **Tests**
  * Added test coverage for resume command sanitization and environment handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/manaflow-ai/cmux/pull/4166)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->