### PR TITLE
Mark workspace unread when a tab is marked unread

### DIFF
--- a/Sources/App/MenuBarExtraController.swift
+++ b/Sources/App/MenuBarExtraController.swift
@@ -332,18 +332,19 @@ enum NotificationMenuSnapshotBuilder {
 
     static func make(
         notifications: [TerminalNotification],
+        workspaceUnreadIndicatorCount: Int = 0,
         maxInlineNotificationItems: Int = defaultInlineNotificationLimit
     ) -> NotificationMenuSnapshot {
         let unreadCount = notifications.reduce(into: 0) { count, notification in
             if !notification.isRead {
                 count += 1
             }
-        }
+        } + workspaceUnreadIndicatorCount
 
         let inlineLimit = max(0, maxInlineNotificationItems)
         return NotificationMenuSnapshot(
             unreadCount: unreadCount,
-            hasNotifications: !notifications.isEmpty,
+            hasNotifications: !notifications.isEmpty || workspaceUnreadIndicatorCount > 0,
             recentNotifications: Array(notifications.prefix(inlineLimit))
         )
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10600,7 +10600,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         var seenWindowIds = Set<UUID>()
         let preferredContext = preferredRegisteredMainWindowContext(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow)
-        let orderedContexts = ([preferredContext].compactMap { $0 } + Array(mainWindowContexts.values))
+        let orderedContexts = ([preferredContext].compactMap { $0 } + sortedMainWindowContextsForSessionSnapshot())
             .filter { seenWindowIds.insert($0.windowId).inserted }
 
         for context in orderedContexts {
@@ -10633,11 +10633,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func clearWorkspaceUnreadAfterJump(workspace: Workspace, panelId: UUID?) {
-        if let panelId {
-            workspace.markPanelRead(panelId)
-        } else {
-            notificationStore?.markRead(forTabId: workspace.id)
-        }
+        workspace.clearUnreadAfterJump(panelId: panelId)
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10589,7 +10589,54 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 return notificationStore.notifications.first(where: { $0.id == notification.id }) ?? notification
             }
         }
+        _ = openLatestWorkspaceUnread()
         return nil
+    }
+
+    private func openLatestWorkspaceUnread() -> Bool {
+        guard let notificationStore else { return false }
+        let unreadWorkspaceIds = notificationStore.workspaceUnreadIndicatorIds
+        guard !unreadWorkspaceIds.isEmpty else { return false }
+
+        var seenWindowIds = Set<UUID>()
+        let preferredContext = preferredRegisteredMainWindowContext(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow)
+        let orderedContexts = ([preferredContext].compactMap { $0 } + Array(mainWindowContexts.values))
+            .filter { seenWindowIds.insert($0.windowId).inserted }
+
+        for context in orderedContexts {
+            guard let workspace = context.tabManager.tabs.first(where: { unreadWorkspaceIds.contains($0.id) }) else {
+                continue
+            }
+            return openWorkspaceUnread(workspace, in: context)
+        }
+
+        guard let tabManager,
+              let workspace = tabManager.tabs.first(where: { unreadWorkspaceIds.contains($0.id) }) else {
+            return false
+        }
+        let panelId = workspace.preferredUnreadPanelIdForJump()
+        let didOpen = openNotificationFallback(tabId: workspace.id, surfaceId: panelId, notificationId: nil)
+        if didOpen {
+            clearWorkspaceUnreadAfterJump(workspace: workspace, panelId: panelId)
+        }
+        return didOpen
+    }
+
+    private func openWorkspaceUnread(_ workspace: Workspace, in context: MainWindowContext) -> Bool {
+        let panelId = workspace.preferredUnreadPanelIdForJump()
+        let didOpen = openNotificationInContext(context, tabId: workspace.id, surfaceId: panelId, notificationId: nil)
+        if didOpen {
+            clearWorkspaceUnreadAfterJump(workspace: workspace, panelId: panelId)
+        }
+        return didOpen
+    }
+
+    private func clearWorkspaceUnreadAfterJump(workspace: Workspace, panelId: UUID?) {
+        if let panelId {
+            workspace.markPanelRead(panelId)
+        } else {
+            notificationStore?.markRead(forTabId: workspace.id)
+        }
     }
 
     @discardableResult

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -10604,10 +10604,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .filter { seenWindowIds.insert($0.windowId).inserted }
 
         for context in orderedContexts {
-            guard let workspace = context.tabManager.tabs.first(where: { unreadWorkspaceIds.contains($0.id) }) else {
-                continue
+            for workspace in context.tabManager.tabs where unreadWorkspaceIds.contains(workspace.id) {
+                if openWorkspaceUnread(workspace, in: context) {
+                    return true
+                }
             }
-            return openWorkspaceUnread(workspace, in: context)
         }
 
         guard let tabManager,

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -74,7 +74,7 @@ struct NotificationsPage: View {
 
             Spacer()
 
-            if !notificationStore.notifications.isEmpty {
+            if notificationStore.notificationMenuSnapshot.hasNotifications {
                 jumpToUnreadButton
 
                 Button(String(localized: "notifications.clearAll", defaultValue: "Clear All")) {
@@ -141,7 +141,7 @@ struct NotificationsPage: View {
     }
 
     private var hasUnreadNotifications: Bool {
-        notificationStore.notifications.contains(where: { !$0.isRead })
+        notificationStore.notificationMenuSnapshot.hasUnreadNotifications
     }
 }
 

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -13,8 +13,10 @@ struct NotificationsPage: View {
             header
             Divider()
 
-            if notificationStore.notifications.isEmpty {
+            if !notificationStore.notificationMenuSnapshot.hasNotifications {
                 emptyState
+            } else if notificationStore.notifications.isEmpty {
+                workspaceUnreadIndicatorState
             } else {
                 ScrollView {
                     LazyVStack(spacing: 8) {
@@ -97,6 +99,17 @@ struct NotificationsPage: View {
             Text(String(localized: "notifications.empty.description", defaultValue: "Desktop notifications will appear here for quick review."))
                 .font(.subheadline)
                 .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var workspaceUnreadIndicatorState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "bell.badge")
+                .font(.system(size: 32))
+                .foregroundColor(.secondary)
+            Text(notificationStore.notificationMenuSnapshot.stateHintTitle)
+                .font(.headline)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1445,12 +1445,14 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        if !idsToClear.isEmpty {
+            notifications = updated
+        }
         setWorkspaceManualUnread(false, forTabId: tabId)
         clearWorkspacePanelUnread(forTabId: tabId)
         setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
         setWorkspaceRestoredUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
-            notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
         }
     }
@@ -1466,13 +1468,15 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        if !idsToClear.isEmpty {
+            notifications = updated
+        }
         if surfaceId == nil {
             clearWorkspacePanelUnread(forTabId: tabId)
             setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
             setWorkspaceRestoredUnread(false, forTabId: tabId)
         }
         if !idsToClear.isEmpty {
-            notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }
@@ -1540,12 +1544,14 @@ final class TerminalNotificationStore: ObservableObject {
                 idsToClear.append(updated[index].id.uuidString)
             }
         }
+        if !idsToClear.isEmpty {
+            notifications = updated
+        }
         clearWorkspaceManualUnread()
         clearAllWorkspacePanelUnread(forTabIds: panelDerivedUnreadWorkspaceIds)
         clearPanelDerivedWorkspaceUnread()
         clearWorkspaceRestoredUnread()
         if !idsToClear.isEmpty {
-            notifications = updated
             center.removeDeliveredNotificationsOffMain(withIdentifiers: idsToClear)
             center.removePendingNotificationRequestsOffMain(withIdentifiers: idsToClear)
         }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -708,9 +708,10 @@ final class TerminalNotificationStore: ObservableObject {
         }
     }
     @Published private(set) var notificationMenuSnapshot = NotificationMenuSnapshotBuilder.make(notifications: [])
-    // Workspace-level manual unread drives sidebar workspace badges; pane-level
-    // manual unread remains owned by Workspace.manualUnreadPanelIds.
+    // Workspace-level unread drives sidebar workspace badges; pane-level manual
+    // unread remains owned by Workspace.manualUnreadPanelIds.
     @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
+    @Published private(set) var panelDerivedUnreadWorkspaceIds: Set<UUID> = []
     @Published private(set) var restoredUnreadWorkspaceIds: Set<UUID> = []
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
@@ -801,7 +802,7 @@ final class TerminalNotificationStore: ObservableObject {
 
     var unreadCount: Int {
         // Global badges count only notification-backed unread items. Per-workspace
-        // badges use unreadCount(forTabId:) and include manualUnreadWorkspaceIds.
+        // badges use unreadCount(forTabId:) and include workspace indicators.
         indexes.unreadCount
     }
 
@@ -917,6 +918,38 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     @discardableResult
+    private func setPanelDerivedWorkspaceUnread(_ isUnread: Bool, forTabId tabId: UUID) -> Bool {
+        var nextIds = panelDerivedUnreadWorkspaceIds
+        let didChange: Bool
+        if isUnread {
+            didChange = nextIds.insert(tabId).inserted
+        } else {
+            didChange = nextIds.remove(tabId) != nil
+        }
+        guard didChange else { return false }
+        panelDerivedUnreadWorkspaceIds = nextIds
+        return true
+    }
+
+    private func clearPanelDerivedWorkspaceUnread() {
+        guard !panelDerivedUnreadWorkspaceIds.isEmpty else { return }
+        panelDerivedUnreadWorkspaceIds = []
+    }
+
+    private func clearWorkspacePanelUnread(forTabId tabId: UUID) {
+        guard let appDelegate = AppDelegate.shared else { return }
+        let workspace = appDelegate.workspaceFor(tabId: tabId) ??
+            appDelegate.tabManager?.tabs.first(where: { $0.id == tabId })
+        workspace?.clearAllPanelUnreadIndicatorsForWorkspaceRead()
+    }
+
+    private func clearAllWorkspacePanelUnread(forTabIds tabIds: Set<UUID>) {
+        for tabId in tabIds {
+            clearWorkspacePanelUnread(forTabId: tabId)
+        }
+    }
+
+    @discardableResult
     private func setWorkspaceRestoredUnread(_ isUnread: Bool, forTabId tabId: UUID) -> Bool {
         var nextIds = restoredUnreadWorkspaceIds
         let didChange: Bool
@@ -939,8 +972,17 @@ final class TerminalNotificationStore: ObservableObject {
         manualUnreadWorkspaceIds.contains(tabId)
     }
 
+    func hasPanelDerivedUnread(forTabId tabId: UUID) -> Bool {
+        panelDerivedUnreadWorkspaceIds.contains(tabId)
+    }
+
     func hasRestoredUnreadIndicator(forTabId tabId: UUID) -> Bool {
         restoredUnreadWorkspaceIds.contains(tabId)
+    }
+
+    @discardableResult
+    func setPanelDerivedUnread(_ isUnread: Bool, forTabId tabId: UUID) -> Bool {
+        setPanelDerivedWorkspaceUnread(isUnread, forTabId: tabId)
     }
 
     @discardableResult
@@ -958,10 +1000,11 @@ final class TerminalNotificationStore: ObservableObject {
         setWorkspaceManualUnread(false, forTabId: tabId)
     }
 
-    // Per-workspace badges treat manual/restored workspace IDs as "has unread
-    // activity"; summing these counts can exceed indexes.unreadCount.
+    // Per-workspace badges treat workspace indicators as unread activity;
+    // summing these counts can exceed indexes.unreadCount.
     func unreadCount(forTabId tabId: UUID) -> Int {
         let hasWorkspaceUnreadIndicator = manualUnreadWorkspaceIds.contains(tabId) ||
+            panelDerivedUnreadWorkspaceIds.contains(tabId) ||
             restoredUnreadWorkspaceIds.contains(tabId)
         return (indexes.unreadCountByTabId[tabId] ?? 0) + (hasWorkspaceUnreadIndicator ? 1 : 0)
     }
@@ -1380,6 +1423,8 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         setWorkspaceManualUnread(false, forTabId: tabId)
+        clearWorkspacePanelUnread(forTabId: tabId)
+        setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
         setWorkspaceRestoredUnread(false, forTabId: tabId)
         if !idsToClear.isEmpty {
             notifications = updated
@@ -1399,6 +1444,8 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         if surfaceId == nil {
+            clearWorkspacePanelUnread(forTabId: tabId)
+            setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
             setWorkspaceRestoredUnread(false, forTabId: tabId)
         }
         if !idsToClear.isEmpty {
@@ -1471,6 +1518,8 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         clearWorkspaceManualUnread()
+        clearAllWorkspacePanelUnread(forTabIds: panelDerivedUnreadWorkspaceIds)
+        clearPanelDerivedWorkspaceUnread()
         clearWorkspaceRestoredUnread()
         if !idsToClear.isEmpty {
             notifications = updated
@@ -1499,10 +1548,13 @@ final class TerminalNotificationStore: ObservableObject {
         guard !notifications.isEmpty ||
             !focusedReadIndicatorByTabId.isEmpty ||
             !manualUnreadWorkspaceIds.isEmpty ||
+            !panelDerivedUnreadWorkspaceIds.isEmpty ||
             !restoredUnreadWorkspaceIds.isEmpty else { return }
         let ids = notifications.map { $0.id.uuidString }
         replaceNotificationsForClear([])
         clearWorkspaceManualUnread()
+        clearAllWorkspacePanelUnread(forTabIds: panelDerivedUnreadWorkspaceIds)
+        clearPanelDerivedWorkspaceUnread()
         clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
         CmuxEventBus.shared.publishNotificationCleared(ids: ids, workspaceId: nil, surfaceId: nil)
@@ -1591,6 +1643,8 @@ final class TerminalNotificationStore: ObservableObject {
             }
         }
         setWorkspaceManualUnread(false, forTabId: tabId)
+        clearWorkspacePanelUnread(forTabId: tabId)
+        setPanelDerivedWorkspaceUnread(false, forTabId: tabId)
         setWorkspaceRestoredUnread(false, forTabId: tabId)
         guard !idsToClear.isEmpty || hadFocusedReadIndicator else { return }
         if !idsToClear.isEmpty {
@@ -1974,6 +2028,7 @@ final class TerminalNotificationStore: ObservableObject {
         TerminalMutationBus.shared.discardPendingNotifications()
         self.notifications = notifications
         clearWorkspaceManualUnread()
+        clearPanelDerivedWorkspaceUnread()
         clearWorkspaceRestoredUnread()
         focusedReadIndicatorByTabId.removeAll()
     }

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -701,18 +701,22 @@ final class TerminalNotificationStore: ObservableObject {
     @Published private(set) var notifications: [TerminalNotification] = [] {
         didSet {
             indexes = Self.buildIndexes(for: notifications)
-            let nextMenuSnapshot = NotificationMenuSnapshotBuilder.make(notifications: notifications)
-            if notificationMenuSnapshot != nextMenuSnapshot { notificationMenuSnapshot = nextMenuSnapshot }
-            refreshDockBadge()
+            refreshUnreadPresentation()
             if !suppressNotificationDiffPublishing { CmuxEventBus.shared.publishNotificationChanges(oldValue: oldValue, newValue: notifications) }
         }
     }
     @Published private(set) var notificationMenuSnapshot = NotificationMenuSnapshotBuilder.make(notifications: [])
     // Workspace-level unread drives sidebar workspace badges; pane-level manual
     // unread remains owned by Workspace.manualUnreadPanelIds.
-    @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
-    @Published private(set) var panelDerivedUnreadWorkspaceIds: Set<UUID> = []
-    @Published private(set) var restoredUnreadWorkspaceIds: Set<UUID> = []
+    @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = [] {
+        didSet { refreshUnreadPresentation() }
+    }
+    @Published private(set) var panelDerivedUnreadWorkspaceIds: Set<UUID> = [] {
+        didSet { refreshUnreadPresentation() }
+    }
+    @Published private(set) var restoredUnreadWorkspaceIds: Set<UUID> = [] {
+        didSet { refreshUnreadPresentation() }
+    }
     @Published private(set) var focusedReadIndicatorByTabId: [UUID: UUID] = [:]
     @Published private(set) var authorizationState: NotificationAuthorizationState = .unknown
     private var suppressNotificationDiffPublishing = false
@@ -801,9 +805,28 @@ final class TerminalNotificationStore: ObservableObject {
     }
 
     var unreadCount: Int {
-        // Global badges count only notification-backed unread items. Per-workspace
-        // badges use unreadCount(forTabId:) and include workspace indicators.
-        indexes.unreadCount
+        indexes.unreadCount + workspaceUnreadIndicatorCount
+    }
+
+    var workspaceUnreadIndicatorIds: Set<UUID> {
+        manualUnreadWorkspaceIds
+            .union(panelDerivedUnreadWorkspaceIds)
+            .union(restoredUnreadWorkspaceIds)
+    }
+
+    private var workspaceUnreadIndicatorCount: Int {
+        workspaceUnreadIndicatorIds.count
+    }
+
+    private func refreshUnreadPresentation() {
+        let nextMenuSnapshot = NotificationMenuSnapshotBuilder.make(
+            notifications: notifications,
+            workspaceUnreadIndicatorCount: workspaceUnreadIndicatorCount
+        )
+        if notificationMenuSnapshot != nextMenuSnapshot {
+            notificationMenuSnapshot = nextMenuSnapshot
+        }
+        refreshDockBadge()
     }
 
     private func logAuthorization(_ message: String) {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1637,7 +1637,7 @@ private struct NotificationsPopoverView: View {
                 }
                 .buttonStyle(.bordered)
                 .accessibilityIdentifier("notificationsPopover.clearAll")
-                .disabled(notificationStore.notifications.isEmpty)
+                .disabled(notificationStore.notificationMenuSnapshot.hasNotifications == false)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
@@ -1686,7 +1686,7 @@ private struct NotificationsPopoverView: View {
     }
 
     private var hasUnreadNotifications: Bool {
-        notificationStore.notifications.contains(where: { !$0.isRead })
+        notificationStore.notificationMenuSnapshot.hasUnreadNotifications
     }
 
     private func jumpToLatestUnread() {

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1644,7 +1644,7 @@ private struct NotificationsPopoverView: View {
 
             Divider()
 
-            if notificationStore.notifications.isEmpty {
+            if !notificationStore.notificationMenuSnapshot.hasNotifications {
                 VStack(spacing: 8) {
                     Image(systemName: "bell.slash")
                         .font(.system(size: 28))
@@ -1654,6 +1654,15 @@ private struct NotificationsPopoverView: View {
                     Text(String(localized: "notifications.empty.subtitle", defaultValue: "Desktop notifications will appear here."))
                         .font(.subheadline)
                         .foregroundColor(.secondary)
+                }
+                .frame(minWidth: 420, idealWidth: 520, maxWidth: 640, minHeight: 180)
+            } else if notificationStore.notifications.isEmpty {
+                VStack(spacing: 8) {
+                    Image(systemName: "bell.badge")
+                        .font(.system(size: 28))
+                        .foregroundColor(.secondary)
+                    Text(notificationStore.notificationMenuSnapshot.stateHintTitle)
+                        .font(.headline)
                 }
                 .frame(minWidth: 420, idealWidth: 520, maxWidth: 640, minHeight: 180)
             } else {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7272,7 +7272,12 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var panelTitles: [UUID: String] = [:]
     @Published var panelCustomTitles: [UUID: String] = [:]
     @Published var pinnedPanelIds: Set<UUID> = []
-    @Published var manualUnreadPanelIds: Set<UUID> = []
+    @Published var manualUnreadPanelIds: Set<UUID> = [] {
+        didSet {
+            guard manualUnreadPanelIds != oldValue else { return }
+            syncPanelDerivedWorkspaceUnread()
+        }
+    }
     @Published private(set) var restoredUnreadPanelIds: Set<UUID> = []
     @Published private(set) var tmuxLayoutSnapshot: LayoutSnapshot?
     @Published private(set) var tmuxWorkspaceFlashPanelId: UUID?
@@ -8380,6 +8385,10 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
+    func syncPanelDerivedWorkspaceUnread() {
+        AppDelegate.shared?.notificationStore?.setPanelDerivedUnread(!manualUnreadPanelIds.isEmpty, forTabId: id)
+    }
+
     private func normalizePinnedTabs(in paneId: PaneID) {
         guard !isNormalizingPinnedTabOrder else { return }
         isNormalizingPinnedTabOrder = true
@@ -8535,6 +8544,19 @@ final class Workspace: Identifiable, ObservableObject {
         let didRemoveRestored = clearRestoredUnreadIndicatorState(panelId: panelId)
         guard didRemoveManual || didRemoveRestored else { return }
         syncUnreadBadgeStateForPanel(panelId)
+    }
+
+    @discardableResult
+    func clearAllPanelUnreadIndicatorsForWorkspaceRead() -> Bool {
+        let affectedPanelIds = manualUnreadPanelIds.union(restoredUnreadPanelIds)
+        guard !affectedPanelIds.isEmpty else { return false }
+        manualUnreadPanelIds.removeAll()
+        restoredUnreadPanelIds.removeAll()
+        manualUnreadMarkedAt.removeAll()
+        for panelId in affectedPanelIds {
+            syncUnreadBadgeStateForPanel(panelId)
+        }
+        return true
     }
 
     private func clearManualUnreadState(panelId: UUID) -> Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8565,7 +8565,10 @@ final class Workspace: Identifiable, ObservableObject {
 
     @discardableResult
     func clearAllPanelUnreadIndicatorsForWorkspaceRead() -> Bool {
-        let affectedPanelIds = manualUnreadPanelIds.union(restoredUnreadPanelIds)
+        let hadLocalUnreadIndicators = !manualUnreadPanelIds.isEmpty || !restoredUnreadPanelIds.isEmpty
+        let affectedPanelIds = Set(panels.keys)
+            .union(manualUnreadPanelIds)
+            .union(restoredUnreadPanelIds)
         guard !affectedPanelIds.isEmpty else { return false }
         manualUnreadPanelIds.removeAll()
         restoredUnreadPanelIds.removeAll()
@@ -8573,7 +8576,7 @@ final class Workspace: Identifiable, ObservableObject {
         for panelId in affectedPanelIds {
             syncUnreadBadgeStateForPanel(panelId)
         }
-        return true
+        return hadLocalUnreadIndicators
     }
 
     private func clearManualUnreadState(panelId: UUID) -> Bool {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8556,6 +8556,15 @@ final class Workspace: Identifiable, ObservableObject {
         syncUnreadBadgeStateForPanel(panelId)
     }
 
+    func clearUnreadAfterJump(panelId: UUID?) {
+        if let panelId,
+           manualUnreadPanelIds.contains(panelId) || restoredUnreadPanelIds.contains(panelId) {
+            markPanelRead(panelId)
+            return
+        }
+        AppDelegate.shared?.notificationStore?.markRead(forTabId: id)
+    }
+
     func clearManualUnread(panelId: UUID) {
         let didRemoveManual = clearManualUnreadState(panelId: panelId)
         let didRemoveRestored = clearRestoredUnreadIndicatorState(panelId: panelId)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8531,6 +8531,23 @@ final class Workspace: Identifiable, ObservableObject {
         syncUnreadBadgeStateForPanel(panelId)
     }
 
+    func preferredUnreadPanelIdForJump() -> UUID? {
+        let latestManualPanelId = manualUnreadMarkedAt
+            .filter { manualUnreadPanelIds.contains($0.key) && panels[$0.key] != nil }
+            .max { $0.value < $1.value }?
+            .key
+        if let latestManualPanelId {
+            return latestManualPanelId
+        }
+        if let manualPanelId = manualUnreadPanelIds.first(where: { panels[$0] != nil }) {
+            return manualPanelId
+        }
+        if let restoredPanelId = restoredUnreadPanelIds.first(where: { panels[$0] != nil }) {
+            return restoredPanelId
+        }
+        return representativePanelIdForWorkspaceManualUnread()
+    }
+
     func markPanelRead(_ panelId: UUID) {
         guard panels[panelId] != nil else { return }
         AppDelegate.shared?.notificationStore?.markRead(forTabId: id, surfaceId: panelId)

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -851,7 +851,7 @@ struct cmuxApp: App {
     }
 
     private var notificationMenuSnapshot: NotificationMenuSnapshot {
-        NotificationMenuSnapshotBuilder.make(notifications: notificationStore.notifications)
+        notificationStore.notificationMenuSnapshot
     }
 
     var activeTabManager: TabManager {

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1431,6 +1431,18 @@ final class NotificationMenuSnapshotBuilderTests: XCTestCase {
         XCTAssertEqual(snapshot.recentNotifications.map(\.id), Array(notifications.prefix(3)).map(\.id))
     }
 
+    func testSnapshotCountsWorkspaceUnreadIndicatorsWithoutNotificationRecords() {
+        let snapshot = NotificationMenuSnapshotBuilder.make(
+            notifications: [],
+            workspaceUnreadIndicatorCount: 2
+        )
+
+        XCTAssertEqual(snapshot.unreadCount, 2)
+        XCTAssertTrue(snapshot.hasNotifications)
+        XCTAssertTrue(snapshot.hasUnreadNotifications)
+        XCTAssertTrue(snapshot.recentNotifications.isEmpty)
+    }
+
     func testStateHintTitleHandlesSingularPluralAndZero() {
         XCTAssertEqual(NotificationMenuSnapshotBuilder.stateHintTitle(unreadCount: 0), "No unread notifications")
         XCTAssertEqual(NotificationMenuSnapshotBuilder.stateHintTitle(unreadCount: 1), "1 unread notification")

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -544,6 +544,15 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         }
     }
 
+    func testWorkspaceReadFlowsClearNotificationBackedPanelBadges() throws {
+        try assertWorkspaceReadFlowClearsNotificationBackedPanelBadge { store, workspaceId in
+            store.markRead(forTabId: workspaceId)
+        }
+        try assertWorkspaceReadFlowClearsNotificationBackedPanelBadge { store, _ in
+            store.markAllRead()
+        }
+    }
+
     private func assertWorkspaceReadFlowClearsRepresentativeBadge(
         _ action: (TerminalNotificationStore, UUID) -> Void,
         line: UInt = #line
@@ -580,6 +589,62 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id), line: line)
         XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id), line: line)
         XCTAssertFalse(workspace.bonsplitController.tab(tabId)?.showsNotificationBadge ?? true, line: line)
+    }
+
+    private func assertWorkspaceReadFlowClearsNotificationBackedPanelBadge(
+        _ action: (TerminalNotificationStore, UUID) -> Void,
+        line: UInt = #line
+    ) throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace, line: line)
+        let manualPanelId = try XCTUnwrap(workspace.focusedPanelId, line: line)
+        let notificationPanel = try XCTUnwrap(
+            workspace.newTerminalSplit(from: manualPanelId, orientation: .horizontal, focus: false),
+            line: line
+        )
+        let manualTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(manualPanelId), line: line)
+        let notificationTabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(notificationPanel.id), line: line)
+
+        workspace.markPanelUnread(manualPanelId)
+        store.replaceNotificationsForTesting([
+            TerminalNotification(
+                id: UUID(),
+                tabId: workspace.id,
+                surfaceId: notificationPanel.id,
+                title: "Unread",
+                subtitle: "",
+                body: "",
+                createdAt: Date(),
+                isRead: false
+            ),
+        ])
+        workspace.bonsplitController.updateTab(notificationTabId, showsNotificationBadge: true)
+
+        XCTAssertTrue(workspace.bonsplitController.tab(manualTabId)?.showsNotificationBadge ?? false, line: line)
+        XCTAssertTrue(workspace.bonsplitController.tab(notificationTabId)?.showsNotificationBadge ?? false, line: line)
+
+        action(store, workspace.id)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(manualPanelId), line: line)
+        XCTAssertFalse(store.hasUnreadNotification(forTabId: workspace.id, surfaceId: notificationPanel.id), line: line)
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id), line: line)
+        XCTAssertFalse(workspace.bonsplitController.tab(manualTabId)?.showsNotificationBadge ?? true, line: line)
+        XCTAssertFalse(workspace.bonsplitController.tab(notificationTabId)?.showsNotificationBadge ?? true, line: line)
     }
 
     func testClearUnreadAfterJumpClearsWorkspaceLevelRepresentativeFallback() throws {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -366,6 +366,38 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspace.id]))
     }
 
+    func testMarkPanelUnreadContributesToGlobalUnreadSurfaces() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        XCTAssertEqual(store.unreadCount, 0)
+        XCTAssertEqual(store.notificationMenuSnapshot.unreadCount, 0)
+
+        workspace.markPanelUnread(panelId)
+
+        XCTAssertEqual(store.unreadCount, 1)
+        XCTAssertEqual(store.notificationMenuSnapshot.unreadCount, 1)
+        XCTAssertTrue(store.notificationMenuSnapshot.hasUnreadNotifications)
+
+        store.markRead(forTabId: workspace.id)
+
+        XCTAssertEqual(store.unreadCount, 0)
+        XCTAssertEqual(store.notificationMenuSnapshot.unreadCount, 0)
+        XCTAssertFalse(store.notificationMenuSnapshot.hasUnreadNotifications)
+    }
+
     func testMarkPanelReadClearsPanelDerivedWorkspaceUnread() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -582,6 +582,65 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(workspace.bonsplitController.tab(tabId)?.showsNotificationBadge ?? true, line: line)
     }
 
+    func testClearUnreadAfterJumpClearsWorkspaceLevelRepresentativeFallback() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertEqual(workspace.preferredUnreadPanelIdForJump(), panelId)
+        XCTAssertTrue(store.hasManualUnread(forTabId: workspace.id))
+
+        workspace.clearUnreadAfterJump(panelId: panelId)
+
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+    }
+
+    func testClearUnreadAfterJumpOnlyClearsTargetPanelWhenPanelIsUnread() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let firstPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let secondPanel = try XCTUnwrap(workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal, focus: false))
+
+        workspace.markPanelUnread(firstPanelId)
+        workspace.markPanelUnread(secondPanel.id)
+
+        workspace.clearUnreadAfterJump(panelId: firstPanelId)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(firstPanelId))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(secondPanel.id))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+    }
+
     func testMarkingOneUnreadPanelReadKeepsWorkspaceUnreadWhileAnotherPanelIsUnread() throws {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let store = TerminalNotificationStore.shared

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -358,9 +358,225 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         workspace.markPanelUnread(panelId)
 
         XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
         XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
         XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspace.id]))
         XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspace.id]))
+    }
+
+    func testMarkPanelReadClearsPanelDerivedWorkspaceUnread() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.markPanelUnread(panelId)
+        workspace.markPanelRead(panelId)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspace.id]))
+    }
+
+    func testMarkPanelReadKeepsExplicitWorkspaceUnread() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        workspace.markPanelUnread(panelId)
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
+
+        workspace.markPanelRead(panelId)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.hasManualUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
+    }
+
+    func testMarkWorkspaceReadClearsPanelDerivedWorkspaceUnreadDurably() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.markPanelUnread(panelId)
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+
+        store.markRead(forTabId: workspace.id)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+
+        workspace.pruneSurfaceMetadata(validSurfaceIds: Set(workspace.panels.keys))
+
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+    }
+
+    func testWorkspaceSurfaceMarkReadClearsPanelDerivedWorkspaceUnreadDurably() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId)
+
+        workspace.markPanelUnread(panelId)
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+
+        store.markRead(forTabId: workspace.id, surfaceId: nil)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+
+        workspace.pruneSurfaceMetadata(validSurfaceIds: Set(workspace.panels.keys))
+
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+    }
+
+    func testWorkspaceReadFlowsClearRepresentativeBadgeWhenPanelAndWorkspaceAreUnread() throws {
+        try assertWorkspaceReadFlowClearsRepresentativeBadge { store, workspaceId in
+            store.markRead(forTabId: workspaceId)
+        }
+        try assertWorkspaceReadFlowClearsRepresentativeBadge { store, _ in
+            store.markAllRead()
+        }
+        try assertWorkspaceReadFlowClearsRepresentativeBadge { store, _ in
+            store.clearAll(discardQueuedNotifications: false)
+        }
+    }
+
+    private func assertWorkspaceReadFlowClearsRepresentativeBadge(
+        _ action: (TerminalNotificationStore, UUID) -> Void,
+        line: UInt = #line
+    ) throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let manager = TabManager()
+        let store = TerminalNotificationStore.shared
+        let originalTabManager = appDelegate.tabManager
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.tabManager = manager
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.tabManager = originalTabManager
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = try XCTUnwrap(manager.selectedWorkspace, line: line)
+        let panelId = try XCTUnwrap(workspace.focusedPanelId, line: line)
+        let tabId = try XCTUnwrap(workspace.surfaceIdFromPanelId(panelId), line: line)
+
+        workspace.markPanelUnread(panelId)
+        store.markUnread(forTabId: workspace.id)
+
+        XCTAssertTrue(workspace.bonsplitController.tab(tabId)?.showsNotificationBadge ?? false, line: line)
+
+        action(store, workspace.id)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId), line: line)
+        XCTAssertFalse(store.hasManualUnread(forTabId: workspace.id), line: line)
+        XCTAssertFalse(store.hasPanelDerivedUnread(forTabId: workspace.id), line: line)
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id), line: line)
+        XCTAssertFalse(workspace.bonsplitController.tab(tabId)?.showsNotificationBadge ?? true, line: line)
+    }
+
+    func testMarkingOneUnreadPanelReadKeepsWorkspaceUnreadWhileAnotherPanelIsUnread() throws {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        let firstPanelId = try XCTUnwrap(workspace.focusedPanelId)
+        let secondPanel = try XCTUnwrap(workspace.newTerminalSplit(from: firstPanelId, orientation: .horizontal, focus: false))
+
+        workspace.markPanelUnread(firstPanelId)
+        workspace.markPanelUnread(secondPanel.id)
+
+        workspace.markPanelRead(firstPanelId)
+
+        XCTAssertFalse(workspace.manualUnreadPanelIds.contains(firstPanelId))
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(secondPanel.id))
+        XCTAssertTrue(store.hasPanelDerivedUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertEqual(store.unreadCount(forTabId: workspace.id), 1)
     }
 
     func testManualPanelUnreadSurvivesNonTerminalDirectInteraction() {

--- a/cmuxTests/WorkspaceManualUnreadTests.swift
+++ b/cmuxTests/WorkspaceManualUnreadTests.swift
@@ -333,6 +333,36 @@ final class WorkspaceManualUnreadTests: XCTestCase {
         XCTAssertFalse(workspace.manualUnreadPanelIds.contains(panelId))
     }
 
+    func testMarkPanelUnreadMarksWorkspaceUnread() {
+        let appDelegate = AppDelegate.shared ?? AppDelegate()
+        let store = TerminalNotificationStore.shared
+        let originalNotificationStore = appDelegate.notificationStore
+
+        store.replaceNotificationsForTesting([])
+        appDelegate.notificationStore = store
+
+        defer {
+            store.replaceNotificationsForTesting([])
+            appDelegate.notificationStore = originalNotificationStore
+        }
+
+        let workspace = Workspace()
+        guard let panelId = workspace.focusedPanelId else {
+            XCTFail("Expected selected workspace with focused panel")
+            return
+        }
+
+        XCTAssertFalse(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.canMarkWorkspaceUnread(forTabIds: [workspace.id]))
+
+        workspace.markPanelUnread(panelId)
+
+        XCTAssertTrue(workspace.manualUnreadPanelIds.contains(panelId))
+        XCTAssertTrue(store.workspaceIsUnread(forTabId: workspace.id))
+        XCTAssertTrue(store.canMarkWorkspaceRead(forTabIds: [workspace.id]))
+        XCTAssertFalse(store.canMarkWorkspaceUnread(forTabIds: [workspace.id]))
+    }
+
     func testManualPanelUnreadSurvivesNonTerminalDirectInteraction() {
         let appDelegate = AppDelegate.shared ?? AppDelegate()
         let manager = TabManager()


### PR DESCRIPTION
Summary:
- Marking a tab unread now also marks its workspace unread, so the sidebar workspace badge appears.
- The shared notification snapshot now includes workspace unread indicators, so the titlebar bell, menu bar item, and dock badge show the unread count for tab-only unread state.
- Jump to unread now falls back to workspace/tab unread indicators when there is no retained notification record.
- Review follow-up a4add37b5 continues unread jump past failed contexts and refreshes all live panel badges on workspace-level read.
- Review follow-up ef3f6eb84 makes unread jump ordering deterministic, clears workspace-level representative fallbacks durably, and avoids the empty notification state when only workspace unread indicators exist.

Tests:
- Red commit b9e288d64: marking a tab unread did not make TerminalNotificationStore.workspaceIsUnread true.
- Green commit 670fad764: fixed workspace unread state from tab unread.
- Red commit 84d9eddb0: marking a tab unread did not contribute to TerminalNotificationStore.unreadCount or NotificationMenuSnapshot unread count.
- Green commit 6792ac435: fixed shared bell/menu/dock unread counting for tab unread.
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tabunread-follow-workspace '-only-testing:cmuxTests/WorkspaceManualUnreadTests' test. Result: 36 tests, 0 failures.
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tabunread-follow-notify '-only-testing:cmuxTests/NotificationDockBadgeTests' '-only-testing:cmuxTests/NotificationMenuSnapshotBuilderTests' '-only-testing:cmuxTests/FocusedNotificationIndicatorTests' test. Result: 35 tests, 0 failures.

Cloud proof:
- Run: https://github.com/manaflow-ai/cmux-loader/actions/runs/25862207291
- Host: cloud-mac-25862207291
- Before video: /tmp/before-tab-unread-clean/recording.mov
- Before checked frames: /tmp/before-tab-unread-clean/frames/02.png, /tmp/before-tab-unread-clean/frames/tail.png
- After video for sidebar behavior: /tmp/after-tab-unread-final/recording.mov
- After checked frames: /tmp/after-tab-unread-final/frames/02.png, /tmp/after-tab-unread-final/frames/tail.png

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core unread counting and clearing behavior across notifications, workspace badges, and jump-to-unread navigation; regressions could cause incorrect badge counts or unread state getting stuck/cleared unexpectedly.
> 
> **Overview**
> Unifies unread presentation so *workspace-level unread indicators* (including panel-derived and restored states) contribute to the shared unread count used by the dock badge, menu bar/titlebar bell, and UI enablement.
> 
> Updates the notifications UI (page + popover) to avoid an empty state when only workspace unread indicators exist, and adds a `jumpToLatestUnread` fallback that opens the most relevant unread workspace/panel even without a retained notification record, clearing the indicator after the jump.
> 
> Refactors unread state management in `TerminalNotificationStore`/`Workspace` to track `panelDerivedUnreadWorkspaceIds`, keep the menu snapshot in sync, and ensure workspace-level read/clear flows also clear associated panel unread badges; adds/expands unit tests covering these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbf2ed3022c133059625a6e99c5bbd1a0b060bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Latest update:
- Manual-only Mark as Oldest Unread and Jump to Next Latest Unread now skips the current workspace and opens the next unread workspace.
- Bulk read and clear flows refresh notification-backed panel badges for every affected workspace.

Latest tests:
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tabunread-manual-jump-red '-only-testing:cmuxTests/WorkspaceManualUnreadTests' test. Result: 39 tests, 0 failures.
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tabunread-manual-jump-red '-only-testing:cmuxTests/TerminalNotificationClearAllTests' '-only-testing:cmuxTests/NotificationDockBadgeTests' '-only-testing:cmuxTests/NotificationMenuSnapshotBuilderTests' '-only-testing:cmuxTests/FocusedNotificationIndicatorTests' test. Result: 44 tests, 0 failures.
- xcodebuild -project GhosttyTabs.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-tabunread-manual-jump-red '-only-testing:cmuxTests/WorkspaceManualUnreadTests/testWorkspaceReadFlowsClearNotificationBackedPanelBadges' test. Result: 1 test, 0 failures.